### PR TITLE
NX-OS: bgp network statement preferred over redistribution

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -267,6 +267,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   /** On NX-OS, management VRF has id 2. */
   public static final int MANAGEMENT_VRF_ID = 2;
 
+  /** Locally-generated BGP routes have a default weight of 32768. */
+  public static final int BGP_LOCAL_WEIGHT = 32768;
+
   // https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus7000/sw/qos/config/cisco_nexus7000_qos_config_guide_8x/configuring_classification.html
   /** On NX-OS, there is an implicit QoS class-map "class-default". */
   public static final String DEFAULT_CLASS_MAP_NAME = "class-default";
@@ -610,6 +613,76 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     // For NX-OS, next-hop is cleared on routes redistributed into BGP (though it may be rewritten
     // later in the policy).
     redistributionPolicy.addStatement(new SetNextHop(DiscardNextHop.INSTANCE));
+    // For NX-OS, local routes have a default weight of 32768.
+    redistributionPolicy.addStatement(new SetWeight(new LiteralInt(BGP_LOCAL_WEIGHT)));
+
+    // BGP network statements take effect before redistribution.
+    if (ipv4af != null) {
+      Multimap<Optional<String>, Prefix> networksByRouteMap =
+          ipv4af.getNetworks().stream()
+              .collect(
+                  Multimaps.toMultimap(
+                      n -> Optional.ofNullable(n.getRouteMap()),
+                      BgpVrfIpv4AddressFamilyConfiguration.Network::getNetwork,
+                      LinkedListMultimap::create));
+      networksByRouteMap
+          .asMap()
+          .forEach(
+              (maybeMap, prefixes) -> {
+                PrefixSpace exportSpace = new PrefixSpace();
+                prefixes.forEach(exportSpace::addPrefix);
+                @Nullable String routeMap = maybeMap.orElse(null);
+                List<BooleanExpr> exportNetworkConditions =
+                    ImmutableList.of(
+                        new MatchPrefixSet(
+                            DestinationNetwork.instance(), new ExplicitPrefixSet(exportSpace)),
+                        new Not(
+                            new MatchProtocol(
+                                RoutingProtocol.BGP,
+                                RoutingProtocol.IBGP,
+                                RoutingProtocol.AGGREGATE)),
+                        routeMap != null && _routeMaps.containsKey(routeMap)
+                            ? new CallExpr(routeMap)
+                            : BooleanExprs.TRUE);
+                newBgpProcess.addToOriginationSpace(exportSpace);
+                redistributionPolicy.addStatement(
+                    new If(
+                        new Conjunction(exportNetworkConditions),
+                        ImmutableList.of(
+                            new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
+                            Statements.ExitAccept.toStaticStatement())));
+              });
+    }
+
+    BgpVrfIpv6AddressFamilyConfiguration ipv6af = nxBgpVrf.getIpv6UnicastAddressFamily();
+    if (ipv6af != null) {
+      ipv6af
+          .getNetworks()
+          .forEach(
+              network -> {
+                @Nullable String routeMap = network.getRouteMap();
+                List<BooleanExpr> exportNetworkConditions =
+                    ImmutableList.of(
+                        new MatchPrefix6Set(
+                            new DestinationNetwork6(),
+                            new ExplicitPrefix6Set(
+                                new Prefix6Space(Prefix6Range.fromPrefix6(network.getNetwork())))),
+                        new Not(
+                            new MatchProtocol(
+                                RoutingProtocol.BGP,
+                                RoutingProtocol.IBGP,
+                                RoutingProtocol.AGGREGATE)),
+                        routeMap != null && _routeMaps.containsKey(routeMap)
+                            ? new CallExpr(routeMap)
+                            : BooleanExprs.TRUE);
+                redistributionPolicy.addStatement(
+                    new If(
+                        new Conjunction(exportNetworkConditions),
+                        ImmutableList.of(
+                            new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
+                            Statements.ExitAccept.toStaticStatement())));
+              });
+    }
 
     // Only redistribute default route if `default-information originate` is set.
     @Nullable
@@ -722,74 +795,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       eigrp.setComment("Redistribute EIGRP routes into BGP");
       redistributionPolicy.addStatement(
           new If(eigrp, ImmutableList.of(Statements.ExitAccept.toStaticStatement())));
-    }
-
-    // Now we add all the per-network export policies.
-    if (ipv4af != null) {
-      Multimap<Optional<String>, Prefix> networksByRouteMap =
-          ipv4af.getNetworks().stream()
-              .collect(
-                  Multimaps.toMultimap(
-                      n -> Optional.ofNullable(n.getRouteMap()),
-                      BgpVrfIpv4AddressFamilyConfiguration.Network::getNetwork,
-                      LinkedListMultimap::create));
-      networksByRouteMap
-          .asMap()
-          .forEach(
-              (maybeMap, prefixes) -> {
-                PrefixSpace exportSpace = new PrefixSpace();
-                prefixes.forEach(exportSpace::addPrefix);
-                @Nullable String routeMap = maybeMap.orElse(null);
-                List<BooleanExpr> exportNetworkConditions =
-                    ImmutableList.of(
-                        new MatchPrefixSet(
-                            DestinationNetwork.instance(), new ExplicitPrefixSet(exportSpace)),
-                        new Not(
-                            new MatchProtocol(
-                                RoutingProtocol.BGP,
-                                RoutingProtocol.IBGP,
-                                RoutingProtocol.AGGREGATE)),
-                        routeMap != null && _routeMaps.containsKey(routeMap)
-                            ? new CallExpr(routeMap)
-                            : BooleanExprs.TRUE);
-                newBgpProcess.addToOriginationSpace(exportSpace);
-                redistributionPolicy.addStatement(
-                    new If(
-                        new Conjunction(exportNetworkConditions),
-                        ImmutableList.of(
-                            new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
-                            Statements.ExitAccept.toStaticStatement())));
-              });
-    }
-
-    BgpVrfIpv6AddressFamilyConfiguration ipv6af = nxBgpVrf.getIpv6UnicastAddressFamily();
-    if (ipv6af != null) {
-      ipv6af
-          .getNetworks()
-          .forEach(
-              network -> {
-                @Nullable String routeMap = network.getRouteMap();
-                List<BooleanExpr> exportNetworkConditions =
-                    ImmutableList.of(
-                        new MatchPrefix6Set(
-                            new DestinationNetwork6(),
-                            new ExplicitPrefix6Set(
-                                new Prefix6Space(Prefix6Range.fromPrefix6(network.getNetwork())))),
-                        new Not(
-                            new MatchProtocol(
-                                RoutingProtocol.BGP,
-                                RoutingProtocol.IBGP,
-                                RoutingProtocol.AGGREGATE)),
-                        routeMap != null && _routeMaps.containsKey(routeMap)
-                            ? new CallExpr(routeMap)
-                            : BooleanExprs.TRUE);
-                redistributionPolicy.addStatement(
-                    new If(
-                        new Conjunction(exportNetworkConditions),
-                        ImmutableList.of(
-                            new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
-                            Statements.ExitAccept.toStaticStatement())));
-              });
     }
 
     // Finalize redistribution policy and attach to process

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -95,6 +95,7 @@ import static org.batfish.grammar.cisco_nxos.CiscoNxosControlPlaneExtractor.TCP_
 import static org.batfish.grammar.cisco_nxos.CiscoNxosControlPlaneExtractor.UDP_PORT_RANGE;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.BGP_LOCAL_WEIGHT;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.DEFAULT_VRF_ID;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.DEFAULT_VRF_NAME;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.MANAGEMENT_VRF_NAME;
@@ -862,6 +863,7 @@ public final class CiscoNxosGrammarTest {
             .setReceivedFromIp(ZERO) // indicates local origination
             .setSrcProtocol(RoutingProtocol.STATIC)
             .setTag(0L)
+            .setWeight(BGP_LOCAL_WEIGHT)
             .build();
     Bgpv4Route bgpRouteVrf2 =
         bgpRouteVrf1.toBuilder().setOriginatorIp(Ip.parse("10.10.10.2")).build();
@@ -926,6 +928,7 @@ public final class CiscoNxosGrammarTest {
                   .setOriginatorIp(bgpRouterId)
                   .setOriginType(OriginType.INCOMPLETE)
                   .setSrcProtocol(RoutingProtocol.EIGRP)
+                  .setWeight(BGP_LOCAL_WEIGHT)
                   .build()));
     }
     {
@@ -957,6 +960,7 @@ public final class CiscoNxosGrammarTest {
                   .setOriginatorIp(bgpRouterId)
                   .setOriginType(OriginType.INCOMPLETE)
                   .setSrcProtocol(RoutingProtocol.EIGRP)
+                  .setWeight(BGP_LOCAL_WEIGHT)
                   .build()));
     }
     {
@@ -999,6 +1003,7 @@ public final class CiscoNxosGrammarTest {
                   .setOriginatorIp(bgpRouterId)
                   .setOriginType(OriginType.INCOMPLETE)
                   .setSrcProtocol(RoutingProtocol.EIGRP_EX)
+                  .setWeight(BGP_LOCAL_WEIGHT)
                   .build()));
     }
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/bgp/nxos-bgp-network-redistribute
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/bgp/nxos-bgp-network-redistribute
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+feature bgp
+!
+hostname nxos-bgp-network-redistribute
+!
+route-map STATIC-ROUTES permit 10
+  match source-protocol static
+!
+ip route 1.1.1.1/32 null0
+!
+router bgp 1
+   router-id 1.2.3.4
+   address-family ipv4 unicast
+      network 1.1.1.1/32
+      redistribute static route-map STATIC-ROUTES
+!


### PR DESCRIPTION
If a route is both redistributed and generated by a network statement, the
network statement version wins.

Also added modeling of the local weight 32768 for these routes.