### PR TITLE
XR OSPF: No address-family stanza

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
@@ -8,7 +8,7 @@ options {
 
 ro_address_family
 :
-   ADDRESS_FAMILY IPV4 UNICAST? NEWLINE ro_common*
+   ADDRESS_FAMILY IPV4 UNICAST? NEWLINE
 ;
 
 ro_area


### PR DESCRIPTION
There is no address-family mode under router ospf; the address-family line is stand-alone.