### PR TITLE
Checkpoint NAT draft

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -1,13 +1,30 @@
 package org.batfish.vendor.check_point_gateway.representation;
 
+import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.applyOriginalDestinationConstraint;
+import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.applyOriginalServiceConstraint;
+import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.applyOriginalSourceConstraint;
+import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.getDestinationTransformationSteps;
+import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.getServiceTransformationSteps;
+import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.getSourceTransformationSteps;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.transformation.TransformationStep;
 import org.batfish.vendor.check_point_management.AddressRange;
+import org.batfish.vendor.check_point_management.NatTranslatedService;
+import org.batfish.vendor.check_point_management.NatTranslatedSrcOrDst;
 import org.batfish.vendor.check_point_management.Network;
+import org.batfish.vendor.check_point_management.Service;
+import org.batfish.vendor.check_point_management.SrcOrDst;
+import org.batfish.vendor.check_point_management.TypedManagementObject;
 
 /** Utility class for Checkpoint conversion methods */
 public final class CheckPointGatewayConversions {
@@ -32,6 +49,72 @@ public final class CheckPointGatewayConversions {
     // "don't care". Flip mask to convert to IpWildcard.
     long flippedMask = network.getSubnetMask().asLong() ^ Ip.MAX.asLong();
     return IpWildcard.ipWithWildcardMask(network.getSubnet4(), flippedMask).toIpSpace();
+  }
+
+  static @Nonnull HeaderSpace constructHeaderSpace(
+      TypedManagementObject src,
+      TypedManagementObject dst,
+      TypedManagementObject service,
+      Warnings warnings) {
+    HeaderSpace.Builder hsb = HeaderSpace.builder();
+    if (src instanceof SrcOrDst) {
+      applyOriginalSourceConstraint((SrcOrDst) src, hsb);
+    } else {
+      warnings.redFlag(
+          String.format(
+              "NAT rule original-source %s has unsupported type %s and will be ignored",
+              src.getName(), src.getClass()));
+    }
+    if (dst instanceof SrcOrDst) {
+      applyOriginalDestinationConstraint((SrcOrDst) src, hsb);
+    } else {
+      warnings.redFlag(
+          String.format(
+              "NAT rule original-destination %s has unsupported type %s and will be ignored",
+              dst.getName(), dst.getClass()));
+    }
+    if (service instanceof Service) {
+      applyOriginalServiceConstraint((Service) service, hsb);
+    } else {
+      warnings.redFlag(
+          String.format(
+              "NAT rule original-service %s has unsupported type %s and will be ignored",
+              service.getName(), service.getClass()));
+    }
+    return hsb.build();
+  }
+
+  static @Nonnull List<TransformationStep> getTransformationSteps(
+      TypedManagementObject src,
+      TypedManagementObject dst,
+      TypedManagementObject service,
+      Warnings warnings) {
+    ImmutableList.Builder<TransformationStep> steps = ImmutableList.builder();
+    if (src instanceof NatTranslatedSrcOrDst) {
+      steps.addAll(getSourceTransformationSteps((NatTranslatedSrcOrDst) src));
+    } else {
+      warnings.redFlag(
+          String.format(
+              "NAT rule translated-source %s has unsupported type %s and will be ignored",
+              src.getName(), src.getClass()));
+    }
+    if (dst instanceof NatTranslatedSrcOrDst) {
+      steps.addAll(getDestinationTransformationSteps((NatTranslatedSrcOrDst) dst));
+    } else {
+      warnings.redFlag(
+          String.format(
+              "NAT rule translated-destination %s has unsupported type %s and will be ignored",
+              dst.getName(), dst.getClass()));
+    }
+    if (service instanceof NatTranslatedService) {
+      steps.addAll(getServiceTransformationSteps((NatTranslatedService) service));
+    } else {
+      warnings.redFlag(
+          String.format(
+              "NAT rule translated-service %s has unsupported type %s and will be ignored",
+              service.getName(), service.getClass()));
+    }
+    return steps.build();
   }
 
   private CheckPointGatewayConversions() {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
@@ -1,0 +1,194 @@
+package org.batfish.vendor.check_point_gateway.representation;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.transformation.TransformationStep;
+import org.batfish.vendor.check_point_management.AddressRange;
+import org.batfish.vendor.check_point_management.ConcreteService;
+import org.batfish.vendor.check_point_management.ConcreteSrcOrDst;
+import org.batfish.vendor.check_point_management.CpmiAnyObject;
+import org.batfish.vendor.check_point_management.CpmiGatewayCluster;
+import org.batfish.vendor.check_point_management.Group;
+import org.batfish.vendor.check_point_management.Host;
+import org.batfish.vendor.check_point_management.NatTranslatedService;
+import org.batfish.vendor.check_point_management.NatTranslatedServiceVisitor;
+import org.batfish.vendor.check_point_management.NatTranslatedSrcOrDst;
+import org.batfish.vendor.check_point_management.Network;
+import org.batfish.vendor.check_point_management.Original;
+import org.batfish.vendor.check_point_management.PolicyTargets;
+import org.batfish.vendor.check_point_management.Service;
+import org.batfish.vendor.check_point_management.ServiceGroup;
+import org.batfish.vendor.check_point_management.ServiceTcp;
+import org.batfish.vendor.check_point_management.ServiceVisitor;
+import org.batfish.vendor.check_point_management.SrcOrDst;
+import org.batfish.vendor.check_point_management.SrcOrDstVisitor;
+import org.batfish.vendor.check_point_management.UnhandledGlobal;
+
+public class CheckpointNatConversions {
+  private static final NatOriginalServiceConverter ORIGINAL_SERVICE_CONVERTER =
+      new NatOriginalServiceConverter();
+  private static final SrcOrDstToIpSpace SRC_OR_DST_TO_IP_SPACE = new SrcOrDstToIpSpace();
+  private static final NatTranslatedServiceConverter TRANSLATED_SERVICE_CONVERTER =
+      new NatTranslatedServiceConverter();
+
+  /**
+   * Restricts the given {@link HeaderSpace.Builder} to protocols/ports matching the given {@link
+   * Service}.
+   */
+  public static void applyOriginalServiceConstraint(Service service, HeaderSpace.Builder hsb) {
+    ORIGINAL_SERVICE_CONVERTER.setHeaderSpace(hsb);
+    ORIGINAL_SERVICE_CONVERTER.visit(service);
+    ORIGINAL_SERVICE_CONVERTER.setHeaderSpace(null);
+  }
+
+  /**
+   * Restricts the given {@link HeaderSpace.Builder} to sources matching the given {@link SrcOrDst}.
+   */
+  public static void applyOriginalSourceConstraint(SrcOrDst source, HeaderSpace.Builder hsb) {
+    SRC_OR_DST_TO_IP_SPACE.visit(source).ifPresent(hsb::setSrcIps);
+  }
+
+  /**
+   * Restricts the given {@link HeaderSpace.Builder} to destinations matching the given {@link
+   * SrcOrDst}.
+   */
+  public static void applyOriginalDestinationConstraint(
+      SrcOrDst destination, HeaderSpace.Builder hsb) {
+    SRC_OR_DST_TO_IP_SPACE.visit(destination).ifPresent(hsb::setDstIps);
+  }
+
+  public static @Nonnull List<TransformationStep> getServiceTransformationSteps(
+      NatTranslatedService service) {
+    return TRANSLATED_SERVICE_CONVERTER.visit(service);
+  }
+
+  public static @Nonnull List<TransformationStep> getSourceTransformationSteps(
+      NatTranslatedSrcOrDst source) {
+    // TODO: Implement visitor to convert translated source to transformation steps.
+    //       Will also be dependent on whether transformation is incoming or outgoing.
+    return ImmutableList.of();
+  }
+
+  public static @Nonnull List<TransformationStep> getDestinationTransformationSteps(
+      NatTranslatedSrcOrDst destination) {
+    // TODO: Implement visitor to convert translated destination to transformation steps.
+    //       Will also be dependent on whether transformation is incoming or outgoing.
+    return ImmutableList.of();
+  }
+
+  /**
+   * Applies a {@link ConcreteService} to its current {@link HeaderSpace.Builder}. Does not modify
+   * the headerspace if the given service object is unconstrained.
+   */
+  private static class NatOriginalServiceConverter implements ServiceVisitor<Void> {
+    private @Nullable HeaderSpace.Builder _hsb;
+
+    private NatOriginalServiceConverter() {}
+
+    private void setHeaderSpace(@Nullable HeaderSpace.Builder hsb) {
+      _hsb = hsb;
+    }
+
+    @Override
+    public Void visitCpmiAnyObject(CpmiAnyObject cpmiAnyObject) {
+      // Does not constrain headerspace
+      return null;
+    }
+
+    @Override
+    public Void visitServiceGroup(ServiceGroup serviceGroup) {
+      // TODO Implement
+      return null;
+    }
+
+    @Override
+    public Void visitServiceTcp(ServiceTcp serviceTcp) {
+      // TODO Is this correct/sufficient? Does it need to modify src port?
+      //      Also, need to verify that port is an integer and decide what to do if not
+      assert _hsb != null;
+      _hsb.setIpProtocols(IpProtocol.TCP);
+      _hsb.setDstPorts(SubRange.singleton(Integer.parseInt(serviceTcp.getPort())));
+      return null;
+    }
+  }
+
+  /**
+   * Converts a {@link ConcreteSrcOrDst} to an {@link IpSpace}. Returns empty Optional if the given
+   * object is inconvertible or unconstrained.
+   */
+  private static class SrcOrDstToIpSpace implements SrcOrDstVisitor<Optional<IpSpace>> {
+    private SrcOrDstToIpSpace() {}
+
+    @Override
+    public Optional<IpSpace> visitCpmiAnyObject(CpmiAnyObject cpmiAnyObject) {
+      // Does not constrain
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<IpSpace> visitAddressRange(AddressRange addressRange) {
+      return Optional.ofNullable(CheckPointGatewayConversions.toIpSpace(addressRange));
+    }
+
+    @Override
+    public Optional<IpSpace> visitCpmiGatewayCluster(CpmiGatewayCluster cpmiGatewayCluster) {
+      // TODO Implement
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<IpSpace> visitGroup(Group group) {
+      // TODO Implement
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<IpSpace> visitHost(Host host) {
+      // TODO Implement
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<IpSpace> visitNetwork(Network network) {
+      return Optional.of(CheckPointGatewayConversions.toIpSpace(network));
+    }
+  }
+
+  // TODO Implement
+  private static class NatTranslatedServiceConverter
+      implements NatTranslatedServiceVisitor<List<TransformationStep>> {
+    private NatTranslatedServiceConverter() {}
+
+    @Override
+    public List<TransformationStep> visitOriginal(Original original) {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public List<TransformationStep> visitPolicyTargets(PolicyTargets policyTargets) {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public List<TransformationStep> visitUnhandledGlobal(UnhandledGlobal unhandledGlobal) {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public List<TransformationStep> visitServiceGroup(ServiceGroup serviceGroup) {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public List<TransformationStep> visitServiceTcp(ServiceTcp serviceTcp) {
+      return ImmutableList.of();
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteService.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteService.java
@@ -1,11 +1,15 @@
 package org.batfish.vendor.check_point_management;
 
 /** A concrete service object (does not include {@link CpmiAnyObject}) */
-public interface ConcreteService extends Service {
+public interface ConcreteService extends Service, NatTranslatedService {
   <T> T accept(ConcreteServiceVisitor<T> visitor);
 
   @Override
   default <T> T accept(ServiceVisitor<T> visitor) {
+    return accept((ConcreteServiceVisitor<T>) visitor);
+  }
+
+  default <T> T accept(NatTranslatedServiceVisitor<T> visitor) {
     return accept((ConcreteServiceVisitor<T>) visitor);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDst.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ConcreteSrcOrDst.java
@@ -3,11 +3,15 @@ package org.batfish.vendor.check_point_management;
 /**
  * A concrete IP space object, e.g. an {@link AddressSpace}. Does not include {@link CpmiAnyObject}.
  */
-public interface ConcreteSrcOrDst extends SrcOrDst {
+public interface ConcreteSrcOrDst extends SrcOrDst, NatTranslatedSrcOrDst {
   <T> T accept(ConcreteSrcOrDstVisitor<T> visitor);
 
   @Override
   default <T> T accept(SrcOrDstVisitor<T> visitor) {
+    return accept((ConcreteSrcOrDstVisitor<T>) visitor);
+  }
+
+  default <T> T accept(NatTranslatedSrcOrDstVisitor<T> visitor) {
     return accept((ConcreteSrcOrDstVisitor<T>) visitor);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Global.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Global.java
@@ -8,7 +8,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** A global pre-defined object. */
-public abstract class Global extends TypedManagementObject {
+public abstract class Global extends TypedManagementObject
+    implements NatTranslatedSrcOrDst, NatTranslatedService {
 
   @Override
   public final boolean equals(Object obj) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRule.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRule.java
@@ -13,6 +13,11 @@ import javax.annotation.Nullable;
 /** A single nat-rule in a {@link NatRulebase}. */
 public final class NatRule extends ManagementObject implements NatRuleOrSection {
 
+  @Override
+  public <T> T accept(NatRuleOrSectionVisitor<T> visitor) {
+    return visitor.visitNatRule(this);
+  }
+
   public @Nonnull String getComments() {
     return _comments;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRuleOrSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRuleOrSection.java
@@ -11,4 +11,6 @@ import java.io.Serializable;
   @JsonSubTypes.Type(value = NatRule.class, name = "nat-rule"),
   @JsonSubTypes.Type(value = NatSection.class, name = "nat-section")
 })
-public interface NatRuleOrSection extends Serializable {}
+public interface NatRuleOrSection extends Serializable {
+  <T> T accept(NatRuleOrSectionVisitor<T> visitor);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRuleOrSectionVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRuleOrSectionVisitor.java
@@ -1,0 +1,11 @@
+package org.batfish.vendor.check_point_management;
+
+public interface NatRuleOrSectionVisitor<T> {
+  default T visit(NatRuleOrSection natRuleOrSection) {
+    return natRuleOrSection.accept(this);
+  }
+
+  T visitNatRule(NatRule natRule);
+
+  T visitNatSection(NatSection natSection);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatSection.java
@@ -12,6 +12,11 @@ import javax.annotation.Nullable;
 
 public final class NatSection extends NamedManagementObject implements NatRuleOrSection {
 
+  @Override
+  public <T> T accept(NatRuleOrSectionVisitor<T> visitor) {
+    return visitor.visitNatSection(this);
+  }
+
   public @Nonnull List<NatRule> getRulebase() {
     return _rulebase;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedService.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedService.java
@@ -1,0 +1,8 @@
+package org.batfish.vendor.check_point_management;
+
+/**
+ * Types that can be used as a {@link NatRule#getTranslatedService() NAT rule's translated service}
+ */
+public interface NatTranslatedService {
+  <T> T accept(NatTranslatedServiceVisitor<T> visitor);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedServiceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedServiceVisitor.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management;
+
+/** Visitor for {@link NatTranslatedService} */
+public interface NatTranslatedServiceVisitor<T> extends ConcreteServiceVisitor<T> {
+  default T visit(NatTranslatedService natTranslatedService) {
+    return natTranslatedService.accept(this);
+  }
+
+  T visitOriginal(Original original);
+
+  T visitPolicyTargets(PolicyTargets policyTargets);
+
+  T visitUnhandledGlobal(UnhandledGlobal unhandledGlobal);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedSrcOrDst.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedSrcOrDst.java
@@ -1,0 +1,9 @@
+package org.batfish.vendor.check_point_management;
+
+/**
+ * Types that can be used as a {@link NatRule#getTranslatedSource()} () NAT rule's translated
+ * source}
+ */
+public interface NatTranslatedSrcOrDst {
+  <T> T accept(NatTranslatedSrcOrDstVisitor<T> visitor);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedSrcOrDstVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedSrcOrDstVisitor.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management;
+
+/** Visitor for {@link NatTranslatedSrcOrDst} */
+public interface NatTranslatedSrcOrDstVisitor<T> extends ConcreteSrcOrDstVisitor<T> {
+  default T visit(NatTranslatedSrcOrDst natTranslatedSrcOrDst) {
+    return natTranslatedSrcOrDst.accept(this);
+  }
+
+  T visitOriginal(Original original);
+
+  T visitPolicyTargets(PolicyTargets policyTargets);
+
+  T visitUnhandledGlobal(UnhandledGlobal unhandledGlobal);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Original.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Original.java
@@ -6,6 +6,15 @@ package org.batfish.vendor.check_point_management;
  * retained for that field when applying the rule.
  */
 public final class Original extends Global {
+  @Override
+  public <T> T accept(NatTranslatedServiceVisitor<T> visitor) {
+    return visitor.visitOriginal(this);
+  }
+
+  @Override
+  public <T> T accept(NatTranslatedSrcOrDstVisitor<T> visitor) {
+    return visitor.visitOriginal(this);
+  }
 
   Original(Uid uid) {
     super(NAME_ORIGINAL, uid);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/PolicyTargets.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/PolicyTargets.java
@@ -3,6 +3,16 @@ package org.batfish.vendor.check_point_management;
 /** Indicates that a rule should be applied to all installation targets of the package. */
 public final class PolicyTargets extends Global {
 
+  @Override
+  public <T> T accept(NatTranslatedServiceVisitor<T> visitor) {
+    return visitor.visitPolicyTargets(this);
+  }
+
+  @Override
+  public <T> T accept(NatTranslatedSrcOrDstVisitor<T> visitor) {
+    return visitor.visitPolicyTargets(this);
+  }
+
   PolicyTargets(Uid uid) {
     super(NAME_POLICY_TARGETS, uid);
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/UnhandledGlobal.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/UnhandledGlobal.java
@@ -2,6 +2,15 @@ package org.batfish.vendor.check_point_management;
 
 /** An object of type {@link Global} whose name is unrecognized or otherwise unhandled. */
 public final class UnhandledGlobal extends Global {
+  @Override
+  public <T> T accept(NatTranslatedServiceVisitor<T> visitor) {
+    return visitor.visitUnhandledGlobal(this);
+  }
+
+  @Override
+  public <T> T accept(NatTranslatedSrcOrDstVisitor<T> visitor) {
+    return visitor.visitUnhandledGlobal(this);
+  }
 
   UnhandledGlobal(String name, Uid uid) {
     super(name, uid);


### PR DESCRIPTION
Opening a PR to put documentation of current state and code changes in a single unified place, but NAT conversion is not done.

Includes:
- Implementation of interfaces and visitors for NAT translated src/dsts and services
- Skeleton pattern for conversion of NAT rules
- Conversion of each NAT rule's original src/dst/service to a headerspace
  - some visitor methods in `NatOriginalServiceConverter` and `SrcOrDstToIpSpace` need implementation
- Refactor of `CheckpointGatewayConfiguration` to allow conversion of different parts of management data at different times (because NAT has to happen after interfaces are converted)

Missing:
- Creation of TransformationSteps corresponding to NAT rules' transformed src, dst, and service
  - Note that for each transformed field in each NAT rule, we need to generate (at least) two TransformationSteps: incoming and outgoing. Compare to `toOutgoingTransformation` and `toIncomingTransformation` in the Juniper `NatRuleSet` class.
- Identifying internal and external interfaces (using `GatewayOrServer -> Interface -> InterfaceTopology -> leadsToInternet`) and attaching the appropriate transformations
- Tests