### PR TITLE
nxos: improve todo warnings for route tracking

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_static.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_static.g4
@@ -26,9 +26,7 @@ ip_route_network
   (
     VRF nhvrf = vrf_name
   )?
-  (
-    TRACK track = track_object_id
-  )?
+  ip_route_network_track?
   (
     NAME name = static_route_name
   )?
@@ -36,6 +34,11 @@ ip_route_network
     (TAG tag = uint32) pref = protocol_distance?
     | pref = protocol_distance (TAG tag = uint32)?
   )? NEWLINE
+;
+
+ip_route_network_track
+:
+    TRACK track = track_object_id
 ;
 
 static_route_name

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_static.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_static.g4
@@ -36,10 +36,7 @@ ip_route_network
   )? NEWLINE
 ;
 
-ip_route_network_track
-:
-    TRACK track = track_object_id
-;
+ip_route_network_track: TRACK track = track_object_id;
 
 static_route_name
 :

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -5915,7 +5915,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       Integer trackNumber = track.get();
       if (!_c.getTracks().containsKey(trackNumber)) {
         warn(
-            track_ctx,
+            ctx,
             String.format(
                 "Cannot reference undefined track %s. This line will be ignored.", trackNumber));
         _c.undefined(

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -2077,7 +2077,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     if (ctx.decrement != null) {
       Optional<Integer> decrementOrErr =
           toIntegerInSpace(
-              ctx, ctx.decrement, HSRP_TRACK_DECREMENT_RANGE, "hspr group track decrement");
+              ctx, ctx.decrement, HSRP_TRACK_DECREMENT_RANGE, "hsrp group track decrement");
       if (!decrementOrErr.isPresent()) {
         return;
       }
@@ -5906,33 +5906,34 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     if (ctx.tag != null) {
       builder.setTag(toLong(ctx.tag));
     }
-    if (ctx.track != null) {
-      Optional<Integer> track = toInteger(ctx, ctx.track);
+    CiscoNxosParser.Ip_route_network_trackContext track_ctx = ctx.ip_route_network_track();
+    if (track_ctx != null) {
+      Optional<Integer> track = toInteger(track_ctx, track_ctx.track);
       if (!track.isPresent()) {
         return;
       }
       Integer trackNumber = track.get();
       if (!_c.getTracks().containsKey(trackNumber)) {
         warn(
-            ctx,
+            track_ctx,
             String.format(
                 "Cannot reference undefined track %s. This line will be ignored.", trackNumber));
         _c.undefined(
             CiscoNxosStructureType.TRACK,
             trackNumber.toString(),
             CiscoNxosStructureUsage.IP_ROUTE_TRACK,
-            ctx.start.getLine());
+            track_ctx.start.getLine());
         return;
       }
       _c.referenceStructure(
           CiscoNxosStructureType.TRACK,
           trackNumber.toString(),
           CiscoNxosStructureUsage.IP_ROUTE_TRACK,
-          ctx.start.getLine());
+          track_ctx.start.getLine());
 
       builder.setTrack(trackNumber);
       // TODO: support track object number
-      todo(ctx);
+      todo(track_ctx);
     }
     StaticRoute route = builder.build();
     _currentVrf.getStaticRoutes().put(route.getPrefix(), route);


### PR DESCRIPTION
We don't yet support NXOS route tracking, and warn when it is configured. Previously the warning generated was for the entire ip_route_network rule. Now it's specific to the `track` option.