### PR TITLE
Layer1Topology: flexible matching for interfaces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/InterfaceUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/InterfaceUtil.java
@@ -1,0 +1,30 @@
+package org.batfish.common.topology;
+
+import java.util.Optional;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+
+/** A helper class for topology-related functions for interfaces. */
+public final class InterfaceUtil {
+  /**
+   * Returns the name of an interface matching the query, or {@link Optional#empty()} if none found.
+   */
+  public static Optional<String> matchingInterfaceName(String query, Set<String> knownInterfaces) {
+    if (knownInterfaces.contains(query)) {
+      return Optional.of(query);
+    }
+    Optional<String> firstMatchingLowercase =
+        knownInterfaces.stream().filter(i -> i.equalsIgnoreCase(query)).findFirst();
+    // TODO: check for canonicalizations?
+    return firstMatchingLowercase;
+  }
+
+  /** Returns the interface matching the query, or {@link Optional#empty()} if none found. */
+  public static Optional<Interface> matchingInterface(String query, Configuration c) {
+    return matchingInterfaceName(query, c.getAllInterfaces().keySet())
+        .map(c.getAllInterfaces()::get);
+  }
+
+  private InterfaceUtil() {} // prevent instantiation of utility clas
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/InterfaceUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/InterfaceUtilTest.java
@@ -1,0 +1,42 @@
+package org.batfish.common.topology;
+
+import static org.batfish.common.topology.InterfaceUtil.matchingInterface;
+import static org.batfish.common.topology.InterfaceUtil.matchingInterfaceName;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.NetworkFactory;
+import org.junit.Test;
+
+public class InterfaceUtilTest {
+  @Test
+  public void testMatchingInterfaceName() {
+    Set<String> known = ImmutableSet.of("Ethernet1", "Ethernet2");
+    assertThat(matchingInterfaceName("Ethernet1", known), equalTo(Optional.of("Ethernet1")));
+    assertThat(matchingInterfaceName("ETHERNET1", known), equalTo(Optional.of("Ethernet1")));
+    assertThat(matchingInterfaceName("Ethernet3", known), equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testMatchingInterface() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface i =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setName("Ethernet1")
+            .setType(InterfaceType.PHYSICAL)
+            .build();
+    assertThat(matchingInterface(i.getName(), c).get(), sameInstance(i));
+    assertThat(matchingInterface(i.getName().toLowerCase(), c).get(), sameInstance(i));
+    assertThat(matchingInterface(i.getName().toUpperCase(), c).get(), sameInstance(i));
+    assertThat(matchingInterface(i.getName() + 'x', c), equalTo(Optional.empty()));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -154,6 +154,7 @@ public final class TopologyUtilTest {
     String c1Name = "c1";
     String c2Name = "c2";
     String c1i1Name = "c1i1";
+    String c1i1NonCanonicalName = c1i1Name.toUpperCase();
     String c1i2Name = "c1i2";
     String c2i1Name = "c2i1";
     String c2i2Name = "c2i2";
@@ -173,12 +174,16 @@ public final class TopologyUtilTest {
     Map<String, Configuration> configurations = ImmutableMap.of(c1Name, c1, c2Name, c2);
     Layer1Topology rawLayer1Topology =
         new Layer1Topology(
-            new Layer1Edge(new Layer1Node(c1Name, c1i1Name), new Layer1Node(c2Name, c2i1Name)),
-            new Layer1Edge(new Layer1Node(c2Name, c2i1Name), new Layer1Node(c1Name, c1i1Name)),
+            new Layer1Edge(
+                new Layer1Node(c1Name, c1i1NonCanonicalName), new Layer1Node(c2Name, c2i1Name)),
+            new Layer1Edge(
+                new Layer1Node(c2Name, c2i1Name), new Layer1Node(c1Name, c1i1NonCanonicalName)),
             new Layer1Edge(new Layer1Node(c1Name, c1i2Name), new Layer1Node(c2Name, c2i2Name)),
             new Layer1Edge(new Layer1Node(c2Name, c2i2Name), new Layer1Node(c1Name, c1i2Name)));
 
     // inactive c2i2 should break c1i2<=>c2i2 link
+    // non-canonical names should be accepted.
+    assertThat(c1i1Name, not(equalTo(c1i1NonCanonicalName)));
     assertThat(
         TopologyUtil.cleanLayer1PhysicalTopology(rawLayer1Topology, configurations)
             .getGraph()


### PR DESCRIPTION
1. Introduce `InterfaceUtil` to be a single place to handle logic
2. Plumb it into cleanLayer1Topology. The raw Layer1Topology is the only one
   that should contain non-canonical names.