### PR TITLE
Support enforcing resolvability of routes in main RIB

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.Prefix.longestCommonPrefix;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
@@ -14,7 +15,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -290,7 +293,33 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
    * The traversal may not mutate the entries (the values are immutable sets).
    */
   public void traverseEntries(BiConsumer<Prefix, Set<T>> consumer) {
-    traverseNodes(node -> consumer.accept(node._prefix, ImmutableSet.copyOf(node._elements)));
+    // Chose null instead of something like BiPredicates.alwaysTrue() because:
+    // - it doesn't exist
+    // - could not custom version to type-check
+    traverseEntriesImpl(consumer, null);
+  }
+
+  /**
+   * Post-order traversal over the entries. Entries will always contain non-null keys and values.
+   * The traversal may not mutate the entries (the values are immutable sets).
+   *
+   * <p>A node will only be visited if {@code visitNode} returns {@code true} for its prefix and
+   * elements.
+   */
+  public void traverseEntries(
+      BiConsumer<Prefix, Set<T>> consumer, BiPredicate<Prefix, Set<T>> visitChild) {
+    traverseEntriesImpl(consumer, visitChild);
+  }
+
+  private void traverseEntriesImpl(
+      BiConsumer<Prefix, Set<T>> consumer, @Nullable BiPredicate<Prefix, Set<T>> visitNode) {
+    Consumer<Node<T>> nodeConsumer =
+        node -> consumer.accept(node._prefix, ImmutableSet.copyOf(node._elements));
+    if (visitNode == null) {
+      traverseNodes(nodeConsumer);
+    } else {
+      traverseNodes(nodeConsumer, node -> visitNode.test(node._prefix, node._elements));
+    }
   }
 
   /**
@@ -306,10 +335,20 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
   }
 
   private void traverseNodes(Consumer<Node<T>> consumer) {
-    if (_root == null) {
+    traverseNodes(consumer, Predicates.alwaysTrue());
+  }
+
+  private void traverseNodes(Consumer<Node<T>> consumer, Predicate<Node<T>> visitNode) {
+    if (_root == null || !visitNode.test(_root)) {
       return;
     }
-    Traverser.<Node<T>>forTree(Node::getChildren).depthFirstPostOrder(_root).forEach(consumer);
+    Traverser.<Node<T>>forTree(
+            node ->
+                node.getChildren().stream()
+                    .filter(visitNode)
+                    .collect(ImmutableList.toImmutableList()))
+        .depthFirstPostOrder(_root)
+        .forEach(consumer);
   }
 
   private @Nullable Node<T> exactMatchNode(Prefix p) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -295,7 +295,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
   public void traverseEntries(BiConsumer<Prefix, Set<T>> consumer) {
     // Chose null instead of something like BiPredicates.alwaysTrue() because:
     // - it doesn't exist
-    // - could not custom version to type-check
+    // - could not get custom version to type-check
     traverseEntriesImpl(consumer, null);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -36,6 +36,15 @@ public class PrefixTrieMultiMapTest {
     return prefixes;
   }
 
+  private static List<Prefix> keysInPostOrderFiltered(
+      PrefixTrieMultiMap<Integer> map, int maxPrefixLength) {
+    List<Prefix> prefixes = new ArrayList<>();
+    map.traverseEntries(
+        (prefix, elems) -> prefixes.add(prefix),
+        (prefix, elems) -> maxPrefixLength >= prefix.getPrefixLength());
+    return prefixes;
+  }
+
   private static <T> List<Entry<Prefix, Set<T>>> entriesPostOrder(PrefixTrieMultiMap<T> map) {
     List<Entry<Prefix, Set<T>>> entries = new ArrayList<>();
     map.traverseEntries((prefix, elems) -> entries.add(immutableEntry(prefix, elems)));
@@ -235,6 +244,29 @@ public class PrefixTrieMultiMapTest {
 
     List<Prefix> prefixes = keysInPostOrder(map);
     assertThat(prefixes, contains(ll, lr, l, rl, rr, r, Prefix.ZERO));
+  }
+
+  @Test
+  public void testTraverseEntriesFiltered() {
+    PrefixTrieMultiMap<Integer> map = new PrefixTrieMultiMap<>(Prefix.ZERO);
+    Prefix l = Prefix.parse("0.0.0.0/8");
+    Prefix ll = Prefix.parse("0.0.0.0/16");
+    Prefix lr = Prefix.parse("0.128.0.0/16");
+    Prefix r = Prefix.parse("128.0.0.0/8");
+    Prefix rl = Prefix.parse("128.0.0.0/16");
+    Prefix rr = Prefix.parse("128.128.0.0/16");
+
+    map.put(l, 0);
+    map.put(ll, 0);
+    map.put(lr, 0);
+
+    // adding in different order just for fun
+    map.put(rr, 0);
+    map.put(rl, 0);
+    map.put(r, 0);
+
+    List<Prefix> prefixes = keysInPostOrderFiltered(map, 8);
+    assertThat(prefixes, contains(l, r, Prefix.ZERO));
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -1,11 +1,29 @@
 package org.batfish.dataplane.rib;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ResolutionRestriction;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DirectedAcyclicGraph;
 
 /**
  * Represents a general RIB, capable of storing routes across different protocols. Uses
@@ -14,9 +32,260 @@ import org.batfish.datamodel.AnnotatedRoute;
 @ParametersAreNonnullByDefault
 public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
 
+  /** Encapsulates optional main RIB behavior of enforcing resolvability for active routes. */
+  private final class ResolvabilityEnforcer {
+
+    private final @Nonnull DirectedAcyclicGraph<AnnotatedRoute<AbstractRoute>, DefaultEdge>
+        _resolutionGraph;
+    private final @Nonnull RibResolutionTrie _ribResolutionTrie;
+    private final @Nonnull SetMultimap<Ip, AnnotatedRoute<AbstractRoute>> _routesByNextHopIp;
+
+    private ResolvabilityEnforcer() {
+      _routesByNextHopIp = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
+      _ribResolutionTrie = new RibResolutionTrie();
+      _resolutionGraph = new DirectedAcyclicGraph<>(DefaultEdge.class);
+    }
+
+    private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> mergeRouteGetDelta(
+        AnnotatedRoute<AbstractRoute> route) {
+      RibDelta.Builder<AnnotatedRoute<AbstractRoute>> delta = RibDelta.builder();
+      boolean isNextHopIpRoute = isNextHopIpRoute(route);
+      if (isNextHopIpRoute) {
+        Ip nextHopIp = route.getAbstractRoute().getNextHopIp();
+        _routesByNextHopIp.put(nextHopIp, route);
+        _ribResolutionTrie.addNextHopIp(nextHopIp);
+      }
+      RibDelta<AnnotatedRoute<AbstractRoute>> initialDelta = Rib.super.mergeRouteGetDelta(route);
+      return delta.from(processSideEffects(route, initialDelta)).build();
+    }
+
+    private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> removeRouteGetDelta(
+        AnnotatedRoute<AbstractRoute> route) {
+      if (isNextHopIpRoute(route)) {
+        Ip nextHopIp = route.getAbstractRoute().getNextHopIp();
+        _routesByNextHopIp.remove(nextHopIp, route);
+        if (_routesByNextHopIp.get(nextHopIp).isEmpty()) {
+          _ribResolutionTrie.removeNextHopIp(nextHopIp);
+        }
+      }
+      RibDelta<AnnotatedRoute<AbstractRoute>> delta =
+          Rib.super.removeRouteGetDelta(route, Reason.WITHDRAW);
+      return processSideEffects(route, delta);
+    }
+
+    void postProcessDelta(RibDelta<AnnotatedRoute<AbstractRoute>> delta) {
+      if (delta.isEmpty()) {
+        return;
+      }
+      Prefix prefix = delta.getPrefixes().findFirst().get();
+      if (delta.getActions().count() == 1) {
+        // no backups
+        if (extractRoutes(prefix).isEmpty()) {
+          _ribResolutionTrie.removePrefix(prefix);
+        } else {
+          _ribResolutionTrie.addPrefix(prefix);
+        }
+      }
+      delta
+          .getActions()
+          .forEach(
+              action -> {
+                AnnotatedRoute<AbstractRoute> route = action.getRoute();
+                if (action.isWithdrawn()) {
+                  _resolutionGraph.removeVertex(route);
+                } else {
+                  _resolutionGraph.addVertex(route);
+                }
+              });
+    }
+
+    /**
+     * Performs longest prefix match on a next hop IP route. If the route contains its own next hop
+     * ip and the result does not contain a more specific route, returns the empty set. Otherwise,
+     * returns the LPM routes.
+     */
+    private @Nonnull Set<AnnotatedRoute<AbstractRoute>> lpmIfValid(
+        AnnotatedRoute<AbstractRoute> nhipRoute) {
+      Set<AnnotatedRoute<AbstractRoute>> lpmRoutes =
+          longestPrefixMatch(
+              nhipRoute.getRoute().getNextHopIp(), ResolutionRestriction.alwaysTrue());
+      if (containsOwnNextHop(nhipRoute)) {
+        int prefixLength = nhipRoute.getNetwork().getPrefixLength();
+        return lpmRoutes.stream()
+                .anyMatch(lpmRoute -> lpmRoute.getNetwork().getPrefixLength() > prefixLength)
+            ? lpmRoutes
+            : ImmutableSet.of();
+      } else {
+        return lpmRoutes;
+      }
+    }
+
+    /**
+     * Processes the side-effects of adding/removing a route to/from the RIB. Returns the transitive
+     * changes to the RIB. Any next hop IP routes (including the input) that become unresolvable
+     * will be deactivated.
+     */
+    private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> processSideEffects(
+        AnnotatedRoute<AbstractRoute> route, RibDelta<AnnotatedRoute<AbstractRoute>> initialDelta) {
+      if (initialDelta.isEmpty()) {
+        return RibDelta.empty();
+      }
+      RibDelta.Builder<AnnotatedRoute<AbstractRoute>> delta =
+          RibDelta.<AnnotatedRoute<AbstractRoute>>builder().from(initialDelta);
+      postProcessDelta(initialDelta);
+      Set<AnnotatedRoute<AbstractRoute>> affectedRoutes = new LinkedHashSet<>();
+      affectedRoutes.add(
+          initialDelta
+              .getActions()
+              .filter(action -> action.getRoute().equals(route))
+              .map(RouteAdvertisement::getRoute)
+              .findFirst()
+              .get());
+      initialDelta
+          .getActions()
+          .filter(action -> !action.getRoute().equals(route))
+          .map(RouteAdvertisement::getRoute)
+          .forEach(affectedRoutes::add);
+      initialDelta
+          .getPrefixes()
+          .flatMap(p -> getAffectedRoutes(p).stream())
+          .forEach(affectedRoutes::add);
+      while (!affectedRoutes.isEmpty()) {
+        AnnotatedRoute<AbstractRoute> nextRoute = affectedRoutes.iterator().next();
+        affectedRoutes.remove(nextRoute);
+        delta.from(processAffectedRoute(nextRoute, affectedRoutes));
+      }
+      return delta.build();
+    }
+
+    /**
+     * If affected route is resolvable when added, add it. Otherwise remove it. If a net change is
+     * made to the RIB and {@code remainingAffectedRoutes} is non-null, then add newly affected
+     * routes to {@code remainingAffectedRoutes}. Returns the net change to the RIB.
+     */
+    private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> processAffectedRoute(
+        AnnotatedRoute<AbstractRoute> affectedRoute,
+        Collection<AnnotatedRoute<AbstractRoute>> remainingAffectedRoutes) {
+      RibDelta<AnnotatedRoute<AbstractRoute>> delta;
+      boolean isNextHopIpRoute = isNextHopIpRoute(affectedRoute);
+      if (isNextHopIpRoute) {
+        if (!_routesByNextHopIp
+            .get(affectedRoute.getRoute().getNextHopIp())
+            .contains(affectedRoute)) {
+          // This route was explicitly removed and should not be re-evaluated.
+          return RibDelta.empty();
+        }
+        Set<AnnotatedRoute<AbstractRoute>> initialLpm = lpmIfValid(affectedRoute);
+        if (initialLpm.isEmpty()) {
+          delta = Rib.super.removeRouteGetDelta(affectedRoute);
+          if (delta.getActions().count() > 1) {
+            // backup routes replaced the removed route
+            delta
+                .getActions()
+                .filter(action -> !action.isWithdrawn())
+                .forEach(action -> remainingAffectedRoutes.add(action.getRoute()));
+          }
+          postProcessDelta(delta);
+        } else {
+          // The route has a next hop, but we need to check for a loop.
+          delta = Rib.super.mergeRouteGetDelta(affectedRoute);
+          postProcessDelta(delta);
+          _resolutionGraph.removeAllEdges(
+              ImmutableSet.copyOf(_resolutionGraph.outgoingEdgesOf(affectedRoute)));
+          // Recompute affected route edges. Should not loop since we haven't
+          // Connected out edges of affectedRoute yet.
+          updateAffectedRoutesOutEdges(affectedRoute);
+          try {
+            // Connect out edges of affected route. If it induces a loop, we must remove the route
+            // and restore the edges of the its affected routes.
+            initialLpm.forEach(lpmRoute -> _resolutionGraph.addEdge(affectedRoute, lpmRoute));
+          } catch (IllegalArgumentException e) {
+            // A cycle was detected.
+            RibDelta<AnnotatedRoute<AbstractRoute>> removal =
+                Rib.super.removeRouteGetDelta(affectedRoute);
+            assert delta.isEmpty() ^ removal.isEmpty();
+            postProcessDelta(removal);
+            RibDelta<AnnotatedRoute<AbstractRoute>> netChange =
+                RibDelta.<AnnotatedRoute<AbstractRoute>>builder().from(delta).from(removal).build();
+            // Either:
+            // - The route was already present, the initial delta was empty, the removal is
+            //   non-empty, and the net change is non-empty.
+            // - The route was added, the initial delta was non-empty, and the removal is also
+            //   non-empty. The net change should be empty.
+            assert !removal.isEmpty() && (delta.isEmpty() ^ netChange.isEmpty());
+            delta = netChange;
+            // Repair out edges of affected routes.
+            updateAffectedRoutesOutEdges(affectedRoute);
+          }
+        }
+      } else {
+        delta = RibDelta.empty();
+      }
+      if (!isNextHopIpRoute || !delta.isEmpty()) {
+        remainingAffectedRoutes.addAll(getAffectedRoutes(affectedRoute.getNetwork()));
+      }
+      return delta;
+    }
+
+    /**
+     * Recompute the out edges for all routes affected by {@code route}. As a precondition, {@code
+     * route} should not have any out edges. Otherwise, a loop may be created when updating edges.
+     */
+    private void updateAffectedRoutesOutEdges(AnnotatedRoute<AbstractRoute> route) {
+      getAffectedRoutes(route.getNetwork()).stream()
+          .filter(_resolutionGraph::containsVertex)
+          .forEach(
+              activeAffectedRoute -> {
+                _resolutionGraph.removeAllEdges(
+                    ImmutableSet.copyOf(_resolutionGraph.outgoingEdgesOf(activeAffectedRoute)));
+                lpmIfValid(activeAffectedRoute)
+                    .forEach(resolver -> _resolutionGraph.addEdge(activeAffectedRoute, resolver));
+              });
+    }
+
+    /**
+     * Get a list of all tracked next hop IP routes affected by an update to a route with the given
+     * {@code prefix}.
+     */
+    private @Nonnull List<AnnotatedRoute<AbstractRoute>> getAffectedRoutes(Prefix prefix) {
+      Set<Ip> affectedNextHopIps = _ribResolutionTrie.getAffectedNextHopIps(prefix);
+      return affectedNextHopIps.stream()
+          .flatMap(nhip -> _routesByNextHopIp.get(nhip).stream())
+          .collect(ImmutableList.toImmutableList());
+    }
+  }
+
+  /**
+   * Returns {@code true} iff {@code route} is a next hop IP route whose network contains its own
+   * next hop IP.
+   */
+  private static boolean containsOwnNextHop(AnnotatedRoute<AbstractRoute> route) {
+    return isNextHopIpRoute(route)
+        && route.getNetwork().containsIp(route.getAbstractRoute().getNextHopIp());
+  }
+
+  /**
+   * Returns {@code true} {@code route} is a next hop IP only route (excludes routes that also have
+   * a next hop interface).
+   */
+  private static boolean isNextHopIpRoute(AnnotatedRoute<AbstractRoute> route) {
+    return route.getAbstractRoute().getNextHop() instanceof NextHopIp;
+  }
+
   /** Create a new empty RIB. */
   public Rib() {
+    this(false);
+  }
+
+  /**
+   * Create a new empty RIB. If {@code enforceResolvability} is {@code true}, then merged routes
+   * that are not resolvable will remain inactive until they become resolvable again. Inactive
+   * routes will not be returned by {@link #getRoutes()}, {@link #getTypedRoutes()}, nor {@link
+   * #getTypedBackupRoutes()}.
+   */
+  public Rib(boolean enforceResolvability) {
     super(true);
+    _resolvabilityEnforcer = enforceResolvability ? new ResolvabilityEnforcer() : null;
   }
 
   @Override
@@ -32,6 +301,23 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
   @Nonnull
   public RibDelta<AnnotatedRoute<AbstractRoute>> mergeRouteGetDelta(
       AnnotatedRoute<AbstractRoute> route) {
-    return !route.getRoute().getNonRouting() ? super.mergeRouteGetDelta(route) : RibDelta.empty();
+    return !route.getRoute().getNonRouting()
+        ? _resolvabilityEnforcer != null
+            ? _resolvabilityEnforcer.mergeRouteGetDelta(route)
+            : super.mergeRouteGetDelta(route)
+        : RibDelta.empty();
   }
+
+  @Nonnull
+  @Override
+  public RibDelta<AnnotatedRoute<AbstractRoute>> removeRouteGetDelta(
+      AnnotatedRoute<AbstractRoute> route) {
+    return !route.getRoute().getNonRouting()
+        ? _resolvabilityEnforcer != null
+            ? _resolvabilityEnforcer.removeRouteGetDelta(route)
+            : super.removeRouteGetDelta(route)
+        : RibDelta.empty();
+  }
+
+  private final @Nullable ResolvabilityEnforcer _resolvabilityEnforcer;
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibResolutionTrie.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibResolutionTrie.java
@@ -1,0 +1,82 @@
+package org.batfish.dataplane.rib;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixTrieMultiMap;
+import org.batfish.datamodel.route.nh.NextHopIp;
+
+/**
+ * A helper structure for determining which {@link NextHopIp} routes' resolvability may change when
+ * a route is added or removed. Clients must register the prefixes of all active routes, and the
+ * next hop IPs of all {@link NextHopIp} routes under consideration. Then they may determine next
+ * hop IPs affected by a route change for a given prefix via {@link #getAffectedNextHopIps(Prefix)}.
+ */
+public final class RibResolutionTrie {
+
+  private static final class ResolutionTrieValue {}
+
+  private static final ResolutionTrieValue PREFIX = new ResolutionTrieValue();
+
+  private static final ResolutionTrieValue NHIP = new ResolutionTrieValue();
+
+  private final PrefixTrieMultiMap<ResolutionTrieValue> _prefixesAndNextHops;
+
+  public RibResolutionTrie() {
+    _prefixesAndNextHops = new PrefixTrieMultiMap<>();
+  }
+
+  /** Add the prefix of a forwarding route to the trie. */
+  public void addPrefix(Prefix prefix) {
+
+    _prefixesAndNextHops.put(prefix, PREFIX);
+  }
+
+  /** Remove the prefix of a forwarding route from the trie. */
+  public void removePrefix(Prefix prefix) {
+    _prefixesAndNextHops.remove(prefix, PREFIX);
+  }
+
+  /** Add the next hop IP of a {@link NextHopIp} route to the trie. */
+  public void addNextHopIp(Ip nextHopIp) {
+    _prefixesAndNextHops.put(Prefix.create(nextHopIp, Prefix.MAX_PREFIX_LENGTH), NHIP);
+  }
+
+  /** Remove the next hop IP of a {@link NextHopIp} route from the trie. */
+  public void removeNextHopIp(Ip nextHopIp) {
+    _prefixesAndNextHops.remove(Prefix.create(nextHopIp, Prefix.MAX_PREFIX_LENGTH), NHIP);
+  }
+
+  /**
+   * Return the set of next hop IPs whose resolution could potentially be affected by the addition
+   * or removal of a route whose network is {@code newPrefix}.
+   */
+  public @Nonnull Set<Ip> getAffectedNextHopIps(Prefix newPrefix) {
+    int newPrefixLength = newPrefix.getPrefixLength();
+    ImmutableSet.Builder<Ip> affectedNextHopIps = ImmutableSet.builder();
+    // If a node contains a NHIP, add it to the result.
+    BiConsumer<Prefix, Set<ResolutionTrieValue>> consumer =
+        (prefix, values) -> {
+          if (values.contains(NHIP)) {
+            affectedNextHopIps.add(prefix.getStartIp());
+          }
+        };
+    // Visit nodes either:
+    // - whose prefix contains newPrefix
+    // - whose prefix is contained within newPrefix and either:
+    //   - do not contain a previously added prefix,
+    //     i.e., an intermediate node, or one with just an NHIP
+    //   - contain a previously added prefix that is not more specific than newPrefix
+    BiPredicate<Prefix, Set<ResolutionTrieValue>> visitNode =
+        (prefix, values) ->
+            prefix.containsPrefix(newPrefix)
+                || (newPrefix.containsPrefix(prefix)
+                    && (!values.contains(PREFIX) || prefix.getPrefixLength() <= newPrefixLength));
+    _prefixesAndNextHops.traverseEntries(consumer, visitNode);
+    return affectedNextHopIps.build();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibResolutionTrieTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibResolutionTrieTest.java
@@ -1,0 +1,67 @@
+package org.batfish.dataplane.rib;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.junit.Test;
+
+/** Tests of {@link RibResolutionTrie} */
+public final class RibResolutionTrieTest {
+
+  @Test
+  public void testGetAffectedNextHopIpsEmpty() {
+    RibResolutionTrie trie = new RibResolutionTrie();
+    assertThat(trie.getAffectedNextHopIps(Prefix.ZERO), empty());
+  }
+
+  @Test
+  public void testGetAffectedNextHopIpsUnaffectedMoreSpecific() {
+    {
+      RibResolutionTrie trie = new RibResolutionTrie();
+      trie.addNextHopIp(Ip.parse("10.0.0.1"));
+      trie.addPrefix(Prefix.strict("10.0.0.0/24"));
+      assertThat(trie.getAffectedNextHopIps(Prefix.strict("10.0.0.0/8")), empty());
+    }
+    {
+      RibResolutionTrie trie = new RibResolutionTrie();
+      trie.addNextHopIp(Ip.parse("10.0.0.1"));
+      trie.addPrefix(Prefix.strict("10.0.0.1/32"));
+      assertThat(trie.getAffectedNextHopIps(Prefix.strict("10.0.0.0/8")), empty());
+    }
+  }
+
+  @Test
+  public void testGetAffectedNextHopIpsAffectedNotMoreSpecific() {
+    {
+      RibResolutionTrie trie = new RibResolutionTrie();
+      Ip nhip = Ip.parse("10.0.0.1");
+      trie.addNextHopIp(nhip);
+      trie.addPrefix(Prefix.ZERO);
+      assertThat(trie.getAffectedNextHopIps(Prefix.ZERO), contains(nhip));
+    }
+    {
+      RibResolutionTrie trie = new RibResolutionTrie();
+      Ip nhip = Ip.parse("10.0.0.1");
+      trie.addNextHopIp(nhip);
+      trie.addPrefix(Prefix.strict("10.0.0.0/24"));
+      assertThat(trie.getAffectedNextHopIps(Prefix.strict("10.0.0.0/24")), contains(nhip));
+    }
+    {
+      RibResolutionTrie trie = new RibResolutionTrie();
+      Ip nhip = Ip.parse("10.0.0.1");
+      trie.addNextHopIp(nhip);
+      trie.addPrefix(Prefix.strict("10.0.0.0/24"));
+      assertThat(trie.getAffectedNextHopIps(Prefix.strict("10.0.0.0/25")), contains(nhip));
+    }
+    {
+      RibResolutionTrie trie = new RibResolutionTrie();
+      Ip nhip = Ip.parse("10.0.0.1");
+      trie.addNextHopIp(nhip);
+      trie.addPrefix(Prefix.strict("10.0.0.1/32"));
+      assertThat(trie.getAffectedNextHopIps(Prefix.strict("10.0.0.1/32")), contains(nhip));
+    }
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -2,15 +2,18 @@ package org.batfish.dataplane.rib;
 
 import static org.batfish.dataplane.ibdp.TestUtils.annotateRoute;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.OspfIntraAreaRoute;
@@ -18,6 +21,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.route.nh.NextHopIp;
 import org.junit.Test;
 
 /** Tests of {@link Rib} */
@@ -102,5 +106,439 @@ public class RibTest {
     assertThat(rib.longestPrefixMatch(ip, ResolutionRestriction.alwaysTrue()), contains(r2));
     rib.removeRoute(r2);
     assertThat(rib.longestPrefixMatch(ip, ResolutionRestriction.alwaysTrue()), contains(r1));
+  }
+
+  @Test
+  public void testEnforceResolvabilityMergeResolvableRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "foo"));
+    AnnotatedRoute<AbstractRoute> nhipRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.1.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    rib.mergeRoute(activatingRoute);
+
+    // NHIP route should be active on merge because it has a resolution path.
+    assertThat(
+        rib.mergeRouteGetDelta(nhipRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(nhipRoute))));
+  }
+
+  @Test
+  public void testEnforceResolvabilityActivateResolvableRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "foo"));
+    AnnotatedRoute<AbstractRoute> nhipRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.1.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    // NHIP route should be inactive on merge because it has no resolution path.
+    assertThat(rib.mergeRouteGetDelta(nhipRoute), equalTo(RibDelta.empty()));
+
+    // Both activating and NHIP route should be added on merge of activating route.
+    assertThat(
+        rib.mergeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.adding(nhipRoute), RouteAdvertisement.adding(activatingRoute)));
+  }
+
+  @Test
+  public void testEnforceResolvabilityActivateRoutesCascade() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> nhipRoute1 =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("1.1.1.1/32"))
+                .setNextHop(NextHopIp.of(Ip.parse("2.2.2.2")))
+                .build());
+    AnnotatedRoute<AbstractRoute> nhipRoute2 =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("2.2.2.2/32"))
+                .setNextHop(NextHopIp.of(Ip.parse("3.3.3.3")))
+                .build());
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("3.3.3.2/31"), "foo"));
+    // NHIP routes should be inactive on merge because they do not have full resolution path.
+    assertThat(rib.mergeRouteGetDelta(nhipRoute1), equalTo(RibDelta.empty()));
+    assertThat(rib.mergeRouteGetDelta(nhipRoute2), equalTo(RibDelta.empty()));
+
+    // Activating and NHIP routes should be added on merge of activating route.
+    assertThat(
+        rib.mergeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.adding(nhipRoute1),
+            RouteAdvertisement.adding(nhipRoute2),
+            RouteAdvertisement.adding(activatingRoute)));
+  }
+
+  @Test
+  public void testEnforceResolvabilityDeactivateRoutesCascade() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> nhipRoute1 =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("1.1.1.1/32"))
+                .setNextHop(NextHopIp.of(Ip.parse("2.2.2.2")))
+                .build());
+    AnnotatedRoute<AbstractRoute> nhipRoute2 =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("2.2.2.2/32"))
+                .setNextHop(NextHopIp.of(Ip.parse("3.3.3.3")))
+                .build());
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("3.3.3.2/31"), "foo"));
+    rib.mergeRoute(activatingRoute);
+
+    // NHIP routes should be active on merge because they have full resolution path.
+    assertThat(
+        rib.mergeRouteGetDelta(nhipRoute2),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(nhipRoute2))));
+    assertThat(
+        rib.mergeRouteGetDelta(nhipRoute1),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(nhipRoute1))));
+
+    // Activating and NHIP routes should be removed on withdrawal of activating route.
+    assertThat(
+        rib.removeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.withdrawing(nhipRoute1),
+            RouteAdvertisement.withdrawing(nhipRoute2),
+            RouteAdvertisement.withdrawing(activatingRoute)));
+  }
+
+  @Test
+  public void testEnforceResolvabilitySimpleLoop() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("1.0.0.0/8"), "foo"));
+    AnnotatedRoute<AbstractRoute> nhipRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("2.0.0.0/8"))
+                .setNextHop(NextHopIp.of(Ip.parse("1.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> loopingRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("1.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("2.0.0.2")))
+                .build());
+    rib.mergeRoute(activatingRoute);
+
+    // First NHIP route should be active on merge because it has full resolution path.
+    assertThat(
+        rib.mergeRouteGetDelta(nhipRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(nhipRoute))));
+
+    // Looping route should not be activated because it induces a loop. No other routes should be
+    // affected.
+    assertThat(rib.mergeRouteGetDelta(loopingRoute), equalTo(RibDelta.empty()));
+  }
+
+  @Test
+  public void testEnforceResolvabilityLargeLoop() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("1.0.0.0/24"), "foo"));
+    AnnotatedRoute<AbstractRoute> nhipRoute1 =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("1.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("2.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> nhipRoute2 =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("2.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("3.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> nhipRoute3 =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setRecursive(true)
+                .setNetwork(Prefix.strict("3.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("1.0.0.1")))
+                .build());
+    rib.mergeRoute(activatingRoute);
+    rib.mergeRoute(nhipRoute1);
+    rib.mergeRoute(nhipRoute2);
+    rib.mergeRoute(nhipRoute3);
+
+    // All routes should be removed due to loop created on removal of activating route
+    assertThat(
+        rib.removeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.withdrawing(activatingRoute),
+            RouteAdvertisement.withdrawing(nhipRoute1),
+            RouteAdvertisement.withdrawing(nhipRoute2),
+            RouteAdvertisement.withdrawing(nhipRoute3)));
+
+    // All route should be re-added when activating route is re-merged, breaking the loop.
+    assertThat(
+        rib.mergeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.adding(activatingRoute),
+            RouteAdvertisement.adding(nhipRoute1),
+            RouteAdvertisement.adding(nhipRoute2),
+            RouteAdvertisement.adding(nhipRoute3)));
+  }
+
+  @Test
+  public void testNoEnforceResolvabilityMergeOwnNextHopRoute() {
+    Rib rib = new Rib(false);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+
+    // Since own next hop check is disabled, route should be added.
+    assertThat(
+        rib.mergeRouteGetDelta(ownNextHopRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(ownNextHopRoute))));
+  }
+
+  @Test
+  public void testNoEnforceResolvabilityPreserveOwnNextHopRoute() {
+    Rib rib = new Rib(false);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> moreSpecificRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "i1"));
+
+    // Since own next hop check is disabled, ownNextHopRoute should remain active when more specific
+    // route is removed.
+    rib.mergeRoute(moreSpecificRoute);
+    rib.mergeRoute(ownNextHopRoute);
+    assertThat(
+        rib.removeRouteGetDelta(moreSpecificRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.withdrawing(moreSpecificRoute))));
+  }
+
+  @Test
+  public void testEnforceResolvabilityMergeInvalidOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+
+    // Route should not be added since it resolves its own next hop.
+    assertThat(rib.mergeRouteGetDelta(ownNextHopRoute), equalTo(RibDelta.empty()));
+  }
+
+  @Test
+  public void testEnforceResolvabilityMergeValidOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    rib.mergeRoute(annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "i1")));
+
+    // Route should be added since there is a more specific route that resolves its next hop.
+    assertThat(
+        rib.mergeRouteGetDelta(ownNextHopRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(ownNextHopRoute))));
+  }
+
+  @Test
+  public void testEnforceResolvabilityActivateOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "i1"));
+
+    rib.mergeRoute(ownNextHopRoute);
+
+    // ownNextHopRoute should be activated by activatingRoute.
+    assertThat(
+        rib.mergeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.adding(activatingRoute),
+            RouteAdvertisement.adding(ownNextHopRoute)));
+  }
+
+  @Test
+  public void testEnforceResolvabilityActivateOwnNextHopRouteCascade() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> moreSpecificOwnNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.1.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.1.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> lessSpecificOwnNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.1.2")))
+                .build());
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.1.1/32"), "lo"));
+
+    rib.mergeRoute(moreSpecificOwnNextHopRoute);
+    rib.mergeRoute(lessSpecificOwnNextHopRoute);
+
+    // moreSpecificOwnNextHopRoute should be activated by activatingRoute, and the former should
+    // activate lessSpecificOwnNextHopRoute.
+    assertThat(
+        rib.mergeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.adding(activatingRoute),
+            RouteAdvertisement.adding(lessSpecificOwnNextHopRoute),
+            RouteAdvertisement.adding(moreSpecificOwnNextHopRoute)));
+  }
+
+  @Test
+  public void testEnforceResolvabilityRemoveActiveOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.1/32"), "lo"));
+
+    rib.mergeRoute(activatingRoute);
+    rib.mergeRoute(ownNextHopRoute);
+
+    // Removing active ownNextHopRoute should result in withdrawal.
+    assertThat(
+        rib.removeRouteGetDelta(ownNextHopRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        contains(RouteAdvertisement.withdrawing(ownNextHopRoute)));
+  }
+
+  @Test
+  public void testEnforceResolvabilityRemoveInactiveOwnNextHopRoute() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+
+    rib.mergeRoute(ownNextHopRoute);
+
+    // Removing inactive ownNextHopRoute should not affect the RIB.
+    assertThat(rib.removeRouteGetDelta(ownNextHopRoute), equalTo(RibDelta.empty()));
+  }
+
+  @Test
+  public void testEnforceResolvabilityRemoveRedundantActivatingRoutes() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> moreSpecificActivatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.1/32"), "i1"));
+    AnnotatedRoute<AbstractRoute> lessSpecificActivatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/24"), "i2"));
+    AnnotatedRoute<AbstractRoute> ownNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.0.1")))
+                .build());
+
+    rib.mergeRoute(moreSpecificActivatingRoute);
+    rib.mergeRoute(lessSpecificActivatingRoute);
+    rib.mergeRoute(ownNextHopRoute);
+
+    // Removing moreSpecificActivatingRoute should not result in removal of ownNextHopRoute since
+    // the lessSpecificActivatingRoute remains.
+    assertThat(
+        rib.removeRouteGetDelta(moreSpecificActivatingRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.withdrawing(moreSpecificActivatingRoute))));
+
+    // Removing lessSpecificActivatingRoute should result in removal of ownNextHopRoute since
+    // no activating route remains.
+    assertThat(
+        rib.removeRouteGetDelta(lessSpecificActivatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.withdrawing(lessSpecificActivatingRoute),
+            RouteAdvertisement.withdrawing(ownNextHopRoute)));
+  }
+
+  @Test
+  public void testEnforceResolvabilityRemoveActivatingRouteCascade() {
+    Rib rib = new Rib(true);
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.1.1/32"), "lo"));
+    AnnotatedRoute<AbstractRoute> moreSpecificOwnNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.1.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.1.1")))
+                .build());
+    AnnotatedRoute<AbstractRoute> lessSpecificOwnNextHopRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("10.0.0.0/16"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.0.1.2")))
+                .build());
+
+    rib.mergeRoute(activatingRoute);
+    rib.mergeRoute(moreSpecificOwnNextHopRoute);
+    rib.mergeRoute(lessSpecificOwnNextHopRoute);
+
+    // Removing activatingRoute should deactivate moreSpecificOwnNextHopRoute, and deactivating the
+    // latter should deactivate lessSpecificOwnNextHopRoute.
+    assertThat(
+        rib.removeRouteGetDelta(activatingRoute)
+            .getActions()
+            .collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            RouteAdvertisement.withdrawing(activatingRoute),
+            RouteAdvertisement.withdrawing(lessSpecificOwnNextHopRoute),
+            RouteAdvertisement.withdrawing(moreSpecificOwnNextHopRoute)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -471,6 +471,14 @@ public class RibTest {
 
     // Removing inactive ownNextHopRoute should not affect the RIB.
     assertThat(rib.removeRouteGetDelta(ownNextHopRoute), equalTo(RibDelta.empty()));
+
+    // ownNextHopRoute should not be activated when an activator is added, because
+    // it has been completely removed from the RIB.
+    AnnotatedRoute<AbstractRoute> activatingRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "foo"));
+    assertThat(
+        rib.mergeRouteGetDelta(activatingRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(activatingRoute))));
   }
 
   @Test


### PR DESCRIPTION
- add support for enforcing resolvability of routes in main RIB
- to be resolvable, a route must:
  - have at least one route of a different prefix on its resolution path
  - have no loops on its resolution path
- unresolvable routes are deactivated in the main RIB until they become resolvable again