### PR TITLE
CheckPoint: Convert `objects` from ManagementDomain

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -51,6 +52,7 @@ import org.batfish.vendor.check_point_management.GatewayOrServer;
 import org.batfish.vendor.check_point_management.ManagementDomain;
 import org.batfish.vendor.check_point_management.ManagementPackage;
 import org.batfish.vendor.check_point_management.ManagementServer;
+import org.batfish.vendor.check_point_management.NamedManagementObject;
 import org.batfish.vendor.check_point_management.NatMethod;
 import org.batfish.vendor.check_point_management.NatRulebase;
 import org.batfish.vendor.check_point_management.TypedManagementObject;
@@ -141,7 +143,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
     if (!maybePackage.isPresent()) {
       return;
     }
-    convertPackage(maybePackage.get(), gateway);
+    convertPackage(maybePackage.get(), gateway, domain);
   }
 
   private void convertAccessLayers(List<AccessLayer> accessLayers) {
@@ -203,18 +205,23 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
    * Convert constructs in the specified package to their VI model equivalent and add them to the VI
    * configuration.
    */
-  private void convertPackage(ManagementPackage pakij, GatewayOrServer gateway) {
-    convertObjects(pakij);
+  private void convertPackage(
+      ManagementPackage pakij, GatewayOrServer gateway, ManagementDomain domain) {
+    convertObjects(pakij, domain);
     convertAccessLayers(pakij.getAccessLayers());
     Optional.ofNullable(pakij.getNatRulebase()).ifPresent(r -> convertNatRulebase(r, gateway));
   }
 
-  private void convertObjects(ManagementPackage pakij) {
+  private void convertObjects(ManagementPackage pakij, ManagementDomain domain) {
     Optional.ofNullable(pakij.getNatRulebase())
         .ifPresent(natRulebase -> convertObjects(natRulebase.getObjectsDictionary()));
     pakij.getAccessLayers().stream()
         .map(AccessLayer::getObjectsDictionary)
         .forEach(this::convertObjects);
+    convertObjects(
+        domain.getObjects().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(NamedManagementObject::getUid, Function.identity())));
   }
 
   /** Converts the given {@link NatRulebase} and applies it to this config. */

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -960,6 +960,49 @@ public class CheckPointGatewayGrammarTest {
   }
 
   @Test
+  public void testConvertDomainObjects() throws IOException {
+    ImmutableMap<Uid, GatewayOrServer> gateways =
+        ImmutableMap.of(
+            Uid.of("1"),
+            new SimpleGateway(
+                Ip.parse("1.0.0.1"),
+                "g1",
+                ImmutableList.of(),
+                new GatewayOrServerPolicy("p1", null),
+                Uid.of("1")));
+    ImmutableMap<Uid, ManagementPackage> packages =
+        ImmutableMap.of(
+            Uid.of("2"),
+            new ManagementPackage(
+                ImmutableList.of(),
+                null,
+                new Package(
+                    new Domain("d", Uid.of("0")),
+                    AllInstallationTargets.instance(),
+                    "p1",
+                    false,
+                    true,
+                    Uid.of("2"))));
+
+    CheckpointManagementConfiguration mgmt =
+        toCheckpointMgmtConfig(
+            gateways,
+            packages,
+            ImmutableList.of(
+                new Network(
+                    "networkObject",
+                    NAT_SETTINGS_TEST_INSTANCE,
+                    Ip.parse("10.11.12.0"),
+                    Ip.parse("255.255.255.0"),
+                    Uid.of("100"))));
+
+    Map<String, Configuration> configs = parseTextConfigs(mgmt, "gw_package_selection_1");
+    Configuration c1 = configs.get("gw_package_selection_1");
+    // Network object from domain should make it to VI model
+    assertThat(c1.getIpSpaces(), hasKey("networkObject"));
+  }
+
+  @Test
   public void testAccessRulesConversion() throws IOException {
     Uid cpmiAnyUid = Uid.of("99999");
     CpmiAnyObject any = new CpmiAnyObject(cpmiAnyUid);


### PR DESCRIPTION
In addition to converting objects embedded in rulebases, convert ManagementDomain objects.
