### PR TITLE
XR: parse and extract `l2vpn`

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -782,7 +782,7 @@ BREAKOUT: 'breakout';
 
 BRIDGE: 'bridge';
 
-BRIDGE_DOMAIN: 'bridge-domain';
+BRIDGE_DOMAIN: 'bridge-domain' -> pushMode(M_Word);
 
 BRIDGE_GROUP: 'bridge-group';
 
@@ -2181,7 +2181,15 @@ GRE: 'gre';
 
 GREEN: 'green';
 
-GROUP: 'group';
+GROUP
+:
+  'group'
+  {
+    if (lastTokenType() == BRIDGE) {
+      pushMode(M_Word);
+    }
+  }
+;
 
 GROUP_ALIAS: 'group-alias';
 
@@ -2548,8 +2556,11 @@ INTERAREA: 'interarea';
 INTERFACE
 :
    'int' 'erface'?
-   { if (lastTokenType() == NEWLINE || lastTokenType() == -1) {pushMode(M_Interface);}}
-
+   {
+     if (lastTokenType() == NEWLINE || lastTokenType() == ROUTED || lastTokenType() == -1) {
+       pushMode(M_Interface);
+     }
+   }
 ;
 
 INTERFACE_INHERITANCE: 'interface-inheritance';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrParser.g4
@@ -518,7 +518,7 @@ l2tpc_null
 
 l2vpn_bridge_group
 :
-   BRIDGE GROUP name = variable NEWLINE
+   BRIDGE GROUP bridge_group_name NEWLINE
    (
       lbg_bridge_domain
    )*
@@ -555,13 +555,19 @@ l2vpn_xconnect_p2p
 
 lbg_bridge_domain
 :
-   BRIDGE_DOMAIN name = variable NEWLINE
+   BRIDGE_DOMAIN bridge_domain_name NEWLINE
    (
       lbgbd_mac
+      | lbgbd_interface
+      | lbgbd_routed_interface
       | lbgbd_null
       | lbgbd_vfi
    )*
 ;
+
+lbgbd_interface: INTERFACE interface_name NEWLINE;
+
+lbgbd_routed_interface: ROUTED INTERFACE interface_name NEWLINE;
 
 lbgbd_mac
 :
@@ -575,10 +581,8 @@ lbgbd_null
 :
    NO?
    (
-      INTERFACE
-      | MTU
+      MTU
       | NEIGHBOR
-      | ROUTED
    ) null_rest_of_line
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_common.g4
@@ -19,6 +19,8 @@ comparator
 // structure names
 access_list_name: WORD;
 as_path_set_name: WORD;
+bridge_domain_name: WORD;
+bridge_group_name: WORD;
 community_set_name: WORD;
 flow_exporter_map_name: WORD;
 flow_monitor_map_name: WORD;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -424,6 +424,8 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Boolean_rp_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Boolean_simple_rp_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Boolean_tag_is_rp_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Boolean_validation_state_is_rp_stanzaContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Bridge_domain_nameContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Bridge_group_nameContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Cd_match_addressContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Cd_set_isakmp_profileContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Cd_set_peerContext;
@@ -597,10 +599,14 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Ipv6_prefix_list_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Is_type_is_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Isis_levelContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Isis_level_exprContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.L2vpn_bridge_groupContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.L_access_classContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.L_exec_timeoutContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.L_login_authenticationContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.L_transportContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Lbg_bridge_domainContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Lbgbd_interfaceContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Lbgbd_routed_interfaceContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Literal_communityContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Local_as_bgp_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Logging_addressContext;
@@ -901,6 +907,8 @@ import org.batfish.representation.cisco_xr.BgpNetwork6;
 import org.batfish.representation.cisco_xr.BgpPeerGroup;
 import org.batfish.representation.cisco_xr.BgpProcess;
 import org.batfish.representation.cisco_xr.BgpRedistributionPolicy;
+import org.batfish.representation.cisco_xr.BridgeDomain;
+import org.batfish.representation.cisco_xr.BridgeGroup;
 import org.batfish.representation.cisco_xr.CiscoXrConfiguration;
 import org.batfish.representation.cisco_xr.CiscoXrStructureType;
 import org.batfish.representation.cisco_xr.CiscoXrStructureUsage;
@@ -1216,6 +1224,10 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   private AaaAuthenticationLoginList _currentAaaAuthenticationLoginList;
 
   private final Set<String> _currentBlockNeighborAddressFamilies;
+
+  private BridgeDomain _currentBridgeDomain;
+
+  private BridgeGroup _currentBridgeGroup;
 
   private CryptoMapEntry _currentCryptoMapEntry;
 
@@ -3226,6 +3238,14 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     return ctx.getText();
   }
 
+  private static @Nonnull String toString(Bridge_domain_nameContext ctx) {
+    return ctx.getText();
+  }
+
+  private static @Nonnull String toString(Bridge_group_nameContext ctx) {
+    return ctx.getText();
+  }
+
   @Override
   public void exitAuto_summary_bgp_tail(Auto_summary_bgp_tailContext ctx) {
     todo(ctx);
@@ -4806,6 +4826,40 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   public void exitLogging_buffered_set_severity(Logging_buffered_set_severityContext ctx) {
     getOrCreateBuffered().setSeverity(toSeverity(ctx.logging_buffered_severity()));
     getOrCreateBuffered().setSeverityNum(toLoggingSeverityNum(ctx.logging_buffered_severity()));
+  }
+
+  @Override
+  public void enterL2vpn_bridge_group(L2vpn_bridge_groupContext ctx) {
+    String name = toString(ctx.bridge_group_name());
+    _currentBridgeGroup =
+        _configuration.getBridgeGroups().computeIfAbsent(name, n -> new BridgeGroup(n));
+  }
+
+  @Override
+  public void exitL2vpn_bridge_group(L2vpn_bridge_groupContext ctx) {
+    _currentBridgeGroup = null;
+  }
+
+  @Override
+  public void enterLbg_bridge_domain(Lbg_bridge_domainContext ctx) {
+    String name = toString(ctx.bridge_domain_name());
+    _currentBridgeDomain =
+        _currentBridgeGroup.getBridgeDomains().computeIfAbsent(name, n -> new BridgeDomain(n));
+  }
+
+  @Override
+  public void exitLbg_bridge_domain(Lbg_bridge_domainContext ctx) {
+    _currentBridgeDomain = null;
+  }
+
+  @Override
+  public void exitLbgbd_interface(Lbgbd_interfaceContext ctx) {
+    _currentBridgeDomain.getInterfaces().add(getOrAddInterface(ctx.interface_name()).getName());
+  }
+
+  @Override
+  public void exitLbgbd_routed_interface(Lbgbd_routed_interfaceContext ctx) {
+    _currentBridgeDomain.setRoutedInterface(getOrAddInterface(ctx.interface_name()).getName());
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -59,6 +59,8 @@ import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.BGP_UPDA
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.BGP_USE_AF_GROUP;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.BGP_USE_NEIGHBOR_GROUP;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.BGP_USE_SESSION_GROUP;
+import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.BRIDGE_DOMAIN_INTERFACE;
+import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.BRIDGE_DOMAIN_ROUTED_INTERFACE;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.CLASS_MAP_ACCESS_GROUP;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.CLASS_MAP_ACCESS_LIST;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.CLASS_MAP_ACTIVATED_SERVICE_TEMPLATE;
@@ -4854,12 +4856,20 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitLbgbd_interface(Lbgbd_interfaceContext ctx) {
-    _currentBridgeDomain.getInterfaces().add(getOrAddInterface(ctx.interface_name()).getName());
+    Interface iface = getOrAddInterface(ctx.interface_name());
+    String ifaceName = iface.getName();
+    _currentBridgeDomain.getInterfaces().add(iface.getName());
+    _configuration.referenceStructure(
+        INTERFACE, ifaceName, BRIDGE_DOMAIN_INTERFACE, ctx.start.getLine());
   }
 
   @Override
   public void exitLbgbd_routed_interface(Lbgbd_routed_interfaceContext ctx) {
-    _currentBridgeDomain.setRoutedInterface(getOrAddInterface(ctx.interface_name()).getName());
+    Interface iface = getOrAddInterface(ctx.interface_name());
+    String ifaceName = iface.getName();
+    _currentBridgeDomain.setRoutedInterface(iface.getName());
+    _configuration.referenceStructure(
+        INTERFACE, ifaceName, BRIDGE_DOMAIN_ROUTED_INTERFACE, ctx.start.getLine());
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -4856,18 +4856,16 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitLbgbd_interface(Lbgbd_interfaceContext ctx) {
-    Interface iface = getOrAddInterface(ctx.interface_name());
-    String ifaceName = iface.getName();
-    _currentBridgeDomain.getInterfaces().add(iface.getName());
+    String ifaceName = getCanonicalInterfaceName(ctx.interface_name().getText());
+    _currentBridgeDomain.getInterfaces().add(ifaceName);
     _configuration.referenceStructure(
         INTERFACE, ifaceName, BRIDGE_DOMAIN_INTERFACE, ctx.start.getLine());
   }
 
   @Override
   public void exitLbgbd_routed_interface(Lbgbd_routed_interfaceContext ctx) {
-    Interface iface = getOrAddInterface(ctx.interface_name());
-    String ifaceName = iface.getName();
-    _currentBridgeDomain.setRoutedInterface(iface.getName());
+    String ifaceName = getCanonicalInterfaceName(ctx.interface_name().getText());
+    _currentBridgeDomain.setRoutedInterface(ifaceName);
     _configuration.referenceStructure(
         INTERFACE, ifaceName, BRIDGE_DOMAIN_ROUTED_INTERFACE, ctx.start.getLine());
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BridgeDomain.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BridgeDomain.java
@@ -1,0 +1,40 @@
+package org.batfish.representation.cisco_xr;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** XR datamodel component containing bridge-domain configuration */
+@ParametersAreNonnullByDefault
+public class BridgeDomain implements Serializable {
+  @Nonnull
+  public String getName() {
+    return _name;
+  }
+
+  @Nonnull
+  public Set<String> getInterfaces() {
+    return _interfaces;
+  }
+
+  @Nullable
+  public String getRoutedInterface() {
+    return _routedInterface;
+  }
+
+  public void setRoutedInterface(String routedInterface) {
+    _routedInterface = routedInterface;
+  }
+
+  public BridgeDomain(String name) {
+    _name = name;
+    _interfaces = new HashSet<>();
+  }
+
+  @Nonnull private final String _name;
+  @Nonnull private final Set<String> _interfaces;
+  @Nullable private String _routedInterface;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BridgeGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BridgeGroup.java
@@ -1,0 +1,29 @@
+package org.batfish.representation.cisco_xr;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** XR datamodel component containing bridge group configuration */
+@ParametersAreNonnullByDefault
+public class BridgeGroup implements Serializable {
+  @Nonnull
+  public String getName() {
+    return _name;
+  }
+
+  @Nonnull
+  public Map<String, BridgeDomain> getBridgeDomains() {
+    return _bridgeDomains;
+  }
+
+  public BridgeGroup(String name) {
+    _name = name;
+    _bridgeDomains = new HashMap<>();
+  }
+
+  @Nonnull private final String _name;
+  @Nonnull private final Map<String, BridgeDomain> _bridgeDomains;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -354,6 +354,8 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
 
   private final Map<String, AsPathSet> _asPathSets;
 
+  private final Map<String, BridgeGroup> _bridgeGroups;
+
   private final CiscoXrFamily _cf;
 
   private final Map<String, CryptoMapSet> _cryptoMapSets;
@@ -427,6 +429,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
 
   public CiscoXrConfiguration() {
     _asPathSets = new TreeMap<>();
+    _bridgeGroups = new TreeMap<>();
     _cf = new CiscoXrFamily();
     _communitySets = new TreeMap<>();
     _cryptoNamedRsaPubKeys = new TreeMap<>();
@@ -495,6 +498,10 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
 
   public Map<String, AsPathSet> getAsPathSets() {
     return _asPathSets;
+  }
+
+  public Map<String, BridgeGroup> getBridgeGroups() {
+    return _bridgeGroups;
   }
 
   private Ip getBgpRouterId(Configuration c, String vrfName, BgpProcess proc) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureUsage.java
@@ -19,6 +19,8 @@ public enum CiscoXrStructureUsage implements StructureUsage {
   BGP_USE_AF_GROUP("bgp use af-group"),
   BGP_USE_NEIGHBOR_GROUP("bgp use neighbor-group"),
   BGP_USE_SESSION_GROUP("bgp use session-group"),
+  BRIDGE_DOMAIN_INTERFACE("bridge-domain interface"),
+  BRIDGE_DOMAIN_ROUTED_INTERFACE("bridge-domain routed interface"),
   CLASS_MAP_ACCESS_GROUP("class-map access-group"),
   CLASS_MAP_ACCESS_LIST("class-map access-list"),
   CLASS_MAP_ACTIVATED_SERVICE_TEMPLATE("class-map activate-service-template"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -3460,5 +3460,12 @@ public final class XrGrammarTest {
         ccae, hasReferencedStructure(filename, INTERFACE, "BVI1", BRIDGE_DOMAIN_ROUTED_INTERFACE));
     assertThat(
         ccae, hasReferencedStructure(filename, INTERFACE, "BVI2", BRIDGE_DOMAIN_ROUTED_INTERFACE));
+
+    assertThat(
+        ccae,
+        hasUndefinedReference(
+            filename, INTERFACE, "GigabitEthernet0/0/0/2.1", BRIDGE_DOMAIN_INTERFACE));
+    assertThat(
+        ccae, hasUndefinedReference(filename, INTERFACE, "BVI2", BRIDGE_DOMAIN_ROUTED_INTERFACE));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -3410,13 +3410,14 @@ public final class XrGrammarTest {
         hasKeys(
             // Routed interface associated with l2vpn
             "BVI1",
+            "BVI2",
             // Referenced but otherwise undefined interfaces
             "GigabitEthernet0/0/0/1.1",
             "GigabitEthernet0/0/0/2.1"));
 
     assertThat(vc.getBridgeGroups(), hasKeys("BG1"));
     Map<String, BridgeDomain> bridgeDomains = vc.getBridgeGroups().get("BG1").getBridgeDomains();
-    assertThat(bridgeDomains, hasKeys("BD1", "BD2"));
+    assertThat(bridgeDomains, hasKeys("BD1", "BD2", "BD3"));
 
     BridgeDomain bd1 = bridgeDomains.get("BD1");
     assertThat(bd1.getName(), equalTo("BD1"));
@@ -3428,6 +3429,11 @@ public final class XrGrammarTest {
     BridgeDomain bd2 = bridgeDomains.get("BD2");
     assertThat(bd2.getName(), equalTo("BD2"));
     assertThat(bd2.getInterfaces(), empty());
-    assertNull(bd2.getRoutedInterface());
+    assertThat(bd2.getRoutedInterface(), equalTo("BVI2"));
+
+    BridgeDomain bd3 = bridgeDomains.get("BD3");
+    assertThat(bd3.getName(), equalTo("BD3"));
+    assertThat(bd3.getInterfaces(), empty());
+    assertNull(bd3.getRoutedInterface());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -43,6 +43,7 @@ import static org.batfish.representation.cisco_xr.CiscoXrStructureType.DYNAMIC_T
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.ETHERNET_SERVICES_ACCESS_LIST;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.FLOW_EXPORTER_MAP;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.FLOW_MONITOR_MAP;
+import static org.batfish.representation.cisco_xr.CiscoXrStructureType.INTERFACE;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.IPV4_ACCESS_LIST;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.IPV6_ACCESS_LIST;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.POLICY_MAP;
@@ -50,6 +51,8 @@ import static org.batfish.representation.cisco_xr.CiscoXrStructureType.PREFIX_SE
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.RD_SET;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.ROUTE_POLICY;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.SAMPLER_MAP;
+import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.BRIDGE_DOMAIN_INTERFACE;
+import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.BRIDGE_DOMAIN_ROUTED_INTERFACE;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.FLOW_MONITOR_MAP_EXPORTER;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.INTERFACE_FLOW_IPV4_MONITOR_EGRESS;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.INTERFACE_FLOW_IPV4_MONITOR_INGRESS;
@@ -3435,5 +3438,27 @@ public final class XrGrammarTest {
     assertThat(bd3.getName(), equalTo("BD3"));
     assertThat(bd3.getInterfaces(), empty());
     assertNull(bd3.getRoutedInterface());
+  }
+
+  @Test
+  public void testL2vpnReferences() {
+    String hostname = "l2vpn";
+    String filename = String.format("configs/%s", hostname);
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, INTERFACE, "GigabitEthernet0/0/0/1.1", BRIDGE_DOMAIN_INTERFACE));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, INTERFACE, "GigabitEthernet0/0/0/2.1", BRIDGE_DOMAIN_INTERFACE));
+    assertThat(
+        ccae, hasReferencedStructure(filename, INTERFACE, "BVI1", BRIDGE_DOMAIN_ROUTED_INTERFACE));
+    assertThat(
+        ccae, hasReferencedStructure(filename, INTERFACE, "BVI2", BRIDGE_DOMAIN_ROUTED_INTERFACE));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -3408,15 +3408,7 @@ public final class XrGrammarTest {
     String hostname = "l2vpn";
     CiscoXrConfiguration vc = parseVendorConfig(hostname);
 
-    assertThat(
-        vc.getInterfaces(),
-        hasKeys(
-            // Routed interface associated with l2vpn
-            "BVI1",
-            "BVI2",
-            // Referenced but otherwise undefined interfaces
-            "GigabitEthernet0/0/0/1.1",
-            "GigabitEthernet0/0/0/2.1"));
+    assertThat(vc.getInterfaces(), hasKeys("BVI1", "GigabitEthernet0/0/0/1.1"));
 
     assertThat(vc.getBridgeGroups(), hasKeys("BG1"));
     Map<String, BridgeDomain> bridgeDomains = vc.getBridgeGroups().get("BG1").getBridgeDomains();

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/l2vpn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/l2vpn
@@ -12,8 +12,12 @@ l2vpn
    interface GigabitEthernet0/0/0/1.1
    interface GigabitEthernet0/0/0/2.1
    !
+   routed interface BVI2
    routed interface BVI1
   !
   bridge-domain BD2
+   routed interface BVI2
+  !
+  bridge-domain BD3
   !
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/l2vpn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/l2vpn
@@ -5,6 +5,8 @@ hostname l2vpn
 interface BVI1
  ipv4 address 10.1.1.1 255.255.255.0
 !
+interface GigabitEthernet0/0/0/1.1
+!
 !
 l2vpn
  bridge group BG1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/l2vpn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/l2vpn
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname l2vpn
+!
+interface BVI1
+ ipv4 address 10.1.1.1 255.255.255.0
+!
+!
+l2vpn
+ bridge group BG1
+  bridge-domain BD1
+   interface GigabitEthernet0/0/0/1.1
+   interface GigabitEthernet0/0/0/2.1
+   !
+   routed interface BVI1
+  !
+  bridge-domain BD2
+  !
+!

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2904,6 +2904,30 @@
         }
       },
       {
+        "File_Name" : "configs/ios_xr_l2vpn",
+        "Struct_Type" : "interface",
+        "Ref_Name" : "BVI1",
+        "Context" : "bridge-domain routed interface",
+        "Lines" : {
+          "filename" : "configs/ios_xr_l2vpn",
+          "lines" : [
+            24
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/ios_xr_l2vpn",
+        "Struct_Type" : "interface",
+        "Ref_Name" : "Bundle-Ether9.1",
+        "Context" : "bridge-domain interface",
+        "Lines" : {
+          "filename" : "configs/ios_xr_l2vpn",
+          "lines" : [
+            15
+          ]
+        }
+      },
+      {
         "File_Name" : "configs/ios_xr_multicast",
         "Struct_Type" : "ipv4 access-list",
         "Ref_Name" : "MSDP_filter",
@@ -4363,10 +4387,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 354 results",
+      "notes" : "Found 356 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 354
+      "numResults" : 356
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -91595,6 +91595,54 @@
         "deviceModel" : "CISCO_UNSPECIFIED",
         "deviceType" : "SWITCH",
         "humanName" : "L2VPN",
+        "interfaces" : {
+          "BVI1" : {
+            "name" : "BVI1",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "declaredNames" : [
+              "BVI1"
+            ],
+            "mtu" : 1500,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "UNKNOWN",
+            "vrf" : "default"
+          },
+          "Bundle-Ether9.1" : {
+            "name" : "Bundle-Ether9.1",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 0.0,
+            "declaredNames" : [
+              "Bundle-Ether9.1"
+            ],
+            "mtu" : 1500,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "AGGREGATE_CHILD",
+            "vrf" : "default"
+          }
+        },
         "routingPolicies" : {
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -91595,54 +91595,6 @@
         "deviceModel" : "CISCO_UNSPECIFIED",
         "deviceType" : "SWITCH",
         "humanName" : "L2VPN",
-        "interfaces" : {
-          "BVI1" : {
-            "name" : "BVI1",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "declaredNames" : [
-              "BVI1"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
-            "vrf" : "default"
-          },
-          "Bundle-Ether9.1" : {
-            "name" : "Bundle-Ether9.1",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 0.0,
-            "declaredNames" : [
-              "Bundle-Ether9.1"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "AGGREGATE_CHILD",
-            "vrf" : "default"
-          }
-        },
         "routingPolicies" : {
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -45379,16 +45379,16 @@
             "      L2VPN:'l2vpn'",
             "      (null_rest_of_line*",
             "        NEWLINE:'\\n')",
-            "      (l2vpn_bridge_group*",
+            "      (l2vpn_bridge_group",
             "        BRIDGE:'bridge'",
             "        GROUP:'group'",
-            "        name = (variable*",
-            "          VARIABLE:'TEST-GROUP-1')",
+            "        (bridge_group_name*",
+            "          WORD:'TEST-GROUP-1'  <== mode:M_Word)",
             "        NEWLINE:'\\n'",
-            "        (lbg_bridge_domain*",
+            "        (lbg_bridge_domain",
             "          BRIDGE_DOMAIN:'bridge-domain'",
-            "          name = (variable*",
-            "            VARIABLE:'TEST-DOMAIN-1')",
+            "          (bridge_domain_name*",
+            "            WORD:'TEST-DOMAIN-1'  <== mode:M_Word)",
             "          NEWLINE:'\\n'",
             "          (lbgbd_mac*",
             "            MAC:'mac'",
@@ -45413,14 +45413,17 @@
             "            (null_rest_of_line*",
             "              UINT16:'9014'",
             "              NEWLINE:'\\n'))",
-            "          (lbgbd_null*",
+            "          (lbgbd_interface",
             "            INTERFACE:'interface'",
-            "            (null_rest_of_line*",
-            "              M_Interface_PREFIX:'Bundle-Ether'  <== mode:M_Interface",
+            "            (interface_name*",
+            "              name_prefix_alpha = M_Interface_PREFIX:'Bundle-Ether'  <== mode:M_Interface",
             "              UINT_BIG:'9'  <== mode:M_Interface",
             "              PERIOD:'.'  <== mode:M_Interface",
-            "              UINT_BIG:'1'  <== mode:M_Interface",
-            "              NEWLINE:'\\n'  <== mode:M_Interface))",
+            "              (range*",
+            "                (subrange*",
+            "                  low = (uint_legacy*",
+            "                    UINT_BIG:'1'  <== mode:M_Interface))))",
+            "            NEWLINE:'\\n'  <== mode:M_Interface)",
             "          (lbgbd_null*",
             "            NEIGHBOR:'neighbor'",
             "            (null_rest_of_line*",
@@ -45447,17 +45450,21 @@
             "                VARIABLE:'pw-id'",
             "                UINT16:'707'",
             "                NEWLINE:'\\n')))",
-            "          (lbgbd_null*",
+            "          (lbgbd_routed_interface",
             "            ROUTED:'routed'",
-            "            (null_rest_of_line*",
-            "              INTERFACE:'interface'",
-            "              VARIABLE:'BVI1'",
-            "              NEWLINE:'\\n'))))",
+            "            INTERFACE:'interface'",
+            "            (interface_name*",
+            "              name_prefix_alpha = M_Interface_PREFIX:'BVI'  <== mode:M_Interface",
+            "              (range*",
+            "                (subrange*",
+            "                  low = (uint_legacy*",
+            "                    UINT_BIG:'1'  <== mode:M_Interface))))",
+            "            NEWLINE:'\\n'  <== mode:M_Interface)))",
             "      (l2vpn_logging*",
             "        LOGGING:'logging'",
             "        NEWLINE:'\\n'",
             "        BRIDGE_DOMAIN:'bridge-domain'",
-            "        NEWLINE:'\\n'",
+            "        NEWLINE:'\\n'  <== mode:M_Word",
             "        PSEUDOWIRE:'pseudowire'",
             "        NEWLINE:'\\n'",
             "        VFI:'vfi'",
@@ -78817,6 +78824,20 @@
             }
           }
         },
+        "configs/ios_xr_l2vpn" : {
+          "interface" : {
+            "BVI1" : {
+              "bridge-domain routed interface" : [
+                24
+              ]
+            },
+            "Bundle-Ether9.1" : {
+              "bridge-domain interface" : [
+                15
+              ]
+            }
+          }
+        },
         "configs/ios_xr_multicast" : {
           "ipv4 access-list" : {
             "MSDP_filter" : {
@@ -82906,7 +82927,20 @@
         "configs/ios_xr_class_map" : { },
         "configs/ios_xr_community_set" : { },
         "configs/ios_xr_isis" : { },
-        "configs/ios_xr_l2vpn" : { },
+        "configs/ios_xr_l2vpn" : {
+          "interface" : {
+            "BVI1" : {
+              "bridge-domain routed interface" : [
+                24
+              ]
+            },
+            "Bundle-Ether9.1" : {
+              "bridge-domain interface" : [
+                15
+              ]
+            }
+          }
+        },
         "configs/ios_xr_logging" : { },
         "configs/ios_xr_misc" : { },
         "configs/ios_xr_multicast" : {


### PR DESCRIPTION
See [here for some details on BVI/l2vpn configuration](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/asr9k_r6-1/interfaces/configuration/guide/b-interfaces-cg-asr9k-61x/b-interfaces-cg-asr9k-61x_chapter_0111.html).

Quick summary:
* `bridge group` is just a grouping of `bridge-domain`s within `l2vpn`
* `bridge-domain` defines a "switch" that bridges all `interfaces` in that domain
* `routed interface` is the L3 `BVI` interface that is used to route interfaces in the `bridge-domain`
