### PR TITLE
NamedAsPathSet: treat non-BGP routes as having empty as path

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedAsPathSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedAsPathSet.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.AsPathAccessList;
-import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.HasReadableAsPath;
 import org.batfish.datamodel.routing_policy.Environment;
 
 public final class NamedAsPathSet extends AsPathSetExpr {
@@ -50,16 +50,18 @@ public final class NamedAsPathSet extends AsPathSetExpr {
     if (list != null) {
       boolean match = false;
       AsPath inputAsPath = null;
-      if (environment.getUseOutputAttributes()
-          && environment.getOutputRoute() instanceof BgpRoute.Builder<?, ?>) {
-        BgpRoute.Builder<?, ?> bgpRouteBuilder =
-            (BgpRoute.Builder<?, ?>) environment.getOutputRoute();
-        inputAsPath = bgpRouteBuilder.getAsPath();
+      if (environment.getUseOutputAttributes()) {
+        if (environment.getOutputRoute() instanceof HasReadableAsPath) {
+          inputAsPath = ((HasReadableAsPath) environment.getOutputRoute()).getAsPath();
+        } else {
+          inputAsPath = AsPath.empty();
+        }
       } else if (environment.getReadFromIntermediateBgpAttributes()) {
         inputAsPath = environment.getIntermediateBgpAttributes().getAsPath();
-      } else if (environment.getOriginalRoute() instanceof BgpRoute) {
-        BgpRoute<?, ?> bgpRoute = (BgpRoute<?, ?>) environment.getOriginalRoute();
-        inputAsPath = bgpRoute.getAsPath();
+      } else if (environment.getOriginalRoute() instanceof HasReadableAsPath) {
+        inputAsPath = ((HasReadableAsPath) environment.getOriginalRoute()).getAsPath();
+      } else {
+        inputAsPath = AsPath.empty();
       }
       if (inputAsPath != null) {
         match = list.permits(inputAsPath);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedAsPathSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedAsPathSet.java
@@ -48,8 +48,7 @@ public final class NamedAsPathSet extends AsPathSetExpr {
   public boolean matches(Environment environment) {
     AsPathAccessList list = environment.getAsPathAccessLists().get(_name);
     if (list != null) {
-      boolean match = false;
-      AsPath inputAsPath = null;
+      AsPath inputAsPath;
       if (environment.getUseOutputAttributes()) {
         if (environment.getOutputRoute() instanceof HasReadableAsPath) {
           inputAsPath = ((HasReadableAsPath) environment.getOutputRoute()).getAsPath();
@@ -63,10 +62,8 @@ public final class NamedAsPathSet extends AsPathSetExpr {
       } else {
         inputAsPath = AsPath.empty();
       }
-      if (inputAsPath != null) {
-        match = list.permits(inputAsPath);
-      }
-      return match;
+      assert inputAsPath != null;
+      return list.permits(inputAsPath);
     } else {
       environment.setError(true);
       return false;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/NamedAsPathSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/NamedAsPathSetTest.java
@@ -1,0 +1,81 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.AsPathAccessList;
+import org.batfish.datamodel.AsPathAccessListLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.route.nh.NextHopInterface;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.junit.Test;
+
+public class NamedAsPathSetTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(new NamedAsPathSet("A"), new NamedAsPathSet("A"))
+        .addEqualityGroup(new NamedAsPathSet("B"))
+        .testEquals();
+  }
+
+  @Test
+  public void testSerialization() {
+    NamedAsPathSet expr = new NamedAsPathSet("A");
+    assertThat(expr, equalTo(BatfishObjectMapper.clone(expr, AsPathSetExpr.class)));
+    assertThat(expr, equalTo(SerializationUtils.clone(expr)));
+  }
+
+  @Test
+  public void testEvaluate() {
+    // Create two AsPathAccessLists, one that permits only the empty AsPath, and one that permits
+    // only the AsPath containing ASN 500.
+    AsPathAccessList emptyAsPath =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                "emptyAsPath",
+                ImmutableList.of(new AsPathAccessListLine(LineAction.PERMIT, "^$"))));
+    AsPathAccessList singleAsPath =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                "singleAsPath",
+                ImmutableList.of(new AsPathAccessListLine(LineAction.PERMIT, "^500$"))));
+
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder()
+            .setHostname("c")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    c.setAsPathAccessLists(
+        ImmutableMap.of(emptyAsPath.getName(), emptyAsPath, singleAsPath.getName(), singleAsPath));
+
+    // Empty
+    ConnectedRoute r =
+        ConnectedRoute.builder()
+            .setNetwork(Prefix.parse("1.2.3.0/24"))
+            .setNextHop(NextHopInterface.of("Ethernet1", Ip.parse("1.2.3.4")))
+            .build();
+    Environment env = Environment.builder(c).setOriginalRoute(r).build();
+    assertTrue(
+        "Empty AS Path regex matches connected route",
+        new NamedAsPathSet(emptyAsPath.getName()).matches(env));
+    assertFalse(
+        "AS Path of 500 does not match connected route",
+        new NamedAsPathSet(singleAsPath.getName()).matches(env));
+  }
+}


### PR DESCRIPTION
Also, relax from BGP to HasReadableAsPath.