### PR TITLE
CP: Convert two types of IP spaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/BUILD
@@ -11,6 +11,7 @@ java_library(
     ),
     deps = [
         "//projects/batfish-common-protocol:common",
+        "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:org_apache_commons_commons_lang3",

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -1,6 +1,7 @@
 package org.batfish.vendor.check_point_gateway.representation;
 
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toIpSpace;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -8,6 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -29,8 +31,13 @@ import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.vendor.ConversionContext;
 import org.batfish.vendor.VendorConfiguration;
 import org.batfish.vendor.check_point_gateway.representation.BondingGroup.Mode;
+import org.batfish.vendor.check_point_management.AddressRange;
+import org.batfish.vendor.check_point_management.CheckpointManagementConfiguration;
+import org.batfish.vendor.check_point_management.ManagementPackage;
+import org.batfish.vendor.check_point_management.Network;
 
 public class CheckPointGatewayConfiguration extends VendorConfiguration {
 
@@ -90,7 +97,35 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
             _staticRoutes.values().stream()
                 .flatMap(staticRoute -> convertStaticRoute(staticRoute, _interfaces))
                 .collect(ImmutableSet.toImmutableSet()));
+
+    Optional<CheckpointManagementConfiguration> mgmtConfig =
+        Optional.ofNullable(getConversionContext())
+            .map(ConversionContext::getCheckpointManagementConfiguration)
+            .map(cmc -> (CheckpointManagementConfiguration) cmc);
+    mgmtConfig.ifPresent(this::convertManagementConfig);
+
     return ImmutableList.of(_c);
+  }
+
+  private void convertManagementConfig(CheckpointManagementConfiguration mgmtConfig) {
+    // TODO: Only convert packages that apply to this gateway
+    // Convert IP spaces
+    mgmtConfig.getServers().values().stream()
+        .flatMap(server -> server.getDomains().values().stream())
+        .flatMap(domain -> domain.getPackages().values().stream())
+        .map(ManagementPackage::getNatRulebase)
+        .filter(Objects::nonNull)
+        .flatMap(natRulebase -> natRulebase.getObjectsDictionary().values().stream())
+        .forEach(
+            natObj -> {
+              if (natObj instanceof AddressRange) {
+                Optional.ofNullable(toIpSpace((AddressRange) natObj))
+                    .ifPresent(ipSpace -> _c.getIpSpaces().put(natObj.getName(), ipSpace));
+              } else if (natObj instanceof Network) {
+                _c.getIpSpaces().put(natObj.getName(), toIpSpace((Network) natObj));
+              }
+            });
+    ;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -1,0 +1,38 @@
+package org.batfish.vendor.check_point_gateway.representation;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpRange;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.vendor.check_point_management.AddressRange;
+import org.batfish.vendor.check_point_management.Network;
+
+/** Utility class for Checkpoint conversion methods */
+public final class CheckPointGatewayConversions {
+  /**
+   * Converts the given {@link AddressRange} into an {@link IpSpace}, or returns {@code null} if the
+   * address range does not represent an IPv4 space.
+   */
+  static @Nullable IpSpace toIpSpace(AddressRange addressRange) {
+    // TODO Convert IPv6 address ranges
+    if (addressRange.getIpv4AddressFirst() == null || addressRange.getIpv4AddressLast() == null) {
+      return null;
+    }
+    return IpRange.range(addressRange.getIpv4AddressFirst(), addressRange.getIpv4AddressLast());
+  }
+
+  /** Converts the given {@link Network} into an {@link IpSpace}. */
+  static @Nonnull IpSpace toIpSpace(Network network) {
+    // TODO Network objects also have a "mask-length4" that we don't currently extract.
+    //  If network objects always represent valid Prefixes, it may be simpler to extract
+    //  that instead of subnet-mask and convert the network to a PrefixIpSpace.
+    // In Network, the mask has bits that matter set, but IpWildcard interprets set mask bits as
+    // "don't care". Flip mask to convert to IpWildcard.
+    long flippedMask = network.getSubnetMask().asLong() ^ Ip.MAX.asLong();
+    return IpWildcard.ipWithWildcardMask(network.getSubnet4(), flippedMask).toIpSpace();
+  }
+
+  private CheckPointGatewayConversions() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressRange.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressRange.java
@@ -44,7 +44,7 @@ public final class AddressRange extends AddressSpace {
   }
 
   @VisibleForTesting
-  AddressRange(
+  public AddressRange(
       @Nullable Ip ipv4AddressFirst,
       @Nullable Ip ipv4AddressLast,
       @Nullable Ip6 ipv6AddressFirst,

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Network.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Network.java
@@ -27,7 +27,7 @@ public final class Network extends AddressSpace {
   }
 
   @VisibleForTesting
-  Network(String name, Ip subnet4, Ip subnetMask, Uid uid) {
+  public Network(String name, Ip subnet4, Ip subnetMask, Uid uid) {
     super(name, uid);
     _subnet4 = subnet4;
     _subnetMask = subnetMask;

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/BUILD
@@ -15,6 +15,7 @@ junit_tests(
         "//projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
         "//projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation",
+        "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_guava_guava_testlib",

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
@@ -1,0 +1,44 @@
+package org.batfish.vendor.check_point_gateway.representation;
+
+import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toIpSpace;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Ip6;
+import org.batfish.datamodel.IpRange;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.vendor.check_point_management.AddressRange;
+import org.batfish.vendor.check_point_management.Network;
+import org.batfish.vendor.check_point_management.Uid;
+import org.junit.Test;
+
+public class CheckPointGatewayConversionsTest {
+
+  @Test
+  public void testToIpSpace_addressRange() {
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+    AddressRange range = new AddressRange(ip1, ip2, null, null, "name", Uid.of("uid"));
+    assertThat(toIpSpace(range), equalTo(IpRange.range(ip1, ip2)));
+  }
+
+  @Test
+  public void testToIpSpace_addressRangeIpv6() {
+    Ip6 ip1 = Ip6.parse("1::1");
+    Ip6 ip2 = Ip6.parse("1::2");
+    AddressRange range = new AddressRange(null, null, ip1, ip2, "name", Uid.of("uid"));
+    assertNull(toIpSpace(range));
+  }
+
+  @Test
+  public void testToIpSpace_network() {
+    Ip ip = Ip.parse("1.1.1.0");
+    Ip mask = Ip.parse("255.255.255.0");
+    Network network = new Network("name", ip, mask, Uid.of("uid"));
+    Ip flippedMask = Ip.parse("0.0.0.255");
+    assertThat(
+        toIpSpace(network), equalTo(IpWildcard.ipWithWildcardMask(ip, flippedMask).toIpSpace()));
+  }
+}


### PR DESCRIPTION
Converts all `AddressRange` and `Network` objects referenced in NAT rulebases to named IP spaces.