### PR TITLE
BatfishLogger: demote passthrough log4j for redFlag

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishLogger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishLogger.java
@@ -311,7 +311,7 @@ public final class BatfishLogger {
   }
 
   public void redflag(String msg) {
-    LOGGER.warn(msg);
+    LOGGER.debug(msg);
     write(LEVEL_REDFLAG, msg);
   }
 


### PR DESCRIPTION
Like unimplemented and pedantic, these should not be surfaced this way.