### PR TITLE
CheckPoint: use names instead of Uids for VI model IpSpaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -143,10 +143,9 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
               //  names are unique
               if (natObj instanceof AddressRange) {
                 Optional.ofNullable(toIpSpace((AddressRange) natObj))
-                    .ifPresent(
-                        ipSpace -> _c.getIpSpaces().put(natObj.getUid().getValue(), ipSpace));
+                    .ifPresent(ipSpace -> _c.getIpSpaces().put(natObj.getName(), ipSpace));
               } else if (natObj instanceof Network) {
-                _c.getIpSpaces().put(natObj.getUid().getValue(), toIpSpace((Network) natObj));
+                _c.getIpSpaces().put(natObj.getName(), toIpSpace((Network) natObj));
               }
             });
   }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -872,8 +872,8 @@ public class CheckPointGatewayGrammarTest {
     Configuration c3 = configs.get("gw_package_selection_3");
     Configuration c4 = configs.get("gw_package_selection_4");
     Configuration c5 = configs.get("gw_package_selection_5");
-    assertThat(c1.getIpSpaces(), hasKey("n1uid"));
-    assertThat(c2.getIpSpaces(), hasKey("n2uid"));
+    assertThat(c1.getIpSpaces(), hasKey("n1"));
+    assertThat(c2.getIpSpaces(), hasKey("n2"));
     assertThat(c3.getIpSpaces(), anEmptyMap());
     assertThat(c4.getIpSpaces(), anEmptyMap());
     assertThat(c5.getIpSpaces(), anEmptyMap());


### PR DESCRIPTION
Names are unique, even across object types, so use names instead of Uids for converted `IpSpaces`.