### PR TITLE
JunOS: handle ## SECRET-DATA after semicolon

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
@@ -83,7 +83,7 @@ OPEN_PAREN
 
 SEMICOLON
 :
-   ';'
+   ';' F_SECRET_DATA?
 ;
 
 WORD
@@ -143,6 +143,14 @@ fragment
 F_QuotedString
 :
    '"' ~'"'* '"'
+;
+
+// This may appear after a semicolon when there is a secret key in the file
+// Search for examples online.
+fragment
+F_SECRET_DATA
+:
+   ' '* '## SECRET-DATA'
 ;
 
 fragment

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2495,6 +2495,18 @@ public final class FlatJuniperGrammarTest {
     assertThat(parseTextConfigs(hostname).keySet(), contains(hostname));
   }
 
+  /** Test for https://github.com/batfish/batfish/issues/7225. */
+  @Test
+  public void testNestedConfigWithSecretData() {
+    String hostname = "nested-config-with-secret-data";
+    Configuration c = parseConfig(hostname);
+    assertThat(c.getVrfs(), hasKey("VRF_NAME"));
+    Vrf v = c.getVrfs().get("VRF_NAME");
+    assertThat(v.getBgpProcess().getActiveNeighbors(), hasKey(Ip.parse("8.8.8.8")));
+    BgpActivePeerConfig peer = v.getBgpProcess().getActiveNeighbors().get(Ip.parse("8.8.8.8"));
+    assertThat(peer, allOf(hasLocalAs(1L), hasRemoteAs(60951L)));
+  }
+
   @Test
   public void testNestedConfigStructureDef() throws IOException {
     String hostname = "nested-config-structure-def";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-with-secret-data
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-with-secret-data
@@ -1,0 +1,23 @@
+#RANCID-CONTENT-TYPE: juniper
+system {
+    host-name nested-config-with-secret-data;
+}
+routing-instances {
+    VRF_NAME {
+        routing-options {
+            autonomous-system 1;
+        }
+        protocols {
+            bgp {
+                group VRF_GROUP {
+                    type external;
+                    authentication-key "abacadd"; ## SECRET-DATA
+                    peer-as 60951;
+                    neighbor 8.8.8.8 {
+                        description description;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix batfish/batfish#7225.