### PR TITLE
Checkpoint vs fix up nat rulebase objects

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressRange.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressRange.java
@@ -1,5 +1,6 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -74,6 +75,19 @@ public final class AddressRange extends AddressSpace {
   public int hashCode() {
     return Objects.hash(
         baseHashcode(), _ipv4AddressFirst, _ipv4AddressLast, _ipv6AddressFirst, _ipv6AddressLast);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .omitNullValues()
+        .add(PROP_IPV4_ADDRESS_FIRST, _ipv4AddressFirst)
+        .add(PROP_IPV4_ADDRESS_LAST, _ipv4AddressLast)
+        .add(PROP_IPV6_ADDRESS_FIRST, _ipv6AddressFirst)
+        .add(PROP_IPV6_ADDRESS_LAST, _ipv6AddressLast)
+        .add(PROP_NAME, getName())
+        .add(PROP_UID, getUid())
+        .toString();
   }
 
   private static final String PROP_IPV4_ADDRESS_FIRST = "ipv4-address-first";

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
@@ -39,9 +39,7 @@ public final class CpmiAnyObject extends TypedManagementObject {
   private static final String NAME_ANY = "Any";
 
   @JsonCreator
-  private static @Nonnull CpmiAnyObject create(
-      @JsonProperty(PROP_NAME) @Nullable String name, @JsonProperty(PROP_UID) @Nullable Uid uid) {
-    checkArgument(name != null, "Missing %s", PROP_NAME);
+  private static @Nonnull CpmiAnyObject create(@JsonProperty(PROP_UID) @Nullable Uid uid) {
     checkArgument(uid != null, "Missing %s", PROP_UID);
     return new CpmiAnyObject(uid);
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
@@ -1,23 +1,48 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * When assigned to {@code original-destination},{@code original-service}, or {@code
+ * original-source} field of a {@link NatRule}, indicates that any value shall be matched for that
+ * field when applying the rule.
+ */
 public final class CpmiAnyObject extends TypedManagementObject {
+
+  @Override
+  public boolean equals(Object o) {
+    return baseEquals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return baseHashcode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).toString();
+  }
+
+  @VisibleForTesting
+  CpmiAnyObject(Uid uid) {
+    super(NAME_ANY, uid);
+  }
+
+  private static final String NAME_ANY = "Any";
 
   @JsonCreator
   private static @Nonnull CpmiAnyObject create(
       @JsonProperty(PROP_NAME) @Nullable String name, @JsonProperty(PROP_UID) @Nullable Uid uid) {
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new CpmiAnyObject(name, uid);
-  }
-
-  private CpmiAnyObject(String name, Uid uid) {
-    super(name, uid);
+    return new CpmiAnyObject(uid);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Global.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Global.java
@@ -1,5 +1,6 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -7,17 +8,43 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class Global extends TypedManagementObject {
+/** A global pre-defined object. */
+public abstract class Global extends TypedManagementObject {
+
+  @Override
+  public final boolean equals(Object obj) {
+    return baseEquals(obj);
+  }
+
+  @Override
+  public final int hashCode() {
+    return baseHashcode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add(PROP_UID, getUid()).toString();
+  }
+
+  protected static final String NAME_ORIGINAL = "Original";
+  protected static final String NAME_POLICY_TARGETS = "Policy Targets";
+
+  protected Global(String name, Uid uid) {
+    super(name, uid);
+  }
 
   @JsonCreator
   private static @Nonnull Global create(
       @JsonProperty(PROP_NAME) @Nullable String name, @JsonProperty(PROP_UID) @Nullable Uid uid) {
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new Global(name, uid);
-  }
-
-  private Global(String name, Uid uid) {
-    super(name, uid);
+    switch (name) {
+      case NAME_ORIGINAL:
+        return new Original(uid);
+      case NAME_POLICY_TARGETS:
+        return new PolicyTargets(uid);
+      default:
+        return new UnhandledGlobal(name, uid);
+    }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Group.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Group.java
@@ -4,10 +4,21 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class Group extends TypedManagementObject {
+
+  @Override
+  public boolean equals(Object o) {
+    return baseEquals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return baseHashcode();
+  }
 
   @JsonCreator
   private static @Nonnull Group create(
@@ -17,7 +28,8 @@ public final class Group extends TypedManagementObject {
     return new Group(name, uid);
   }
 
-  private Group(String name, Uid uid) {
+  @VisibleForTesting
+  Group(String name, Uid uid) {
     super(name, uid);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Host.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Host.java
@@ -1,5 +1,6 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -46,6 +47,15 @@ public final class Host extends AddressSpace {
   @Override
   public int hashCode() {
     return Objects.hash(baseHashcode(), _ipv4Address);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add(PROP_IPV4_ADDRESS, _ipv4Address)
+        .add(PROP_NAME, getName())
+        .add(PROP_UID, getUid())
+        .toString();
   }
 
   private static final String PROP_IPV4_ADDRESS = "ipv4-address";

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRulebase.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRulebase.java
@@ -1,5 +1,6 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -9,14 +10,15 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Data model for an entry of the list response to the {@code show-nat-rulebase} command. */
 public final class NatRulebase extends ManagementObject {
 
-  public @Nonnull Map<Uid, AddressSpace> getAddressSpaces() {
-    return _addressSpaces;
+  public @Nonnull Map<Uid, TypedManagementObject> getObjectsDictionary() {
+    return _objectsDictionary;
   }
 
   public @Nonnull List<NatRuleOrSection> getRulebase() {
@@ -32,19 +34,18 @@ public final class NatRulebase extends ManagementObject {
     checkArgument(objectsDictionary != null, "Missing %s", PROP_OBJECTS_DICTIONARY);
     checkArgument(rulebase != null, "Missing %s", PROP_RULEBASE);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    Map<Uid, AddressSpace> addressSpaces =
+    return new NatRulebase(
         objectsDictionary.stream()
-            .filter(AddressSpace.class::isInstance)
-            .collect(
-                ImmutableMap.toImmutableMap(
-                    TypedManagementObject::getUid, obj -> (AddressSpace) obj));
-    return new NatRulebase(addressSpaces, rulebase, uid);
+            .collect(ImmutableMap.toImmutableMap(ManagementObject::getUid, Function.identity())),
+        rulebase,
+        uid);
   }
 
   @VisibleForTesting
-  NatRulebase(Map<Uid, AddressSpace> addressSpaces, List<NatRuleOrSection> rulebase, Uid uid) {
+  NatRulebase(
+      Map<Uid, TypedManagementObject> objectsDictionary, List<NatRuleOrSection> rulebase, Uid uid) {
     super(uid);
-    _addressSpaces = addressSpaces;
+    _objectsDictionary = objectsDictionary;
     _rulebase = rulebase;
   }
 
@@ -54,17 +55,25 @@ public final class NatRulebase extends ManagementObject {
       return false;
     }
     NatRulebase that = (NatRulebase) o;
-    return _addressSpaces.equals(that._addressSpaces) && _rulebase.equals(that._rulebase);
+    return _objectsDictionary.equals(that._objectsDictionary) && _rulebase.equals(that._rulebase);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add(PROP_OBJECTS_DICTIONARY, _objectsDictionary)
+        .add(PROP_RULEBASE, _rulebase)
+        .toString();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(baseHashcode(), _addressSpaces, _rulebase);
+    return Objects.hash(baseHashcode(), _objectsDictionary, _rulebase);
   }
 
   private static final String PROP_OBJECTS_DICTIONARY = "objects-dictionary";
   private static final String PROP_RULEBASE = "rulebase";
 
-  private final @Nonnull Map<Uid, AddressSpace> _addressSpaces;
+  private final @Nonnull Map<Uid, TypedManagementObject> _objectsDictionary;
   private final @Nonnull List<NatRuleOrSection> _rulebase;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Original.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Original.java
@@ -1,0 +1,13 @@
+package org.batfish.vendor.check_point_management;
+
+/**
+ * When assigned to {@code translated-destination},{@code translated-service}, or {@code
+ * translated-source} field of a {@link NatRule}, indicates that the original value should be
+ * retained for that field when applying the rule.
+ */
+public final class Original extends Global {
+
+  Original(Uid uid) {
+    super(NAME_ORIGINAL, uid);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/PolicyTargets.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/PolicyTargets.java
@@ -1,0 +1,9 @@
+package org.batfish.vendor.check_point_management;
+
+/** Indicates that a rule should be applied to all installation targets of the package. */
+public final class PolicyTargets extends Global {
+
+  PolicyTargets(Uid uid) {
+    super(NAME_POLICY_TARGETS, uid);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
@@ -1,13 +1,30 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class ServiceGroup extends TypedManagementObject {
+
+  @Override
+  public boolean equals(Object o) {
+    return baseEquals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return baseHashcode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add(PROP_NAME, getName()).add(PROP_UID, getUid()).toString();
+  }
 
   @JsonCreator
   private static @Nonnull ServiceGroup create(
@@ -17,7 +34,8 @@ public final class ServiceGroup extends TypedManagementObject {
     return new ServiceGroup(name, uid);
   }
 
-  private ServiceGroup(String name, Uid uid) {
+  @VisibleForTesting
+  ServiceGroup(String name, Uid uid) {
     super(name, uid);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceTcp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceTcp.java
@@ -1,13 +1,30 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class ServiceTcp extends TypedManagementObject {
+
+  @Override
+  public boolean equals(Object o) {
+    return baseEquals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return baseHashcode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add(PROP_NAME, getName()).add(PROP_UID, getUid()).toString();
+  }
 
   @JsonCreator
   private static @Nonnull ServiceTcp create(
@@ -17,7 +34,8 @@ public final class ServiceTcp extends TypedManagementObject {
     return new ServiceTcp(name, uid);
   }
 
-  private ServiceTcp(String name, Uid uid) {
+  @VisibleForTesting
+  ServiceTcp(String name, Uid uid) {
     super(name, uid);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Uid.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Uid.java
@@ -1,5 +1,7 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Nonnull;
@@ -29,6 +31,11 @@ public final class Uid implements NatInstallTarget {
     }
     Uid uid = (Uid) o;
     return _value.equals(uid._value);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("_value", _value).toString();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/UnhandledGlobal.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/UnhandledGlobal.java
@@ -1,0 +1,9 @@
+package org.batfish.vendor.check_point_management;
+
+/** An object of type {@link Global} whose name is unrecognized or otherwise unhandled. */
+public final class UnhandledGlobal extends Global {
+
+  UnhandledGlobal(String name, Uid uid) {
+    super(name, uid);
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NatRulebaseTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NatRulebaseTest.java
@@ -33,12 +33,12 @@ public final class NatRulebaseTest {
             + "{" // object: CpmiAnyObject
             + "\"type\":\"CpmiAnyObject\","
             + "\"uid\":\"2\","
-            + "\"name\":\"foo\""
+            + "\"name\":\"Any\""
             + "}," // object: CpmiAnyObject
             + "{" // object: Global
             + "\"type\":\"Global\","
             + "\"uid\":\"3\","
-            + "\"name\":\"foo\""
+            + "\"name\":\"Original\""
             + "}," // object: Global
             + "{" // object: group
             + "\"type\":\"group\","
@@ -113,13 +113,18 @@ public final class NatRulebaseTest {
         BatfishObjectMapper.ignoreUnknownMapper().readValue(input, NatRulebase.class),
         equalTo(
             new NatRulebase(
-                ImmutableMap.<Uid, AddressSpace>builder()
+                ImmutableMap.<Uid, TypedManagementObject>builder()
                     .put(
                         Uid.of("1"),
                         new AddressRange(
                             Ip.ZERO, Ip.parse("0.0.0.1"), null, null, "foo", Uid.of("1")))
+                    .put(Uid.of("2"), new CpmiAnyObject(Uid.of("2")))
+                    .put(Uid.of("3"), new Original(Uid.of("3")))
+                    .put(Uid.of("4"), new Group("foo", Uid.of("4")))
                     .put(Uid.of("5"), new Host(Ip.ZERO, "foo", Uid.of("5")))
                     .put(Uid.of("6"), new Network("foo", Ip.ZERO, Ip.MAX, Uid.of("6")))
+                    .put(Uid.of("7"), new ServiceGroup("foo", Uid.of("7")))
+                    .put(Uid.of("8"), new ServiceTcp("foo", Uid.of("8")))
                     .build(),
                 ImmutableList.of(
                     new NatRule(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/OriginalTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/OriginalTest.java
@@ -1,0 +1,43 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link Original}. */
+public final class OriginalTest {
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"GARBAGE\":0,"
+            + "\"type\":\"Global\","
+            + "\"uid\":\"0\","
+            + "\"name\":\"Original\""
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Global.class),
+        equalTo(new Original(Uid.of("0"))));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    Original obj = new Original(Uid.of("1"));
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    Original obj = new Original(Uid.of("1"));
+    new EqualsTester()
+        .addEqualityGroup(obj, new Original(Uid.of("1")))
+        .addEqualityGroup(new Original(Uid.of("2")))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/PolicyTargetsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/PolicyTargetsTest.java
@@ -1,0 +1,43 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link PolicyTargets}. */
+public final class PolicyTargetsTest {
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"GARBAGE\":0,"
+            + "\"type\":\"Global\","
+            + "\"uid\":\"0\","
+            + "\"name\":\"Policy Targets\""
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Global.class),
+        equalTo(new PolicyTargets(Uid.of("0"))));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    PolicyTargets obj = new PolicyTargets(Uid.of("1"));
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    PolicyTargets obj = new PolicyTargets(Uid.of("1"));
+    new EqualsTester()
+        .addEqualityGroup(obj, new PolicyTargets(Uid.of("1")))
+        .addEqualityGroup(new PolicyTargets(Uid.of("2")))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/UnhandledGlobalTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/UnhandledGlobalTest.java
@@ -1,0 +1,44 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link UnhandledGlobal}. */
+public final class UnhandledGlobalTest {
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"GARBAGE\":0,"
+            + "\"type\":\"Global\","
+            + "\"uid\":\"0\","
+            + "\"name\":\"what\""
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Global.class),
+        equalTo(new UnhandledGlobal("what", Uid.of("0"))));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    UnhandledGlobal obj = new UnhandledGlobal("what", Uid.of("1"));
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    UnhandledGlobal obj = new UnhandledGlobal("what", Uid.of("1"));
+    new EqualsTester()
+        .addEqualityGroup(obj, new UnhandledGlobal("what", Uid.of("1")))
+        .addEqualityGroup(new UnhandledGlobal("where", Uid.of("1")))
+        .addEqualityGroup(new UnhandledGlobal("what", Uid.of("2")))
+        .testEquals();
+  }
+}


### PR DESCRIPTION
- just serialize objects-dictionary directly
- flesh out special objects like Globals and CpmiAnyObject