### PR TITLE
Enable backup routes in main RIB

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AnnotatedRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AnnotatedRib.java
@@ -16,7 +16,11 @@ public abstract class AnnotatedRib<R extends AbstractRoute> extends AbstractRib<
     implements Serializable {
 
   AnnotatedRib() {
-    super();
+    this(false);
+  }
+
+  AnnotatedRib(boolean withBackupRoutes) {
+    super(withBackupRoutes);
   }
 
   /*

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -16,7 +16,7 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
 
   /** Create a new empty RIB. */
   public Rib() {
-    super();
+    super(true);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -13,6 +13,7 @@ import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.OspfIntraAreaRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
@@ -72,24 +73,34 @@ public class RibTest {
 
   @Test
   public void testBackup() {
+    Prefix prefix = Prefix.strict("1.0.0.0/31");
+    Ip ip = Ip.parse("1.0.0.0");
     Rib rib = new Rib();
-    StaticRoute.Builder sb = StaticRoute.testBuilder().setNetwork(Prefix.ZERO);
     AnnotatedRoute<AbstractRoute> r1 =
-        annotateRoute(sb.setAdministrativeCost(250).setNextHopInterface("foo").build());
+        annotateRoute(
+            OspfIntraAreaRoute.builder()
+                .setNetwork(prefix)
+                .setArea(0L)
+                .setNextHopInterface("foo")
+                .setAdmin(110)
+                .setMetric(1L)
+                .setNextHopIp(Ip.parse("2.0.0.1"))
+                .build());
     AnnotatedRoute<AbstractRoute> r2 =
         annotateRoute(
             Bgpv4Route.testBuilder()
-                .setNetwork(Prefix.ZERO)
-                .setNextHopInterface("blah")
+                .setAdmin(20)
+                .setNetwork(prefix)
+                .setNextHopInterface("bar")
                 .setOriginatorIp(Ip.parse("1.1.1.1"))
                 .setOriginType(OriginType.IGP)
                 .setProtocol(RoutingProtocol.BGP)
                 .build());
     rib.mergeRoute(r1);
-    assertThat(rib.longestPrefixMatch(Ip.ZERO, ResolutionRestriction.alwaysTrue()), contains(r1));
+    assertThat(rib.longestPrefixMatch(ip, ResolutionRestriction.alwaysTrue()), contains(r1));
     rib.mergeRoute(r2);
-    assertThat(rib.longestPrefixMatch(Ip.ZERO, ResolutionRestriction.alwaysTrue()), contains(r2));
+    assertThat(rib.longestPrefixMatch(ip, ResolutionRestriction.alwaysTrue()), contains(r2));
     rib.removeRoute(r2);
-    assertThat(rib.longestPrefixMatch(Ip.ZERO, ResolutionRestriction.alwaysTrue()), contains(r1));
+    assertThat(rib.longestPrefixMatch(ip, ResolutionRestriction.alwaysTrue()), contains(r1));
   }
 }


### PR DESCRIPTION
- prevent loss of routes when a better route is installed and later
withdrawn
- enables experimental merge and rollback needed for planned loop checking implementation