### PR TITLE
Edges question: add keys for l1 mode

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -694,7 +694,7 @@ public class EdgesAnswerer extends Answerer {
                 COL_INTERFACE,
                 Schema.INTERFACE,
                 "Interface from which the edge originates",
-                Boolean.FALSE,
+                Boolean.TRUE,
                 Boolean.TRUE));
 
         columnBuilder.add(
@@ -702,7 +702,7 @@ public class EdgesAnswerer extends Answerer {
                 COL_REMOTE_INTERFACE,
                 Schema.INTERFACE,
                 "Interface at which the edge terminates",
-                Boolean.FALSE,
+                Boolean.TRUE,
                 Boolean.TRUE));
     }
     return new TableMetadata(columnBuilder.build(), "Display Edges");


### PR DESCRIPTION
Keys allow us to diff the answer table (i.e. see added/removed edges across snapshots).