### PR TITLE
BGP: Infer local IPs dynamically

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Node.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Node.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 @ParametersAreNonnullByDefault
 public final class Layer1Node implements Comparable<Layer1Node> {
@@ -33,6 +34,10 @@ public final class Layer1Node implements Comparable<Layer1Node> {
     // Guarantee hostname is canonical (lowercase)
     _hostname = hostname.toLowerCase();
     _interfaceName = interfaceName;
+  }
+
+  public @Nonnull NodeInterfacePair asNodeInterfacePair() {
+    return NodeInterfacePair.of(_hostname, _interfaceName);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -594,6 +594,7 @@ public class IncrementalDataPlanePluginTest {
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs));
     BgpSessionInitiationResult bgpSessionInitiationResult =
         Iterables.getOnlyElement(initiationResults);
+    assertTrue(bgpSessionInitiationResult.isSuccessful());
     assertThat(
         Iterables.getOnlyElement(bgpSessionInitiationResult.getForwardTraces()),
         hasHops(contains(hasNodeName("node1"), hasNodeName("node2"))));

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ebgp-dynamic-local-ips/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ebgp-dynamic-local-ips/configs/r1
@@ -1,0 +1,50 @@
+!! IOS XR Configuration version = 6.2.2
+!
+hostname r1
+!
+interface Loopback0
+ description BGP router-id
+ ipv4 address 1.1.1.1 255.255.255.255
+!
+interface GigabitEthernet0/0/0/1
+ ipv4 address 11.11.11.1 255.255.255.252
+!
+prefix-set REDIST_STATIC
+  21.21.21.21/32
+end-set
+!
+route-policy REDIST_STATIC
+  if destination in REDIST_STATIC then
+    pass
+  else
+    drop
+  endif
+end-policy
+!
+route-policy allow-all
+  pass
+end-policy
+!
+router static
+ address-family ipv4 unicast
+  13.13.13.1/32 11.11.11.2
+  ! To redistribute into BGP
+  21.21.21.21/32 Null0
+ !
+!
+router bgp 65101
+ bgp router-id 1.1.1.1
+ address-family ipv4 unicast
+  redistribute static route-policy REDIST_STATIC
+ !
+ neighbor 13.13.13.1
+  remote-as 65103
+  ebgp-multihop 4
+  address-family ipv4 unicast
+  ! XR eBGP peers default deny imports and exports
+  route-policy allow-all in
+  route-policy allow-all out
+  !
+ !
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ebgp-dynamic-local-ips/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ebgp-dynamic-local-ips/configs/r2
@@ -1,14 +1,13 @@
 !! IOS XR Configuration version = 6.2.2
-!! Last configuration change at Wed Apr  7 16:22:27 2021 by cisco
 !
 hostname r2
 !
 interface GigabitEthernet0/0/0/1
- description border01
- ipv4 address 13.13.13.2 255.255.255.252
+ description r1
+ ipv4 address 11.11.11.2 255.255.255.252
 !
 interface GigabitEthernet0/0/0/2
- description border02
- ipv4 address 11.11.11.2 255.255.255.252
+ description r3
+ ipv4 address 13.13.13.2 255.255.255.252
 !
 end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ebgp-dynamic-local-ips/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ebgp-dynamic-local-ips/configs/r2
@@ -1,0 +1,14 @@
+!! IOS XR Configuration version = 6.2.2
+!! Last configuration change at Wed Apr  7 16:22:27 2021 by cisco
+!
+hostname r2
+!
+interface GigabitEthernet0/0/0/1
+ description border01
+ ipv4 address 13.13.13.2 255.255.255.252
+!
+interface GigabitEthernet0/0/0/2
+ description border02
+ ipv4 address 11.11.11.2 255.255.255.252
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ebgp-dynamic-local-ips/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ebgp-dynamic-local-ips/configs/r3
@@ -1,0 +1,50 @@
+!! IOS XR Configuration version = 6.2.2
+!
+hostname r3
+!
+interface Loopback0
+ description BGP router-id
+ ipv4 address 3.3.3.3 255.255.255.255
+!
+interface GigabitEthernet0/0/0/1
+ ipv4 address 13.13.13.1 255.255.255.252
+!
+prefix-set REDIST_STATIC
+  23.23.23.23/32
+end-set
+!
+route-policy REDIST_STATIC
+  if destination in REDIST_STATIC then
+    pass
+  else
+    drop
+  endif
+end-policy
+!
+route-policy allow-all
+  pass
+end-policy
+!
+router static
+ address-family ipv4 unicast
+  11.11.11.1/32 13.13.13.2
+  ! To redistribute into BGP
+  23.23.23.23/32 Null0
+ !
+!
+router bgp 65103
+ bgp router-id 3.3.3.3
+ address-family ipv4 unicast
+  redistribute static route-policy REDIST_STATIC
+ !
+ neighbor 11.11.11.1
+  remote-as 65101
+  ebgp-multihop 4
+  address-family ipv4 unicast
+  ! XR eBGP peers default deny imports and exports
+  route-policy allow-all in
+  route-policy allow-all out
+  !
+ !
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ibgp-dynamic-local-ips/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ibgp-dynamic-local-ips/configs/r1
@@ -1,0 +1,43 @@
+!! IOS XR Configuration version = 6.2.2
+!
+hostname r1
+!
+interface Loopback0
+ description BGP router-id
+ ipv4 address 1.1.1.1 255.255.255.255
+!
+interface GigabitEthernet0/0/0/1
+ ipv4 address 11.11.11.1 255.255.255.252
+!
+prefix-set REDIST_STATIC
+  21.21.21.21/32
+end-set
+!
+route-policy REDIST_STATIC
+  if destination in REDIST_STATIC then
+    pass
+  else
+    drop
+  endif
+end-policy
+!
+router static
+ address-family ipv4 unicast
+  13.13.13.1/32 11.11.11.2
+  ! To redistribute into BGP
+  21.21.21.21/32 Null0
+ !
+!
+router bgp 65100
+ bgp router-id 1.1.1.1
+ address-family ipv4 unicast
+  redistribute static route-policy REDIST_STATIC
+ !
+ neighbor 13.13.13.1
+  remote-as 65100
+  ebgp-multihop 4
+  address-family ipv4 unicast
+  !
+ !
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ibgp-dynamic-local-ips/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ibgp-dynamic-local-ips/configs/r2
@@ -1,14 +1,13 @@
 !! IOS XR Configuration version = 6.2.2
-!! Last configuration change at Wed Apr  7 16:22:27 2021 by cisco
 !
 hostname r2
 !
 interface GigabitEthernet0/0/0/1
- description border01
- ipv4 address 13.13.13.2 255.255.255.252
+ description r1
+ ipv4 address 11.11.11.2 255.255.255.252
 !
 interface GigabitEthernet0/0/0/2
- description border02
- ipv4 address 11.11.11.2 255.255.255.252
+ description r3
+ ipv4 address 13.13.13.2 255.255.255.252
 !
 end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ibgp-dynamic-local-ips/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ibgp-dynamic-local-ips/configs/r2
@@ -1,0 +1,14 @@
+!! IOS XR Configuration version = 6.2.2
+!! Last configuration change at Wed Apr  7 16:22:27 2021 by cisco
+!
+hostname r2
+!
+interface GigabitEthernet0/0/0/1
+ description border01
+ ipv4 address 13.13.13.2 255.255.255.252
+!
+interface GigabitEthernet0/0/0/2
+ description border02
+ ipv4 address 11.11.11.2 255.255.255.252
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ibgp-dynamic-local-ips/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/ibgp-dynamic-local-ips/configs/r3
@@ -1,0 +1,43 @@
+!! IOS XR Configuration version = 6.2.2
+!
+hostname r3
+!
+interface Loopback0
+ description BGP router-id
+ ipv4 address 3.3.3.3 255.255.255.255
+!
+interface GigabitEthernet0/0/0/1
+ ipv4 address 13.13.13.1 255.255.255.252
+!
+prefix-set REDIST_STATIC
+  23.23.23.23/32
+end-set
+!
+route-policy REDIST_STATIC
+  if destination in REDIST_STATIC then
+    pass
+  else
+    drop
+  endif
+end-policy
+!
+router static
+ address-family ipv4 unicast
+  11.11.11.1/32 13.13.13.2
+  ! To redistribute into BGP
+  23.23.23.23/32 Null0
+ !
+!
+router bgp 65100
+ bgp router-id 3.3.3.3
+ address-family ipv4 unicast
+  redistribute static route-policy REDIST_STATIC
+ !
+ neighbor 11.11.11.1
+  remote-as 65100
+  ebgp-multihop 4
+  address-family ipv4 unicast
+  !
+ !
+!
+end

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -445,14 +445,8 @@ public class EdgesAnswerer extends Answerer {
   @VisibleForTesting
   static Row layer1EdgeToRow(Layer1Edge layer1Edge) {
     RowBuilder row = Row.builder();
-    row.put(
-            COL_INTERFACE,
-            NodeInterfacePair.of(
-                layer1Edge.getNode1().getHostname(), layer1Edge.getNode1().getInterfaceName()))
-        .put(
-            COL_REMOTE_INTERFACE,
-            NodeInterfacePair.of(
-                layer1Edge.getNode2().getHostname(), layer1Edge.getNode2().getInterfaceName()));
+    row.put(COL_INTERFACE, layer1Edge.getNode1().asNodeInterfacePair())
+        .put(COL_REMOTE_INTERFACE, layer1Edge.getNode2().asNodeInterfacePair());
 
     return row.build();
   }


### PR DESCRIPTION
Allows BGP peers with no configured local IP to initiate BGP sessions during dataplane computation using dynamically inferred local IPs. The inferred local IPs are determined by finding LPM routes for the peer's peer address (i.e. remote IP) and taking the interface IPs of those routes' forwarding interfaces as potential local IPs for the peer.

Does not yet remove any local IP inference done during conversion (this will go in a follow-up PR). This could cause a bug if the connected route that was used for inference in conversion:
- is not an LPM route for the peer address
- is one of multiple LPM routes for the peer address (unlikely since it will be the only connected route for the peer address)

Ultimately, even peers whose peer address is contained in a connected route ought to determine their local IP dynamically if update-source isn't explicitly configured. For now, behavior for such peers will be the same as in current master.