### PR TITLE
XR: Support OSPF distribute-list prefix-list in

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_acl.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_acl.g4
@@ -255,7 +255,7 @@ interface_rs_stanza
 
 ip_prefix_list_stanza
 :
-   IPV4 PREFIX_LIST name = variable
+   IPV4 PREFIX_LIST name = prefix_list_name
    (
       (
          NEWLINE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_common.g4
@@ -26,6 +26,7 @@ flow_exporter_map_name: WORD;
 flow_monitor_map_name: WORD;
 parameter: PARAMETER;
 policy_map_name: WORD;
+prefix_list_name: WORD;
 rd_set_name: WORD;
 route_policy_name: WORD;
 sampler_map_name: WORD;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
@@ -141,11 +141,14 @@ ro_distribute_list
   DISTRIBUTE_LIST
   (
     rodl_acl
+    | rodl_prefix_list
     | rodl_route_policy
   )
 ;
 
 rodl_acl: acl = access_list_name (IN | OUT) NEWLINE;
+
+rodl_prefix_list: PREFIX_LIST pl = prefix_list_name (IN | OUT) NEWLINE;
 
 rodl_route_policy: ROUTE_POLICY rp = route_policy_name IN NEWLINE;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -6115,8 +6115,8 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
       _configuration.referenceStructure(
           IP_ACCESS_LIST, name, OSPF_DISTRIBUTE_LIST_PREFIX_LIST_OUT, ctx.pl.getStart().getLine());
       _currentOspfProcess.setOutboundGlobalDistributeList(distributeList);
+      todo(ctx);
     }
-    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
@@ -1433,6 +1433,9 @@ public class CiscoXrConversions {
                 filterName));
         return null;
       }
+    } else if (distributeList.getFilterType() == DistributeListFilterType.PREFIX_LIST) {
+      // todo
+      return null;
     } else {
       assert distributeList.getFilterType() == DistributeListFilterType.ROUTE_POLICY;
       if (c.getRoutingPolicies().containsKey(filterName)) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
@@ -1410,7 +1410,8 @@ public class CiscoXrConversions {
       return null;
     }
     String filterName = distributeList.getFilterName();
-    if (distributeList.getFilterType() == DistributeListFilterType.ACCESS_LIST) {
+    if (distributeList.getFilterType() == DistributeListFilterType.ACCESS_LIST
+        || distributeList.getFilterType() == DistributeListFilterType.PREFIX_LIST) {
       if (c.getRouteFilterLists().containsKey(filterName)) {
         String rpName = generatedOspfInboundDistributeListName(vrfName, procName);
         if (!c.getRoutingPolicies().containsKey(rpName)) {
@@ -1429,13 +1430,13 @@ public class CiscoXrConversions {
       } else {
         w.redFlag(
             String.format(
-                "Ignoring OSPF distribute-list %s: access-list is not defined or failed to convert",
-                filterName));
+                "Ignoring OSPF distribute-list %s: %s is not defined or failed to convert",
+                filterName,
+                distributeList.getFilterType() == DistributeListFilterType.ACCESS_LIST
+                    ? "access-list"
+                    : "prefix-list"));
         return null;
       }
-    } else if (distributeList.getFilterType() == DistributeListFilterType.PREFIX_LIST) {
-      // todo
-      return null;
     } else {
       assert distributeList.getFilterType() == DistributeListFilterType.ROUTE_POLICY;
       if (c.getRoutingPolicies().containsKey(filterName)) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureUsage.java
@@ -107,6 +107,8 @@ public enum CiscoXrStructureUsage implements StructureUsage {
   OSPF_DEFAULT_INFORMATION_ROUTE_POLICY("router ospf default-information route-policy"),
   OSPF_DISTRIBUTE_LIST_ACCESS_LIST_IN("router ospf distribute-list in"),
   OSPF_DISTRIBUTE_LIST_ACCESS_LIST_OUT("router ospf distribute-list out"),
+  OSPF_DISTRIBUTE_LIST_PREFIX_LIST_IN("router ospf distribute-list prefix-list in"),
+  OSPF_DISTRIBUTE_LIST_PREFIX_LIST_OUT("router ospf distribute-list prefix-list out"),
   OSPF_DISTRIBUTE_LIST_ROUTE_POLICY_IN("router ospf distribute-list route-policy in"),
   OSPF_REDISTRIBUTE_ROUTE_POLICY("router ospf redistribute route-policy"),
   ROUTER_PIM_ACCEPT_REGISTER("router pim accept-register"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/DistributeList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/DistributeList.java
@@ -9,6 +9,7 @@ public final class DistributeList implements Serializable {
   /** OSPF distribute-list can be route-policy (in) or ACL (in | out). */
   public enum DistributeListFilterType {
     ACCESS_LIST,
+    PREFIX_LIST,
     ROUTE_POLICY,
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -1236,7 +1236,7 @@ public final class XrGrammarTest {
   @Test
   public void testOspfDistributeListExtraction() {
     CiscoXrConfiguration c = parseVendorConfig("ospf-distribute-list");
-    assertThat(c.getDefaultVrf().getOspfProcesses(), hasKeys("1", "2"));
+    assertThat(c.getDefaultVrf().getOspfProcesses(), hasKeys("1", "2", "3"));
     OspfProcess p1 = c.getDefaultVrf().getOspfProcesses().get("1");
     assertThat(
         p1.getInboundGlobalDistributeList(),
@@ -1249,18 +1249,27 @@ public final class XrGrammarTest {
         p2.getInboundGlobalDistributeList(),
         equalTo(new DistributeList("ACL3", DistributeListFilterType.ACCESS_LIST)));
     assertThat(p2.getOutboundGlobalDistributeList(), nullValue());
+    OspfProcess p3 = c.getDefaultVrf().getOspfProcesses().get("3");
+    assertThat(
+        p3.getInboundGlobalDistributeList(),
+        equalTo(new DistributeList("PL1", DistributeListFilterType.PREFIX_LIST)));
+    assertThat(
+        p3.getOutboundGlobalDistributeList(),
+        equalTo(new DistributeList("PL2", DistributeListFilterType.PREFIX_LIST)));
   }
 
   @Test
   public void testOspfDistributeListConversion() {
     Configuration c = parseConfig("ospf-distribute-list");
-    assertThat(c.getDefaultVrf().getOspfProcesses(), hasKeys("1", "2"));
+    assertThat(c.getDefaultVrf().getOspfProcesses(), hasKeys("1", "2", "3"));
 
     String iface1Name = "GigabitEthernet0/0/0/1";
     String iface2Name = "GigabitEthernet0/0/0/2";
+    String iface3Name = "GigabitEthernet0/0/0/3";
     OspfInterfaceSettings settings1 = c.getActiveInterfaces().get(iface1Name).getOspfSettings();
     OspfInterfaceSettings settings2 = c.getActiveInterfaces().get(iface2Name).getOspfSettings();
-    assert settings1 != null && settings2 != null;
+    OspfInterfaceSettings settings3 = c.getActiveInterfaces().get(iface3Name).getOspfSettings();
+    assert settings1 != null && settings2 != null && settings3 != null;
 
     // First OSPF process uses a routing policy called RP for inbound distribute-list
     assertThat(settings1.getInboundDistributeListPolicy(), equalTo("RP"));
@@ -1271,6 +1280,8 @@ public final class XrGrammarTest {
     String generatedRpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "2");
     assertThat(settings2.getInboundDistributeListPolicy(), equalTo(generatedRpName));
     assertThat(c.getRoutingPolicies(), hasKey(generatedRpName));
+
+    // TODO Test settings3 (distribute-list prefix-list in/out)
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -1277,11 +1277,15 @@ public final class XrGrammarTest {
 
     // Second OSPF process uses an ACL for inbound distribute-list.
     // Semantics of the generated routing policy are tested elsewhere.
-    String generatedRpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "2");
-    assertThat(settings2.getInboundDistributeListPolicy(), equalTo(generatedRpName));
-    assertThat(c.getRoutingPolicies(), hasKey(generatedRpName));
+    String generatedRpNameProc2 = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "2");
+    assertThat(settings2.getInboundDistributeListPolicy(), equalTo(generatedRpNameProc2));
+    assertThat(c.getRoutingPolicies(), hasKey(generatedRpNameProc2));
 
-    // TODO Test settings3 (distribute-list prefix-list in/out)
+    // Third OSPF process uses a prefix-set for inbound distribute-list.
+    // Semantics of the generated routing policy are tested elsewhere.
+    String generatedRpNameProc3 = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "3");
+    assertThat(settings3.getInboundDistributeListPolicy(), equalTo(generatedRpNameProc3));
+    assertThat(c.getRoutingPolicies(), hasKey(generatedRpNameProc3));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco_xr/CiscoXrConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco_xr/CiscoXrConversionsTest.java
@@ -79,6 +79,24 @@ public class CiscoXrConversionsTest extends TestCase {
   }
 
   @Test
+  public void testGetOspfInboundDistributeListPolicy_undefinedPrefixList() {
+    DistributeList distList =
+        new DistributeList("pl", DistributeList.DistributeListFilterType.PREFIX_LIST);
+    Configuration c = new Configuration("c", ConfigurationFormat.CISCO_IOS_XR);
+    Warnings w = new Warnings(true, true, true);
+    assertNull(getOspfInboundDistributeListPolicy(distList, "vrf", "proc", c, w));
+    assertThat(
+        w,
+        hasRedFlags(
+            contains(
+                hasText(
+                    String.format(
+                        "Ignoring OSPF distribute-list %s: prefix-list is not defined or failed to"
+                            + " convert",
+                        distList.getFilterName())))));
+  }
+
+  @Test
   public void testGetOspfInboundDistributeListPolicy_undefinedRoutePolicy() {
     DistributeList distList =
         new DistributeList("rp", DistributeList.DistributeListFilterType.ROUTE_POLICY);
@@ -111,6 +129,36 @@ public class CiscoXrConversionsTest extends TestCase {
     Warnings w = new Warnings(true, true, true);
 
     // Function should create a routing policy corresponding to the ACL's route filter list
+    String vrfName = "vrf";
+    String procName = "proc";
+    String rpName = generatedOspfInboundDistributeListName(vrfName, procName);
+    assertThat(
+        getOspfInboundDistributeListPolicy(distList, vrfName, procName, c, w), equalTo(rpName));
+    assertThat(w, hasRedFlags(empty()));
+
+    // Test the generated routing policy
+    RoutingPolicy generatedRp = c.getRoutingPolicies().get(rpName);
+    StaticRoute permittedRoute = StaticRoute.testBuilder().setNetwork(permitted).build();
+    StaticRoute deniedRoute = StaticRoute.testBuilder().setNetwork(Prefix.ZERO).build();
+    assertTrue(generatedRp.process(permittedRoute, permittedRoute.toBuilder(), Direction.IN));
+    assertFalse(generatedRp.process(deniedRoute, deniedRoute.toBuilder(), Direction.IN));
+  }
+
+  @Test
+  public void testGetOspfInboundDistributeListPolicy_pl() {
+    DistributeList distList =
+        new DistributeList("pl", DistributeList.DistributeListFilterType.PREFIX_LIST);
+    Configuration c = new Configuration("c", ConfigurationFormat.CISCO_IOS_XR);
+    Prefix permitted = Prefix.parse("1.1.1.0/24");
+    RouteFilterList rfl =
+        new RouteFilterList(
+            distList.getFilterName(),
+            ImmutableList.of(
+                new RouteFilterLine(LineAction.PERMIT, PrefixRange.fromPrefix(permitted))));
+    c.getRouteFilterLists().put(rfl.getName(), rfl);
+    Warnings w = new Warnings(true, true, true);
+
+    // Function should create a routing policy corresponding to the prefix-list
     String vrfName = "vrf";
     String procName = "proc";
     String rpName = generatedOspfInboundDistributeListName(vrfName, procName);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-distribute-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-distribute-list
@@ -8,8 +8,18 @@ interface GigabitEthernet0/0/0/1
 interface GigabitEthernet0/0/0/2
  no shutdown
 !
+interface GigabitEthernet0/0/0/3
+ no shutdown
+!
 ipv4 access-list ACL2
 ipv4 access-list ACL3
+!
+prefix-set PL1
+  5.5.5.5/32
+end-set
+prefix-set PL2
+  6.6.6.6/32
+end-set
 !
 route-policy RP
 end-policy
@@ -28,4 +38,11 @@ router ospf 2
   distribute-list ACL3 in
   area 2
     interface GigabitEthernet0/0/0/2
+!
+router ospf 3
+  router-id 3.3.3.3
+  distribute-list prefix-list PL1 in
+  distribute-list prefix-list PL2 out
+  area 3
+    interface GigabitEthernet0/0/0/3
 !


### PR DESCRIPTION
Adds parsing and extraction for `distribute-list prefix-list FOO in` and `distribute-list prefix-list BAR out`, and adds conversion for the inbound direction (we do not currently convert outbound OSPF distribute-lists of any type on XR).