### PR TITLE
FRR: support route map set as-path exclude

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -39,6 +39,10 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
     return of(asNums.stream().map(AsSet::of).collect(ImmutableList.toImmutableList()));
   }
 
+  public static AsPath ofAsSets(AsSet... asSets) {
+    return of(Arrays.asList(asSets));
+  }
+
   private final List<AsSet> _asSets;
 
   // Soft values: let it be garbage collected in times of pressure.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -102,6 +102,18 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
             .collect(ImmutableList.toImmutableList()));
   }
 
+  /**
+   * Returns a new {@link AsPath} with all specified ASNs removed form any {@link AsSet} in the
+   * path.
+   */
+  public AsPath removeASNs(List<Long> asns) {
+    return AsPath.of(
+        _asSets.stream()
+            .map(asSet -> asSet.removeASNsIfExists(asns))
+            .filter(asSet -> !asSet.isEmpty())
+            .collect(ImmutableList.toImmutableList()));
+  }
+
   @Override
   public int compareTo(AsPath rhs) {
     return Comparators.lexicographical(Ordering.<AsSet>natural()).compare(_asSets, rhs._asSets);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -13,7 +13,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.StringUtils;
@@ -106,10 +108,10 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
    * Returns a new {@link AsPath} with all specified ASNs removed form any {@link AsSet} in the
    * path.
    */
-  public AsPath removeASNs(List<Long> asns) {
+  public @Nonnull AsPath removeASNs(Collection<Long> asns) {
     return AsPath.of(
         _asSets.stream()
-            .map(asSet -> asSet.removeASNsIfExists(asns))
+            .map(asSet -> asSet.removeASNs(asns))
             .filter(asSet -> !asSet.isEmpty())
             .collect(ImmutableList.toImmutableList()));
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
@@ -13,6 +13,7 @@ import com.google.common.primitives.Longs;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.SortedSet;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -157,6 +158,14 @@ public class AsSet implements Serializable, Comparable<AsSet> {
   /** Returns a new {@link AsSet} that consists of this set with any private ASNs removed. */
   public AsSet removePrivateAs() {
     return AsSet.of(Arrays.stream(_value).filter(asn -> !AsPath.isPrivateAs(asn)).toArray());
+  }
+
+  /**
+   * Returns a new {@link AsSet} that consists of this set with the provided ASNs removed if they
+   * exists
+   */
+  public AsSet removeASNsIfExists(List<Long> asns) {
+    return AsSet.of(Arrays.stream(_value).filter(asn -> !asns.contains(asn)).toArray());
   }
 
   public int size() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
@@ -12,9 +12,10 @@ import com.google.common.collect.Ordering;
 import com.google.common.primitives.Longs;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.SortedSet;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.StringUtils;
@@ -160,11 +161,8 @@ public class AsSet implements Serializable, Comparable<AsSet> {
     return AsSet.of(Arrays.stream(_value).filter(asn -> !AsPath.isPrivateAs(asn)).toArray());
   }
 
-  /**
-   * Returns a new {@link AsSet} that consists of this set with the provided ASNs removed if they
-   * exists
-   */
-  public AsSet removeASNsIfExists(List<Long> asns) {
+  /** Returns a new {@link AsSet} that consists of this set with the provided ASNs removed. */
+  public @Nonnull AsSet removeASNs(Collection<Long> asns) {
     return AsSet.of(Arrays.stream(_value).filter(asn -> !asns.contains(asn)).toArray());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
@@ -89,6 +89,7 @@ import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.Comment;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
@@ -675,6 +676,12 @@ public final class CommunityStructuresVerifier {
     @Override
     public Void visitPrependAsPath(
         PrependAsPath prependAsPath, CommunityStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitExcludeAsPath(
+        ExcludeAsPath excludeAsPath, CommunityStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
@@ -44,6 +44,7 @@ import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.Comment;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
@@ -406,6 +407,12 @@ public final class AsPathStructuresVerifier {
     @Override
     public Void visitPrependAsPath(
         PrependAsPath prependAsPath, AsPathStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitExcludeAsPath(
+        ExcludeAsPath excludeAsPath, AsPathStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/ExcludeAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/ExcludeAsPath.java
@@ -76,7 +76,7 @@ public final class ExcludeAsPath extends Statement {
               AsPath.of(
                   ImmutableList.<AsSet>builder()
                       .addAll(
-                          outputRoute.getAsPath().getAsSets().stream()
+                          ir.getAsPath().getAsSets().stream()
                               .filter(currentAsSet -> !excludeAsPath.contains(currentAsSet))
                               .collect(Collectors.toSet()))
                       .build()));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/ExcludeAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/ExcludeAsPath.java
@@ -1,0 +1,107 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.AsSet;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.HasWritableAsPath;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+import org.batfish.datamodel.routing_policy.expr.AsPathListExpr;
+
+@ParametersAreNonnullByDefault
+public final class ExcludeAsPath extends Statement {
+  private static final String PROP_EXPR = "expr";
+
+  @Nonnull private AsPathListExpr _expr;
+
+  @JsonCreator
+  private static ExcludeAsPath jsonCreator(@Nullable @JsonProperty(PROP_EXPR) AsPathListExpr expr) {
+    checkArgument(expr != null, "%s must be provided", PROP_EXPR);
+    return new ExcludeAsPath(expr);
+  }
+
+  public ExcludeAsPath(AsPathListExpr expr) {
+    _expr = expr;
+  }
+
+  @Override
+  public <T, U> T accept(StatementVisitor<T, U> visitor, U arg) {
+    return visitor.visitExcludeAsPath(this, arg);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof ExcludeAsPath)) {
+      return false;
+    }
+    ExcludeAsPath other = (ExcludeAsPath) obj;
+    return _expr.equals(other._expr);
+  }
+
+  @Override
+  public Result execute(Environment environment) {
+    if ((environment.getOutputRoute() instanceof HasWritableAsPath<?, ?>)) {
+      List<AsSet> excludeAsPath =
+          _expr.evaluate(environment).stream().map(AsSet::of).collect(Collectors.toList());
+
+      HasWritableAsPath<?, ?> outputRoute = (HasWritableAsPath<?, ?>) environment.getOutputRoute();
+      if (Collections.indexOfSubList(outputRoute.getAsPath().getAsSets(), excludeAsPath) != -1) {
+        outputRoute.setAsPath(
+            AsPath.of(
+                ImmutableList.<AsSet>builder()
+                    .addAll(
+                        outputRoute.getAsPath().getAsSets().stream()
+                            .filter(currentAsSet -> !excludeAsPath.contains(currentAsSet))
+                            .collect(Collectors.toSet()))
+                    .build()));
+      }
+
+      if (environment.getWriteToIntermediateBgpAttributes()) {
+        BgpRoute.Builder<?, ?> ir = environment.getIntermediateBgpAttributes();
+        if (Collections.indexOfSubList(ir.getAsPath().getAsSets(), excludeAsPath) != -1) {
+          ir.setAsPath(
+              AsPath.of(
+                  ImmutableList.<AsSet>builder()
+                      .addAll(
+                          outputRoute.getAsPath().getAsSets().stream()
+                              .filter(currentAsSet -> !excludeAsPath.contains(currentAsSet))
+                              .collect(Collectors.toSet()))
+                      .build()));
+        }
+      }
+    }
+
+    return new Result();
+  }
+
+  @JsonProperty(PROP_EXPR)
+  @Nonnull
+  public AsPathListExpr getExpr() {
+    return _expr;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + _expr.hashCode();
+    return result;
+  }
+
+  public void setExpr(AsPathListExpr expr) {
+    _expr = expr;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/PrependAsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/PrependAsPath.java
@@ -76,8 +76,7 @@ public final class PrependAsPath extends Statement {
                   .build()));
     }
 
-    Result result = new Result();
-    return result;
+    return new Result();
   }
 
   @JsonProperty(PROP_EXPR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/StatementVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/StatementVisitor.java
@@ -16,6 +16,8 @@ public interface StatementVisitor<T, U> {
 
   T visitPrependAsPath(PrependAsPath prependAsPath, U arg);
 
+  T visitExcludeAsPath(ExcludeAsPath excludeAsPath, U arg);
+
   T visitSetAdministrativeCost(SetAdministrativeCost setAdministrativeCost, U arg);
 
   T visitSetCommunities(SetCommunities setCommunities, U arg);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifierTest.java
@@ -89,6 +89,7 @@ import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.Comment;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
@@ -162,6 +163,8 @@ public final class CommunityStructuresVerifierTest {
     assertNull(new Comment("a").accept(STATEMENT_VERIFIER, ctx));
     assertNull(
         new PrependAsPath(new LiteralAsList(ImmutableList.of())).accept(STATEMENT_VERIFIER, ctx));
+    assertNull(
+        new ExcludeAsPath(new LiteralAsList(ImmutableList.of())).accept(STATEMENT_VERIFIER, ctx));
     assertNull(new SetAdministrativeCost(new LiteralInt(1)).accept(STATEMENT_VERIFIER, ctx));
     assertNull(new SetDefaultPolicy("a").accept(STATEMENT_VERIFIER, ctx));
     assertNull(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifierTest.java
@@ -74,6 +74,7 @@ import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.Comment;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
@@ -150,6 +151,8 @@ public final class AsPathStructuresVerifierTest {
     assertNull(new Comment("a").accept(STATEMENT_VERIFIER, ctx));
     assertNull(
         new PrependAsPath(new LiteralAsList(ImmutableList.of())).accept(STATEMENT_VERIFIER, ctx));
+    assertNull(
+        new ExcludeAsPath(new LiteralAsList(ImmutableList.of())).accept(STATEMENT_VERIFIER, ctx));
     assertNull(new SetAdministrativeCost(new LiteralInt(1)).accept(STATEMENT_VERIFIER, ctx));
     assertNull(new SetCommunities(InputCommunities.instance()).accept(STATEMENT_VERIFIER, ctx));
     assertNull(new SetDefaultPolicy("a").accept(STATEMENT_VERIFIER, ctx));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/ExcludeAsPathTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/ExcludeAsPathTest.java
@@ -1,0 +1,57 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static org.batfish.datamodel.AsPath.ofSingletonAsSets;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.expr.AsExpr;
+import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
+import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ExcludeAsPathTest {
+
+  private static Environment newTestEnvironment(Bgpv4Route.Builder outputRoute) {
+    Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
+    return Environment.builder(c).setOutputRoute(outputRoute).build();
+  }
+
+  @Test
+  public void testExclude() {
+    List<AsExpr> exclude = Lists.newArrayList(new ExplicitAs(3));
+    ExcludeAsPath operation = new ExcludeAsPath(new LiteralAsList(exclude));
+    Bgpv4Route.Builder builder = Bgpv4Route.testBuilder();
+    builder.setAsPath(ofSingletonAsSets(3L, 4L));
+    Environment env = newTestEnvironment(builder);
+
+    operation.execute(env);
+    assertThat(builder.getAsPath(), equalTo(ofSingletonAsSets(4L)));
+  }
+
+  @Test
+  public void testExcludeWithIntermediateAttributes() {
+    List<AsExpr> exclude = Lists.newArrayList(new ExplicitAs(3));
+    ExcludeAsPath operation = new ExcludeAsPath(new LiteralAsList(exclude));
+    Bgpv4Route.Builder outputRoute = Bgpv4Route.testBuilder();
+    outputRoute.setAsPath(ofSingletonAsSets(3L, 4L));
+
+    Bgpv4Route.Builder intermediateAttributes = Bgpv4Route.testBuilder();
+    intermediateAttributes.setAsPath(ofSingletonAsSets(3L, 5L));
+    Environment env = newTestEnvironment(outputRoute);
+    env.setIntermediateBgpAttributes(intermediateAttributes);
+    env.setWriteToIntermediateBgpAttributes(true);
+
+    operation.execute(env);
+    assertThat(outputRoute.getAsPath(), equalTo(ofSingletonAsSets(4L)));
+    assertThat(intermediateAttributes.getAsPath(), equalTo(ofSingletonAsSets(5L)));
+  }
+}

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -371,6 +371,8 @@ PREFIX_LIST
 
 PREPEND: 'prepend';
 
+EXCLUDE: 'exclude';
+
 RA_INTERVAL: 'ra-interval';
 
 RANGE: 'range';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
@@ -186,9 +186,15 @@ rmm_interface
   INTERFACE name = WORD NEWLINE
 ;
 
+as_path_action
+:
+  prepend = PREPEND
+  | exclude = EXCLUDE
+;
+
 rms_as_path
 :
-  AS_PATH PREPEND as_path = literal_as_path NEWLINE
+  AS_PATH action = as_path_action as_path = literal_as_path NEWLINE
 ;
 
 rm_on_match

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
@@ -188,18 +188,18 @@ rmm_interface
 
 rms_as_path_exclude
 :
-  EXCLUDE as_path = literal_as_path
+  EXCLUDE as_path = literal_as_path NEWLINE
 ;
 
 rms_as_path_prepend
 :
-  PREPEND as_path = literal_as_path
+  PREPEND as_path = literal_as_path NEWLINE
 ;
 
 
 rms_as_path
 :
-  AS_PATH (rms_as_path_exclude | rms_as_path_prepend) NEWLINE
+  AS_PATH (rms_as_path_exclude | rms_as_path_prepend)
 ;
 
 rm_on_match

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
@@ -186,15 +186,9 @@ rmm_interface
   INTERFACE name = WORD NEWLINE
 ;
 
-as_path_action
-:
-  prepend = PREPEND
-  | exclude = EXCLUDE
-;
-
 rms_as_path
 :
-  AS_PATH action = as_path_action as_path = literal_as_path NEWLINE
+  AS_PATH (EXCLUDE | PREPEND) as_path = literal_as_path NEWLINE
 ;
 
 rm_on_match

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
@@ -186,9 +186,20 @@ rmm_interface
   INTERFACE name = WORD NEWLINE
 ;
 
+rms_as_path_exclude
+:
+  EXCLUDE as_path = literal_as_path
+;
+
+rms_as_path_prepend
+:
+  PREPEND as_path = literal_as_path
+;
+
+
 rms_as_path
 :
-  AS_PATH (EXCLUDE | PREPEND) as_path = literal_as_path NEWLINE
+  AS_PATH (rms_as_path_exclude | rms_as_path_prepend) NEWLINE
 ;
 
 rm_on_match

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -241,9 +241,10 @@ import org.batfish.representation.cumulus.RouteMapMatchSourceProtocol;
 import org.batfish.representation.cumulus.RouteMapMatchSourceProtocol.Protocol;
 import org.batfish.representation.cumulus.RouteMapMatchTag;
 import org.batfish.representation.cumulus.RouteMapMetricType;
-import org.batfish.representation.cumulus.RouteMapSetAsPath;
+import org.batfish.representation.cumulus.RouteMapSetPrependAsPath;
 import org.batfish.representation.cumulus.RouteMapSetCommListDelete;
 import org.batfish.representation.cumulus.RouteMapSetCommunity;
+import org.batfish.representation.cumulus.RouteMapSetExcludeAsPath;
 import org.batfish.representation.cumulus.RouteMapSetIpNextHopLiteral;
 import org.batfish.representation.cumulus.RouteMapSetLocalPreference;
 import org.batfish.representation.cumulus.RouteMapSetMetric;
@@ -1575,7 +1576,12 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   public void exitRms_as_path(Rms_as_pathContext ctx) {
     List<Long> asns =
         ctx.as_path.asns.stream().map(this::toLong).collect(ImmutableList.toImmutableList());
-    _currentRouteMapEntry.setSetAsPath(new RouteMapSetAsPath(asns));
+
+    if (ctx.action.prepend != null) {
+      _currentRouteMapEntry.setSetAsPath(new RouteMapSetPrependAsPath(asns));
+    }else if (ctx.action.exclude != null){
+      _currentRouteMapEntry.setSetExcludeAsPath(new RouteMapSetExcludeAsPath(asns));
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -241,7 +241,6 @@ import org.batfish.representation.cumulus.RouteMapMatchSourceProtocol;
 import org.batfish.representation.cumulus.RouteMapMatchSourceProtocol.Protocol;
 import org.batfish.representation.cumulus.RouteMapMatchTag;
 import org.batfish.representation.cumulus.RouteMapMetricType;
-import org.batfish.representation.cumulus.RouteMapSetPrependAsPath;
 import org.batfish.representation.cumulus.RouteMapSetCommListDelete;
 import org.batfish.representation.cumulus.RouteMapSetCommunity;
 import org.batfish.representation.cumulus.RouteMapSetExcludeAsPath;
@@ -249,6 +248,7 @@ import org.batfish.representation.cumulus.RouteMapSetIpNextHopLiteral;
 import org.batfish.representation.cumulus.RouteMapSetLocalPreference;
 import org.batfish.representation.cumulus.RouteMapSetMetric;
 import org.batfish.representation.cumulus.RouteMapSetMetricType;
+import org.batfish.representation.cumulus.RouteMapSetPrependAsPath;
 import org.batfish.representation.cumulus.RouteMapSetTag;
 import org.batfish.representation.cumulus.RouteMapSetWeight;
 import org.batfish.representation.cumulus.StaticRoute;
@@ -1579,7 +1579,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
 
     if (ctx.action.prepend != null) {
       _currentRouteMapEntry.setSetAsPath(new RouteMapSetPrependAsPath(asns));
-    }else if (ctx.action.exclude != null){
+    } else if (ctx.action.exclude != null) {
       _currentRouteMapEntry.setSetExcludeAsPath(new RouteMapSetExcludeAsPath(asns));
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -105,7 +105,8 @@ import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rmmipa_prefix_lenContext
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rmmipa_prefix_listContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rmom_gotoContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rmom_nextContext;
-import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rms_as_pathContext;
+import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rms_as_path_excludeContext;
+import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rms_as_path_prependContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rms_comm_listContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rms_communityContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Rms_local_preferenceContext;
@@ -1573,16 +1574,17 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   }
 
   @Override
-  public void exitRms_as_path(Rms_as_pathContext ctx) {
+  public void exitRms_as_path_exclude(Rms_as_path_excludeContext ctx) {
     List<Long> asns =
         ctx.as_path.asns.stream().map(this::toLong).collect(ImmutableList.toImmutableList());
+    _currentRouteMapEntry.setSetExcludeAsPath(new RouteMapSetExcludeAsPath(asns));
+  }
 
-    if (ctx.PREPEND() != null) {
-      _currentRouteMapEntry.setSetAsPath(new RouteMapSetPrependAsPath(asns));
-    } else {
-      assert ctx.EXCLUDE() != null;
-      _currentRouteMapEntry.setSetExcludeAsPath(new RouteMapSetExcludeAsPath(asns));
-    }
+  @Override
+  public void exitRms_as_path_prepend(Rms_as_path_prependContext ctx) {
+    List<Long> asns =
+        ctx.as_path.asns.stream().map(this::toLong).collect(ImmutableList.toImmutableList());
+    _currentRouteMapEntry.setSetAsPath(new RouteMapSetPrependAsPath(asns));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -1577,9 +1577,10 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     List<Long> asns =
         ctx.as_path.asns.stream().map(this::toLong).collect(ImmutableList.toImmutableList());
 
-    if (ctx.action.prepend != null) {
+    if (ctx.PREPEND() != null) {
       _currentRouteMapEntry.setSetAsPath(new RouteMapSetPrependAsPath(asns));
-    } else if (ctx.action.exclude != null) {
+    } else {
+      assert ctx.EXCLUDE() != null;
       _currentRouteMapEntry.setSetExcludeAsPath(new RouteMapSetExcludeAsPath(asns));
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapEntry.java
@@ -25,7 +25,8 @@ public final class RouteMapEntry implements Serializable {
   private final int _number;
   private @Nullable String _description;
 
-  private @Nullable RouteMapSetAsPath _setAsPath;
+  private @Nullable RouteMapSetPrependAsPath _setAsPath;
+  private @Nullable RouteMapSetExcludeAsPath _setExcludeAsPath;
   private @Nullable RouteMapSetMetric _setMetric;
   private @Nullable RouteMapSetMetricType _setMetricType;
   private @Nullable RouteMapSetIpNextHopLiteral _setIpNextHop;
@@ -120,6 +121,7 @@ public final class RouteMapEntry implements Serializable {
   public @Nonnull Stream<RouteMapSet> getSets() {
     return Stream.of(
             _setAsPath,
+            _setExcludeAsPath,
             _setCommListDelete,
             _setMetric,
             _setMetricType,
@@ -131,8 +133,12 @@ public final class RouteMapEntry implements Serializable {
         .filter(Objects::nonNull);
   }
 
-  public @Nullable RouteMapSetAsPath getSetAsPath() {
+  public @Nullable RouteMapSetPrependAsPath getSetAsPath() {
     return _setAsPath;
+  }
+
+  public @Nullable RouteMapSetExcludeAsPath getSetExcludeAsPath() {
+    return _setExcludeAsPath;
   }
 
   public @Nullable RouteMapSetMetric getSetMetric() {
@@ -180,8 +186,13 @@ public final class RouteMapEntry implements Serializable {
     _description = description;
   }
 
-  public void setSetAsPath(@Nullable RouteMapSetAsPath setAsPath) {
+  // TODO: check usage
+  public void setSetAsPath(@Nullable RouteMapSetPrependAsPath setAsPath) {
     _setAsPath = setAsPath;
+  }
+
+  public void setSetExcludeAsPath(@Nullable RouteMapSetExcludeAsPath setExcludeAsPath) {
+    _setExcludeAsPath = setExcludeAsPath;
   }
 
   public void setSetIpNextHop(@Nullable RouteMapSetIpNextHopLiteral setIpNextHop) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapEntry.java
@@ -186,7 +186,6 @@ public final class RouteMapEntry implements Serializable {
     _description = description;
   }
 
-  // TODO: check usage
   public void setSetAsPath(@Nullable RouteMapSetPrependAsPath setAsPath) {
     _setAsPath = setAsPath;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
@@ -1,0 +1,33 @@
+package org.batfish.representation.cumulus;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.expr.AsExpr;
+import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
+import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+public class RouteMapSetExcludeAsPath implements RouteMapSet {
+  @Nonnull private final List<Long> _asns;
+
+  public RouteMapSetExcludeAsPath(List<Long> asns) {
+    _asns = asns;
+  }
+
+  @Nonnull @Override public Stream<Statement> toStatements(Configuration c,
+      CumulusConcatenatedConfiguration vc, Warnings w) {
+    List<AsExpr> asExprs = _asns.stream()
+        .map(ExplicitAs::new)
+        .collect(ImmutableList.toImmutableList());
+    return Stream.of(new ExcludeAsPath(new LiteralAsList(asExprs)));
+  }
+
+  @Nonnull public List<Long> getAsns() {
+    return _asns;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
@@ -19,15 +19,17 @@ public class RouteMapSetExcludeAsPath implements RouteMapSet {
     _asns = asns;
   }
 
-  @Nonnull @Override public Stream<Statement> toStatements(Configuration c,
-      CumulusConcatenatedConfiguration vc, Warnings w) {
-    List<AsExpr> asExprs = _asns.stream()
-        .map(ExplicitAs::new)
-        .collect(ImmutableList.toImmutableList());
+  @Nonnull
+  @Override
+  public Stream<Statement> toStatements(
+      Configuration c, CumulusConcatenatedConfiguration vc, Warnings w) {
+    List<AsExpr> asExprs =
+        _asns.stream().map(ExplicitAs::new).collect(ImmutableList.toImmutableList());
     return Stream.of(new ExcludeAsPath(new LiteralAsList(asExprs)));
   }
 
-  @Nonnull public List<Long> getAsns() {
+  @Nonnull
+  public List<Long> getAsns() {
     return _asns;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
@@ -14,7 +14,7 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 
 /**
  * Clause of set as-path exclude in route map {@see <a
- * href="https://docs.frrouting.org/en/latest/routemap.html#clicmd-set-as-path-exclude-AS-NUMBER">docs.frrouting.org/a>}.
+ * href="https://docs.frrouting.org/en/latest/routemap.html#clicmd-set-as-path-exclude-AS-NUMBER...">docs.frrouting.org/a>}.
  */
 public final class RouteMapSetExcludeAsPath implements RouteMapSet {
   /** List of as numbers to be excluded from an as-path */

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
@@ -12,7 +12,10 @@ import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
-/** Clause of set as-path exclude in route map. */
+/**
+ * Clause of set as-path exclude in route map {@see <a
+ * href="https://docs.frrouting.org/en/latest/routemap.html#clicmd-set-as-path-exclude-AS-NUMBER">docs.frrouting.org/a>}.
+ */
 public final class RouteMapSetExcludeAsPath implements RouteMapSet {
   /** List of as numbers to be excluded from an as-path */
   @Nonnull private final List<Long> _asns;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPath.java
@@ -12,7 +12,9 @@ import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
-public class RouteMapSetExcludeAsPath implements RouteMapSet {
+/** Clause of set as-path exclude in route map. */
+public final class RouteMapSetExcludeAsPath implements RouteMapSet {
+  /** List of as numbers to be excluded from an as-path */
   @Nonnull private final List<Long> _asns;
 
   public RouteMapSetExcludeAsPath(List<Long> asns) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetPrependAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetPrependAsPath.java
@@ -14,12 +14,13 @@ import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
 /** Clause of set as-path prepend in route map. */
+// TODO rename RouteMapSetPrependAsPath
 @ParametersAreNonnullByDefault
-public class RouteMapSetAsPath implements RouteMapSet {
+public class RouteMapSetPrependAsPath implements RouteMapSet {
 
   @Nonnull private final List<Long> _asns;
 
-  public RouteMapSetAsPath(List<Long> asns) {
+  public RouteMapSetPrependAsPath(List<Long> asns) {
     _asns = asns;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetPrependAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetPrependAsPath.java
@@ -14,7 +14,6 @@ import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
 /** Clause of set as-path prepend in route map. */
-// TODO rename RouteMapSetPrependAsPath
 @ParametersAreNonnullByDefault
 public class RouteMapSetPrependAsPath implements RouteMapSet {
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetPrependAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetPrependAsPath.java
@@ -15,7 +15,7 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 
 /** Clause of set as-path prepend in route map. */
 @ParametersAreNonnullByDefault
-public class RouteMapSetPrependAsPath implements RouteMapSet {
+public final class RouteMapSetPrependAsPath implements RouteMapSet {
 
   @Nonnull private final List<Long> _asns;
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
@@ -35,6 +35,7 @@ import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
@@ -159,7 +160,9 @@ public class GeneratedRouteHelperTest {
                         new LiteralCommunitySet(CommunitySet.of(StandardCommunity.of(2L)))),
                     new PrependAsPath(
                         new LiteralAsList(
-                            ImmutableList.of(new ExplicitAs(1L), new ExplicitAs(65100L)))),
+                            ImmutableList.of(
+                                new ExplicitAs(1L), new ExplicitAs(2L), new ExplicitAs(65100L)))),
+                    new ExcludeAsPath(new LiteralAsList(ImmutableList.of(new ExplicitAs(2L)))),
                     new SetOrigin(new LiteralOrigin(IGP, null)),
                     Statements.RemovePrivateAs.toStaticStatement(),
                     new SetLocalPreference(new LiteralLong(123L)),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -1278,6 +1278,14 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
+  public void testCumulusFrrVrfRouteMapSetExcludeAsPath() {
+    String name = "ROUTE-MAP-NAME";
+    parse(String.format("route-map %s permit 10\nset as-path exclude 11111 22222 33333\n", name));
+    RouteMapEntry entry = _frr.getRouteMaps().get(name).getEntries().get(10);
+    assertThat(entry.getSetExcludeAsPath().getAsns(), contains(11111L, 22222L, 33333L));
+  }
+
+  @Test
   public void testCumulusFrrVrfRouteMapSetMetric() {
     String name = "ROUTE-MAP-NAME";
 

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPathTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/RouteMapSetExcludeAsPathTest.java
@@ -1,0 +1,28 @@
+package org.batfish.representation.cumulus;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
+import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.junit.Test;
+
+/** Test of {@link RouteMapSetExcludeAsPath} */
+public class RouteMapSetExcludeAsPathTest {
+  @Test
+  public void testToStatements() {
+    RouteMapSetExcludeAsPath set = new RouteMapSetExcludeAsPath(ImmutableList.of(1L, 2L, 3L));
+    List<Statement> result =
+        set.toStatements(null, null, null).collect(ImmutableList.toImmutableList());
+    assertThat(
+        result,
+        contains(
+            new ExcludeAsPath(
+                new LiteralAsList(
+                    ImmutableList.of(new ExplicitAs(1), new ExplicitAs(2), new ExplicitAs(3))))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/RouteMapSetPrependAsPathTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/RouteMapSetPrependAsPathTest.java
@@ -11,12 +11,12 @@ import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.junit.Test;
 
-/** Test of {@link RouteMapSetAsPath} */
-public class RouteMapSetAsPathTest {
+/** Test of {@link RouteMapSetPrependAsPath} */
+public class RouteMapSetPrependAsPathTest {
 
   @Test
   public void testToStatements() {
-    RouteMapSetAsPath set = new RouteMapSetAsPath(ImmutableList.of(1L, 2L, 3L));
+    RouteMapSetPrependAsPath set = new RouteMapSetPrependAsPath(ImmutableList.of(1L, 2L, 3L));
     List<Statement> result =
         set.toStatements(null, null, null).collect(ImmutableList.toImmutableList());
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus_nclu/RouteMapSetPrependAsPathTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus_nclu/RouteMapSetPrependAsPathTest.java
@@ -12,7 +12,7 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.junit.Test;
 
 /** Test of {@link RouteMapSetAsPath} */
-public class RouteMapSetAsPathTest {
+public class RouteMapSetPrependAsPathTest {
 
   @Test
   public void testToStatements() {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
@@ -9,6 +9,7 @@ import org.batfish.datamodel.routing_policy.communities.SetCommunities;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.Comment;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
@@ -67,6 +68,14 @@ public class RoutePolicyStatementAsPathCollector
   @Override
   public Set<SymbolicAsPathRegex> visitPrependAsPath(
       PrependAsPath prependAsPath, Configuration arg) {
+    // if/when we update TransferBDD to support AS-path prepending, we will need to update this as
+    // well
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<SymbolicAsPathRegex> visitExcludeAsPath(
+      ExcludeAsPath excludeAsPath, Configuration arg) {
     // if/when we update TransferBDD to support AS-path prepending, we will need to update this as
     // well
     return ImmutableSet.of();

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
@@ -76,8 +76,6 @@ public class RoutePolicyStatementAsPathCollector
   @Override
   public Set<SymbolicAsPathRegex> visitExcludeAsPath(
       ExcludeAsPath excludeAsPath, Configuration arg) {
-    // if/when we update TransferBDD to support AS-path prepending, we will need to update this as
-    // well
     return ImmutableSet.of();
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
@@ -76,6 +76,7 @@ public class RoutePolicyStatementAsPathCollector
   @Override
   public Set<SymbolicAsPathRegex> visitExcludeAsPath(
       ExcludeAsPath excludeAsPath, Configuration arg) {
+    // if/when TransferBDD gets updated to support AS-path excluding, this will have to be updated
     return ImmutableSet.of();
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollector.java
@@ -9,6 +9,7 @@ import org.batfish.datamodel.routing_policy.communities.SetCommunities;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.Comment;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
@@ -65,6 +66,11 @@ public class RoutePolicyStatementVarCollector
 
   @Override
   public Set<CommunityVar> visitPrependAsPath(PrependAsPath prependAsPath, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<CommunityVar> visitExcludeAsPath(ExcludeAsPath excludeAsPath, Configuration arg) {
     return ImmutableSet.of();
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollector.java
@@ -71,6 +71,7 @@ public class RoutePolicyStatementVarCollector
 
   @Override
   public Set<CommunityVar> visitExcludeAsPath(ExcludeAsPath excludeAsPath, Configuration arg) {
+    // if/when TransferBDD gets updated to support AS-path excluding, this will have to be updated
     return ImmutableSet.of();
   }
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollectorTest.java
@@ -10,10 +10,13 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
 import org.batfish.datamodel.routing_policy.expr.ExplicitAsPathSet;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
 import org.batfish.datamodel.routing_policy.expr.RegexAsPathSetElem;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
@@ -100,5 +103,14 @@ public class RoutePolicyStatementAsPathCollectorTest {
     assertEquals(
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2)),
         result);
+  }
+
+  @Test
+  public void testVisitExcludeAsPath() {
+    ExcludeAsPath excludeAsPath =
+        new ExcludeAsPath(new LiteralAsList(ImmutableList.of(new ExplicitAs(1L))));
+
+    assertEquals(
+        ImmutableSet.of(), _asPathCollector.visitExcludeAsPath(excludeAsPath, _baseConfig));
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollectorTest.java
@@ -19,7 +19,10 @@ import org.batfish.datamodel.routing_policy.communities.InputCommunities;
 import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
 import org.batfish.datamodel.routing_policy.communities.SetCommunities;
+import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
+import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
 import org.batfish.minesweeper.CommunityVar;
@@ -97,5 +100,13 @@ public class RoutePolicyStatementVarCollectorTest {
     assertEquals(
         _varCollector.visitTraceableStatement(traceableStatement, _baseConfig),
         ImmutableSet.of(CommunityVar.from(COMM1)));
+  }
+
+  @Test
+  public void testVisitExcludeAsPath() {
+    ExcludeAsPath excludeAsPath =
+        new ExcludeAsPath(new LiteralAsList(ImmutableList.of(new ExplicitAs(1L))));
+
+    assertEquals(ImmutableSet.of(), _varCollector.visitExcludeAsPath(excludeAsPath, _baseConfig));
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/TracingHintsStripper.java
+++ b/projects/question/src/main/java/org/batfish/question/TracingHintsStripper.java
@@ -6,6 +6,7 @@ import org.batfish.datamodel.routing_policy.communities.SetCommunities;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.Comment;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
@@ -67,6 +68,11 @@ public final class TracingHintsStripper implements StatementVisitor<Statement, V
   @Override
   public Statement visitPrependAsPath(PrependAsPath prependAsPath, Void arg) {
     return prependAsPath;
+  }
+
+  @Override
+  public Statement visitExcludeAsPath(ExcludeAsPath excludeAsPath, Void arg) {
+    return excludeAsPath;
   }
 
   @Override

--- a/projects/question/src/test/java/org/batfish/question/TracingHintsStripperTest.java
+++ b/projects/question/src/test/java/org/batfish/question/TracingHintsStripperTest.java
@@ -9,6 +9,9 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
+import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
+import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
@@ -61,5 +64,14 @@ public class TracingHintsStripperTest {
                 ImmutableList.of(
                     new TraceableStatement(
                         TraceElement.of(STRIP_TOKEN), ImmutableList.of(new If()))))));
+  }
+
+  @Test
+  public void testVisitExcludeAsPath() {
+    ExcludeAsPath excludeAsPath =
+        new ExcludeAsPath(new LiteralAsList(ImmutableList.of(new ExplicitAs(1L))));
+
+    assertThat(
+        excludeAsPath, equalTo((ExcludeAsPath) excludeAsPath.accept(TRACING_HINTS_STRIPPER, null)));
   }
 }


### PR DESCRIPTION
Add exclude option to modify AS_PATH in route map. 
See [bgp_routemap.c](https://github.com/FRRouting/frr/blob/master/bgpd/bgp_routemap.c)

- update grammar
- update representation
- add test