### PR TITLE
FilterLineReachability: Factor out answering logic

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -64,18 +64,24 @@ public class FilterLineReachabilityAnswerer extends Answerer {
   @Override
   public TableAnswerElement answer(NetworkSnapshot snapshot) {
     FilterLineReachabilityQuestion question = (FilterLineReachabilityQuestion) _question;
-    FilterLineReachabilityRows answerRows = new FilterLineReachabilityRows();
-
     SpecifierContext ctxt = _batfish.specifierContext(snapshot);
-
     Map<String, Set<IpAccessList>> specifiedAcls = getSpecifiedFilters(question, ctxt);
-
     SortedMap<String, Configuration> configurations = _batfish.loadConfigurations(snapshot);
-    List<AclSpecs> aclSpecs = getAclSpecs(configurations, specifiedAcls, answerRows);
-    answerAclReachability(aclSpecs, answerRows);
+
+    FilterLineReachabilityRows answerRows = computeAnswer(configurations, specifiedAcls);
+
     TableAnswerElement answer = new TableAnswerElement(createMetadata(question));
     answer.postProcessAnswer(question, answerRows.getRows());
     return answer;
+  }
+
+  public FilterLineReachabilityRows computeAnswer(
+      SortedMap<String, Configuration> configurations,
+      Map<String, Set<IpAccessList>> specifiedAcls) {
+    FilterLineReachabilityRows answerRows = new FilterLineReachabilityRows();
+    List<AclSpecs> aclSpecs = getAclSpecs(configurations, specifiedAcls, answerRows);
+    answerAclReachability(aclSpecs, answerRows);
+    return answerRows;
   }
 
   private static final class AclNode {


### PR DESCRIPTION
Make the core logic available to outsiders. Earlier, one had to construct a question object to get the answer. 