### PR TITLE
Checkpoint mgmt convert show-gateways-and-servers data to IpSpace

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -56,9 +56,9 @@ import org.batfish.vendor.check_point_management.GatewayOrServer;
 import org.batfish.vendor.check_point_management.ManagementDomain;
 import org.batfish.vendor.check_point_management.ManagementPackage;
 import org.batfish.vendor.check_point_management.ManagementServer;
+import org.batfish.vendor.check_point_management.NamedManagementObject;
 import org.batfish.vendor.check_point_management.NatMethod;
 import org.batfish.vendor.check_point_management.NatRulebase;
-import org.batfish.vendor.check_point_management.TypedManagementObject;
 import org.batfish.vendor.check_point_management.Uid;
 import org.batfish.vendor.check_point_management.UnknownTypedManagementObject;
 
@@ -186,8 +186,10 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
    * object.</b>
    *
    * <p>Warns about unknown object types.
+   *
+   * @param objs
    */
-  private void convertObjects(Map<Uid, TypedManagementObject> objs) {
+  private void convertObjects(Map<Uid, NamedManagementObject> objs) {
     AddressSpaceToIpSpace addressSpaceToIpSpace = new AddressSpaceToIpSpace(objs);
     objs.values()
         .forEach(
@@ -222,7 +224,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
   }
 
   private void convertObjects(ManagementPackage pakij, ManagementDomain domain) {
-    Map<Uid, TypedManagementObject> objects = new HashMap<>();
+    Map<Uid, NamedManagementObject> objects = new HashMap<>();
     Optional.ofNullable(pakij.getNatRulebase())
         .map(NatRulebase::getObjectsDictionary)
         .ifPresent(objects::putAll);
@@ -230,6 +232,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
         .map(AccessLayer::getObjectsDictionary)
         .forEach(objects::putAll);
     domain.getObjects().forEach(object -> objects.put(object.getUid(), object));
+    objects.putAll(domain.getGatewaysAndServers());
     convertObjects(objects);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -186,8 +186,6 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
    * object.</b>
    *
    * <p>Warns about unknown object types.
-   *
-   * @param objs
    */
   private void convertObjects(Map<Uid, NamedManagementObject> objs) {
     AddressSpaceToIpSpace addressSpaceToIpSpace = new AddressSpaceToIpSpace(objs);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressRange.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressRange.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
 
-public final class AddressRange extends AddressSpace {
+public final class AddressRange extends TypedManagementObject implements AddressSpace {
 
   @Override
   public <T> T accept(AddressSpaceVisitor<T> visitor) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressSpace.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressSpace.java
@@ -1,17 +1,12 @@
 package org.batfish.vendor.check_point_management;
 
 /** An object that may be used to represent an address space. */
-public abstract class AddressSpace extends TypedManagementObject implements NatTranslatedAddress {
+public interface AddressSpace extends HasName, NatTranslatedAddress {
 
-  protected AddressSpace(String name, Uid uid) {
-    super(name, uid);
-  }
-
-  @Override
-  public <T> T accept(NatTranslatedAddressVisitor<T> visitor) {
+  default <T> T accept(NatTranslatedAddressVisitor<T> visitor) {
     // TODO: may want to implement solely in implementing classes instead
     return visitor.visitAddressSpace(this);
   }
 
-  public abstract <T> T accept(AddressSpaceVisitor<T> visitor);
+  <T> T accept(AddressSpaceVisitor<T> visitor);
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressSpace.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AddressSpace.java
@@ -3,6 +3,7 @@ package org.batfish.vendor.check_point_management;
 /** An object that may be used to represent an address space. */
 public interface AddressSpace extends HasName, NatTranslatedAddress {
 
+  @Override
   default <T> T accept(NatTranslatedAddressVisitor<T> visitor) {
     // TODO: may want to implement solely in implementing classes instead
     return visitor.visitAddressSpace(this);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
  * original-source} field of a {@link NatRule}, indicates that any value shall be matched for that
  * field when applying the rule.
  */
-public final class CpmiAnyObject extends AddressSpace implements Service {
+public final class CpmiAnyObject extends TypedManagementObject implements AddressSpace, Service {
 
   @Override
   public <T> T accept(AddressSpaceVisitor<T> visitor) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/GatewayOrServer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/GatewayOrServer.java
@@ -26,7 +26,7 @@ import org.batfish.datamodel.Ip;
   @JsonSubTypes.Type(value = CpmiVsxNetobj.class, name = "CpmiVsxNetobj"),
   @JsonSubTypes.Type(value = SimpleGateway.class, name = "simple-gateway"),
 })
-public abstract class GatewayOrServer extends NamedManagementObject {
+public abstract class GatewayOrServer extends NamedManagementObject implements AddressSpace {
 
   protected GatewayOrServer(
       @Nullable Ip ipv4Address,
@@ -38,6 +38,12 @@ public abstract class GatewayOrServer extends NamedManagementObject {
     _interfaces = interfaces;
     _ipv4Address = ipv4Address;
     _policy = policy;
+  }
+
+  @Override
+  public final <T> T accept(AddressSpaceVisitor<T> visitor) {
+    // TODO: more granularity?
+    return visitor.visitGatewayOrServer(this);
   }
 
   public @Nonnull List<Interface> getInterfaces() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Group.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Group.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class Group extends AddressSpace {
+public final class Group extends TypedManagementObject implements AddressSpace {
   @Override
   public <T> T accept(AddressSpaceVisitor<T> visitor) {
     return visitor.visitGroup(this);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/HasName.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/HasName.java
@@ -1,0 +1,9 @@
+package org.batfish.vendor.check_point_management;
+
+import javax.annotation.Nonnull;
+
+/** An object that has a name. */
+public interface HasName {
+  @Nonnull
+  String getName();
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Host.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Host.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 
 /** A single host address. */
-public final class Host extends AddressSpace implements Machine {
+public final class Host extends TypedManagementObject implements AddressSpace, Machine {
 
   @Override
   public <T> T accept(AddressSpaceVisitor<T> visitor) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NamedManagementObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NamedManagementObject.java
@@ -14,6 +14,7 @@ public abstract class NamedManagementObject extends ManagementObject implements 
     _name = name;
   }
 
+  @Override
   public final @Nonnull String getName() {
     return _name;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NamedManagementObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NamedManagementObject.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /** Abstract class representing a management object with a name and UID. */
-public abstract class NamedManagementObject extends ManagementObject {
+public abstract class NamedManagementObject extends ManagementObject implements HasName {
 
   protected static final String PROP_NAME = "name";
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Network.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Network.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 
 /** An IPv4 network. */
-public final class Network extends AddressSpace {
+public final class Network extends TypedManagementObject implements AddressSpace {
 
   @Override
   public <T> T accept(AddressSpaceVisitor<T> visitor) {

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AddressSpaceToIpSpaceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AddressSpaceToIpSpaceTest.java
@@ -46,8 +46,6 @@ public class AddressSpaceToIpSpaceTest {
     assertThat(cpmiAnyObject.accept(visitor), equalTo(UniverseIpSpace.INSTANCE));
   }
 
-  // TODO: uncomment and use forthcoming show-objects schema gateway or server class
-  /*
   @Test
   public void testGatewayOrServer() {
     AddressSpaceToIpSpace visitor = new AddressSpaceToIpSpace(ImmutableMap.of());
@@ -62,12 +60,8 @@ public class AddressSpaceToIpSpaceTest {
                     "eth2", InterfaceTopologyTest.TEST_INSTANCE, Ip.parse("10.0.2.1"), 24)),
             new GatewayOrServerPolicy(null, null),
             Uid.of("1"));
-    assertThat(
-        gatewayOrServer.accept(visitor),
-        equalTo(
-            AclIpSpace.union(Ip.parse("10.0.1.1").toIpSpace(), Ip.parse("10.0.2.1").toIpSpace())));
-
-  }*/
+    assertThat(gatewayOrServer.accept(visitor), equalTo(Ip.parse("10.0.0.1").toIpSpace()));
+  }
 
   @Test
   public void testGroup() {
@@ -91,7 +85,7 @@ public class AddressSpaceToIpSpaceTest {
 
     AddressSpaceToIpSpace visitor =
         new AddressSpaceToIpSpace(
-            ImmutableMap.<Uid, TypedManagementObject>builder()
+            ImmutableMap.<Uid, NamedManagementObject>builder()
                 .put(group1Uid, group1)
                 .put(group2Uid, group2)
                 .put(group3Uid, group3)


### PR DESCRIPTION
- yet another hierarchy reorganization
- assume gateway as IpSpace means its IPv4 mgmt address, since other
  ata does not appear in show-objects schema.