### PR TITLE
Insufficient Info: consider network/broadcast IPs to be internal

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -252,7 +252,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
               ownedIps);
 
       // ips belonging to any subnet in the network, including inactive interfaces.
-      IpSpace internalIps = computeInternalIps(ipOwners.getAllInterfaceHostIps());
+      IpSpace internalIps = computeInternalIps(configurations);
 
       _insufficientInfo =
           computeInsufficientInfo(
@@ -1175,16 +1175,17 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
     }
   }
 
-  private static IpSpace computeInternalIps(
-      Map<String, Map<String, IpSpace>> interfaceHostSubnetIps) {
+  private static IpSpace computeInternalIps(Map<String, Configuration> configs) {
     Span span = GlobalTracer.get().buildSpan("ForwardingAnalysisImpl.computeInternalIps").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
       return firstNonNull(
           AclIpSpace.union(
-              interfaceHostSubnetIps.values().stream()
-                  .flatMap(ifaceSubnetIps -> ifaceSubnetIps.values().stream())
-                  .collect(Collectors.toList())),
+              configs.values().stream()
+                  .flatMap(config -> config.getAllInterfaces().values().stream())
+                  .flatMap(iface -> iface.getAllConcreteAddresses().stream())
+                  .map(addr -> addr.getPrefix().toIpSpace())
+                  .toArray(IpSpace[]::new)),
           EmptyIpSpace.INSTANCE);
     } finally {
       span.finish();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -22,31 +22,14 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.NetworkFactory;
-import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.hsrp.HsrpGroup;
 import org.batfish.datamodel.tracking.DecrementPriority;
 import org.batfish.datamodel.tracking.TrackInterface;
-import org.junit.Before;
 import org.junit.Test;
 
 /** Tests of {@link IpOwners}. */
 public class IpOwnersTest {
-  private Configuration.Builder _cb;
-  private Interface.Builder _ib;
-  private Vrf.Builder _vb;
-  private static final Prefix P1 = Prefix.parse("1.0.0.0/8");
-  private static final Prefix P2 = Prefix.parse("2.0.0.0/16");
-
-  @Before
-  public void setup() {
-    NetworkFactory nf = new NetworkFactory();
-    _cb = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    _vb = nf.vrfBuilder();
-    _ib = nf.interfaceBuilder();
-  }
-
   @Test
   public void testComputeIpIfaceOwners() {
     String node = "node";

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -1,16 +1,11 @@
 package org.batfish.common.topology;
 
 import static org.batfish.common.topology.IpOwners.computeHsrpPriority;
-import static org.batfish.common.topology.IpOwners.computeInterfaceHostSubnetIps;
 import static org.batfish.common.topology.IpOwners.computeIpIfaceOwners;
 import static org.batfish.common.topology.IpOwners.computeIpVrfOwners;
 import static org.batfish.common.topology.IpOwners.extractHsrp;
 import static org.batfish.common.topology.IpOwners.processHsrpGroups;
-import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -27,7 +22,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
@@ -51,68 +45,6 @@ public class IpOwnersTest {
     _cb = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     _vb = nf.vrfBuilder();
     _ib = nf.interfaceBuilder();
-  }
-
-  @Test
-  public void testComputeInterfaceHostSubnetIps() {
-    Configuration c1 = _cb.build();
-    Map<String, Configuration> configs = ImmutableMap.of(c1.getHostname(), c1);
-    Vrf vrf1 = _vb.setOwner(c1).build();
-    Interface i1 =
-        _ib.setOwner(c1)
-            .setVrf(vrf1)
-            .setAddress(ConcreteInterfaceAddress.create(P1.getStartIp(), P1.getPrefixLength()))
-            .build();
-    Interface i2 =
-        _ib.setOwner(c1)
-            .setVrf(vrf1)
-            .setAddress(ConcreteInterfaceAddress.create(P2.getStartIp(), P2.getPrefixLength()))
-            .setActive(false)
-            .build();
-
-    assertThat(
-        computeInterfaceHostSubnetIps(configs),
-        hasEntry(
-            equalTo(c1.getHostname()),
-            allOf(
-                hasEntry(
-                    equalTo(i1.getName()),
-                    allOf(
-                        not(containsIp(P1.getStartIp())),
-                        containsIp(Ip.create(P1.getStartIp().asLong() + 1)),
-                        containsIp(Ip.create(P1.getEndIp().asLong() - 1)),
-                        not(containsIp(P1.getEndIp())))),
-                hasEntry(
-                    equalTo(i2.getName()),
-                    allOf(
-                        not(containsIp(P2.getStartIp())),
-                        containsIp(Ip.create(P2.getStartIp().asLong() + 1)),
-                        containsIp(Ip.create(P2.getEndIp().asLong() - 1)),
-                        not(containsIp(P2.getEndIp())))))));
-  }
-
-  @Test
-  public void testComputeInterfaceHostSubnetIpsWithPrefixLength31() {
-    Configuration c1 = _cb.build();
-    Map<String, Configuration> configs = ImmutableMap.of(c1.getHostname(), c1);
-    Vrf vrf1 = _vb.setOwner(c1).build();
-    Prefix prefix = Prefix.parse("1.0.0.1/31");
-    Interface i1 =
-        _ib.setOwner(c1)
-            .setVrf(vrf1)
-            .setAddress(
-                ConcreteInterfaceAddress.create(prefix.getStartIp(), prefix.getPrefixLength()))
-            .build();
-    Map<String, Map<String, IpSpace>> interfaceHostSubnetIps =
-        computeInterfaceHostSubnetIps(configs);
-
-    assertThat(
-        interfaceHostSubnetIps,
-        hasEntry(
-            equalTo(c1.getHostname()),
-            hasEntry(
-                equalTo(i1.getName()),
-                allOf(containsIp(prefix.getStartIp()), containsIp(prefix.getEndIp())))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -10,7 +10,6 @@ import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -71,24 +70,8 @@ public class IpOwnersTest {
             .setActive(false)
             .build();
 
-    // Test with only active IPs.
     assertThat(
-        computeInterfaceHostSubnetIps(configs, true),
-        hasEntry(
-            equalTo(c1.getHostname()),
-            allOf(
-                hasEntry(
-                    equalTo(i1.getName()),
-                    allOf(
-                        not(containsIp(P1.getStartIp())),
-                        containsIp(Ip.create(P1.getStartIp().asLong() + 1)),
-                        containsIp(Ip.create(P1.getEndIp().asLong() - 1)),
-                        not(containsIp(P1.getEndIp())))),
-                not(hasKey(i2.getName())))));
-
-    // Test including inactive IPs.
-    assertThat(
-        computeInterfaceHostSubnetIps(configs, false),
+        computeInterfaceHostSubnetIps(configs),
         hasEntry(
             equalTo(c1.getHostname()),
             allOf(
@@ -121,7 +104,7 @@ public class IpOwnersTest {
                 ConcreteInterfaceAddress.create(prefix.getStartIp(), prefix.getPrefixLength()))
             .build();
     Map<String, Map<String, IpSpace>> interfaceHostSubnetIps =
-        computeInterfaceHostSubnetIps(configs, false);
+        computeInterfaceHostSubnetIps(configs);
 
     assertThat(
         interfaceHostSubnetIps,

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisArpFailureDispositionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisArpFailureDispositionsTest.java
@@ -297,7 +297,14 @@ public class BDDReachabilityAnalysisArpFailureDispositionsTest {
     checkDispositionsDisjoint();
     BDDReachabilityAnalysis analysis = initAnalysis(INSUFFICIENT_INFO);
     Map<IngressLocation, BDD> reach = analysis.getIngressLocationReachableBDDs();
-    assertThat(reach, hasEntry(_loc, dstIpToBDD(DST_IP)));
+    BDD insufficientInfoIps =
+        Stream.of(
+                DST_IP,
+                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getStartIp(),
+                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getEndIp())
+            .map(this::dstIpToBDD)
+            .reduce(_pkt.getFactory().zero(), BDD::or);
+    assertThat(reach, hasEntry(_loc, insufficientInfoIps));
   }
 
   private void setup_noNHIp_subnetNotFull_externalDstIp() {
@@ -321,14 +328,7 @@ public class BDDReachabilityAnalysisArpFailureDispositionsTest {
     checkDispositionsDisjoint();
     BDDReachabilityAnalysis analysis = initAnalysis(EXITS_NETWORK);
     Map<IngressLocation, BDD> reach = analysis.getIngressLocationReachableBDDs();
-    BDD exitsNetworkIps =
-        Stream.of(
-                DST_IP,
-                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getStartIp(),
-                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getEndIp())
-            .map(this::dstIpToBDD)
-            .reduce(_pkt.getFactory().zero(), BDD::or);
-    assertThat(reach, hasEntry(_loc, exitsNetworkIps));
+    assertThat(reach, hasEntry(_loc, dstIpToBDD(DST_IP)));
   }
 
   private void setup_externalNHIp_subnetFull_internalDstIp() {
@@ -428,8 +428,14 @@ public class BDDReachabilityAnalysisArpFailureDispositionsTest {
     checkDispositionsDisjoint();
     BDDReachabilityAnalysis analysis = initAnalysis(INSUFFICIENT_INFO);
     Map<IngressLocation, BDD> reach = analysis.getIngressLocationReachableBDDs();
-    BDD neighborUnreachableIps = dstIpToBDD(DST_IP);
-    assertThat(reach, hasEntry(_loc, neighborUnreachableIps));
+    BDD insufficientInfoIps =
+        Stream.of(
+                DST_IP,
+                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getStartIp(),
+                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getEndIp())
+            .map(this::dstIpToBDD)
+            .reduce(_pkt.getFactory().zero(), BDD::or);
+    assertThat(reach, hasEntry(_loc, insufficientInfoIps));
   }
 
   private void setup_externalNHIp_subnetNotFull_externalDstIp() {
@@ -454,14 +460,7 @@ public class BDDReachabilityAnalysisArpFailureDispositionsTest {
     checkDispositionsDisjoint();
     BDDReachabilityAnalysis analysis = initAnalysis(EXITS_NETWORK);
     Map<IngressLocation, BDD> reach = analysis.getIngressLocationReachableBDDs();
-    BDD exitsNetworkIps =
-        Stream.of(
-                DST_IP,
-                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getStartIp(),
-                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getEndIp())
-            .map(this::dstIpToBDD)
-            .reduce(_pkt.getFactory().zero(), BDD::or);
-    assertThat(reach, hasEntry(_loc, exitsNetworkIps));
+    assertThat(reach, hasEntry(_loc, dstIpToBDD(DST_IP)));
   }
 
   private void setup_internalNHIp_subnetFull_internalDstIp() {
@@ -570,7 +569,14 @@ public class BDDReachabilityAnalysisArpFailureDispositionsTest {
     checkDispositionsDisjoint();
     BDDReachabilityAnalysis analysis = initAnalysis(INSUFFICIENT_INFO);
     Map<IngressLocation, BDD> reach = analysis.getIngressLocationReachableBDDs();
-    assertThat(reach, hasEntry(_loc, dstIpToBDD(DST_IP)));
+    BDD insufficientInfoIps =
+        Stream.of(
+                DST_IP,
+                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getStartIp(),
+                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getEndIp())
+            .map(this::dstIpToBDD)
+            .reduce(_pkt.getFactory().zero(), BDD::or);
+    assertThat(reach, hasEntry(_loc, insufficientInfoIps));
   }
 
   private void setup_internalNHIp_subnetNotFull_externalDstIp() {
@@ -606,6 +612,13 @@ public class BDDReachabilityAnalysisArpFailureDispositionsTest {
     checkDispositionsDisjoint();
     BDDReachabilityAnalysis analysis = initAnalysis(INSUFFICIENT_INFO);
     Map<IngressLocation, BDD> reach = analysis.getIngressLocationReachableBDDs();
-    assertThat(reach, hasEntry(_loc, dstIpToBDD(DST_IP)));
+    BDD insufficientInfoIps =
+        Stream.of(
+                DST_IP,
+                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getStartIp(),
+                NEXT_HOP_INTERFACE_NOT_FULL_ADDR.getPrefix().getEndIp())
+            .map(this::dstIpToBDD)
+            .reduce(_pkt.getFactory().zero(), BDD::or);
+    assertThat(reach, hasEntry(_loc, insufficientInfoIps));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1091,9 +1091,9 @@ public final class BDDReachabilityAnalysisFactoryTest {
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(_pkt, ImmutableMap.of());
     IpSpaceToBDD dstToBdd = toBDD.getDstIpSpaceToBdd();
 
-    BDD resultBDD = dstToBdd.toBDD(Prefix.parse("8.8.8.0/24"));
+    BDD exitsNetworkBdd = dstToBdd.toBDD(Prefix.parse("8.8.8.0/24"));
 
-    assertThat(transition.transitForward(resultBDD), equalTo(resultBDD));
+    assertThat(transition.transitForward(_one), equalTo(exitsNetworkBdd));
 
     Transition transitionII =
         analysis
@@ -1101,7 +1101,11 @@ public final class BDDReachabilityAnalysisFactoryTest {
             .get(new PreOutVrf(c1.getHostname(), v1.getName()))
             .get(new PreOutInterfaceInsufficientInfo(c1.getHostname(), i1.getName()));
 
-    assertThat(transitionII, nullValue());
+    BDD insufficientInfoBdd =
+        dstToBdd
+            .toBDD(i1.getPrimaryNetwork().getStartIp())
+            .or(dstToBdd.toBDD(i1.getPrimaryNetwork().getEndIp()));
+    assertThat(transitionII.transitForward(_one), equalTo(insufficientInfoBdd));
   }
 
   /*
@@ -1167,9 +1171,14 @@ public final class BDDReachabilityAnalysisFactoryTest {
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(_pkt, ImmutableMap.of());
     IpSpaceToBDD dstToBdd = toBDD.getDstIpSpaceToBdd();
 
-    BDD resultBDD = dstToBdd.toBDD(Prefix.parse("8.8.8.0/24"));
+    BDD insufficientInfoBdd =
+        _pkt.getFactory()
+            .orAll(
+                dstToBdd.toBDD(Prefix.parse("8.8.8.0/24")),
+                dstToBdd.toBDD(i1.getPrimaryNetwork().getStartIp()),
+                dstToBdd.toBDD(i1.getPrimaryNetwork().getEndIp()));
 
-    assertThat(transition.transitForward(resultBDD), equalTo(resultBDD));
+    assertThat(transition.transitForward(_one), equalTo(insufficientInfoBdd));
 
     Transition transitionEN =
         analysis
@@ -1177,7 +1186,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
             .get(new PreOutVrf(c1.getHostname(), v1.getName()))
             .get(new PreOutInterfaceExitsNetwork(c1.getHostname(), i1.getName()));
 
-    assertThat(transitionEN.transitForward(resultBDD), equalTo(_pkt.getFactory().zero()));
+    assertThat(transitionEN, nullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
@@ -186,7 +186,7 @@ public final class BidirectionalReachabilityAnalysisTest {
     SFL_INGRESS_LOCATION = new InterfaceLinkLocation(SFL_INGRESS_NODE, SFL_INGRESS_IFACE);
     SFL_DST_IP_SPACE_SINGLE_NODE =
         AclIpSpace.difference(
-            SFL_EGRESS_IFACE_ADDRESS.getPrefix().toIpSpace(),
+            SFL_EGRESS_IFACE_ADDRESS.getPrefix().toHostIpSpace(),
             SFL_EGRESS_IFACE_ADDRESS.getIp().toIpSpace());
     SFL_DST_IP_SPACE_DUAL_NODE = SFL_NEIGHBOR_IFACE_ADDRESS.getIp().toIpSpace();
   }
@@ -914,7 +914,7 @@ public final class BidirectionalReachabilityAnalysisTest {
         new InterfaceLocation(FPFN_START_NODE, FPFN_EGRESS_IFACE),
         FPFN_START_EGRESS_ADDRESS.getIp().toIpSpace(),
         AclIpSpace.difference(
-            FPFN_END_EXIT_ADDRESS.getPrefix().toIpSpace(),
+            FPFN_END_EXIT_ADDRESS.getPrefix().toHostIpSpace(),
             FPFN_END_EXIT_ADDRESS.getIp().toIpSpace()));
   }
 
@@ -926,7 +926,7 @@ public final class BidirectionalReachabilityAnalysisTest {
             FPFN_START_INGRESS_ADDRESS.getPrefix().toIpSpace(),
             FPFN_START_INGRESS_ADDRESS.getIp().toIpSpace()),
         AclIpSpace.difference(
-            FPFN_END_EXIT_ADDRESS.getPrefix().toIpSpace(),
+            FPFN_END_EXIT_ADDRESS.getPrefix().toHostIpSpace(),
             FPFN_END_EXIT_ADDRESS.getIp().toIpSpace()));
   }
 


### PR DESCRIPTION
The INSUFFICIENT_INFO disposition is assigned to destination IPs that are considered internal to the network, but terminate away from the location where it is configured. Previously insufficient info excluded network and broadcast IPs of connected networks, and those IPs were given the EXITS_NETWORK (which is a success disposition, while INSUFFICIENT_INFO is a failure).