### PR TITLE
NX-OS: fix bandwidth parsing

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -75,12 +75,18 @@ i_bandwidth
   ) NEWLINE
 ;
 
+interface_bandwidth_eigrp_kbps
+:
+// 1-2560000000, units are kbps (for effective range of 1kbps-2.56Tbps)
+  uint32
+;
+
 interface_bandwidth_kbps
 :
-// 1-100000000, units are kbps (for effective range of 1kbps-100Gbps)
-  UINT8
-  | UINT16
-  | UINT32
+// 1-100000000, units are kbps (for effective range of 1kbps-100Gbps) for physical interfaces.
+// 1-3200000000, units are kbps (for effective range of 1kbps-3.2Tbps) for port-channels,
+//               which can bundle 32 physical interfaces
+  uint32
 ;
 
 i_channel_group
@@ -463,8 +469,7 @@ i_ip_address_concrete
 
 i_ip_bandwidth
 :
-  // bandwidth 1 - 2,560,000,000 kb/s
-  BANDWIDTH EIGRP router_eigrp_process_tag bw = interface_bandwidth_kbps NEWLINE
+  BANDWIDTH EIGRP router_eigrp_process_tag bw = interface_bandwidth_eigrp_kbps NEWLINE
 ;
 
 i_ip_delay

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -403,6 +403,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inos_accessContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inos_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.InoshutContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_addressContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_bandwidth_eigrp_kbpsContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_bandwidth_kbpsContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_descriptionContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_ipv6_addressContext;
@@ -860,7 +861,11 @@ import org.batfish.representation.cisco_nxos.VrfAddressFamily;
 public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseListener
     implements SilentSyntaxListener {
 
-  private static final IntegerSpace BANDWIDTH_RANGE = IntegerSpace.of(Range.closed(1, 100_000_000));
+  private static final LongSpace BANDWIDTH_RANGE = LongSpace.of(Range.closed(1L, 100_000_000L));
+  private static final LongSpace BANDWIDTH_EIGRP_RANGE =
+      LongSpace.of(Range.closed(1L, 2_560_000_000L));
+  private static final LongSpace BANDWIDTH_PORT_CHANNEL_RANGE =
+      LongSpace.of(Range.closed(1L, 3_200_000_000L));
   private static final IntegerSpace BGP_ALLOWAS_IN = IntegerSpace.of(Range.closed(1, 10));
   private static final LongSpace BGP_ASN_RANGE = LongSpace.of(Range.closed(1L, 4294967295L));
   private static final IntegerSpace BGP_EBGP_MULTIHOP_TTL_RANGE =
@@ -5402,11 +5407,12 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   @Override
   public void exitI_bandwidth(I_bandwidthContext ctx) {
     if (ctx.bw != null) {
-      Integer bandwidth = toBandwidth(ctx, ctx.bw);
-      if (bandwidth == null) {
-        return;
-      }
-      _currentInterfaces.forEach(iface -> iface.setBandwidth(bandwidth));
+      boolean hasPortChannel =
+          _currentInterfaces.stream()
+              .anyMatch(i -> i.getType() == CiscoNxosInterfaceType.PORT_CHANNEL);
+      Optional<Long> bandwidth =
+          hasPortChannel ? toPortChannelBandwidth(ctx, ctx.bw) : toBandwidth(ctx, ctx.bw);
+      bandwidth.ifPresent(bw -> _currentInterfaces.forEach(iface -> iface.setBandwidth(bw)));
     }
     if (ctx.inherit != null) {
       // TODO: support bandwidth inherit
@@ -5527,8 +5533,8 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
 
   @Override
   public void exitI_ip_bandwidth(I_ip_bandwidthContext ctx) {
-    Integer bandwidth = toBandwidth(ctx, ctx.bw);
-    _currentInterfaces.forEach(iface -> iface.setEigrpBandwidth(bandwidth));
+    toBandwidthEigrp(ctx, ctx.bw)
+        .ifPresent(bw -> _currentInterfaces.forEach(iface -> iface.setEigrpBandwidth(bw)));
   }
 
   @Override
@@ -6699,17 +6705,19 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     _currentVlans.forEach(v -> v.setVni(vni));
   }
 
-  private @Nullable Integer toBandwidth(
+  private @Nonnull Optional<Long> toBandwidthEigrp(
+      ParserRuleContext messageCtx, Interface_bandwidth_eigrp_kbpsContext ctx) {
+    return toLongInSpace(messageCtx, ctx, BANDWIDTH_EIGRP_RANGE, "bandwidth eigrp");
+  }
+
+  private @Nonnull Optional<Long> toBandwidth(
       ParserRuleContext messageCtx, Interface_bandwidth_kbpsContext ctx) {
-    int bandwidth = Integer.parseInt(ctx.getText());
-    if (!BANDWIDTH_RANGE.contains(bandwidth)) {
-      warn(
-          messageCtx,
-          String.format(
-              "Expected bandwidth in range %s, but got '%d'", BANDWIDTH_RANGE, bandwidth));
-      return null;
-    }
-    return bandwidth;
+    return toLongInSpace(messageCtx, ctx, BANDWIDTH_RANGE, "bandwidth");
+  }
+
+  private Optional<Long> toPortChannelBandwidth(
+      ParserRuleContext messageCtx, Interface_bandwidth_kbpsContext ctx) {
+    return toLongInSpace(messageCtx, ctx, BANDWIDTH_PORT_CHANNEL_RANGE, "bandwidth");
   }
 
   private @Nonnull Optional<Integer> toInteger(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -2000,7 +2000,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       speed = getDefaultSpeed(type);
     }
     newIfaceBuilder.setSpeed(speed);
-    Integer nxosBandwidth = iface.getBandwidth();
+    Long nxosBandwidth = iface.getBandwidth();
     Double finalBandwidth;
     if (nxosBandwidth != null) {
       finalBandwidth = nxosBandwidth * BANDWIDTH_CONVERSION_FACTOR;
@@ -2217,12 +2217,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   @Nonnull
   private EigrpMetric computeEigrpMetricForInterface(Interface iface) {
     // configuredBw is in kb/s
-    Integer configuredBw =
-        Optional.ofNullable(iface.getEigrpBandwidth()).orElse(iface.getBandwidth());
-    Long bw = null;
-    if (configuredBw != null) {
-      bw = configuredBw.longValue();
-    } else {
+    Long bw = Optional.ofNullable(iface.getEigrpBandwidth()).orElse(iface.getBandwidth());
+    if (bw == null) {
       Double defaultBw = getDefaultBandwidth(iface.getType());
       if (defaultBw != null) {
         // default bandwidth is in bits per second

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
@@ -143,14 +143,14 @@ public final class Interface implements Serializable {
   private @Nullable InterfaceAddressWithAttributes _address;
   private @Nullable IntegerSpace _allowedVlans;
   private boolean _autostate;
-  private @Nullable Integer _bandwidth;
+  private @Nullable Long _bandwidth;
   private @Nullable String _channelGroup;
   private final @Nonnull Set<String> _declaredNames;
   private @Nullable Integer _delayTensOfMicroseconds;
   private @Nullable String _description;
   private final @Nonnull SortedSet<Ip> _dhcpRelayAddresses;
   private @Nullable String _eigrp;
-  private @Nullable Integer _eigrpBandwidth;
+  private @Nullable Long _eigrpBandwidth;
   private @Nullable Integer _eigrpDelay;
   private boolean _eigrpPassive;
   private @Nullable DistributeList _eigrpInboundDistributeList;
@@ -221,7 +221,7 @@ public final class Interface implements Serializable {
   }
 
   /** Bandwidth in kbits */
-  public @Nullable Integer getBandwidth() {
+  public @Nullable Long getBandwidth() {
     return _bandwidth;
   }
 
@@ -254,7 +254,7 @@ public final class Interface implements Serializable {
   }
 
   /** Configured bandwidth for EIGRP, in kb/s */
-  public @Nullable Integer getEigrpBandwidth() {
+  public @Nullable Long getEigrpBandwidth() {
     return _eigrpBandwidth;
   }
 
@@ -476,7 +476,7 @@ public final class Interface implements Serializable {
     _autostate = autostate;
   }
 
-  public void setBandwidth(@Nullable Integer bandwidth) {
+  public void setBandwidth(@Nullable Long bandwidth) {
     _bandwidth = bandwidth;
   }
 
@@ -492,7 +492,7 @@ public final class Interface implements Serializable {
     _description = description;
   }
 
-  public void setEigrpBandwidth(@Nullable Integer eigrpBandwidth) {
+  public void setEigrpBandwidth(@Nullable Long eigrpBandwidth) {
     _eigrpBandwidth = eigrpBandwidth;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -3032,8 +3032,10 @@ public final class CiscoNxosGrammarTest {
 
   @Test
   public void testInterfacePortChannelParsing() {
-    // TODO: change to extraction test
-    assertThat(parseVendorConfig("nxos_interface_port_channel"), notNullValue());
+    CiscoNxosConfiguration c = parseVendorConfig("nxos_interface_port_channel");
+    assertThat(c.getInterfaces().keySet(), contains("port-channel1"));
+    Interface pc1 = c.getInterfaces().get("port-channel1");
+    assertThat(pc1.getBandwidth(), equalTo(3_200_000_000L));
   }
 
   /**
@@ -8551,7 +8553,7 @@ public final class CiscoNxosGrammarTest {
       // Interface with custom EIGRP BW, delay, passive-interface
       Interface iface = vc.getInterfaces().get("Ethernet1/1");
       assertThat(iface.getEigrp(), equalTo("1"));
-      assertThat(iface.getEigrpBandwidth(), equalTo(300));
+      assertThat(iface.getEigrpBandwidth(), equalTo(2560000000L));
       assertThat(iface.getEigrpDelay(), equalTo(400));
       assertTrue(iface.getEigrpPassive());
     }
@@ -8575,7 +8577,7 @@ public final class CiscoNxosGrammarTest {
         vrf member VRF
         ip address 192.0.2.2/24
         ip router eigrp 1
-        ip bandwidth eigrp 1 300
+        ip bandwidth eigrp 1 2560000000
         ip delay eigrp 1 400
         ip hold-time eigrp 1 100
         ip hello-interval eigrp 1 200
@@ -8587,7 +8589,7 @@ public final class CiscoNxosGrammarTest {
           iface.getBandwidth(), equalTo(getDefaultBandwidth(CiscoNxosInterfaceType.ETHERNET)));
       EigrpInterfaceSettings eigrp = iface.getEigrp();
       assertNotNull(eigrp);
-      assertThat(eigrp.getMetric().getValues().getBandwidth(), equalTo(300L));
+      assertThat(eigrp.getMetric().getValues().getBandwidth(), equalTo(2560000000L));
       // EIGRP metric values have delay in ps (1e-12); config has it in tens of µs (1e-5)
       assertThat(eigrp.getMetric().getValues().getDelay(), equalTo((long) (400 * 1e7)));
       assertTrue(eigrp.getPassive());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_eigrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_eigrp
@@ -20,7 +20,7 @@ interface Ethernet1/1
   vrf member VRF
   ip address 192.0.2.2/24
   ip router eigrp 1
-  ip bandwidth eigrp 1 300
+  ip bandwidth eigrp 1 2560000000
   ip delay eigrp 1 400
   ip eigrp 1 bfd
   ip eigrp 1 bfd disable

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_port_channel
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_port_channel
@@ -6,4 +6,5 @@ feature lacp
 !
 interface port-channel1
   lacp suspend-individual
+  bandwidth 3200000000
 !


### PR DESCRIPTION
1. Bandwidth can exceed int32_max, even though it is in kbps.
2. Physical interfaces and port-channel interfaces have different maximum bandwidths.
3. Fix EIGRP bandwidth parsing as well.

and tests.