### PR TITLE
CheckPoint: Use `IpSpace` visitor for conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -11,12 +11,9 @@ import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
-import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
@@ -25,37 +22,12 @@ import org.batfish.vendor.check_point_management.AccessLayer;
 import org.batfish.vendor.check_point_management.AccessRule;
 import org.batfish.vendor.check_point_management.AccessRuleOrSection;
 import org.batfish.vendor.check_point_management.AccessSection;
-import org.batfish.vendor.check_point_management.AddressRange;
-import org.batfish.vendor.check_point_management.Network;
 import org.batfish.vendor.check_point_management.RulebaseAction;
 import org.batfish.vendor.check_point_management.TypedManagementObject;
 import org.batfish.vendor.check_point_management.Uid;
 
 /** Utility class for Checkpoint conversion methods */
 public final class CheckPointGatewayConversions {
-  /**
-   * Converts the given {@link AddressRange} into an {@link IpSpace}, or returns {@code null} if the
-   * address range does not represent an IPv4 space.
-   */
-  static @Nullable IpSpace toIpSpace(AddressRange addressRange) {
-    // TODO Convert IPv6 address ranges
-    if (addressRange.getIpv4AddressFirst() == null || addressRange.getIpv4AddressLast() == null) {
-      return null;
-    }
-    return IpRange.range(addressRange.getIpv4AddressFirst(), addressRange.getIpv4AddressLast());
-  }
-
-  /** Converts the given {@link Network} into an {@link IpSpace}. */
-  static @Nonnull IpSpace toIpSpace(Network network) {
-    // TODO Network objects also have a "mask-length4" that we don't currently extract.
-    //  If network objects always represent valid Prefixes, it may be simpler to extract
-    //  that instead of subnet-mask and convert the network to a PrefixIpSpace.
-    // In Network, the mask has bits that matter set, but IpWildcard interprets set mask bits as
-    // "don't care". Flip mask to convert to IpWildcard.
-    long flippedMask = network.getSubnetMask().asLong() ^ Ip.MAX.asLong();
-    return IpWildcard.ipWithWildcardMask(network.getSubnet4(), flippedMask).toIpSpace();
-  }
-
   /**
    * Returns a {@code Map} of names to {@link IpAccessList}s corresponding to specified {@link
    * AccessLayer}.

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressSpaceToIpSpace.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressSpaceToIpSpace.java
@@ -32,7 +32,13 @@ public class AddressSpaceToIpSpace implements AddressSpaceVisitor<IpSpace> {
 
   @Override
   public IpSpace visitGatewayOrServer(GatewayOrServer gatewayOrServer) {
-    return gatewayOrServer.getIpv4Address().toIpSpace();
+    // TODO confirm semantics, should we use interface addresses or networks or ???
+    IpSpace ipSpace =
+        AclIpSpace.union(
+            gatewayOrServer.getInterfaces().stream()
+                .map(i -> i.getIpv4Address().toIpSpace())
+                .collect(ImmutableList.toImmutableList()));
+    return ipSpace == null ? EmptyIpSpace.INSTANCE : ipSpace;
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
@@ -6,11 +6,9 @@ import static org.batfish.datamodel.matchers.IpAccessListMatchers.accepts;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toAction;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toIpAccessLists;
-import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toIpSpace;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toMatchExpr;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -19,13 +17,10 @@ import java.util.Map;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpProtocol;
-import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
-import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.UniverseIpSpace;
@@ -34,7 +29,6 @@ import org.batfish.vendor.check_point_management.AccessLayer;
 import org.batfish.vendor.check_point_management.AccessRule;
 import org.batfish.vendor.check_point_management.AccessRuleOrSection;
 import org.batfish.vendor.check_point_management.AccessSection;
-import org.batfish.vendor.check_point_management.AddressRange;
 import org.batfish.vendor.check_point_management.CpmiAnyObject;
 import org.batfish.vendor.check_point_management.Network;
 import org.batfish.vendor.check_point_management.RulebaseAction;
@@ -98,32 +92,6 @@ public class CheckPointGatewayConversionsTest {
         .setDstPort(destinationPort)
         .setSrcPort(sourcePort)
         .build();
-  }
-
-  @Test
-  public void testToIpSpace_addressRange() {
-    Ip ip1 = Ip.parse("1.1.1.1");
-    Ip ip2 = Ip.parse("2.2.2.2");
-    AddressRange range = new AddressRange(ip1, ip2, null, null, "name", Uid.of("uid"));
-    assertThat(toIpSpace(range), equalTo(IpRange.range(ip1, ip2)));
-  }
-
-  @Test
-  public void testToIpSpace_addressRangeIpv6() {
-    Ip6 ip1 = Ip6.parse("1::1");
-    Ip6 ip2 = Ip6.parse("1::2");
-    AddressRange range = new AddressRange(null, null, ip1, ip2, "name", Uid.of("uid"));
-    assertNull(toIpSpace(range));
-  }
-
-  @Test
-  public void testToIpSpace_network() {
-    Ip ip = Ip.parse("1.1.1.0");
-    Ip mask = Ip.parse("255.255.255.0");
-    Network network = new Network("name", ip, mask, Uid.of("uid"));
-    Ip flippedMask = Ip.parse("0.0.0.255");
-    assertThat(
-        toIpSpace(network), equalTo(IpWildcard.ipWithWildcardMask(ip, flippedMask).toIpSpace()));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AddressSpaceToIpSpaceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AddressSpaceToIpSpaceTest.java
@@ -42,6 +42,26 @@ public class AddressSpaceToIpSpaceTest {
   }
 
   @Test
+  public void testGatewayOrServer() {
+    AddressSpaceToIpSpace visitor = new AddressSpaceToIpSpace(ImmutableMap.of());
+    GatewayOrServer gatewayOrServer =
+        new SimpleGateway(
+            Ip.parse("10.0.0.1"),
+            "simpleGateway",
+            ImmutableList.of(
+                new Interface(
+                    "eth1", InterfaceTopologyTest.TEST_INSTANCE, Ip.parse("10.0.1.1"), 24),
+                new Interface(
+                    "eth2", InterfaceTopologyTest.TEST_INSTANCE, Ip.parse("10.0.2.1"), 24)),
+            new GatewayOrServerPolicy(null, null),
+            Uid.of("1"));
+    assertThat(
+        gatewayOrServer.accept(visitor),
+        equalTo(
+            AclIpSpace.union(Ip.parse("10.0.1.1").toIpSpace(), Ip.parse("10.0.2.1").toIpSpace())));
+  }
+
+  @Test
   public void testGroup() {
     Uid group1Uid = Uid.of("1");
     Uid group2Uid = Uid.of("2");


### PR DESCRIPTION
Remove old toIpSpace conversion helpers and just use the AddressSpace to IpSpace visitors. Also add a reasonable placeholder `GatewayOrServer`->`IpSpace` impl.
