### PR TITLE
Revert "Improve flow dispositions for network/broadcast IPs"

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfo.java
@@ -3,7 +3,6 @@ package org.batfish.specifier;
 import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.IpSpace;
 
 /** Information about whether/how to treat a location as a source or sink of traffic. */
@@ -11,18 +10,11 @@ public final class LocationInfo implements Serializable {
   private final boolean _isSource;
   private final IpSpace _sourceIps;
   private final IpSpace _arpIps;
-  private final IpSpace _networkOrBroadcastIps;
 
   public LocationInfo(boolean isSource, IpSpace sourceIps, IpSpace arpIps) {
-    this(isSource, sourceIps, arpIps, EmptyIpSpace.INSTANCE);
-  }
-
-  public LocationInfo(
-      boolean isSource, IpSpace sourceIps, IpSpace arpIps, IpSpace networkOrBroadcastIps) {
     _isSource = isSource;
     _sourceIps = sourceIps;
     _arpIps = arpIps;
-    _networkOrBroadcastIps = networkOrBroadcastIps;
   }
 
   @Override
@@ -36,13 +28,12 @@ public final class LocationInfo implements Serializable {
     LocationInfo other = (LocationInfo) o;
     return _isSource == other._isSource
         && _sourceIps.equals(other._sourceIps)
-        && _arpIps.equals(other._arpIps)
-        && _networkOrBroadcastIps.equals(other._networkOrBroadcastIps);
+        && _arpIps.equals(other._arpIps);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_isSource, _sourceIps, _arpIps, _networkOrBroadcastIps);
+    return Objects.hash(_isSource, _sourceIps, _arpIps);
   }
 
   /**
@@ -75,15 +66,5 @@ public final class LocationInfo implements Serializable {
    */
   public IpSpace getArpIps() {
     return _arpIps;
-  }
-
-  /**
-   * For {@link InterfaceLinkLocation} only. Used for disposition assignment when a flow is
-   * terminates at the network or broadcast IP of an {@link InterfaceLinkLocation}. Batfish will
-   * give disposition {@link org.batfish.datamodel.FlowDisposition.DELIVERED_TO_SUBNET} for these
-   * IPs.
-   */
-  public IpSpace getNetworkOrBroadcastIps() {
-    return _networkOrBroadcastIps;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfoUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfoUtils.java
@@ -57,20 +57,6 @@ public final class LocationInfoUtils {
         EmptyIpSpace.INSTANCE);
   }
 
-  /** @return the network or broadcast IPs of all connected subnets. */
-  @Nonnull
-  public static IpSpace connectedSubnetNetworkOrBroadcastIps(Interface iface) {
-    return firstNonNull(
-        AclIpSpace.union(
-            iface.getAllConcreteAddresses().stream()
-                .map(ConcreteInterfaceAddress::getPrefix)
-                .filter(pfx -> pfx.getPrefixLength() < 31)
-                .flatMap(pfx -> Stream.of(pfx.getStartIp(), pfx.getEndIp()))
-                .map(Ip::toIpSpace)
-                .toArray(IpSpace[]::new)),
-        EmptyIpSpace.INSTANCE);
-  }
-
   public static Map<Location, LocationInfo> computeLocationInfo(
       Map<String, Configuration> configs) {
     return computeLocationInfo(new IpOwners(configs), configs);
@@ -163,8 +149,7 @@ public final class LocationInfoUtils {
         true,
         firstNonNull(
             difference(connectedHostSubnetHostIps(iface), snapshotOwnedIps), EmptyIpSpace.INSTANCE),
-        connectedSubnetHostIps(iface),
-        connectedSubnetNetworkOrBroadcastIps(iface));
+        connectedSubnetHostIps(iface));
   }
 
   private static LocationInfo subtractSnapshotOwnedIpsFromSourceIps(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -1,11 +1,17 @@
 package org.batfish.common.topology;
 
 import static org.batfish.common.topology.IpOwners.computeHsrpPriority;
+import static org.batfish.common.topology.IpOwners.computeInterfaceHostSubnetIps;
 import static org.batfish.common.topology.IpOwners.computeIpIfaceOwners;
 import static org.batfish.common.topology.IpOwners.computeIpVrfOwners;
 import static org.batfish.common.topology.IpOwners.extractHsrp;
 import static org.batfish.common.topology.IpOwners.processHsrpGroups;
+import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -22,14 +28,110 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.hsrp.HsrpGroup;
 import org.batfish.datamodel.tracking.DecrementPriority;
 import org.batfish.datamodel.tracking.TrackInterface;
+import org.junit.Before;
 import org.junit.Test;
 
 /** Tests of {@link IpOwners}. */
 public class IpOwnersTest {
+  private Configuration.Builder _cb;
+  private Interface.Builder _ib;
+  private Vrf.Builder _vb;
+  private static final Prefix P1 = Prefix.parse("1.0.0.0/8");
+  private static final Prefix P2 = Prefix.parse("2.0.0.0/16");
+
+  @Before
+  public void setup() {
+    NetworkFactory nf = new NetworkFactory();
+    _cb = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _vb = nf.vrfBuilder();
+    _ib = nf.interfaceBuilder();
+  }
+
+  @Test
+  public void testComputeInterfaceHostSubnetIps() {
+    Configuration c1 = _cb.build();
+    Map<String, Configuration> configs = ImmutableMap.of(c1.getHostname(), c1);
+    Vrf vrf1 = _vb.setOwner(c1).build();
+    Interface i1 =
+        _ib.setOwner(c1)
+            .setVrf(vrf1)
+            .setAddress(ConcreteInterfaceAddress.create(P1.getFirstHostIp(), P1.getPrefixLength()))
+            .build();
+    Interface i2 =
+        _ib.setOwner(c1)
+            .setVrf(vrf1)
+            .setAddress(ConcreteInterfaceAddress.create(P2.getFirstHostIp(), P2.getPrefixLength()))
+            .setActive(false)
+            .build();
+
+    // Test with only active IPs.
+    assertThat(
+        computeInterfaceHostSubnetIps(configs, true),
+        hasEntry(
+            equalTo(c1.getHostname()),
+            allOf(
+                hasEntry(
+                    equalTo(i1.getName()),
+                    allOf(
+                        not(containsIp(P1.getStartIp())),
+                        containsIp(Ip.create(P1.getStartIp().asLong() + 1)),
+                        containsIp(Ip.create(P1.getEndIp().asLong() - 1)),
+                        not(containsIp(P1.getEndIp())))),
+                not(hasKey(i2.getName())))));
+
+    // Test including inactive IPs.
+    assertThat(
+        computeInterfaceHostSubnetIps(configs, false),
+        hasEntry(
+            equalTo(c1.getHostname()),
+            allOf(
+                hasEntry(
+                    equalTo(i1.getName()),
+                    allOf(
+                        not(containsIp(P1.getStartIp())),
+                        containsIp(Ip.create(P1.getStartIp().asLong() + 1)),
+                        containsIp(Ip.create(P1.getEndIp().asLong() - 1)),
+                        not(containsIp(P1.getEndIp())))),
+                hasEntry(
+                    equalTo(i2.getName()),
+                    allOf(
+                        not(containsIp(P2.getStartIp())),
+                        containsIp(Ip.create(P2.getStartIp().asLong() + 1)),
+                        containsIp(Ip.create(P2.getEndIp().asLong() - 1)),
+                        not(containsIp(P2.getEndIp())))))));
+  }
+
+  @Test
+  public void testComputeInterfaceHostSubnetIpsWithPrefixLength31() {
+    Configuration c1 = _cb.build();
+    Map<String, Configuration> configs = ImmutableMap.of(c1.getHostname(), c1);
+    Vrf vrf1 = _vb.setOwner(c1).build();
+    Prefix prefix = Prefix.parse("1.0.0.1/31");
+    Interface i1 =
+        _ib.setOwner(c1)
+            .setVrf(vrf1)
+            .setAddress(
+                ConcreteInterfaceAddress.create(prefix.getStartIp(), prefix.getPrefixLength()))
+            .build();
+    Map<String, Map<String, IpSpace>> interfaceHostSubnetIps =
+        computeInterfaceHostSubnetIps(configs, false);
+
+    assertThat(
+        interfaceHostSubnetIps,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(
+                equalTo(i1.getName()),
+                allOf(containsIp(prefix.getStartIp()), containsIp(prefix.getEndIp())))));
+  }
+
   @Test
   public void testComputeIpIfaceOwners() {
     String node = "node";

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -47,8 +47,6 @@ import java.util.Objects;
 import java.util.Set;
 import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
-import org.batfish.specifier.InterfaceLinkLocation;
-import org.batfish.specifier.LocationInfo;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -1379,9 +1377,6 @@ public class ForwardingAnalysisImplTest {
                 interfacesWithMissingDevices,
                 arpFalseDestIp,
                 interfaceHostSubnetIps,
-                ImmutableMap.of(
-                    new InterfaceLinkLocation(CONFIG1, INTERFACE1),
-                    new LocationInfo(false, EmptyIpSpace.INSTANCE, EmptyIpSpace.INSTANCE)),
                 ownedIps)
             .get(CONFIG1)
             .get(VRF1)

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1091,9 +1091,9 @@ public final class BDDReachabilityAnalysisFactoryTest {
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(_pkt, ImmutableMap.of());
     IpSpaceToBDD dstToBdd = toBDD.getDstIpSpaceToBdd();
 
-    BDD exitsNetworkBdd = dstToBdd.toBDD(Prefix.parse("8.8.8.0/24"));
+    BDD resultBDD = dstToBdd.toBDD(Prefix.parse("8.8.8.0/24"));
 
-    assertThat(transition.transitForward(_one), equalTo(exitsNetworkBdd));
+    assertThat(transition.transitForward(resultBDD), equalTo(resultBDD));
 
     Transition transitionII =
         analysis
@@ -1167,9 +1167,9 @@ public final class BDDReachabilityAnalysisFactoryTest {
     HeaderSpaceToBDD toBDD = new HeaderSpaceToBDD(_pkt, ImmutableMap.of());
     IpSpaceToBDD dstToBdd = toBDD.getDstIpSpaceToBdd();
 
-    BDD insufficientInfoBdd = dstToBdd.toBDD(Prefix.parse("8.8.8.0/24"));
+    BDD resultBDD = dstToBdd.toBDD(Prefix.parse("8.8.8.0/24"));
 
-    assertThat(transition.transitForward(_one), equalTo(insufficientInfoBdd));
+    assertThat(transition.transitForward(resultBDD), equalTo(resultBDD));
 
     Transition transitionEN =
         analysis
@@ -1177,7 +1177,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
             .get(new PreOutVrf(c1.getHostname(), v1.getName()))
             .get(new PreOutInterfaceExitsNetwork(c1.getHostname(), i1.getName()));
 
-    assertThat(transitionEN, nullValue());
+    assertThat(transitionEN.transitForward(resultBDD), equalTo(_pkt.getFactory().zero()));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
@@ -186,7 +186,7 @@ public final class BidirectionalReachabilityAnalysisTest {
     SFL_INGRESS_LOCATION = new InterfaceLinkLocation(SFL_INGRESS_NODE, SFL_INGRESS_IFACE);
     SFL_DST_IP_SPACE_SINGLE_NODE =
         AclIpSpace.difference(
-            SFL_EGRESS_IFACE_ADDRESS.getPrefix().toHostIpSpace(),
+            SFL_EGRESS_IFACE_ADDRESS.getPrefix().toIpSpace(),
             SFL_EGRESS_IFACE_ADDRESS.getIp().toIpSpace());
     SFL_DST_IP_SPACE_DUAL_NODE = SFL_NEIGHBOR_IFACE_ADDRESS.getIp().toIpSpace();
   }
@@ -914,7 +914,7 @@ public final class BidirectionalReachabilityAnalysisTest {
         new InterfaceLocation(FPFN_START_NODE, FPFN_EGRESS_IFACE),
         FPFN_START_EGRESS_ADDRESS.getIp().toIpSpace(),
         AclIpSpace.difference(
-            FPFN_END_EXIT_ADDRESS.getPrefix().toHostIpSpace(),
+            FPFN_END_EXIT_ADDRESS.getPrefix().toIpSpace(),
             FPFN_END_EXIT_ADDRESS.getIp().toIpSpace()));
   }
 
@@ -926,7 +926,7 @@ public final class BidirectionalReachabilityAnalysisTest {
             FPFN_START_INGRESS_ADDRESS.getPrefix().toIpSpace(),
             FPFN_START_INGRESS_ADDRESS.getIp().toIpSpace()),
         AclIpSpace.difference(
-            FPFN_END_EXIT_ADDRESS.getPrefix().toHostIpSpace(),
+            FPFN_END_EXIT_ADDRESS.getPrefix().toIpSpace(),
             FPFN_END_EXIT_ADDRESS.getIp().toIpSpace()));
   }
 


### PR DESCRIPTION
Reverts batfish/batfish#7127

This broke some pybf notebooks: https://github.com/batfish/pybatfish/compare/matt-updrefs

The problematic change is the forwarding analysis notebook, where we check that a particular change has no unintended effects. The goal is for differential reachability to identify one such unintended effect, where a host becomes reachable. With this PR, we're seeing that traffic to the network IP becomes reachable.