### PR TITLE
Checkpoint cluster class cleanup

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiGatewayCluster.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiGatewayCluster.java
@@ -29,7 +29,7 @@ public final class CpmiGatewayCluster extends Cluster {
     checkArgument(policy != null, "Missing %s", PROP_POLICY);
     checkArgument(uid != null, "Missing %s", PROP_UID);
     return new CpmiGatewayCluster(
-        firstNonNull(clusterMemberNames, ImmutableList.of()),
+        ImmutableList.copyOf(firstNonNull(clusterMemberNames, ImmutableList.of())),
         ipv4Address,
         name,
         interfaces,

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobj.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobj.java
@@ -1,10 +1,12 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,13 +23,18 @@ public final class CpmiVsClusterNetobj extends Cluster {
       @JsonProperty(PROP_NAME) @Nullable String name,
       @JsonProperty(PROP_POLICY) @Nullable GatewayOrServerPolicy policy,
       @JsonProperty(PROP_UID) @Nullable Uid uid) {
-    checkArgument(clusterMemberNames != null, "Missing %s", PROP_CLUSTER_MEMBER_NAMES);
     checkArgument(interfaces != null, "Missing %s", PROP_INTERFACES);
     checkArgument(ipv4Address != null, "Missing %s", PROP_IPV4_ADDRESS);
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(policy != null, "Missing %s", PROP_POLICY);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new CpmiVsClusterNetobj(clusterMemberNames, ipv4Address, name, interfaces, policy, uid);
+    return new CpmiVsClusterNetobj(
+        ImmutableList.copyOf(firstNonNull(clusterMemberNames, ImmutableList.of())),
+        ipv4Address,
+        name,
+        interfaces,
+        policy,
+        uid);
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobj.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobj.java
@@ -1,10 +1,12 @@
 package org.batfish.vendor.check_point_management;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,13 +23,18 @@ public final class CpmiVsxClusterNetobj extends Cluster {
       @JsonProperty(PROP_NAME) @Nullable String name,
       @JsonProperty(PROP_POLICY) @Nullable GatewayOrServerPolicy policy,
       @JsonProperty(PROP_UID) @Nullable Uid uid) {
-    checkArgument(clusterMemberNames != null, "Missing %s", PROP_CLUSTER_MEMBER_NAMES);
     checkArgument(interfaces != null, "Missing %s", PROP_INTERFACES);
     checkArgument(ipv4Address != null, "Missing %s", PROP_IPV4_ADDRESS);
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(policy != null, "Missing %s", PROP_POLICY);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new CpmiVsxClusterNetobj(clusterMemberNames, ipv4Address, name, interfaces, policy, uid);
+    return new CpmiVsxClusterNetobj(
+        ImmutableList.copyOf(firstNonNull(clusterMemberNames, ImmutableList.of())),
+        ipv4Address,
+        name,
+        interfaces,
+        policy,
+        uid);
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobjTest.java
@@ -46,6 +46,35 @@ public final class CpmiVsClusterNetobjTest {
   }
 
   @Test
+  public void testJacksonDeserialization_noMembers() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"GARBAGE\":0,"
+            + "\"type\":\"CpmiVsClusterNetobj\","
+            + "\"uid\":\"0\","
+            + "\"name\":\"foo\","
+            + "\"ipv4-address\":\"0.0.0.0\","
+            + "\"interfaces\": [],"
+            + "\"policy\":{"
+            + "\"access-policy-installed\": true,"
+            + "\"access-policy-name\": \"p1\","
+            + "\"threat-policy-installed\": true,"
+            + "\"threat-policy-name\": \"p2\""
+            + "}" // policy
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiVsClusterNetobj.class),
+        equalTo(
+            new CpmiVsClusterNetobj(
+                ImmutableList.of(),
+                Ip.ZERO,
+                "foo",
+                ImmutableList.of(),
+                new GatewayOrServerPolicy("p1", "p2"),
+                Uid.of("0"))));
+  }
+
+  @Test
   public void testJavaSerialization() {
     CpmiVsClusterNetobj obj =
         new CpmiVsClusterNetobj(

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
@@ -46,6 +46,35 @@ public final class CpmiVsxClusterNetobjTest {
   }
 
   @Test
+  public void testJacksonDeserialization_noMembers() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"GARBAGE\":0,"
+            + "\"type\":\"CpmiVsxClusterNetobj\","
+            + "\"uid\":\"0\","
+            + "\"name\":\"foo\","
+            + "\"ipv4-address\":\"0.0.0.0\","
+            + "\"interfaces\": [],"
+            + "\"policy\":{"
+            + "\"access-policy-installed\": true,"
+            + "\"access-policy-name\": \"p1\","
+            + "\"threat-policy-installed\": true,"
+            + "\"threat-policy-name\": \"p2\""
+            + "}" // policy
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiVsxClusterNetobj.class),
+        equalTo(
+            new CpmiVsxClusterNetobj(
+                ImmutableList.of(),
+                Ip.ZERO,
+                "foo",
+                ImmutableList.of(),
+                new GatewayOrServerPolicy("p1", "p2"),
+                Uid.of("0"))));
+  }
+
+  @Test
   public void testJavaSerialization() {
     CpmiVsxClusterNetobj obj =
         new CpmiVsxClusterNetobj(


### PR DESCRIPTION
- use ImmutableList for cluster member names
- allow cluster member names to be absent on all cluster subclasses