### PR TITLE
main rib resolver non-recursive static routes and resolution restriction

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -69,6 +69,7 @@ public final class Configuration implements Serializable {
     private String _domainName;
     private LineAction _defaultCrossZoneAction;
     private LineAction _defaultInboundAction;
+    private boolean _mainRibEnforceResolvability;
 
     private Builder(@Nullable Supplier<String> hostnameGenerator) {
       _hostnameGenerator = hostnameGenerator;
@@ -89,6 +90,7 @@ public final class Configuration implements Serializable {
       }
       configuration.setDeviceModel(_deviceModel);
       configuration.setDomainName(_domainName);
+      configuration.setMainRibEnforceResolvability(_mainRibEnforceResolvability);
       return configuration;
     }
 
@@ -130,6 +132,11 @@ public final class Configuration implements Serializable {
       _defaultInboundAction = defaultInboundAction;
       return this;
     }
+
+    public @Nonnull Builder setMainRibEnforceResolvability(boolean mainRibEnforceResolvability) {
+      _mainRibEnforceResolvability = mainRibEnforceResolvability;
+      return this;
+    }
   }
 
   public static final String DEFAULT_VRF_NAME = "default";
@@ -166,6 +173,7 @@ public final class Configuration implements Serializable {
   private static final String PROP_IPSEC_PHASE2_PROPOSALS = "ipsecPhase2Proposals";
   private static final String PROP_LOGGING_SERVERS = "loggingServers";
   private static final String PROP_LOGGING_SOURCE_INTERFACE = "loggingSourceInterface";
+  private static final String PROP_MAIN_RIB_ENFORCE_RESOLVABILITY = "mainRibEnforceResolvability";
   private static final String PROP_MLAGS = "mlags";
   private static final String PROP_NAME = "name";
   private static final String PROP_NTP_SERVERS = "ntpServers";
@@ -248,6 +256,8 @@ public final class Configuration implements Serializable {
   private Set<String> _loggingServers;
 
   private String _loggingSourceInterface;
+
+  private boolean _mainRibEnforceResolvability;
 
   private Map<String, Mlag> _mlags;
 
@@ -665,6 +675,11 @@ public final class Configuration implements Serializable {
     return _loggingSourceInterface;
   }
 
+  @JsonProperty(PROP_MAIN_RIB_ENFORCE_RESOLVABILITY)
+  public boolean getMainRibEnforceResolvability() {
+    return _mainRibEnforceResolvability;
+  }
+
   @JsonProperty(PROP_MLAGS)
   @Nonnull
   public Map<String, Mlag> getMlags() {
@@ -934,6 +949,11 @@ public final class Configuration implements Serializable {
   @JsonProperty(PROP_LOGGING_SOURCE_INTERFACE)
   public void setLoggingSourceInterface(String loggingSourceInterface) {
     _loggingSourceInterface = loggingSourceInterface;
+  }
+
+  @JsonProperty(PROP_MAIN_RIB_ENFORCE_RESOLVABILITY)
+  public void setMainRibEnforceResolvability(boolean mainRibEnforceResolvability) {
+    _mainRibEnforceResolvability = mainRibEnforceResolvability;
   }
 
   @JsonProperty(PROP_MLAGS)

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -248,7 +248,7 @@ public final class VirtualRouter {
             ? alwaysTrue()
             : _c.getRoutingPolicies().get(resolutionPolicy)::processReadOnly;
     // Main RIB + delta builder
-    _mainRib = new Rib();
+    _mainRib = new Rib(_c.getMainRibEnforceResolvability() ? _resolutionRestriction : null);
     _mainRibs = ImmutableMap.of(RibId.DEFAULT_RIB_NAME, _mainRib);
     _mainRibDeltaPrevRound = RibDelta.empty();
     _mainRibRouteDeltaBuilder = RibDelta.builder();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -157,9 +157,9 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
     }
 
     /**
-     * Performs longest prefix match on a next hop IP route. If the route contains its own next hop
-     * ip and the result does not contain a more specific route, returns the empty set. Otherwise,
-     * returns the LPM routes.
+     * Performs longest prefix match on a next hop IP route. If the route passes the resolution
+     * restriction, contains its own next hop IP, and the result does not contain a more specific
+     * route, returns the empty set. Otherwise, returns the LPM routes.
      */
     private @Nonnull Set<AnnotatedRoute<AbstractRoute>> lpmIfValid(
         AnnotatedRoute<AbstractRoute> nhipRoute) {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -623,10 +623,9 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityConnectedRouteWhitelist() {
-    // A route forbidden by resolution restriction cannot form a loop, even if it contains its own
-    // next hop.
+    // A connected route may be used to resolve any next hop IP route regardless of resolution
+    // restriction.
     Rib rib = new Rib(route -> route.getNetwork().getPrefixLength() != 16);
-    // would loop if non-recursive route were allowed to use it for resolution
     AnnotatedRoute<AbstractRoute> recursiveRoute =
         annotateRoute(
             StaticRoute.testBuilder()

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -110,7 +110,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityMergeResolvableRoute() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> activatingRoute =
         annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "foo"));
     AnnotatedRoute<AbstractRoute> nhipRoute =
@@ -129,7 +129,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityActivateResolvableRoute() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> activatingRoute =
         annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.0/31"), "foo"));
     AnnotatedRoute<AbstractRoute> nhipRoute =
@@ -152,7 +152,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityActivateRoutesCascade() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> nhipRoute1 =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -186,7 +186,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityDeactivateRoutesCascade() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> nhipRoute1 =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -226,7 +226,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilitySimpleLoop() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> activatingRoute =
         annotateRoute(new ConnectedRoute(Prefix.strict("1.0.0.0/8"), "foo"));
     AnnotatedRoute<AbstractRoute> nhipRoute =
@@ -257,7 +257,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityLargeLoop() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> activatingRoute =
         annotateRoute(new ConnectedRoute(Prefix.strict("1.0.0.0/24"), "foo"));
     AnnotatedRoute<AbstractRoute> nhipRoute1 =
@@ -311,7 +311,7 @@ public class RibTest {
 
   @Test
   public void testNoEnforceResolvabilityMergeOwnNextHopRoute() {
-    Rib rib = new Rib(false);
+    Rib rib = new Rib(null);
     AnnotatedRoute<AbstractRoute> ownNextHopRoute =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -327,7 +327,7 @@ public class RibTest {
 
   @Test
   public void testNoEnforceResolvabilityPreserveOwnNextHopRoute() {
-    Rib rib = new Rib(false);
+    Rib rib = new Rib(null);
     AnnotatedRoute<AbstractRoute> ownNextHopRoute =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -348,7 +348,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityMergeInvalidOwnNextHopRoute() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> ownNextHopRoute =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -362,7 +362,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityMergeValidOwnNextHopRoute() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> ownNextHopRoute =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -379,7 +379,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityActivateOwnNextHopRoute() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> ownNextHopRoute =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -403,7 +403,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityActivateOwnNextHopRouteCascade() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> moreSpecificOwnNextHopRoute =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -436,7 +436,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityRemoveActiveOwnNextHopRoute() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> ownNextHopRoute =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -459,7 +459,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityRemoveInactiveOwnNextHopRoute() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> ownNextHopRoute =
         annotateRoute(
             StaticRoute.testBuilder()
@@ -483,7 +483,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityRemoveRedundantActivatingRoutes() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> moreSpecificActivatingRoute =
         annotateRoute(new ConnectedRoute(Prefix.strict("10.0.0.1/32"), "i1"));
     AnnotatedRoute<AbstractRoute> lessSpecificActivatingRoute =
@@ -518,7 +518,7 @@ public class RibTest {
 
   @Test
   public void testEnforceResolvabilityRemoveActivatingRouteCascade() {
-    Rib rib = new Rib(true);
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
     AnnotatedRoute<AbstractRoute> activatingRoute =
         annotateRoute(new ConnectedRoute(Prefix.strict("10.0.1.1/32"), "lo"));
     AnnotatedRoute<AbstractRoute> moreSpecificOwnNextHopRoute =
@@ -548,5 +548,99 @@ public class RibTest {
             RouteAdvertisement.withdrawing(activatingRoute),
             RouteAdvertisement.withdrawing(lessSpecificOwnNextHopRoute),
             RouteAdvertisement.withdrawing(moreSpecificOwnNextHopRoute)));
+  }
+
+  @Test
+  public void testEnforceResolvabilityStaticNonrecursiveRouteCannotLoop() {
+    Rib rib = new Rib(ResolutionRestriction.alwaysTrue());
+    // would loop if non-recursive route were allowed to use it for resolution
+    AnnotatedRoute<AbstractRoute> notLoopingRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("2.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("1.0.0.1")))
+                .setRecursive(false)
+                .build());
+    AnnotatedRoute<AbstractRoute> connectedRoute1 =
+        annotateRoute(new ConnectedRoute(Prefix.strict("1.0.0.0/16"), "foo"));
+    AnnotatedRoute<AbstractRoute> connectedRoute2 =
+        annotateRoute(new ConnectedRoute(Prefix.strict("2.0.0.0/16"), "bar"));
+    AnnotatedRoute<AbstractRoute> staticNonrecursiveRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("1.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("2.0.0.1")))
+                .setRecursive(false)
+                .build());
+    rib.mergeRoute(connectedRoute1);
+    rib.mergeRoute(connectedRoute2);
+    rib.mergeRoute(notLoopingRoute);
+
+    // Route should be added just fine since it will only resolve via the connected route.
+    assertThat(
+        rib.mergeRouteGetDelta(staticNonrecursiveRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(staticNonrecursiveRoute))));
+  }
+
+  @Test
+  public void testEnforceResolvabilityRestrictedUnresolvable() {
+    // A route forbidden by resolution restriction can still be prevented from being installed
+    // if it cannot resolve.
+    Rib rib = new Rib(route -> route.getNetwork().getPrefixLength() != 24);
+    AnnotatedRoute<AbstractRoute> restrictedRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("1.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("2.0.0.1")))
+                .setRecursive(true)
+                .build());
+
+    assertThat(rib.mergeRouteGetDelta(restrictedRoute), equalTo(RibDelta.empty()));
+  }
+
+  @Test
+  public void testEnforceResolvabilityRestrictedRouteNoLoopOwnNextHop() {
+    // A route forbidden by resolution restriction cannot form a loop, even if it contains its own
+    // next hop.
+    Rib rib = new Rib(route -> route.getNetwork().getPrefixLength() != 24);
+    // would loop if non-recursive route were allowed to use it for resolution
+    AnnotatedRoute<AbstractRoute> restrictedRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("1.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("1.0.0.1")))
+                .setRecursive(true)
+                .build());
+    AnnotatedRoute<AbstractRoute> connectedRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("1.0.0.0/16"), "foo"));
+    rib.mergeRoute(connectedRoute);
+
+    // Route should be added since it resolves via unrestricted connected route.
+    assertThat(
+        rib.mergeRouteGetDelta(restrictedRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(restrictedRoute))));
+  }
+
+  @Test
+  public void testEnforceResolvabilityConnectedRouteWhitelist() {
+    // A route forbidden by resolution restriction cannot form a loop, even if it contains its own
+    // next hop.
+    Rib rib = new Rib(route -> route.getNetwork().getPrefixLength() != 16);
+    // would loop if non-recursive route were allowed to use it for resolution
+    AnnotatedRoute<AbstractRoute> recursiveRoute =
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.strict("1.0.0.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("2.0.0.1")))
+                .setRecursive(true)
+                .build());
+    AnnotatedRoute<AbstractRoute> connectedRoute =
+        annotateRoute(new ConnectedRoute(Prefix.strict("2.0.0.0/16"), "foo"));
+    rib.mergeRoute(connectedRoute);
+
+    // Recursive route can resolve via connected route even if latter is nominally restricted.
+    assertThat(
+        rib.mergeRouteGetDelta(recursiveRoute),
+        equalTo(RibDelta.of(RouteAdvertisement.adding(recursiveRoute))));
   }
 }

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -206,6 +206,7 @@
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -437,6 +438,7 @@
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -550,6 +552,7 @@
             "vrf" : "default"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~asgw~to~backbone~export~policy~" : {
             "name" : "~asgw~to~backbone~export~policy~",
@@ -26648,6 +26651,7 @@
             "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~igw~to~backbone~export~policy~" : {
             "name" : "~igw~to~backbone~export~policy~",
@@ -26829,6 +26833,7 @@
             "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~igw~to~backbone~export~policy~" : {
             "name" : "~igw~to~backbone~export~policy~",
@@ -27009,6 +27014,7 @@
             "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~igw~to~backbone~export~policy~" : {
             "name" : "~igw~to~backbone~export~policy~",
@@ -27162,6 +27168,7 @@
             "vrf" : "default"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "exportPolicyOnInternet" : {
             "name" : "exportPolicyOnInternet",
@@ -27771,6 +27778,7 @@
             "name" : "Block outgoing traffic using reserved addresses"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "exportPolicyOnIspToCustomers" : {
             "name" : "exportPolicyOnIspToCustomers",
@@ -61064,6 +61072,7 @@
             ]
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routeFilterLists" : {
           "MATCH_ALL_BGP" : {
             "lines" : [
@@ -62195,6 +62204,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -62405,6 +62415,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -62626,6 +62637,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -62836,6 +62848,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -63046,6 +63059,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -63256,6 +63270,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -63466,6 +63481,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -63687,6 +63703,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -63908,6 +63925,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -64118,6 +64136,7 @@
             "sourceType" : "Network ACL"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -64640,6 +64659,7 @@
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -64975,6 +64995,7 @@
             ]
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~vgw~export-policy~" : {
             "name" : "~vgw~export-policy~",
@@ -65233,6 +65254,7 @@
             "vrf" : "vrf-vgw-81fd279f"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -65401,6 +65423,7 @@
             "vrf" : "vrf-igw-fac5839d"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -65737,6 +65760,7 @@
             "vrf" : "vrf-igw-9b93ddfc"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",
@@ -66038,6 +66062,7 @@
             "vrf" : "vrf-igw-068fee63"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : {
           "aws" : {
             "region" : "us-west-2",

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -431,6 +431,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routeFilterLists" : {
           "101" : {
             "lines" : [
@@ -2024,6 +2025,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "ntpServers" : [
           "18.18.18.18",
           "23.23.23.23"
@@ -3347,6 +3349,7 @@
           "1.1.1.1",
           "2.2.2.2"
         ],
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -4238,6 +4241,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "ntpServers" : [
           "18.18.18.18",
           "23.23.23.23"
@@ -5827,6 +5831,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "ntpServers" : [
           "18.18.18.18"
         ],
@@ -7124,6 +7129,7 @@
           "1.1.1.1",
           "2.1.2.2"
         ],
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -7770,6 +7776,7 @@
           "1.1.1.1",
           "2.2.2.2"
         ],
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -8753,6 +8760,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routeFilterLists" : {
           "102" : {
             "lines" : [
@@ -9667,6 +9675,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routeFilterLists" : {
           "105" : {
             "lines" : [
@@ -10620,6 +10629,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "routeFilterLists" : {
           "105" : {
             "lines" : [
@@ -11634,6 +11644,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "ntpServers" : [
           "18.18.18.18",
           "23.23.23.23"
@@ -13105,6 +13116,7 @@
             "sourceType" : "extended ipv4 access-list"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "ntpServers" : [
           "18.18.18.18",
           "23.23.23.23"
@@ -14276,6 +14288,7 @@
           "1.1.1.1",
           "2.2.2.2"
         ],
+        "mainRibEnforceResolvability" : false,
         "routingPolicies" : {
           "~BGP_COMMON_EXPORT_POLICY:default~" : {
             "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
@@ -14993,6 +15006,7 @@
             "name" : "nat::PREROUTING"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : { },
         "vrfs" : {
           "default" : {
@@ -15330,6 +15344,7 @@
             "name" : "nat::PREROUTING"
           }
         },
+        "mainRibEnforceResolvability" : false,
         "vendorFamily" : { },
         "vrfs" : {
           "default" : {


### PR DESCRIPTION
- apply vrf-level resolution restriction when finding LPM routes
  - connected routes always get a pass
  - skip loop checking for routes that fail resolution restriction
- skip resolvability check for non-recursive static routes
- update Configuration data model to support enabling main rib resolvability check
