### PR TITLE
Cisco and Arista: OSPF export policies per process

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
@@ -120,6 +120,14 @@ public final class Names {
     return String.format("~BGP_PEER_IMPORT_POLICY_EVPN:%s:%s~", vrf, peer);
   }
 
+  public static String generatedOspfDefaultRouteGenerationPolicyName(String vrf, String proc) {
+    return String.format("~OSPF_DEFAULT_ROUTE_GENERATION_POLICY:%s:%s~", vrf, proc);
+  }
+
+  public static String generatedOspfExportPolicyName(String vrf, String proc) {
+    return String.format("~OSPF_EXPORT_POLICY:%s:%s~", vrf, proc);
+  }
+
   public static String generatedOspfInboundDistributeListName(
       String vrf, String procName, long areaNum, String ifaceName) {
     return String.format(

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -2901,8 +2901,6 @@ LOCALIP: 'localip';
 
 LOG: 'log';
 
-LOG_ADJ_CHANGES: 'log-adj-changes';
-
 LOG_ADJACENCY_CHANGES: 'log-adjacency-changes';
 
 LOG_ENABLE: 'log-enable';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
@@ -114,7 +114,7 @@ ro_common
 
 ro_default_information
 :
-   NO? DEFAULT_INFORMATION ORIGINATE
+   DEFAULT_INFORMATION ORIGINATE
    (
       METRIC metric = uint_legacy
       | METRIC_TYPE metric_type = uint_legacy
@@ -126,7 +126,7 @@ ro_default_information
 
 ro_default_metric
 :
-   NO? DEFAULT_METRIC metric = uint_legacy NEWLINE
+   DEFAULT_METRIC metric = uint_legacy NEWLINE
 ;
 
 ro_distance
@@ -192,6 +192,14 @@ ro_maximum_paths
 ;
 
 roc_network: NETWORK ospf_network_type NEWLINE;
+
+ro_no
+:
+   NO (
+      DEFAULT_INFORMATION ORIGINATE
+      | DEFAULT_METRIC uint_legacy
+   ) NEWLINE
+;
 
 roa_nssa
 :
@@ -396,6 +404,7 @@ s_router_ospf
       | ro_max_metric
       | ro_maximum_paths
       | ro_mpls
+      | ro_no
       | ro_redistribute
       | ro_router_id
       | ro_summary_address

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
@@ -114,15 +114,10 @@ ro_common
 
 ro_default_information
 :
-   DEFAULT_INFORMATION ORIGINATE
+   NO? DEFAULT_INFORMATION ORIGINATE
    (
-      (
-         METRIC metric = uint_legacy
-      )
-      |
-      (
-         METRIC_TYPE metric_type = uint_legacy
-      )
+      METRIC metric = uint_legacy
+      | METRIC_TYPE metric_type = uint_legacy
       | ALWAYS
       | ROUTE_POLICY policy = route_policy_name
       | TAG uint_legacy
@@ -223,48 +218,18 @@ roc_null
 :
    NO?
    (
-      (
-         AREA variable AUTHENTICATION
-      )
+      AREA variable AUTHENTICATION
       | AUTO_COST
       | BFD
       | CAPABILITY
       | DEAD_INTERVAL
-      | DISCARD_ROUTE
       | FAST_REROUTE
-      | GRACEFUL_RESTART
       | HELLO_INTERVAL
-      |
-      (
-         IP
-         (
-            OSPF
-            (
-               EVENT_HISTORY
-            )
-         )
-      )
-      | ISPF
       | LOG
-      | LOG_ADJ_CHANGES
-      | LOG_ADJACENCY_CHANGES
       | MAX_LSA
-      |
-      (
-         MAXIMUM
-         (
-            REDISTRIBUTED_PREFIXES
-         )
-      )
+      | MAXIMUM REDISTRIBUTED_PREFIXES
       | MESSAGE_DIGEST_KEY
       | MTU_IGNORE
-      |
-      (
-         NO
-         (
-            DEFAULT_INFORMATION
-         )
-      )
       | NSF
       | NSR
       | SNMP

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -967,6 +967,7 @@ import org.batfish.representation.cisco_xr.NetworkObjectGroup;
 import org.batfish.representation.cisco_xr.NssaSettings;
 import org.batfish.representation.cisco_xr.OriginatesFromAsPathSetElem;
 import org.batfish.representation.cisco_xr.OspfArea;
+import org.batfish.representation.cisco_xr.OspfDefaultInformationOriginate;
 import org.batfish.representation.cisco_xr.OspfInterfaceSettings;
 import org.batfish.representation.cisco_xr.OspfNetworkType;
 import org.batfish.representation.cisco_xr.OspfProcess;
@@ -5958,24 +5959,30 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitRo_default_information(Ro_default_informationContext ctx) {
-    if (ctx.policy != null) {
-      todo(ctx);
-      String name = toString(ctx.policy);
-      _configuration.referenceStructure(
-          ROUTE_POLICY, name, OSPF_DEFAULT_INFORMATION_ROUTE_POLICY, ctx.start.getLine());
-    }
     OspfProcess proc = _currentOspfProcess;
-    proc.setDefaultInformationOriginate(true);
-    boolean always = ctx.ALWAYS().size() > 0;
-    proc.setDefaultInformationOriginateAlways(always);
-    if (ctx.metric != null) {
-      int metric = toInteger(ctx.metric);
-      proc.setDefaultInformationMetric(metric);
-    }
-    if (ctx.metric_type != null) {
-      int metricTypeInt = toInteger(ctx.metric_type);
-      OspfMetricType metricType = OspfMetricType.fromInteger(metricTypeInt);
-      proc.setDefaultInformationMetricType(metricType);
+    if (ctx.NO() != null) {
+      proc.setDefaultInformationOriginate(null);
+    } else {
+      if (ctx.policy != null) {
+        todo(ctx);
+        String name = toString(ctx.policy);
+        _configuration.referenceStructure(
+            ROUTE_POLICY, name, OSPF_DEFAULT_INFORMATION_ROUTE_POLICY, ctx.start.getLine());
+      }
+      OspfDefaultInformationOriginate defaultInformationOriginate =
+          new OspfDefaultInformationOriginate();
+      boolean always = ctx.ALWAYS().size() > 0;
+      defaultInformationOriginate.setAlways(always);
+      if (ctx.metric != null) {
+        int metric = toInteger(ctx.metric);
+        defaultInformationOriginate.setMetric(metric);
+      }
+      if (ctx.metric_type != null) {
+        int metricTypeInt = toInteger(ctx.metric_type);
+        OspfMetricType metricType = OspfMetricType.fromInteger(metricTypeInt);
+        defaultInformationOriginate.setMetricType(metricType);
+      }
+      proc.setDefaultInformationOriginate(defaultInformationOriginate);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -5959,42 +5959,32 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitRo_default_information(Ro_default_informationContext ctx) {
-    OspfProcess proc = _currentOspfProcess;
-    if (ctx.NO() != null) {
-      proc.setDefaultInformationOriginate(null);
-    } else {
-      if (ctx.policy != null) {
-        todo(ctx);
-        String name = toString(ctx.policy);
-        _configuration.referenceStructure(
-            ROUTE_POLICY, name, OSPF_DEFAULT_INFORMATION_ROUTE_POLICY, ctx.start.getLine());
-      }
-      OspfDefaultInformationOriginate defaultInformationOriginate =
-          new OspfDefaultInformationOriginate();
-      boolean always = ctx.ALWAYS().size() > 0;
-      defaultInformationOriginate.setAlways(always);
-      if (ctx.metric != null) {
-        int metric = toInteger(ctx.metric);
-        defaultInformationOriginate.setMetric(metric);
-      }
-      if (ctx.metric_type != null) {
-        int metricTypeInt = toInteger(ctx.metric_type);
-        OspfMetricType metricType = OspfMetricType.fromInteger(metricTypeInt);
-        defaultInformationOriginate.setMetricType(metricType);
-      }
-      proc.setDefaultInformationOriginate(defaultInformationOriginate);
+    if (ctx.policy != null) {
+      todo(ctx);
+      String name = toString(ctx.policy);
+      _configuration.referenceStructure(
+          ROUTE_POLICY, name, OSPF_DEFAULT_INFORMATION_ROUTE_POLICY, ctx.start.getLine());
     }
+    OspfDefaultInformationOriginate defaultInformationOriginate =
+        new OspfDefaultInformationOriginate();
+    boolean always = ctx.ALWAYS().size() > 0;
+    defaultInformationOriginate.setAlways(always);
+    if (ctx.metric != null) {
+      int metric = toInteger(ctx.metric);
+      defaultInformationOriginate.setMetric(metric);
+    }
+    if (ctx.metric_type != null) {
+      int metricTypeInt = toInteger(ctx.metric_type);
+      OspfMetricType metricType = OspfMetricType.fromInteger(metricTypeInt);
+      defaultInformationOriginate.setMetricType(metricType);
+    }
+    _currentOspfProcess.setDefaultInformationOriginate(defaultInformationOriginate);
   }
 
   @Override
   public void exitRo_default_metric(Ro_default_metricContext ctx) {
-    OspfProcess proc = _currentOspfProcess;
-    if (ctx.NO() != null) {
-      proc.setDefaultMetric(null);
-    } else {
-      long metric = toLong(ctx.metric);
-      proc.setDefaultMetric(metric);
-    }
+    long metric = toLong(ctx.metric);
+    _currentOspfProcess.setDefaultMetric(metric);
   }
 
   @Override
@@ -6057,6 +6047,16 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   @Override
   public void exitRoc_network(Roc_networkContext ctx) {
     _currentOspfSettings.setNetworkType(toOspfNetworkType(ctx.ospf_network_type()));
+  }
+
+  @Override
+  public void exitRo_no(CiscoXrParser.Ro_noContext ctx) {
+    OspfProcess proc = _currentOspfProcess;
+    if (ctx.DEFAULT_INFORMATION() != null) {
+      proc.setDefaultInformationOriginate(null);
+    } else if (ctx.DEFAULT_METRIC() != null) {
+      proc.setDefaultMetric(null);
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -9,6 +9,8 @@ import static org.batfish.datamodel.Interface.isRealInterfaceName;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
 import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
+import static org.batfish.datamodel.Names.generatedOspfDefaultRouteGenerationPolicyName;
+import static org.batfish.datamodel.Names.generatedOspfExportPolicyName;
 import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
 import static org.batfish.representation.arista.AristaConversions.getVrfForVlan;
@@ -281,10 +283,6 @@ public final class AristaConfiguration extends VendorConfiguration {
         .filter(e -> Objects.nonNull(e.getValue().getAddress()))
         .collect(
             ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getAddress().getIp()));
-  }
-
-  public static String computeOspfDefaultRouteGenerationPolicyName(String vrf, String proc) {
-    return String.format("~OSPF_DEFAULT_ROUTE_GENERATION_POLICY:%s:%s~", vrf, proc);
   }
 
   @Override
@@ -1462,7 +1460,7 @@ public final class AristaConfiguration extends VendorConfiguration {
     }
     newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));
 
-    String ospfExportPolicyName = "~OSPF_EXPORT_POLICY:" + vrfName + "~";
+    String ospfExportPolicyName = generatedOspfExportPolicyName(vrfName, proc.getName());
     RoutingPolicy ospfExportPolicy = new RoutingPolicy(ospfExportPolicyName, c);
     c.getRoutingPolicies().put(ospfExportPolicyName, ospfExportPolicy);
     List<Statement> ospfExportStatements = ospfExportPolicy.getStatements();
@@ -1500,7 +1498,7 @@ public final class AristaConfiguration extends VendorConfiguration {
       } else {
         // Use a generated route that will only be generated if a default route exists in RIB
         String defaultRouteGenerationPolicyName =
-            computeOspfDefaultRouteGenerationPolicyName(vrfName, proc.getName());
+            generatedOspfDefaultRouteGenerationPolicyName(vrfName, proc.getName());
         RoutingPolicy.builder()
             .setOwner(c)
             .setName(defaultRouteGenerationPolicyName)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -10,6 +10,8 @@ import static org.batfish.datamodel.Interface.isRealInterfaceName;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
 import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
+import static org.batfish.datamodel.Names.generatedOspfDefaultRouteGenerationPolicyName;
+import static org.batfish.datamodel.Names.generatedOspfExportPolicyName;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
@@ -333,10 +335,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
         .filter(e -> Objects.nonNull(e.getValue().getAddress()))
         .collect(
             ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getAddress().getIp()));
-  }
-
-  public static String computeOspfDefaultRouteGenerationPolicyName(String vrf, String proc) {
-    return String.format("~OSPF_DEFAULT_ROUTE_GENERATION_POLICY:%s:%s~", vrf, proc);
   }
 
   public static String computeProtocolObjectGroupAclName(String name) {
@@ -1887,7 +1885,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     }
     newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));
 
-    String ospfExportPolicyName = "~OSPF_EXPORT_POLICY:" + vrfName + "~";
+    String ospfExportPolicyName = generatedOspfExportPolicyName(vrfName, proc.getName());
     RoutingPolicy ospfExportPolicy = new RoutingPolicy(ospfExportPolicyName, c);
     c.getRoutingPolicies().put(ospfExportPolicyName, ospfExportPolicy);
     List<Statement> ospfExportStatements = ospfExportPolicy.getStatements();
@@ -1925,7 +1923,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       } else {
         // Use a generated route that will only be generated if a default route exists in RIB
         String defaultRouteGenerationPolicyName =
-            computeOspfDefaultRouteGenerationPolicyName(vrfName, proc.getName());
+            generatedOspfDefaultRouteGenerationPolicyName(vrfName, proc.getName());
         RoutingPolicy.builder()
             .setOwner(c)
             .setName(defaultRouteGenerationPolicyName)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -11,6 +11,8 @@ import static org.batfish.datamodel.Interface.isRealInterfaceName;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
 import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
+import static org.batfish.datamodel.Names.generatedOspfDefaultRouteGenerationPolicyName;
+import static org.batfish.datamodel.Names.generatedOspfExportPolicyName;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
@@ -364,10 +366,6 @@ public final class AsaConfiguration extends VendorConfiguration {
         .filter(e -> Objects.nonNull(e.getValue().getAddress()))
         .collect(
             ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getAddress().getIp()));
-  }
-
-  public static String computeOspfDefaultRouteGenerationPolicyName(String vrf, String proc) {
-    return String.format("~OSPF_DEFAULT_ROUTE_GENERATION_POLICY:%s:%s~", vrf, proc);
   }
 
   public static String computeProtocolObjectGroupAclName(String name) {
@@ -2215,7 +2213,7 @@ public final class AsaConfiguration extends VendorConfiguration {
     }
     newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));
 
-    String ospfExportPolicyName = "~OSPF_EXPORT_POLICY:" + vrfName + "~";
+    String ospfExportPolicyName = generatedOspfExportPolicyName(vrfName, proc.getName());
     RoutingPolicy ospfExportPolicy = new RoutingPolicy(ospfExportPolicyName, c);
     c.getRoutingPolicies().put(ospfExportPolicyName, ospfExportPolicy);
     List<Statement> ospfExportStatements = ospfExportPolicy.getStatements();
@@ -2253,7 +2251,7 @@ public final class AsaConfiguration extends VendorConfiguration {
       } else {
         // Use a generated route that will only be generated if a default route exists in RIB
         String defaultRouteGenerationPolicyName =
-            computeOspfDefaultRouteGenerationPolicyName(vrfName, proc.getName());
+            generatedOspfDefaultRouteGenerationPolicyName(vrfName, proc.getName());
         RoutingPolicy.builder()
             .setOwner(c)
             .setName(defaultRouteGenerationPolicyName)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/OspfDefaultInformationOriginate.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/OspfDefaultInformationOriginate.java
@@ -1,0 +1,45 @@
+package org.batfish.representation.cisco_xr;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.ospf.OspfMetricType;
+
+/** Represents options for default-information originate in OSPF */
+public class OspfDefaultInformationOriginate implements Serializable {
+  @VisibleForTesting public static final long DEFAULT_METRIC = 1L;
+  @VisibleForTesting public static final OspfMetricType DEFAULT_METRIC_TYPE = OspfMetricType.E2;
+
+  public OspfDefaultInformationOriginate() {
+    _metric = DEFAULT_METRIC;
+    _metricType = DEFAULT_METRIC_TYPE;
+  }
+
+  public boolean getAlways() {
+    return _always;
+  }
+
+  public long getMetric() {
+    return _metric;
+  }
+
+  public @Nonnull OspfMetricType getMetricType() {
+    return _metricType;
+  }
+
+  public void setAlways(boolean b) {
+    _always = b;
+  }
+
+  public void setMetric(int metric) {
+    _metric = metric;
+  }
+
+  public void setMetricType(@Nonnull OspfMetricType metricType) {
+    _metricType = metricType;
+  }
+
+  private boolean _always;
+  private long _metric;
+  private @Nonnull OspfMetricType _metricType;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/OspfProcess.java
@@ -7,12 +7,9 @@ import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.RoutingProtocol;
-import org.batfish.datamodel.ospf.OspfMetricType;
 
 public class OspfProcess implements Serializable {
 
-  private static final long DEFAULT_DEFAULT_INFORMATION_METRIC = 1L;
-  private static final OspfMetricType DEFAULT_DEFAULT_INFORMATION_METRIC_TYPE = OspfMetricType.E2;
   // Although not clearly documented; from GNS3 emulation and CiscoXr forum
   // (https://community.cisco_xr.com/t5/switching/ospf-cost-calculation/td-p/2917356)
   public static final int DEFAULT_LOOPBACK_OSPF_COST = 1;
@@ -23,11 +20,7 @@ public class OspfProcess implements Serializable {
   public static final long MAX_METRIC_ROUTER_LSA = 0xFFFFL;
 
   private final Map<Long, OspfArea> _areas;
-  private long _defaultInformationMetric;
-  private OspfMetricType _defaultInformationMetricType;
-  private boolean _defaultInformationOriginate;
-  private boolean _defaultInformationOriginateAlways;
-  private String _defaultInformationOriginateMap;
+  @Nullable private OspfDefaultInformationOriginate _defaultInformationOriginate;
   private Long _defaultMetric;
   @Nullable private DistributeList _distributeListOut;
   private Long _maxMetricExternalLsa;
@@ -56,8 +49,6 @@ public class OspfProcess implements Serializable {
   public OspfProcess(String name) {
     _name = name;
     _referenceBandwidth = DEFAULT_OSPF_REFERENCE_BANDWIDTH;
-    _defaultInformationMetric = DEFAULT_DEFAULT_INFORMATION_METRIC;
-    _defaultInformationMetricType = DEFAULT_DEFAULT_INFORMATION_METRIC_TYPE;
     _areas = new TreeMap<>();
     _ospfSettings = new OspfSettings();
     _redistributionPolicies = new EnumMap<>(RoutingProtocol.class);
@@ -67,24 +58,11 @@ public class OspfProcess implements Serializable {
     return _areas;
   }
 
-  public long getDefaultInformationMetric() {
-    return _defaultInformationMetric;
-  }
-
-  public OspfMetricType getDefaultInformationMetricType() {
-    return _defaultInformationMetricType;
-  }
-
-  public boolean getDefaultInformationOriginate() {
+  /**
+   * Associated {@link OspfDefaultInformationOriginate} for this process, or null if not configured.
+   */
+  public @Nullable OspfDefaultInformationOriginate getDefaultInformationOriginate() {
     return _defaultInformationOriginate;
-  }
-
-  public boolean getDefaultInformationOriginateAlways() {
-    return _defaultInformationOriginateAlways;
-  }
-
-  public String getDefaultInformationOriginateMap() {
-    return _defaultInformationOriginateMap;
   }
 
   public Long getDefaultMetric() {
@@ -132,24 +110,9 @@ public class OspfProcess implements Serializable {
     return _routerId;
   }
 
-  public void setDefaultInformationMetric(int metric) {
-    _defaultInformationMetric = metric;
-  }
-
-  public void setDefaultInformationMetricType(OspfMetricType metricType) {
-    _defaultInformationMetricType = metricType;
-  }
-
-  public void setDefaultInformationOriginate(boolean b) {
-    _defaultInformationOriginate = b;
-  }
-
-  public void setDefaultInformationOriginateAlways(boolean b) {
-    _defaultInformationOriginateAlways = b;
-  }
-
-  public void setDefaultInformationOriginateMap(String name) {
-    _defaultInformationOriginateMap = name;
+  public void setDefaultInformationOriginate(
+      @Nullable OspfDefaultInformationOriginate defaultInformationOriginate) {
+    _defaultInformationOriginate = defaultInformationOriginate;
   }
 
   public void setDefaultMetric(Long metric) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-default-information
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-default-information
@@ -1,0 +1,47 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname ospf-default-information
+!
+interface GigabitEthernet0/0/0/1
+ no shutdown
+!
+interface GigabitEthernet0/0/0/2
+ no shutdown
+!
+interface GigabitEthernet0/0/0/3
+ no shutdown
+!
+interface GigabitEthernet0/0/0/4
+ no shutdown
+!
+route-policy RP
+end-policy
+!
+router ospf 1
+  router-id 1.1.1.1
+  default-information originate
+  area 1
+    interface GigabitEthernet0/0/0/1
+!
+router ospf 2
+  router-id 1.1.1.1
+  default-information originate always metric 10 metric-type 2 route-policy RP
+  default-information originate metric 12 metric-type 1
+  area 1
+    interface GigabitEthernet0/0/0/2
+!
+router ospf 3
+  router-id 1.1.1.1
+  default-information originate always metric 10 metric-type 2
+  no default-information originate
+  area 1
+    interface GigabitEthernet0/0/0/3
+!
+router ospf 4
+  router-id 1.1.1.1
+  default-information originate metric 12 metric-type 1
+  no default-information originate
+  default-information originate always metric 10 route-policy RP
+  area 1
+    interface GigabitEthernet0/0/0/4
+!

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -61538,8 +61538,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~"
           },
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",
@@ -61756,7 +61756,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "10.10.255.8",

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -3183,7 +3183,7 @@
                   "stubType" : "NONE"
                 }
               },
-              "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
               "processId" : "1",
               "referenceBandwidth" : 1.0E8,
               "routerId" : "1.1.1.1",

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -1224,8 +1224,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -1423,7 +1423,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.1.1.1",
@@ -2862,8 +2862,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -3071,7 +3071,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.2.2.2",
@@ -3416,8 +3416,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~"
           },
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",
@@ -3574,7 +3574,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.10.1.1",
@@ -4896,8 +4896,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -5150,7 +5150,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.1.1",
@@ -6484,8 +6484,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -6700,7 +6700,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.1.2",
@@ -7243,8 +7243,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~"
           },
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",
@@ -7403,7 +7403,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.2.1",
@@ -7889,8 +7889,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~"
           },
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",
@@ -8049,7 +8049,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.2.2",
@@ -9939,8 +9939,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -10139,7 +10139,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.3.1",
@@ -10892,8 +10892,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -11092,7 +11092,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.3.2",
@@ -12381,8 +12381,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -12590,7 +12590,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "3.1.1.1",
@@ -13769,8 +13769,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -13978,7 +13978,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "3.2.2.2",
@@ -14435,8 +14435,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~"
           },
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",
@@ -14593,7 +14593,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "3.10.1.1",

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -29582,8 +29582,8 @@
           }
         },
         "routingPolicies" : {
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~"
           }
         },
         "vendorFamily" : {
@@ -29622,7 +29622,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "192.168.1.1",
@@ -38594,8 +38594,8 @@
           }
         },
         "routingPolicies" : {
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -38823,7 +38823,7 @@
                     "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:0~"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "1.2.3.4",
@@ -39081,8 +39081,14 @@
           }
         },
         "routingPolicies" : {
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~"
+          },
+          "~OSPF_EXPORT_POLICY:default:abcdefg~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:abcdefg~"
+          },
+          "~OSPF_EXPORT_POLICY:default:ignored~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:ignored~"
           },
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",
@@ -39160,7 +39166,7 @@
                     "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:0~"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.1.1.1",
@@ -39175,7 +39181,7 @@
                   "ospfIA" : 110,
                   "ospfIS" : 110
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:abcdefg~",
                 "processId" : "abcdefg",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.1.1.1",
@@ -39213,7 +39219,7 @@
                     "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:1~"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:ignored~",
                 "processId" : "ignored",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.1.1.1",
@@ -48225,8 +48231,8 @@
           }
         },
         "routingPolicies" : {
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
+          "~OSPF_EXPORT_POLICY:default:1~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:1~"
           },
           "~RESOLUTION_POLICY~" : {
             "name" : "~RESOLUTION_POLICY~",
@@ -48294,7 +48300,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:1~",
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.130.0.1",
@@ -53087,8 +53093,8 @@
               }
             ]
           },
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~",
+          "~OSPF_EXPORT_POLICY:default:2~" : {
+            "name" : "~OSPF_EXPORT_POLICY:default:2~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -53204,7 +53210,7 @@
                     "stubType" : "NONE"
                   }
                 },
-                "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+                "exportPolicy" : "~OSPF_EXPORT_POLICY:default:2~",
                 "generatedRoutes" : [
                   {
                     "class" : "org.batfish.datamodel.GeneratedRoute",


### PR DESCRIPTION
This PR is a bit overloaded, but the most important change is that Cisco vendors and Arista were using the same name for all OSPF export policies in a given VRF, so the export policy was only accurate for the last OSPF process converted. Updated to use different export policy names for each process.

Other changes consist of XR OSPF cleanup:
* Test OSPF `default-information originate` and add support for `no default-information originate`
* Clear out invalid grammar from null block