### PR TITLE
Main RIB track and update routes whose network contains next hop

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -259,6 +259,20 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
     return !removeRouteGetDelta(route, Reason.WITHDRAW).isEmpty();
   }
 
+  /** Apply a delta, then return the actual resulting delta excluding NOPs */
+  public @Nonnull RibDelta<R> applyDeltaGetDelta(RibDelta<R> delta) {
+    RibDelta.Builder<R> result = RibDelta.builder();
+    delta
+        .getActions()
+        .forEach(
+            action ->
+                result.from(
+                    action.isWithdrawn()
+                        ? removeRouteGetDelta(action.getRoute(), action.getReason())
+                        : mergeRouteGetDelta(action.getRoute())));
+    return result.build();
+  }
+
   /**
    * Extract routes stored for this exact prefix, if any.
    *

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -28,7 +28,7 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
 
   private final class OwnNextHopManager {
 
-    private final SetMultimap<Ip, AnnotatedRoute<AbstractRoute>> _routesByNextHopIp;
+    private final @Nonnull SetMultimap<Ip, AnnotatedRoute<AbstractRoute>> _routesByNextHopIp;
 
     private OwnNextHopManager() {
       _routesByNextHopIp = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -139,8 +139,7 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
       // no next-hop resolution, so stop here
       return false;
     }
-    Ip nextHopIp = ((NextHopIp) nextHop).getIp();
-    return network.containsIp(nextHopIp);
+    return network.containsIp(((NextHopIp) nextHop).getIp());
   }
 
   /** Create a new empty RIB. */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -1,11 +1,23 @@
 package org.batfish.dataplane.rib;
 
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ResolutionRestriction;
+import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 /**
  * Represents a general RIB, capable of storing routes across different protocols. Uses
@@ -14,9 +26,130 @@ import org.batfish.datamodel.AnnotatedRoute;
 @ParametersAreNonnullByDefault
 public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
 
+  private final class OwnNextHopManager {
+
+    private final SetMultimap<Ip, AnnotatedRoute<AbstractRoute>> _routesByNextHopIp;
+
+    private OwnNextHopManager() {
+      _routesByNextHopIp = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
+    }
+
+    private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> mergeRouteGetDelta(
+        AnnotatedRoute<AbstractRoute> route) {
+      if (containsOwnNextHop(route)) {
+        // invariant: containsOwnNextHop(route) guarantees route has next hop IP
+        _routesByNextHopIp.put(route.getAbstractRoute().getNextHopIp(), route);
+        if (!canActivate(route)) {
+          // If there is no existing more-specific LPM for the nextHopIp, this route cannot be
+          // merged.
+          return RibDelta.empty();
+        }
+      }
+      return processSideEffects(Rib.super.mergeRouteGetDelta(route));
+    }
+
+    private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> removeRouteGetDelta(
+        AnnotatedRoute<AbstractRoute> route) {
+      if (containsOwnNextHop(route)) {
+        // invariant: containsOwnNextHop(route) guarantees route has next hop IP
+        _routesByNextHopIp.remove(route.getAbstractRoute().getNextHopIp(), route);
+      }
+      return processSideEffects(Rib.super.removeRouteGetDelta(route, Reason.WITHDRAW));
+    }
+
+    /** Returns true iff a route whose network contains its own next hop IP can be activated. */
+    private boolean canActivate(AnnotatedRoute<AbstractRoute> ownNextHopRoute) {
+      int prefixLength = ownNextHopRoute.getNetwork().getPrefixLength();
+      return longestPrefixMatch(
+              ownNextHopRoute.getRoute().getNextHopIp(), ResolutionRestriction.alwaysTrue())
+          .stream()
+          .anyMatch(lpmRoute -> lpmRoute.getNetwork().getPrefixLength() > prefixLength);
+    }
+
+    /**
+     * Process the side-effects of applied changes to the RIB. Returns all changes to the RIB,
+     * including the initial ones.
+     */
+    private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> processSideEffects(
+        RibDelta<AnnotatedRoute<AbstractRoute>> changes) {
+      RibDelta<AnnotatedRoute<AbstractRoute>> currentSideEffects = changes;
+      RibDelta.Builder<AnnotatedRoute<AbstractRoute>> cumulativeResult =
+          RibDelta.<AnnotatedRoute<AbstractRoute>>builder().from(currentSideEffects);
+      // loop invariant: currentSideEffects have been applied to the RIB
+      while (!currentSideEffects.isEmpty()) {
+        currentSideEffects = applyDeltaGetDelta(getSideEffects(currentSideEffects));
+        cumulativeResult.from(currentSideEffects);
+      }
+      return cumulativeResult.build();
+    }
+
+    /**
+     * Returns the side-effects of an applied delta to the RIB. Affected prefixes are the networks
+     * of the routes in the delta. Affected next hop IPs are those contained in any affected prefix.
+     * Affected routes are those with an affected next hop IP, and whose network contains their own
+     * next hop IP. For each such route, if there is no more specific route that resolves its next
+     * hop IP, a withdrawal is returned. Otherwise, an add is returned.
+     */
+    private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> getSideEffects(
+        RibDelta<AnnotatedRoute<AbstractRoute>> delta) {
+      RibDelta.Builder<AnnotatedRoute<AbstractRoute>> sideEffects = RibDelta.builder();
+      delta
+          .getPrefixes()
+          .forEach(
+              affectedPrefix ->
+                  _routesByNextHopIp.keySet().stream()
+                      .filter(affectedPrefix::containsIp)
+                      .forEach(
+                          affectedNextHopIp -> {
+                            Optional<Integer> maybeLpmPrefixLength =
+                                longestPrefixMatch(
+                                        affectedNextHopIp, ResolutionRestriction.alwaysTrue())
+                                    .stream()
+                                    .findFirst()
+                                    .map(lpmRoute -> lpmRoute.getNetwork().getPrefixLength());
+                            if (!maybeLpmPrefixLength.isPresent()) {
+                              _routesByNextHopIp
+                                  .get(affectedNextHopIp)
+                                  .forEach(
+                                      affectedRoute ->
+                                          sideEffects.remove(affectedRoute, Reason.WITHDRAW));
+                            } else {
+                              int lpmPrefixLength = maybeLpmPrefixLength.get();
+                              _routesByNextHopIp
+                                  .get(affectedNextHopIp)
+                                  .forEach(
+                                      affectedRoute -> {
+                                        if (affectedRoute.getNetwork().getPrefixLength()
+                                            < lpmPrefixLength) {
+                                          sideEffects.add(affectedRoute);
+                                        } else {
+                                          sideEffects.remove(affectedRoute, Reason.WITHDRAW);
+                                        }
+                                      });
+                            }
+                          }));
+      return sideEffects.build();
+    }
+  }
+
+  private static boolean containsOwnNextHop(AnnotatedRoute<AbstractRoute> route) {
+    Prefix network = route.getNetwork();
+    NextHop nextHop = route.getAbstractRoute().getNextHop();
+    if (!(nextHop instanceof NextHopIp)) {
+      // no next-hop resolution, so stop here
+      return false;
+    }
+    Ip nextHopIp = ((NextHopIp) nextHop).getIp();
+    return network.containsIp(nextHopIp);
+  }
+
   /** Create a new empty RIB. */
   public Rib() {
-    super();
+    this(false);
+  }
+
+  public Rib(boolean noInstallOwnNextHop) {
+    _ownNextHopManager = noInstallOwnNextHop ? new OwnNextHopManager() : null;
   }
 
   @Override
@@ -32,6 +165,23 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
   @Nonnull
   public RibDelta<AnnotatedRoute<AbstractRoute>> mergeRouteGetDelta(
       AnnotatedRoute<AbstractRoute> route) {
-    return !route.getRoute().getNonRouting() ? super.mergeRouteGetDelta(route) : RibDelta.empty();
+    return !route.getRoute().getNonRouting()
+        ? _ownNextHopManager != null
+            ? _ownNextHopManager.mergeRouteGetDelta(route)
+            : super.mergeRouteGetDelta(route)
+        : RibDelta.empty();
   }
+
+  @Nonnull
+  @Override
+  public RibDelta<AnnotatedRoute<AbstractRoute>> removeRouteGetDelta(
+      AnnotatedRoute<AbstractRoute> route) {
+    return !route.getRoute().getNonRouting()
+        ? _ownNextHopManager != null
+            ? _ownNextHopManager.removeRouteGetDelta(route)
+            : super.removeRouteGetDelta(route)
+        : RibDelta.empty();
+  }
+
+  private final @Nullable OwnNextHopManager _ownNextHopManager;
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -13,7 +13,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopIp;
@@ -133,13 +132,12 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
   }
 
   private static boolean containsOwnNextHop(AnnotatedRoute<AbstractRoute> route) {
-    Prefix network = route.getNetwork();
     NextHop nextHop = route.getAbstractRoute().getNextHop();
     if (!(nextHop instanceof NextHopIp)) {
       // no next-hop resolution, so stop here
       return false;
     }
-    return network.containsIp(((NextHopIp) nextHop).getIp());
+    return route.getNetwork().containsIp(((NextHopIp) nextHop).getIp());
   }
 
   /** Create a new empty RIB. */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -291,8 +291,8 @@ public class RibTest {
     rib.mergeRoute(moreSpecificOwnNextHopRoute);
     rib.mergeRoute(lessSpecificOwnNextHopRoute);
 
-    // moreSpecificOwnNextHopRoute should be activated by activatingRoute, and the former should
-    // activate lessSpecificOwnNextHopRoute.
+    // Removing activatingRoute should deactivate moreSpecificOwnNextHopRoute, and deactivating the
+    // latter should deactivate lessSpecificOwnNextHopRoute.
     assertThat(
         rib.removeRouteGetDelta(activatingRoute)
             .getActions()

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -1,16 +1,22 @@
 package org.batfish.dataplane.rib;
 
 import static org.batfish.dataplane.ibdp.TestUtils.annotateRoute;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.route.nh.NextHopIp;
 import org.junit.Test;
 
 /** Tests of {@link Rib} */
@@ -62,5 +68,238 @@ public class RibTest {
     AbstractRoute route2 = sb.build();
 
     assertThat(rib.comparePreference(annotateRoute(route1), annotateRoute(route2)), equalTo(0));
+  }
+
+  @Test
+  public void testInstallOwnNextHopMergeOwnNextHopRoute() {
+    Rib rib = new Rib(false);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+
+    // Since own next hop check is disabled, route should be added.
+    assertThat(
+        rib.mergeRouteGetDelta(ownNextHopRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(ownNextHopRoute))));
+  }
+
+  @Test
+  public void testInstallOwnNextHopPreserveOwnNextHopRoute() {
+    Rib rib = new Rib(false);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> moreSpecificRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "i1"));
+
+    // Since own next hop check is disabled, ownNextHopRoute should remain active when more specific
+    // route is removed.
+    rib.mergeRoute(moreSpecificRoute);
+    rib.mergeRoute(ownNextHopRoute);
+    assertThat(
+        rib.removeRouteGetDelta(moreSpecificRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.withdrawing(moreSpecificRoute))));
+  }
+
+  @Test
+  public void testNoInstallOwnNextHopMergeInvalidOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+
+    // Route should not be added since it resolves its own next hop.
+    assertThat(rib.mergeRouteGetDelta(ownNextHopRoute), equalTo(RibDelta.empty()));
+  }
+
+  @Test
+  public void testNoInstallOwnNextHopMergeValidOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    rib.mergeRoute(annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "i1")));
+
+    // Route should be added since there is a more specific route that resolves its next hop.
+    assertThat(
+        rib.mergeRouteGetDelta(ownNextHopRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(ownNextHopRoute))));
+  }
+
+  @Test
+  public void testNoInstallOwnNextHopActivateOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "i1"));
+
+    rib.mergeRoute(ownNextHopRoute);
+
+    // ownNextHopRoute should be activated by activatingRoute.
+    assertThat(
+        rib.mergeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.adding(activatingRoute),
+            RouteAdvertisement.adding(ownNextHopRoute)));
+  }
+
+  @Test
+  public void testNoInstallOwnNextHopActivateOwnNextHopRouteCascade() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> moreSpecificOwnNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.1.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.1.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> lessSpecificOwnNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.1.2")))
+                .build());
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.1.1/32"), "lo"));
+
+    rib.mergeRoute(moreSpecificOwnNextHopRoute);
+    rib.mergeRoute(lessSpecificOwnNextHopRoute);
+
+    // moreSpecificOwnNextHopRoute should be activated by activatingRoute, and the former should
+    // activate lessSpecificOwnNextHopRoute.
+    assertThat(
+        rib.mergeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.adding(activatingRoute),
+            RouteAdvertisement.adding(lessSpecificOwnNextHopRoute),
+            RouteAdvertisement.adding(moreSpecificOwnNextHopRoute)));
+  }
+
+  @Test
+  public void testNoInstallOwnNextHopRemoveActiveOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.1/32"), "lo"));
+
+    rib.mergeRoute(activatingRoute);
+    rib.mergeRoute(ownNextHopRoute);
+
+    // Removing active ownNextHopRoute should result in withdrawal.
+    assertThat(
+        rib.removeRouteGetDelta(ownNextHopRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        contains(RouteAdvertisement.withdrawing(ownNextHopRoute)));
+  }
+
+  @Test
+  public void testNoInstallOwnNextHopRemoveInactiveOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+
+    rib.mergeRoute(ownNextHopRoute);
+
+    // Removing inactive ownNextHopRoute should not affect the RIB.
+    assertThat(rib.removeRouteGetDelta(ownNextHopRoute), equalTo(RibDelta.empty()));
+  }
+
+  @Test
+  public void testNoInstallOwnNextHopRemoveRedundantActivatingRoutes() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> moreSpecificActivatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.1/32"), "i1"));
+    AnnotatedRoute<AbstractRoute> lessSpecificActivatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/24"), "i2"));
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+
+    rib.mergeRoute(moreSpecificActivatingRoute);
+    rib.mergeRoute(lessSpecificActivatingRoute);
+    rib.mergeRoute(ownNextHopRoute);
+
+    // Removing moreSpecificActivatingRoute should not result in removal of ownNextHopRoute since
+    // the lessSpecificActivatingRoute remains.
+    assertThat(
+        rib.removeRouteGetDelta(moreSpecificActivatingRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.withdrawing(moreSpecificActivatingRoute))));
+
+    // Removing lessSpecificActivatingRoute should result in removal of ownNextHopRoute since
+    // no activating route remains.
+    assertThat(
+        rib.removeRouteGetDelta(lessSpecificActivatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.withdrawing(lessSpecificActivatingRoute),
+            RouteAdvertisement.withdrawing(ownNextHopRoute)));
+  }
+
+  @Test
+  public void testNoInstallOwnNextHopRemoveActivatingRouteCascade() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.1.1/32"), "lo"));
+    AnnotatedRoute<AbstractRoute> moreSpecificOwnNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.1.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.1.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> lessSpecificOwnNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.1.2")))
+                .build());
+
+    rib.mergeRoute(activatingRoute);
+    rib.mergeRoute(moreSpecificOwnNextHopRoute);
+    rib.mergeRoute(lessSpecificOwnNextHopRoute);
+
+    // moreSpecificOwnNextHopRoute should be activated by activatingRoute, and the former should
+    // activate lessSpecificOwnNextHopRoute.
+    assertThat(
+        rib.removeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.withdrawing(activatingRoute),
+            RouteAdvertisement.withdrawing(lessSpecificOwnNextHopRoute),
+            RouteAdvertisement.withdrawing(moreSpecificOwnNextHopRoute)));
   }
 }


### PR DESCRIPTION
- If a route in the main RIB contains its own next hop within its
  network, it may only be activated if that next hop ip resolves
  to a more specific route