### PR TITLE
CheckPoint: use VS model to determine domain -> gateway association

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -173,6 +173,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
 
   private @Nonnull Optional<Map.Entry<ManagementDomain, GatewayOrServer>> findGatewayAndDomain(
       CheckpointManagementConfiguration mgmtConfig) {
+    // TODO handle linking to secondary IP addresses, if that is allowed
     Set<Ip> ips =
         _interfaces.values().stream()
             .map(Interface::getAddress)

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -92,6 +92,12 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
     _c.setDefaultCrossZoneAction(LineAction.DENY);
     _c.setDefaultInboundAction(LineAction.PERMIT);
 
+    Optional<CheckpointManagementConfiguration> mgmtConfig =
+        Optional.ofNullable(getConversionContext())
+            .map(ConversionContext::getCheckpointManagementConfiguration)
+            .map(cmc -> (CheckpointManagementConfiguration) cmc);
+    mgmtConfig.ifPresent(this::convertManagementConfig);
+
     // Gateways don't have VRFs, so put everything in a generated default VRF
     Vrf vrf = new Vrf(VRF_NAME);
     _c.setVrfs(ImmutableMap.of(VRF_NAME, vrf));
@@ -103,12 +109,6 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
             _staticRoutes.values().stream()
                 .flatMap(staticRoute -> convertStaticRoute(staticRoute, _interfaces))
                 .collect(ImmutableSet.toImmutableSet()));
-
-    Optional<CheckpointManagementConfiguration> mgmtConfig =
-        Optional.ofNullable(getConversionContext())
-            .map(ConversionContext::getCheckpointManagementConfiguration)
-            .map(cmc -> (CheckpointManagementConfiguration) cmc);
-    mgmtConfig.ifPresent(this::convertManagementConfig);
 
     return ImmutableList.of(_c);
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -174,8 +174,8 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
   private @Nonnull Optional<Map.Entry<ManagementDomain, GatewayOrServer>> findGatewayAndDomain(
       CheckpointManagementConfiguration mgmtConfig) {
     Set<Ip> ips =
-        _c.getAllInterfaces().values().stream()
-            .flatMap(i -> i.getAllAddresses().stream())
+        _interfaces.values().stream()
+            .map(Interface::getAddress)
             .filter(ConcreteInterfaceAddress.class::isInstance)
             .map(ConcreteInterfaceAddress.class::cast)
             .map(ConcreteInterfaceAddress::getIp)


### PR DESCRIPTION
Don't rely on VI model being populated yet, to determine domain to gateway association.

Also, go ahead and convert management config earlier in the pipeline, so we can use that information for converting other datamodel classes in the future.
