### PR TITLE
Turn on routing policy simplification

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -130,8 +130,7 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
       throw new BatfishException(
           "Implementation error: missing default inbound action for host: '" + hostname + "'");
     }
-    // Simplification does not work with tracing for route maps
-    // c.simplifyRoutingPolicies();
+    c.simplifyRoutingPolicies();
     c.computeRoutingPolicySources(w);
     verifyInterfaces(c, w);
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -2759,10 +2759,8 @@ public final class CiscoGrammarTest {
         equalTo(
             ImmutableList.of(
                 new If(
-                    new Conjunction(
-                        ImmutableList.of(
-                            new MatchPrefixSet(
-                                DestinationNetwork.instance(), new NamedPrefixSet("filter_1")))),
+                    new MatchPrefixSet(
+                        DestinationNetwork.instance(), new NamedPrefixSet("filter_1")),
                     ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
                     ImmutableList.of(Statements.ExitReject.toStaticStatement())))));
 
@@ -2807,10 +2805,8 @@ public final class CiscoGrammarTest {
         equalTo(
             ImmutableList.of(
                 new If(
-                    new Conjunction(
-                        ImmutableList.of(
-                            new MatchPrefixSet(
-                                DestinationNetwork.instance(), new NamedPrefixSet("filter_2")))),
+                    new MatchPrefixSet(
+                        DestinationNetwork.instance(), new NamedPrefixSet("filter_2")),
                     ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
                     ImmutableList.of(Statements.ExitReject.toStaticStatement())))));
 
@@ -5625,30 +5621,23 @@ public final class CiscoGrammarTest {
 
     // Ensure the converted route-map ignores the match-interface clause
     Configuration c = batfish.loadConfigurations(batfish.getSnapshot()).get(hostname);
-    List<Statement> statements =
-        ((If) Iterables.getOnlyElement(c.getRoutingPolicies().get("rm").getStatements()))
-            .getTrueStatements();
-    // get the true statements past the traceable wrapper
-    List<Statement> innerStatements =
-        ((TraceableStatement) Iterables.getOnlyElement(statements)).getInnerStatements();
-    assertThat(innerStatements, contains(Statements.ReturnTrue.toStaticStatement()));
+    RoutingPolicy rm = c.getRoutingPolicies().get("rm");
+    assertThat(
+        rm.getStatements(), contains(Statements.ReturnLocalDefaultAction.toStaticStatement()));
   }
 
   @Test
   public void testSetMetricEigrp() throws IOException {
     Configuration c = parseConfig("ios-route-map-set-metric-eigrp");
 
-    // get the true statements past the traceable wrapper
-    List<Statement> trueStatements =
+    // get the real statements past the traceable wrapper
+    List<Statement> statements =
         ((TraceableStatement)
                 Iterables.getOnlyElement(
-                    ((If)
-                            Iterables.getOnlyElement(
-                                c.getRoutingPolicies().get("rm_set_metric").getStatements()))
-                        .getTrueStatements()))
+                    c.getRoutingPolicies().get("rm_set_metric").getStatements()))
             .getInnerStatements();
     assertThat(
-        trueStatements,
+        statements,
         // Being intentionally lax here because pretty sure conversion is busted.
         // TODO: update when convinced eigrp settings have correct values
         hasItem(instanceOf(SetEigrpMetric.class)));

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -59015,24 +59015,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "PROTECT_LOOPBACK"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "PROTECT_LOOPBACK"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -59069,106 +59059,37 @@
             "name" : "SET_LOCAL_PREF",
             "statements" : [
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "~RMCLAUSE~SET_LOCAL_PREF~10~",
-                "falseStatements" : [
+                "class" : "org.batfish.datamodel.routing_policy.statement.TraceableStatement",
+                "innerStatements" : [
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                    "comment" : "~RMCLAUSE~SET_LOCAL_PREF~20~",
-                    "falseStatements" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                        "type" : "ReturnLocalDefaultAction"
-                      }
-                    ],
-                    "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "MATCH_ALL_BGP"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "trueStatements" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.statement.TraceableStatement",
-                        "innerStatements" : [
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                            "type" : "ReturnTrue"
-                          }
-                        ],
-                        "traceElement" : {
-                          "fragments" : [
-                            {
-                              "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                              "text" : "Matched "
-                            },
-                            {
-                              "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
-                              "text" : "route-map SET_LOCAL_PREF clause 20",
-                              "vendorStructureId" : {
-                                "filename" : "configs/lhr-border-02.cfg",
-                                "structureName" : "SET_LOCAL_PREF 20",
-                                "structureType" : "route-map-clause"
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    ]
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
+                    "localPreference" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
                   }
                 ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.TraceableStatement",
-                    "innerStatements" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.statement.SetLocalPreference",
-                        "localPreference" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
-                          "value" : 50
-                        }
-                      },
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                        "type" : "ReturnTrue"
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched "
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
+                      "text" : "route-map SET_LOCAL_PREF clause 10",
+                      "vendorStructureId" : {
+                        "filename" : "configs/lhr-border-02.cfg",
+                        "structureName" : "SET_LOCAL_PREF 10",
+                        "structureType" : "route-map-clause"
                       }
-                    ],
-                    "traceElement" : {
-                      "fragments" : [
-                        {
-                          "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                          "text" : "Matched "
-                        },
-                        {
-                          "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
-                          "text" : "route-map SET_LOCAL_PREF clause 10",
-                          "vendorStructureId" : {
-                            "filename" : "configs/lhr-border-02.cfg",
-                            "structureName" : "SET_LOCAL_PREF 10",
-                            "structureType" : "route-map-clause"
-                          }
-                        }
-                      ]
                     }
-                  }
-                ]
+                  ]
+                }
               }
             ]
           },
@@ -59292,13 +59213,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -59322,13 +59238,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -59358,13 +59269,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -59388,13 +59294,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -59432,13 +59333,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -59476,13 +59372,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -772,24 +772,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                        "prefix" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                        },
-                        "prefixSet" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                          "name" : "105"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                "prefix" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                },
+                "prefixSet" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                  "name" : "105"
+                }
               },
               "trueStatements" : [
                 {
@@ -868,24 +858,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "dept_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "dept_community"
+                }
               },
               "trueStatements" : [
                 {
@@ -1558,69 +1538,54 @@
           "name" : "as1_to_as4",
           "statements" : [
             {
-              "class" : "org.batfish.datamodel.routing_policy.statement.If",
-              "comment" : "~RMCLAUSE~as1_to_as4~2~",
-              "falseStatements" : [
+              "class" : "org.batfish.datamodel.routing_policy.statement.TraceableStatement",
+              "innerStatements" : [
                 {
-                  "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                  "type" : "ReturnLocalDefaultAction"
-                }
-              ],
-              "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction"
-              },
-              "trueStatements" : [
+                  "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                  "metric" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                    "value" : 50
+                  }
+                },
                 {
-                  "class" : "org.batfish.datamodel.routing_policy.statement.TraceableStatement",
-                  "innerStatements" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
-                      "metric" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
-                        "value" : 50
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.communities.SetCommunities",
-                      "communitySetExpr" : {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetUnion",
-                        "exprs" : [
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet",
-                            "communitySet" : [
-                              "1:4"
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                      "type" : "ReturnTrue"
-                    }
-                  ],
-                  "traceElement" : {
-                    "fragments" : [
+                  "class" : "org.batfish.datamodel.routing_policy.communities.SetCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetUnion",
+                    "exprs" : [
                       {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched "
+                        "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
                       },
                       {
-                        "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
-                        "text" : "route-map as1_to_as4 clause 2",
-                        "vendorStructureId" : {
-                          "filename" : "configs/as1border2.cfg",
-                          "structureName" : "as1_to_as4 2",
-                          "structureType" : "route-map-clause"
-                        }
+                        "class" : "org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet",
+                        "communitySet" : [
+                          "1:4"
+                        ]
                       }
                     ]
                   }
+                },
+                {
+                  "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                  "type" : "ReturnTrue"
                 }
-              ]
+              ],
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched "
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
+                    "text" : "route-map as1_to_as4 clause 2",
+                    "vendorStructureId" : {
+                      "filename" : "configs/as1border2.cfg",
+                      "structureName" : "as1_to_as4 2",
+                      "structureType" : "route-map-clause"
+                    }
+                  }
+                ]
+              }
             }
           ]
         },
@@ -1645,24 +1610,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as2_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "as2_community"
+                }
               },
               "trueStatements" : [
                 {
@@ -1726,34 +1681,24 @@
                 "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
                 "conjuncts" : [
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as4_community"
-                        }
-                      }
-                    ]
+                    "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                    "communitySetExpr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                    },
+                    "communitySetMatchExpr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                      "name" : "as4_community"
+                    }
                   },
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                        "prefix" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                        },
-                        "prefixSet" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                          "name" : "as4-prefixes"
-                        }
-                      }
-                    ]
+                    "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                    "prefix" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                    },
+                    "prefixSet" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                      "name" : "as4-prefixes"
+                    }
                   }
                 ]
               },
@@ -1816,24 +1761,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                        "prefix" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                        },
-                        "prefixSet" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                          "name" : "102"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                "prefix" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                },
+                "prefixSet" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                  "name" : "102"
+                }
               },
               "trueStatements" : [
                 {
@@ -2280,24 +2215,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as1_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "as1_community"
+                }
               },
               "trueStatements" : [
                 {
@@ -2384,24 +2309,14 @@
                     }
                   ],
                   "guard" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                    "conjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                        "disjuncts" : [
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                            "prefix" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                            },
-                            "prefixSet" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                              "name" : "102"
-                            }
-                          }
-                        ]
-                      }
-                    ]
+                    "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                    "prefix" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                    },
+                    "prefixSet" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                      "name" : "102"
+                    }
                   },
                   "trueStatements" : [
                     {
@@ -2458,24 +2373,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                        "prefix" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                        },
-                        "prefixSet" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                          "name" : "101"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                "prefix" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                },
+                "prefixSet" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                  "name" : "101"
+                }
               },
               "trueStatements" : [
                 {
@@ -2558,24 +2463,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as2_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "as2_community"
+                }
               },
               "trueStatements" : [
                 {
@@ -2645,24 +2540,14 @@
                     }
                   ],
                   "guard" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                    "conjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                        "disjuncts" : [
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                            "prefix" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                            },
-                            "prefixSet" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                              "name" : "outbound_routes"
-                            }
-                          }
-                        ]
-                      }
-                    ]
+                    "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                    "prefix" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                    },
+                    "prefixSet" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                      "name" : "outbound_routes"
+                    }
                   },
                   "trueStatements" : [
                     {
@@ -2719,24 +2604,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                        "prefix" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                        },
-                        "prefixSet" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                          "name" : "101"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                "prefix" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                },
+                "prefixSet" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                  "name" : "101"
+                }
               },
               "trueStatements" : [
                 {
@@ -2819,24 +2694,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as3_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "as3_community"
+                }
               },
               "trueStatements" : [
                 {
@@ -2902,24 +2767,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as3_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "as3_community"
+                }
               },
               "trueStatements" : [
                 {

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -550,24 +550,14 @@
                           }
                         ],
                         "guard" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                          "conjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                              "disjuncts" : [
-                                {
-                                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                                  "prefix" : {
-                                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                                  },
-                                  "prefixSet" : {
-                                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                    "name" : "default_list"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                            "name" : "default_list"
+                          }
                         },
                         "trueStatements" : [
                           {
@@ -624,24 +614,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "103"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -698,24 +678,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "101"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -789,24 +759,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "102"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "102"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -863,24 +823,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "101"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -950,24 +900,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as2_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as2_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -1020,24 +960,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as3_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as3_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -1099,13 +1029,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -1163,13 +1088,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -1193,13 +1113,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -2223,24 +2138,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "103"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -2297,24 +2202,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "101"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -2388,24 +2283,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "102"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "102"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -2462,24 +2347,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "101"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -2540,69 +2415,54 @@
             "name" : "as1_to_as4",
             "statements" : [
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "~RMCLAUSE~as1_to_as4~2~",
-                "falseStatements" : [
+                "class" : "org.batfish.datamodel.routing_policy.statement.TraceableStatement",
+                "innerStatements" : [
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnLocalDefaultAction"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction"
-                },
-                "trueStatements" : [
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
+                    "metric" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
+                      "value" : 50
+                    }
+                  },
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.TraceableStatement",
-                    "innerStatements" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
-                        "metric" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
-                          "value" : 50
-                        }
-                      },
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.SetCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetUnion",
-                          "exprs" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                            },
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet",
-                              "communitySet" : [
-                                "1:4"
-                              ]
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                        "type" : "ReturnTrue"
-                      }
-                    ],
-                    "traceElement" : {
-                      "fragments" : [
+                    "class" : "org.batfish.datamodel.routing_policy.communities.SetCommunities",
+                    "communitySetExpr" : {
+                      "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetUnion",
+                      "exprs" : [
                         {
-                          "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                          "text" : "Matched "
+                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
                         },
                         {
-                          "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
-                          "text" : "route-map as1_to_as4 clause 2",
-                          "vendorStructureId" : {
-                            "filename" : "configs/as1border2.cfg",
-                            "structureName" : "as1_to_as4 2",
-                            "structureType" : "route-map-clause"
-                          }
+                          "class" : "org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet",
+                          "communitySet" : [
+                            "1:4"
+                          ]
                         }
                       ]
                     }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
                   }
-                ]
+                ],
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched "
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
+                      "text" : "route-map as1_to_as4 clause 2",
+                      "vendorStructureId" : {
+                        "filename" : "configs/as1border2.cfg",
+                        "structureName" : "as1_to_as4 2",
+                        "structureType" : "route-map-clause"
+                      }
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -2619,24 +2479,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as2_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as2_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -2689,24 +2539,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as3_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as3_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -2762,34 +2602,24 @@
                   "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
                   "conjuncts" : [
                     {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as4_community"
-                          }
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                      "communitySetExpr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                      },
+                      "communitySetMatchExpr" : {
+                        "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                        "name" : "as4_community"
+                      }
                     },
                     {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "as4-prefixes"
-                          }
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "as4-prefixes"
+                      }
                     }
                   ]
                 },
@@ -2853,13 +2683,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -3545,13 +3370,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -3575,13 +3395,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -4528,24 +4343,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as1_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as1_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -4619,24 +4424,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "103"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -4693,24 +4488,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "outbound_routes"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "outbound_routes"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -4784,24 +4569,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "outbound_routes"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "outbound_routes"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -4858,24 +4633,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "101"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -4945,24 +4710,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as3_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as3_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -5095,13 +4850,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -5125,13 +4875,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -6186,24 +5931,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as1_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as1_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -6277,24 +6012,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "103"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -6351,24 +6076,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "outbound_routes"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "outbound_routes"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -6442,24 +6157,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "outbound_routes"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "outbound_routes"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -6516,24 +6221,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "101"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -6603,24 +6298,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as3_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as3_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -6753,13 +6438,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -6783,13 +6463,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -7472,13 +7147,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -7502,13 +7172,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -7532,13 +7197,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -7562,13 +7222,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -8138,13 +7793,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -8168,13 +7818,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -8198,13 +7843,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -8228,13 +7868,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -9154,24 +8789,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as2_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as2_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -9224,24 +8849,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "102"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "102"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -10098,24 +9713,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "105"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "105"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -10185,24 +9790,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "dept_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "dept_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -10264,13 +9859,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -10294,13 +9884,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -11081,24 +10666,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "105"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "105"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -11168,24 +10743,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "dept_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "dept_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -11247,13 +10812,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -11277,13 +10837,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -12194,24 +11749,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as1_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as1_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -12264,24 +11809,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as2_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as2_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -12338,24 +11873,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "103"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -12412,24 +11937,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "102"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "102"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -12507,24 +12022,14 @@
                           }
                         ],
                         "guard" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                          "conjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                              "disjuncts" : [
-                                {
-                                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                                  "prefix" : {
-                                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                                  },
-                                  "prefixSet" : {
-                                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                    "name" : "default_list"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                          "prefix" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                          },
+                          "prefixSet" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                            "name" : "default_list"
+                          }
                         },
                         "trueStatements" : [
                           {
@@ -12581,24 +12086,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "103"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -12655,24 +12150,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "101"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -12785,13 +12270,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -13725,24 +13205,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as1_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as1_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -13795,24 +13265,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                          "communitySetExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                          },
-                          "communitySetMatchExpr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                            "name" : "as2_community"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                  "communitySetExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                  },
+                  "communitySetMatchExpr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                    "name" : "as2_community"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -13869,24 +13329,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "103"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -13943,24 +13393,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "102"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "102"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -14034,24 +13474,14 @@
                       }
                     ],
                     "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "conjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                              "prefix" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                              },
-                              "prefixSet" : {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                "name" : "103"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                        "name" : "103"
+                      }
                     },
                     "trueStatements" : [
                       {
@@ -14108,24 +13538,14 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                          "prefix" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                          },
-                          "prefixSet" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                            "name" : "101"
-                          }
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                    "name" : "101"
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -14238,13 +13658,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -14884,13 +14299,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -14914,13 +14324,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {

--- a/tests/roles/perRoleOutliers.ref
+++ b/tests/roles/perRoleOutliers.ref
@@ -257,24 +257,14 @@
                         }
                       ],
                       "guard" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                        "conjuncts" : [
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                            "disjuncts" : [
-                              {
-                                "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                                "prefix" : {
-                                  "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                                },
-                                "prefixSet" : {
-                                  "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                                  "name" : "default_list"
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                        "prefix" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                        },
+                        "prefixSet" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                          "name" : "default_list"
+                        }
                       },
                       "trueStatements" : [
                         {
@@ -331,24 +321,14 @@
                     }
                   ],
                   "guard" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                    "conjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                        "disjuncts" : [
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                            "prefix" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                            },
-                            "prefixSet" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                              "name" : "103"
-                            }
-                          }
-                        ]
-                      }
-                    ]
+                    "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                    "prefix" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                    },
+                    "prefixSet" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                      "name" : "103"
+                    }
                   },
                   "trueStatements" : [
                     {
@@ -405,24 +385,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                        "prefix" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                        },
-                        "prefixSet" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                          "name" : "101"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                "prefix" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                },
+                "prefixSet" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                  "name" : "101"
+                }
               },
               "trueStatements" : [
                 {
@@ -512,24 +482,14 @@
                     }
                   ],
                   "guard" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                    "conjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                        "disjuncts" : [
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                            "prefix" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                            },
-                            "prefixSet" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                              "name" : "102"
-                            }
-                          }
-                        ]
-                      }
-                    ]
+                    "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                    "prefix" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                    },
+                    "prefixSet" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                      "name" : "102"
+                    }
                   },
                   "trueStatements" : [
                     {
@@ -586,24 +546,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                        "prefix" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                        },
-                        "prefixSet" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                          "name" : "101"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                "prefix" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                },
+                "prefixSet" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                  "name" : "101"
+                }
               },
               "trueStatements" : [
                 {
@@ -689,24 +639,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as2_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "as2_community"
+                }
               },
               "trueStatements" : [
                 {
@@ -779,24 +719,14 @@
                     }
                   ],
                   "guard" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                    "conjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                        "disjuncts" : [
-                          {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                            "prefix" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                            },
-                            "prefixSet" : {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                              "name" : "outbound_routes"
-                            }
-                          }
-                        ]
-                      }
-                    ]
+                    "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                    "prefix" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                    },
+                    "prefixSet" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                      "name" : "outbound_routes"
+                    }
                   },
                   "trueStatements" : [
                     {
@@ -853,24 +783,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                        "prefix" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                        },
-                        "prefixSet" : {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                          "name" : "101"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                "prefix" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                },
+                "prefixSet" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
+                  "name" : "101"
+                }
               },
               "trueStatements" : [
                 {
@@ -956,24 +876,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as3_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "as3_community"
+                }
               },
               "trueStatements" : [
                 {
@@ -1042,24 +952,14 @@
                 }
               ],
               "guard" : {
-                "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                "conjuncts" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                    "disjuncts" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
-                        "communitySetExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
-                        },
-                        "communitySetMatchExpr" : {
-                          "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
-                          "name" : "as3_community"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.communities.MatchCommunities",
+                "communitySetExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.InputCommunities"
+                },
+                "communitySetMatchExpr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference",
+                  "name" : "as3_community"
+                }
               },
               "trueStatements" : [
                 {


### PR DESCRIPTION
With routing policy tracing in place, we can turn on routing policy simplification. Since simplification is statement-by-statement, and traceable wraps statements, there is no interference between the simplification and tracing. 

(A separate PR will push simplification deeper within the traceable statement.) 