### PR TITLE
CheckPoint: Use all objects during Access/NAT rule conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -24,12 +25,13 @@ import org.batfish.vendor.check_point_management.GatewayOrServer;
 import org.batfish.vendor.check_point_management.Host;
 import org.batfish.vendor.check_point_management.Machine;
 import org.batfish.vendor.check_point_management.MachineVisitor;
+import org.batfish.vendor.check_point_management.NamedManagementObject;
 import org.batfish.vendor.check_point_management.NatRule;
 import org.batfish.vendor.check_point_management.NatRuleOrSectionVisitor;
 import org.batfish.vendor.check_point_management.NatRulebase;
 import org.batfish.vendor.check_point_management.NatSection;
 import org.batfish.vendor.check_point_management.Original;
-import org.batfish.vendor.check_point_management.TypedManagementObject;
+import org.batfish.vendor.check_point_management.Uid;
 
 public class CheckpointNatConversions {
 
@@ -72,9 +74,9 @@ public class CheckpointNatConversions {
    * manual HIDE NAT rule.
    */
   static @Nonnull Optional<List<TransformationStep>> manualHideTransformationSteps(
-      TypedManagementObject src,
-      TypedManagementObject dst,
-      TypedManagementObject service,
+      NamedManagementObject src,
+      NamedManagementObject dst,
+      NamedManagementObject service,
       Warnings warnings) {
     ImmutableList.Builder<TransformationStep> steps = ImmutableList.builder();
     if (!checkValidManualHide(src, dst, service, warnings)) {
@@ -91,9 +93,9 @@ public class CheckpointNatConversions {
    */
   @VisibleForTesting
   static boolean checkValidManualHide(
-      TypedManagementObject src,
-      TypedManagementObject dst,
-      TypedManagementObject service,
+      NamedManagementObject src,
+      NamedManagementObject dst,
+      NamedManagementObject service,
       Warnings warnings) {
     boolean valid = true;
     if (!(src instanceof Machine)) {
@@ -158,20 +160,20 @@ public class CheckpointNatConversions {
    * fields.
    */
   static @Nonnull Optional<Transformation> manualHideRuleTransformation(
-      NatRulebase natRulebase,
       org.batfish.vendor.check_point_management.NatRule natRule,
+      Map<Uid, ? extends NamedManagementObject> objects,
       Warnings warnings) {
     Optional<HeaderSpace> maybeOriginalHeaderSpace =
         toHeaderSpace(
-            natRulebase.getObjectsDictionary().get(natRule.getOriginalSource()),
-            natRulebase.getObjectsDictionary().get(natRule.getOriginalDestination()),
-            natRulebase.getObjectsDictionary().get(natRule.getOriginalService()),
+            objects.get(natRule.getOriginalSource()),
+            objects.get(natRule.getOriginalDestination()),
+            objects.get(natRule.getOriginalService()),
             warnings);
     Optional<List<TransformationStep>> maybeSteps =
         manualHideTransformationSteps(
-            natRulebase.getObjectsDictionary().get(natRule.getTranslatedSource()),
-            natRulebase.getObjectsDictionary().get(natRule.getTranslatedDestination()),
-            natRulebase.getObjectsDictionary().get(natRule.getTranslatedService()),
+            objects.get(natRule.getTranslatedSource()),
+            objects.get(natRule.getTranslatedDestination()),
+            objects.get(natRule.getTranslatedService()),
             warnings);
     if (!maybeOriginalHeaderSpace.isPresent() || !maybeSteps.isPresent()) {
       return Optional.empty();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessLayer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessLayer.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 /** Data model for an entry of the list response to the {@code show-access-rulebase} command. */
 public final class AccessLayer extends NamedManagementObject {
 
-  public @Nonnull Map<Uid, TypedManagementObject> getObjectsDictionary() {
+  public @Nonnull Map<Uid, NamedManagementObject> getObjectsDictionary() {
     return _objectsDictionary;
   }
 
@@ -46,7 +46,7 @@ public final class AccessLayer extends NamedManagementObject {
 
   @VisibleForTesting
   public AccessLayer(
-      Map<Uid, TypedManagementObject> objectsDictionary,
+      Map<Uid, NamedManagementObject> objectsDictionary,
       List<AccessRuleOrSection> rulebase,
       Uid uid,
       String name) {
@@ -81,6 +81,6 @@ public final class AccessLayer extends NamedManagementObject {
   private static final String PROP_OBJECTS_DICTIONARY = "objects-dictionary";
   private static final String PROP_RULEBASE = "rulebase";
 
-  private final @Nonnull Map<Uid, TypedManagementObject> _objectsDictionary;
+  private final @Nonnull Map<Uid, NamedManagementObject> _objectsDictionary;
   private final @Nonnull List<AccessRuleOrSection> _rulebase;
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
@@ -41,6 +41,7 @@ import org.batfish.vendor.check_point_management.AccessRuleOrSection;
 import org.batfish.vendor.check_point_management.AccessSection;
 import org.batfish.vendor.check_point_management.CpmiAnyObject;
 import org.batfish.vendor.check_point_management.Host;
+import org.batfish.vendor.check_point_management.NamedManagementObject;
 import org.batfish.vendor.check_point_management.NatSettings;
 import org.batfish.vendor.check_point_management.Network;
 import org.batfish.vendor.check_point_management.PolicyTargets;
@@ -66,8 +67,8 @@ public final class CheckPointGatewayConversionsTest {
   private static final Uid UID_SERVICE_TCP_22 = Uid.of("13");
   private static final Uid UID_SERVICE_UDP_222 = Uid.of("14");
   private static final CpmiAnyObject CPMI_ANY = new CpmiAnyObject(UID_CPMI_ANY);
-  private static final ImmutableMap<Uid, TypedManagementObject> TEST_OBJS =
-      ImmutableMap.<Uid, TypedManagementObject>builder()
+  private static final ImmutableMap<Uid, NamedManagementObject> TEST_OBJS =
+      ImmutableMap.<Uid, NamedManagementObject>builder()
           .put(
               UID_NET0,
               new Network(
@@ -170,7 +171,7 @@ public final class CheckPointGatewayConversionsTest {
     AccessLayer accessLayer =
         new AccessLayer(TEST_OBJS, rulebase, Uid.of("uidLayer"), "accessLayerName");
 
-    Map<String, IpAccessList> ipAccessLists = toIpAccessLists(accessLayer);
+    Map<String, IpAccessList> ipAccessLists = toIpAccessLists(accessLayer, TEST_OBJS);
     assertThat(
         ipAccessLists.keySet(), containsInAnyOrder(aclName(accessLayer), aclName(accessSection)));
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversionsTest.java
@@ -176,6 +176,8 @@ public final class CheckpointNatConversionsTest {
     String hostname = "host";
     Host host = new Host(hostIp, NAT_SETTINGS_TEST_INSTANCE, hostname, hostUid);
     {
+      ImmutableMap<Uid, TypedManagementObject> objs =
+          ImmutableMap.of(hostUid, host, PT_UID, POLICY_TARGETS, ORIG_UID, ORIG);
       NatRule rule =
           new NatRule(
               false,
@@ -190,18 +192,14 @@ public final class CheckpointNatConversionsTest {
               ORIG_UID,
               ORIG_UID,
               hostUid,
-              UID);
-      NatRulebase natRulebase =
-          new NatRulebase(
-              ImmutableMap.of(hostUid, host, PT_UID, POLICY_TARGETS, ORIG_UID, ORIG),
-              ImmutableList.of(rule),
               UID);
 
       // invalid original fields
-      assertThat(
-          manualHideRuleTransformation(natRulebase, rule, warnings), equalTo(Optional.empty()));
+      assertThat(manualHideRuleTransformation(rule, objs, warnings), equalTo(Optional.empty()));
     }
     {
+      ImmutableMap<Uid, TypedManagementObject> objs =
+          ImmutableMap.of(ANY_UID, ANY, PT_UID, POLICY_TARGETS);
       NatRule rule =
           new NatRule(
               false,
@@ -217,15 +215,13 @@ public final class CheckpointNatConversionsTest {
               PT_UID,
               PT_UID,
               UID);
-      NatRulebase natRulebase =
-          new NatRulebase(
-              ImmutableMap.of(ANY_UID, ANY, PT_UID, POLICY_TARGETS), ImmutableList.of(rule), UID);
 
       // invalid translated fields
-      assertThat(
-          manualHideRuleTransformation(natRulebase, rule, warnings), equalTo(Optional.empty()));
+      assertThat(manualHideRuleTransformation(rule, objs, warnings), equalTo(Optional.empty()));
     }
     {
+      ImmutableMap<Uid, TypedManagementObject> objs =
+          ImmutableMap.of(ANY_UID, ANY, ORIG_UID, ORIG, hostUid, host);
       NatRule rule =
           new NatRule(
               false,
@@ -241,14 +237,9 @@ public final class CheckpointNatConversionsTest {
               ORIG_UID,
               hostUid,
               UID);
-      NatRulebase natRulebase =
-          new NatRulebase(
-              ImmutableMap.of(ANY_UID, ANY, ORIG_UID, ORIG, hostUid, host),
-              ImmutableList.of(rule),
-              UID);
 
       assertThat(
-          manualHideRuleTransformation(natRulebase, rule, warnings),
+          manualHideRuleTransformation(rule, objs, warnings),
           equalTo(
               Optional.of(
                   Transformation.when(new MatchHeaderSpace(HeaderSpace.builder().build()))


### PR DESCRIPTION
Use all objects during conversion, not just the ones directly attached to the rulebase.
