### PR TITLE
FilterLineReachability: erase TraceElements and VendorStructureIds from ACLs for CanonicalAcl

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/AclEraser.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/AclEraser.java
@@ -1,0 +1,119 @@
+package org.batfish.question.filterlinereachability;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.AclAclLine;
+import org.batfish.datamodel.AclLine;
+import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.acl.DeniedByAcl;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
+import org.batfish.datamodel.acl.GenericAclLineVisitor;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSrcInterface;
+import org.batfish.datamodel.acl.NotMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.datamodel.acl.OriginatingFromDevice;
+import org.batfish.datamodel.acl.PermittedByAcl;
+import org.batfish.datamodel.acl.TrueExpr;
+
+/**
+ * Erases {@link TraceElement TraceElements} and {@link org.batfish.vendor.VendorStructureId
+ * VendorStructureIds} from {@link IpAccessList ACLs}.
+ */
+public final class AclEraser
+    implements GenericAclLineVisitor<AclLine>, GenericAclLineMatchExprVisitor<AclLineMatchExpr> {
+  @VisibleForTesting static final AclEraser INSTANCE = new AclEraser();
+
+  private AclEraser() {}
+
+  /**
+   * Return a functionally-equivalent version of the input {@link
+   * org.batfish.datamodel.IpAccessList} with all {@link TraceElement TraceElements} and {@link
+   * org.batfish.vendor.VendorStructureId VendorStructureIds} removed.
+   */
+  public static IpAccessList erase(IpAccessList acl) {
+    ImmutableList<AclLine> lines =
+        acl.getLines().stream().map(INSTANCE::visit).collect(ImmutableList.toImmutableList());
+    return IpAccessList.builder()
+        .setName(acl.getName())
+        .setLines(lines)
+        .setSourceName(acl.getSourceName())
+        .setSourceType(acl.getSourceType())
+        .build();
+  }
+
+  @Override
+  public AclLine visitAclAclLine(AclAclLine aclAclLine) {
+    return new AclAclLine(aclAclLine.getName(), aclAclLine.getAclName());
+  }
+
+  @Override
+  public AclLine visitExprAclLine(ExprAclLine exprAclLine) {
+    return new ExprAclLine(
+        exprAclLine.getAction(),
+        exprAclLine.getMatchCondition().accept(this),
+        exprAclLine.getName());
+  }
+
+  @Override
+  public AclLineMatchExpr visitAndMatchExpr(AndMatchExpr andMatchExpr) {
+    return new AndMatchExpr(
+        andMatchExpr.getConjuncts().stream()
+            .map(this::visit)
+            .collect(ImmutableList.toImmutableList()));
+  }
+
+  @Override
+  public AclLineMatchExpr visitDeniedByAcl(DeniedByAcl deniedByAcl) {
+    return new DeniedByAcl(deniedByAcl.getAclName());
+  }
+
+  @Override
+  public AclLineMatchExpr visitFalseExpr(FalseExpr falseExpr) {
+    return FalseExpr.INSTANCE;
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
+    // TODO erase within IpSpaces if/when we add TraceElements to them
+    return new MatchHeaderSpace(matchHeaderSpace.getHeaderspace());
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
+    return new MatchSrcInterface(matchSrcInterface.getSrcInterfaces());
+  }
+
+  @Override
+  public AclLineMatchExpr visitNotMatchExpr(NotMatchExpr notMatchExpr) {
+    return new NotMatchExpr(visit(notMatchExpr.getOperand()));
+  }
+
+  @Override
+  public AclLineMatchExpr visitOriginatingFromDevice(OriginatingFromDevice originatingFromDevice) {
+    return OriginatingFromDevice.INSTANCE;
+  }
+
+  @Override
+  public AclLineMatchExpr visitOrMatchExpr(OrMatchExpr orMatchExpr) {
+    return new OrMatchExpr(
+        orMatchExpr.getDisjuncts().stream()
+            .map(this::visit)
+            .collect(ImmutableList.toImmutableList()));
+  }
+
+  @Override
+  public AclLineMatchExpr visitPermittedByAcl(PermittedByAcl permittedByAcl) {
+    return new PermittedByAcl(permittedByAcl.getAclName());
+  }
+
+  @Override
+  public AclLineMatchExpr visitTrueExpr(TrueExpr trueExpr) {
+    return TrueExpr.INSTANCE;
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/AclEraserTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/AclEraserTest.java
@@ -1,0 +1,87 @@
+package org.batfish.question.filterlinereachability;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.batfish.datamodel.AclAclLine;
+import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.acl.DeniedByAcl;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSrcInterface;
+import org.batfish.datamodel.acl.NotMatchExpr;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.batfish.datamodel.acl.OriginatingFromDevice;
+import org.batfish.datamodel.acl.PermittedByAcl;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.batfish.vendor.VendorStructureId;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AclEraserTest {
+  private AclEraser _eraser;
+  private TraceElement _traceElem;
+  private VendorStructureId _vsId;
+
+  @Before
+  public void setup() {
+    _eraser = AclEraser.INSTANCE;
+    _traceElem = TraceElement.of("trace elem");
+    _vsId = new VendorStructureId("file", "type", "name");
+  }
+
+  @Test
+  public void testAclLineMatchExprs() {
+    TrueExpr trueExpr = new TrueExpr(_traceElem);
+    assertEquals(TrueExpr.INSTANCE, _eraser.visit(trueExpr));
+    assertEquals(FalseExpr.INSTANCE, _eraser.visit(new FalseExpr(_traceElem)));
+    assertEquals(OriginatingFromDevice.INSTANCE, _eraser.visit(OriginatingFromDevice.INSTANCE));
+    assertEquals(new PermittedByAcl("acl"), _eraser.visit(new PermittedByAcl("acl", _traceElem)));
+    assertEquals(new DeniedByAcl("acl"), _eraser.visit(new DeniedByAcl("acl", _traceElem)));
+    assertEquals(
+        new NotMatchExpr(TrueExpr.INSTANCE), _eraser.visit(new NotMatchExpr(trueExpr, _traceElem)));
+    {
+      List<String> ifaces = ImmutableList.of("i");
+      assertEquals(
+          new MatchSrcInterface(ifaces), _eraser.visit(new MatchSrcInterface(ifaces, _traceElem)));
+    }
+    {
+      List<AclLineMatchExpr> origInners = ImmutableList.of(trueExpr);
+      List<AclLineMatchExpr> erasedInners = ImmutableList.of(TrueExpr.INSTANCE);
+      assertEquals(
+          new OrMatchExpr(erasedInners), _eraser.visit(new OrMatchExpr(origInners, _traceElem)));
+      assertEquals(
+          new AndMatchExpr(erasedInners), _eraser.visit(new AndMatchExpr(origInners, _traceElem)));
+    }
+    {
+      HeaderSpace headerSpace = HeaderSpace.builder().setDstIps(UniverseIpSpace.INSTANCE).build();
+      assertEquals(
+          new MatchHeaderSpace(headerSpace),
+          _eraser.visit(new MatchHeaderSpace(headerSpace, _traceElem)));
+    }
+  }
+
+  @Test
+  public void testAclLines() {
+    assertEquals(
+        new AclAclLine("name", "acl"),
+        _eraser.visit(new AclAclLine("name", "acl", _traceElem, _vsId)));
+
+    assertEquals(
+        new ExprAclLine(LineAction.PERMIT, TrueExpr.INSTANCE, "name"),
+        _eraser.visit(
+            ExprAclLine.accepting()
+                .setName("name")
+                .setVendorStructureId(_vsId)
+                .setTraceElement(_traceElem)
+                .setMatchCondition(new TrueExpr(_traceElem))
+                .build()));
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
@@ -203,7 +203,7 @@ public class FilterLineReachabilityAnswererTest {
     // we should get the one acl we put in otherwise
     assertThat(
         getSpecifiedFilters(new FilterLineReachabilityQuestion((String) null, null, false), ctxt),
-        equalTo(ImmutableMap.of("c1", ImmutableSet.of(aclGenerated))));
+        equalTo(ImmutableMap.of("c1", ImmutableSet.of(aclGenerated.getName()))));
   }
 
   @Test
@@ -837,13 +837,13 @@ public class FilterLineReachabilityAnswererTest {
 
   private List<AclSpecs> getAclSpecs(Set<String> configNames) {
     SortedMap<String, Configuration> configs = ImmutableSortedMap.of("c1", _c1, "c2", _c2);
-    Map<String, Set<IpAccessList>> acls =
+    Map<String, Set<String>> acls =
         CollectionUtil.toImmutableMap(
             configs,
             Entry::getKey,
             entry ->
                 configNames.contains(entry.getKey())
-                    ? ImmutableSet.copyOf(entry.getValue().getIpAccessLists().values())
+                    ? ImmutableSet.copyOf(entry.getValue().getIpAccessLists().keySet())
                     : ImmutableSet.of());
     return FilterLineReachabilityAnswerer.getAclSpecs(
         configs, acls, new FilterLineReachabilityRows());


### PR DESCRIPTION
This will allow acls with TraceElements and VendorStructureIds on different devices to be considered equal.