### PR TITLE
Delete unused field in BgpPeerConfig builder

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -330,7 +330,6 @@ public abstract class BgpPeerConfig implements Serializable {
     protected String _description;
     protected boolean _ebgpMultihop;
     protected boolean _enforceFirstAs;
-    protected String _exportPolicy;
     @Nullable protected Set<GeneratedRoute> _generatedRoutes;
     @Nullable protected String _group;
     @Nullable protected Long _localAs;


### PR DESCRIPTION
Seems to be completely unreferenced