### PR TITLE
ISPs,Amazon: use physical interfaces where appropriate

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModelingUtils.java
@@ -42,6 +42,7 @@ import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.DeviceType;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.LinkLocalAddress;
@@ -360,6 +361,7 @@ public final class IspModelingUtils {
               .setName(internetToIspInterfaceName(ispConfiguration.getHostname()))
               .setVrf(internet.getDefaultVrf())
               .setAddress(LINK_LOCAL_ADDRESS)
+              .setType(InterfaceType.PHYSICAL)
               .build();
       Interface ispIface = ispConfiguration.getAllInterfaces().get(ISP_TO_INTERNET_INTERFACE_NAME);
 
@@ -602,6 +604,7 @@ public final class IspModelingUtils {
         .setAddress(LINK_LOCAL_ADDRESS)
         .setIncomingFilter(fromInternet)
         .setOutgoingFilter(toInternet)
+        .setType(InterfaceType.PHYSICAL)
         .build();
 
     ispInfo
@@ -618,6 +621,7 @@ public final class IspModelingUtils {
                       .setAddress(remote.getIspIfaceAddress())
                       .setIncomingFilter(fromNetwork)
                       .setOutgoingFilter(toNetwork)
+                      .setType(InterfaceType.PHYSICAL)
                       .build();
               modeledNodes.addLayer1Edge(
                   ispConfiguration.getHostname(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilIspTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilIspTest.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.NetworkFactory;
@@ -41,7 +42,7 @@ public class TopologyUtilIspTest {
   public void setup() {
     NetworkFactory nf = new NetworkFactory();
     _cb = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    _ib = nf.interfaceBuilder();
+    _ib = nf.interfaceBuilder().setType(InterfaceType.PHYSICAL);
   }
 
   private static class TopologySetup {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -39,6 +39,7 @@ import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
@@ -354,6 +355,7 @@ public class AwsConfiguration extends VendorConfiguration {
             cfgNode,
             LinkLocalAddress.of(LINK_LOCAL_IP),
             "To AWS services");
+    outInterface.setInterfaceType(InterfaceType.PHYSICAL);
 
     Set<Prefix> awsServicesPrefixes = AwsPrefixes.getAwsServicesPrefixes();
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -31,6 +31,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.LineAction;
@@ -492,12 +493,14 @@ public final class Utils {
    * separately.
    */
   static void createBackboneConnection(Configuration cfgNode, Vrf vrf, String exportPolicyName) {
-    Utils.newInterface(
-        BACKBONE_FACING_INTERFACE_NAME,
-        cfgNode,
-        vrf.getName(),
-        LinkLocalAddress.of(LINK_LOCAL_IP),
-        "To AWS backbone");
+    Interface toBackbone =
+        Utils.newInterface(
+            BACKBONE_FACING_INTERFACE_NAME,
+            cfgNode,
+            vrf.getName(),
+            LinkLocalAddress.of(LINK_LOCAL_IP),
+            "To AWS backbone");
+    toBackbone.setInterfaceType(InterfaceType.PHYSICAL);
     BgpProcess bgpProcess =
         BgpProcess.builder()
             .setRouterId(LINK_LOCAL_IP)

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationVpcEndpointGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationVpcEndpointGatewayTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.TemporaryFolder;
  * E2e tests for VPC endpoints of type gateway. There is a single VPC with two subnets, one public
  * and one private. Both subnets have one instance each.
  *
- * <p>The configuration was pulled * manually after deployment using the setup.tf file in {@link
+ * <p>The configuration was pulled manually after deployment using the setup.tf file in {@link
  * #TESTCONFIGS_DIR}.
  */
 public class AwsConfigurationVpcEndpointGatewayTest {

--- a/tests/aws/topology-example-aws.ref
+++ b/tests/aws/topology-example-aws.ref
@@ -309,6 +309,20 @@
       "properties" : null
     },
     {
+      "id" : "interface-node-isp_16509-To-igw-fac5839d-backbone",
+      "name" : "To-igw-fac5839d-backbone",
+      "nodeId" : "node-isp_16509",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-__aws-services-gateway__-backbone",
+      "name" : "backbone",
+      "nodeId" : "node-__aws-services-gateway__",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "id" : "interface-node-vpc-b390fad5-subnet-1641fa70",
       "name" : "subnet-1641fa70",
       "nodeId" : "node-vpc-b390fad5",
@@ -351,6 +365,13 @@
       "properties" : null
     },
     {
+      "id" : "interface-node-isp_16509-To-__aws-services-gateway__-backbone",
+      "name" : "To-__aws-services-gateway__-backbone",
+      "nodeId" : "node-isp_16509",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "id" : "interface-node-vgw-81fd279f-vpc-815775e7",
       "name" : "vpc-815775e7",
       "nodeId" : "node-vgw-81fd279f",
@@ -379,10 +400,10 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-isp_16509-To-__aws-services-gateway__-backbone",
-      "name" : "To-__aws-services-gateway__-backbone",
+      "id" : "interface-node-isp_16509-To-vgw-81fd279f-backbone",
+      "name" : "To-vgw-81fd279f-backbone",
       "nodeId" : "node-isp_16509",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -393,10 +414,10 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-isp_16509-To-vgw-81fd279f-backbone",
-      "name" : "To-vgw-81fd279f-backbone",
-      "nodeId" : "node-isp_16509",
-      "type" : "UNKNOWN",
+      "id" : "interface-node-internet-To-isp_16509",
+      "name" : "To-isp_16509",
+      "nodeId" : "node-internet",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -404,20 +425,6 @@
       "name" : "subnet-30398256-vrf-igw-9b93ddfc",
       "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-internet-To-isp_16509",
-      "name" : "To-isp_16509",
-      "nodeId" : "node-internet",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-isp_16509-To-igw-fac5839d-backbone",
-      "name" : "To-igw-fac5839d-backbone",
-      "nodeId" : "node-isp_16509",
-      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -442,13 +449,6 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-isp_16509-To-igw-068fee63-backbone",
-      "name" : "To-igw-068fee63-backbone",
-      "nodeId" : "node-isp_16509",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
       "id" : "interface-node-vpc-925131f4-igw-fac5839d",
       "name" : "igw-fac5839d",
       "nodeId" : "node-vpc-925131f4",
@@ -456,16 +456,23 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-isp_16509-To-igw-9b93ddfc-backbone",
-      "name" : "To-igw-9b93ddfc-backbone",
-      "nodeId" : "node-isp_16509",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
       "id" : "interface-node-vpc-b390fad5-subnet-073b8061-vrf-igw-9b93ddfc",
       "name" : "subnet-073b8061-vrf-igw-9b93ddfc",
       "nodeId" : "node-vpc-b390fad5",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-isp_16509-To-igw-068fee63-backbone",
+      "name" : "To-igw-068fee63-backbone",
+      "nodeId" : "node-isp_16509",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-isp_16509-To-igw-9b93ddfc-backbone",
+      "name" : "To-igw-9b93ddfc-backbone",
+      "nodeId" : "node-isp_16509",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -509,13 +516,6 @@
       "name" : "backbone",
       "nodeId" : "node-vgw-81fd279f",
       "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-__aws-services-gateway__-backbone",
-      "name" : "backbone",
-      "nodeId" : "node-__aws-services-gateway__",
-      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -575,13 +575,6 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-isp_16509-To-Internet",
-      "name" : "To-Internet",
-      "nodeId" : "node-isp_16509",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
       "id" : "interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
       "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
       "nodeId" : "node-subnet-30398256",
@@ -599,6 +592,13 @@
       "id" : "interface-node-vpc-f8fad69d-subnet-d9cafabc-vrf-igw-068fee63",
       "name" : "subnet-d9cafabc-vrf-igw-068fee63",
       "nodeId" : "node-vpc-f8fad69d",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-isp_16509-To-Internet",
+      "name" : "To-Internet",
+      "nodeId" : "node-isp_16509",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -629,21 +629,21 @@
       "dstId" : "interface-node-igw-9b93ddfc-backbone",
       "id" : "link-interface-node-isp_16509-To-igw-9b93ddfc-backbone-interface-node-igw-9b93ddfc-backbone",
       "srcId" : "interface-node-isp_16509-To-igw-9b93ddfc-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
       "dstId" : "interface-node-isp_16509-To-vgw-81fd279f-backbone",
       "id" : "link-interface-node-vgw-81fd279f-backbone-interface-node-isp_16509-To-vgw-81fd279f-backbone",
       "srcId" : "interface-node-vgw-81fd279f-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
       "dstId" : "interface-node-isp_16509-To-igw-fac5839d-backbone",
       "id" : "link-interface-node-igw-fac5839d-backbone-interface-node-isp_16509-To-igw-fac5839d-backbone",
       "srcId" : "interface-node-igw-fac5839d-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -657,7 +657,7 @@
       "dstId" : "interface-node-__aws-services-gateway__-backbone",
       "id" : "link-interface-node-isp_16509-To-__aws-services-gateway__-backbone-interface-node-__aws-services-gateway__-backbone",
       "srcId" : "interface-node-isp_16509-To-__aws-services-gateway__-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -678,7 +678,7 @@
       "dstId" : "interface-node-vgw-81fd279f-backbone",
       "id" : "link-interface-node-isp_16509-To-vgw-81fd279f-backbone-interface-node-vgw-81fd279f-backbone",
       "srcId" : "interface-node-isp_16509-To-vgw-81fd279f-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -706,7 +706,7 @@
       "dstId" : "interface-node-isp_16509-To-igw-9b93ddfc-backbone",
       "id" : "link-interface-node-igw-9b93ddfc-backbone-interface-node-isp_16509-To-igw-9b93ddfc-backbone",
       "srcId" : "interface-node-igw-9b93ddfc-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -727,7 +727,7 @@
       "dstId" : "interface-node-isp_16509-To-igw-068fee63-backbone",
       "id" : "link-interface-node-igw-068fee63-backbone-interface-node-isp_16509-To-igw-068fee63-backbone",
       "srcId" : "interface-node-igw-068fee63-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -797,14 +797,14 @@
       "dstId" : "interface-node-isp_16509-To-Internet",
       "id" : "link-interface-node-internet-To-isp_16509-interface-node-isp_16509-To-Internet",
       "srcId" : "interface-node-internet-To-isp_16509",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
       "dstId" : "interface-node-isp_16509-To-__aws-services-gateway__-backbone",
       "id" : "link-interface-node-__aws-services-gateway__-backbone-interface-node-isp_16509-To-__aws-services-gateway__-backbone",
       "srcId" : "interface-node-__aws-services-gateway__-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -986,7 +986,7 @@
       "dstId" : "interface-node-internet-To-isp_16509",
       "id" : "link-interface-node-isp_16509-To-Internet-interface-node-internet-To-isp_16509",
       "srcId" : "interface-node-isp_16509-To-Internet",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -1070,7 +1070,7 @@
       "dstId" : "interface-node-igw-fac5839d-backbone",
       "id" : "link-interface-node-isp_16509-To-igw-fac5839d-backbone-interface-node-igw-fac5839d-backbone",
       "srcId" : "interface-node-isp_16509-To-igw-fac5839d-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -1091,7 +1091,7 @@
       "dstId" : "interface-node-igw-068fee63-backbone",
       "id" : "link-interface-node-isp_16509-To-igw-068fee63-backbone-interface-node-igw-068fee63-backbone",
       "srcId" : "interface-node-isp_16509-To-igw-068fee63-backbone",
-      "type" : "UNKNOWN",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -518,7 +518,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "backbone" : {
@@ -546,7 +546,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           }
         },
@@ -26155,7 +26155,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "out" : {
@@ -26337,7 +26337,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "To-__aws-services-gateway__-backbone" : {
@@ -26357,7 +26357,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "To-igw-068fee63-backbone" : {
@@ -26377,7 +26377,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "To-igw-9b93ddfc-backbone" : {
@@ -26397,7 +26397,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "To-igw-fac5839d-backbone" : {
@@ -26417,7 +26417,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "To-vgw-81fd279f-backbone" : {
@@ -26437,7 +26437,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           }
         },

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -37,7 +37,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "backbone" : {
@@ -65,7 +65,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           }
         },
@@ -48411,7 +48411,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "out" : {
@@ -51405,7 +51405,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           },
           "To-__aws-services-gateway__-backbone" : {
@@ -51425,7 +51425,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
+            "type" : "PHYSICAL",
             "vrf" : "default"
           }
         },


### PR DESCRIPTION
Interfaces that correspond to physical interfaces should have type physical.
VPNs, Tunnels, etc. in AWS stay the same.