### PR TITLE
feat: add regex to as path access lists

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -7,7 +7,8 @@ options {
 tokens {
   QUOTED_TEXT,
   REMARK_TEXT,
-  WORD
+  WORD,
+  REGEXP
 }
 
 ACCESS_LIST
@@ -800,6 +801,18 @@ F_Uint32
 ;
 
 fragment
+F_Regex
+:
+  F_RegexChar+
+;
+
+fragment
+F_RegexChar
+:
+  [0-9_^|[,{}()\]$*+.?-]
+;
+
+fragment
 F_Word
 :
   F_WordChar+
@@ -810,18 +823,6 @@ F_WordChar
 :
   [0-9A-Za-z!@#$^*_=+.;:{}]
   | '-'
-;
-
-fragment
-F_Regex
-:
-  F_RegexChar+
-;
-
-fragment
-F_RegexChar
-:
-  [0-9_^|[,{}()\]$*+.?-]
 ;
 
 fragment
@@ -1128,9 +1129,14 @@ M_AccessList_PERMIT
    'permit' -> type(PERMIT)
 ;
 
+M_AsPathAccessList_REGEX
+:
+   F_Regex -> type(REGEXP)
+;
+
 M_AsPathAccessList_WORD
 :
-   F_Regex -> type(WORD)
+   F_Word -> type(WORD)
 ;
 
 M_AccessList_NEWLINE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -12,7 +12,7 @@ tokens {
 
 ACCESS_LIST
 :
-  'access-list' -> pushMode(M_Word)
+  'access-list' -> pushMode(M_AccessList)
 ;
 
 ACTIVATE: 'activate';
@@ -1104,3 +1104,29 @@ M_Update_NEWLINE
   F_Newline+ -> type ( NEWLINE ), popMode
 ;
 
+mode M_AccessList;
+
+M_AccessList_DENY
+:
+   'deny' -> type( DENY )
+;
+
+M_AccessList_PERMIT
+:
+   'permit' -> type( PERMIT )
+;
+
+M_AsPathAccessList_WORD
+:
+   F_Word -> type( WORD )
+;
+
+M_AccessList_NEWLINE
+:
+   F_Newline+ -> type ( NEWLINE ) , popMode
+;
+
+M_AccessList_WS
+:
+   F_Whitespace+ -> channel ( HIDDEN )
+;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -808,8 +808,20 @@ F_Word
 fragment
 F_WordChar
 :
-  [0-9A-Za-z!@#$^*_=+.;:{}\\[\]|()]
+  [0-9A-Za-z!@#$^*_=+.;:{}]
   | '-'
+;
+
+fragment
+F_Regex
+:
+  F_RegexChar+
+;
+
+fragment
+F_RegexChar
+:
+  [0-9_^|[,{}()\]$*+.?-]
 ;
 
 fragment
@@ -1118,15 +1130,15 @@ M_AccessList_PERMIT
 
 M_AsPathAccessList_WORD
 :
-   F_Word -> type( WORD )
+   F_Regex -> type(WORD)
 ;
 
 M_AccessList_NEWLINE
 :
-   F_Newline+ -> type ( NEWLINE ) , popMode
+   F_Newline+ -> type (NEWLINE) , popMode
 ;
 
 M_AccessList_WS
 :
-   F_Whitespace+ -> channel ( HIDDEN )
+   F_Whitespace+ -> channel (HIDDEN)
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -808,7 +808,7 @@ F_Word
 fragment
 F_WordChar
 :
-  [0-9A-Za-z!@#$^*_=+.;:{}]
+  [0-9A-Za-z!@#$^*_=+.;:{}\\[\]|()]
   | '-'
 ;
 
@@ -1108,12 +1108,12 @@ mode M_AccessList;
 
 M_AccessList_DENY
 :
-   'deny' -> type( DENY )
+   'deny' -> type(DENY)
 ;
 
 M_AccessList_PERMIT
 :
-   'permit' -> type( PERMIT )
+   'permit' -> type(PERMIT)
 ;
 
 M_AsPathAccessList_WORD

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -8,7 +8,7 @@ tokens {
   QUOTED_TEXT,
   REMARK_TEXT,
   WORD,
-  REGEXP
+  REGEX
 }
 
 ACCESS_LIST
@@ -1131,7 +1131,7 @@ M_AccessList_PERMIT
 
 M_AsPathAccessList_REGEX
 :
-   F_Regex -> type(REGEXP)
+   F_Regex -> type(REGEX)
 ;
 
 M_AsPathAccessList_WORD

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrParser.g4
@@ -39,7 +39,7 @@ statement
 
 ip_as_path
 :
-  AS_PATH ACCESS_LIST name = word action = line_action asn = uint32 NEWLINE
+  AS_PATH ACCESS_LIST name = word action = access_list_action as_path_regex = word NEWLINE
 ;
 
 s_agentx
@@ -185,5 +185,3 @@ s_username
 :
   USERNAME null_rest_of_line
 ;
-
-

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrParser.g4
@@ -39,7 +39,7 @@ statement
 
 ip_as_path
 :
-  AS_PATH ACCESS_LIST name = word action = access_list_action as_path_regex = regexp NEWLINE
+  AS_PATH ACCESS_LIST name = word action = access_list_action as_path_regex = REGEX NEWLINE
 ;
 
 s_agentx

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrParser.g4
@@ -39,7 +39,7 @@ statement
 
 ip_as_path
 :
-  AS_PATH ACCESS_LIST name = word action = access_list_action as_path_regex = word NEWLINE
+  AS_PATH ACCESS_LIST name = word action = access_list_action as_path_regex = regexp NEWLINE
 ;
 
 s_agentx

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
@@ -38,6 +38,12 @@ ip_prefix_length
   UINT8
 ;
 
+access_list_action
+:
+   PERMIT
+   | DENY
+;
+
 line_action
 :
   deny = DENY

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
@@ -151,11 +151,6 @@ uint32
   | UINT32
 ;
 
-regexp
-:
-  REGEXP
-;
-
 word
 :
   WORD

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
@@ -151,6 +151,11 @@ uint32
   | UINT32
 ;
 
+regexp
+:
+  REGEXP
+;
+
 word
 :
   WORD

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -1779,12 +1779,9 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   private LineAction toLineAction(Access_list_actionContext ctx) {
     if (ctx.PERMIT() != null) {
       return LineAction.PERMIT;
-    } else if (ctx.DENY() != null) {
-      return LineAction.DENY;
     } else {
-      throw new BatfishException(
-          String.format(
-              "Could not convert to %s: %s", LineAction.class.getSimpleName(), getFullText(ctx)));
+      assert ctx.DENY() != null;
+      return LineAction.DENY;
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -1782,14 +1782,14 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     } else if (ctx.DENY() != null) {
       return LineAction.DENY;
     } else {
-      throw new BatfishException(String.format(
-          "Could not convert to %s: %s",
-          LineAction.class.getSimpleName(),
-          getFullText(ctx)));
+      throw new BatfishException(
+          String.format(
+              "Could not convert to %s: %s", LineAction.class.getSimpleName(), getFullText(ctx)));
     }
   }
 
-  @Override public void exitIp_as_path(Ip_as_pathContext ctx) {
+  @Override
+  public void exitIp_as_path(Ip_as_pathContext ctx) {
     String name = ctx.name.getText();
     LineAction action = toLineAction(ctx.action);
     String regex = ctx.as_path_regex.getText();

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -135,6 +135,7 @@ import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.datamodel.vxlan.Vni;
+import org.batfish.representation.cumulus.IpAsPathAccessListLine;
 import org.batfish.vendor.VendorStructureId;
 
 /** Utilities that convert Cumulus-specific representations to vendor-independent model. */
@@ -1559,7 +1560,7 @@ public final class CumulusConversions {
         new CommunityMatchRegex(ColonSeparatedRendering.instance(), toJavaRegex(line.getRegex())));
   }
 
-  private static @Nonnull String toJavaRegex(String cumulusRegex) {
+  static @Nonnull String toJavaRegex(String cumulusRegex) {
     String withoutQuotes;
     if (cumulusRegex.charAt(0) == '"' && cumulusRegex.charAt(cumulusRegex.length() - 1) == '"') {
       withoutQuotes = cumulusRegex.substring(1, cumulusRegex.length() - 1);
@@ -1585,10 +1586,7 @@ public final class CumulusConversions {
         asPathAccessList.getLines().stream()
             // TODO Check FRR AS path match semantics.
             // This regex assumes we should match any path containing the specified ASN anywhere.
-            .map(
-                line ->
-                    new AsPathAccessListLine(
-                        line.getAction(), String.format("(^| )%s($| )", line.getAsNum())))
+            .map(IpAsPathAccessListLine::toAsPathAccessListLine)
             .collect(ImmutableList.toImmutableList());
     return new AsPathAccessList(name, lines);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -1585,7 +1585,7 @@ public final class CumulusConversions {
         asPathAccessList.getLines().stream()
             // TODO Check FRR AS path match semantics.
             // This regex assumes we should match any path containing the specified ASN anywhere.
-            .map(IpAsPathAccessListLine::toAsPathAccessListLine)
+            .map(line -> new AsPathAccessListLine(line.getAction(), line.getRegex()))
             .collect(ImmutableList.toImmutableList());
     return new AsPathAccessList(name, lines);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -135,7 +135,6 @@ import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.datamodel.vxlan.Vni;
-import org.batfish.representation.cumulus.IpAsPathAccessListLine;
 import org.batfish.vendor.VendorStructureId;
 
 /** Utilities that convert Cumulus-specific representations to vendor-independent model. */

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpAsPathAccessListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpAsPathAccessListLine.java
@@ -2,16 +2,17 @@ package org.batfish.representation.cumulus;
 
 import java.io.Serializable;
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.AsPathAccessListLine;
 import org.batfish.datamodel.LineAction;
 
 /** Represents one line of a Cumulus AS-path access list. */
 public class IpAsPathAccessListLine implements Serializable {
   private final @Nonnull LineAction _action;
-  private final long _asNum;
+  private final String _regex;
 
-  public IpAsPathAccessListLine(@Nonnull LineAction action, long asNum) {
+  public IpAsPathAccessListLine(@Nonnull LineAction action, String regex) {
     _action = action;
-    _asNum = asNum;
+    _regex = regex;
   }
 
   @Nonnull
@@ -19,7 +20,12 @@ public class IpAsPathAccessListLine implements Serializable {
     return _action;
   }
 
-  public long getAsNum() {
-    return _asNum;
+  public String getRegex() {
+    return _regex;
+  }
+
+  public AsPathAccessListLine toAsPathAccessListLine() {
+    String regex = CumulusConversions.toJavaRegex(_regex);
+    return new AsPathAccessListLine(_action, regex);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpAsPathAccessListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpAsPathAccessListLine.java
@@ -2,7 +2,6 @@ package org.batfish.representation.cumulus;
 
 import java.io.Serializable;
 import javax.annotation.Nonnull;
-import org.batfish.datamodel.AsPathAccessListLine;
 import org.batfish.datamodel.LineAction;
 
 /** Represents one line of a Cumulus AS-path access list. */

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpAsPathAccessListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpAsPathAccessListLine.java
@@ -23,9 +23,4 @@ public class IpAsPathAccessListLine implements Serializable {
   public String getRegex() {
     return _regex;
   }
-
-  public AsPathAccessListLine toAsPathAccessListLine() {
-    String regex = CumulusConversions.toJavaRegex(_regex);
-    return new AsPathAccessListLine(_action, regex);
-  }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -1447,8 +1447,8 @@ public class CumulusFrrGrammarTest {
   @Test
   public void testCumulusFrrIpAsPathAccessList() {
     String name = "NAME";
-    long as1 = 11111;
-    long as2 = 22222;
+    String as1 = "^11111$";
+    String as2 = "^22222$";
     parse(
         String.format(
             "ip as-path access-list %s permit %s\n" + "ip as-path access-list %s deny %s\n",
@@ -1465,8 +1465,8 @@ public class CumulusFrrGrammarTest {
     IpAsPathAccessListLine line1 = asPathAccessList.getLines().get(1);
     assertThat(line0.getAction(), equalTo(LineAction.PERMIT));
     assertThat(line1.getAction(), equalTo(LineAction.DENY));
-    assertThat(line0.getAsNum(), equalTo(as1));
-    assertThat(line1.getAsNum(), equalTo(as2));
+    assertThat(line0.getRegex(), equalTo(as1));
+    assertThat(line1.getRegex(), equalTo(as2));
 
     // Check that the AS-path access list definition was registered
     DefinedStructureInfo definedStructureInfo =

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -1448,30 +1448,61 @@ public class CumulusFrrGrammarTest {
   public void testCumulusFrrIpAsPathAccessList() {
     String name = "NAME";
     String as1 = "^11111$";
-    String as2 = "^22222$";
+    String as2 = "_1_";
+    String as3 = "^1[1-2]";
+    String as4 = "^1(1)";
     parse(
         String.format(
-            "ip as-path access-list %s permit %s\n" + "ip as-path access-list %s deny %s\n",
-            name, as1, name, as2));
+            "ip as-path access-list %s permit %s\n"
+                + "ip as-path access-list %s permit %s\n"
+                + "ip as-path access-list %s permit %s\n"
+                + "ip as-path access-list %s permit %s\n"
+                + "ip as-path access-list %s deny %s\n"
+                + "ip as-path access-list %s deny %s\n"
+                + "ip as-path access-list %s deny %s\n"
+                + "ip as-path access-list %s deny %s\n",
+            name, as1, name, as2, name, as3, name, as4, name, as1, name, as2, name, as3, name,
+            as4));
 
     // Check that config has the expected AS-path access list with the expected name and num lines
     assertThat(_frr.getIpAsPathAccessLists().keySet(), contains(name));
     IpAsPathAccessList asPathAccessList = _frr.getIpAsPathAccessLists().get(name);
     assertThat(asPathAccessList.getName(), equalTo(name));
-    assertThat(asPathAccessList.getLines(), hasSize(2));
+    assertThat(asPathAccessList.getLines(), hasSize(8));
 
     // Check that lines look as expected
     IpAsPathAccessListLine line0 = asPathAccessList.getLines().get(0);
     IpAsPathAccessListLine line1 = asPathAccessList.getLines().get(1);
+    IpAsPathAccessListLine line2 = asPathAccessList.getLines().get(2);
+    IpAsPathAccessListLine line3 = asPathAccessList.getLines().get(3);
+    IpAsPathAccessListLine line4 = asPathAccessList.getLines().get(4);
+    IpAsPathAccessListLine line5 = asPathAccessList.getLines().get(5);
+    IpAsPathAccessListLine line6 = asPathAccessList.getLines().get(6);
+    IpAsPathAccessListLine line7 = asPathAccessList.getLines().get(7);
+
     assertThat(line0.getAction(), equalTo(LineAction.PERMIT));
-    assertThat(line1.getAction(), equalTo(LineAction.DENY));
+    assertThat(line1.getAction(), equalTo(LineAction.PERMIT));
+    assertThat(line2.getAction(), equalTo(LineAction.PERMIT));
+    assertThat(line3.getAction(), equalTo(LineAction.PERMIT));
+    assertThat(line4.getAction(), equalTo(LineAction.DENY));
+    assertThat(line5.getAction(), equalTo(LineAction.DENY));
+    assertThat(line6.getAction(), equalTo(LineAction.DENY));
+    assertThat(line7.getAction(), equalTo(LineAction.DENY));
+
     assertThat(line0.getRegex(), equalTo(as1));
     assertThat(line1.getRegex(), equalTo(as2));
+    assertThat(line2.getRegex(), equalTo(as3));
+    assertThat(line3.getRegex(), equalTo(as4));
+    assertThat(line4.getRegex(), equalTo(as1));
+    assertThat(line5.getRegex(), equalTo(as2));
+    assertThat(line6.getRegex(), equalTo(as3));
+    assertThat(line7.getRegex(), equalTo(as4));
 
     // Check that the AS-path access list definition was registered
     DefinedStructureInfo definedStructureInfo =
         getDefinedStructureInfo(CumulusStructureType.IP_AS_PATH_ACCESS_LIST, name);
-    assertThat(definedStructureInfo.getDefinitionLines().enumerate(), contains(1, 2));
+    assertThat(
+        definedStructureInfo.getDefinitionLines().enumerate(), contains(1, 2, 3, 4, 5, 6, 7, 8));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -269,10 +269,10 @@ public final class CumulusConversionsTest {
     // Cache initialization only happens in AsPathAccessList on deserialization o.O
     viList = SerializationUtils.clone(viList);
 
-    List<AsPathAccessListLine> expectedViLines = ImmutableList.of(new AsPathAccessListLine(
-            LineAction.DENY,
-            denied_regex),
-        new AsPathAccessListLine(LineAction.PERMIT, permitted_regex));
+    List<AsPathAccessListLine> expectedViLines =
+        ImmutableList.of(
+            new AsPathAccessListLine(LineAction.DENY, denied_regex),
+            new AsPathAccessListLine(LineAction.PERMIT, permitted_regex));
     assertThat(viList, equalTo(new AsPathAccessList("name", expectedViLines)));
 
     // Matches paths containing permitted ASN


### PR DESCRIPTION
Use a regular expression to match AS_PATH in access-list instead of converting a single integer to a regular expression.

- update lexer / parser
- update conversion
- update tests