### PR TITLE
Support querying backup routes from BGP/EVPN RIBs

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/routes/BUILD
+++ b/projects/allinone/src/test/java/org/batfish/question/routes/BUILD
@@ -1,0 +1,27 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:private"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    resources = [
+      "//projects/allinone/src/test/resources/org/batfish/allinone/testrigs/bgpv4-routes/configs",
+    ],
+    deps = [
+        "//projects/batfish:batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/question",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/allinone/src/test/java/org/batfish/question/routes/Bgpv4RoutesTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/routes/Bgpv4RoutesTest.java
@@ -1,0 +1,80 @@
+package org.batfish.question.routes;
+
+import static org.batfish.datamodel.RoutingProtocol.IBGP;
+import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
+import static org.batfish.question.routes.RoutesAnswerer.COL_LOCAL_PREF;
+import static org.batfish.question.routes.RoutesAnswerer.COL_NETWORK;
+import static org.batfish.question.routes.RoutesAnswerer.COL_PROTOCOL;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.questions.BgpRouteStatus;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.batfish.question.routes.RoutesQuestion.RibProtocol;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Test of routes answer for BGP routes */
+public final class Bgpv4RoutesTest {
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private static final String NODE1 = "r1";
+  private static final String NODE2 = "r2";
+  private static final String TESTRIG_NAME = "bgpv4-routes";
+  private static final List<String> TESTRIG_NODE_NAMES = ImmutableList.of(NODE1, NODE2);
+  private static final String TESTRIGS_PREFIX = "org/batfish/allinone/testrigs/";
+
+  private Batfish _batfish;
+
+  @Before
+  public void setup() throws IOException {
+    _batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(TESTRIGS_PREFIX + TESTRIG_NAME, TESTRIG_NODE_NAMES)
+                .build(),
+            _folder);
+    _batfish.computeDataPlane(_batfish.getSnapshot());
+  }
+
+  @Test
+  public void testBestRoutes() {
+    RoutesQuestion question =
+        new RoutesQuestion(null, NODE1, null, null, BgpRouteStatus.BEST.name(), RibProtocol.BGP);
+    TableAnswerElement answer =
+        (TableAnswerElement) new RoutesAnswerer(question, _batfish).answer(_batfish.getSnapshot());
+    assertThat(
+        answer.getRowsList(),
+        hasItem(
+            allOf(
+                hasColumn(COL_NETWORK, Prefix.strict("5.5.5.5/32"), Schema.PREFIX),
+                hasColumn(COL_LOCAL_PREF, 1000, Schema.INTEGER))));
+  }
+
+  @Test
+  public void testBackupRoutes() {
+    RoutesQuestion question =
+        new RoutesQuestion(null, NODE1, null, null, BgpRouteStatus.BACKUP.name(), RibProtocol.BGP);
+    TableAnswerElement answer =
+        (TableAnswerElement) new RoutesAnswerer(question, _batfish).answer(_batfish.getSnapshot());
+    assertThat(
+        answer.getRowsList(),
+        contains(
+            allOf(
+                hasColumn(COL_NETWORK, Prefix.strict("5.5.5.5/32"), Schema.PREFIX),
+                hasColumn(COL_PROTOCOL, IBGP.protocolName(), Schema.STRING),
+                hasColumn(COL_LOCAL_PREF, 100, Schema.INTEGER))));
+  }
+}

--- a/projects/allinone/src/test/resources/org/batfish/allinone/testrigs/bgpv4-routes/configs/BUILD
+++ b/projects/allinone/src/test/resources/org/batfish/allinone/testrigs/bgpv4-routes/configs/BUILD
@@ -1,0 +1,14 @@
+package(
+    default_testonly = True,
+    default_visibility = [
+        "//projects/allinone/src/test/java/org/batfish/question/routes:__subpackages__",
+    ],
+)
+
+filegroup(
+    name = "configs",
+    srcs = [
+        "r1",
+        "r2",
+    ],
+)

--- a/projects/allinone/src/test/resources/org/batfish/allinone/testrigs/bgpv4-routes/configs/r1
+++ b/projects/allinone/src/test/resources/org/batfish/allinone/testrigs/bgpv4-routes/configs/r1
@@ -1,0 +1,25 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname r1
+!
+interface Loopback0
+ ip address 10.1.0.0 255.255.255.255
+!
+interface GigabitEthernet0/0
+ ip address 10.0.0.0 255.255.255.254
+ no shutdown
+!
+ip route 5.5.5.5 255.255.255.255 null0
+ip route 10.1.0.1 255.255.255.255 GigabitEthernet0/0
+!
+route-map pref permit 100
+  set local-preference 1000
+!
+router bgp 1
+ bgp router-id 10.1.0.0
+ neighbor 10.1.0.1 remote-as 1
+ address-family ipv4 unicast
+  redistribute static route-map pref
+  neighbor 10.1.0.1 activate
+  neighbor 10.1.0.1 update-source Loopback0
+!

--- a/projects/allinone/src/test/resources/org/batfish/allinone/testrigs/bgpv4-routes/configs/r2
+++ b/projects/allinone/src/test/resources/org/batfish/allinone/testrigs/bgpv4-routes/configs/r2
@@ -1,0 +1,23 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname r2
+!
+interface Loopback0
+ ip address 10.1.0.1 255.255.255.255
+!
+interface GigabitEthernet0/0
+ ip address 10.0.0.1 255.255.255.254
+ no shutdown
+!
+ip route 5.5.5.5 255.255.255.255 null0
+ip route 10.1.0.0 255.255.255.255 GigabitEthernet0/0
+!
+router bgp 1
+ bgp router-id 10.1.0.1
+ neighbor 10.1.0.0 remote-as 1
+ address-family ipv4 unicast
+  redistribute static
+  neighbor 10.1.0.0 activate
+  neighbor 10.1.0.0 update-source Loopback0
+ !
+!

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -359,6 +359,12 @@ public class Client extends AbstractClient implements IClient {
                   "Not a valid BGP route constraints object: %s", expectedType.getName()));
         }
         break;
+      case BGP_ROUTE_STATUS_SPEC:
+        if (!value.isTextual()) {
+          throw new BatfishException(
+              String.format("A Batfish %s must be a JSON string", expectedType.getName()));
+        }
+        break;
       case BGP_SESSION_COMPAT_STATUS_SPEC:
         if (!value.isTextual()) {
           throw new BatfishException(

--- a/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
+++ b/projects/batfish-client/src/test/java/org/batfish/client/ClientTest.java
@@ -29,6 +29,7 @@ import static org.batfish.client.Command.TEST;
 import static org.batfish.common.CoordConsts.DEFAULT_API_KEY;
 import static org.batfish.datamodel.questions.Variable.Type.ADDRESS_GROUP_NAME;
 import static org.batfish.datamodel.questions.Variable.Type.APPLICATION_SPEC;
+import static org.batfish.datamodel.questions.Variable.Type.BGP_ROUTE_STATUS_SPEC;
 import static org.batfish.datamodel.questions.Variable.Type.BGP_SESSION_COMPAT_STATUS_SPEC;
 import static org.batfish.datamodel.questions.Variable.Type.BGP_SESSION_STATUS_SPEC;
 import static org.batfish.datamodel.questions.Variable.Type.BGP_SESSION_TYPE_SPEC;
@@ -363,6 +364,15 @@ public final class ClientTest {
     Type expectedType = APPLICATION_SPEC;
     String expectedMessage =
         String.format("It is not a valid JSON %s value", APPLICATION_SPEC.getName());
+    validateTypeWithInvalidInput(input, expectedMessage, expectedType);
+  }
+
+  @Test
+  public void testInvalidBgpRouteStatusSpecValue() throws IOException {
+    String input = "5";
+    Type expectedType = BGP_ROUTE_STATUS_SPEC;
+    String expectedMessage =
+        String.format("A Batfish %s must be a JSON string", expectedType.getName());
     validateTypeWithInvalidInput(input, expectedMessage, expectedType);
   }
 
@@ -1392,6 +1402,14 @@ public final class ClientTest {
     Variable variable = new Variable();
     variable.setType(BOOLEAN);
     Client.validateType(booleanNode, variable);
+  }
+
+  @Test
+  public void testValidBgpRouteStatusSpecValue() throws IOException {
+    JsonNode sessionStatusNode = _mapper.readTree("\"valid\"");
+    Variable variable = new Variable();
+    variable.setType(BGP_ROUTE_STATUS_SPEC);
+    Client.validateType(sessionStatusNode, variable);
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -5,34 +5,43 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 
 public interface DataPlane extends Serializable {
 
   /** Return routes in the BGP rib for each node/VRF */
+  @Nonnull
   Table<String, String, Set<Bgpv4Route>> getBgpRoutes();
 
   /** Return backup routes in the BGP rib for each node/VRF */
+  @Nonnull
   Table<String, String, Set<Bgpv4Route>> getBgpBackupRoutes();
 
   /** Return routes in the EVPN RIB on each node/VRF */
+  @Nonnull
   Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes();
 
   /** Return backup routes in the EVPN RIB on each node/VRF */
+  @Nonnull
   Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes();
 
   /** Return a {@link Fib} for each node/VRF */
+  @Nonnull
   Map<String, Map<String, Fib>> getFibs();
 
+  @Nonnull
   ForwardingAnalysis getForwardingAnalysis();
 
   /** Return the set of all (main) RIBs. Map structure: hostname -&gt; VRF name -&gt; GenericRib */
+  @Nonnull
   SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> getRibs();
 
   /**
    * Return the summary of route prefix propagation. Map structure: Hostname -&gt; VRF name -&gt;
    * Prefix -&gt; action taken -&gt; set of hostnames (peers).
    */
+  @Nonnull
   SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
       getPrefixTracingInfoSummary();
 
@@ -41,5 +50,6 @@ public interface DataPlane extends Serializable {
    * a {@link Vrf}, but may include additional information obtained during dataplane computation,
    * such as updated flood lists due to EVPN route exchange.
    */
+  @Nonnull
   Table<String, String, Set<Layer2Vni>> getLayer2Vnis();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -12,8 +12,14 @@ public interface DataPlane extends Serializable {
   /** Return routes in the BGP rib for each node/VRF */
   Table<String, String, Set<Bgpv4Route>> getBgpRoutes();
 
+  /** Return backup routes in the BGP rib for each node/VRF */
+  Table<String, String, Set<Bgpv4Route>> getBgpBackupRoutes();
+
   /** Return routes in the EVPN RIB on each node/VRF */
   Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes();
+
+  /** Return backup routes in the EVPN RIB on each node/VRF */
+  Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes();
 
   /** Return a {@link Fib} for each node/VRF */
   Map<String, Map<String, Fib>> getFibs();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
@@ -14,6 +14,9 @@ public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Se
   /** Return set of {@link R typed routes} this RIB contains. */
   Set<R> getTypedRoutes();
 
+  /** Return set of backup {@link R typed routes} this RIB contains. */
+  Set<R> getTypedBackupRoutes();
+
   /**
    * Execute the longest prefix match for a given IP address.
    *

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
@@ -295,6 +295,20 @@ public final class AutoCompleteUtils {
                     referenceLibrary);
             break;
           }
+        case BGP_ROUTE_STATUS_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.BGP_ROUTE_STATUS_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
         case BGP_SESSION_COMPAT_STATUS_SPEC:
           {
             suggestions =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/InputValidationUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/InputValidationUtils.java
@@ -56,6 +56,13 @@ public final class InputValidationUtils {
             completionMetadata,
             nodeRolesData,
             referenceLibrary);
+      case BGP_ROUTE_STATUS_SPEC:
+        return ParboiledInputValidator.validate(
+            Grammar.BGP_ROUTE_STATUS_SPECIFIER,
+            query,
+            completionMetadata,
+            nodeRolesData,
+            referenceLibrary);
       case BGP_SESSION_COMPAT_STATUS_SPEC:
         return ParboiledInputValidator.validate(
             Grammar.BGP_SESSION_COMPAT_STATUS_SPECIFIER,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteStatus.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteStatus.java
@@ -1,0 +1,15 @@
+package org.batfish.datamodel.questions;
+
+/** Status of a BGP route advertisement. */
+public enum BgpRouteStatus {
+  // these should all be upper case for parsing below to work
+
+  /** A backup route that is not selected, installed, or advertised. */
+  BACKUP,
+  /** An overall best route, or a route equivalent to the best route for the purpose of ECMP. */
+  BEST;
+
+  public static BgpRouteStatus parse(String status) {
+    return Enum.valueOf(BgpRouteStatus.class, status.toUpperCase());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/Variable.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/Variable.java
@@ -32,6 +32,7 @@ public class Variable {
     BGP_PROCESS_PROPERTY_SPEC("bgpProcessPropertySpec", true),
     BGP_ROUTES("bgpRoutes", false),
     BGP_ROUTE_CONSTRAINTS("bgpRouteConstraints", false),
+    BGP_ROUTE_STATUS_SPEC("bgpRouteStatusSpec", true),
     BGP_SESSION_COMPAT_STATUS_SPEC("bgpSessionCompatStatusSpec", true),
     BGP_SESSION_STATUS_SPEC("bgpSessionStatusSpec", true),
     BGP_SESSION_TYPE_SPEC("bgpSessionTypeSpec", true),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Grammar.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Grammar.java
@@ -11,6 +11,7 @@ import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.ospf.OspfSessionStatus;
 import org.batfish.datamodel.questions.BgpPeerPropertySpecifier;
 import org.batfish.datamodel.questions.BgpProcessPropertySpecifier;
+import org.batfish.datamodel.questions.BgpRouteStatus;
 import org.batfish.datamodel.questions.BgpSessionStatus;
 import org.batfish.datamodel.questions.ConfiguredSessionStatus;
 import org.batfish.datamodel.questions.InterfacePropertySpecifier;
@@ -28,6 +29,7 @@ public enum Grammar {
   APPLICATION_SPECIFIER("applicationSpecifier", "application-specifier"),
   BGP_PEER_PROPERTY_SPECIFIER("bgpPeerPropertySpecifier", "bgp-peer-property-specifier"),
   BGP_PROCESS_PROPERTY_SPECIFIER("bgpProcessPropertySpecifier", "bgp-process-property-specifier"),
+  BGP_ROUTE_STATUS_SPECIFIER("bgpRouteStatusSpecifier", "bgp-route-status-specifier"),
   BGP_SESSION_COMPAT_STATUS_SPECIFIER(
       "bgpSessionCompatStatusSpecifier", "bgp-session-compat-status-specifier"),
   BGP_SESSION_STATUS_SPECIFIER("bgpSessionStatusSpecifier", "bgp-session-status-specifier"),
@@ -96,6 +98,8 @@ public enum Grammar {
         return BgpPeerPropertySpecifier.ALL.getMatchingProperties();
       case BGP_PROCESS_PROPERTY_SPECIFIER:
         return BgpProcessPropertySpecifier.ALL.getMatchingProperties();
+      case BGP_ROUTE_STATUS_SPECIFIER:
+        return Arrays.asList(BgpRouteStatus.values());
       case BGP_SESSION_COMPAT_STATUS_SPECIFIER:
         return Arrays.asList(ConfiguredSessionStatus.values());
       case BGP_SESSION_STATUS_SPECIFIER:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -125,6 +125,7 @@ public class Parser extends CommonParser {
         return input(AppSpec());
       case BGP_PEER_PROPERTY_SPECIFIER:
       case BGP_PROCESS_PROPERTY_SPECIFIER:
+      case BGP_ROUTE_STATUS_SPECIFIER:
       case BGP_SESSION_COMPAT_STATUS_SPECIFIER:
       case BGP_SESSION_STATUS_SPECIFIER:
       case BGP_SESSION_TYPE_SPECIFIER:

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -15,7 +15,9 @@ public class MockDataPlane implements DataPlane {
 
   public static class Builder {
     @Nonnull private Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
+    @Nonnull private Table<String, String, Set<Bgpv4Route>> _bgpBackupRoutes;
     @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
+    @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnBackupRoutes;
     @Nonnull private Map<String, Map<String, Fib>> _fibs;
     @Nullable private ForwardingAnalysis _forwardingAnalysis;
 
@@ -41,8 +43,20 @@ public class MockDataPlane implements DataPlane {
       return this;
     }
 
+    public Builder setBgpBackupRoutes(
+        @Nonnull Table<String, String, Set<Bgpv4Route>> bgpBackupRoutes) {
+      _bgpBackupRoutes = bgpBackupRoutes;
+      return this;
+    }
+
     public Builder setEvpnRoutes(@Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> evpnRoutes) {
       _evpnRoutes = evpnRoutes;
+      return this;
+    }
+
+    public Builder setEvpnBackupRoutes(
+        @Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> evpnBackupRoutes) {
+      _evpnBackupRoutes = evpnBackupRoutes;
       return this;
     }
 
@@ -73,7 +87,9 @@ public class MockDataPlane implements DataPlane {
   }
 
   @Nonnull private Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
+  @Nonnull private Table<String, String, Set<Bgpv4Route>> _bgpBackupRoutes;
   @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
+  @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnBackupRoutes;
   @Nonnull private final Map<String, Map<String, Fib>> _fibs;
   @Nullable private final ForwardingAnalysis _forwardingAnalysis;
 
@@ -85,7 +101,9 @@ public class MockDataPlane implements DataPlane {
 
   private MockDataPlane(Builder builder) {
     _bgpRoutes = builder._bgpRoutes;
+    _bgpBackupRoutes = builder._bgpBackupRoutes;
     _evpnRoutes = builder._evpnRoutes;
+    _evpnBackupRoutes = builder._evpnBackupRoutes;
     _fibs = builder._fibs;
     _forwardingAnalysis = builder._forwardingAnalysis;
     _ribs = ImmutableSortedMap.copyOf(builder._ribs);
@@ -100,8 +118,20 @@ public class MockDataPlane implements DataPlane {
 
   @Nonnull
   @Override
+  public Table<String, String, Set<Bgpv4Route>> getBgpBackupRoutes() {
+    return _bgpBackupRoutes;
+  }
+
+  @Nonnull
+  @Override
   public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes() {
     return _evpnRoutes;
+  }
+
+  @Nonnull
+  @Override
+  public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes() {
+    return _evpnBackupRoutes;
   }
 
   @Nonnull

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -14,12 +14,14 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
     private Set<AnnotatedRoute<AbstractRoute>> _mergeRouteTrues;
     private Comparator<AnnotatedRoute<AbstractRoute>> _routePreferenceComparator;
     private Set<AnnotatedRoute<AbstractRoute>> _routes;
+    private Set<AnnotatedRoute<AbstractRoute>> _backupRoutes;
 
     private Builder() {
       _longestPrefixMatchResults = ImmutableMap.of();
       _mergeRouteTrues = ImmutableSet.of();
       _routePreferenceComparator = (a, b) -> 0;
       _routes = ImmutableSet.of();
+      _backupRoutes = ImmutableSet.of();
     }
 
     public MockRib build() {
@@ -47,6 +49,11 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
       _routes = routes;
       return this;
     }
+
+    public Builder setBackupRoutes(Set<AnnotatedRoute<AbstractRoute>> backupRoutes) {
+      _backupRoutes = backupRoutes;
+      return this;
+    }
   }
 
   public static Builder builder() {
@@ -57,12 +64,14 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
   private final Set<AnnotatedRoute<AbstractRoute>> _mergeRouteTrues;
   private final Comparator<AnnotatedRoute<AbstractRoute>> _routePreferenceComparator;
   private final Set<AnnotatedRoute<AbstractRoute>> _routes;
+  private final Set<AnnotatedRoute<AbstractRoute>> _backupRoutes;
 
   private MockRib(Builder builder) {
     _longestPrefixMatchResults = builder._longestPrefixMatchResults;
     _mergeRouteTrues = builder._mergeRouteTrues;
     _routePreferenceComparator = builder._routePreferenceComparator;
     _routes = builder._routes;
+    _backupRoutes = builder._backupRoutes;
   }
 
   @Override
@@ -91,6 +100,11 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
   @Override
   public Set<AnnotatedRoute<AbstractRoute>> getTypedRoutes() {
     return _routes;
+  }
+
+  @Override
+  public Set<AnnotatedRoute<AbstractRoute>> getTypedBackupRoutes() {
+    return _backupRoutes;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
@@ -15,6 +15,8 @@ import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.REMOTE_AS
 import static org.batfish.datamodel.questions.BgpProcessPropertySpecifier.MULTIPATH_EBGP;
 import static org.batfish.datamodel.questions.BgpProcessPropertySpecifier.MULTIPATH_EQUIVALENT_AS_PATH_MATCH_MODE;
 import static org.batfish.datamodel.questions.BgpProcessPropertySpecifier.MULTIPATH_IBGP;
+import static org.batfish.datamodel.questions.BgpRouteStatus.BACKUP;
+import static org.batfish.datamodel.questions.BgpRouteStatus.BEST;
 import static org.batfish.datamodel.questions.BgpSessionStatus.ESTABLISHED;
 import static org.batfish.datamodel.questions.BgpSessionStatus.NOT_ESTABLISHED;
 import static org.batfish.datamodel.questions.ConfiguredSessionStatus.DYNAMIC_MATCH;
@@ -197,6 +199,15 @@ public class AutoCompleteUtilsTest {
         equalTo(
             ImmutableSet.of(
                 MULTIPATH_EQUIVALENT_AS_PATH_MATCH_MODE, MULTIPATH_EBGP, MULTIPATH_IBGP)));
+  }
+
+  @Test
+  public void testBgpRouteStatusSpecAutocomplete() {
+    assertThat(
+        AutoCompleteUtils.autoComplete(Type.BGP_ROUTE_STATUS_SPEC, "b", 5).stream()
+            .map(AutocompleteSuggestion::getText)
+            .collect(Collectors.toSet()),
+        equalTo(ImmutableSet.of(BACKUP.toString(), BEST.toString())));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserEnumSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserEnumSetTest.java
@@ -16,6 +16,7 @@ import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.ospf.OspfSessionStatus;
 import org.batfish.datamodel.questions.BgpPeerPropertySpecifier;
 import org.batfish.datamodel.questions.BgpProcessPropertySpecifier;
+import org.batfish.datamodel.questions.BgpRouteStatus;
 import org.batfish.datamodel.questions.BgpSessionStatus;
 import org.batfish.datamodel.questions.ConfiguredSessionStatus;
 import org.batfish.datamodel.questions.InterfacePropertySpecifier;
@@ -396,6 +397,14 @@ public class ParserEnumSetTest {
         BgpProcessPropertySpecifier.ROUTE_REFLECTOR,
         BgpProcessPropertySpecifier.TIE_BREAKER,
         Grammar.BGP_PROCESS_PROPERTY_SPECIFIER);
+  }
+
+  @Test
+  public void testParseBgpRouteStatus() {
+    testParseOtherProperties(
+        BgpRouteStatus.BEST.toString(),
+        BgpRouteStatus.BACKUP.toString(),
+        Grammar.BGP_ROUTE_STATUS_SPECIFIER);
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -2048,6 +2048,10 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     return _bgpv4Rib.getTypedRoutes();
   }
 
+  public Set<Bgpv4Route> getV4BackupRoutes() {
+    return _bgpv4Rib.getTypedBackupRoutes();
+  }
+
   /** Return a set of all bgpv4 bestpath routes */
   public Set<Bgpv4Route> getBestPathRoutes() {
     return _bgpv4Rib.getBestPathRoutes();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -2044,12 +2044,23 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   /**
    * Return a set of all bgpv4 routes. Excludes locally-generated (redistributed) routes for now.
    */
-  public Set<Bgpv4Route> getV4Routes() {
+  public @Nonnull Set<Bgpv4Route> getV4Routes() {
     return _bgpv4Rib.getTypedRoutes();
   }
 
-  public Set<Bgpv4Route> getV4BackupRoutes() {
+  /** Return a set of all bgpv4 backup routes */
+  public @Nonnull Set<Bgpv4Route> getV4BackupRoutes() {
     return _bgpv4Rib.getTypedBackupRoutes();
+  }
+
+  /** Return a set of all multipath-best evpn routes. */
+  public @Nonnull Set<EvpnRoute<?, ?>> getEvpnRoutes() {
+    return _evpnRib.getTypedRoutes();
+  }
+
+  /** Return a set of all evpn backup routes. */
+  public @Nonnull Set<EvpnRoute<?, ?>> getEvpnBackupRoutes() {
+    return _evpnRib.getTypedBackupRoutes();
   }
 
   /** Return a set of all bgpv4 bestpath routes */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
@@ -81,7 +81,8 @@ public final class DataplaneUtil {
   @Nonnull
   static Table<String, String, Set<Bgpv4Route>> computeBgpBackupRoutes(Map<String, Node> nodes) {
     ImmutableTable.Builder<String, String, Set<Bgpv4Route>> table = ImmutableTable.builder();
-
+    // TODO: Instead of subtracting RIB best routes from RIB backup routes, RIB backup routes should
+    //       not store best routes to begin with.
     nodes.forEach(
         (hostname, node) ->
             node.getVirtualRouters()
@@ -113,6 +114,8 @@ public final class DataplaneUtil {
   static Table<String, String, Set<EvpnRoute<?, ?>>> computeEvpnBackupRoutes(
       Map<String, Node> nodes) {
     ImmutableTable.Builder<String, String, Set<EvpnRoute<?, ?>>> table = ImmutableTable.builder();
+    // TODO: Instead of subtracting RIB best routes from RIB backup routes, RIB backup routes should
+    //       not store best routes to begin with.
     nodes.forEach(
         (hostname, node) ->
             node.getVirtualRouters()

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
@@ -5,7 +5,9 @@ import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.specifier.LocationInfoUtils.computeLocationInfo;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -77,6 +79,24 @@ public final class DataplaneUtil {
   }
 
   @Nonnull
+  static Table<String, String, Set<Bgpv4Route>> computeBgpBackupRoutes(Map<String, Node> nodes) {
+    ImmutableTable.Builder<String, String, Set<Bgpv4Route>> table = ImmutableTable.builder();
+
+    nodes.forEach(
+        (hostname, node) ->
+            node.getVirtualRouters()
+                .forEach(
+                    vr -> {
+                      table.put(
+                          hostname,
+                          vr.getName(),
+                          ImmutableSet.copyOf(
+                              Sets.difference(vr.getBgpBackupRoutes(), vr.getBgpRoutes())));
+                    }));
+    return table.build();
+  }
+
+  @Nonnull
   static Table<String, String, Set<EvpnRoute<?, ?>>> computeEvpnRoutes(Map<String, Node> nodes) {
     ImmutableTable.Builder<String, String, Set<EvpnRoute<?, ?>>> table = ImmutableTable.builder();
     nodes.forEach(
@@ -85,6 +105,24 @@ public final class DataplaneUtil {
                 .forEach(
                     vr -> {
                       table.put(hostname, vr.getName(), vr.getEvpnRoutes());
+                    }));
+    return table.build();
+  }
+
+  @Nonnull
+  static Table<String, String, Set<EvpnRoute<?, ?>>> computeEvpnBackupRoutes(
+      Map<String, Node> nodes) {
+    ImmutableTable.Builder<String, String, Set<EvpnRoute<?, ?>>> table = ImmutableTable.builder();
+    nodes.forEach(
+        (hostname, node) ->
+            node.getVirtualRouters()
+                .forEach(
+                    vr -> {
+                      table.put(
+                          hostname,
+                          vr.getName(),
+                          ImmutableSet.copyOf(
+                              Sets.difference(vr.getEvpnBackupRoutes(), vr.getEvpnRoutes())));
                     }));
     return table.build();
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -52,10 +52,22 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     return _bgpRoutes;
   }
 
+  @Nonnull
+  @Override
+  public Table<String, String, Set<Bgpv4Route>> getBgpBackupRoutes() {
+    return _bgpBackupRoutes;
+  }
+
   @Override
   @Nonnull
   public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes() {
     return _evpnRoutes;
+  }
+
+  @Override
+  @Nonnull
+  public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes() {
+    return _evpnBackupRoutes;
   }
 
   @Override
@@ -102,9 +114,11 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   /////////////////////////
 
   @Nonnull private final Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
+  @Nonnull private final Table<String, String, Set<Bgpv4Route>> _bgpBackupRoutes;
   @Nonnull private final Map<String, Map<String, Fib>> _fibs;
   @Nonnull private final ForwardingAnalysis _forwardingAnalysis;
   @Nonnull private final Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
+  @Nonnull private final Table<String, String, Set<EvpnRoute<?, ?>>> _evpnBackupRoutes;
   @Nonnull private final Table<String, String, Set<Layer2Vni>> _vniSettings;
 
   @Nonnull
@@ -123,7 +137,9 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     Map<String, Configuration> configs = DataplaneUtil.computeConfigurations(nodes);
     // Order of initialization matters:
     _bgpRoutes = DataplaneUtil.computeBgpRoutes(nodes);
+    _bgpBackupRoutes = DataplaneUtil.computeBgpBackupRoutes(nodes);
     _evpnRoutes = DataplaneUtil.computeEvpnRoutes(nodes);
+    _evpnBackupRoutes = DataplaneUtil.computeEvpnBackupRoutes(nodes);
     _ribs = DataplaneUtil.computeRibs(nodes);
     _fibs = DataplaneUtil.computeFibs(nodes);
     _forwardingAnalysis =

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
@@ -56,9 +56,21 @@ public final class PartialDataplane implements DataPlane {
     throw new UnsupportedOperationException();
   }
 
+  @Nonnull
+  @Override
+  public Table<String, String, Set<Bgpv4Route>> getBgpBackupRoutes() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   @Nonnull
   public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  @Nonnull
+  public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes() {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1235,6 +1235,11 @@ public final class VirtualRouter {
     return _bgpRoutingProcess == null ? ImmutableSet.of() : _bgpRoutingProcess.getV4Routes();
   }
 
+  /** Get current BGP backup routes. To be used during dataplane computation only */
+  Set<Bgpv4Route> getBgpBackupRoutes() {
+    return _bgpRoutingProcess == null ? ImmutableSet.of() : _bgpRoutingProcess.getV4BackupRoutes();
+  }
+
   /** Get the number of best-path BGP routes. To be used during dataplane computation only */
   int getNumBgpBestPaths() {
     return _bgpRoutingProcess == null ? 0 : _bgpRoutingProcess.getBestPathRoutes().size();
@@ -1545,6 +1550,14 @@ public final class VirtualRouter {
       return ImmutableSet.of();
     }
     return _bgpRoutingProcess._evpnRib.getTypedRoutes();
+  }
+
+  /** Return all EVPN backup routes in this VRF */
+  Set<EvpnRoute<?, ?>> getEvpnBackupRoutes() {
+    if (_bgpRoutingProcess == null) {
+      return ImmutableSet.of();
+    }
+    return _bgpRoutingProcess._evpnRib.getTypedBackupRoutes();
   }
 
   /** Return the VRF name */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1231,11 +1231,13 @@ public final class VirtualRouter {
   }
 
   /** Get current BGP routes. To be used during dataplane computation only */
+  @Nonnull
   Set<Bgpv4Route> getBgpRoutes() {
     return _bgpRoutingProcess == null ? ImmutableSet.of() : _bgpRoutingProcess.getV4Routes();
   }
 
   /** Get current BGP backup routes. To be used during dataplane computation only */
+  @Nonnull
   Set<Bgpv4Route> getBgpBackupRoutes() {
     return _bgpRoutingProcess == null ? ImmutableSet.of() : _bgpRoutingProcess.getV4BackupRoutes();
   }
@@ -1545,19 +1547,17 @@ public final class VirtualRouter {
   }
 
   /** Return all EVPN routes in this VRF */
+  @Nonnull
   Set<EvpnRoute<?, ?>> getEvpnRoutes() {
-    if (_bgpRoutingProcess == null) {
-      return ImmutableSet.of();
-    }
-    return _bgpRoutingProcess._evpnRib.getTypedRoutes();
+    return _bgpRoutingProcess == null ? ImmutableSet.of() : _bgpRoutingProcess.getEvpnRoutes();
   }
 
   /** Return all EVPN backup routes in this VRF */
+  @Nonnull
   Set<EvpnRoute<?, ?>> getEvpnBackupRoutes() {
-    if (_bgpRoutingProcess == null) {
-      return ImmutableSet.of();
-    }
-    return _bgpRoutingProcess._evpnRib.getTypedBackupRoutes();
+    return _bgpRoutingProcess == null
+        ? ImmutableSet.of()
+        : _bgpRoutingProcess.getEvpnBackupRoutes();
   }
 
   /** Return the VRF name */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -2,7 +2,9 @@ package org.batfish.dataplane.rib;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -153,6 +155,15 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
       _allRoutes = ImmutableSet.copyOf(_tree.getRoutes());
     }
     return _allRoutes;
+  }
+
+  @Override
+  @Nonnull
+  public Set<R> getTypedBackupRoutes() {
+    return Optional.ofNullable(_backupRoutes)
+        .map(Multimap::values)
+        .map(ImmutableSet::copyOf)
+        .orElse(ImmutableSet.of());
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -763,49 +763,49 @@ public class Batfish extends PluginConsumer implements IBatfish {
       new DataPlane() {
         @Override
         public Table<String, String, Set<Bgpv4Route>> getBgpRoutes() {
-          return null;
+          throw new UnsupportedOperationException();
         }
 
         @Override
         public Table<String, String, Set<Bgpv4Route>> getBgpBackupRoutes() {
-          return null;
+          throw new UnsupportedOperationException();
         }
 
         @Override
         public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes() {
-          return null;
+          throw new UnsupportedOperationException();
         }
 
         @Override
         public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes() {
-          return null;
+          throw new UnsupportedOperationException();
         }
 
         @Override
         public Map<String, Map<String, Fib>> getFibs() {
-          return null;
+          throw new UnsupportedOperationException();
         }
 
         @Override
         public ForwardingAnalysis getForwardingAnalysis() {
-          return null;
+          throw new UnsupportedOperationException();
         }
 
         @Override
         public SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
             getRibs() {
-          return null;
+          throw new UnsupportedOperationException();
         }
 
         @Override
         public SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
             getPrefixTracingInfoSummary() {
-          return null;
+          throw new UnsupportedOperationException();
         }
 
         @Override
         public Table<String, String, Set<Layer2Vni>> getLayer2Vnis() {
-          return null;
+          throw new UnsupportedOperationException();
         }
       };
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -767,7 +767,17 @@ public class Batfish extends PluginConsumer implements IBatfish {
         }
 
         @Override
+        public Table<String, String, Set<Bgpv4Route>> getBgpBackupRoutes() {
+          return null;
+        }
+
+        @Override
         public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes() {
+          return null;
+        }
+
+        @Override
+        public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes() {
           return null;
         }
 

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -262,8 +262,8 @@ public class RoutesAnswererTest {
         ImmutableList.of(
             COL_NODE,
             COL_VRF_NAME,
-            COL_STATUS,
             COL_NETWORK,
+            COL_STATUS,
             COL_NEXT_HOP_IP,
             COL_NEXT_HOP_INTERFACE,
             COL_PROTOCOL,
@@ -292,8 +292,8 @@ public class RoutesAnswererTest {
         ImmutableList.of(
             COL_NODE,
             COL_VRF_NAME,
-            COL_STATUS,
             COL_NETWORK,
+            COL_STATUS,
             COL_ROUTE_DISTINGUISHER,
             COL_NEXT_HOP_IP,
             COL_NEXT_HOP_INTERFACE,

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -262,6 +262,7 @@ public class RoutesAnswererTest {
         ImmutableList.of(
             COL_NODE,
             COL_VRF_NAME,
+            COL_STATUS,
             COL_NETWORK,
             COL_NEXT_HOP_IP,
             COL_NEXT_HOP_INTERFACE,
@@ -275,7 +276,6 @@ public class RoutesAnswererTest {
             COL_ORIGIN_TYPE,
             COL_ORIGINATOR_ID,
             COL_CLUSTER_LIST,
-            COL_STATUS,
             COL_TAG);
 
     List<ColumnMetadata> columnMetadata = getTableMetadata(RibProtocol.BGP).getColumnMetadata();
@@ -292,6 +292,7 @@ public class RoutesAnswererTest {
         ImmutableList.of(
             COL_NODE,
             COL_VRF_NAME,
+            COL_STATUS,
             COL_NETWORK,
             COL_ROUTE_DISTINGUISHER,
             COL_NEXT_HOP_IP,
@@ -306,7 +307,6 @@ public class RoutesAnswererTest {
             COL_ORIGIN_TYPE,
             COL_ORIGINATOR_ID,
             COL_CLUSTER_LIST,
-            COL_STATUS,
             COL_TAG);
 
     List<ColumnMetadata> columnMetadata = getTableMetadata(RibProtocol.EVPN).getColumnMetadata();

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -22,6 +22,7 @@ import static org.batfish.question.routes.RoutesAnswerer.COL_ORIGIN_TYPE;
 import static org.batfish.question.routes.RoutesAnswerer.COL_PROTOCOL;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ROUTE_DISTINGUISHER;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ROUTE_ENTRY_PRESENCE;
+import static org.batfish.question.routes.RoutesAnswerer.COL_STATUS;
 import static org.batfish.question.routes.RoutesAnswerer.COL_TAG;
 import static org.batfish.question.routes.RoutesAnswerer.COL_VRF_NAME;
 import static org.batfish.question.routes.RoutesAnswerer.getDiffTableMetadata;
@@ -274,6 +275,7 @@ public class RoutesAnswererTest {
             COL_ORIGIN_TYPE,
             COL_ORIGINATOR_ID,
             COL_CLUSTER_LIST,
+            COL_STATUS,
             COL_TAG);
 
     List<ColumnMetadata> columnMetadata = getTableMetadata(RibProtocol.BGP).getColumnMetadata();
@@ -304,6 +306,7 @@ public class RoutesAnswererTest {
             COL_ORIGIN_TYPE,
             COL_ORIGINATOR_ID,
             COL_CLUSTER_LIST,
+            COL_STATUS,
             COL_TAG);
 
     List<ColumnMetadata> columnMetadata = getTableMetadata(RibProtocol.EVPN).getColumnMetadata();
@@ -547,6 +550,11 @@ public class RoutesAnswererTest {
     @Override
     public Set<R> getTypedRoutes() {
       return _routes;
+    }
+
+    @Override
+    public Set<R> getTypedBackupRoutes() {
+      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -1,6 +1,7 @@
 package org.batfish.question.routes;
 
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
+import static org.batfish.datamodel.questions.BgpRouteStatus.BEST;
 import static org.batfish.datamodel.table.TableDiff.COL_BASE_PREFIX;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ADMIN_DISTANCE;
 import static org.batfish.question.routes.RoutesAnswerer.COL_AS_PATH;
@@ -240,7 +241,8 @@ public class RoutesAnswererUtilTest {
             ImmutableSet.of("node"),
             null,
             RoutingProtocolSpecifier.ALL_PROTOCOLS_SPECIFIER,
-            ".*");
+            ".*",
+            ImmutableSet.of(BEST));
 
     // Both routes should have the same values for these columns
     Matcher<Row> commonMatcher =
@@ -297,7 +299,8 @@ public class RoutesAnswererUtilTest {
             ImmutableSet.of("node"),
             null,
             RoutingProtocolSpecifier.ALL_PROTOCOLS_SPECIFIER,
-            ".*");
+            ".*",
+            ImmutableSet.of(BEST));
     assertThat(
         rows.iterator().next().get(COL_COMMUNITIES, Schema.list(Schema.STRING)),
         equalTo(ImmutableList.of("1:1")));
@@ -328,7 +331,8 @@ public class RoutesAnswererUtilTest {
             ImmutableSet.of("node"),
             null,
             RoutingProtocolSpecifier.ALL_PROTOCOLS_SPECIFIER,
-            ".*");
+            ".*",
+            ImmutableSet.of(BEST));
 
     assertThat(
         rows,

--- a/questions/Parameters.md
+++ b/questions/Parameters.md
@@ -10,6 +10,8 @@ For many parameters types, there is a "resolver" question that may be used to le
 
 * [`bgpProcessPropertySpec`](#bgp-process-property-specifier)
 
+* [`bgpRouteStatusSpec`](#bgp-route-status-specifier)
+
 * [`bgpSessionCompatStatusSpec`](#bgp-session-compat-status-specifier)
 
 * [`bgpSessionStatusSpec`](#bgp-session-status-specifier)
@@ -149,6 +151,15 @@ A BGP peer property property specifier follows the [enum set grammar](#set-of-en
 A specification for a set of BGP process properties (e.g., those returned by the `bgpProcessConfiguration` question).
 
 A BGP process property specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `Multipath_Match_Mode`, `Multipath_EBGP`, `Multipath_IBGP`, `Neighbors`, `Route_Reflector`, `Tie_Breaker`.
+
+### BGP Route Status Specifier
+
+A specification for a set of BGP route statuses.
+
+A BGP route status specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values:
+
+* `BEST` - a route that is the unique best route for an NLRI (e.g. an IP prefix for IPv4 unicast) in the BGP RIB, or a route that is equivalent to the unique best route for the purpose of ECMP routing. A `BEST` route may be installed in the main RIB.
+* `BACKUP` - a route that is inferior to all `BEST` routes in the BGP RIB for the same NLRI. Such a route will not be installed in the main RIB. However, it may be advertised on a BGP ADD-PATH-enabled session and the route matches the add-path policy.
 
 ### BGP Session Compat Status Specifier
 

--- a/questions/stable/bgpRib.json
+++ b/questions/stable/bgpRib.json
@@ -8,7 +8,8 @@
         "orderedVariableNames": [
             "nodes",
             "network",
-            "vrfs"
+            "vrfs",
+            "status"
         ],
         "tags": [
             "dataplane",
@@ -32,11 +33,18 @@
                 "type": "prefix",
                 "optional": true,
                 "displayName": "Network"
+            },
+            "status": {
+               "description": "Examine routes whose status matches this specifier",
+               "type": "bgpRouteStatusSpec",
+               "optional": true,
+               "displayName": "Status"
             }
         }
     },
     "network": "${network}",
     "nodes": "${nodes}",
     "vrfs": "${vrfs}",
-    "rib": "bgp"
+    "rib": "bgp",
+    "bgpRouteStatus": "${status}"
 }

--- a/tests/questions/stable/bgpRib.ref
+++ b/tests/questions/stable/bgpRib.ref
@@ -1,5 +1,6 @@
 {
   "class" : "org.batfish.question.routes.RoutesQuestion",
+  "bgpRouteStatus" : "backup",
   "network" : "1.1.1.0/24",
   "nodes" : "n1",
   "protocols" : "all",
@@ -14,7 +15,8 @@
     "orderedVariableNames" : [
       "nodes",
       "network",
-      "vrfs"
+      "vrfs",
+      "status"
     ],
     "tags" : [
       "dataplane",
@@ -34,6 +36,13 @@
         "optional" : true,
         "type" : "nodeSpec",
         "value" : "n1"
+      },
+      "status" : {
+        "description" : "Examine routes whose status matches this specifier",
+        "displayName" : "Status",
+        "optional" : true,
+        "type" : "bgpRouteStatusSpec",
+        "value" : "backup"
       },
       "vrfs" : {
         "description" : "Examine routes on VRFs matching this name or regex",

--- a/tests/questions/stable/commands
+++ b/tests/questions/stable/commands
@@ -22,7 +22,7 @@ test -raw tests/questions/stable/edges.ref validate-template edges edgeType="bgp
 test -raw tests/questions/stable/bgpEdges.ref validate-template bgpEdges nodes=".*", remoteNodes=".*"
 
 # validate bgpRib
-test -raw tests/questions/stable/bgpRib.ref validate-template bgpRib network="1.1.1.1/24", nodes="n1", vrfs="default"
+test -raw tests/questions/stable/bgpRib.ref validate-template bgpRib network="1.1.1.1/24", nodes="n1", vrfs="default", status="backup"
 
 # validate eigrpEdges
 test -raw tests/questions/stable/eigrpEdges.ref validate-template eigrpEdges nodes=".*", remoteNodes=".*"


### PR DESCRIPTION
- add `BgpRouteStatus` `EnumSet` specifier:
  - `BEST`: unique best and ECMP-best routes 
  - `BACKUP`: valid routes that are not `BEST`
- store BGP/EVPN backup routes in serialized data plane
- update data plane APIs to support retrieval of backup routes
- update `bgpRib` question to support retrieving routes with status according to BgpRouteStatus specifier
