### PR TITLE
XR: ignore bridge interface storm-control

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrParser.g4
@@ -565,7 +565,11 @@ lbg_bridge_domain
    )*
 ;
 
-lbgbd_interface: INTERFACE interface_name NEWLINE;
+lbgbd_interface: INTERFACE interface_name NEWLINE lbgbdi_inner*;
+
+lbgbdi_inner: lbgbdi_null;
+
+lbgbdi_null: STORM_CONTROL ~NEWLINE* NEWLINE;
 
 lbgbd_routed_interface: ROUTED INTERFACE interface_name NEWLINE;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrParser.g4
@@ -569,7 +569,7 @@ lbgbd_interface: INTERFACE interface_name NEWLINE lbgbdi_inner*;
 
 lbgbdi_inner: lbgbdi_null;
 
-lbgbdi_null: STORM_CONTROL ~NEWLINE* NEWLINE;
+lbgbdi_null: STORM_CONTROL null_rest_of_line;
 
 lbgbd_routed_interface: ROUTED INTERFACE interface_name NEWLINE;
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -1709,8 +1709,16 @@ public final class XrGrammarTest {
   @Test
   public void testMiscIgnoredParsing() {
     String hostname = "xr-misc-ignored";
+    CiscoXrConfiguration vc = parseVendorConfig(hostname);
+
     // Do not crash
-    assertNotNull(parseVendorConfig(hostname));
+    assertNotNull(vc);
+
+    // Also make sure context isn't lost when hitting ignored lines, specifically:
+    // Interface is still associated with bridge-domain, not interpreted as top-level
+    assertThat(
+        vc.getBridgeGroups().get("BG1").getBridgeDomains().get("BD1").getInterfaces(),
+        contains("GigabitEthernet0/0/0/1.123"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/xr-misc-ignored
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/xr-misc-ignored
@@ -47,6 +47,16 @@ vty-pool default 0 15 line-template default
 
 end
 
+l2vpn
+ bridge group BG1
+  bridge-domain BD1
+   interface GigabitEthernet0/0/0/1.123
+    storm-control multicast pps 1000
+   !
+  !
+ !
+!
+
 ############ MultiConfigPart END
 
 ############ MultiConfigPart admin configuration


### PR DESCRIPTION
Ignore `storm-control` within `bridge-domain` interface configuration, otherwise parser loses context and assumes interface config is top-level.
