### PR TITLE
IOS-XR: fix some issues with prefix-sets

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyBooleanDestination.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyBooleanDestination.java
@@ -1,10 +1,12 @@
 package org.batfish.representation.cisco_xr;
 
+import com.google.common.collect.ImmutableList;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork6;
+import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefix6Set;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.Prefix6SetExpr;
@@ -12,7 +14,7 @@ import org.batfish.datamodel.routing_policy.expr.PrefixSetExpr;
 
 public class RoutePolicyBooleanDestination extends RoutePolicyBoolean {
 
-  private RoutePolicyPrefixSet _prefixSet;
+  private final RoutePolicyPrefixSet _prefixSet;
 
   public RoutePolicyBooleanDestination(RoutePolicyPrefixSet prefixSet) {
     _prefixSet = prefixSet;
@@ -24,12 +26,15 @@ public class RoutePolicyBooleanDestination extends RoutePolicyBoolean {
 
   @Override
   public BooleanExpr toBooleanExpr(CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    ImmutableList.Builder<BooleanExpr> exprs = ImmutableList.builder();
     PrefixSetExpr prefixSetExpr = _prefixSet.toPrefixSetExpr(cc, c, w);
     if (prefixSetExpr != null) {
-      return new MatchPrefixSet(DestinationNetwork.instance(), prefixSetExpr);
-    } else {
-      Prefix6SetExpr prefix6SetExpr = _prefixSet.toPrefix6SetExpr(cc, c, w);
-      return new MatchPrefix6Set(new DestinationNetwork6(), prefix6SetExpr);
+      exprs.add(new MatchPrefixSet(DestinationNetwork.instance(), prefixSetExpr));
     }
+    Prefix6SetExpr prefix6SetExpr = _prefixSet.toPrefix6SetExpr(cc, c, w);
+    if (prefix6SetExpr != null) {
+      exprs.add(new MatchPrefix6Set(new DestinationNetwork6(), prefix6SetExpr));
+    }
+    return new Disjunction(exprs.build());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyBooleanNextHopIn.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyBooleanNextHopIn.java
@@ -1,10 +1,12 @@
 package org.batfish.representation.cisco_xr;
 
+import com.google.common.collect.ImmutableList;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
+import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.Ip6Prefix;
 import org.batfish.datamodel.routing_policy.expr.IpPrefix;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
@@ -17,7 +19,7 @@ import org.batfish.datamodel.routing_policy.expr.PrefixSetExpr;
 
 public class RoutePolicyBooleanNextHopIn extends RoutePolicyBoolean {
 
-  private RoutePolicyPrefixSet _prefixSet;
+  private final RoutePolicyPrefixSet _prefixSet;
 
   public RoutePolicyBooleanNextHopIn(RoutePolicyPrefixSet prefixSet) {
     _prefixSet = prefixSet;
@@ -25,16 +27,21 @@ public class RoutePolicyBooleanNextHopIn extends RoutePolicyBoolean {
 
   @Override
   public BooleanExpr toBooleanExpr(CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    ImmutableList.Builder<BooleanExpr> exprs = ImmutableList.builder();
     PrefixSetExpr prefixSetExpr = _prefixSet.toPrefixSetExpr(cc, c, w);
     if (prefixSetExpr != null) {
-      return new MatchPrefixSet(
-          new IpPrefix(NextHopIp.instance(), new LiteralInt(Prefix.MAX_PREFIX_LENGTH)),
-          prefixSetExpr);
-    } else {
-      Prefix6SetExpr prefix6SetExpr = _prefixSet.toPrefix6SetExpr(cc, c, w);
-      return new MatchPrefix6Set(
-          new Ip6Prefix(new NextHopIp6(), new LiteralInt(Prefix6.MAX_PREFIX_LENGTH)),
-          prefix6SetExpr);
+      exprs.add(
+          new MatchPrefixSet(
+              new IpPrefix(NextHopIp.instance(), new LiteralInt(Prefix.MAX_PREFIX_LENGTH)),
+              prefixSetExpr));
     }
+    Prefix6SetExpr prefix6SetExpr = _prefixSet.toPrefix6SetExpr(cc, c, w);
+    if (prefix6SetExpr != null) {
+      exprs.add(
+          new MatchPrefix6Set(
+              new Ip6Prefix(new NextHopIp6(), new LiteralInt(Prefix6.MAX_PREFIX_LENGTH)),
+              prefix6SetExpr));
+    }
+    return new Disjunction(exprs.build());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyBooleanRibHasRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyBooleanRibHasRoute.java
@@ -1,8 +1,10 @@
 package org.batfish.representation.cisco_xr;
 
+import com.google.common.collect.ImmutableList;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
+import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.HasRoute6;
 import org.batfish.datamodel.routing_policy.expr.Prefix6SetExpr;
@@ -10,7 +12,7 @@ import org.batfish.datamodel.routing_policy.expr.PrefixSetExpr;
 
 public class RoutePolicyBooleanRibHasRoute extends RoutePolicyBoolean {
 
-  private RoutePolicyPrefixSet _prefixSet;
+  private final RoutePolicyPrefixSet _prefixSet;
 
   public RoutePolicyBooleanRibHasRoute(RoutePolicyPrefixSet prefixSet) {
     _prefixSet = prefixSet;
@@ -22,12 +24,15 @@ public class RoutePolicyBooleanRibHasRoute extends RoutePolicyBoolean {
 
   @Override
   public BooleanExpr toBooleanExpr(CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    ImmutableList.Builder<BooleanExpr> exprs = ImmutableList.builder();
     PrefixSetExpr prefixSetExpr = _prefixSet.toPrefixSetExpr(cc, c, w);
     if (prefixSetExpr != null) {
-      return new HasRoute(prefixSetExpr);
-    } else {
-      Prefix6SetExpr prefix6SetExpr = _prefixSet.toPrefix6SetExpr(cc, c, w);
-      return new HasRoute6(prefix6SetExpr);
+      exprs.add(new HasRoute(prefixSetExpr));
     }
+    Prefix6SetExpr prefix6SetExpr = _prefixSet.toPrefix6SetExpr(cc, c, w);
+    if (prefix6SetExpr != null) {
+      exprs.add(new HasRoute6(prefix6SetExpr));
+    }
+    return new Disjunction(exprs.build());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyInlinePrefix6Set.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyInlinePrefix6Set.java
@@ -25,9 +25,9 @@ public class RoutePolicyInlinePrefix6Set extends RoutePolicyPrefixSet {
     return new ExplicitPrefix6Set(_prefix6Space);
   }
 
-  @Nullable
   @Override
-  public PrefixSetExpr toPrefixSetExpr(CiscoXrConfiguration cc, Configuration c, Warnings w) {
+  public @Nullable PrefixSetExpr toPrefixSetExpr(
+      CiscoXrConfiguration cc, Configuration c, Warnings w) {
     return null;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyPrefixSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyPrefixSet.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.cisco_xr;
 
 import java.io.Serializable;
+import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.expr.Prefix6SetExpr;
@@ -8,9 +9,9 @@ import org.batfish.datamodel.routing_policy.expr.PrefixSetExpr;
 
 public abstract class RoutePolicyPrefixSet implements Serializable {
 
-  public abstract Prefix6SetExpr toPrefix6SetExpr(
+  public abstract @Nullable Prefix6SetExpr toPrefix6SetExpr(
       CiscoXrConfiguration cc, Configuration c, Warnings w);
 
-  public abstract PrefixSetExpr toPrefixSetExpr(
+  public abstract @Nullable PrefixSetExpr toPrefixSetExpr(
       CiscoXrConfiguration cc, Configuration c, Warnings w);
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyPrefixSetName.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyPrefixSetName.java
@@ -20,19 +20,19 @@ public class RoutePolicyPrefixSetName extends RoutePolicyPrefixSet {
     return _name;
   }
 
-  @Nullable
   @Override
-  public Prefix6SetExpr toPrefix6SetExpr(CiscoXrConfiguration cc, Configuration c, Warnings w) {
-    if (cc.getPrefixLists().containsKey(_name)) {
+  public @Nullable Prefix6SetExpr toPrefix6SetExpr(
+      CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    if (!cc.getPrefix6Lists().containsKey(_name)) {
       return null;
     }
     return new NamedPrefix6Set(_name);
   }
 
-  @Nullable
   @Override
-  public PrefixSetExpr toPrefixSetExpr(CiscoXrConfiguration cc, Configuration c, Warnings w) {
-    if (cc.getPrefix6Lists().containsKey(_name)) {
+  public @Nullable PrefixSetExpr toPrefixSetExpr(
+      CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    if (!cc.getPrefixLists().containsKey(_name)) {
       return null;
     }
     return new NamedPrefixSet(_name);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/route-policy-done
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/route-policy-done
@@ -6,7 +6,8 @@ prefix-set accept_this_ip
 end-set
 
 prefix-set accept_this_ip_2
-  1.2.3.5/32
+  1.2.3.5/32,
+  2001::ffff:0/124
 end-set
 
 route-policy rp_ip


### PR DESCRIPTION
1. Add null annotations, so we get warnings in users.
2. Make the visitor more readable, and fix a bug where mixed prefix-sets would
   not get converted.
3. Add a test that v4 addresses in combo prefix-sets are permitted.