### PR TITLE
Checkpoint: fix handling of ServiceTcp port ranges

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -14,12 +14,12 @@ import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
@@ -269,7 +269,7 @@ public final class CheckPointGatewayConversions {
       //      Also, need to verify that port is an integer and decide what to do if not
       assert _hsb != null;
       _hsb.setIpProtocols(IpProtocol.TCP);
-      _hsb.setDstPorts(SubRange.singleton(Integer.parseInt(serviceTcp.getPort())));
+      _hsb.setDstPorts(IntegerSpace.parse(serviceTcp.getPort()).getSubRanges());
       return null;
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceTcp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceTcp.java
@@ -15,6 +15,7 @@ public final class ServiceTcp extends TypedManagementObject implements Service {
     return visitor.visitServiceTcp(this);
   }
 
+  /** Docs: Destination ports, a comma separated list of ports/ranges. */
   @Nonnull
   public String getPort() {
     return _port;

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
@@ -251,14 +251,14 @@ public final class CheckPointGatewayConversionsTest {
           toHeaderSpace(
               new Host(Ip.parse("1.1.1.1"), NAT_SETTINGS_TEST_INSTANCE, "source", uid),
               new Host(Ip.parse("2.2.2.2"), NAT_SETTINGS_TEST_INSTANCE, "dest", uid),
-              new ServiceTcp("foo", "1", uid),
+              new ServiceTcp("foo", "1-100,105-106", uid),
               warnings),
           equalTo(
               Optional.of(
                   HeaderSpace.builder()
                       .setSrcIps(new IpSpaceReference("source"))
                       .setDstIps(new IpSpaceReference("dest"))
-                      .setDstPorts(ImmutableList.of(SubRange.singleton(1)))
+                      .setDstPorts(ImmutableList.of(new SubRange(1, 100), new SubRange(105, 106)))
                       .setIpProtocols(IpProtocol.TCP)
                       .build())));
     }


### PR DESCRIPTION
This hotfix assumes that IntegerSpace parse just works.
We should probably have VS special handling, unless we can
confirm that the syntax used on device always confirms to
that accepted by IntegerSpace.