### PR TITLE
BroadcastL3Adjacencies: initial draft

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/BroadcastL3Adjacencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/BroadcastL3Adjacencies.java
@@ -1,0 +1,54 @@
+package org.batfish.common.topology.broadcast;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.L3Adjacencies;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.vxlan.VxlanTopology;
+
+/**
+ * An {@link L3Adjacencies} implementation based on fully modeling L1 and L2 domains, even when no
+ * layer-1 information is provided with the snapshot.
+ *
+ * @see L3AdjacencyComputer
+ */
+public class BroadcastL3Adjacencies implements L3Adjacencies {
+  public static BroadcastL3Adjacencies create(
+      Layer1Topology l1, VxlanTopology vxlan, Map<String, Configuration> configs) {
+    assert vxlan != null; // suppress unused warning.
+    L3AdjacencyComputer adj = new L3AdjacencyComputer(configs, l1);
+    return new BroadcastL3Adjacencies(adj.findAllBroadcastDomains());
+  }
+
+  private BroadcastL3Adjacencies(Map<NodeInterfacePair, Integer> domains) {
+    _domains = ImmutableMap.copyOf(domains);
+  }
+
+  @Override
+  public boolean inSameBroadcastDomain(NodeInterfacePair i1, NodeInterfacePair i2) {
+    checkArgument(_domains.containsKey(i1), "Missing domain for %s: is it an L3 interface?", i1);
+    checkArgument(_domains.containsKey(i2), "Missing domain for %s: is it an L3 interface?", i2);
+    return _domains.get(i1).equals(_domains.get(i2));
+  }
+
+  @Override
+  public boolean inSamePointToPointDomain(NodeInterfacePair i1, NodeInterfacePair i2) {
+    // TODO
+    return false;
+  }
+
+  @Nonnull
+  @Override
+  public Optional<NodeInterfacePair> pairedPointToPointL3Interface(NodeInterfacePair iface) {
+    // TODO
+    return Optional.empty();
+  }
+
+  private final @Nonnull Map<NodeInterfacePair, Integer> _domains;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/DeviceBroadcastDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/DeviceBroadcastDomain.java
@@ -2,6 +2,7 @@ package org.batfish.common.topology.broadcast;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -65,6 +66,16 @@ public final class DeviceBroadcastDomain extends Node<Integer> {
   @Override
   public int hashCode() {
     return 31 * DeviceBroadcastDomain.class.hashCode() + _hostname.hashCode();
+  }
+
+  @VisibleForTesting
+  Map<L3Interface, Edge<Integer, Unit>> getL3InterfacesForTest() {
+    return _l3Interfaces;
+  }
+
+  @VisibleForTesting
+  Map<PhysicalInterface, Edge<Integer, EthernetTag>> getPhysicalInterfacesForTest() {
+    return _physicalInterfaces;
   }
 
   private final @Nonnull String _hostname;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/EthernetHub.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/EthernetHub.java
@@ -1,5 +1,6 @@
 package org.batfish.common.topology.broadcast;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +38,12 @@ public final class EthernetHub extends Node<EthernetTag> {
   }
 
   // Internal implementation details.
+
+  @VisibleForTesting
+  @Nonnull
+  Map<PhysicalInterface, Edge<EthernetTag, EthernetTag>> getAttachedInterfacesForTesting() {
+    return _attachedInterfaces;
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/L3AdjacencyComputer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/L3AdjacencyComputer.java
@@ -1,0 +1,415 @@
+package org.batfish.common.topology.broadcast;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.annotation.Nonnull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.batfish.common.topology.Layer1Edge;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.Interface.DependencyType;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.SwitchportMode;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.jgrapht.alg.util.UnionFind;
+
+/** Computes the set of L3 interfaces that are in the same broadcast domain as a given interface. */
+public class L3AdjacencyComputer {
+  private static final Logger LOGGER = LogManager.getLogger(L3AdjacencyComputer.class);
+  private final @Nonnull Layer1Topology _layer1Topology;
+  private final @Nonnull Map<NodeInterfacePair, PhysicalInterface> _physicalInterfaces;
+  private final @Nonnull Map<NodeInterfacePair, L3Interface> _layer3Interfaces;
+
+  @SuppressWarnings("unused")
+  private final @Nonnull Map<String, EthernetHub> _ethernetHubs;
+
+  private final @Nonnull Map<String, DeviceBroadcastDomain> _deviceBroadcastDomains;
+
+  private static final EnumSet<InterfaceType> PHYSICAL_INTERFACE_TYPES =
+      EnumSet.of(InterfaceType.PHYSICAL, InterfaceType.AGGREGATED);
+  @VisibleForTesting static final String BATFISH_GLOBAL_HUB = "Batfish Global Ethernet Hub";
+
+  public L3AdjacencyComputer(Map<String, Configuration> configs, Layer1Topology layer1Topology) {
+    _layer1Topology = layer1Topology;
+    _physicalInterfaces = computePhysicalInterfaces(configs);
+    _ethernetHubs = computeEthernetHubs(configs, _physicalInterfaces, _layer1Topology);
+    _deviceBroadcastDomains = computeDeviceBroadcastDomains(configs, _physicalInterfaces);
+    _layer3Interfaces =
+        computeLayer3Interfaces(configs, _deviceBroadcastDomains, _physicalInterfaces);
+  }
+
+  private static Map<String, DeviceBroadcastDomain> computeDeviceBroadcastDomains(
+      Map<String, Configuration> configs,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces) {
+    ImmutableMap.Builder<String, DeviceBroadcastDomain> ret = ImmutableMap.builder();
+    for (Configuration c : configs.values()) {
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      ret.put(c.getHostname(), domain);
+      for (Interface i : c.getAllInterfaces().values()) {
+        connectL2InterfaceToBroadcastDomain(i, c.getAllInterfaces(), physicalInterfaces, domain);
+      }
+    }
+    return ret.build();
+  }
+
+  @VisibleForTesting
+  static void connectL2InterfaceToBroadcastDomain(
+      Interface i,
+      Map<String, Interface> allInterfaces,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces,
+      DeviceBroadcastDomain domain) {
+    NodeInterfacePair nip = NodeInterfacePair.of(i);
+    if (!i.getSwitchport()) {
+      LOGGER.debug("Skipping non-L2 interface {}: switchport is not set", nip);
+      return;
+    }
+
+    // Identify the physical interface corresponding to this L2 interface.
+    Optional<PhysicalInterface> maybeIface =
+        findCorrespondingPhysicalInterface(i, nip, allInterfaces, physicalInterfaces);
+    if (!maybeIface.isPresent()) {
+      // Already warned/logged inside the prior function.
+      return;
+    }
+    PhysicalInterface iface = maybeIface.get();
+    if (!iface.getIface().equals(nip)) {
+      // TODO: allow multiple L2 subinterfaces of a given physical interface
+      LOGGER.warn("Faking L2 connection for subinterface {} to parent {}", nip, iface.getIface());
+    }
+
+    // Connect physical interface to domain based on L2 config.
+    if (i.getSwitchportMode() == SwitchportMode.ACCESS) {
+      Integer vlan = i.getAccessVlan();
+      if (vlan == null) {
+        LOGGER.warn("Skipping L2 connection for {}: access mode vlan is missing", nip);
+        return;
+      }
+      Edges.connectInAccessMode(vlan, iface, domain);
+    } else if (i.getSwitchportMode() == SwitchportMode.TRUNK) {
+      Edges.connectTrunk(iface, domain, i.getAllowedVlans(), i.getNativeVlan());
+    } else {
+      LOGGER.warn("Surprised by L2 interface {}: unsure how to connect", nip);
+    }
+  }
+
+  /**
+   * Returns the {@link PhysicalInterface} corresponding to the given {@link Interface}, if one
+   * exists. This function returns a present {@link Optional} if {@code i} is a physical interface
+   * already, or if {@code i} is a correctly configured subinterface.
+   *
+   * <p>In other cases (virtual interface like Vlan, missing parent interface, etc.) the return
+   * value will be {@link Optional#empty()}.
+   */
+  @VisibleForTesting
+  static Optional<PhysicalInterface> findCorrespondingPhysicalInterface(
+      Interface i,
+      NodeInterfacePair nip,
+      Map<String, Interface> deviceInterfaces,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces) {
+    PhysicalInterface iface = physicalInterfaces.get(nip);
+    if (iface != null) {
+      return Optional.of(iface);
+    }
+    Optional<Dependency> parent =
+        i.getDependencies().stream().filter(d -> d.getType() == DependencyType.BIND).findFirst();
+    if (!parent.isPresent()) {
+      LOGGER.debug("No corresponding physical interface found for {}", nip);
+      return Optional.empty();
+    }
+    String parentName = parent.get().getInterfaceName();
+    NodeInterfacePair parentNip = NodeInterfacePair.of(nip.getHostname(), parentName);
+    if (!deviceInterfaces.containsKey(parentName)) {
+      LOGGER.warn("Subinterface {}: missing parent {}, skipping", nip, parentNip);
+      return Optional.empty();
+    }
+    iface = physicalInterfaces.get(parentNip);
+    if (iface == null) {
+      LOGGER.debug("Subinterface {}: parent {} has no physical interface", nip, parentNip);
+      return Optional.empty();
+    } else {
+      return Optional.of(iface);
+    }
+  }
+
+  private static Map<NodeInterfacePair, PhysicalInterface> computePhysicalInterfaces(
+      Map<String, Configuration> configs) {
+    ImmutableMap.Builder<NodeInterfacePair, PhysicalInterface> ret = ImmutableMap.builder();
+    for (Configuration c : configs.values()) {
+      for (Interface i : c.getAllInterfaces().values()) {
+        if (shouldCreatePhysicalInterface(i)) {
+          NodeInterfacePair nip = NodeInterfacePair.of(i);
+          ret.put(nip, new PhysicalInterface(nip));
+        }
+      }
+    }
+    return ret.build();
+  }
+
+  /**
+   * Returns whether this {@link Interface} should be modeled as a {@link PhysicalInterface}. Only
+   * active, interfaces that should be in the logical {@link Layer1Topology} are included --
+   * physical interfaces and aggregated interfaces.
+   */
+  @VisibleForTesting
+  static boolean shouldCreatePhysicalInterface(Interface i) {
+    if (!PHYSICAL_INTERFACE_TYPES.contains(i.getInterfaceType())) {
+      LOGGER.debug(
+          "Not creating physical interface {}: not a physical interface", NodeInterfacePair.of(i));
+      return false;
+    } else if (isAggregated(i)) {
+      LOGGER.debug(
+          "Not creating physical interface {}: physical interface but aggregated",
+          NodeInterfacePair.of(i));
+      return false;
+    } else if (!i.getActive()) {
+      LOGGER.debug("Not creating physical interface {}: not active", NodeInterfacePair.of(i));
+      return false;
+    }
+    return true;
+  }
+
+  private static Map<NodeInterfacePair, L3Interface> computeLayer3Interfaces(
+      Map<String, Configuration> configs,
+      Map<String, DeviceBroadcastDomain> deviceBroadcastDomains,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces) {
+    ImmutableMap.Builder<NodeInterfacePair, L3Interface> ret = ImmutableMap.builder();
+    for (Configuration c : configs.values()) {
+      for (Interface i : c.getAllInterfaces().values()) {
+        if (!shouldCreateL3Interface(i)) {
+          continue;
+        }
+        NodeInterfacePair nip = NodeInterfacePair.of(i);
+        L3Interface iface = new L3Interface(nip);
+        ret.put(nip, iface);
+        connectL3InterfaceToPhysicalOrDomain(
+            i, iface, c.getAllInterfaces(), physicalInterfaces, deviceBroadcastDomains);
+      }
+    }
+    return ret.build();
+  }
+
+  @VisibleForTesting
+  static boolean shouldCreateL3Interface(Interface i) {
+    NodeInterfacePair nip = NodeInterfacePair.of(i);
+    if (i.getAllAddresses().isEmpty()) {
+      LOGGER.debug("Not creating L3 interface {}: no addresses", nip);
+      return false;
+    } else if (!i.getActive()) {
+      LOGGER.debug("Not creating L3 interface {}: not active", nip);
+      return false;
+    } else if (i.getInterfaceType() == InterfaceType.LOOPBACK) {
+      LOGGER.debug("Skipping L3 interface {}: loopback", nip);
+      return false;
+    } else if (i.getSwitchport()) {
+      LOGGER.warn("Skipping L3 interface {}: has switchport set to true", nip);
+      return false;
+    }
+    LOGGER.debug("Created L3 interface for {} with addresses {}", nip, i.getAllAddresses());
+    return true;
+  }
+
+  @VisibleForTesting
+  static void connectL3InterfaceToPhysicalOrDomain(
+      Interface i,
+      L3Interface iface,
+      Map<String, Interface> deviceInterfaces,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces,
+      Map<String, DeviceBroadcastDomain> deviceBroadcastDomains) {
+    NodeInterfacePair nip = iface.getIface();
+    if (PHYSICAL_INTERFACE_TYPES.contains(i.getInterfaceType())) {
+      PhysicalInterface physIface = physicalInterfaces.get(nip);
+      if (physIface == null) {
+        LOGGER.warn("L3 interface {}: surprised not to find physical interface; skipping", nip);
+        return;
+      }
+      // This is a physical interface with an IP address. Either it has encapsulation or
+      // it sends out untagged.
+      if (i.getEncapsulationVlan() == null) {
+        LOGGER.debug("L3 interface {} connected to physical interface {} untagged", nip, nip);
+        Edges.connectL3Untagged(iface, physIface);
+        return;
+      } else {
+        LOGGER.debug(
+            "L3 interface {} connected to physical interface {} in vlan {}",
+            nip,
+            nip,
+            i.getEncapsulationVlan());
+        Edges.connectL3Dot1q(iface, physIface, i.getEncapsulationVlan());
+        return;
+      }
+    }
+
+    Optional<Dependency> parent =
+        i.getDependencies().stream().filter(d -> d.getType() == DependencyType.BIND).findFirst();
+    if (parent.isPresent()) {
+      String parentName = parent.get().getInterfaceName();
+      NodeInterfacePair parentNip = NodeInterfacePair.of(nip.getHostname(), parentName);
+      if (!deviceInterfaces.containsKey(parentName)) {
+        LOGGER.warn("Not connecting L3 interface {} to parent: {} not found", nip, parentNip);
+        return;
+      }
+      PhysicalInterface parentIface = physicalInterfaces.get(parentNip);
+      if (parentIface == null) {
+        LOGGER.warn(
+            "Not connecting L3 interface {} to parent {}: physical interface not found",
+            nip,
+            parentNip);
+        return;
+      } else if (i.getEncapsulationVlan() == null) {
+        LOGGER.warn(
+            "Not connecting L3 interface {} to parent {}: no encapsulation VLAN set",
+            nip,
+            parentNip);
+        return;
+      }
+      LOGGER.debug(
+          "Connecting L3 interface {} to physical interface {} in vlan {}",
+          nip,
+          parentNip,
+          i.getEncapsulationVlan());
+      Edges.connectL3Dot1q(iface, parentIface, i.getEncapsulationVlan());
+      return;
+    }
+
+    if (i.getInterfaceType() == InterfaceType.VLAN) {
+      Integer vlan = i.getVlan();
+      if (vlan == null) {
+        LOGGER.warn("Not connecting L3 interface {}: surprised vlan is not set", nip);
+        return;
+      }
+      DeviceBroadcastDomain domain = deviceBroadcastDomains.get(nip.getHostname());
+      if (domain == null) {
+        LOGGER.warn(
+            "Not connecting L3 interface {}: surprised not to find device broadcast domain", nip);
+        return;
+      }
+      LOGGER.debug(
+          "Connecting L3 interface {} to broadcast domain {} in vlan {}",
+          nip,
+          domain.getHostname(),
+          vlan);
+      Edges.connectIRB(iface, domain, vlan);
+      return;
+    }
+
+    LOGGER.warn("Surprised by L3 interface {}: unsure how to connect", nip);
+  }
+
+  @VisibleForTesting
+  static Map<String, EthernetHub> computeEthernetHubs(
+      Map<String, Configuration> configs,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces,
+      Layer1Topology layer1Topology) {
+    Set<NodeInterfacePair> physicalInterfacesMentionedInL1 =
+        layer1Topology.getGraph().nodes().stream()
+            .map(l1node -> NodeInterfacePair.of(l1node.getHostname(), l1node.getInterfaceName()))
+            .sorted() // sorted for determinism
+            .collect(ImmutableSet.toImmutableSet());
+
+    // Build the global hub if needed.
+    Set<NodeInterfacePair> interfacesAttachedToGlobalHub =
+        Sets.difference(physicalInterfaces.keySet(), physicalInterfacesMentionedInL1);
+    ImmutableMap.Builder<String, EthernetHub> ret = ImmutableMap.builder();
+    if (interfacesAttachedToGlobalHub.isEmpty()) {
+      LOGGER.debug("Not creating a global Ethernet hub: all physical interfaces have L1 edges");
+    } else {
+      LOGGER.debug(
+          "Creating a global Ethernet hub with {} physical interfaces",
+          interfacesAttachedToGlobalHub.size());
+      EthernetHub globalHub = new EthernetHub(BATFISH_GLOBAL_HUB);
+      Edges.connectToHub(
+          globalHub,
+          interfacesAttachedToGlobalHub.stream()
+              .filter(nip -> getInterface(nip, configs).getActive())
+              .map(physicalInterfaces::get)
+              .toArray(PhysicalInterface[]::new));
+      ret.put(globalHub.getId(), globalHub);
+    }
+
+    // Build an EthernetHub for every L1 cluster.
+    if (physicalInterfacesMentionedInL1.isEmpty()) {
+      LOGGER.debug("L1 topology is empty, so only the global hub exists");
+    } else {
+      UnionFind<NodeInterfacePair> clusters = new UnionFind<>(physicalInterfacesMentionedInL1);
+      for (Layer1Edge edge : layer1Topology.getGraph().edges()) {
+        NodeInterfacePair i1 =
+            NodeInterfacePair.of(edge.getNode1().getHostname(), edge.getNode1().getInterfaceName());
+        NodeInterfacePair i2 =
+            NodeInterfacePair.of(edge.getNode2().getHostname(), edge.getNode2().getInterfaceName());
+        if (physicalInterfaces.containsKey(i1) && physicalInterfaces.containsKey(i2)) {
+          // Only apply L1 edges where both interfaces exist.
+          clusters.union(i1, i2);
+        }
+      }
+      // Build up the set of interfaces attached to each hub. Note that since we are only looking
+      // at interfaces that exist in this snapshot, and we only applied edges that exist in this
+      // snapshot, we guarantee both the representative NodeInterfacePair and the elements in the
+      // group are actually in the snapshot.
+      Multimap<NodeInterfacePair, NodeInterfacePair> groups =
+          LinkedListMultimap.create(clusters.numberOfSets());
+      for (NodeInterfacePair nip :
+          Sets.intersection(physicalInterfaces.keySet(), physicalInterfacesMentionedInL1)) {
+        groups.put(clusters.find(nip), nip);
+      }
+      // Create one EthernetHub for each group.
+      groups
+          .asMap()
+          .forEach(
+              (id, nodes) -> {
+                EthernetHub hub = new EthernetHub("Hub for " + id);
+                PhysicalInterface[] interfaces = new PhysicalInterface[nodes.size()];
+                int i = 0;
+                for (NodeInterfacePair node : nodes) {
+                  PhysicalInterface pi = physicalInterfaces.get(node);
+                  assert pi != null;
+                  interfaces[i] = pi;
+                  ++i;
+                }
+                Edges.connectToHub(hub, interfaces);
+                ret.put(hub.getId(), hub);
+              });
+    }
+    return ret.build();
+  }
+
+  public Map<NodeInterfacePair, Integer> findAllBroadcastDomains() {
+    ImmutableMap.Builder<NodeInterfacePair, Integer> ret = ImmutableMap.builder();
+    TreeSet<NodeInterfacePair> unchecked = new TreeSet<>(_layer3Interfaces.keySet());
+    while (!unchecked.isEmpty()) {
+      Set<NodeInterfacePair> domain = findBroadcastDomain(unchecked.first());
+      int cur = unchecked.size();
+      domain.forEach(i -> ret.put(i, cur));
+      unchecked.removeAll(domain);
+    }
+    return ret.build();
+  }
+
+  private Set<NodeInterfacePair> findBroadcastDomain(NodeInterfacePair first) {
+    L3Interface originator = _layer3Interfaces.get(first);
+    Set<L3Interface> domain = new HashSet<>();
+    Set<NodeAndData<?, ?>> visited = new HashSet<>();
+    originator.originate(domain, visited);
+    return domain.stream().map(L3Interface::getIface).collect(ImmutableSet.toImmutableSet());
+  }
+
+  private static boolean isAggregated(Interface i) {
+    return i.getChannelGroup() != null;
+  }
+
+  private static Interface getInterface(NodeInterfacePair i, Map<String, Configuration> configs) {
+    return configs.get(i.getHostname()).getAllInterfaces().get(i.getInterface());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/L3Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/L3Interface.java
@@ -2,6 +2,7 @@ package org.batfish.common.topology.broadcast;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -76,6 +77,18 @@ public final class L3Interface extends Node<L3Interface.Unit> {
   private @Nullable Edge<Unit, EthernetTag> _sendToInterfaceEdge;
   private @Nullable DeviceBroadcastDomain _sendToSwitch;
   private @Nullable Edge<Unit, Integer> _sendToSwitchEdge;
+
+  @VisibleForTesting
+  @Nullable
+  PhysicalInterface getSendToInterfaceForTesting() {
+    return _sendToInterface;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  DeviceBroadcastDomain getSendToSwitchForTesting() {
+    return _sendToSwitch;
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/PhysicalInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/PhysicalInterface.java
@@ -3,6 +3,7 @@ package org.batfish.common.topology.broadcast;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -105,6 +106,21 @@ public final class PhysicalInterface extends Node<EthernetTag> {
   @Override
   public int hashCode() {
     return 31 * PhysicalInterface.class.hashCode() + _iface.hashCode();
+  }
+
+  @VisibleForTesting
+  EthernetHub getAttachedHubForTest() {
+    return _attachedHub;
+  }
+
+  @VisibleForTesting
+  Map<L3Interface, Edge<EthernetTag, Unit>> getL3InterfacesForTest() {
+    return _l3Interfaces;
+  }
+
+  @VisibleForTesting
+  DeviceBroadcastDomain getSwitchForTest() {
+    return _switch;
   }
 
   private final @Nonnull NodeInterfacePair _iface;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/broadcast/BroadcastL3AdjacenciesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/broadcast/BroadcastL3AdjacenciesTest.java
@@ -1,0 +1,101 @@
+package org.batfish.common.topology.broadcast;
+
+import static org.batfish.datamodel.InterfaceType.PHYSICAL;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import org.batfish.common.topology.Layer1Edge;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.vxlan.VxlanTopology;
+import org.junit.Test;
+
+public class BroadcastL3AdjacenciesTest {
+  /** A simple test that the code works end-to-end. */
+  @Test
+  public void testE2e() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c1 = nf.configurationBuilder().build();
+    Interface i1 =
+        nf.interfaceBuilder()
+            .setOwner(c1)
+            .setType(PHYSICAL)
+            .setActive(true)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.1/24"))
+            .build();
+    NodeInterfacePair n1 = NodeInterfacePair.of(i1);
+    Configuration c2 = nf.configurationBuilder().build();
+    Interface i2 =
+        nf.interfaceBuilder()
+            .setOwner(c2)
+            .setType(PHYSICAL)
+            .setActive(true)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.2/24"))
+            .build();
+    NodeInterfacePair n2 = NodeInterfacePair.of(i2);
+    Configuration c3 = nf.configurationBuilder().build();
+    Interface i3 =
+        nf.interfaceBuilder()
+            .setOwner(c3)
+            .setType(PHYSICAL)
+            .setActive(true)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.3/24"))
+            .build();
+    NodeInterfacePair n3 = NodeInterfacePair.of(i3);
+    {
+      // With no L1 topology, all 3 interfaces in same domain but not p2p domain.
+      BroadcastL3Adjacencies adjacencies =
+          BroadcastL3Adjacencies.create(
+              Layer1Topology.EMPTY,
+              VxlanTopology.EMPTY,
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3));
+      assertTrue(adjacencies.inSameBroadcastDomain(n1, n2));
+      assertTrue(adjacencies.inSameBroadcastDomain(n2, n1));
+      assertTrue(adjacencies.inSameBroadcastDomain(n2, n3));
+      assertTrue(adjacencies.inSameBroadcastDomain(n3, n1));
+      assertFalse(adjacencies.inSamePointToPointDomain(n1, n2));
+      assertFalse(adjacencies.inSamePointToPointDomain(n2, n3));
+      assertFalse(adjacencies.inSamePointToPointDomain(n3, n1));
+    }
+    {
+      // With L1 topology, only connected interfaces in same domain.
+      BroadcastL3Adjacencies adjacencies =
+          BroadcastL3Adjacencies.create(
+              new Layer1Topology(
+                  new Layer1Edge(
+                      n1.getHostname(), n1.getInterface(), n3.getHostname(), n3.getInterface())),
+              VxlanTopology.EMPTY,
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3));
+      assertTrue(adjacencies.inSameBroadcastDomain(n1, n3));
+      assertFalse(adjacencies.inSameBroadcastDomain(n2, n3));
+      assertFalse(adjacencies.inSameBroadcastDomain(n2, n1));
+      // TODO
+      //      assertTrue(adjacencies.inSamePointToPointDomain(n1, n3));
+      //      assertTrue(adjacencies.inSamePointToPointDomain(n3, n1));
+      assertFalse(adjacencies.inSamePointToPointDomain(n2, n3));
+      assertFalse(adjacencies.inSamePointToPointDomain(n1, n2));
+    }
+    {
+      // Encapsulation vlan honored, even with no L1.
+      i1.setEncapsulationVlan(4);
+      BroadcastL3Adjacencies adjacencies =
+          BroadcastL3Adjacencies.create(
+              Layer1Topology.EMPTY,
+              VxlanTopology.EMPTY,
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3));
+      assertTrue(adjacencies.inSameBroadcastDomain(n2, n3));
+      assertFalse(adjacencies.inSameBroadcastDomain(n1, n2));
+      assertFalse(adjacencies.inSameBroadcastDomain(n1, n3));
+      // TODO
+      //      assertTrue(adjacencies.inSamePointToPointDomain(n1, n3));
+      //      assertTrue(adjacencies.inSamePointToPointDomain(n3, n1));
+      assertFalse(adjacencies.inSamePointToPointDomain(n2, n3));
+      assertFalse(adjacencies.inSamePointToPointDomain(n1, n2));
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/broadcast/L3AdjacencyComputerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/broadcast/L3AdjacencyComputerTest.java
@@ -1,0 +1,779 @@
+package org.batfish.common.topology.broadcast;
+
+import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.BATFISH_GLOBAL_HUB;
+import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.computeEthernetHubs;
+import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.connectL2InterfaceToBroadcastDomain;
+import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.connectL3InterfaceToPhysicalOrDomain;
+import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.findCorrespondingPhysicalInterface;
+import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.shouldCreateL3Interface;
+import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.shouldCreatePhysicalInterface;
+import static org.batfish.datamodel.InterfaceType.LOGICAL;
+import static org.batfish.datamodel.InterfaceType.LOOPBACK;
+import static org.batfish.datamodel.InterfaceType.PHYSICAL;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.batfish.common.topology.Layer1Edge;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.Interface.DependencyType;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LinkLocalAddress;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.SwitchportMode;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.junit.Test;
+
+public class L3AdjacencyComputerTest {
+  private static final InterfaceAddress CONCRETE = ConcreteInterfaceAddress.parse("1.2.3.4/24");
+
+  private static Set<Dependency> dependsOn(Interface i) {
+    return ImmutableSet.of(new Dependency(i.getName(), DependencyType.BIND));
+  }
+
+  @Test
+  public void testFindCorrespondingPhysicalInterface_physical() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair nip = NodeInterfacePair.of(physical);
+    PhysicalInterface iface = new PhysicalInterface(nip);
+    // Correct
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            physical, nip, c.getAllInterfaces(), ImmutableMap.of(nip, iface)),
+        equalTo(Optional.of(iface)));
+    // Missing physical interface
+    assertThat(
+        findCorrespondingPhysicalInterface(physical, nip, c.getAllInterfaces(), ImmutableMap.of()),
+        equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testFindCorrespondingPhysicalInterface_subinterface() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair physicalNip = NodeInterfacePair.of(physical);
+    PhysicalInterface physicalIface = new PhysicalInterface(physicalNip);
+
+    // Correct
+    Interface subif =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(LOGICAL)
+            .setDependencies(dependsOn(physical))
+            .build();
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            subif,
+            NodeInterfacePair.of(subif),
+            c.getAllInterfaces(),
+            ImmutableMap.of(physicalNip, physicalIface)),
+        equalTo(Optional.of(physicalIface)));
+
+    // Dep not in configuration
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            subif,
+            NodeInterfacePair.of(subif),
+            ImmutableMap.of(subif.getName(), subif),
+            ImmutableMap.of()),
+        equalTo(Optional.empty()));
+    // Dep not a physical interface
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            subif, NodeInterfacePair.of(subif), c.getAllInterfaces(), ImmutableMap.of()),
+        equalTo(Optional.empty()));
+
+    // No deps
+    Interface subifNoDeps = nf.interfaceBuilder().setOwner(c).setType(LOGICAL).build();
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            subifNoDeps,
+            NodeInterfacePair.of(subifNoDeps),
+            c.getAllInterfaces(),
+            ImmutableMap.of(physicalNip, physicalIface)),
+        equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBroadcastDomain_l3() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface l3 =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setAddress(CONCRETE)
+            .setType(PHYSICAL)
+            .setSwitchport(false)
+            .setSwitchportMode(SwitchportMode.NONE)
+            .build();
+    NodeInterfacePair nip = NodeInterfacePair.of(l3);
+    DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+    PhysicalInterface iface = new PhysicalInterface(nip);
+
+    // Since L3 interface, no edges should be established.
+    connectL2InterfaceToBroadcastDomain(
+        l3, c.getAllInterfaces(), ImmutableMap.of(nip, iface), domain);
+    assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+    assertThat(iface.getAttachedHubForTest(), nullValue());
+    assertThat(iface.getSwitchForTest(), nullValue());
+    assertThat(iface.getL3InterfacesForTest(), anEmptyMap());
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBroadcastDomain_access() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface access =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(PHYSICAL)
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.ACCESS)
+            .setAccessVlan(3)
+            .build();
+    NodeInterfacePair nip = NodeInterfacePair.of(access);
+
+    {
+      // Access should be attached
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      PhysicalInterface iface = new PhysicalInterface(nip);
+      connectL2InterfaceToBroadcastDomain(
+          access, c.getAllInterfaces(), ImmutableMap.of(nip, iface), domain);
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(domain.getPhysicalInterfacesForTest().keySet(), contains(sameInstance(iface)));
+      assertThat(iface.getAttachedHubForTest(), nullValue());
+      assertThat(iface.getSwitchForTest(), sameInstance(domain));
+      assertThat(iface.getL3InterfacesForTest(), anEmptyMap());
+    }
+
+    {
+      // Missing access vlan should be no results
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      PhysicalInterface iface = new PhysicalInterface(nip);
+      access.setAccessVlan(null);
+      connectL2InterfaceToBroadcastDomain(
+          access, c.getAllInterfaces(), ImmutableMap.of(nip, iface), domain);
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(iface.getAttachedHubForTest(), nullValue());
+      assertThat(iface.getSwitchForTest(), nullValue());
+      assertThat(iface.getL3InterfacesForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBroadcastDomain_trunk() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface trunk =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(PHYSICAL)
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.TRUNK)
+            .setAllowedVlans(IntegerSpace.of(3))
+            .setNativeVlan(3)
+            .build();
+    NodeInterfacePair nip = NodeInterfacePair.of(trunk);
+
+    // Trunk should be attached
+    DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+    PhysicalInterface iface = new PhysicalInterface(nip);
+    connectL2InterfaceToBroadcastDomain(
+        trunk, c.getAllInterfaces(), ImmutableMap.of(nip, iface), domain);
+    assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    assertThat(domain.getPhysicalInterfacesForTest().keySet(), contains(sameInstance(iface)));
+    assertThat(iface.getAttachedHubForTest(), nullValue());
+    assertThat(iface.getSwitchForTest(), sameInstance(domain));
+    assertThat(iface.getL3InterfacesForTest(), anEmptyMap());
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBroadcastDomain_subif_access() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    Interface subif =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(LOGICAL)
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.ACCESS)
+            .setDependencies(dependsOn(physical))
+            .setAccessVlan(3)
+            .build();
+    NodeInterfacePair physicalNip = NodeInterfacePair.of(physical);
+
+    {
+      // Should be attached to physical iface
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      PhysicalInterface iface = new PhysicalInterface(physicalNip);
+      connectL2InterfaceToBroadcastDomain(
+          subif, c.getAllInterfaces(), ImmutableMap.of(physicalNip, iface), domain);
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(domain.getPhysicalInterfacesForTest().keySet(), contains(sameInstance(iface)));
+      assertThat(iface.getAttachedHubForTest(), nullValue());
+      assertThat(iface.getSwitchForTest(), sameInstance(domain));
+      assertThat(iface.getL3InterfacesForTest(), anEmptyMap());
+    }
+    {
+      // Clear the dependency, should find nothing
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      PhysicalInterface iface = new PhysicalInterface(physicalNip);
+      subif.setDependencies(ImmutableSet.of());
+      connectL2InterfaceToBroadcastDomain(
+          subif, c.getAllInterfaces(), ImmutableMap.of(physicalNip, iface), domain);
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(iface.getAttachedHubForTest(), nullValue());
+      assertThat(iface.getSwitchForTest(), nullValue());
+      assertThat(iface.getL3InterfacesForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBroadcastDomain_unknown_mode() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface unhandledMode =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(PHYSICAL)
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.MONITOR)
+            .build();
+    NodeInterfacePair nip = NodeInterfacePair.of(unhandledMode);
+
+    DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+    PhysicalInterface iface = new PhysicalInterface(nip);
+    connectL2InterfaceToBroadcastDomain(
+        unhandledMode, c.getAllInterfaces(), ImmutableMap.of(nip, iface), domain);
+    assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+    assertThat(iface.getAttachedHubForTest(), nullValue());
+    assertThat(iface.getSwitchForTest(), nullValue());
+    assertThat(iface.getL3InterfacesForTest(), anEmptyMap());
+  }
+
+  @Test
+  public void testShouldCreatePhysicalInterface() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    assertTrue(
+        "physical should be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).setActive(true).build()));
+    assertFalse(
+        "physical but shutdown should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).setActive(false).build()));
+    assertFalse(
+        "physical, active but aggregated should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setChannelGroup("Port-Channel1")
+                .setActive(true)
+                .build()));
+    assertFalse(
+        "logical should not be created",
+        shouldCreatePhysicalInterface(nf.interfaceBuilder().setOwner(c).setType(LOGICAL).build()));
+    assertFalse(
+        "vlan should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder().setOwner(c).setType(InterfaceType.VLAN).setActive(true).build()));
+    assertTrue(
+        "aggregate,active should be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(InterfaceType.AGGREGATED)
+                .setActive(true)
+                .build()));
+    assertFalse(
+        "aggregate but shutdown should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(InterfaceType.AGGREGATED)
+                .setActive(false)
+                .build()));
+    assertFalse(
+        "aggregate child should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(InterfaceType.AGGREGATE_CHILD)
+                .setActive(true)
+                .build()));
+  }
+
+  @Test
+  public void testShouldCreateL3Interface() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    assertTrue(
+        "l3 should be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(false)
+                .setAddress(CONCRETE)
+                .setActive(true)
+                .build()));
+    assertTrue(
+        "l3 with LLA should be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(false)
+                .setAddress(LinkLocalAddress.of(Ip.parse("169.254.0.1")))
+                .setActive(true)
+                .build()));
+    assertFalse(
+        "l3 with no addresses should not be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(false)
+                .setActive(true)
+                .build()));
+    assertFalse(
+        "l3 shutdown should not be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(false)
+                .setAddress(CONCRETE)
+                .setActive(false)
+                .build()));
+    assertFalse(
+        "l3 loopback should not be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(LOOPBACK)
+                .setSwitchport(false)
+                .setAddress(CONCRETE)
+                .setActive(true)
+                .build()));
+    assertFalse(
+        "l3 in weird l3/switchport mode should not be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(true)
+                .setSwitchportMode(SwitchportMode.ACCESS)
+                .setAddress(CONCRETE)
+                .setActive(true)
+                .build()));
+  }
+
+  @Test
+  public void testConnectL3InterfaceToPhysicalOrDomain_physical() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical =
+        nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).setAddress(CONCRETE).build();
+    {
+      // Connect to physical interface and not domain
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(physical));
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          physical,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(physicalInterface.getIface(), physicalInterface),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), sameInstance(physicalInterface));
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(physicalInterface.getL3InterfacesForTest().keySet(), contains(iface));
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    }
+    {
+      // Missing physical interface
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(physical));
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          physical,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(physicalInterface.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL3InterfaceToPhysicalOrDomain_subif() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    Interface subif =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(LOGICAL)
+            .setAddress(CONCRETE)
+            .setDependencies(dependsOn(physical))
+            .setEncapsulationVlan(3)
+            .build();
+    {
+      // Connect to physical interface and not domain
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(subif));
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          subif,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(physicalInterface.getIface(), physicalInterface),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), sameInstance(physicalInterface));
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(physicalInterface.getL3InterfacesForTest().keySet(), contains(iface));
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    }
+    {
+      // Parent is missing on config
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(subif));
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          subif,
+          iface,
+          ImmutableMap.of(),
+          ImmutableMap.of(physicalInterface.getIface(), physicalInterface),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(physicalInterface.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    }
+    {
+      // Parent is missing PhysicalInterface
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(subif));
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          subif,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(physicalInterface.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    }
+    {
+      // Subif is missing encapsulation vlan
+      subif.setEncapsulationVlan(null);
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(subif));
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          subif,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(physicalInterface.getIface(), physicalInterface),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(physicalInterface.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL3InterfaceToPhysicalOrDomain_vlan() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface vlan =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(InterfaceType.VLAN)
+            .setAddress(CONCRETE)
+            .setVlan(4)
+            .build();
+    {
+      // Connect to domain and not physical interface
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(vlan));
+      // Should not create physical iface for VLAN, but ensure the connection doesn't happen anyway.
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(vlan));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          vlan,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(physicalInterface.getIface(), physicalInterface),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToSwitchForTesting(), sameInstance(domain));
+      assertThat(physicalInterface.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest().keySet(), contains(iface));
+    }
+    {
+      // Missing domain
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(vlan));
+      // Should not create physical iface for VLAN, but ensure the connection doesn't happen anyway.
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(vlan));
+      connectL3InterfaceToPhysicalOrDomain(
+          vlan,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(physicalInterface.getIface(), physicalInterface),
+          ImmutableMap.of());
+      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(physicalInterface.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+    }
+    {
+      // Missing VLAN
+      vlan.setVlan(null);
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(vlan));
+      // Should not create physical iface for VLAN, but ensure the connection doesn't happen anyway.
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(vlan));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          vlan,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(physicalInterface.getIface(), physicalInterface),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(physicalInterface.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(physicalInterface.getSwitchForTest(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL3InterfaceToPhysicalOrDomain_unknown() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface loopback =
+        nf.interfaceBuilder().setOwner(c).setType(LOOPBACK).setAddress(CONCRETE).build();
+    {
+      // Loopback should be filtered out ahead of time, but if it makes it here
+      // then there should still be no issues.
+      L3Interface iface = new L3Interface(NodeInterfacePair.of(loopback));
+      DeviceBroadcastDomain domain = new DeviceBroadcastDomain(c.getHostname());
+      connectL3InterfaceToPhysicalOrDomain(
+          loopback,
+          iface,
+          c.getAllInterfaces(),
+          ImmutableMap.of(),
+          ImmutableMap.of(domain.getHostname(), domain));
+      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToSwitchForTesting(), nullValue());
+      assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
+      assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
+    }
+  }
+
+  private static Map<NodeInterfacePair, PhysicalInterface> makePhysicalMap(
+      Interface... interfaces) {
+    return Arrays.stream(interfaces)
+        .map(NodeInterfacePair::of)
+        .collect(ImmutableMap.toImmutableMap(nip -> nip, PhysicalInterface::new));
+  }
+
+  private static Set<NodeInterfacePair> getPairs(Collection<PhysicalInterface> interfaces) {
+    return interfaces.stream()
+        .map(PhysicalInterface::getIface)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Test
+  public void testComputeEthernetHubs() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface i1 = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair n1 = NodeInterfacePair.of(i1);
+    Interface i2 = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair n2 = NodeInterfacePair.of(i2);
+    Interface i3 = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair n3 = NodeInterfacePair.of(i3);
+    {
+      // No l1 topology.
+      Map<NodeInterfacePair, PhysicalInterface> physical = makePhysicalMap(i1, i2, i3);
+      Map<String, EthernetHub> hubs =
+          computeEthernetHubs(ImmutableMap.of(c.getHostname(), c), physical, Layer1Topology.EMPTY);
+      assertThat(hubs.keySet(), contains(BATFISH_GLOBAL_HUB));
+      assertThat(
+          getPairs(hubs.get(BATFISH_GLOBAL_HUB).getAttachedInterfacesForTesting().keySet()),
+          containsInAnyOrder(n1, n2, n3));
+    }
+    {
+      // One edge.
+      Map<String, EthernetHub> hubs =
+          computeEthernetHubs(
+              ImmutableMap.of(c.getHostname(), c),
+              makePhysicalMap(i1, i2, i3),
+              new Layer1Topology(
+                  ImmutableSet.of(
+                      new Layer1Edge(
+                          c.getHostname(), i1.getName(), c.getHostname(), i2.getName()))));
+      assertThat(hubs, aMapWithSize(2));
+      String otherKey =
+          Iterables.getOnlyElement(
+              Sets.difference(hubs.keySet(), ImmutableSet.of(BATFISH_GLOBAL_HUB)));
+      assertThat(
+          getPairs(hubs.get(BATFISH_GLOBAL_HUB).getAttachedInterfacesForTesting().keySet()),
+          contains(n3));
+      assertThat(
+          getPairs(hubs.get(otherKey).getAttachedInterfacesForTesting().keySet()),
+          containsInAnyOrder(n1, n2));
+    }
+    {
+      // Line.
+      Map<String, EthernetHub> hubs =
+          computeEthernetHubs(
+              ImmutableMap.of(c.getHostname(), c),
+              makePhysicalMap(i1, i2, i3),
+              new Layer1Topology(
+                  ImmutableSet.of(
+                      new Layer1Edge(c.getHostname(), i1.getName(), c.getHostname(), i2.getName()),
+                      new Layer1Edge(
+                          c.getHostname(), i3.getName(), c.getHostname(), i2.getName()))));
+      assertThat(hubs, aMapWithSize(1));
+      assertThat(
+          getPairs(
+              Iterables.getOnlyElement(hubs.values()).getAttachedInterfacesForTesting().keySet()),
+          containsInAnyOrder(n1, n2, n3));
+    }
+  }
+
+  /** A simple test that the code works end-to-end. */
+  @Test
+  public void testE2e() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c1 = nf.configurationBuilder().build();
+    Interface i1 =
+        nf.interfaceBuilder()
+            .setOwner(c1)
+            .setType(PHYSICAL)
+            .setActive(true)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.1/24"))
+            .build();
+    NodeInterfacePair n1 = NodeInterfacePair.of(i1);
+    Configuration c2 = nf.configurationBuilder().build();
+    Interface i2 =
+        nf.interfaceBuilder()
+            .setOwner(c2)
+            .setType(PHYSICAL)
+            .setActive(true)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.2/24"))
+            .build();
+    NodeInterfacePair n2 = NodeInterfacePair.of(i2);
+    Configuration c3 = nf.configurationBuilder().build();
+    Interface i3 =
+        nf.interfaceBuilder()
+            .setOwner(c3)
+            .setType(PHYSICAL)
+            .setActive(true)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.3/24"))
+            .build();
+    NodeInterfacePair n3 = NodeInterfacePair.of(i3);
+    {
+      // With no L1 topology, all 3 interfaces in same domain.
+      L3AdjacencyComputer l3 =
+          new L3AdjacencyComputer(
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3),
+              Layer1Topology.EMPTY);
+      Map<NodeInterfacePair, Integer> domains = l3.findAllBroadcastDomains();
+      assertThat("all interfaces have a domain", domains, aMapWithSize(3));
+      assertThat(
+          "all interfaces in same domain", ImmutableSet.copyOf(domains.values()), hasSize(1));
+    }
+    {
+      // With L1 topology, only connected interfaces in same domain.
+      L3AdjacencyComputer l3 =
+          new L3AdjacencyComputer(
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3),
+              new Layer1Topology(
+                  new Layer1Edge(
+                      n1.getHostname(), n1.getInterface(), n3.getHostname(), n3.getInterface())));
+      Map<NodeInterfacePair, Integer> domains = l3.findAllBroadcastDomains();
+      assertThat("all interfaces have a domain", domains, aMapWithSize(3));
+      assertThat("connected ifaces in same domain", domains.get(n1), equalTo(domains.get(n3)));
+      assertThat(
+          "global hub not connected to other interfaces",
+          domains.get(n2),
+          not(equalTo(domains.get(n1))));
+    }
+    {
+      // Encapsulation vlan honored, even with no L1.
+      i1.setEncapsulationVlan(4);
+      L3AdjacencyComputer l3 =
+          new L3AdjacencyComputer(
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3),
+              Layer1Topology.EMPTY);
+      Map<NodeInterfacePair, Integer> domains = l3.findAllBroadcastDomains();
+      assertThat("all interfaces have a domain", domains, aMapWithSize(3));
+      assertThat(
+          "unencapsulated interface in same domain", domains.get(n2), equalTo(domains.get(n3)));
+      assertThat(
+          "encapsulated interface not connected to unencapsulated interfaces",
+          domains.get(n2),
+          not(equalTo(domains.get(n1))));
+    }
+  }
+}


### PR DESCRIPTION
An L3Adjacencies implementation that models all interfaces' L1, L2, L3
configuration. This differs from `GlobalBroadcastNoPointToPoint` in that
interfaces with incompatible L2 configuration are not considered connected.

This differs from `HybridL3Adjacencies` in that it models every interface as
being connected to some Ethernet hub, whether or not it appears in the L1
topology. By using a flood-fill-style algorithm, performance is also greatly
improved.

This algorithm is not yet plumbed into any accessible path, as it cannot handle
all networks.

* Does not handle VxLAN or multiple L2 subinterfaces yet