### PR TITLE
Checkpoint MGMT VS: Visitors for address spaces and services

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressRange.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressRange.java
@@ -13,6 +13,11 @@ import org.batfish.datamodel.Ip6;
 
 public final class AddressRange extends AddressSpace {
 
+  @Override
+  public <T> T accept(ConcreteSrcOrDstVisitor<T> visitor) {
+    return visitor.visitAddressRange(this);
+  }
+
   public @Nullable Ip getIpv4AddressFirst() {
     return _ipv4AddressFirst;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressSpace.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressSpace.java
@@ -1,7 +1,7 @@
 package org.batfish.vendor.check_point_management;
 
 /** Parent class for objects that may used to represent an address space. */
-public abstract class AddressSpace extends TypedManagementObject {
+public abstract class AddressSpace extends TypedManagementObject implements ConcreteSrcOrDst {
 
   protected AddressSpace(String name, Uid uid) {
     super(name, uid);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteService.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteService.java
@@ -4,6 +4,7 @@ package org.batfish.vendor.check_point_management;
 public interface ConcreteService extends Service {
   <T> T accept(ConcreteServiceVisitor<T> visitor);
 
+  @Override
   default <T> T accept(ServiceVisitor<T> visitor) {
     return accept((ConcreteServiceVisitor<T>) visitor);
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteService.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteService.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management;
+
+/** A concrete service object (does not include {@link CpmiAnyObject}) */
+public interface ConcreteService extends Service, NatTranslatedService {
+  <T> T accept(ConcreteServiceVisitor<T> visitor);
+
+  default <T> T accept(ServiceVisitor<T> visitor) {
+    return accept((ConcreteServiceVisitor<T>) visitor);
+  }
+
+  default <T> T accept(NatTranslatedServiceVisitor<T> visitor) {
+    return accept((ConcreteServiceVisitor<T>) visitor);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteService.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteService.java
@@ -1,14 +1,10 @@
 package org.batfish.vendor.check_point_management;
 
 /** A concrete service object (does not include {@link CpmiAnyObject}) */
-public interface ConcreteService extends Service, NatTranslatedService {
+public interface ConcreteService extends Service {
   <T> T accept(ConcreteServiceVisitor<T> visitor);
 
   default <T> T accept(ServiceVisitor<T> visitor) {
-    return accept((ConcreteServiceVisitor<T>) visitor);
-  }
-
-  default <T> T accept(NatTranslatedServiceVisitor<T> visitor) {
     return accept((ConcreteServiceVisitor<T>) visitor);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteServiceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteServiceVisitor.java
@@ -10,5 +10,5 @@ public interface ConcreteServiceVisitor<T> {
 
   T visitServiceTcp(ServiceTcp serviceTcp);
 
-  // TODO Add ServiceUdp when created
+  // TODO Add ServiceOther, ServiceUdp when created
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteServiceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteServiceVisitor.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management;
+
+/** Visitor for {@link ConcreteService} */
+public interface ConcreteServiceVisitor<T> {
+  default T visit(ConcreteService concreteService) {
+    return concreteService.accept(this);
+  }
+
+  T visitServiceGroup(ServiceGroup serviceGroup);
+
+  T visitServiceTcp(ServiceTcp serviceTcp);
+
+  // TODO Add ServiceUdp when created
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDst.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDst.java
@@ -1,0 +1,16 @@
+package org.batfish.vendor.check_point_management;
+
+/**
+ * A concrete IP space object, e.g. an {@link AddressSpace}. Does not include {@link CpmiAnyObject}.
+ */
+public interface ConcreteSrcOrDst extends SrcOrDst, NatTranslatedSrcOrDst {
+  <T> T accept(ConcreteSrcOrDstVisitor<T> visitor);
+
+  default <T> T accept(SrcOrDstVisitor<T> visitor) {
+    return accept((ConcreteSrcOrDstVisitor<T>) visitor);
+  }
+
+  default <T> T accept(NatTranslatedSrcOrDstVisitor<T> visitor) {
+    return accept((ConcreteSrcOrDstVisitor<T>) visitor);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDst.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDst.java
@@ -3,14 +3,10 @@ package org.batfish.vendor.check_point_management;
 /**
  * A concrete IP space object, e.g. an {@link AddressSpace}. Does not include {@link CpmiAnyObject}.
  */
-public interface ConcreteSrcOrDst extends SrcOrDst, NatTranslatedSrcOrDst {
+public interface ConcreteSrcOrDst extends SrcOrDst {
   <T> T accept(ConcreteSrcOrDstVisitor<T> visitor);
 
   default <T> T accept(SrcOrDstVisitor<T> visitor) {
-    return accept((ConcreteSrcOrDstVisitor<T>) visitor);
-  }
-
-  default <T> T accept(NatTranslatedSrcOrDstVisitor<T> visitor) {
     return accept((ConcreteSrcOrDstVisitor<T>) visitor);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDst.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDst.java
@@ -6,6 +6,7 @@ package org.batfish.vendor.check_point_management;
 public interface ConcreteSrcOrDst extends SrcOrDst {
   <T> T accept(ConcreteSrcOrDstVisitor<T> visitor);
 
+  @Override
   default <T> T accept(SrcOrDstVisitor<T> visitor) {
     return accept((ConcreteSrcOrDstVisitor<T>) visitor);
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDstVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDstVisitor.java
@@ -1,0 +1,18 @@
+package org.batfish.vendor.check_point_management;
+
+/** Visitor for {@link ConcreteSrcOrDst} */
+public interface ConcreteSrcOrDstVisitor<T> {
+  default T visit(ConcreteSrcOrDst concreteSrcOrDst) {
+    return concreteSrcOrDst.accept(this);
+  }
+
+  T visitAddressRange(AddressRange addressRange);
+
+  T visitCpmiGatewayCluster(CpmiGatewayCluster cpmiGatewayCluster);
+
+  T visitGroup(Group group);
+
+  T visitHost(Host host);
+
+  T visitNetwork(Network network);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
@@ -9,11 +9,21 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * When assigned to {@code original-destination},{@code original-service}, or {@code
+ * When assigned to {@code original-destination}, {@code original-service}, or {@code
  * original-source} field of a {@link NatRule}, indicates that any value shall be matched for that
  * field when applying the rule.
  */
-public final class CpmiAnyObject extends TypedManagementObject {
+public final class CpmiAnyObject extends TypedManagementObject implements SrcOrDst, Service {
+
+  @Override
+  public <T> T accept(SrcOrDstVisitor<T> visitor) {
+    return visitor.visitCpmiAnyObject(this);
+  }
+
+  @Override
+  public <T> T accept(ServiceVisitor<T> visitor) {
+    return visitor.visitCpmiAnyObject(this);
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiGatewayCluster.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiGatewayCluster.java
@@ -11,7 +11,11 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 
 /** Data model for an object of type {@code CpmiGatewayCluster}. */
-public final class CpmiGatewayCluster extends Cluster {
+public final class CpmiGatewayCluster extends Cluster implements ConcreteSrcOrDst {
+  @Override
+  public <T> T accept(ConcreteSrcOrDstVisitor<T> visitor) {
+    return visitor.visitCpmiGatewayCluster(this);
+  }
 
   @JsonCreator
   private static @Nonnull CpmiGatewayCluster create(

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Group.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Group.java
@@ -8,7 +8,11 @@ import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class Group extends TypedManagementObject {
+public final class Group extends TypedManagementObject implements ConcreteSrcOrDst {
+  @Override
+  public <T> T accept(ConcreteSrcOrDstVisitor<T> visitor) {
+    return visitor.visitGroup(this);
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Host.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Host.java
@@ -13,6 +13,11 @@ import org.batfish.datamodel.Ip;
 /** A single host address. */
 public final class Host extends AddressSpace {
 
+  @Override
+  public <T> T accept(ConcreteSrcOrDstVisitor<T> visitor) {
+    return visitor.visitHost(this);
+  }
+
   @JsonCreator
   private static @Nonnull Host create(
       @JsonProperty(PROP_IPV4_ADDRESS) @Nullable Ip ipv4Address,

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Network.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Network.java
@@ -12,6 +12,10 @@ import org.batfish.datamodel.Ip;
 
 /** An IPv4 network. */
 public final class Network extends AddressSpace {
+  @Override
+  public <T> T accept(ConcreteSrcOrDstVisitor<T> visitor) {
+    return visitor.visitNetwork(this);
+  }
 
   @JsonCreator
   private static @Nonnull Network create(

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Service.java
@@ -1,0 +1,6 @@
+package org.batfish.vendor.check_point_management;
+
+/** Types that represent services, including {@link CpmiAnyObject} */
+public interface Service {
+  <T> T accept(ServiceVisitor<T> visitor);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
@@ -8,7 +8,11 @@ import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class ServiceGroup extends TypedManagementObject {
+public final class ServiceGroup extends TypedManagementObject implements ConcreteService {
+  @Override
+  public <T> T accept(ConcreteServiceVisitor<T> visitor) {
+    return visitor.visitServiceGroup(this);
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceTcp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceTcp.java
@@ -8,7 +8,11 @@ import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class ServiceTcp extends TypedManagementObject {
+public final class ServiceTcp extends TypedManagementObject implements ConcreteService {
+  @Override
+  public <T> T accept(ConcreteServiceVisitor<T> visitor) {
+    return visitor.visitServiceTcp(this);
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceVisitor.java
@@ -1,0 +1,10 @@
+package org.batfish.vendor.check_point_management;
+
+/** Visitor for {@link Service} */
+public interface ServiceVisitor<T> extends ConcreteServiceVisitor<T> {
+  default T visit(Service service) {
+    return service.accept(this);
+  }
+
+  T visitCpmiAnyObject(CpmiAnyObject cpmiAnyObject);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/SrcOrDst.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/SrcOrDst.java
@@ -1,0 +1,6 @@
+package org.batfish.vendor.check_point_management;
+
+/** An object representing a space of IPs (includes {@link CpmiAnyObject}). */
+public interface SrcOrDst {
+  <T> T accept(SrcOrDstVisitor<T> visitor);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/SrcOrDstVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/SrcOrDstVisitor.java
@@ -1,0 +1,10 @@
+package org.batfish.vendor.check_point_management;
+
+/** Visitor for {@link SrcOrDst} */
+public interface SrcOrDstVisitor<T> extends ConcreteSrcOrDstVisitor<T> {
+  default T visit(SrcOrDst srcOrDst) {
+    return srcOrDst.accept(this);
+  }
+
+  T visitCpmiAnyObject(CpmiAnyObject cpmiAnyObject);
+}


### PR DESCRIPTION
These interfaces should be useful at least for NAT and filter rules. If we find that they're useful more generally, we may want to rename the `SrcAndDst` ones. The new hierarchies (with new interfaces in bold+italics):
- ***Service***
    - CpmiAnyObject
    - ***ConcreteService***
        - ServiceTcp
        - ServiceGroup
- ***SrcOrDst***
    - CpmiAnyObject
    - ***ConcreteSrcOrDst***
        - AddressSpace
            - AddressRange
            - Host
            - Network
        - CpmiGatewayCluster
        - Group

It's possible that the pre-existing `AddressSpace` interface was meant to be `SrcOrDst` (@arifogel?), in which case that adjustment could be made to the PR.

It's useful to separate `CpmiAnyObject` from the concrete types because `CpmiAnyObject` is not valid as a NAT translated src/dst/service, while I believe all the concrete types are.