### PR TITLE
IOS: Remove generated routes for BGP IPv6 aggregates

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Common.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Common.java
@@ -4,7 +4,6 @@ import static java.util.Collections.singletonList;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -54,31 +53,6 @@ public final class Common {
                     DestinationNetwork.instance(),
                     new ExplicitPrefixSet(new PrefixSpace(PrefixRange.moreSpecificThan(prefix)))),
                 singletonList(Statements.ReturnTrue.toStaticStatement())))
-        .build();
-  }
-
-  /**
-   * Creates a generation policy for the aggregate network with the given {@link Prefix6}. The
-   * generation policy matches any route with a destination more specific than {@code prefix}.
-   *
-   * @param c {@link Configuration} in which to create the generation policy
-   * @param vrfName Name of VRF in which the aggregate network exists
-   * @param prefix The aggregate network prefix
-   */
-  public static RoutingPolicy generateGenerationPolicy(
-      Configuration c, String vrfName, Prefix6 prefix) {
-    SubRange prefixRange = new SubRange(prefix.getPrefixLength() + 1, Prefix6.MAX_PREFIX_LENGTH);
-    return RoutingPolicy.builder()
-        .setOwner(c)
-        .setName(generatedBgpGenerationPolicyName(false, vrfName, prefix.toString()))
-        .addStatement(
-            new If(
-                new MatchPrefix6Set(
-                    new DestinationNetwork6(),
-                    new ExplicitPrefix6Set(
-                        new Prefix6Space(
-                            Collections.singleton(new Prefix6Range(prefix, prefixRange))))),
-                ImmutableList.of(Statements.ReturnTrue.toStaticStatement())))
         .build();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -12,7 +12,6 @@ import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENG
 import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
-import static org.batfish.datamodel.routing_policy.Common.generateGenerationPolicy;
 import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
 import static org.batfish.datamodel.routing_policy.Common.matchDefaultRoute;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
@@ -984,6 +983,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     proc.getAggregateNetworks().values().stream()
         .map(ipv4Aggregate -> toBgpAggregate(ipv4Aggregate, c))
         .forEach(newBgpProcess::addAggregate);
+    // TODO Handle IPv6 aggregates
 
     /*
      * Create common BGP export policy. This policy's only function is to prevent export of
@@ -1011,29 +1011,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     String redistPolicyName = generatedBgpRedistributionPolicyName(vrfName);
     RoutingPolicy.Builder redistributionPolicy =
         RoutingPolicy.builder().setOwner(c).setName(redistPolicyName);
-
-    // add generated routes for aggregate ipv6 addresses
-    // TODO: merge with above to make cleaner
-    for (Entry<Prefix6, BgpAggregateIpv6Network> e : proc.getAggregateIpv6Networks().entrySet()) {
-      Prefix6 prefix6 = e.getKey();
-      BgpAggregateIpv6Network aggNet = e.getValue();
-
-      // create generation policy for aggregate network
-      RoutingPolicy genPolicy = generateGenerationPolicy(c, vrfName, prefix6);
-      GeneratedRoute6 gr = new GeneratedRoute6(prefix6, CISCO_AGGREGATE_ROUTE_ADMIN_COST);
-      gr.setGenerationPolicy(genPolicy.getName());
-      gr.setDiscard(true);
-      v.getGeneratedIpv6Routes().add(gr);
-
-      // set attribute map for aggregate network
-      String attributeMapName = aggNet.getAttributeMap();
-      if (attributeMapName != null) {
-        RouteMap attributeMap = _routeMaps.get(attributeMapName);
-        if (attributeMap != null) {
-          gr.setAttributePolicy(attributeMapName);
-        }
-      }
-    }
 
     // Redistribute routes
     Stream.of(

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -25570,32 +25570,6 @@
           }
         },
         "routingPolicies" : {
-          "~AGGREGATE_ROUTE6_GEN:default:2607:f010:3f9:8000:0:0:0:0/52~" : {
-            "name" : "~AGGREGATE_ROUTE6_GEN:default:2607:f010:3f9:8000:0:0:0:0/52~",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefix6Set",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork6"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefix6Set",
-                    "prefix6Space" : [
-                      "2607:f010:3f9:8000:0:0:0:0/52;53-128"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnTrue"
-                  }
-                ]
-              }
-            ]
-          },
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
             "statements" : [
@@ -25766,15 +25740,6 @@
               "multipathIbgp" : false,
               "tieBreaker" : "ARRIVAL_ORDER"
             },
-            "generatedIpv6Routes" : [
-              {
-                "class" : "org.batfish.datamodel.GeneratedRoute6",
-                "network" : "2607:f010:3f9:8000:0:0:0:0/52",
-                "administrativeCost" : 200,
-                "discard" : true,
-                "generationPolicy" : "~AGGREGATE_ROUTE6_GEN:default:2607:f010:3f9:8000:0:0:0:0/52~"
-              }
-            ],
             "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }


### PR DESCRIPTION
When supported, these should populate a new IPv6 aggregates field in the BGP process instead of the VRF.