### PR TITLE
L3AdjacencyComputer: do not connect interfaces with L1 to global hub

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/L3AdjacencyComputer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/L3AdjacencyComputer.java
@@ -48,7 +48,7 @@ public class L3AdjacencyComputer {
     _layer1Topologies = layer1Topologies;
     _physicalInterfaces = computePhysicalInterfaces(configs);
     _ethernetHubs =
-        computeEthernetHubs(configs, _physicalInterfaces, _layer1Topologies.getActiveLogicalL1());
+        computeEthernetHubs(configs, _physicalInterfaces, _layer1Topologies.getLogicalL1());
     _deviceBroadcastDomains = computeDeviceBroadcastDomains(configs, _physicalInterfaces);
     _layer3Interfaces =
         computeLayer3Interfaces(configs, _deviceBroadcastDomains, _physicalInterfaces);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/broadcast/L3AdjacencyComputerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/broadcast/L3AdjacencyComputerTest.java
@@ -1,5 +1,6 @@
 package org.batfish.common.topology.broadcast;
 
+import static org.batfish.common.topology.Layer1Topologies.INVALID_INTERFACE;
 import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.BATFISH_GLOBAL_HUB;
 import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.computeEthernetHubs;
 import static org.batfish.common.topology.broadcast.L3AdjacencyComputer.connectL2InterfaceToBroadcastDomain;
@@ -684,6 +685,26 @@ public class L3AdjacencyComputerTest {
           containsInAnyOrder(n1, n2));
     }
     {
+      // One interface with disconnected edge.
+      Map<String, EthernetHub> hubs =
+          computeEthernetHubs(
+              ImmutableMap.of(c.getHostname(), c),
+              makePhysicalMap(i1, i2, i3),
+              new Layer1Topology(
+                  ImmutableSet.of(
+                      new Layer1Edge(
+                          c.getHostname(), i1.getName(), "no-such-hostname", "no-such-iface"))));
+      assertThat(hubs, aMapWithSize(2));
+      String otherKey =
+          Iterables.getOnlyElement(
+              Sets.difference(hubs.keySet(), ImmutableSet.of(BATFISH_GLOBAL_HUB)));
+      assertThat(
+          getPairs(hubs.get(BATFISH_GLOBAL_HUB).getAttachedInterfacesForTesting().keySet()),
+          containsInAnyOrder(n2, n3));
+      assertThat(
+          getPairs(hubs.get(otherKey).getAttachedInterfacesForTesting().keySet()), contains(n1));
+    }
+    {
       // Line.
       Map<String, EthernetHub> hubs =
           computeEthernetHubs(
@@ -777,6 +798,31 @@ public class L3AdjacencyComputerTest {
           "encapsulated interface not connected to unencapsulated interfaces",
           domains.get(n2),
           not(equalTo(domains.get(n1))));
+    }
+    {
+      // With L1 topology to disconnected interface, only global hub connected.
+      Layer1Topology physical =
+          new Layer1Topology(
+              new Layer1Edge(n1.getHostname(), n1.getInterface(), "no-such-host", "no-such-iface"));
+      Layer1Topology logical =
+          new Layer1Topology(
+              new Layer1Edge(
+                  n1.getHostname(),
+                  n1.getInterface(),
+                  INVALID_INTERFACE.getHostname(),
+                  INVALID_INTERFACE.getInterfaceName()));
+      Layer1Topology cleanLogical = Layer1Topology.EMPTY;
+      L3AdjacencyComputer l3 =
+          new L3AdjacencyComputer(
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3),
+              new Layer1Topologies(physical, Layer1Topology.EMPTY, logical, cleanLogical));
+      Map<NodeInterfacePair, Integer> domains = l3.findAllBroadcastDomains();
+      assertThat("all interfaces have a domain", domains, aMapWithSize(3));
+      assertThat("global hub ifaces in same domain", domains.get(n2), equalTo(domains.get(n3)));
+      assertThat(
+          "n1 is disconnected, not connected to other interfaces",
+          domains.get(n1),
+          not(equalTo(domains.get(n2))));
     }
   }
 }


### PR DESCRIPTION
The activeLogicalL1Topology does not include edges where one or both sides are
inactive or not present in the snapshot. For deciding whether an interface is
attached to the global hub, however, we need to consider these removed edges.
Fall back to the logicalL1Topology, which does include all (logical) interfaces
mentioned in any L1 topology and present in the snapshot.