### PR TITLE
CheckPoint: make static routes non-recursive

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -108,6 +108,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
                     .setNextHop(toNextHop(nh.getNexthopTarget()))
                     // Unset priority is preferred over other priorities
                     .setAdministrativeCost(firstNonNull(nh.getPriority(), 0))
+                    .setRecursive(false)
                     .build());
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -406,36 +406,43 @@ public class CheckPointGatewayGrammarTest {
                         .setAdministrativeCost(0)
                         .setNetwork(Prefix.ZERO)
                         .setNextHop(NextHopInterface.of("eth0"))
+                        .setRecursive(false)
                         .build(),
                     org.batfish.datamodel.StaticRoute.testBuilder()
                         .setAdministrativeCost(0)
                         .setNetwork(Prefix.parse("10.1.0.0/16"))
                         .setNextHop(NextHopDiscard.instance())
+                        .setRecursive(false)
                         .build(),
                     org.batfish.datamodel.StaticRoute.testBuilder()
                         .setAdministrativeCost(0)
                         .setNetwork(Prefix.parse("10.2.0.0/16"))
                         .setNextHop(NextHopDiscard.instance())
+                        .setRecursive(false)
                         .build(),
                     org.batfish.datamodel.StaticRoute.testBuilder()
                         .setAdministrativeCost(8)
                         .setNetwork(Prefix.parse("10.3.0.0/16"))
                         .setNextHop(NextHopIp.of(Ip.parse("10.0.0.2")))
+                        .setRecursive(false)
                         .build(),
                     org.batfish.datamodel.StaticRoute.testBuilder()
                         .setAdministrativeCost(0)
                         .setNetwork(Prefix.parse("10.4.0.0/16"))
                         .setNextHop(NextHopIp.of(Ip.parse("10.0.0.3")))
+                        .setRecursive(false)
                         .build(),
                     org.batfish.datamodel.StaticRoute.testBuilder()
                         .setAdministrativeCost(1)
                         .setNetwork(Prefix.parse("10.4.0.0/16"))
                         .setNextHop(NextHopIp.of(Ip.parse("10.0.0.4")))
+                        .setRecursive(false)
                         .build(),
                     org.batfish.datamodel.StaticRoute.testBuilder()
                         .setAdministrativeCost(3)
                         .setNetwork(Prefix.parse("10.5.0.0/16"))
                         .setNextHop(NextHopIp.of(Ip.parse("10.0.0.5")))
+                        .setRecursive(false)
                         .build()))));
   }
 


### PR DESCRIPTION
Afaict, CheckPoint static routes must resolve via a connected route, so make sure they're marked as non-recursive