### PR TITLE
MatchBgpSessionType: a new routing policy BooleanExpr

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
@@ -66,6 +66,7 @@ import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.HasRoute6;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MainRib;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -196,6 +197,12 @@ public final class CommunityStructuresVerifier {
     @Override
     public Void visitMatchLegacyAsPath(
         LegacyMatchAsPath legacyMatchAsPath, CommunityStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchBgpSessionType(
+        MatchBgpSessionType matchBgpSessionType, CommunityStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
@@ -21,6 +21,7 @@ import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.HasRoute6;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -151,6 +152,12 @@ public final class AsPathStructuresVerifier {
     @Override
     public Void visitMatchLegacyAsPath(
         LegacyMatchAsPath legacyMatchAsPath, AsPathStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchBgpSessionType(
+        MatchBgpSessionType matchBgpSessionType, AsPathStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprVisitor.java
@@ -27,6 +27,8 @@ public interface BooleanExprVisitor<T, U> {
 
   T visitMatchAsPath(MatchAsPath matchAsPath, U arg);
 
+  T visitMatchBgpSessionType(MatchBgpSessionType matchBgpSessionType, U arg);
+
   T visitMatchLegacyAsPath(LegacyMatchAsPath legacyMatchAsPath, U arg);
 
   T visitMatchColor(MatchColor matchColor, U arg);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchBgpSessionType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchBgpSessionType.java
@@ -1,0 +1,111 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+
+/**
+ * Evaluates to true when evaluated in an environment with {@link BgpSessionProperties} present and
+ * of the specified types.
+ */
+@ParametersAreNonnullByDefault
+public final class MatchBgpSessionType extends BooleanExpr {
+  private static final String PROP_TYPES = "types";
+
+  /** Which types of BgpSessionProperties to match. */
+  public enum Type {
+    /** Matches any EBGP type in {@link BgpSessionProperties.SessionType}. */
+    EBGP,
+    /** Matches any IBGP type in {@link BgpSessionProperties.SessionType}. */
+    IBGP,
+  }
+
+  @Nonnull private final EnumSet<Type> _types;
+
+  public MatchBgpSessionType(Type... types) {
+    this(Arrays.asList(types));
+  }
+
+  public MatchBgpSessionType(Collection<Type> types) {
+    checkArgument(!types.isEmpty(), "Must match at least 1 type");
+    _types = EnumSet.copyOf(types);
+  }
+
+  @JsonCreator
+  private static MatchBgpSessionType create(
+      @Nullable @JsonProperty(PROP_TYPES) Collection<Type> types) {
+    checkArgument(types != null, "Missing %s", PROP_TYPES);
+    return new MatchBgpSessionType(types);
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprVisitor<T, U> visitor, U arg) {
+    return visitor.visitMatchBgpSessionType(this, arg);
+  }
+
+  @Override
+  public Result evaluate(Environment environment) {
+    @Nullable BgpSessionProperties props = environment.getBgpSessionProperties();
+    if (props == null) {
+      return new Result(false);
+    }
+    switch (props.getSessionType()) {
+      case EBGP_SINGLEHOP:
+      case EBGP_MULTIHOP:
+      case EBGP_UNNUMBERED:
+        return new Result(_types.contains(Type.EBGP));
+      case IBGP:
+      case IBGP_UNNUMBERED:
+        return new Result(_types.contains(Type.IBGP));
+      case UNSET:
+      default:
+        throw new IllegalStateException(
+            "Established session cannot have type " + props.getSessionType());
+    }
+  }
+
+  @Nonnull
+  @JsonProperty(PROP_TYPES)
+  public Set<Type> getTypes() {
+    return _types;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MatchBgpSessionType)) {
+      return false;
+    }
+    MatchBgpSessionType that = (MatchBgpSessionType) o;
+    return _types.equals(that._types);
+  }
+
+  @Override
+  public int hashCode() {
+    // Consistent hash for a set of enums: the Set hashcode algorithm but on ordinal value.
+    int hash = 0;
+    for (Type t : _types) {
+      hash += t.ordinal();
+    }
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(MatchBgpSessionType.class).add(PROP_TYPES, _types).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifierTest.java
@@ -62,6 +62,8 @@ import org.batfish.datamodel.routing_policy.expr.LiteralIsisLevel;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MainRib;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType.Type;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -123,6 +125,7 @@ public final class CommunityStructuresVerifierTest {
     assertNull(new HasRoute(new NamedPrefixSet("a")).accept(BOOLEAN_EXPR_VERIFIER, ctx));
     assertNull(new HasRoute6(new NamedPrefix6Set("a")).accept(BOOLEAN_EXPR_VERIFIER, ctx));
     assertNull(new LegacyMatchAsPath(new NamedAsPathSet("a")).accept(BOOLEAN_EXPR_VERIFIER, ctx));
+    assertNull(new MatchBgpSessionType(Type.EBGP).accept(BOOLEAN_EXPR_VERIFIER, ctx));
     assertNull(new MatchColor(1).accept(BOOLEAN_EXPR_VERIFIER, ctx));
     assertNull(new MatchIp6AccessList("a").accept(BOOLEAN_EXPR_VERIFIER, ctx));
     assertNull(MatchIpv4.instance().accept(BOOLEAN_EXPR_VERIFIER, ctx));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/BUILD
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/BUILD
@@ -1,0 +1,22 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:private"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "*Test.java",
+    ]),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchBgpSessionTypeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchBgpSessionTypeTest.java
@@ -1,0 +1,100 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.BgpSessionProperties.SessionType;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType.Type;
+import org.junit.Test;
+
+public class MatchBgpSessionTypeTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(new MatchBgpSessionType(Type.EBGP), new MatchBgpSessionType(Type.EBGP))
+        .addEqualityGroup(new MatchBgpSessionType(Type.EBGP, Type.IBGP))
+        .addEqualityGroup(new MatchBgpSessionType(Type.IBGP))
+        .testEquals();
+  }
+
+  @Test
+  public void testSerialization() {
+    BooleanExpr ebgp = new MatchBgpSessionType(Type.EBGP);
+    assertThat(SerializationUtils.clone(ebgp), equalTo(ebgp));
+    assertThat(BatfishObjectMapper.clone(ebgp, BooleanExpr.class), equalTo(ebgp));
+  }
+
+  private static void runAssertion(
+      boolean expected, MatchBgpSessionType match, @Nullable SessionType type) {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder()
+            .setHostname("h")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    Environment.Builder env = Environment.builder(c);
+    if (type != null) {
+      env.setBgpSessionProperties(
+          BgpSessionProperties.builder()
+              .setSessionType(type)
+              .setHeadAs(1234)
+              .setHeadIp(Ip.parse("1.2.3.4"))
+              .setTailAs(2345)
+              .setTailIp(Ip.parse("2.3.4.5"))
+              .build());
+    }
+    Result result = match.evaluate(env.build());
+    assertThat(result.getBooleanValue(), equalTo(expected));
+  }
+
+  @Test
+  public void testEvaluate() {
+    MatchBgpSessionType ebgp = new MatchBgpSessionType(Type.EBGP);
+    MatchBgpSessionType ibgp = new MatchBgpSessionType(Type.IBGP);
+    MatchBgpSessionType eibgp = new MatchBgpSessionType(Type.EBGP, Type.IBGP);
+
+    // No BGP props, no match
+    runAssertion(false, ebgp, null);
+    runAssertion(false, ibgp, null);
+    runAssertion(false, eibgp, null);
+
+    // EBGP session types
+    for (SessionType type :
+        new SessionType[] {
+          SessionType.EBGP_MULTIHOP, SessionType.EBGP_SINGLEHOP, SessionType.EBGP_UNNUMBERED
+        }) {
+      runAssertion(true, ebgp, type);
+      runAssertion(false, ibgp, type);
+      runAssertion(true, eibgp, type);
+    }
+
+    // IBGP session types
+    for (SessionType type : new SessionType[] {SessionType.IBGP, SessionType.IBGP_UNNUMBERED}) {
+      runAssertion(false, ebgp, type);
+      runAssertion(true, ibgp, type);
+      runAssertion(true, eibgp, type);
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testUnsetCrashes() {
+    runAssertion(false, new MatchBgpSessionType(Type.EBGP), SessionType.UNSET);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTypeRequired() {
+    new MatchBgpSessionType(ImmutableList.of());
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollector.java
@@ -24,6 +24,7 @@ import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.HasRoute6;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -104,6 +105,12 @@ public class BooleanExprAsPathCollector
   public Set<SymbolicAsPathRegex> visitMatchAsPath(MatchAsPath matchAsPath, Configuration arg) {
     AsPathMatchExpr matchExpr = matchAsPath.getAsPathMatchExpr();
     return matchExpr.accept(new AsPathMatchExprAsPathCollector(), arg);
+  }
+
+  @Override
+  public Set<SymbolicAsPathRegex> visitMatchBgpSessionType(
+      MatchBgpSessionType matchBgpSessionType, Configuration arg) {
+    return ImmutableSet.of();
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
@@ -18,6 +18,7 @@ import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.HasRoute6;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -101,6 +102,12 @@ public class BooleanExprVarCollector
   @Override
   public Set<CommunityVar> visitMatchLegacyAsPath(
       LegacyMatchAsPath legacyMatchAsPath, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<CommunityVar> visitMatchBgpSessionType(
+      MatchBgpSessionType matchBgpSessionType, Configuration arg) {
     return ImmutableSet.of();
   }
 


### PR DESCRIPTION
Returns true only when being evaluated in the context of a specific type of BGP Session.