### PR TITLE
XR: parse and extract `l2transport` interfaces

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -4044,6 +4044,8 @@ POLICY_MAP_OUTPUT: 'policy-map-output';
 
 POOL: 'pool';
 
+POP: 'pop';
+
 POP2: 'pop2';
 
 POP3: 'pop3';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_interface.g4
@@ -990,6 +990,15 @@ if_private_vlan
    PRIVATE_VLAN MAPPING (ADD | REMOVE)? null_rest_of_line
 ;
 
+if_rewrite_ingress_tag: REWRITE INGRESS TAG ifrit_policy NEWLINE;
+
+ifrit_policy: ifrit_pop;
+
+ifrit_pop: POP ifrit_pop_count SYMMETRIC?;
+
+// 1 or 2
+ifrit_pop_count: uint8;
+
 if_routing_dynamic
 :
    ROUTING DYNAMIC NEWLINE
@@ -1653,6 +1662,7 @@ if_inner
    | if_no_routing_dynamic
    | if_port_security
    | if_private_vlan
+   | if_rewrite_ingress_tag
    | if_routing_dynamic
    | if_service_instance
    | if_service_policy

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -2735,7 +2735,9 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
         for (int i = range.getStart(); i <= range.getEnd(); i++) {
           String name = namePrefix.toString() + i;
           Interface iface = addInterface(name, ctx.iname, true);
-          iface.setL2transport(ctx.L2TRANSPORT() != null);
+          if (ctx.L2TRANSPORT() != null) {
+            iface.setL2transport(true);
+          }
           _configuration.defineStructure(INTERFACE, name, ctx);
           _configuration.referenceStructure(
               INTERFACE, name, INTERFACE_SELF_REF, ctx.getStart().getLine());
@@ -2743,7 +2745,9 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
       }
     } else {
       Interface iface = addInterface(namePrefix.toString(), ctx.iname, true);
-      iface.setL2transport(ctx.L2TRANSPORT() != null);
+      if (ctx.L2TRANSPORT() != null) {
+        iface.setL2transport(true);
+      }
     }
     if (ctx.MULTIPOINT() != null) {
       todo(ctx);
@@ -4277,6 +4281,12 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   public void exitIf_rewrite_ingress_tag(If_rewrite_ingress_tagContext ctx) {
     Optional<TagRewritePolicy> policy = toTagRewritePolicy(ctx.ifrit_policy());
     for (Interface currentInterface : _currentInterfaces) {
+      if (!currentInterface.getL2transport()) {
+        warn(
+            ctx,
+            "Rewrite policy can only be configured on l2transport interfaces. Ignoring this line.");
+        continue;
+      }
       policy.ifPresent(currentInterface::setRewriteIngressTag);
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -1374,6 +1374,7 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     _statementCollectors.peek().accept(statement);
   }
 
+  /** Add or update an interface based on its definition. */
   private Interface addInterface(String name, S_interfaceContext ctx, boolean explicit) {
     Interface newInterface = addInterface(name, ctx.iname, explicit);
     if (ctx.L2TRANSPORT() != null) {
@@ -1382,6 +1383,10 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     return newInterface;
   }
 
+  /**
+   * Add an interface by name. This should only be directly used in contexts where an interface is
+   * created due to a reference.
+   */
   private Interface addInterface(String name, Interface_nameContext ctx, boolean explicit) {
     Interface newInterface = _configuration.getInterfaces().get(name);
     if (newInterface == null) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -1374,19 +1374,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     _statementCollectors.peek().accept(statement);
   }
 
-  /** Add or update an interface based on its definition. */
-  private Interface addInterface(String name, S_interfaceContext ctx, boolean explicit) {
-    Interface newInterface = addInterface(name, ctx.iname, explicit);
-    if (ctx.L2TRANSPORT() != null) {
-      newInterface.setL2transport(true);
-    }
-    return newInterface;
-  }
-
-  /**
-   * Add an interface by name. This should only be directly used in contexts where an interface is
-   * created due to a reference.
-   */
   private Interface addInterface(String name, Interface_nameContext ctx, boolean explicit) {
     Interface newInterface = _configuration.getInterfaces().get(name);
     if (newInterface == null) {
@@ -2747,14 +2734,16 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
       for (SubRange range : ranges) {
         for (int i = range.getStart(); i <= range.getEnd(); i++) {
           String name = namePrefix.toString() + i;
-          addInterface(name, ctx, true);
+          Interface iface = addInterface(name, ctx.iname, true);
+          iface.setL2transport(ctx.L2TRANSPORT() != null);
           _configuration.defineStructure(INTERFACE, name, ctx);
           _configuration.referenceStructure(
               INTERFACE, name, INTERFACE_SELF_REF, ctx.getStart().getLine());
         }
       }
     } else {
-      addInterface(namePrefix.toString(), ctx, true);
+      Interface iface = addInterface(namePrefix.toString(), ctx.iname, true);
+      iface.setL2transport(ctx.L2TRANSPORT() != null);
     }
     if (ctx.MULTIPOINT() != null) {
       todo(ctx);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/Interface.java
@@ -144,6 +144,8 @@ public class Interface implements Serializable {
 
   @Nullable private IsisInterfaceMode _isisInterfaceMode;
 
+  private boolean _l2transport = false;
+
   private int _mtu;
 
   private final String _name;
@@ -187,6 +189,8 @@ public class Interface implements Serializable {
   private SwitchportMode _switchportMode;
 
   private SwitchportEncapsulationType _switchportTrunkEncapsulation;
+
+  @Nullable private TagRewritePolicy _rewriteIngressTagPolicy;
 
   private Tunnel _tunnel;
 
@@ -318,6 +322,11 @@ public class Interface implements Serializable {
     return _isisInterfaceMode;
   }
 
+  /** Indicates if this interface is an l2transport interface. */
+  public boolean getL2transport() {
+    return _l2transport;
+  }
+
   public int getMtu() {
     return _mtu;
   }
@@ -374,6 +383,12 @@ public class Interface implements Serializable {
 
   public String getOutgoingFilter() {
     return _outgoingFilter;
+  }
+
+  /** Configured policy for rewriting ingress tags. */
+  @Nullable
+  public TagRewritePolicy getRewriteIngressTag() {
+    return _rewriteIngressTagPolicy;
   }
 
   public ConcreteInterfaceAddress getAddress() {
@@ -489,6 +504,10 @@ public class Interface implements Serializable {
     _isisInterfaceMode = mode;
   }
 
+  public void setL2transport(boolean l2transport) {
+    _l2transport = l2transport;
+  }
+
   public void setMtu(int mtu) {
     _mtu = mtu;
   }
@@ -535,6 +554,10 @@ public class Interface implements Serializable {
 
   public void setOutgoingFilter(String accessListName) {
     _outgoingFilter = accessListName;
+  }
+
+  public void setRewriteIngressTag(TagRewritePolicy tagRewritePolicy) {
+    _rewriteIngressTagPolicy = tagRewritePolicy;
   }
 
   public void setAddress(ConcreteInterfaceAddress address) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/TagRewritePolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/TagRewritePolicy.java
@@ -1,0 +1,6 @@
+package org.batfish.representation.cisco_xr;
+
+import java.io.Serializable;
+
+/** Interface for different tag rewrite policies for an interface. */
+public interface TagRewritePolicy extends Serializable {}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/TagRewritePop.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/TagRewritePop.java
@@ -1,0 +1,23 @@
+package org.batfish.representation.cisco_xr;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** XR datamodel component containing configuration for pop-based ingress tag rewriting. */
+@ParametersAreNonnullByDefault
+public class TagRewritePop implements TagRewritePolicy {
+  public int getCount() {
+    return _count;
+  }
+
+  public boolean getSymmetric() {
+    return _symmetric;
+  }
+
+  public TagRewritePop(int count, boolean symmetric) {
+    _count = count;
+    _symmetric = symmetric;
+  }
+
+  private final int _count;
+  private final boolean _symmetric;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/TagRewritePop.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/TagRewritePop.java
@@ -5,19 +5,19 @@ import javax.annotation.ParametersAreNonnullByDefault;
 /** XR datamodel component containing configuration for pop-based ingress tag rewriting. */
 @ParametersAreNonnullByDefault
 public class TagRewritePop implements TagRewritePolicy {
-  public int getCount() {
-    return _count;
+  public int getPopCount() {
+    return _popCount;
   }
 
   public boolean getSymmetric() {
     return _symmetric;
   }
 
-  public TagRewritePop(int count, boolean symmetric) {
-    _count = count;
+  public TagRewritePop(int popCount, boolean symmetric) {
+    _popCount = popCount;
     _symmetric = symmetric;
   }
 
-  private final int _count;
+  private final int _popCount;
   private final boolean _symmetric;
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -3426,14 +3426,33 @@ public final class XrGrammarTest {
 
     assertTrue(ge11.getL2transport());
     assertThat(ge11Policy, instanceOf(TagRewritePop.class));
-    assertThat(((TagRewritePop) ge11Policy).getCount(), equalTo(1));
+    assertThat(((TagRewritePop) ge11Policy).getPopCount(), equalTo(1));
     assertFalse(((TagRewritePop) ge11Policy).getSymmetric());
     assertThat(ge11.getEncapsulationVlan(), equalTo(1));
 
     assertTrue(ge12.getL2transport());
     assertThat(ge12Policy, instanceOf(TagRewritePop.class));
-    assertThat(((TagRewritePop) ge12Policy).getCount(), equalTo(2));
+    assertThat(((TagRewritePop) ge12Policy).getPopCount(), equalTo(2));
     assertTrue(((TagRewritePop) ge12Policy).getSymmetric());
     assertThat(ge12.getEncapsulationVlan(), equalTo(2));
+  }
+
+  @Test
+  public void testInterfaceL2transportWarning() {
+    String hostname = "interface_l2transport_warning";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    Warnings warnings =
+        getOnlyElement(
+            batfish
+                .loadParseVendorConfigurationAnswerElement(batfish.getSnapshot())
+                .getWarnings()
+                .values());
+    assertThat(
+        warnings,
+        hasParseWarnings(
+            containsInAnyOrder(
+                hasComment("Expected rewrite ingress tag pop range in range 1-2, but got '0'"),
+                hasComment("Expected rewrite ingress tag pop range in range 1-2, but got '3'"))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -3422,13 +3422,18 @@ public final class XrGrammarTest {
     TagRewritePolicy ge12Policy = ge12.getRewriteIngressTag();
 
     assertFalse(ge1.getL2transport());
+    assertThat(ge1.getEncapsulationVlan(), nullValue());
+
     assertTrue(ge11.getL2transport());
     assertThat(ge11Policy, instanceOf(TagRewritePop.class));
     assertThat(((TagRewritePop) ge11Policy).getCount(), equalTo(1));
     assertFalse(((TagRewritePop) ge11Policy).getSymmetric());
+    assertThat(ge11.getEncapsulationVlan(), equalTo(1));
+
     assertTrue(ge12.getL2transport());
     assertThat(ge12Policy, instanceOf(TagRewritePop.class));
     assertThat(((TagRewritePop) ge12Policy).getCount(), equalTo(2));
     assertTrue(((TagRewritePop) ge12Policy).getSymmetric());
+    assertThat(ge12.getEncapsulationVlan(), equalTo(2));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -3453,6 +3453,11 @@ public final class XrGrammarTest {
         hasParseWarnings(
             containsInAnyOrder(
                 hasComment("Expected rewrite ingress tag pop range in range 1-2, but got '0'"),
-                hasComment("Expected rewrite ingress tag pop range in range 1-2, but got '3'"))));
+                hasComment("Expected rewrite ingress tag pop range in range 1-2, but got '3'"),
+                allOf(
+                    hasComment(
+                        "Rewrite policy can only be configured on l2transport interfaces. Ignoring"
+                            + " this line."),
+                    hasText("rewrite ingress tag pop 1 symmetric")))));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport
@@ -1,0 +1,16 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname interface_l2transport
+!
+interface GigabitEthernet0/0/0/1
+ negotiation auto
+!
+interface GigabitEthernet0/0/0/1.1 l2transport
+ encapsulation dot1q 1
+ rewrite ingress tag pop 1
+!
+interface GigabitEthernet0/0/0/1.2 l2transport
+ encapsulation dot1q 2
+ rewrite ingress tag pop 2 symmetric
+!
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport
@@ -3,7 +3,6 @@
 hostname interface_l2transport
 !
 interface GigabitEthernet0/0/0/1
- negotiation auto
 !
 interface GigabitEthernet0/0/0/1.1 l2transport
  encapsulation dot1q 1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport
@@ -10,6 +10,8 @@ interface GigabitEthernet0/0/0/1.1 l2transport
 !
 interface GigabitEthernet0/0/0/1.2 l2transport
  encapsulation dot1q 2
- rewrite ingress tag pop 2 symmetric
 !
+! Reconfiguring the interface doesn't remove the l2transport flag
+interface GigabitEthernet0/0/0/1.2
+ rewrite ingress tag pop 2 symmetric
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport_warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport_warning
@@ -2,14 +2,9 @@
 !
 hostname interface_l2transport_warning
 !
-interface GigabitEthernet0/0/0/1
-!
 interface GigabitEthernet0/0/0/1.1 l2transport
- encapsulation dot1q 1
  rewrite ingress tag pop 0
 !
 interface GigabitEthernet0/0/0/1.2 l2transport
- encapsulation dot1q 2
  rewrite ingress tag pop 3 symmetric
-!
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport_warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport_warning
@@ -8,3 +8,6 @@ interface GigabitEthernet0/0/0/1.1 l2transport
 interface GigabitEthernet0/0/0/1.2 l2transport
  rewrite ingress tag pop 3 symmetric
 !
+interface GigabitEthernet0/0/0/1.3
+ rewrite ingress tag pop 1 symmetric
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport_warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface_l2transport_warning
@@ -1,0 +1,15 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname interface_l2transport_warning
+!
+interface GigabitEthernet0/0/0/1
+!
+interface GigabitEthernet0/0/0/1.1 l2transport
+ encapsulation dot1q 1
+ rewrite ingress tag pop 0
+!
+interface GigabitEthernet0/0/0/1.2 l2transport
+ encapsulation dot1q 2
+ rewrite ingress tag pop 3 symmetric
+!
+!


### PR DESCRIPTION
Parse and extract interface `l2transport` and related properties; these can be used in conjunction with `bridge-domain`s (see [docs](https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/asr9k_r6-1/interfaces/configuration/guide/b-interfaces-cg-asr9k-61x/b-interfaces-cg-asr9k-61x_chapter_0111.html) and [related PR](https://github.com/batfish/batfish/pull/7106)).
