### PR TITLE
NXOS: ignore HSRP BFD

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -198,6 +198,7 @@ ihg_ipv6
 ihg_common
 :
   ihg_authentication
+  | ihg_bfd
   | ihg_mac_address
   | ihg_name
   | ihg_no
@@ -243,6 +244,8 @@ ihgam_key_chain
   KEY_CHAIN name = key_chain_name NEWLINE
 ;
 
+ihg_bfd: BFD NEWLINE;
+
 ihg_mac_address
 :
   MAC_ADDRESS mac = mac_address_literal NEWLINE
@@ -255,13 +258,15 @@ ihg_name
 
 ihg_no
 :
-  NO ihg_no_preempt
+  NO (
+    ihg_no_bfd
+    | ihg_no_preempt
+  )
 ;
 
-ihg_no_preempt
-:
-  PREEMPT NEWLINE
-;
+ihg_no_bfd: BFD NEWLINE;
+
+ihg_no_preempt: PREEMPT NEWLINE;
 
 ihg_preempt
 :

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_hsrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_hsrp
@@ -22,7 +22,6 @@ interface Ethernet1/1
   hsrp delay minimum 59 reload 60
   hsrp 2
     authentication md5 key-chain hsrp-keys
-    # BFD is not handled yet, but make sure Batfish doesn't lose context
     bfd
     no bfd
     ip 192.0.2.1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_hsrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_hsrp
@@ -22,6 +22,9 @@ interface Ethernet1/1
   hsrp delay minimum 59 reload 60
   hsrp 2
     authentication md5 key-chain hsrp-keys
+    # BFD is not handled yet, but make sure Batfish doesn't lose context
+    bfd
+    no bfd
     ip 192.0.2.1
     ip 192.168.0.1 secondary
     ip 192.168.1.1 secondary


### PR DESCRIPTION
BFD isn't handled yet, but make sure Batfish doesn't lose context when encountering it under HSRP.
