### PR TITLE
TransferBDD: Support formats that use output attributes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
@@ -40,7 +40,6 @@ public class Environment {
    * several fields.
    */
   public static Builder builder(@Nonnull Configuration c) {
-    ConfigurationFormat format = c.getConfigurationFormat();
     return new Builder()
         .setAsPathAccessLists(c.getAsPathAccessLists())
         .setAsPathExprs(c.getAsPathExprs())
@@ -54,10 +53,19 @@ public class Environment {
         .setRouteFilterLists(c.getRouteFilterLists())
         .setRoute6FilterLists(c.getRoute6FilterLists())
         .setRoutingPolicies(c.getRoutingPolicies())
-        .setUseOutputAttributes(
-            format == ConfigurationFormat.JUNIPER
-                || format == ConfigurationFormat.JUNIPER_SWITCH
-                || format == ConfigurationFormat.FLAT_JUNIPER);
+        .setUseOutputAttributes(useOutputAttributes(c));
+  }
+
+  /**
+   * Indicates whether the given {@link Configuration} should use the output route attributes
+   * instead of the original route attributes during route-policy evaluation, based on the
+   * configuration's format.
+   */
+  public static boolean useOutputAttributes(@Nonnull Configuration c) {
+    ConfigurationFormat format = c.getConfigurationFormat();
+    return format == ConfigurationFormat.JUNIPER
+        || format == ConfigurationFormat.JUNIPER_SWITCH
+        || format == ConfigurationFormat.FLAT_JUNIPER;
   }
 
   public enum Direction {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
@@ -53,15 +53,15 @@ public class Environment {
         .setRouteFilterLists(c.getRouteFilterLists())
         .setRoute6FilterLists(c.getRoute6FilterLists())
         .setRoutingPolicies(c.getRoutingPolicies())
-        .setUseOutputAttributes(useOutputAttributes(c));
+        .setUseOutputAttributes(useOutputAttributesFor(c));
   }
 
   /**
-   * Indicates whether the given {@link Configuration} should use the output route attributes
-   * instead of the original route attributes during route-policy evaluation, based on the
+   * Indicates whether simulation of route policies in the given {@link Configuration} should match
+   * on the output route attributes instead of the original route attributes, based on the
    * configuration's format.
    */
-  public static boolean useOutputAttributes(@Nonnull Configuration c) {
+  public static boolean useOutputAttributesFor(@Nonnull Configuration c) {
     ConfigurationFormat format = c.getConfigurationFormat();
     return format == ConfigurationFormat.JUNIPER
         || format == ConfigurationFormat.JUNIPER_SWITCH

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/SetCommunitiesVisitor.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/SetCommunitiesVisitor.java
@@ -22,7 +22,9 @@ import org.batfish.minesweeper.communities.CommunitySetExprVarCollector;
 /**
  * Collect the sets of community variables that should be set to true / false during the symbolic
  * route analysis of a {@link org.batfish.datamodel.routing_policy.communities.SetCommunities}
- * statement.
+ * statement. Note: The {@link BDDRoute} component of the {@link Arg} should always be a fresh
+ * BDDRoute rather than the current one, since it is used to map community regexes to their
+ * corresponding BDD variables.
  */
 @ParametersAreNonnullByDefault
 public class SetCommunitiesVisitor

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -119,15 +119,21 @@ public class TransferBDD {
   private final boolean _useOutputAttributes;
 
   public TransferBDD(Graph g, Configuration conf, List<Statement> statements) {
+    this(g, conf, statements, Environment.useOutputAttributesFor(conf));
+  }
+
+  @VisibleForTesting
+  TransferBDD(
+      Graph g, Configuration conf, List<Statement> statements, boolean useOutputAttributes) {
     _graph = g;
     _conf = conf;
     _statements = statements;
 
     _originalRoute = new BDDRoute(g);
-    _useOutputAttributes = Environment.useOutputAttributes(_conf);
     _communityAtomicPredicates = _graph.getCommunityAtomicPredicates().getRegexAtomicPredicates();
     _asPathRegexAtomicPredicates =
         _graph.getAsPathRegexAtomicPredicates().getRegexAtomicPredicates();
+    _useOutputAttributes = useOutputAttributes;
   }
 
   /*
@@ -328,10 +334,7 @@ public class TransferBDD {
       }
       RoutingProtocol rp = Iterables.getOnlyElement(rps);
       Protocol proto = Protocol.fromRoutingProtocol(rp);
-      // MatchProtocol::evaluate looks up the protocol of the original route,
-      // so we do the same here
-      BDD protBDD =
-          proto == null ? factory.zero() : _originalRoute.getProtocolHistory().value(proto);
+      BDD protBDD = proto == null ? factory.zero() : p.getData().getProtocolHistory().value(proto);
       return result.setReturnValueBDD(protBDD);
 
     } else if (expr instanceof MatchPrefixSet) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -668,6 +668,8 @@ public class TransferBDD {
       SetCommunities sc = (SetCommunities) stmt;
       org.batfish.datamodel.routing_policy.communities.CommunitySetExpr setExpr =
           sc.getCommunitySetExpr();
+      // SetCommunitiesVisitor requires a BDDRoute that maps each community atomic predicate BDD
+      // to its corresponding BDD variable, so we use the original route here
       CommunityAPDispositions dispositions =
           setExpr.accept(new SetCommunitiesVisitor(), new Arg(this, _originalRoute));
       updateCommunities(dispositions, curP, result);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -1179,4 +1179,8 @@ public class TransferBDD {
   public Graph getGraph() {
     return _graph;
   }
+
+  public boolean getUseOutputAttributes() {
+    return _useOutputAttributes;
+  }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -2,6 +2,7 @@ package org.batfish.minesweeper.bdd;
 
 import static org.batfish.minesweeper.bdd.TransferBDD.isRelevantFor;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -143,11 +144,13 @@ public class TransferBDDTest {
 
   @Before
   public void setup() {
+    setup(ConfigurationFormat.CISCO_IOS);
+  }
+
+  public void setup(ConfigurationFormat format) {
     _nf = new NetworkFactory();
     Configuration.Builder cb =
-        _nf.configurationBuilder()
-            .setHostname(HOSTNAME)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+        _nf.configurationBuilder().setHostname(HOSTNAME).setConfigurationFormat(format);
     _baseConfig = cb.build();
     _nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
     _policyBuilder = _nf.routingPolicyBuilder().setOwner(_baseConfig).setName(POLICY_NAME);
@@ -1067,7 +1070,7 @@ public class TransferBDDTest {
             .build();
     _g = new Graph(_batfish, _batfish.getSnapshot());
 
-    // by default we use the original route for matching during the analysis
+    // the analysis will use the original route for matching
     TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
@@ -1539,57 +1542,6 @@ public class TransferBDDTest {
   }
 
   @Test
-  public void testSetThenMatchCommunities() {
-    Community comm = StandardCommunity.parse("30:40");
-    RoutingPolicy policy =
-        _policyBuilder
-            .addStatement(
-                new SetCommunities(
-                    CommunitySetUnion.of(
-                        InputCommunities.instance(),
-                        new LiteralCommunitySet(CommunitySet.of(comm)))))
-            .addStatement(
-                new If(
-                    new MatchCommunities(
-                        InputCommunities.instance(), new HasCommunity(new CommunityIs(comm))),
-                    ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
-            .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
-
-    BDDRoute anyRoute = new BDDRoute(_g);
-    BDD[] aps = anyRoute.getCommunityAtomicPredicates();
-    // get the atomic predicates that correspond to 30:40
-    Set<Integer> ap3040 =
-        _g.getCommunityAtomicPredicates().getRegexAtomicPredicates().get(CommunityVar.from(comm));
-
-    // by default we use the original route for matching during the analysis
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
-    TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
-    BDD acceptedAnnouncements = result.getSecond();
-    BDDRoute outAnnouncements = result.getFirst();
-    // the original route must have the community 30:40
-    BDD expectedBDD =
-        BDDRoute.factory.orAll(ap3040.stream().map(i -> aps[i]).collect(Collectors.toList()));
-    assertEquals(expectedBDD, acceptedAnnouncements);
-    BDDRoute expected = tbdd.iteZero(acceptedAnnouncements, anyRoute);
-    assertEquals(expected, outAnnouncements);
-
-    // now do the analysis again but use the output attributes for matching
-    tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), true);
-    result = tbdd.compute(ImmutableSet.of()).getReturnValue();
-    acceptedAnnouncements = result.getSecond();
-    outAnnouncements = result.getFirst();
-    // the original route is now unconstrained
-    assertTrue(acceptedAnnouncements.isOne());
-    for (int i = 0; i < _g.getCommunityAtomicPredicates().getNumAtomicPredicates(); i++) {
-      // each atomic predicate for 30:40 has the 1 BDD; all others have their original values
-      assertEquals(
-          ap3040.contains(i) ? outAnnouncements.getFactory().one() : aps[i],
-          outAnnouncements.getCommunityAtomicPredicates()[i]);
-    }
-  }
-
-  @Test
   public void testMatchCommunities() {
     RoutingPolicy policy =
         _policyBuilder
@@ -1665,6 +1617,57 @@ public class TransferBDDTest {
     assertEquals(expectedBDD, acceptedAnnouncements);
 
     assertEquals(tbdd.iteZero(acceptedAnnouncements, anyRoute), outAnnouncements);
+  }
+
+  @Test
+  public void testSetThenMatchCommunities() {
+    Community comm = StandardCommunity.parse("30:40");
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(
+                new SetCommunities(
+                    CommunitySetUnion.of(
+                        InputCommunities.instance(),
+                        new LiteralCommunitySet(CommunitySet.of(comm)))))
+            .addStatement(
+                new If(
+                    new MatchCommunities(
+                        InputCommunities.instance(), new HasCommunity(new CommunityIs(comm))),
+                    ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
+            .build();
+    _g = new Graph(_batfish, _batfish.getSnapshot());
+
+    BDDRoute anyRoute = new BDDRoute(_g);
+    BDD[] aps = anyRoute.getCommunityAtomicPredicates();
+    // get the atomic predicates that correspond to 30:40
+    Set<Integer> ap3040 =
+        _g.getCommunityAtomicPredicates().getRegexAtomicPredicates().get(CommunityVar.from(comm));
+
+    // the analysis will use the original route for matching
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
+    TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
+    BDD acceptedAnnouncements = result.getSecond();
+    BDDRoute outAnnouncements = result.getFirst();
+    // the original route must have the community 30:40
+    BDD expectedBDD =
+        BDDRoute.factory.orAll(ap3040.stream().map(i -> aps[i]).collect(Collectors.toList()));
+    assertEquals(expectedBDD, acceptedAnnouncements);
+    BDDRoute expected = tbdd.iteZero(acceptedAnnouncements, anyRoute);
+    assertEquals(expected, outAnnouncements);
+
+    // now do the analysis again but use the output attributes for matching
+    tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), true);
+    result = tbdd.compute(ImmutableSet.of()).getReturnValue();
+    acceptedAnnouncements = result.getSecond();
+    outAnnouncements = result.getFirst();
+    // the original route is now unconstrained
+    assertTrue(acceptedAnnouncements.isOne());
+    for (int i = 0; i < _g.getCommunityAtomicPredicates().getNumAtomicPredicates(); i++) {
+      // each atomic predicate for 30:40 has the 1 BDD; all others have their original values
+      assertEquals(
+          ap3040.contains(i) ? outAnnouncements.getFactory().one() : aps[i],
+          outAnnouncements.getCommunityAtomicPredicates()[i]);
+    }
   }
 
   @Test
@@ -1893,5 +1896,20 @@ public class TransferBDDTest {
 
     assertTrue(len0.imp(rangeBdd.not()).isOne());
     assertTrue(len32.imp(rangeBdd).isOne());
+  }
+
+  @Test
+  public void testUseOutputAttributes() {
+    // useOutputAttributes is false for CISCO_IOS
+    setup(ConfigurationFormat.CISCO_IOS);
+    _g = new Graph(_batfish, _batfish.getSnapshot());
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, ImmutableList.of());
+    assertFalse(tbdd.getUseOutputAttributes());
+
+    // useOutputAttributes is true for JUNIPER
+    setup(ConfigurationFormat.JUNIPER);
+    _g = new Graph(_batfish, _batfish.getSnapshot());
+    tbdd = new TransferBDD(_g, _baseConfig, ImmutableList.of());
+    assertTrue(tbdd.getUseOutputAttributes());
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -34,6 +34,7 @@ import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.LargeCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
@@ -1055,6 +1056,41 @@ public class TransferBDDTest {
   }
 
   @Test
+  public void testSetThenMatchTag() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(new SetTag(new LiteralLong(42)))
+            .addStatement(
+                new If(
+                    new MatchTag(IntComparator.EQ, new LiteralLong(42)),
+                    ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
+            .build();
+    _g = new Graph(_batfish, _batfish.getSnapshot());
+
+    // by default we use the original route for matching during the analysis
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
+    TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
+    BDD acceptedAnnouncements = result.getSecond();
+    BDDRoute outAnnouncements = result.getFirst();
+    // the original route's tag must be 42
+    assertEquals(acceptedAnnouncements, _anyRoute.getTag().value(42));
+    assertEquals(tbdd.iteZero(acceptedAnnouncements, _anyRoute), outAnnouncements);
+
+    // now do the analysis again but use the output attributes for matching
+    tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), true);
+    result = tbdd.compute(ImmutableSet.of()).getReturnValue();
+    acceptedAnnouncements = result.getSecond();
+    outAnnouncements = result.getFirst();
+    // the original route's tag is irrelevant
+    assertTrue(acceptedAnnouncements.isOne());
+    // the tag is now 42
+    BDDRoute expected = new BDDRoute(_anyRoute);
+    BDDInteger tag = expected.getTag();
+    expected.setTag(BDDInteger.makeFromValue(tag.getFactory(), 32, 42));
+    assertEquals(expected, outAnnouncements);
+  }
+
+  @Test
   public void testMatchTagLT() {
     RoutingPolicy policy =
         _policyBuilder
@@ -1498,6 +1534,57 @@ public class TransferBDDTest {
           aps3040.contains(i) || aps4040.contains(i)
               ? outAnnouncements.getFactory().one()
               : outAnnouncements.getFactory().zero(),
+          outAnnouncements.getCommunityAtomicPredicates()[i]);
+    }
+  }
+
+  @Test
+  public void testSetThenMatchCommunities() {
+    Community comm = StandardCommunity.parse("30:40");
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(
+                new SetCommunities(
+                    CommunitySetUnion.of(
+                        InputCommunities.instance(),
+                        new LiteralCommunitySet(CommunitySet.of(comm)))))
+            .addStatement(
+                new If(
+                    new MatchCommunities(
+                        InputCommunities.instance(), new HasCommunity(new CommunityIs(comm))),
+                    ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
+            .build();
+    _g = new Graph(_batfish, _batfish.getSnapshot());
+
+    BDDRoute anyRoute = new BDDRoute(_g);
+    BDD[] aps = anyRoute.getCommunityAtomicPredicates();
+    // get the atomic predicates that correspond to 30:40
+    Set<Integer> ap3040 =
+        _g.getCommunityAtomicPredicates().getRegexAtomicPredicates().get(CommunityVar.from(comm));
+
+    // by default we use the original route for matching during the analysis
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
+    TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
+    BDD acceptedAnnouncements = result.getSecond();
+    BDDRoute outAnnouncements = result.getFirst();
+    // the original route must have the community 30:40
+    BDD expectedBDD =
+        BDDRoute.factory.orAll(ap3040.stream().map(i -> aps[i]).collect(Collectors.toList()));
+    assertEquals(expectedBDD, acceptedAnnouncements);
+    BDDRoute expected = tbdd.iteZero(acceptedAnnouncements, anyRoute);
+    assertEquals(expected, outAnnouncements);
+
+    // now do the analysis again but use the output attributes for matching
+    tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), true);
+    result = tbdd.compute(ImmutableSet.of()).getReturnValue();
+    acceptedAnnouncements = result.getSecond();
+    outAnnouncements = result.getFirst();
+    // the original route is now unconstrained
+    assertTrue(acceptedAnnouncements.isOne());
+    for (int i = 0; i < _g.getCommunityAtomicPredicates().getNumAtomicPredicates(); i++) {
+      // each atomic predicate for 30:40 has the 1 BDD; all others have their original values
+      assertEquals(
+          ap3040.contains(i) ? outAnnouncements.getFactory().one() : aps[i],
           outAnnouncements.getCommunityAtomicPredicates()[i]);
     }
   }


### PR DESCRIPTION
Updates the symbolic route analysis to properly handle configuration formats that use output attributes for matching, rather than the attributes of the original route.