### PR TITLE
CP: Convert link-speed to interface speed and bandwidth

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -200,7 +200,14 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
       newIface.setEncapsulationVlan(iface.getVlanId());
     }
     if (iface.getParentInterface() != null) {
-      assert _interfaces.containsKey(iface.getParentInterface());
+      Interface parent = _interfaces.get(iface.getParentInterface());
+      assert parent != null;
+      Double parentSpeed = parent.getLinkSpeedEffective();
+      if (parentSpeed != null) {
+        // Don't worry about overwriting because speed can't be configured on vlan interfaces
+        newIface.setSpeed(parentSpeed);
+        newIface.setBandwidth(parentSpeed);
+      }
       newIface.setDependencies(
           ImmutableList.of(new Dependency(iface.getParentInterface(), DependencyType.BIND)));
     }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -201,10 +201,13 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
     }
     if (iface.getParentInterface() != null) {
       Interface parent = _interfaces.get(iface.getParentInterface());
+      // This is a subinterface. Its speed can't be set explicitly.
+      // If its parent is physical, this interface should inherit the parent's speed/bw now.
+      // If its parent is a bond interface, then this interface's bandwidth will be set after
+      // the parent's bandwidth is calculated post-conversion.
       assert parent != null;
       Double parentSpeed = parent.getLinkSpeedEffective();
       if (parentSpeed != null) {
-        // Don't worry about overwriting because speed can't be configured on vlan interfaces
         newIface.setSpeed(parentSpeed);
         newIface.setBandwidth(parentSpeed);
       }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -191,6 +191,11 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
           .setMtu(iface.getMtuEffective());
     }
 
+    Double speed = iface.getLinkSpeedEffective();
+    if (speed != null) {
+      newIface.setSpeed(speed);
+      newIface.setBandwidth(speed);
+    }
     if (iface.getVlanId() != null) {
       newIface.setEncapsulationVlan(iface.getVlanId());
     }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/Interface.java
@@ -139,6 +139,8 @@ public class Interface implements Serializable {
 
   /** Default link speed in bits per second for an interface with the given name */
   public static @Nullable Double getDefaultSpeed(String name) {
+    // Use default ethernet speed for physical interfaces.
+    // Exclude subinterfaces (their speed should equal their parent's speed).
     if (name.startsWith("eth") && !name.contains(".")) {
       return DEFAULT_ETH_SPEED;
     }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/Interface.java
@@ -47,6 +47,28 @@ public class Interface implements Serializable {
     return _linkSpeed;
   }
 
+  /**
+   * Returns effective link speed in bits per second, or null if not applicable (e.g., this is an
+   * aggregated or logical interface)
+   */
+  public @Nullable Double getLinkSpeedEffective() {
+    if (_linkSpeed == null) {
+      return getDefaultSpeed(_name);
+    }
+    switch (_linkSpeed) {
+      case TEN_M_FULL:
+      case TEN_M_HALF:
+        return 1E7;
+      case HUNDRED_M_FULL:
+      case HUNDRED_M_HALF:
+        return 1E8;
+      case THOUSAND_M_FULL:
+        return 1E9;
+      default:
+        throw new IllegalStateException("Unsupported link speed " + _linkSpeed);
+    }
+  }
+
   @Nullable
   public Integer getMtu() {
     return _mtu;
@@ -105,6 +127,14 @@ public class Interface implements Serializable {
 
   public void setVlanId(@Nullable Integer vlanId) {
     _vlanId = vlanId;
+  }
+
+  /** Default link speed in bits per second for an interface with the given name */
+  public static @Nullable Double getDefaultSpeed(String name) {
+    if (name.startsWith("eth")) {
+      return 1E9;
+    }
+    return null;
   }
 
   @Nullable private ConcreteInterfaceAddress _address;

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/Interface.java
@@ -1,7 +1,5 @@
 package org.batfish.vendor.check_point_gateway.representation;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -76,7 +74,7 @@ public class Interface implements Serializable {
 
   /** Returns the effective MTU for this interface, even if not explicitly configured. */
   public int getMtuEffective() {
-    return firstNonNull(_mtu, DEFAULT_INTERFACE_MTU);
+    return _mtu != null ? _mtu : getDefaultMtu(_name);
   }
 
   @Nonnull
@@ -127,6 +125,14 @@ public class Interface implements Serializable {
 
   public void setVlanId(@Nullable Integer vlanId) {
     _vlanId = vlanId;
+  }
+
+  /** Default MTU for an interface with the given name */
+  public static int getDefaultMtu(String name) {
+    if (name.startsWith("lo")) {
+      return 65536;
+    }
+    return DEFAULT_INTERFACE_MTU;
   }
 
   /** Default link speed in bits per second for an interface with the given name */

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/Interface.java
@@ -15,7 +15,9 @@ public class Interface implements Serializable {
     THOUSAND_M_FULL,
   }
 
+  public static final double DEFAULT_ETH_SPEED = 1E9;
   public static final int DEFAULT_INTERFACE_MTU = 1500;
+  public static final int DEFAULT_LOOPBACK_MTU = 65536;
 
   public Interface(String name) {
     _state = true;
@@ -56,12 +58,12 @@ public class Interface implements Serializable {
     switch (_linkSpeed) {
       case TEN_M_FULL:
       case TEN_M_HALF:
-        return 1E7;
+        return 10E6;
       case HUNDRED_M_FULL:
       case HUNDRED_M_HALF:
-        return 1E8;
+        return 100E6;
       case THOUSAND_M_FULL:
-        return 1E9;
+        return 1000E6;
       default:
         throw new IllegalStateException("Unsupported link speed " + _linkSpeed);
     }
@@ -130,15 +132,15 @@ public class Interface implements Serializable {
   /** Default MTU for an interface with the given name */
   public static int getDefaultMtu(String name) {
     if (name.startsWith("lo")) {
-      return 65536;
+      return DEFAULT_LOOPBACK_MTU;
     }
     return DEFAULT_INTERFACE_MTU;
   }
 
   /** Default link speed in bits per second for an interface with the given name */
   public static @Nullable Double getDefaultSpeed(String name) {
-    if (name.startsWith("eth")) {
-      return 1E9;
+    if (name.startsWith("eth") && !name.contains(".")) {
+      return DEFAULT_ETH_SPEED;
     }
     return null;
   }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -13,6 +13,7 @@ import static org.batfish.datamodel.InterfaceType.AGGREGATED;
 import static org.batfish.datamodel.InterfaceType.PHYSICAL;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasConfigurationFormat;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasBandwidth;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRedFlagWarning;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasChannelGroup;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasChannelGroupMembers;
@@ -532,42 +533,58 @@ public class CheckPointGatewayGrammarTest {
   public void testBondInterfaceConversion() {
     String hostname = "bond_interface_conversion";
     Configuration c = parseConfig(hostname);
-    assertThat(c, notNullValue());
-    assertThat(c.getAllInterfaces(), hasKeys("bond0", "bond1", "eth0", "eth1"));
 
     String bond0Name = "bond0";
     String bond1Name = "bond1";
     String eth0Name = "eth0";
     String eth1Name = "eth1";
-
-    assertThat(c, hasInterface(bond0Name, isActive(true)));
-    assertThat(c, hasInterface(bond0Name, hasInterfaceType(AGGREGATED)));
-    assertThat(
-        c,
-        hasInterface(
-            bond0Name,
-            hasDependencies(
-                containsInAnyOrder(
-                    new Dependency(eth0Name, AGGREGATE), new Dependency(eth1Name, AGGREGATE)))));
-    assertThat(
-        c, hasInterface(bond0Name, hasChannelGroupMembers(containsInAnyOrder(eth0Name, eth1Name))));
-    assertThat(c, hasInterface(bond0Name, hasChannelGroup(nullValue())));
-    assertThat(c, hasInterface(bond0Name, hasMtu(1234)));
-
-    assertThat(c, hasInterface(bond1Name, isActive(false)));
-    assertThat(c, hasInterface(bond1Name, hasInterfaceType(AGGREGATED)));
-    assertThat(c, hasInterface(bond1Name, hasDependencies(emptyIterable())));
-    assertThat(c, hasInterface(bond1Name, hasChannelGroupMembers(emptyIterable())));
-    assertThat(c, hasInterface(bond1Name, hasChannelGroup(nullValue())));
-
-    assertThat(c, hasInterface(eth0Name, isActive(true)));
-    assertThat(c, hasInterface(eth0Name, hasInterfaceType(PHYSICAL)));
-    assertThat(c, hasInterface(eth0Name, hasChannelGroup(equalTo("0"))));
-    assertThat(c, hasInterface(eth0Name, hasMtu(1234)));
-
-    assertThat(c, hasInterface(eth1Name, isActive(true)));
-    assertThat(c, hasInterface(eth1Name, hasInterfaceType(PHYSICAL)));
-    assertThat(c, hasInterface(eth1Name, hasChannelGroup(equalTo("0"))));
+    String eth2Name = "eth2";
+    assertThat(c.getAllInterfaces(), hasKeys(bond0Name, bond1Name, eth0Name, eth1Name, eth2Name));
+    {
+      org.batfish.datamodel.Interface bond0 = c.getAllInterfaces().get(bond0Name);
+      assertThat(bond0, isActive(true));
+      assertThat(bond0, hasInterfaceType(AGGREGATED));
+      assertThat(
+          bond0,
+          hasDependencies(
+              containsInAnyOrder(
+                  new Dependency(eth0Name, AGGREGATE), new Dependency(eth1Name, AGGREGATE))));
+      assertThat(bond0, hasChannelGroupMembers(containsInAnyOrder(eth0Name, eth1Name)));
+      assertThat(bond0, hasChannelGroup(nullValue()));
+      assertThat(bond0, hasMtu(1234));
+      assertThat(bond0, hasBandwidth(2E9));
+    }
+    {
+      org.batfish.datamodel.Interface bond1 = c.getAllInterfaces().get(bond1Name);
+      assertThat(bond1, isActive(false));
+      assertThat(bond1, hasInterfaceType(AGGREGATED));
+      assertThat(bond1, hasDependencies(emptyIterable()));
+      assertThat(bond1, hasChannelGroupMembers(emptyIterable()));
+      assertThat(bond1, hasChannelGroup(nullValue()));
+      assertThat(bond1, hasBandwidth(0D));
+    }
+    {
+      org.batfish.datamodel.Interface eth0 = c.getAllInterfaces().get(eth0Name);
+      assertThat(eth0, isActive(true));
+      assertThat(eth0, hasInterfaceType(PHYSICAL));
+      assertThat(eth0, hasChannelGroup(equalTo("0")));
+      assertThat(eth0, hasMtu(1234));
+      assertThat(eth0, hasBandwidth(1E9));
+    }
+    {
+      org.batfish.datamodel.Interface eth1 = c.getAllInterfaces().get(eth1Name);
+      assertThat(eth1, isActive(true));
+      assertThat(eth1, hasInterfaceType(PHYSICAL));
+      assertThat(eth1, hasChannelGroup(equalTo("0")));
+      assertThat(eth1, hasBandwidth(1E9));
+    }
+    {
+      org.batfish.datamodel.Interface eth2 = c.getAllInterfaces().get(eth2Name);
+      assertThat(eth2, isActive(true));
+      assertThat(eth2, hasInterfaceType(PHYSICAL));
+      assertThat(eth2, hasChannelGroup(nullValue()));
+      assertThat(eth2, hasBandwidth(1E7));
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/bond_interface_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/bond_interface_conversion
@@ -13,6 +13,8 @@ add bonding group 1
 #
 set interface eth0 state on
 set interface eth1 state on
+set interface eth2 state on
+set interface eth2 link-speed 10M/half
 set interface bond0 ipv4-address 10.10.10.10 mask-length 24
 set interface bond0 mtu 1234
 set interface bond1 state off

--- a/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/bond_interface_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/bond_interface_conversion
@@ -13,8 +13,6 @@ add bonding group 1
 #
 set interface eth0 state on
 set interface eth1 state on
-set interface eth2 state on
-set interface eth2 link-speed 10M/half
 set interface bond0 ipv4-address 10.10.10.10 mask-length 24
 set interface bond0 mtu 1234
 set interface bond1 state off

--- a/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/interface_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/interface_conversion
@@ -9,7 +9,16 @@ set hostname interface_conversion
 set interface eth0 state on
 set interface eth0 ipv4-address 192.168.1.1 mask-length 24
 set interface eth0 mtu 1234
+set interface eth0 link-speed 1000M/full
 #
 set interface eth1 state off
+#
+set interface eth2 link-speed 100M/full
+#
+set interface eth3 link-speed 100M/half
+#
+set interface eth4 link-speed 10M/half
+#
+set interface eth5 link-speed 10M/full
 #
 set interface lo ipv4-address 10.10.10.10 mask-length 32

--- a/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/vlan_interface
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/vlan_interface
@@ -7,7 +7,8 @@
 set hostname vlan_interface
 #
 add bonding group 2 interface eth0
-add bonding group 3 interface eth1
+add bonding group 2 interface eth1
+add bonding group 3 interface eth2
 #
 add interface bond2 vlan 2
 add interface bond3 vlan 3
@@ -19,8 +20,10 @@ set interface bond3.3 state off
 # in bond groups
 set interface eth0 state on
 set interface eth1 state on
+set interface eth2 state on
 #
 set interface eth10 state on
+set interface eth10 link-speed 10M/half
 set interface eth11 state off
 set interface eth12 state on
 #


### PR DESCRIPTION
Since there is no explicit `set interface IFACE_NAME bandwidth` command, I think interface bandwidths are equivalent ot their speeds.