### PR TITLE
CP: Adding interface to bonding group can create it

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -217,10 +216,9 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
     getBondingGroup(ifaceName)
         .ifPresent(
             bg -> {
-              Set<String> members = getValidMembers(bg);
-              newIface.setChannelGroupMembers(members);
+              newIface.setChannelGroupMembers(bg.getInterfaces());
               newIface.setDependencies(
-                  members.stream()
+                  bg.getInterfaces().stream()
                       .map(member -> new Dependency(member, DependencyType.AGGREGATE))
                       .collect(ImmutableSet.toImmutableSet()));
 
@@ -267,29 +265,6 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
   @Nonnull
   public static String getBondInterfaceName(int groupNumber) {
     return "bond" + groupNumber;
-  }
-
-  /**
-   * Returns a {@link Set} of valid members for the specified bonding group. Adds warnings if any
-   * member interfaces are invalid.
-   *
-   * <p>Filters out things like non-existent interfaces.
-   */
-  @Nonnull
-  private Set<String> getValidMembers(BondingGroup bondingGroup) {
-    return bondingGroup.getInterfaces().stream()
-        .filter(
-            m -> {
-              boolean exists = _interfaces.containsKey(m);
-              if (!exists) {
-                _w.redFlag(
-                    String.format(
-                        "Cannot reference non-existent interface %s in bonding group %d.",
-                        m, bondingGroup.getNumber()));
-              }
-              return exists;
-            })
-        .collect(ImmutableSet.toImmutableSet());
   }
 
   @Nonnull private Map<Integer, BondingGroup> _bondingGroups;

--- a/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/bond_interface_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/bond_interface_conversion
@@ -8,6 +8,7 @@ set hostname bond_interface_conversion
 #
 add bonding group 0 interface eth0
 add bonding group 0 interface eth1
+add bonding group 0 interface eth2
 #
 add bonding group 1
 #

--- a/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/bond_interface_warn
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/bond_interface_warn
@@ -23,7 +23,6 @@ set interface lo state on
 #
 # "Reconfiguration" section
 add bonding group 1000 interface eth1
-add bonding group 1000 interface eth2
 set interface eth0 state off
 set interface eth0 mtu 2345
 set interface eth0 ipv4-address 10.20.30.40 mask-length 24


### PR DESCRIPTION
Previously thought that adding an otherwise-unconfigured interface to a bonding group was invalid, but in fact it's not necessary for there to be any other mention of the added interface.