### PR TITLE
XR: remove todos for implemented as-path constructs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -6986,16 +6986,12 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspse_dfa_regex(Aspse_dfa_regexContext ctx) {
-    todo(ctx);
-    // For now, just treat like ios-regex
     String regex = toString(ctx.as_path_regex());
     _currentAsPathSet.addElement(new DfaRegexAsPathSetElem(regex));
   }
 
   @Override
   public void exitAspsee_dfa_regex(Aspsee_dfa_regexContext ctx) {
-    todo(ctx);
-    // For now, just treat like ios-regex
     String regex = toString(ctx.as_path_regex());
     _currentInlineAsPathSet.addElement(new DfaRegexAsPathSetElem(regex));
   }
@@ -7014,7 +7010,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspse_length(Aspse_lengthContext ctx) {
-    todo(ctx);
     toInteger(ctx, ctx.as_path_length())
         .ifPresent(
             length ->
@@ -7025,7 +7020,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspsee_length(Aspsee_lengthContext ctx) {
-    todo(ctx);
     toInteger(ctx, ctx.as_path_length_expr())
         .ifPresent(
             length ->
@@ -7036,7 +7030,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspse_neighbor_is(Aspse_neighbor_isContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_list())
         .ifPresent(
             ranges ->
@@ -7093,7 +7086,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspsee_neighbor_is(Aspsee_neighbor_isContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_expr_list())
         .ifPresent(
             ranges ->
@@ -7139,7 +7131,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspse_originates_from(Aspse_originates_fromContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_list())
         .ifPresent(
             ranges ->
@@ -7149,7 +7140,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspsee_originates_from(Aspsee_originates_fromContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_expr_list())
         .ifPresent(
             ranges ->
@@ -7159,7 +7149,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspse_passes_through(Aspse_passes_throughContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_list())
         .ifPresent(
             ranges ->
@@ -7169,7 +7158,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspsee_passes_through(Aspsee_passes_throughContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_expr_list())
         .ifPresent(
             ranges ->
@@ -7179,7 +7167,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspse_unique_length(Aspse_unique_lengthContext ctx) {
-    todo(ctx);
     toInteger(ctx, ctx.as_path_length())
         .ifPresent(
             length ->
@@ -7190,7 +7177,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitAspsee_unique_length(Aspsee_unique_lengthContext ctx) {
-    todo(ctx);
     toInteger(ctx, ctx.as_path_length_expr())
         .ifPresent(
             length ->
@@ -8448,7 +8434,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitBoolean_as_path_length(Boolean_as_path_lengthContext ctx) {
-    todo(ctx);
     toInteger(ctx, ctx.as_path_length_expr())
         .ifPresent(
             length ->
@@ -8459,7 +8444,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitBoolean_as_path_neighbor_is(Boolean_as_path_neighbor_isContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_expr_list())
         .ifPresent(
             ranges ->
@@ -8469,7 +8453,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitBoolean_as_path_originates_from(Boolean_as_path_originates_fromContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_expr_list())
         .ifPresent(
             ranges ->
@@ -8479,7 +8462,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitBoolean_as_path_passes_through(Boolean_as_path_passes_throughContext ctx) {
-    todo(ctx);
     toRanges(ctx, ctx.as_range_expr_list())
         .ifPresent(
             ranges ->
@@ -8489,7 +8471,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitBoolean_as_path_unique_length(Boolean_as_path_unique_lengthContext ctx) {
-    todo(ctx);
     toInteger(ctx, ctx.as_path_length_expr())
         .ifPresent(
             length ->

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1199,34 +1199,6 @@
       },
       {
         "Filename" : "configs/ios_xr_route_policy",
-        "Line" : 77,
-        "Text" : "passes-through '[65412..65535]'",
-        "Parser_Context" : "[boolean_as_path_passes_through boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/ios_xr_route_policy",
-        "Line" : 101,
-        "Text" : "neighbor-is '17369'",
-        "Parser_Context" : "[boolean_as_path_neighbor_is boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/ios_xr_route_policy",
-        "Line" : 133,
-        "Text" : "neighbor-is '17369'",
-        "Parser_Context" : "[boolean_as_path_neighbor_is boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/ios_xr_route_policy",
-        "Line" : 148,
-        "Text" : "neighbor-is '12345  6360'",
-        "Parser_Context" : "[boolean_as_path_neighbor_is boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/ios_xr_route_policy",
         "Line" : 161,
         "Text" : "$hub_comm",
         "Parser_Context" : "[community_set_expr_elem_half community_set_expr_elem community_set_expr set_community_rp_stanza set_rp_stanza rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
@@ -1380,20 +1352,6 @@
         "Comment" : "This feature is not currently supported"
       },
       {
-        "Filename" : "configs/route_policy_as_path",
-        "Line" : 17,
-        "Text" : "passes-through '5556'",
-        "Parser_Context" : "[boolean_as_path_passes_through boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/route_policy_as_path",
-        "Line" : 23,
-        "Text" : "originates-from '64527'",
-        "Parser_Context" : "[boolean_as_path_originates_from boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
         "Filename" : "configs/route_policy_param",
         "Line" : 6,
         "Text" : "in $cust_v4_as_path",
@@ -1416,10 +1374,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 196 results",
+      "notes" : "Found 190 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 196
+      "numResults" : 190
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -70363,30 +70363,6 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 77,
-              "Parser_Context" : "[boolean_as_path_passes_through boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-              "Text" : "passes-through '[65412..65535]'"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 101,
-              "Parser_Context" : "[boolean_as_path_neighbor_is boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-              "Text" : "neighbor-is '17369'"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 133,
-              "Parser_Context" : "[boolean_as_path_neighbor_is boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-              "Text" : "neighbor-is '17369'"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 148,
-              "Parser_Context" : "[boolean_as_path_neighbor_is boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-              "Text" : "neighbor-is '12345  6360'"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
               "Line" : 161,
               "Parser_Context" : "[community_set_expr_elem_half community_set_expr_elem community_set_expr set_community_rp_stanza set_rp_stanza rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
               "Text" : "$hub_comm"
@@ -70624,22 +70600,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "apply-groups statement at path: 'system tacplus-server 1.2.3.4' refers to non-existent group: 'bippety'\n"
-            }
-          ]
-        },
-        "configs/route_policy_as_path" : {
-          "Parse warnings" : [
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 17,
-              "Parser_Context" : "[boolean_as_path_passes_through boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-              "Text" : "passes-through '5556'"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 23,
-              "Parser_Context" : "[boolean_as_path_originates_from boolean_as_path boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza boolean_simple_rp_stanza boolean_not_rp_stanza boolean_and_rp_stanza boolean_rp_stanza elseif_rp_stanza if_rp_stanza rp_stanza route_policy_stanza stanza cisco_xr_configuration]",
-              "Text" : "originates-from '64527'"
             }
           ]
         },


### PR DESCRIPTION
See batfish/batfish#7000.