### PR TITLE
CheckPoint: parse Interface addresses

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Interface.java
@@ -13,14 +13,6 @@ import org.batfish.datamodel.Ip;
 
 /** An interface as shown in show-gateways-and-servers */
 public final class Interface implements Serializable {
-
-  /**
-   * Instance of this class populated with arbitrary values. Useful for generating a valid object
-   * for use in tests.
-   */
-  public static final Interface TEST_INSTANCE =
-      new Interface("eth0", InterfaceTopology.TEST_INSTANCE, Ip.parse("10.0.1.1"), 24);
-
   @JsonCreator
   private static @Nonnull Interface create(
       @JsonProperty(PROP_NAME) @Nullable String name,

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Interface.java
@@ -9,22 +9,37 @@ import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
 
 /** An interface as shown in show-gateways-and-servers */
 public final class Interface implements Serializable {
+
+  /**
+   * Instance of this class populated with arbitrary values. Useful for generating a valid object
+   * for use in tests.
+   */
+  public static final Interface TEST_INSTANCE =
+      new Interface("eth0", InterfaceTopology.TEST_INSTANCE, Ip.parse("10.0.1.1"), 24);
+
   @JsonCreator
   private static @Nonnull Interface create(
       @JsonProperty(PROP_NAME) @Nullable String name,
-      @JsonProperty(PROP_TOPOLOGY) @Nullable InterfaceTopology topology) {
+      @JsonProperty(PROP_TOPOLOGY) @Nullable InterfaceTopology topology,
+      @JsonProperty(PROP_IPV4_ADDRESS) @Nullable Ip ipv4Address,
+      @JsonProperty(PROP_IPV4_MASK_LENGTH) @Nullable Integer ipv4MaskLength) {
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(topology != null, "Missing %s", PROP_TOPOLOGY);
-    return new Interface(name, topology);
+    checkArgument(ipv4Address != null, "Missing %s", PROP_IPV4_ADDRESS);
+    checkArgument(ipv4MaskLength != null, "Missing %s", PROP_IPV4_MASK_LENGTH);
+    return new Interface(name, topology, ipv4Address, ipv4MaskLength);
   }
 
   @VisibleForTesting
-  public Interface(String name, InterfaceTopology topology) {
+  public Interface(String name, InterfaceTopology topology, Ip ipv4Address, int ipv4MaskLength) {
     _name = name;
     _topology = topology;
+    _ipv4Address = ipv4Address;
+    _ipv4MaskLength = ipv4MaskLength;
   }
 
   public @Nonnull String getName() {
@@ -35,6 +50,14 @@ public final class Interface implements Serializable {
     return _topology;
   }
 
+  public @Nonnull Ip getIpv4Address() {
+    return _ipv4Address;
+  }
+
+  public int getIpv4MaskLength() {
+    return _ipv4MaskLength;
+  }
+
   @Override
   public boolean equals(@Nullable Object o) {
     if (this == o) {
@@ -43,16 +66,23 @@ public final class Interface implements Serializable {
       return false;
     }
     Interface that = (Interface) o;
-    return _name.equals(that._name) && _topology.equals(that._topology);
+    return _ipv4MaskLength == that._ipv4MaskLength
+        && _name.equals(that._name)
+        && _topology.equals(that._topology)
+        && _ipv4Address.equals(that._ipv4Address);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_name, _topology);
+    return Objects.hash(_name, _topology, _ipv4Address, _ipv4MaskLength);
   }
 
   private static final String PROP_NAME = "interface-name";
   private static final String PROP_TOPOLOGY = "topology";
+  private static final String PROP_IPV4_ADDRESS = "ipv4-address";
+  private static final String PROP_IPV4_MASK_LENGTH = "ipv4-mask-length";
   private final @Nonnull String _name;
+  private final @Nonnull Ip _ipv4Address;
+  private final int _ipv4MaskLength;
   private final @Nonnull InterfaceTopology _topology;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/InterfaceTopology.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/InterfaceTopology.java
@@ -11,13 +11,6 @@ import javax.annotation.Nullable;
 
 /** An interface topology as shown in show-gateways-and-servers */
 public class InterfaceTopology implements Serializable {
-
-  /**
-   * Instance of this class populated with arbitrary values. Useful for generating a valid object
-   * for use in tests.
-   */
-  public static final InterfaceTopology TEST_INSTANCE = new InterfaceTopology(false);
-
   @JsonCreator
   private static @Nonnull InterfaceTopology create(
       @JsonProperty(PROP_LEADS_TO_INTERNET) @Nullable Boolean leadsToInternet) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/InterfaceTopology.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/InterfaceTopology.java
@@ -11,6 +11,13 @@ import javax.annotation.Nullable;
 
 /** An interface topology as shown in show-gateways-and-servers */
 public class InterfaceTopology implements Serializable {
+
+  /**
+   * Instance of this class populated with arbitrary values. Useful for generating a valid object
+   * for use in tests.
+   */
+  public static final InterfaceTopology TEST_INSTANCE = new InterfaceTopology(false);
+
   @JsonCreator
   private static @Nonnull InterfaceTopology create(
       @JsonProperty(PROP_LEADS_TO_INTERNET) @Nullable Boolean leadsToInternet) {

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -1005,11 +1005,11 @@ public class CheckPointGatewayGrammarTest {
                 "access_rules",
                 ImmutableList.of(
                     new org.batfish.vendor.check_point_management.Interface(
-                        "eth1", new InterfaceTopology(false)),
+                        "eth1", new InterfaceTopology(false), Ip.parse("10.0.1.1"), 24),
                     new org.batfish.vendor.check_point_management.Interface(
-                        "eth2", new InterfaceTopology(true)),
+                        "eth2", new InterfaceTopology(true), Ip.parse("10.0.2.1"), 24),
                     new org.batfish.vendor.check_point_management.Interface(
-                        "eth3", new InterfaceTopology(true))),
+                        "eth3", new InterfaceTopology(true), Ip.parse("10.0.3.1"), 24)),
                 new GatewayOrServerPolicy("p1", null),
                 Uid.of("1")));
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiClusterMemberTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiClusterMemberTest.java
@@ -75,7 +75,7 @@ public final class CpmiClusterMemberTest {
             new CpmiClusterMember(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(Interface.TEST_INSTANCE),
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiClusterMemberTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiClusterMemberTest.java
@@ -75,7 +75,7 @@ public final class CpmiClusterMemberTest {
             new CpmiClusterMember(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(new Interface("iface", new InterfaceTopology(true))),
+                ImmutableList.of(Interface.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiGatewayClusterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiGatewayClusterTest.java
@@ -107,7 +107,7 @@ public final class CpmiGatewayClusterTest {
                 ImmutableList.of(),
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(new Interface("iface", new InterfaceTopology(true))),
+                ImmutableList.of(Interface.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiGatewayClusterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiGatewayClusterTest.java
@@ -107,7 +107,7 @@ public final class CpmiGatewayClusterTest {
                 ImmutableList.of(),
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(Interface.TEST_INSTANCE),
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobjTest.java
@@ -107,7 +107,7 @@ public final class CpmiVsClusterNetobjTest {
                 ImmutableList.of(),
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(new Interface("iface", new InterfaceTopology(true))),
+                ImmutableList.of(Interface.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobjTest.java
@@ -107,7 +107,7 @@ public final class CpmiVsClusterNetobjTest {
                 ImmutableList.of(),
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(Interface.TEST_INSTANCE),
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsNetobjTest.java
@@ -75,7 +75,7 @@ public final class CpmiVsNetobjTest {
             new CpmiVsNetobj(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(Interface.TEST_INSTANCE),
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsNetobjTest.java
@@ -75,7 +75,7 @@ public final class CpmiVsNetobjTest {
             new CpmiVsNetobj(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(new Interface("iface", new InterfaceTopology(true))),
+                ImmutableList.of(Interface.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterMemberTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterMemberTest.java
@@ -75,7 +75,7 @@ public final class CpmiVsxClusterMemberTest {
             new CpmiVsxClusterMember(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(Interface.TEST_INSTANCE),
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterMemberTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterMemberTest.java
@@ -75,7 +75,7 @@ public final class CpmiVsxClusterMemberTest {
             new CpmiVsxClusterMember(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(new Interface("iface", new InterfaceTopology(true))),
+                ImmutableList.of(Interface.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
@@ -107,7 +107,7 @@ public final class CpmiVsxClusterNetobjTest {
                 ImmutableList.of(),
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(new Interface("iface", new InterfaceTopology(true))),
+                ImmutableList.of(Interface.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
@@ -107,7 +107,7 @@ public final class CpmiVsxClusterNetobjTest {
                 ImmutableList.of(),
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(Interface.TEST_INSTANCE),
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxNetobjTest.java
@@ -75,7 +75,7 @@ public final class CpmiVsxNetobjTest {
             new CpmiVsxNetobj(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(new Interface("iface", new InterfaceTopology(true))),
+                ImmutableList.of(Interface.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxNetobjTest.java
@@ -75,7 +75,7 @@ public final class CpmiVsxNetobjTest {
             new CpmiVsxNetobj(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(Interface.TEST_INSTANCE),
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/InterfaceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/InterfaceTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
 import org.junit.Test;
 
 public class InterfaceTest {
@@ -17,26 +18,35 @@ public class InterfaceTest {
         "{"
             + "\"GARBAGE\":0,"
             + "\"interface-name\": \"iface\","
+            + "\"ipv4-address\": \"10.10.10.1\","
+            + "\"ipv4-mask-length\": 24,"
             + "\"topology\": {\"leads-to-internet\":true}"
             + "}";
     assertThat(
         BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Interface.class),
-        equalTo(new Interface("iface", new InterfaceTopology(true))));
+        equalTo(new Interface("iface", new InterfaceTopology(true), Ip.parse("10.10.10.1"), 24)));
   }
 
   @Test
   public void testJavaSerialization() {
-    Interface obj = new Interface("iface", new InterfaceTopology(true));
+    Interface obj = Interface.TEST_INSTANCE;
     assertEquals(obj, SerializationUtils.clone(obj));
   }
 
   @Test
   public void testEquals() {
-    Interface obj = new Interface("iface", new InterfaceTopology(true));
+    Interface obj = new Interface("iface", new InterfaceTopology(true), Ip.parse("10.10.10.1"), 24);
     new EqualsTester()
-        .addEqualityGroup(obj, new Interface("iface", new InterfaceTopology(true)))
-        .addEqualityGroup(new Interface("foo", new InterfaceTopology(true)))
-        .addEqualityGroup(new Interface("iface", new InterfaceTopology(false)))
+        .addEqualityGroup(
+            obj, new Interface("iface", new InterfaceTopology(true), Ip.parse("10.10.10.1"), 24))
+        .addEqualityGroup(
+            new Interface("foo", new InterfaceTopology(true), Ip.parse("10.10.10.1"), 24))
+        .addEqualityGroup(
+            new Interface("iface", new InterfaceTopology(false), Ip.parse("10.10.10.1"), 24))
+        .addEqualityGroup(
+            new Interface("iface", new InterfaceTopology(true), Ip.parse("10.10.10.10"), 24))
+        .addEqualityGroup(
+            new Interface("iface", new InterfaceTopology(true), Ip.parse("10.10.10.1"), 25))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/InterfaceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/InterfaceTest.java
@@ -12,6 +12,13 @@ import org.batfish.datamodel.Ip;
 import org.junit.Test;
 
 public class InterfaceTest {
+  /**
+   * Instance of this class populated with arbitrary values. Useful for generating a valid object
+   * for use in tests.
+   */
+  public static final Interface TEST_INSTANCE =
+      new Interface("eth0", InterfaceTopologyTest.TEST_INSTANCE, Ip.parse("10.0.1.1"), 24);
+
   @Test
   public void testJacksonDeserialization() throws JsonProcessingException {
     String input =
@@ -29,7 +36,7 @@ public class InterfaceTest {
 
   @Test
   public void testJavaSerialization() {
-    Interface obj = Interface.TEST_INSTANCE;
+    Interface obj = TEST_INSTANCE;
     assertEquals(obj, SerializationUtils.clone(obj));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/InterfaceTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/InterfaceTopologyTest.java
@@ -11,6 +11,12 @@ import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 public class InterfaceTopologyTest {
+  /**
+   * Instance of this class populated with arbitrary values. Useful for generating a valid object
+   * for use in tests.
+   */
+  public static final InterfaceTopology TEST_INSTANCE = new InterfaceTopology(false);
+
   @Test
   public void testJacksonDeserialization() throws JsonProcessingException {
     String input = "{ \"GARBAGE\":0, \"leads-to-internet\":\"true\" }";
@@ -21,7 +27,7 @@ public class InterfaceTopologyTest {
 
   @Test
   public void testJavaSerialization() {
-    InterfaceTopology obj = new InterfaceTopology(true);
+    InterfaceTopology obj = TEST_INSTANCE;
     assertEquals(obj, SerializationUtils.clone(obj));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/SimpleGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/SimpleGatewayTest.java
@@ -75,7 +75,7 @@ public final class SimpleGatewayTest {
             new SimpleGateway(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(Interface.TEST_INSTANCE),
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/SimpleGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/SimpleGatewayTest.java
@@ -75,7 +75,7 @@ public final class SimpleGatewayTest {
             new SimpleGateway(
                 Ip.ZERO,
                 "foo",
-                ImmutableList.of(new Interface("iface", new InterfaceTopology(true))),
+                ImmutableList.of(Interface.TEST_INSTANCE),
                 GatewayOrServerPolicy.empty(),
                 Uid.of("0")))
         .addEqualityGroup(


### PR DESCRIPTION
Parse `Interface` addresses and mask lengths.

Also, add `TEST_INSTANCE` to use in most tests, instead of manually constructing objects everywhere (with frequently changing params).
