### PR TITLE
XR: OSPF distribute lists only use prefix-lists in v3

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
@@ -139,28 +139,16 @@ ro_distance
    DISTANCE value = uint_legacy NEWLINE
 ;
 
-roc_distribute_list_in
-:
-  DISTRIBUTE_LIST
-  (
-    rodl_acl_in
-    | rodl_prefix_list_in
-    | rodl_route_policy
-  )
-;
+roc_distribute_list_in: DISTRIBUTE_LIST (rodl_acl_in | rodl_route_policy);
 
-ro_distribute_list_out: DISTRIBUTE_LIST (rodl_acl_out | rodl_prefix_list_out);
+ro_distribute_list_out: DISTRIBUTE_LIST rodl_acl_out;
 
 rodl_acl_in: acl = access_list_name IN NEWLINE;
-
-rodl_prefix_list_in: PREFIX_LIST pl = prefix_list_name IN NEWLINE;
 
 // route-policies can't be used on outbound traffic
 rodl_route_policy: ROUTE_POLICY rp = route_policy_name IN NEWLINE;
 
 rodl_acl_out: acl = access_list_name OUT NEWLINE;
-
-rodl_prefix_list_out: PREFIX_LIST pl = prefix_list_name OUT NEWLINE;
 
 ro_max_metric
 :

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -128,8 +128,6 @@ import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.OSPF_ARE
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.OSPF_DEFAULT_INFORMATION_ROUTE_POLICY;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.OSPF_DISTRIBUTE_LIST_ACCESS_LIST_IN;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.OSPF_DISTRIBUTE_LIST_ACCESS_LIST_OUT;
-import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.OSPF_DISTRIBUTE_LIST_PREFIX_LIST_IN;
-import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.OSPF_DISTRIBUTE_LIST_PREFIX_LIST_OUT;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.OSPF_DISTRIBUTE_LIST_ROUTE_POLICY_IN;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.OSPF_REDISTRIBUTE_ROUTE_POLICY;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.POLICY_MAP_EVENT_CLASS;
@@ -758,8 +756,6 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Roc_networkContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Roc_passiveContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Rodl_acl_inContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Rodl_acl_outContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Rodl_prefix_list_inContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Rodl_prefix_list_outContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Rodl_route_policyContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Ror_routing_instanceContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Ror_routing_instance_nullContext;
@@ -6020,25 +6016,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     DistributeList distributeList = new DistributeList(name, DistributeListFilterType.ACCESS_LIST);
     _configuration.referenceStructure(
         IP_ACCESS_LIST, name, OSPF_DISTRIBUTE_LIST_ACCESS_LIST_OUT, ctx.acl.getStart().getLine());
-    _currentOspfProcess.setDistributeListOut(distributeList);
-    todo(ctx);
-  }
-
-  @Override
-  public void exitRodl_prefix_list_in(Rodl_prefix_list_inContext ctx) {
-    String name = toString(ctx.pl);
-    DistributeList distributeList = new DistributeList(name, DistributeListFilterType.PREFIX_LIST);
-    _configuration.referenceStructure(
-        IP_ACCESS_LIST, name, OSPF_DISTRIBUTE_LIST_PREFIX_LIST_IN, ctx.pl.getStart().getLine());
-    _currentOspfSettings.setDistributeListIn(distributeList);
-  }
-
-  @Override
-  public void exitRodl_prefix_list_out(Rodl_prefix_list_outContext ctx) {
-    String name = toString(ctx.pl);
-    DistributeList distributeList = new DistributeList(name, DistributeListFilterType.PREFIX_LIST);
-    _configuration.referenceStructure(
-        IP_ACCESS_LIST, name, OSPF_DISTRIBUTE_LIST_PREFIX_LIST_OUT, ctx.pl.getStart().getLine());
     _currentOspfProcess.setDistributeListOut(distributeList);
     todo(ctx);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
@@ -1418,8 +1418,7 @@ public class CiscoXrConversions {
       return null;
     }
     String filterName = distributeList.getFilterName();
-    if (distributeList.getFilterType() == DistributeListFilterType.ACCESS_LIST
-        || distributeList.getFilterType() == DistributeListFilterType.PREFIX_LIST) {
+    if (distributeList.getFilterType() == DistributeListFilterType.ACCESS_LIST) {
       if (c.getRouteFilterLists().containsKey(filterName)) {
         String rpName =
             generatedOspfInboundDistributeListName(vrfName, procName, areaNum, ifaceName);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/DistributeList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/DistributeList.java
@@ -10,7 +10,6 @@ public final class DistributeList implements Serializable {
   /** OSPF distribute-list can be route-policy (in) or ACL (in | out). */
   public enum DistributeListFilterType {
     ACCESS_LIST,
-    PREFIX_LIST,
     ROUTE_POLICY,
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -1275,7 +1275,7 @@ public final class XrGrammarTest {
   @Test
   public void testOspfDistributeListExtraction() {
     CiscoXrConfiguration c = parseVendorConfig("ospf-distribute-list");
-    assertThat(c.getDefaultVrf().getOspfProcesses(), hasKeys("1", "2", "3", "4"));
+    assertThat(c.getDefaultVrf().getOspfProcesses(), hasKeys("1", "2", "3"));
     OspfProcess proc1 = c.getDefaultVrf().getOspfProcesses().get("1");
     OspfSettings settings1 = proc1.getOspfSettings();
     assertThat(
@@ -1290,62 +1290,54 @@ public final class XrGrammarTest {
         settings2.getDistributeListIn(),
         equalTo(new DistributeList("ACL3", DistributeListFilterType.ACCESS_LIST)));
     assertThat(proc2.getDistributeListOut(), nullValue());
-    OspfProcess proc3 = c.getDefaultVrf().getOspfProcesses().get("3");
-    OspfSettings settings3 = proc3.getOspfSettings();
-    assertThat(
-        settings3.getDistributeListIn(),
-        equalTo(new DistributeList("PL1", DistributeListFilterType.PREFIX_LIST)));
-    assertThat(
-        proc3.getDistributeListOut(),
-        equalTo(new DistributeList("PL2", DistributeListFilterType.PREFIX_LIST)));
 
-    // Process 4 has inbound distribute lists set at process, area, and interface levels.
+    // Process 3 has inbound distribute lists set at process, area, and interface levels.
     // (Outbound distribute lists can only be configured at process level.)
-    OspfProcess proc4 = c.getDefaultVrf().getOspfProcesses().get("4");
-    OspfSettings proc4Settings = proc4.getOspfSettings();
+    OspfProcess proc3 = c.getDefaultVrf().getOspfProcesses().get("3");
+    OspfSettings proc3Settings = proc3.getOspfSettings();
     assertThat(
-        proc4Settings.getDistributeListIn(),
+        proc3Settings.getDistributeListIn(),
         equalTo(new DistributeList("ACL1", DistributeListFilterType.ACCESS_LIST)));
     {
-      // Area 4 does not have distribute lists at area or interface levels
-      OspfArea area = proc4.getAreas().get(4L);
+      // Area 3 does not have distribute lists at area or interface levels
+      OspfArea area = proc3.getAreas().get(3L);
       OspfSettings areaSettings = area.getOspfSettings();
       assertNull(areaSettings.getDistributeListIn());
+      OspfSettings ifaceSettings =
+          area.getInterfaceSettings().get("GigabitEthernet0/0/0/3").getOspfSettings();
+      assertNull(ifaceSettings.getDistributeListIn());
+    }
+    {
+      // Area 4 has distribute lists at area level but not interface level
+      OspfArea area = proc3.getAreas().get(4L);
+      OspfSettings areaSettings = area.getOspfSettings();
+      assertThat(
+          areaSettings.getDistributeListIn(),
+          equalTo(new DistributeList("ACL2", DistributeListFilterType.ACCESS_LIST)));
       OspfSettings ifaceSettings =
           area.getInterfaceSettings().get("GigabitEthernet0/0/0/4").getOspfSettings();
       assertNull(ifaceSettings.getDistributeListIn());
     }
     {
-      // Area 5 has distribute lists at area level but not interface level
-      OspfArea area = proc4.getAreas().get(5L);
-      OspfSettings areaSettings = area.getOspfSettings();
-      assertThat(
-          areaSettings.getDistributeListIn(),
-          equalTo(new DistributeList("ACL2", DistributeListFilterType.ACCESS_LIST)));
-      OspfSettings ifaceSettings =
-          area.getInterfaceSettings().get("GigabitEthernet0/0/0/5").getOspfSettings();
-      assertNull(ifaceSettings.getDistributeListIn());
-    }
-    {
-      // Area 6 has distribute lists at interface level but not area level
-      OspfArea area = proc4.getAreas().get(6L);
+      // Area 5 has distribute lists at interface level but not area level
+      OspfArea area = proc3.getAreas().get(5L);
       OspfSettings areaSettings = area.getOspfSettings();
       assertNull(areaSettings.getDistributeListIn());
       OspfSettings ifaceSettings =
-          area.getInterfaceSettings().get("GigabitEthernet0/0/0/6").getOspfSettings();
+          area.getInterfaceSettings().get("GigabitEthernet0/0/0/5").getOspfSettings();
       assertThat(
           ifaceSettings.getDistributeListIn(),
           equalTo(new DistributeList("ACL3", DistributeListFilterType.ACCESS_LIST)));
     }
     {
-      // Area 7 has distribute lists at both area and interface levels
-      OspfArea area = proc4.getAreas().get(7L);
+      // Area 6 has distribute lists at both area and interface levels
+      OspfArea area = proc3.getAreas().get(6L);
       OspfSettings areaSettings = area.getOspfSettings();
       assertThat(
           areaSettings.getDistributeListIn(),
           equalTo(new DistributeList("ACL2", DistributeListFilterType.ACCESS_LIST)));
       OspfSettings ifaceSettings =
-          area.getInterfaceSettings().get("GigabitEthernet0/0/0/7").getOspfSettings();
+          area.getInterfaceSettings().get("GigabitEthernet0/0/0/6").getOspfSettings();
       assertThat(
           ifaceSettings.getDistributeListIn(),
           equalTo(new DistributeList("ACL3", DistributeListFilterType.ACCESS_LIST)));
@@ -1355,7 +1347,7 @@ public final class XrGrammarTest {
   @Test
   public void testOspfDistributeListConversion() {
     Configuration c = parseConfig("ospf-distribute-list");
-    assertThat(c.getDefaultVrf().getOspfProcesses(), hasKeys("1", "2", "3", "4"));
+    assertThat(c.getDefaultVrf().getOspfProcesses(), hasKeys("1", "2", "3"));
     {
       // First OSPF process uses a routing policy called RP for inbound distribute-list
       Interface iface = c.getActiveInterfaces().get("GigabitEthernet0/0/0/1");
@@ -1371,17 +1363,8 @@ public final class XrGrammarTest {
       assertThat(iface.getOspfSettings().getInboundDistributeListPolicy(), equalTo(rpName));
       assertThat(c.getRoutingPolicies(), hasKey(rpName));
     }
-    {
-      // Third OSPF process uses a prefix-set for inbound distribute-list.
-      // Semantics of the generated routing policy are tested elsewhere.
-      String ifaceName = "GigabitEthernet0/0/0/3";
-      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "3", 3, ifaceName);
-      Interface iface = c.getActiveInterfaces().get(ifaceName);
-      assertThat(iface.getOspfSettings().getInboundDistributeListPolicy(), equalTo(rpName));
-      assertThat(c.getRoutingPolicies(), hasKey(rpName));
-    }
     /*
-    Fourth OSPF process is for testing inheritance. When configured:
+    Third OSPF process is for testing inheritance. When configured:
     - Process-level distribute list permits 1.1.1.0/24
     - Area-level distribute list permits 2.2.2.0/24
     - Interface-level distribute list permits 3.3.3.0/24
@@ -1391,9 +1374,9 @@ public final class XrGrammarTest {
     StaticRoute permittedByAreaList = srb.setNetwork(Prefix.parse("2.2.2.0/24")).build();
     StaticRoute permittedByIfaceList = srb.setNetwork(Prefix.parse("3.3.3.0/24")).build();
     {
-      // Area 4: Interface inherits process-level distribute list
-      String ifaceName = "GigabitEthernet0/0/0/4";
-      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "4", 4, ifaceName);
+      // Area 3: Interface inherits process-level distribute list
+      String ifaceName = "GigabitEthernet0/0/0/3";
+      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "3", 3, ifaceName);
       Interface iface = c.getActiveInterfaces().get(ifaceName);
       assertThat(iface.getOspfSettings().getInboundDistributeListPolicy(), equalTo(rpName));
       RoutingPolicy rp = c.getRoutingPolicies().get(rpName);
@@ -1402,9 +1385,9 @@ public final class XrGrammarTest {
       assertRoutingPolicyDeniesRoute(rp, permittedByIfaceList);
     }
     {
-      // Area 5: Interface inherits area-level distribute list
-      String ifaceName = "GigabitEthernet0/0/0/5";
-      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "4", 5, ifaceName);
+      // Area 4: Interface inherits area-level distribute list
+      String ifaceName = "GigabitEthernet0/0/0/4";
+      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "3", 4, ifaceName);
       Interface iface = c.getActiveInterfaces().get(ifaceName);
       assertThat(iface.getOspfSettings().getInboundDistributeListPolicy(), equalTo(rpName));
       RoutingPolicy rp = c.getRoutingPolicies().get(rpName);
@@ -1413,9 +1396,9 @@ public final class XrGrammarTest {
       assertRoutingPolicyDeniesRoute(rp, permittedByIfaceList);
     }
     {
-      // Area 6: Interface has its own distribute lists, overriding process-level lists
-      String ifaceName = "GigabitEthernet0/0/0/6";
-      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "4", 6, ifaceName);
+      // Area 5: Interface has its own distribute lists, overriding process-level lists
+      String ifaceName = "GigabitEthernet0/0/0/5";
+      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "3", 5, ifaceName);
       Interface iface = c.getActiveInterfaces().get(ifaceName);
       assertThat(iface.getOspfSettings().getInboundDistributeListPolicy(), equalTo(rpName));
       RoutingPolicy rp = c.getRoutingPolicies().get(rpName);
@@ -1424,9 +1407,9 @@ public final class XrGrammarTest {
       assertRoutingPolicyPermitsRoute(rp, permittedByIfaceList);
     }
     {
-      // Area 7: Interface has its own distribute lists, overriding both process and area lists
-      String ifaceName = "GigabitEthernet0/0/0/7";
-      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "4", 7, ifaceName);
+      // Area 6: Interface has its own distribute lists, overriding both process and area lists
+      String ifaceName = "GigabitEthernet0/0/0/6";
+      String rpName = generatedOspfInboundDistributeListName(DEFAULT_VRF_NAME, "3", 6, ifaceName);
       Interface iface = c.getActiveInterfaces().get(ifaceName);
       assertThat(iface.getOspfSettings().getInboundDistributeListPolicy(), equalTo(rpName));
       RoutingPolicy rp = c.getRoutingPolicies().get(rpName);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-distribute-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-distribute-list
@@ -20,22 +20,12 @@ interface GigabitEthernet0/0/0/5
 interface GigabitEthernet0/0/0/6
  no shutdown
 !
-interface GigabitEthernet0/0/0/7
- no shutdown
-!
 ipv4 access-list ACL1
  permit tcp host 1.1.1.0 host 255.255.255.0
 ipv4 access-list ACL2
  permit tcp host 2.2.2.0 host 255.255.255.0
 ipv4 access-list ACL3
  permit tcp host 3.3.3.0 host 255.255.255.0
-!
-prefix-set PL1
-  5.5.5.5/32
-end-set
-prefix-set PL2
-  6.6.6.6/32
-end-set
 !
 route-policy RP
 end-policy
@@ -57,28 +47,21 @@ router ospf 2
 !
 router ospf 3
   router-id 3.3.3.3
-  distribute-list prefix-list PL1 in
-  distribute-list prefix-list PL2 out
-  area 3
-    interface GigabitEthernet0/0/0/3
-!
-router ospf 4
-  router-id 4.4.4.4
   distribute-list ACL1 in
   # Inherits from router level
-  area 4
-    interface GigabitEthernet0/0/0/4
+  area 3
+    interface GigabitEthernet0/0/0/3
   # Inherits from area level, overrides router level
-  area 5
+  area 4
     distribute-list ACL2 in
-    interface GigabitEthernet0/0/0/5
+    interface GigabitEthernet0/0/0/4
   # Uses interface settings, overrides router level
-  area 6
-    interface GigabitEthernet0/0/0/6
+  area 5
+    interface GigabitEthernet0/0/0/5
       distribute-list ACL3 in
   # Uses interface settings, overrides router and area levels
-  area 7
+  area 6
     distribute-list ACL2 in
-    interface GigabitEthernet0/0/0/7
+    interface GigabitEthernet0/0/0/6
       distribute-list ACL3 in
 !


### PR DESCRIPTION
Delete grammar that would have parsed `distribute-list prefix-list` outside of v3.