### PR TITLE
Checkpoint: test type hierarchy

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AccessRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AccessRuleTest.java
@@ -40,7 +40,7 @@ public final class AccessRuleTest {
               + "\"vpn\":[\"9\"]"
               + "}";
       assertThat(
-          BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessRule.class),
+          BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessRuleOrSection.class),
           equalTo(
               AccessRule.testBuilder()
                   .setAction(Uid.of("1"))
@@ -81,7 +81,7 @@ public final class AccessRuleTest {
               + "\"vpn\":[\"9\"]"
               + "}";
       assertThat(
-          BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessRule.class),
+          BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessRuleOrSection.class),
           equalTo(
               AccessRule.testBuilder()
                   .setAction(Uid.of("1"))

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AccessSectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AccessSectionTest.java
@@ -46,7 +46,7 @@ public final class AccessSectionTest {
             + "]" // rulebase
             + "}"; // AccessSection
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessSection.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessRuleOrSection.class),
         equalTo(
             new AccessSection(
                 "foo",
@@ -79,7 +79,7 @@ public final class AccessSectionTest {
             + "\"rulebase\":[]"
             + "}"; // AccessSection
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessSection.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AccessRuleOrSection.class),
         equalTo(new AccessSection("Section 0", ImmutableList.of(), Uid.of("0"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AddressRangeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/AddressRangeTest.java
@@ -45,7 +45,7 @@ public final class AddressRangeTest {
             + "\"ipv6-address-last\":\"::1\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, AddressRange.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(
             new AddressRange(
                 Ip.ZERO,

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiClusterMemberTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiClusterMemberTest.java
@@ -33,7 +33,7 @@ public final class CpmiClusterMemberTest {
             + "}" // policy
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiClusterMember.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new CpmiClusterMember(
                 Ip.ZERO,

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiGatewayClusterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiGatewayClusterTest.java
@@ -34,7 +34,7 @@ public final class CpmiGatewayClusterTest {
             + "}" // policy
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiGatewayCluster.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new CpmiGatewayCluster(
                 ImmutableList.of("m1"),

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiHostCkpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiHostCkpTest.java
@@ -28,7 +28,7 @@ public final class CpmiHostCkpTest {
             + "\"policy\":{}"
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiHostCkp.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new CpmiHostCkp(
                 Ip.ZERO, ImmutableList.of(), "foo", GatewayOrServerPolicy.empty(), Uid.of("0"))));

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsClusterNetobjTest.java
@@ -34,7 +34,7 @@ public final class CpmiVsClusterNetobjTest {
             + "}" // policy
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiVsClusterNetobj.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new CpmiVsClusterNetobj(
                 ImmutableList.of("m1"),

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsNetobjTest.java
@@ -33,7 +33,7 @@ public final class CpmiVsNetobjTest {
             + "}" // policy
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiVsNetobj.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new CpmiVsNetobj(
                 Ip.ZERO,

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterMemberTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterMemberTest.java
@@ -33,7 +33,7 @@ public final class CpmiVsxClusterMemberTest {
             + "}" // policy
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiVsxClusterMember.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new CpmiVsxClusterMember(
                 Ip.ZERO,

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
@@ -34,7 +34,7 @@ public final class CpmiVsxClusterNetobjTest {
             + "}" // policy
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiVsxClusterNetobj.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new CpmiVsxClusterNetobj(
                 ImmutableList.of("m1"),

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxNetobjTest.java
@@ -33,7 +33,7 @@ public final class CpmiVsxNetobjTest {
             + "}" // policy
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, CpmiVsxNetobj.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new CpmiVsxNetobj(
                 Ip.ZERO,

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/GroupTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/GroupTest.java
@@ -25,7 +25,7 @@ public final class GroupTest {
             + "\"members\":[\"2\", \"42\"]"
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Group.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(new Group("foo", ImmutableList.of(Uid.of("2"), Uid.of("42")), Uid.of("1"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/HostTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/HostTest.java
@@ -34,7 +34,7 @@ public final class HostTest {
             + "\"ipv4-address\":\"0.0.0.0\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Host.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(TEST_INSTANCE));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NatRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NatRuleTest.java
@@ -52,7 +52,7 @@ public final class NatRuleTest {
               + "\"translated-source\":\"6\""
               + "}";
       assertThat(
-          BatfishObjectMapper.ignoreUnknownMapper().readValue(input, NatRule.class),
+          BatfishObjectMapper.ignoreUnknownMapper().readValue(input, NatRuleOrSection.class),
           equalTo(TEST_INSTANCE));
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NatSectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NatSectionTest.java
@@ -28,7 +28,7 @@ public final class NatSectionTest {
             + "\"rulebase\":[]" // rulebase
             + "}"; // NatSection
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, NatSection.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, NatRuleOrSection.class),
         equalTo(TEST_INSTANCE));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NetworkTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/NetworkTest.java
@@ -35,7 +35,7 @@ public final class NetworkTest {
             + "\"subnet-mask\":\"255.255.255.255\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Network.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(TEST_INSTANCE));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/OriginalTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/OriginalTest.java
@@ -22,7 +22,7 @@ public final class OriginalTest {
             + "\"name\":\"Original\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Global.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(new Original(Uid.of("0"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/PackageTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/PackageTest.java
@@ -34,7 +34,7 @@ public final class PackageTest {
               + "}"; // Package
 
       assertThat(
-          BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Package.class),
+          BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
           equalTo(
               new Package(
                   new Domain("bar", Uid.of("1")),

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/PolicyTargetsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/PolicyTargetsTest.java
@@ -22,7 +22,7 @@ public final class PolicyTargetsTest {
             + "\"name\":\"Policy Targets\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Global.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(new PolicyTargets(Uid.of("0"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/RulebaseActionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/RulebaseActionTest.java
@@ -27,7 +27,7 @@ public final class RulebaseActionTest {
             + "\"comments\":\"bar\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, RulebaseAction.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(new RulebaseAction("foo", Uid.of("0"), "bar")));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceTcpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceTcpTest.java
@@ -24,7 +24,7 @@ public final class ServiceTcpTest {
             + "\"port\":\"8642\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, ServiceTcp.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(new ServiceTcp("foo", "8642", Uid.of("1"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceUdpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceUdpTest.java
@@ -24,7 +24,7 @@ public final class ServiceUdpTest {
             + "\"port\":\"8642\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, ServiceUdp.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(new ServiceUdp("foo", "8642", Uid.of("1"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/SimpleGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/SimpleGatewayTest.java
@@ -33,7 +33,7 @@ public final class SimpleGatewayTest {
             + "}" // policy
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, SimpleGateway.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, GatewayOrServer.class),
         equalTo(
             new SimpleGateway(
                 Ip.ZERO,

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/UnhandledGlobalTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/UnhandledGlobalTest.java
@@ -22,7 +22,7 @@ public final class UnhandledGlobalTest {
             + "\"name\":\"what\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, Global.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(new UnhandledGlobal("what", Uid.of("0"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/UnknownTypedManagementObjectTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/UnknownTypedManagementObjectTest.java
@@ -24,8 +24,7 @@ public final class UnknownTypedManagementObjectTest {
             + "\"a field that also isn't handled\":\"0.0.0.0\""
             + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper()
-            .readValue(input, UnknownTypedManagementObject.class),
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
         equalTo(
             new UnknownTypedManagementObject(
                 "foo", Uid.of("0"), "some type that isn't handled yet")));


### PR DESCRIPTION
JSON serialization tests should always test the class with @JsonTypeInfo on it.
This is because that is what the known type will be when deserializing these
fields as part of another object.