### PR TITLE
Batfish: improve message when disabling unusable vlan interface

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -961,9 +961,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
             Interface iface = vlanInterfaces.get(vlanNumber);
             if ((iface != null) && iface.getAutoState()) {
               _logger.warnf(
-                  "WARNING: Disabling unusable vlan interface because no switch port is assigned "
-                      + "to it: \"%s:%d\"\n",
-                  hostname, vlanNumber);
+                  "Disabling unusable vlan interface because no switch port is assigned to it: %s",
+                  NodeInterfacePair.of(iface));
               iface.blacklist();
             }
           }


### PR DESCRIPTION
Remove unnecessary prefix
Rwmove unnecessary newline
Print the interface name canonically using NodeInterfacePair