### PR TITLE
CheckPoint: Access Layer cleanup

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -241,7 +241,7 @@ import org.batfish.symbolic.IngressLocation;
 import org.batfish.topology.TopologyProviderImpl;
 import org.batfish.vendor.ConversionContext;
 import org.batfish.vendor.VendorConfiguration;
-import org.batfish.vendor.check_point_management.AccessRulebase;
+import org.batfish.vendor.check_point_management.AccessLayer;
 import org.batfish.vendor.check_point_management.CheckpointManagementConfiguration;
 import org.batfish.vendor.check_point_management.Domain;
 import org.batfish.vendor.check_point_management.GatewaysAndServers;
@@ -1581,13 +1581,13 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return config;
   }
 
-  private @Nonnull List<AccessRulebase> getAccessLayers(Map<String, String> packageFiles)
+  private @Nonnull List<AccessLayer> getAccessLayers(Map<String, String> packageFiles)
       throws JsonProcessingException {
     return packageFiles.containsKey(RELPATH_CHECKPOINT_SHOW_ACCESS_RULEBASE)
         ? BatfishObjectMapper.ignoreUnknownMapper()
             .readValue(
                 packageFiles.get(RELPATH_CHECKPOINT_SHOW_ACCESS_RULEBASE),
-                new TypeReference<List<AccessRulebase>>() {})
+                new TypeReference<List<AccessLayer>>() {})
         : ImmutableList.of();
   }
 
@@ -1702,7 +1702,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
               BatfishObjectMapper.ignoreUnknownMapper()
                   .readValue(packageFiles.get(RELPATH_CHECKPOINT_SHOW_PACKAGE), Package.class);
           ManagementPackage mgmtPackage;
-          List<AccessRulebase> accessLayers = getAccessLayers(packageFiles);
+          List<AccessLayer> accessLayers = getAccessLayers(packageFiles);
           NatRulebase natRulebase = getNatRulebase(pakij, packageFiles, pvcae, serverName);
           mgmtPackage = new ManagementPackage(accessLayers, natRulebase, pakij);
           packagesBuilder.put(mgmtPackage.getPackage().getUid(), mgmtPackage);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessLayer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessLayer.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Data model for an entry of the list response to the {@code show-access-rulebase} command. */
-public final class AccessRulebase extends NamedManagementObject {
+public final class AccessLayer extends NamedManagementObject {
 
   public @Nonnull Map<Uid, TypedManagementObject> getObjectsDictionary() {
     return _objectsDictionary;
@@ -26,7 +26,7 @@ public final class AccessRulebase extends NamedManagementObject {
   }
 
   @JsonCreator
-  private static @Nonnull AccessRulebase create(
+  private static @Nonnull AccessLayer create(
       @JsonProperty(PROP_OBJECTS_DICTIONARY) @Nullable
           List<TypedManagementObject> objectsDictionary,
       @JsonProperty(PROP_RULEBASE) @Nullable List<AccessRuleOrSection> rulebase,
@@ -36,7 +36,7 @@ public final class AccessRulebase extends NamedManagementObject {
     checkArgument(rulebase != null, "Missing %s", PROP_RULEBASE);
     checkArgument(uid != null, "Missing %s", PROP_UID);
     checkArgument(name != null, "Missing %s", PROP_NAME);
-    return new AccessRulebase(
+    return new AccessLayer(
         objectsDictionary.stream()
             .collect(ImmutableMap.toImmutableMap(ManagementObject::getUid, Function.identity())),
         rulebase,
@@ -45,7 +45,7 @@ public final class AccessRulebase extends NamedManagementObject {
   }
 
   @VisibleForTesting
-  AccessRulebase(
+  AccessLayer(
       Map<Uid, TypedManagementObject> objectsDictionary,
       List<AccessRuleOrSection> rulebase,
       Uid uid,
@@ -60,7 +60,7 @@ public final class AccessRulebase extends NamedManagementObject {
     if (!baseEquals(o)) {
       return false;
     }
-    AccessRulebase that = (AccessRulebase) o;
+    AccessLayer that = (AccessLayer) o;
     return _objectsDictionary.equals(that._objectsDictionary) && _rulebase.equals(that._rulebase);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessRule.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessRule.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** A single access-rule in an {@link AccessRulebase}. */
+/** A single access-rule in an {@link AccessLayer}. */
 public final class AccessRule extends NamedManagementObject implements AccessRuleOrSection {
 
   public @Nonnull Uid getAction() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessRuleOrSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessRuleOrSection.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import java.io.Serializable;
 
-/** A member of an {@link AccessRulebase}. */
+/** A member of an {@link AccessLayer}. */
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = AccessRule.class, name = "access-rule"),

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessSection.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** A logical grouping of access-rules in a {@link AccessRulebase}. */
+/** A logical grouping of access-rules in a {@link AccessLayer}. */
 public final class AccessSection extends NamedManagementObject implements AccessRuleOrSection {
 
   public @Nonnull List<AccessRule> getRulebase() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessSection.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** A logical grouping of access-rules in a {@link AccessLayer}. */
+/** A logical grouping of access-rules in an {@link AccessLayer}. */
 public final class AccessSection extends NamedManagementObject implements AccessRuleOrSection {
 
   public @Nonnull List<AccessRule> getRulebase() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ManagementPackage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ManagementPackage.java
@@ -13,15 +13,13 @@ import javax.annotation.Nullable;
 public final class ManagementPackage implements Serializable {
 
   public ManagementPackage(
-      @Nonnull List<AccessRulebase> accessLayers,
-      @Nullable NatRulebase natRulebase,
-      Package pakij) {
+      List<AccessLayer> accessLayers, @Nullable NatRulebase natRulebase, Package pakij) {
     _accessLayers = ImmutableList.copyOf(accessLayers);
     _natRulebase = natRulebase;
     _package = pakij;
   }
 
-  public @Nonnull List<AccessRulebase> getAccessLayers() {
+  public @Nonnull List<AccessLayer> getAccessLayers() {
     return _accessLayers;
   }
 
@@ -60,7 +58,7 @@ public final class ManagementPackage implements Serializable {
         .toString();
   }
 
-  private final @Nonnull List<AccessRulebase> _accessLayers;
+  private final @Nonnull List<AccessLayer> _accessLayers;
   private final @Nullable NatRulebase _natRulebase;
   private final @Nonnull Package _package;
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AccessLayerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AccessLayerTest.java
@@ -12,8 +12,8 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
-/** Test of {@link AccessRulebase}. */
-public final class AccessRulebaseTest {
+/** Test of {@link AccessLayer}. */
+public final class AccessLayerTest {
 
   @Test
   public void testJacksonDeserialization() throws JsonProcessingException {
@@ -79,11 +79,11 @@ public final class AccessRulebaseTest {
             + "]" // rulebase in access-section
             + "}" // access-section
             + "]" // rulebase
-            + "}"; // AccessRulebase
+            + "}"; // AccessLayer
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessRulebase.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessLayer.class),
         equalTo(
-            new AccessRulebase(
+            new AccessLayer(
                 ImmutableMap.of(
                     Uid.of("100"), new RulebaseAction("Accept", Uid.of("100"), "Accept")),
                 ImmutableList.of(
@@ -133,8 +133,8 @@ public final class AccessRulebaseTest {
 
   @Test
   public void testSerialization() {
-    AccessRulebase obj =
-        new AccessRulebase(
+    AccessLayer obj =
+        new AccessLayer(
             ImmutableMap.of(
                 Uid.of("0"), new AddressRange(null, null, null, null, "foo", Uid.of("0"))),
             ImmutableList.of(),
@@ -145,28 +145,27 @@ public final class AccessRulebaseTest {
 
   @Test
   public void testEquals() {
-    AccessRulebase obj =
-        new AccessRulebase(ImmutableMap.of(), ImmutableList.of(), Uid.of("0"), "foo");
+    AccessLayer obj = new AccessLayer(ImmutableMap.of(), ImmutableList.of(), Uid.of("0"), "foo");
     new EqualsTester()
         .addEqualityGroup(
-            obj, new AccessRulebase(ImmutableMap.of(), ImmutableList.of(), Uid.of("0"), "foo"))
+            obj, new AccessLayer(ImmutableMap.of(), ImmutableList.of(), Uid.of("0"), "foo"))
         .addEqualityGroup(
-            new AccessRulebase(
+            new AccessLayer(
                 ImmutableMap.of(
                     Uid.of("1"), new AddressRange(null, null, null, null, "foo", Uid.of("1"))),
                 ImmutableList.of(),
                 Uid.of("0"),
                 "foo"))
         .addEqualityGroup(
-            new AccessRulebase(
+            new AccessLayer(
                 ImmutableMap.of(),
                 ImmutableList.of(new AccessSection("n", ImmutableList.of(), Uid.of("1"))),
                 Uid.of("0"),
                 "foo"))
         .addEqualityGroup(
-            new AccessRulebase(ImmutableMap.of(), ImmutableList.of(), Uid.of("2"), "foo"))
+            new AccessLayer(ImmutableMap.of(), ImmutableList.of(), Uid.of("2"), "foo"))
         .addEqualityGroup(
-            new AccessRulebase(ImmutableMap.of(), ImmutableList.of(), Uid.of("2"), "bar"))
+            new AccessLayer(ImmutableMap.of(), ImmutableList.of(), Uid.of("2"), "bar"))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ManagementPackageTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ManagementPackageTest.java
@@ -56,7 +56,7 @@ public final class ManagementPackageTest {
         .addEqualityGroup(
             new ManagementPackage(
                 ImmutableList.of(
-                    new AccessRulebase(ImmutableMap.of(), ImmutableList.of(), Uid.of("1"), "foo")),
+                    new AccessLayer(ImmutableMap.of(), ImmutableList.of(), Uid.of("1"), "foo")),
                 null,
                 new Package(
                     new Domain("a", Uid.of("1")),


### PR DESCRIPTION
Rename to class to `AccessLayer` and remove redundant annotation.

Follow-up to https://github.com/batfish/batfish/pull/7279 and https://github.com/batfish/batfish/pull/7272
