### PR TITLE
CheckPoint: Support `interfaces` in `CpmiHostCkp`

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiHostCkp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiHostCkp.java
@@ -20,17 +20,18 @@ public final class CpmiHostCkp extends GatewayOrServer {
       @JsonProperty(PROP_NAME) @Nullable String name,
       @JsonProperty(PROP_POLICY) @Nullable GatewayOrServerPolicy policy,
       @JsonProperty(PROP_UID) @Nullable Uid uid) {
+    checkArgument(interfaces != null, "Missing %s", PROP_INTERFACES);
     checkArgument(ipv4Address != null, "Missing %s", PROP_IPV4_ADDRESS);
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(policy != null, "Missing %s", PROP_POLICY);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new CpmiHostCkp(interfaces, ipv4Address, name, policy, uid);
+    return new CpmiHostCkp(ipv4Address, interfaces, name, policy, uid);
   }
 
   @VisibleForTesting
   CpmiHostCkp(
-      List<Interface> interfaces,
       Ip ipv4Address,
+      List<Interface> interfaces,
       String name,
       GatewayOrServerPolicy policy,
       Uid uid) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiHostCkp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiHostCkp.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -20,12 +21,12 @@ public final class CpmiHostCkp extends GatewayOrServer {
       @JsonProperty(PROP_NAME) @Nullable String name,
       @JsonProperty(PROP_POLICY) @Nullable GatewayOrServerPolicy policy,
       @JsonProperty(PROP_UID) @Nullable Uid uid) {
-    checkArgument(interfaces != null, "Missing %s", PROP_INTERFACES);
     checkArgument(ipv4Address != null, "Missing %s", PROP_IPV4_ADDRESS);
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(policy != null, "Missing %s", PROP_POLICY);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new CpmiHostCkp(ipv4Address, interfaces, name, policy, uid);
+    return new CpmiHostCkp(
+        ipv4Address, interfaces == null ? ImmutableList.of() : interfaces, name, policy, uid);
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiHostCkp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiHostCkp.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
@@ -15,6 +15,7 @@ public final class CpmiHostCkp extends GatewayOrServer {
 
   @JsonCreator
   private static @Nonnull CpmiHostCkp create(
+      @JsonProperty(PROP_INTERFACES) @Nullable List<Interface> interfaces,
       @JsonProperty(PROP_IPV4_ADDRESS) @Nullable Ip ipv4Address,
       @JsonProperty(PROP_NAME) @Nullable String name,
       @JsonProperty(PROP_POLICY) @Nullable GatewayOrServerPolicy policy,
@@ -23,12 +24,17 @@ public final class CpmiHostCkp extends GatewayOrServer {
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(policy != null, "Missing %s", PROP_POLICY);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new CpmiHostCkp(ipv4Address, name, policy, uid);
+    return new CpmiHostCkp(interfaces, ipv4Address, name, policy, uid);
   }
 
   @VisibleForTesting
-  CpmiHostCkp(Ip ipv4Address, String name, GatewayOrServerPolicy policy, Uid uid) {
-    super(ipv4Address, name, ImmutableList.of(), policy, uid);
+  CpmiHostCkp(
+      List<Interface> interfaces,
+      Ip ipv4Address,
+      String name,
+      GatewayOrServerPolicy policy,
+      Uid uid) {
+    super(ipv4Address, name, interfaces, policy, uid);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiHostCkpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiHostCkpTest.java
@@ -38,7 +38,11 @@ public final class CpmiHostCkpTest {
   public void testJavaSerialization() {
     CpmiHostCkp obj =
         new CpmiHostCkp(
-            Ip.ZERO, ImmutableList.of(), "foo", GatewayOrServerPolicy.empty(), Uid.of("0"));
+            Ip.ZERO,
+            ImmutableList.of(InterfaceTest.TEST_INSTANCE),
+            "foo",
+            GatewayOrServerPolicy.empty(),
+            Uid.of("0"));
     assertEquals(obj, SerializationUtils.clone(obj));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiHostCkpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiHostCkpTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -23,33 +24,61 @@ public final class CpmiHostCkpTest {
             + "\"uid\":\"0\","
             + "\"name\":\"foo\","
             + "\"ipv4-address\":\"0.0.0.0\","
+            + "\"interfaces\": [],"
             + "\"policy\":{}"
             + "}";
     assertThat(
         BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiHostCkp.class),
-        equalTo(new CpmiHostCkp(Ip.ZERO, "foo", GatewayOrServerPolicy.empty(), Uid.of("0"))));
+        equalTo(
+            new CpmiHostCkp(
+                Ip.ZERO, ImmutableList.of(), "foo", GatewayOrServerPolicy.empty(), Uid.of("0"))));
   }
 
   @Test
   public void testJavaSerialization() {
-    CpmiHostCkp obj = new CpmiHostCkp(Ip.ZERO, "foo", GatewayOrServerPolicy.empty(), Uid.of("0"));
+    CpmiHostCkp obj =
+        new CpmiHostCkp(
+            Ip.ZERO, ImmutableList.of(), "foo", GatewayOrServerPolicy.empty(), Uid.of("0"));
     assertEquals(obj, SerializationUtils.clone(obj));
   }
 
   @Test
   public void testEquals() {
-    CpmiHostCkp obj = new CpmiHostCkp(Ip.ZERO, "foo", GatewayOrServerPolicy.empty(), Uid.of("0"));
+    CpmiHostCkp obj =
+        new CpmiHostCkp(
+            Ip.ZERO, ImmutableList.of(), "foo", GatewayOrServerPolicy.empty(), Uid.of("0"));
     new EqualsTester()
         .addEqualityGroup(
-            obj, new CpmiHostCkp(Ip.ZERO, "foo", GatewayOrServerPolicy.empty(), Uid.of("0")))
+            obj,
+            new CpmiHostCkp(
+                Ip.ZERO, ImmutableList.of(), "foo", GatewayOrServerPolicy.empty(), Uid.of("0")))
         .addEqualityGroup(
-            new CpmiHostCkp(Ip.parse("0.0.0.1"), "foo", GatewayOrServerPolicy.empty(), Uid.of("0")))
+            new CpmiHostCkp(
+                Ip.parse("0.0.0.1"),
+                ImmutableList.of(),
+                "foo",
+                GatewayOrServerPolicy.empty(),
+                Uid.of("0")))
         .addEqualityGroup(
-            new CpmiHostCkp(Ip.ZERO, "bar", GatewayOrServerPolicy.empty(), Uid.of("0")))
+            new CpmiHostCkp(
+                Ip.ZERO, ImmutableList.of(), "bar", GatewayOrServerPolicy.empty(), Uid.of("0")))
         .addEqualityGroup(
-            new CpmiHostCkp(Ip.ZERO, "foo", new GatewayOrServerPolicy("t1", null), Uid.of("0")))
+            new CpmiHostCkp(
+                Ip.ZERO,
+                ImmutableList.of(),
+                "foo",
+                new GatewayOrServerPolicy("t1", null),
+                Uid.of("0")))
         .addEqualityGroup(
-            new CpmiHostCkp(Ip.ZERO, "foo", GatewayOrServerPolicy.empty(), Uid.of("1")))
+            new CpmiHostCkp(
+                Ip.ZERO, ImmutableList.of(), "foo", GatewayOrServerPolicy.empty(), Uid.of("1")))
+        .addEqualityGroup(
+            new CpmiHostCkp(
+                Ip.ZERO,
+                ImmutableList.of(InterfaceTest.TEST_INSTANCE),
+                "foo",
+                GatewayOrServerPolicy.empty(),
+                Uid.of("0")))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/GatewaysAndServersTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/GatewaysAndServersTest.java
@@ -43,6 +43,7 @@ public final class GatewaysAndServersTest {
             + "\"uid\":\"2\","
             + "\"name\":\"foo\","
             + "\"ipv4-address\":\"0.0.0.0\","
+            + "\"interfaces\":[],"
             + "\"policy\": {}"
             + "}," // object: CpmiHostCkp
             + "{" // object: CpmiVsClusterNetobj
@@ -121,7 +122,12 @@ public final class GatewaysAndServersTest {
                             Uid.of("1")))
                     .put(
                         Uid.of("2"),
-                        new CpmiHostCkp(Ip.ZERO, "foo", GatewayOrServerPolicy.empty(), Uid.of("2")))
+                        new CpmiHostCkp(
+                            Ip.ZERO,
+                            ImmutableList.of(),
+                            "foo",
+                            GatewayOrServerPolicy.empty(),
+                            Uid.of("2")))
                     .put(
                         Uid.of("3"),
                         new CpmiVsClusterNetobj(


### PR DESCRIPTION
`CpmiHostCkp` can contain `interfaces`