### PR TITLE
HybridL3Adjacencies: fix behavior under incomplete L1 topology

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/e2e/l1/asymmetric/BUILD
+++ b/projects/allinone/src/test/java/org/batfish/e2e/l1/asymmetric/BUILD
@@ -1,0 +1,20 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:private"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob(["*Test.java"]),
+    resources = ["//projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric"],
+    deps = [
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/allinone/src/test/java/org/batfish/e2e/l1/asymmetric/L1AsymmetricTest.java
+++ b/projects/allinone/src/test/java/org/batfish/e2e/l1/asymmetric/L1AsymmetricTest.java
@@ -1,0 +1,44 @@
+package org.batfish.e2e.l1.asymmetric;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests that a network with IP Reuse and asymmetric L1 topology is not connected redundantly. */
+public class L1AsymmetricTest {
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private Topology getLayer3Edges() throws IOException {
+    String prefix = "org/batfish/e2e/l1/asymmetric";
+    IBatfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(prefix, "a1", "a2", "b1", "b2")
+                .setLayer1TopologyPrefix(prefix + "/batfish")
+                .build(),
+            _folder);
+    return batfish.getTopologyProvider().getInitialLayer3Topology(batfish.getSnapshot());
+  }
+
+  @Test
+  public void testLayer3Connectivity() throws IOException {
+    Edge forward1 =
+        new Edge(NodeInterfacePair.of("a1", "Ethernet1"), NodeInterfacePair.of("b1", "Ethernet1"));
+    Edge forward2 =
+        new Edge(NodeInterfacePair.of("a2", "Ethernet1"), NodeInterfacePair.of("b2", "Ethernet1"));
+    // NB: should not contain a1-b2 or b2-a1.
+    assertThat(
+        getLayer3Edges().getEdges(),
+        containsInAnyOrder(forward1, forward1.reverse(), forward2, forward2.reverse()));
+  }
+}

--- a/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/BUILD
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/BUILD
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "asymmetric",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD"],
+    ),
+)

--- a/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/batfish/layer1_topology.json
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/batfish/layer1_topology.json
@@ -1,0 +1,12 @@
+{
+  "edges": [
+    {
+      "node1": { "hostname": "a1", "interfaceName": "Ethernet1" },
+      "node2": { "hostname": "b1", "interfaceName": "Ethernet1" }
+    },
+    {
+      "node1": { "hostname": "a2", "interfaceName": "Ethernet1" },
+      "node2": { "hostname": "b2", "interfaceName": "Ethernet1" }
+    }
+  ]
+}

--- a/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/configs/a1
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/configs/a1
@@ -1,0 +1,6 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname a1
+interface Ethernet1
+  no shutdown
+  no switchport
+  ip address 1.2.3.4 255.255.255.0

--- a/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/configs/a2
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/configs/a2
@@ -1,0 +1,6 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname a2
+interface Ethernet1
+  no shutdown
+  no switchport
+  ip address 1.2.3.4 255.255.255.0

--- a/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/configs/b1
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/configs/b1
@@ -1,0 +1,6 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname b1
+interface Ethernet1
+  no shutdown
+  no switchport
+  ip address 1.2.3.5 255.255.255.0

--- a/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/configs/b2
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/l1/asymmetric/configs/b2
@@ -1,0 +1,6 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname b2
+interface Ethernet1
+  no shutdown
+  no switchport
+  ip address 1.2.3.5 255.255.255.0

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/HybridL3Adjacencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/HybridL3Adjacencies.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
@@ -43,7 +44,9 @@ public final class HybridL3Adjacencies implements L3Adjacencies {
       Layer2Topology layer2Topology,
       Map<String, Configuration> configurations) {
     Set<String> nodesWithL1Topology =
-        layer1Topologies.getCombinedL1().getGraph().edges().stream()
+        Stream.concat(
+                layer1Topologies.getUserProvidedL1().getGraph().edges().stream(),
+                layer1Topologies.getActiveLogicalL1().getGraph().edges().stream())
             .filter(
                 // Ignore border-to-ISP edges when computing the set of nodes for which users
                 // provided L1 topology. Batfish adds these edges during ISP modeling, and not


### PR DESCRIPTION
Some user-provided layer1 topologies are asymmetric. While behavior has always
been best-effort in these scenarios, it has changed since the last release.
Switch back to the behavior before batfish/batfish#7207.