### PR TITLE
Fix GC race condition causing improper deletion of network dir

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -2038,13 +2038,14 @@ public class FileBasedStorage implements StorageProvider {
   }
 
   /**
-   * Returns if it is safe to delete this network's folder, based on the last modified of its
-   * subdirs and snapshots.
+   * Returns if it is safe to delete this network's folder, based on the last modified times of
+   * itself, its subdirs, and its snapshots.
    */
   @VisibleForTesting
   boolean canExpungeNetwork(NetworkId networkId, Instant expungeBeforeDate) throws IOException {
-    try (Stream<Path> subdirs = list(getNetworkDir(networkId))) {
-      if (!canExpunge(expungeBeforeDate, Streams.concat(subdirs))) {
+    Path networkDir = getNetworkDir(networkId);
+    try (Stream<Path> subdirs = list(networkDir)) {
+      if (!canExpunge(expungeBeforeDate, Streams.concat(Stream.of(networkDir), subdirs))) {
         return false;
       }
     }


### PR DESCRIPTION
- network dir is created right before ID is assigned
- if GC runs in between dir creation and ID assignment, it considers the
  network dir orphaned and expunges it
- we avoid this condition generally by requiring dirs to be a certain
age before deletion, but we improperly neglected to check age of network
dir itself
  - fix is to check age of network dir before deleting it