### PR TITLE
CheckPoint: initial parsing of `<object>.json` files

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -129,6 +129,7 @@ public class BfConsts {
   public static final String RELPATH_CHECKPOINT_SHOW_GATEWAYS_AND_SERVERS =
       "show-gateways-and-servers.json";
   public static final String RELPATH_CHECKPOINT_SHOW_NAT_RULEBASE = "show-nat-rulebase.json";
+  public static final String RELPATH_CHECKPOINT_SHOW_NETWORKS = "show-networks.json";
   public static final String RELPATH_CHECKPOINT_SHOW_PACKAGE = "show-package.json";
   public static final String RELPATH_CONFIGURATIONS_DIR = "configs";
   public static final String RELPATH_EDGE_BLACKLIST_FILE = "edge_blacklist";

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -11,6 +11,7 @@ import static org.batfish.bddreachability.BDDReachabilityUtils.constructFlows;
 import static org.batfish.common.BfConsts.RELPATH_CHECKPOINT_SHOW_ACCESS_RULEBASE;
 import static org.batfish.common.BfConsts.RELPATH_CHECKPOINT_SHOW_GATEWAYS_AND_SERVERS;
 import static org.batfish.common.BfConsts.RELPATH_CHECKPOINT_SHOW_NAT_RULEBASE;
+import static org.batfish.common.BfConsts.RELPATH_CHECKPOINT_SHOW_NETWORKS;
 import static org.batfish.common.BfConsts.RELPATH_CHECKPOINT_SHOW_PACKAGE;
 import static org.batfish.common.runtime.SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA;
 import static org.batfish.common.util.CompletionMetadataUtils.getFilterNames;
@@ -249,7 +250,9 @@ import org.batfish.vendor.check_point_management.ManagementDomain;
 import org.batfish.vendor.check_point_management.ManagementPackage;
 import org.batfish.vendor.check_point_management.ManagementServer;
 import org.batfish.vendor.check_point_management.NatRulebase;
+import org.batfish.vendor.check_point_management.ObjectPage;
 import org.batfish.vendor.check_point_management.Package;
+import org.batfish.vendor.check_point_management.TypedManagementObject;
 import org.batfish.vendor.check_point_management.Uid;
 import org.batfish.version.BatfishVersion;
 import org.codehaus.jettison.json.JSONException;
@@ -1620,41 +1623,78 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return natRulebases.isEmpty() ? null : natRulebases.get(0);
   }
 
-  private @Nonnull CheckpointManagementConfiguration parseCheckpointManagementData(
-      @Nonnull Map<String, String> cpManagementData,
-      @Nonnull ParseVendorConfigurationAnswerElement pvcae)
-      throws IOException {
-    /* Organize server data into maps */
-    // server -> domain -> filename -> file contents
-    Map<String, Map<String, Map<String, String>>> domainFileMap = new HashMap<>();
-    // server -> domain -> -> package -> filename -> file contents
-    Map<String, Map<String, Map<String, Map<String, String>>>> packageFileMap = new HashMap<>();
-    cpManagementData.forEach(
-        (filePath, fileContent) -> {
-          String[] parts = filePath.split("/");
-          if (parts.length == 4) {
-            // checkpoint_management/SERVER_NAME/DOMAIN_NAME/foo.json
-            String serverName = parts[1];
-            String domainName = parts[2];
-            String fileName = parts[3];
-            domainFileMap
-                .computeIfAbsent(serverName, n -> new HashMap<>())
-                .computeIfAbsent(domainName, n -> new HashMap<>())
-                .put(fileName, fileContent);
-          } else if (parts.length == 5) {
-            // checkpoint_management/SERVER_NAME/DOMAIN_NAME/PACKAGE_NAME/foo.json
-            String serverName = parts[1];
-            String domainName = parts[2];
-            String packageName = parts[3];
-            String fileName = parts[4];
-            packageFileMap
-                .computeIfAbsent(serverName, n -> new HashMap<>())
-                .computeIfAbsent(domainName, n -> new HashMap<>())
-                .computeIfAbsent(packageName, n -> new HashMap<>())
-                .put(fileName, fileContent);
-          }
-        });
-    /* Extract server data into CheckpointManagementConfiguration */
+  /**
+   * Reads all {@link ObjectPage}s from specified {@code filename} and returns a consolidated list
+   * of {@link TypedManagementObject} from all pages.
+   */
+  private List<TypedManagementObject> readObjects(
+      String filename,
+      Map<String, Map<String, Map<String, String>>> domainFileMap,
+      String domainName,
+      String serverName,
+      ParseVendorConfigurationAnswerElement pvcae) {
+    String objFileContents =
+        domainFileMap
+            .getOrDefault(serverName, ImmutableMap.of())
+            .getOrDefault(domainName, ImmutableMap.of())
+            .get(filename);
+    if (objFileContents == null) {
+      pvcae.addRedFlagWarning(
+          BfConsts.RELPATH_CHECKPOINT_MANAGEMENT_DIR,
+          new Warning(
+              String.format(
+                  "Checkpoint management domain %s on server %s missing %s",
+                  domainName, serverName, filename),
+              "Checkpoint"));
+      return ImmutableList.of();
+    }
+
+    List<ObjectPage> objectPages = null;
+    try {
+      objectPages =
+          BatfishObjectMapper.ignoreUnknownMapper()
+              .readValue(objFileContents, new TypeReference<List<ObjectPage>>() {});
+    } catch (JsonProcessingException e) {
+      pvcae.addRedFlagWarning(
+          BfConsts.RELPATH_CHECKPOINT_MANAGEMENT_DIR,
+          new Warning(
+              String.format(
+                  "JsonProcessingException on Checkpoint management domain %s on server %s in %s",
+                  domainName, serverName, filename),
+              "Checkpoint"));
+      _logger.errorf("Failed to process JSON for domain %s on server %s in %s: %s", e);
+      return ImmutableList.of();
+    }
+    return objectPages.stream()
+        .flatMap(p -> p.getObjects().stream())
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private List<TypedManagementObject> buildObjectsList(
+      Map<String, Map<String, Map<String, String>>> domainFileMap,
+      String domainName,
+      String serverName,
+      ParseVendorConfigurationAnswerElement pvcae) {
+    return ImmutableList.of(RELPATH_CHECKPOINT_SHOW_NETWORKS).stream()
+        .flatMap(f -> readObjects(f, domainFileMap, domainName, serverName, pvcae).stream())
+        .filter(Objects::nonNull)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /**
+   * Returns a map of server name to {@link ManagementServer} based on supplied domain and package
+   * files.
+   *
+   * <p>{@code domainFileMap} is a map of server -> domain -> filename -> file contents
+   *
+   * <p>{@code packageFileMap} is a map of server -> domain -> -> package -> filename -> file
+   * contents
+   */
+  private Map<String, ManagementServer> buildServersMap(
+      Map<String, Map<String, Map<String, String>>> domainFileMap,
+      Map<String, Map<String, Map<String, Map<String, String>>>> packageFileMap,
+      ParseVendorConfigurationAnswerElement pvcae)
+      throws JsonProcessingException {
     ImmutableMap.Builder<String, ManagementServer> serversMap = ImmutableMap.builder();
     for (Entry<String, Map<String, Map<String, Map<String, String>>>> serverEntry :
         packageFileMap.entrySet()) {
@@ -1684,6 +1724,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
                     showGatewaysAndServers, new TypeReference<List<GatewaysAndServers>>() {});
         GatewaysAndServers gatewaysAndServers =
             mergeGatewaysAndServersPages(gatewaysAndServersList);
+
+        List<TypedManagementObject> objects =
+            buildObjectsList(domainFileMap, domainName, serverName, pvcae);
 
         ImmutableMap.Builder<Uid, ManagementPackage> packagesBuilder = ImmutableMap.builder();
         for (Entry<String, Map<String, String>> packageEntry : domainEntry.getValue().entrySet()) {
@@ -1725,12 +1768,51 @@ public class Batfish extends PluginConsumer implements IBatfish {
         // Use any package to find domain
         Domain domain = packages.values().iterator().next().getPackage().getDomain();
         ManagementDomain mgmtDomain =
-            new ManagementDomain(domain, gatewaysAndServers.getGatewaysAndServers(), packages);
+            new ManagementDomain(
+                domain, gatewaysAndServers.getGatewaysAndServers(), packages, objects);
         domainsMap.put(mgmtDomain.getName(), mgmtDomain);
       }
       serversMap.put(serverName, new ManagementServer(domainsMap.build(), serverName));
     }
-    return new CheckpointManagementConfiguration(serversMap.build());
+    return serversMap.build();
+  }
+
+  private @Nonnull CheckpointManagementConfiguration parseCheckpointManagementData(
+      @Nonnull Map<String, String> cpManagementData,
+      @Nonnull ParseVendorConfigurationAnswerElement pvcae)
+      throws IOException {
+    /* Organize server data into maps */
+    // server -> domain -> filename -> file contents
+    Map<String, Map<String, Map<String, String>>> domainFileMap = new HashMap<>();
+    // server -> domain -> -> package -> filename -> file contents
+    Map<String, Map<String, Map<String, Map<String, String>>>> packageFileMap = new HashMap<>();
+    cpManagementData.forEach(
+        (filePath, fileContent) -> {
+          String[] parts = filePath.split("/");
+          if (parts.length == 4) {
+            // checkpoint_management/SERVER_NAME/DOMAIN_NAME/foo.json
+            String serverName = parts[1];
+            String domainName = parts[2];
+            String fileName = parts[3];
+            domainFileMap
+                .computeIfAbsent(serverName, n -> new HashMap<>())
+                .computeIfAbsent(domainName, n -> new HashMap<>())
+                .put(fileName, fileContent);
+          } else if (parts.length == 5) {
+            // checkpoint_management/SERVER_NAME/DOMAIN_NAME/PACKAGE_NAME/foo.json
+            String serverName = parts[1];
+            String domainName = parts[2];
+            String packageName = parts[3];
+            String fileName = parts[4];
+            packageFileMap
+                .computeIfAbsent(serverName, n -> new HashMap<>())
+                .computeIfAbsent(domainName, n -> new HashMap<>())
+                .computeIfAbsent(packageName, n -> new HashMap<>())
+                .put(fileName, fileContent);
+          }
+        });
+    return new CheckpointManagementConfiguration(
+        buildServersMap(domainFileMap, packageFileMap, pvcae));
   }
 
   private @Nonnull GatewaysAndServers mergeGatewaysAndServersPages(

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ManagementDomain.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ManagementDomain.java
@@ -1,5 +1,7 @@
 package org.batfish.vendor.check_point_management;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -10,14 +12,20 @@ public final class ManagementDomain extends NamedManagementObject {
   public ManagementDomain(
       Domain domain,
       Map<Uid, GatewayOrServer> gatewaysAndServers,
-      Map<Uid, ManagementPackage> packages) {
+      Map<Uid, ManagementPackage> packages,
+      List<TypedManagementObject> objects) {
     super(domain.getName(), domain.getUid());
     _gatewaysAndServers = gatewaysAndServers;
     _packages = packages;
+    _objects = ImmutableList.copyOf(objects);
   }
 
   public @Nonnull Map<Uid, GatewayOrServer> getGatewaysAndServers() {
     return _gatewaysAndServers;
+  }
+
+  public @Nonnull List<TypedManagementObject> getObjects() {
+    return _objects;
   }
 
   public @Nonnull Map<Uid, ManagementPackage> getPackages() {
@@ -30,22 +38,26 @@ public final class ManagementDomain extends NamedManagementObject {
       return false;
     }
     ManagementDomain that = (ManagementDomain) o;
-    return _gatewaysAndServers.equals(that._gatewaysAndServers) && _packages.equals(that._packages);
+    return _gatewaysAndServers.equals(that._gatewaysAndServers)
+        && _objects.equals(that._objects)
+        && _packages.equals(that._packages);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(baseHashcode(), _gatewaysAndServers, _packages);
+    return Objects.hash(baseHashcode(), _gatewaysAndServers, _objects, _packages);
   }
 
   @Override
   public String toString() {
     return baseToStringHelper()
         .add("_gatewaysAndServers", _gatewaysAndServers)
+        .add("_objects", _objects)
         .add("_packages", _packages)
         .toString();
   }
 
   private final @Nonnull Map<Uid, GatewayOrServer> _gatewaysAndServers;
+  private final @Nonnull List<TypedManagementObject> _objects;
   private final @Nonnull Map<Uid, ManagementPackage> _packages;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Network.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Network.java
@@ -27,14 +27,17 @@ public final class Network extends TypedManagementObject implements AddressSpace
       @JsonProperty(PROP_UID) @Nullable Uid uid) {
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(natSettings != null, "Missing %s", PROP_NAT_SETTINGS);
-    checkArgument(subnet4 != null, "Missing %s", PROP_SUBNET4);
-    checkArgument(subnetMask != null, "Missing %s", PROP_SUBNET_MASK);
     checkArgument(uid != null, "Missing %s", PROP_UID);
     return new Network(name, natSettings, subnet4, subnetMask, uid);
   }
 
   @VisibleForTesting
-  public Network(String name, NatSettings natSettings, Ip subnet4, Ip subnetMask, Uid uid) {
+  public Network(
+      String name,
+      NatSettings natSettings,
+      @Nullable Ip subnet4,
+      @Nullable Ip subnetMask,
+      Uid uid) {
     super(name, uid);
     _natSettings = natSettings;
     _subnet4 = subnet4;
@@ -45,11 +48,11 @@ public final class Network extends TypedManagementObject implements AddressSpace
     return _natSettings;
   }
 
-  public @Nonnull Ip getSubnet4() {
+  public @Nullable Ip getSubnet4() {
     return _subnet4;
   }
 
-  public @Nonnull Ip getSubnetMask() {
+  public @Nullable Ip getSubnetMask() {
     return _subnetMask;
   }
 
@@ -60,8 +63,8 @@ public final class Network extends TypedManagementObject implements AddressSpace
     }
     Network network = (Network) o;
     return _natSettings.equals(network._natSettings)
-        && _subnet4.equals(network._subnet4)
-        && _subnetMask.equals(network._subnetMask);
+        && Objects.equals(_subnet4, network._subnet4)
+        && Objects.equals(_subnetMask, network._subnetMask);
   }
 
   @Override
@@ -83,6 +86,6 @@ public final class Network extends TypedManagementObject implements AddressSpace
   private static final String PROP_SUBNET_MASK = "subnet-mask";
 
   private final @Nonnull NatSettings _natSettings;
-  private final @Nonnull Ip _subnet4;
-  private final @Nonnull Ip _subnetMask;
+  private final @Nullable Ip _subnet4;
+  private final @Nullable Ip _subnetMask;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ObjectPage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ObjectPage.java
@@ -1,0 +1,58 @@
+package org.batfish.vendor.check_point_management;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Representation of a single page of objects, as returned by a single call to the CheckPoint REST
+ * API.
+ */
+public final class ObjectPage implements Serializable {
+
+  public @Nonnull List<TypedManagementObject> getObjects() {
+    return _objects;
+  }
+
+  @JsonCreator
+  private static @Nonnull ObjectPage create(
+      @JsonProperty(PROP_OBJECTS) @Nullable List<TypedManagementObject> objects) {
+    checkArgument(objects != null, "Missing %s", PROP_OBJECTS);
+    return new ObjectPage(objects);
+  }
+
+  @VisibleForTesting
+  public ObjectPage(List<TypedManagementObject> objects) {
+    _objects = ImmutableList.copyOf(objects);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof ObjectPage)) {
+      return false;
+    }
+    ObjectPage that = (ObjectPage) o;
+    return _objects.equals(that._objects);
+  }
+
+  @Override
+  public String toString() {
+    return _objects.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return _objects.hashCode();
+  }
+
+  private static final String PROP_OBJECTS = "objects";
+
+  private final @Nonnull List<TypedManagementObject> _objects;
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -54,6 +54,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -197,13 +198,17 @@ public class CheckPointGatewayGrammarTest {
    * with the specified {@code gateways} and {@code packages}.
    */
   private CheckpointManagementConfiguration toCheckpointMgmtConfig(
-      Map<Uid, GatewayOrServer> gateways, Map<Uid, ManagementPackage> packages) {
+      Map<Uid, GatewayOrServer> gateways,
+      Map<Uid, ManagementPackage> packages,
+      List<TypedManagementObject> objects) {
     return new CheckpointManagementConfiguration(
         ImmutableMap.of(
             "s",
             new ManagementServer(
                 ImmutableMap.of(
-                    "d", new ManagementDomain(new Domain("d", Uid.of("0")), gateways, packages)),
+                    "d",
+                    new ManagementDomain(
+                        new Domain("d", Uid.of("0")), gateways, packages, objects)),
                 "s")));
   }
 
@@ -932,7 +937,8 @@ public class CheckPointGatewayGrammarTest {
                     true,
                     Uid.of("16"))));
 
-    CheckpointManagementConfiguration mgmt = toCheckpointMgmtConfig(gateways, packages);
+    CheckpointManagementConfiguration mgmt =
+        toCheckpointMgmtConfig(gateways, packages, ImmutableList.of());
     Map<String, Configuration> configs =
         parseTextConfigs(
             mgmt,
@@ -1029,7 +1035,8 @@ public class CheckPointGatewayGrammarTest {
                 new GatewayOrServerPolicy("p1", null),
                 Uid.of("1")));
 
-    CheckpointManagementConfiguration mgmt = toCheckpointMgmtConfig(gateways, packages);
+    CheckpointManagementConfiguration mgmt =
+        toCheckpointMgmtConfig(gateways, packages, ImmutableList.of());
     Map<String, Configuration> configs = parseTextConfigs(mgmt, "access_rules");
     Configuration c = configs.get("access_rules");
 
@@ -1092,7 +1099,8 @@ public class CheckPointGatewayGrammarTest {
                 new GatewayOrServerPolicy("p1", null),
                 Uid.of("1")));
 
-    CheckpointManagementConfiguration mgmt = toCheckpointMgmtConfig(gateways, packages);
+    CheckpointManagementConfiguration mgmt =
+        toCheckpointMgmtConfig(gateways, packages, ImmutableList.of());
     Batfish batfish = getBatfishForConfigurationNames(mgmt, access_rules);
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ManagementDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ManagementDomainTest.java
@@ -15,22 +15,30 @@ public final class ManagementDomainTest {
   @Test
   public void testJavaSerialization() {
     ManagementDomain obj =
-        new ManagementDomain(new Domain("a", Uid.of("1")), ImmutableMap.of(), ImmutableMap.of());
+        new ManagementDomain(
+            new Domain("a", Uid.of("1")), ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
     assertEquals(obj, SerializationUtils.clone(obj));
   }
 
   @Test
   public void testEquals() {
     ManagementDomain obj =
-        new ManagementDomain(new Domain("a", Uid.of("1")), ImmutableMap.of(), ImmutableMap.of());
+        new ManagementDomain(
+            new Domain("a", Uid.of("1")), ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
     new EqualsTester()
         .addEqualityGroup(
             obj,
             new ManagementDomain(
-                new Domain("a", Uid.of("1")), ImmutableMap.of(), ImmutableMap.of()))
+                new Domain("a", Uid.of("1")),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableList.of()))
         .addEqualityGroup(
             new ManagementDomain(
-                new Domain("b", Uid.of("1")), ImmutableMap.of(), ImmutableMap.of()))
+                new Domain("b", Uid.of("1")),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableList.of()))
         .addEqualityGroup(
             new ManagementDomain(
                 new Domain("a", Uid.of("1")),
@@ -42,7 +50,8 @@ public final class ManagementDomainTest {
                         ImmutableList.of(),
                         GatewayOrServerPolicy.empty(),
                         Uid.of("2"))),
-                ImmutableMap.of()))
+                ImmutableMap.of(),
+                ImmutableList.of()))
         .addEqualityGroup(
             new ManagementDomain(
                 new Domain("a", Uid.of("1")),
@@ -58,7 +67,14 @@ public final class ManagementDomainTest {
                             "b",
                             false,
                             false,
-                            Uid.of("1"))))))
+                            Uid.of("1")))),
+                ImmutableList.of()))
+        .addEqualityGroup(
+            new ManagementDomain(
+                new Domain("a", Uid.of("1")),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableList.of(NetworkTest.TEST_INSTANCE)))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ManagementServerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ManagementServerTest.java
@@ -3,6 +3,7 @@ package org.batfish.vendor.check_point_management;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
@@ -27,7 +28,10 @@ public final class ManagementServerTest {
                 ImmutableMap.of(
                     "d",
                     new ManagementDomain(
-                        new Domain("a", Uid.of("1")), ImmutableMap.of(), ImmutableMap.of())),
+                        new Domain("a", Uid.of("1")),
+                        ImmutableMap.of(),
+                        ImmutableMap.of(),
+                        ImmutableList.of())),
                 "a"))
         .addEqualityGroup(new ManagementServer(ImmutableMap.of(), "b"))
         .testEquals();

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NetworkTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NetworkTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 /** Test of {@link Network}. */
 public final class NetworkTest {
 
-  private static final Network TEST_INSTANCE =
+  public static final Network TEST_INSTANCE =
       new Network("foo", NatSettingsTest.TEST_INSTANCE, Ip.ZERO, Ip.MAX, Uid.of("0"));
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ObjectPageTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ObjectPageTest.java
@@ -1,0 +1,84 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
+import org.junit.Test;
+
+/** Test of {@link ObjectPage}. */
+public final class ObjectPageTest {
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"GARBAGE\":0,"
+            + "\"objects\":["
+            + "{" // object: CpmiClusterMember
+            + "\"type\":\"CpmiClusterMember\","
+            + "\"uid\":\"0\","
+            + "\"name\":\"foo\","
+            + "\"interfaces\":[],"
+            + "\"ipv4-address\":\"0.0.0.0\","
+            + "\"policy\": {}"
+            + "}," // object: CpmiClusterMember
+            + "{" // object: Network
+            + "\"GARBAGE\":0,"
+            + "\"type\":\"network\","
+            + "\"uid\":\"0\","
+            + "\"name\":\"foo\","
+            + "\"nat-settings\": {" // nat-settings
+            + "\"auto-rule\":true,"
+            + "\"hide-behind\":\"gateway\","
+            + "\"install-on\":\"All\","
+            + "\"method\":\"hide\""
+            + "}," // nat-settings
+            + "\"subnet4\":\"0.0.0.0\","
+            + "\"subnet-mask\":\"255.255.255.255\""
+            + "}" // object: Network
+            + "]"
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, ObjectPage.class),
+        equalTo(
+            new ObjectPage(
+                ImmutableList.of(
+                    new CpmiClusterMember(
+                        Ip.parse("0.0.0.0"),
+                        "foo",
+                        ImmutableList.of(),
+                        new GatewayOrServerPolicy(null, null),
+                        Uid.of("0")),
+                    NetworkTest.TEST_INSTANCE))));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    ObjectPage obj =
+        new ObjectPage(
+            ImmutableList.of(
+                new CpmiClusterMember(
+                    Ip.parse("0.0.0.0"),
+                    "foo",
+                    ImmutableList.of(),
+                    new GatewayOrServerPolicy(null, null),
+                    Uid.of("0")),
+                NetworkTest.TEST_INSTANCE));
+    assertEquals(obj, SerializationUtils.clone(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    ObjectPage obj = new ObjectPage(ImmutableList.of(NetworkTest.TEST_INSTANCE));
+    new EqualsTester()
+        .addEqualityGroup(obj, new ObjectPage(ImmutableList.of(NetworkTest.TEST_INSTANCE)))
+        .addEqualityGroup(new ObjectPage(ImmutableList.of()))
+        .testEquals();
+  }
+}


### PR DESCRIPTION
This PR adds initial parsing of object JSON files for CheckPoint management data. This is required to resolve object references for things like NAT and Access Rulebases.

So far, only `show-networks.json` is supported.

Also in this PR:
* Tweak to `Network`, to allow parsing of Ipv6 networks
* Small reorg of existing CheckPoint management data parsing
* Adding these parsed objects to the `ManagementDomain` (not yet actually used in conversion)
