### PR TITLE
CheckPoint: Parse unknown object types

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/TypedManagementObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/TypedManagementObject.java
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 /** Abstract class representing a management object containing type and name fields. */
-@JsonTypeInfo(use = Id.NAME, property = "type", defaultImpl = UnknownTypedManagementObject.class)
+@JsonTypeInfo(
+    use = Id.NAME,
+    visible = true,
+    property = "type",
+    defaultImpl = UnknownTypedManagementObject.class)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = AddressRange.class, name = "address-range"),
   @JsonSubTypes.Type(value = CpmiAnyObject.class, name = "CpmiAnyObject"),

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/UnknownTypedManagementObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/UnknownTypedManagementObject.java
@@ -4,30 +4,47 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Catch-all for unknown and unhandled object types, so Jackson deserialization can work with object
+ * types that aren't supported yet.
+ */
 public class UnknownTypedManagementObject extends TypedManagementObject {
 
   @Override
   public boolean equals(Object o) {
-    return baseEquals(o);
+    if (!baseEquals(o)) {
+      return false;
+    }
+    UnknownTypedManagementObject that = (UnknownTypedManagementObject) o;
+    return _type.equals(that._type);
   }
 
   @Override
   public int hashCode() {
-    return baseHashcode();
+    return Objects.hash(baseHashcode(), _type);
   }
 
   @JsonCreator
   private static @Nonnull UnknownTypedManagementObject create(
-      @JsonProperty(PROP_NAME) @Nullable String name, @JsonProperty(PROP_UID) @Nullable Uid uid) {
+      @JsonProperty(PROP_NAME) @Nullable String name,
+      @JsonProperty(PROP_UID) @Nullable Uid uid,
+      @JsonProperty(PROP_TYPE) @Nullable String type) {
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new UnknownTypedManagementObject(name, uid);
+    checkArgument(type != null, "Missing %s", PROP_TYPE);
+    return new UnknownTypedManagementObject(name, uid, type);
   }
 
-  protected UnknownTypedManagementObject(String name, Uid uid) {
+  protected UnknownTypedManagementObject(String name, Uid uid, String type) {
     super(name, uid);
+    _type = type;
   }
+
+  private static final String PROP_TYPE = "type";
+
+  private final String _type;
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NatRulebaseTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NatRulebaseTest.java
@@ -125,7 +125,7 @@ public final class NatRulebaseTest {
                             Ip.ZERO, Ip.parse("0.0.0.1"), null, null, "foo", Uid.of("1")))
                     .put(
                         Uid.of("100"),
-                        new UnknownTypedManagementObject("unknown-foo", Uid.of("100")))
+                        new UnknownTypedManagementObject("unknown-foo", Uid.of("100"), "unknown"))
                     .put(Uid.of("2"), new CpmiAnyObject(Uid.of("2")))
                     .put(Uid.of("3"), new Original(Uid.of("3")))
                     .put(Uid.of("4"), new Group("foo", Uid.of("4")))

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/UnknownTypedManagementObjectTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/UnknownTypedManagementObjectTest.java
@@ -1,0 +1,51 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link AddressRange}. */
+public final class UnknownTypedManagementObjectTest {
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"GARBAGE\":0,"
+            + "\"type\":\"some type that isn't handled yet\","
+            + "\"uid\":\"0\","
+            + "\"name\":\"foo\","
+            + "\"a field that also isn't handled\":\"0.0.0.0\""
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper()
+            .readValue(input, UnknownTypedManagementObject.class),
+        equalTo(
+            new UnknownTypedManagementObject(
+                "foo", Uid.of("0"), "some type that isn't handled yet")));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    UnknownTypedManagementObject obj =
+        new UnknownTypedManagementObject("foo", Uid.of("0"), "some type that isn't handled yet");
+    assertEquals(obj, SerializationUtils.clone(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    UnknownTypedManagementObject obj = new UnknownTypedManagementObject("foo", Uid.of("1"), "type");
+    new EqualsTester()
+        .addEqualityGroup(obj, new UnknownTypedManagementObject("foo", Uid.of("1"), "type"))
+        .addEqualityGroup(new UnknownTypedManagementObject("foo0", Uid.of("1"), "type"))
+        .addEqualityGroup(new UnknownTypedManagementObject("foo", Uid.of("10"), "type"))
+        .addEqualityGroup(new UnknownTypedManagementObject("foo", Uid.of("1"), "type0"))
+        .testEquals();
+  }
+}


### PR DESCRIPTION
We can add warnings about these objects, but go ahead and parse them so Jackson doesn't crash when we get object types that aren't yet supported.
