### PR TITLE
CheckPoint: revamp service conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.NotMatchExpr;
@@ -64,7 +65,7 @@ public final class CheckPointGatewayConversions {
     exprs.add(new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(toIpSpace(src)).build()));
     exprs.add(new MatchHeaderSpace(HeaderSpace.builder().setDstIps(toIpSpace(dst)).build()));
     exprs.add(((Service) service).accept(serviceToMatchExpr));
-    return Optional.of(new AndMatchExpr(exprs.build()));
+    return Optional.of(AclLineMatchExprs.and(exprs.build()));
   }
 
   /**
@@ -214,7 +215,7 @@ public final class CheckPointGatewayConversions {
         new OrMatchExpr(
             services.stream()
                 .map(objs::get)
-                .filter(Service.class::isInstance)
+                .filter(Service.class::isInstance) // TODO warn about bad refs
                 .map(Service.class::cast)
                 .map(s -> s.accept(serviceToMatchExpr))
                 .collect(ImmutableList.toImmutableList()));

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -15,13 +15,11 @@ import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
-import org.batfish.datamodel.HeaderSpace.Builder;
-import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
@@ -37,11 +35,7 @@ import org.batfish.vendor.check_point_management.GatewayOrServer;
 import org.batfish.vendor.check_point_management.NamedManagementObject;
 import org.batfish.vendor.check_point_management.RulebaseAction;
 import org.batfish.vendor.check_point_management.Service;
-import org.batfish.vendor.check_point_management.ServiceGroup;
-import org.batfish.vendor.check_point_management.ServiceIcmp;
-import org.batfish.vendor.check_point_management.ServiceTcp;
-import org.batfish.vendor.check_point_management.ServiceUdp;
-import org.batfish.vendor.check_point_management.ServiceVisitor;
+import org.batfish.vendor.check_point_management.ServiceToMatchExpr;
 import org.batfish.vendor.check_point_management.TypedManagementObject;
 import org.batfish.vendor.check_point_management.Uid;
 
@@ -49,26 +43,23 @@ import org.batfish.vendor.check_point_management.Uid;
 public final class CheckPointGatewayConversions {
 
   /**
-   * Convert src, dst, and service to a {@link HeaderSpace} if they are of valid types. Else, return
-   * {@link Optional#empty()}.
+   * Convert src, dst, and service to an {@link AclLineMatchExpr} if they are of valid types. Else,
+   * return {@link Optional#empty()}.
    */
-  static @Nonnull Optional<HeaderSpace> toHeaderSpace(
+  static @Nonnull Optional<AclLineMatchExpr> toMatchExpr(
       NamedManagementObject src,
       NamedManagementObject dst,
       NamedManagementObject service,
+      ServiceToMatchExpr serviceToMatchExpr,
       Warnings warnings) {
     if (!checkValidHeaderSpaceInputs(src, dst, service, warnings)) {
       return Optional.empty();
     }
-    HeaderSpace.Builder hsb = HeaderSpace.builder();
-    if (!(src instanceof CpmiAnyObject)) {
-      hsb.setSrcIps(new IpSpaceReference(src.getName()));
-    }
-    if (!(dst instanceof CpmiAnyObject)) {
-      hsb.setDstIps(new IpSpaceReference(dst.getName()));
-    }
-    applyServiceConstraint((Service) service, hsb);
-    return Optional.of(hsb.build());
+    ImmutableList.Builder<AclLineMatchExpr> exprs = ImmutableList.builder();
+    exprs.add(new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(toIpSpace(src)).build()));
+    exprs.add(new MatchHeaderSpace(HeaderSpace.builder().setDstIps(toIpSpace(dst)).build()));
+    exprs.add(((Service) service).accept(serviceToMatchExpr));
+    return Optional.of(new AndMatchExpr(exprs.build()));
   }
 
   /**
@@ -114,16 +105,18 @@ public final class CheckPointGatewayConversions {
    * {@link AccessRule}s will be embedded directly in their parent's {@link IpAccessList}.
    */
   static Map<String, IpAccessList> toIpAccessLists(
-      @Nonnull AccessLayer access, Map<Uid, NamedManagementObject> objects) {
+      @Nonnull AccessLayer access,
+      Map<Uid, NamedManagementObject> objects,
+      ServiceToMatchExpr serviceToMatchExpr) {
     ImmutableMap.Builder<String, IpAccessList> acls = ImmutableMap.builder();
     ImmutableList.Builder<AclLine> accessLayerLines = ImmutableList.builder();
     for (AccessRuleOrSection acl : access.getRulebase()) {
       if (acl instanceof AccessRule) {
-        accessLayerLines.add(toAclLine((AccessRule) acl, objects));
+        accessLayerLines.add(toAclLine((AccessRule) acl, objects, serviceToMatchExpr));
         continue;
       }
       assert acl instanceof AccessSection;
-      IpAccessList accessSection = toIpAccessList((AccessSection) acl, objects);
+      IpAccessList accessSection = toIpAccessList((AccessSection) acl, objects, serviceToMatchExpr);
       acls.put(accessSection.getName(), accessSection);
       accessLayerLines.add(new AclAclLine(accessSection.getName(), accessSection.getName()));
     }
@@ -141,23 +134,28 @@ public final class CheckPointGatewayConversions {
 
   /** Convert the specified {@link AccessSection} into an {@link IpAccessList}. */
   private static IpAccessList toIpAccessList(
-      @Nonnull AccessSection section, Map<Uid, NamedManagementObject> objs) {
+      @Nonnull AccessSection section,
+      Map<Uid, NamedManagementObject> objs,
+      ServiceToMatchExpr serviceToMatchExpr) {
     return IpAccessList.builder()
         .setName(aclName(section))
         .setSourceName(section.getName())
         .setLines(
             section.getRulebase().stream()
-                .map(r -> toAclLine(r, objs))
+                .map(r -> toAclLine(r, objs, serviceToMatchExpr))
                 .collect(ImmutableList.toImmutableList()))
         .build();
   }
 
   /** Convert specified {@link AccessRule} to an {@link AclLine}. */
   @Nonnull
-  static AclLine toAclLine(AccessRule rule, Map<Uid, NamedManagementObject> objs) {
+  static AclLine toAclLine(
+      AccessRule rule,
+      Map<Uid, NamedManagementObject> objs,
+      ServiceToMatchExpr serviceToMatchExpr) {
     return ExprAclLine.builder()
         .setName(rule.getName())
-        .setMatchCondition(toMatchExpr(rule, objs))
+        .setMatchCondition(toMatchExpr(rule, objs, serviceToMatchExpr))
         .setAction(toAction(objs.get(rule.getAction())))
         // TODO trace element and structure ID
         .build();
@@ -168,7 +166,10 @@ public final class CheckPointGatewayConversions {
    * conditions of the rule.
    */
   @Nonnull
-  static AclLineMatchExpr toMatchExpr(AccessRule rule, Map<Uid, NamedManagementObject> objs) {
+  static AclLineMatchExpr toMatchExpr(
+      AccessRule rule,
+      Map<Uid, NamedManagementObject> objs,
+      ServiceToMatchExpr serviceToMatchExpr) {
     ImmutableList.Builder<AclLineMatchExpr> conjuncts = ImmutableList.builder();
 
     // Source
@@ -188,7 +189,8 @@ public final class CheckPointGatewayConversions {
     conjuncts.add(dstMatch);
 
     // Service
-    conjuncts.add(servicesToMatchExpr(rule.getService(), rule.getServiceNegate(), objs));
+    conjuncts.add(
+        servicesToMatchExpr(rule.getService(), rule.getServiceNegate(), objs, serviceToMatchExpr));
 
     return new AndMatchExpr(conjuncts.build());
   }
@@ -199,26 +201,19 @@ public final class CheckPointGatewayConversions {
    */
   @Nonnull
   private static AclLineMatchExpr servicesToMatchExpr(
-      List<Uid> services, boolean negate, Map<Uid, NamedManagementObject> objs) {
+      List<Uid> services,
+      boolean negate,
+      Map<Uid, NamedManagementObject> objs,
+      ServiceToMatchExpr serviceToMatchExpr) {
     AclLineMatchExpr matchExpr =
         new OrMatchExpr(
             services.stream()
                 .map(objs::get)
                 .filter(Service.class::isInstance)
                 .map(Service.class::cast)
-                .map(CheckPointGatewayConversions::serviceToMatchExpr)
+                .map(s -> s.accept(serviceToMatchExpr))
                 .collect(ImmutableList.toImmutableList()));
     return negate ? new NotMatchExpr(matchExpr) : matchExpr;
-  }
-
-  @Nonnull
-  static AclLineMatchExpr serviceToMatchExpr(Service service) {
-    Builder serviceHsb = HeaderSpace.builder();
-    SERVICE_TO_HEADER_SPACE_CONSTRAINTS.setHeaderSpace(serviceHsb);
-    service.accept(SERVICE_TO_HEADER_SPACE_CONSTRAINTS);
-    SERVICE_TO_HEADER_SPACE_CONSTRAINTS.setHeaderSpace(null);
-    // TODO trace element and structure ID
-    return new MatchHeaderSpace(serviceHsb.build());
   }
 
   /** Convert specified {@link TypedManagementObject} to a {@link LineAction}. */
@@ -256,75 +251,21 @@ public final class CheckPointGatewayConversions {
             targets.stream()
                 .map(objs::get)
                 .filter(Objects::nonNull) // TODO warn about missing refs?
-                .map(NamedManagementObject::getName)
-                .map(IpSpaceReference::new)
+                .map(CheckPointGatewayConversions::toIpSpace)
                 .collect(ImmutableList.toImmutableList()))
         .build();
   }
 
-  private static final ServiceToHeaderSpaceConstraints SERVICE_TO_HEADER_SPACE_CONSTRAINTS =
-      new ServiceToHeaderSpaceConstraints();
-
   /**
-   * Restricts the given {@link HeaderSpace.Builder} to protocols/ports matching the given {@link
-   * Service}.
+   * Returns an {@link IpSpace} containing the specified {@link NamedManagementObject}. Relies on a
+   * named {@link IpSpace} existing for the supplied object.
    */
-  public static void applyServiceConstraint(Service service, HeaderSpace.Builder hsb) {
-    SERVICE_TO_HEADER_SPACE_CONSTRAINTS.setHeaderSpace(hsb);
-    service.accept(SERVICE_TO_HEADER_SPACE_CONSTRAINTS);
-    SERVICE_TO_HEADER_SPACE_CONSTRAINTS.setHeaderSpace(null);
-  }
-
-  /**
-   * Applies a {@link Service} to its current {@link HeaderSpace.Builder}. Does not modify the
-   * headerspace if the given service object is unconstrained.
-   */
-  private static class ServiceToHeaderSpaceConstraints implements ServiceVisitor<Void> {
-    private @Nullable HeaderSpace.Builder _hsb;
-
-    private ServiceToHeaderSpaceConstraints() {}
-
-    private void setHeaderSpace(@Nullable HeaderSpace.Builder hsb) {
-      _hsb = hsb;
+  @Nonnull
+  private static IpSpace toIpSpace(NamedManagementObject obj) {
+    if (obj instanceof CpmiAnyObject) {
+      return UniverseIpSpace.INSTANCE;
     }
-
-    @Override
-    public Void visitCpmiAnyObject(CpmiAnyObject cpmiAnyObject) {
-      // Does not constrain headerspace
-      return null;
-    }
-
-    @Override
-    public Void visitServiceGroup(ServiceGroup serviceGroup) {
-      // TODO Implement
-      return null;
-    }
-
-    @Override
-    public Void visitServiceIcmp(ServiceIcmp serviceIcmp) {
-      assert _hsb != null;
-      _hsb.setIpProtocols(IpProtocol.ICMP);
-      _hsb.setIcmpTypes(serviceIcmp.getIcmpType());
-      Optional.ofNullable(serviceIcmp.getIcmpCode()).ifPresent(_hsb::setIcmpCodes);
-      return null;
-    }
-
-    @Override
-    public Void visitServiceTcp(ServiceTcp serviceTcp) {
-      // TODO Is this correct/sufficient? Does it need to modify src port?
-      assert _hsb != null;
-      _hsb.setIpProtocols(IpProtocol.TCP);
-      _hsb.setDstPorts(IntegerSpace.parse(serviceTcp.getPort()).getSubRanges());
-      return null;
-    }
-
-    @Override
-    public Void visitServiceUdp(ServiceUdp serviceUdp) {
-      assert _hsb != null;
-      _hsb.setIpProtocols(IpProtocol.UDP);
-      _hsb.setDstPorts(IntegerSpace.parse(serviceUdp.getPort()).getSubRanges());
-      return null;
-    }
+    return new IpSpaceReference(obj.getName());
   }
 
   /** Return {@code true} iff any of the install-on UIDs applies to the given gateway. */

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
@@ -16,6 +16,10 @@ public final class ServiceGroup extends TypedManagementObject implements Service
     return visitor.visitServiceGroup(this);
   }
 
+  public List<Uid> getMembers() {
+    return _members;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!baseEquals(o)) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
@@ -16,6 +16,7 @@ public final class ServiceGroup extends TypedManagementObject implements Service
     return visitor.visitServiceGroup(this);
   }
 
+  @Nonnull
   public List<Uid> getMembers() {
     return _members;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
@@ -26,7 +26,6 @@ public class ServiceToMatchExpr implements ServiceVisitor<AclLineMatchExpr> {
   @Override
   public AclLineMatchExpr visitServiceGroup(ServiceGroup serviceGroup) {
     // TODO implement
-    assert _objs != null; // avoid unused warning
     return TrueExpr.INSTANCE;
   }
 
@@ -57,5 +56,6 @@ public class ServiceToMatchExpr implements ServiceVisitor<AclLineMatchExpr> {
             .build());
   }
 
+  @SuppressWarnings("unused")
   private final @Nonnull Map<Uid, NamedManagementObject> _objs;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
@@ -26,6 +26,7 @@ public class ServiceToMatchExpr implements ServiceVisitor<AclLineMatchExpr> {
   @Override
   public AclLineMatchExpr visitServiceGroup(ServiceGroup serviceGroup) {
     // TODO implement
+    assert _objs != null; // avoid unused warning
     return TrueExpr.INSTANCE;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
@@ -1,0 +1,60 @@
+package org.batfish.vendor.check_point_management;
+
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.TrueExpr;
+
+/** Generates an {@link AclLineMatchExpr} for the specified {@link Service}. */
+public class ServiceToMatchExpr implements ServiceVisitor<AclLineMatchExpr> {
+
+  public ServiceToMatchExpr(Map<Uid, NamedManagementObject> objs) {
+    _objs = objs;
+  }
+
+  @Override
+  public AclLineMatchExpr visitCpmiAnyObject(CpmiAnyObject cpmiAnyObject) {
+    // Does not constrain headerspace
+    return TrueExpr.INSTANCE;
+  }
+
+  @Override
+  public AclLineMatchExpr visitServiceGroup(ServiceGroup serviceGroup) {
+    // TODO implement
+    return TrueExpr.INSTANCE;
+  }
+
+  @Override
+  public AclLineMatchExpr visitServiceIcmp(ServiceIcmp serviceIcmp) {
+    HeaderSpace.Builder hsb = HeaderSpace.builder();
+    hsb.setIpProtocols(IpProtocol.ICMP);
+    hsb.setIcmpTypes(serviceIcmp.getIcmpType());
+    Optional.ofNullable(serviceIcmp.getIcmpCode()).ifPresent(hsb::setIcmpCodes);
+    return new MatchHeaderSpace(hsb.build());
+  }
+
+  @Override
+  public AclLineMatchExpr visitServiceTcp(ServiceTcp serviceTcp) {
+    return new MatchHeaderSpace(
+        HeaderSpace.builder()
+            .setIpProtocols(IpProtocol.TCP)
+            .setDstPorts(IntegerSpace.parse(serviceTcp.getPort()).getSubRanges())
+            .build());
+  }
+
+  @Override
+  public AclLineMatchExpr visitServiceUdp(ServiceUdp serviceUdp) {
+    return new MatchHeaderSpace(
+        HeaderSpace.builder()
+            .setIpProtocols(IpProtocol.UDP)
+            .setDstPorts(IntegerSpace.parse(serviceUdp.getPort()).getSubRanges())
+            .build());
+  }
+
+  private final @Nonnull Map<Uid, NamedManagementObject> _objs;
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
@@ -5,7 +5,6 @@ import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.aclName;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.checkValidHeaderSpaceInputs;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toAction;
-import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toHeaderSpace;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toIpAccessLists;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toMatchExpr;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -48,6 +47,7 @@ import org.batfish.vendor.check_point_management.PolicyTargets;
 import org.batfish.vendor.check_point_management.RulebaseAction;
 import org.batfish.vendor.check_point_management.ServiceIcmp;
 import org.batfish.vendor.check_point_management.ServiceTcp;
+import org.batfish.vendor.check_point_management.ServiceToMatchExpr;
 import org.batfish.vendor.check_point_management.ServiceUdp;
 import org.batfish.vendor.check_point_management.TypedManagementObject;
 import org.batfish.vendor.check_point_management.Uid;
@@ -55,7 +55,6 @@ import org.junit.Test;
 
 /** Test of {@link CheckPointGatewayConversions}. */
 public final class CheckPointGatewayConversionsTest {
-
   public static final NatSettings NAT_SETTINGS_TEST_INSTANCE =
       new NatSettings(true, "gateway", "All", "hide");
   private static final Uid UID_ACCEPT = Uid.of("99997");
@@ -67,37 +66,52 @@ public final class CheckPointGatewayConversionsTest {
   private static final Uid UID_SERVICE_TCP_22 = Uid.of("13");
   private static final Uid UID_SERVICE_UDP_222 = Uid.of("14");
   private static final CpmiAnyObject CPMI_ANY = new CpmiAnyObject(UID_CPMI_ANY);
+  private static final Uid UID_TCP_RANGES = Uid.of("15");
+  private static final Uid UID_UDP = Uid.of("16");
+  private static final Uid UID_ICMP = Uid.of("17");
+  private static final Uid UID_ICMP_NO_CODE = Uid.of("18");
+  private static final ServiceTcp SERVICE_TCP_RANGES =
+      new ServiceTcp("tcp_ranges", "1-100,105-106", UID_TCP_RANGES);
+  private static final ServiceUdp SERVICE_UDP = new ServiceUdp("udp", "1234", UID_UDP);
+  private static final ServiceIcmp SERVICE_ICMP = new ServiceIcmp("icmp", 8, 3, UID_ICMP);
+  private static final ServiceIcmp SERVICE_ICMP_NO_CODE =
+      new ServiceIcmp("icmpNoCode", 8, null, UID_ICMP_NO_CODE);
+  private static final Network NETWORK_0 =
+      new Network(
+          "net0",
+          NAT_SETTINGS_TEST_INSTANCE,
+          Ip.parse("10.0.0.0"),
+          Ip.parse("255.255.255.0"),
+          UID_NET0);
+  private static final Network NETWORK_1 =
+      new Network(
+          "net1",
+          NAT_SETTINGS_TEST_INSTANCE,
+          Ip.parse("10.0.1.0"),
+          Ip.parse("255.255.255.0"),
+          UID_NET1);
+  private static final Network NETWORK_2 =
+      new Network(
+          "net2",
+          NAT_SETTINGS_TEST_INSTANCE,
+          Ip.parse("10.0.2.0"),
+          Ip.parse("255.255.255.0"),
+          UID_NET2);
+
   private static final ImmutableMap<Uid, NamedManagementObject> TEST_OBJS =
       ImmutableMap.<Uid, NamedManagementObject>builder()
-          .put(
-              UID_NET0,
-              new Network(
-                  "net0",
-                  NAT_SETTINGS_TEST_INSTANCE,
-                  Ip.parse("10.0.0.0"),
-                  Ip.parse("255.255.255.0"),
-                  UID_NET0))
-          .put(
-              UID_NET1,
-              new Network(
-                  "net1",
-                  NAT_SETTINGS_TEST_INSTANCE,
-                  Ip.parse("10.0.1.0"),
-                  Ip.parse("255.255.255.0"),
-                  UID_NET1))
-          .put(
-              UID_NET2,
-              new Network(
-                  "net2",
-                  NAT_SETTINGS_TEST_INSTANCE,
-                  Ip.parse("10.0.2.0"),
-                  Ip.parse("255.255.255.0"),
-                  UID_NET2))
+          .put(UID_NET0, NETWORK_0)
+          .put(UID_NET1, NETWORK_1)
+          .put(UID_NET2, NETWORK_2)
           .put(UID_CPMI_ANY, CPMI_ANY)
           .put(UID_ACCEPT, new RulebaseAction("Accept", UID_ACCEPT, "Accept"))
           .put(UID_DROP, new RulebaseAction("Drop", UID_DROP, "Drop"))
           .put(UID_SERVICE_TCP_22, new ServiceTcp("service_tcp_22", "22", UID_SERVICE_TCP_22))
           .put(UID_SERVICE_UDP_222, new ServiceUdp("service_udp_222", "222", UID_SERVICE_UDP_222))
+          .put(UID_TCP_RANGES, SERVICE_TCP_RANGES)
+          .put(UID_UDP, SERVICE_UDP)
+          .put(UID_ICMP, SERVICE_ICMP)
+          .put(UID_ICMP_NO_CODE, SERVICE_ICMP_NO_CODE)
           .build();
   private static final ImmutableMap<String, IpSpace> TEST_IP_SPACES =
       ImmutableMap.of(
@@ -112,6 +126,9 @@ public final class CheckPointGatewayConversionsTest {
   private static final String NET0_ADDR = "10.0.0.100";
   private static final String NET1_ADDR = "10.0.1.100";
   private static final String NET2_ADDR = "10.0.2.100";
+
+  private final BddTestbed _tb = new BddTestbed(ImmutableMap.of(), TEST_IP_SPACES);
+  private final ServiceToMatchExpr _serviceToMatchExpr = new ServiceToMatchExpr(TEST_OBJS);
 
   private static Flow createFlow(String sourceAddress, String destinationAddress) {
     return createFlow(sourceAddress, destinationAddress, IpProtocol.TCP, 1, 1);
@@ -171,7 +188,8 @@ public final class CheckPointGatewayConversionsTest {
     AccessLayer accessLayer =
         new AccessLayer(TEST_OBJS, rulebase, Uid.of("uidLayer"), "accessLayerName");
 
-    Map<String, IpAccessList> ipAccessLists = toIpAccessLists(accessLayer, TEST_OBJS);
+    Map<String, IpAccessList> ipAccessLists =
+        toIpAccessLists(accessLayer, TEST_OBJS, _serviceToMatchExpr);
     assertThat(
         ipAccessLists.keySet(), containsInAnyOrder(aclName(accessLayer), aclName(accessSection)));
 
@@ -189,8 +207,7 @@ public final class CheckPointGatewayConversionsTest {
   }
 
   @Test
-  public void testToAclLineMatchExpr() {
-    BddTestbed tb = new BddTestbed(ImmutableMap.of(), TEST_IP_SPACES);
+  public void testAccessRuleToMatchExpr() {
     AclLineMatchExpr matchNet0 =
         new MatchHeaderSpace(HeaderSpace.builder().setDstIps(new IpSpaceReference("net0")).build());
     AclLineMatchExpr matchNotNet0 =
@@ -233,10 +250,11 @@ public final class CheckPointGatewayConversionsTest {
                 .setName("ruleName")
                 .setUid(Uid.of("2"))
                 .build(),
-            TEST_OBJS);
+            TEST_OBJS,
+            _serviceToMatchExpr);
     assertThat(
-        tb.toBDD(matches),
-        equalTo(tb.toBDD(matchNet0).and(tb.toBDD(matchNet1).and(tb.toBDD(matchSvc)))));
+        _tb.toBDD(matches),
+        equalTo(_tb.toBDD(matchNet0).and(_tb.toBDD(matchNet1).and(_tb.toBDD(matchSvc)))));
 
     // Negated matches
     AclLineMatchExpr negatedMatches =
@@ -253,10 +271,11 @@ public final class CheckPointGatewayConversionsTest {
                 .setName("ruleName")
                 .setUid(Uid.of("2"))
                 .build(),
-            TEST_OBJS);
+            TEST_OBJS,
+            _serviceToMatchExpr);
     assertThat(
-        tb.toBDD(negatedMatches),
-        equalTo(tb.toBDD(matchNotNet0).and(tb.toBDD(matchNotNet1).and(tb.toBDD(matchNotSvc)))));
+        _tb.toBDD(negatedMatches),
+        equalTo(_tb.toBDD(matchNotNet0).and(_tb.toBDD(matchNotNet1).and(_tb.toBDD(matchNotSvc)))));
 
     // Multiple services
     AclLineMatchExpr mutliSvc =
@@ -270,8 +289,9 @@ public final class CheckPointGatewayConversionsTest {
                 .setName("ruleName")
                 .setUid(Uid.of("2"))
                 .build(),
-            TEST_OBJS);
-    assertThat(tb.toBDD(mutliSvc), equalTo(tb.toBDD(matchSvc).or(tb.toBDD(matchUdpSvc))));
+            TEST_OBJS,
+            _serviceToMatchExpr);
+    assertThat(_tb.toBDD(mutliSvc), equalTo(_tb.toBDD(matchSvc).or(_tb.toBDD(matchUdpSvc))));
   }
 
   @Test
@@ -285,63 +305,73 @@ public final class CheckPointGatewayConversionsTest {
   }
 
   @Test
-  public void testToHeaderSpace() {
+  public void testNatOrigToMatchExpr() {
     Uid uid = Uid.of("1");
     Warnings warnings = new Warnings();
     {
       TypedManagementObject policyTargets = new PolicyTargets(uid);
       assertThat(
-          toHeaderSpace(policyTargets, policyTargets, policyTargets, warnings),
+          toMatchExpr(policyTargets, policyTargets, policyTargets, _serviceToMatchExpr, warnings),
           equalTo(Optional.empty()));
     }
     {
       assertThat(
-          toHeaderSpace(
-              new Host(Ip.parse("1.1.1.1"), NAT_SETTINGS_TEST_INSTANCE, "source", uid),
-              new Host(Ip.parse("2.2.2.2"), NAT_SETTINGS_TEST_INSTANCE, "dest", uid),
-              new ServiceTcp("foo", "1-100,105-106", uid),
-              warnings),
+          _tb.toBDD(
+              toMatchExpr(NETWORK_0, NETWORK_1, SERVICE_TCP_RANGES, _serviceToMatchExpr, warnings)
+                  .get()),
           equalTo(
-              Optional.of(
-                  HeaderSpace.builder()
-                      .setSrcIps(new IpSpaceReference("source"))
-                      .setDstIps(new IpSpaceReference("dest"))
-                      .setDstPorts(ImmutableList.of(new SubRange(1, 100), new SubRange(105, 106)))
-                      .setIpProtocols(IpProtocol.TCP)
-                      .build())));
+              _tb.toBDD(
+                  new MatchHeaderSpace(
+                      HeaderSpace.builder()
+                          .setSrcIps(new IpSpaceReference(NETWORK_0.getName()))
+                          .setDstIps(new IpSpaceReference(NETWORK_1.getName()))
+                          .setDstPorts(
+                              ImmutableList.of(new SubRange(1, 100), new SubRange(105, 106)))
+                          .setIpProtocols(IpProtocol.TCP)
+                          .build()))));
     }
     {
       assertThat(
-          toHeaderSpace(CPMI_ANY, CPMI_ANY, CPMI_ANY, warnings),
-          equalTo(Optional.of(HeaderSpace.builder().build())));
+          _tb.toBDD(toMatchExpr(CPMI_ANY, CPMI_ANY, CPMI_ANY, _serviceToMatchExpr, warnings).get()),
+          equalTo(_tb.toBDD(new MatchHeaderSpace(HeaderSpace.builder().build()))));
     }
     {
       assertThat(
-          toHeaderSpace(CPMI_ANY, CPMI_ANY, new ServiceUdp("foo", "1234", uid), warnings),
+          _tb.toBDD(
+              toMatchExpr(CPMI_ANY, CPMI_ANY, SERVICE_UDP, _serviceToMatchExpr, warnings).get()),
           equalTo(
-              Optional.of(
-                  HeaderSpace.builder()
-                      .setDstPorts(ImmutableList.of(new SubRange(1234)))
-                      .setIpProtocols(IpProtocol.UDP)
-                      .build())));
+              _tb.toBDD(
+                  new MatchHeaderSpace(
+                      HeaderSpace.builder()
+                          .setDstPorts(ImmutableList.of(new SubRange(1234)))
+                          .setIpProtocols(IpProtocol.UDP)
+                          .build()))));
     }
     {
       assertThat(
-          toHeaderSpace(CPMI_ANY, CPMI_ANY, new ServiceIcmp("foo", 8, 3, uid), warnings),
+          _tb.toBDD(
+              toMatchExpr(CPMI_ANY, CPMI_ANY, SERVICE_ICMP, _serviceToMatchExpr, warnings).get()),
           equalTo(
-              Optional.of(
-                  HeaderSpace.builder()
-                      .setIcmpTypes(8)
-                      .setIcmpCodes(3)
-                      .setIpProtocols(IpProtocol.ICMP)
-                      .build())));
+              _tb.toBDD(
+                  new MatchHeaderSpace(
+                      HeaderSpace.builder()
+                          .setIcmpTypes(8)
+                          .setIcmpCodes(3)
+                          .setIpProtocols(IpProtocol.ICMP)
+                          .build()))));
     }
     {
       assertThat(
-          toHeaderSpace(CPMI_ANY, CPMI_ANY, new ServiceIcmp("foo", 8, null, uid), warnings),
+          _tb.toBDD(
+              toMatchExpr(CPMI_ANY, CPMI_ANY, SERVICE_ICMP_NO_CODE, _serviceToMatchExpr, warnings)
+                  .get()),
           equalTo(
-              Optional.of(
-                  HeaderSpace.builder().setIcmpTypes(8).setIpProtocols(IpProtocol.ICMP).build())));
+              _tb.toBDD(
+                  new MatchHeaderSpace(
+                      HeaderSpace.builder()
+                          .setIcmpTypes(8)
+                          .setIpProtocols(IpProtocol.ICMP)
+                          .build()))));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversionsTest.java
@@ -13,6 +13,7 @@ import static org.batfish.vendor.check_point_gateway.representation.CheckpointNa
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.manualHideRuleTransformation;
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.manualHideTransformationSteps;
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.mergeTransformations;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -23,9 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Optional;
 import org.batfish.common.Warnings;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationStep;
 import org.batfish.vendor.check_point_management.CpmiAnyObject;
@@ -39,6 +38,7 @@ import org.batfish.vendor.check_point_management.NatSettings;
 import org.batfish.vendor.check_point_management.Original;
 import org.batfish.vendor.check_point_management.PolicyTargets;
 import org.batfish.vendor.check_point_management.ServiceTcp;
+import org.batfish.vendor.check_point_management.ServiceToMatchExpr;
 import org.batfish.vendor.check_point_management.SimpleGateway;
 import org.batfish.vendor.check_point_management.TypedManagementObject;
 import org.batfish.vendor.check_point_management.Uid;
@@ -175,6 +175,7 @@ public final class CheckpointNatConversionsTest {
     Ip hostIp = Ip.parse("1.1.1.1");
     String hostname = "host";
     Host host = new Host(hostIp, NAT_SETTINGS_TEST_INSTANCE, hostname, hostUid);
+    ServiceToMatchExpr serviceToMatchExpr = new ServiceToMatchExpr(ImmutableMap.of());
     {
       ImmutableMap<Uid, TypedManagementObject> objs =
           ImmutableMap.of(hostUid, host, PT_UID, POLICY_TARGETS, ORIG_UID, ORIG);
@@ -195,7 +196,9 @@ public final class CheckpointNatConversionsTest {
               UID);
 
       // invalid original fields
-      assertThat(manualHideRuleTransformation(rule, objs, warnings), equalTo(Optional.empty()));
+      assertThat(
+          manualHideRuleTransformation(rule, serviceToMatchExpr, objs, warnings),
+          equalTo(Optional.empty()));
     }
     {
       ImmutableMap<Uid, TypedManagementObject> objs =
@@ -217,7 +220,9 @@ public final class CheckpointNatConversionsTest {
               UID);
 
       // invalid translated fields
-      assertThat(manualHideRuleTransformation(rule, objs, warnings), equalTo(Optional.empty()));
+      assertThat(
+          manualHideRuleTransformation(rule, serviceToMatchExpr, objs, warnings),
+          equalTo(Optional.empty()));
     }
     {
       ImmutableMap<Uid, TypedManagementObject> objs =
@@ -238,14 +243,12 @@ public final class CheckpointNatConversionsTest {
               hostUid,
               UID);
 
+      Transformation xform =
+          manualHideRuleTransformation(rule, serviceToMatchExpr, objs, warnings).get();
       assertThat(
-          manualHideRuleTransformation(rule, objs, warnings),
-          equalTo(
-              Optional.of(
-                  Transformation.when(new MatchHeaderSpace(HeaderSpace.builder().build()))
-                      .apply(
-                          assignSourceIp(hostIp), assignSourcePort(NAT_PORT_FIRST, NAT_PORT_LAST))
-                      .build())));
+          xform.getTransformationSteps(),
+          containsInAnyOrder(
+              assignSourceIp(hostIp), assignSourcePort(NAT_PORT_FIRST, NAT_PORT_LAST)));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/BUILD
@@ -12,6 +12,7 @@ junit_tests(
         exclude = ["Test*.java"],
     ),
     deps = [
+        "//projects/batfish:batfish_testlib",
         "//projects/batfish-common-protocol:common",
         "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management",
         "@maven//:com_fasterxml_jackson_core_jackson_core",

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceToMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceToMatchExprTest.java
@@ -1,0 +1,74 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.batfish.datamodel.BddTestbed;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.TrueExpr;
+import org.junit.Test;
+
+/** Test of {@link ServiceToMatchExpr}. */
+public final class ServiceToMatchExprTest {
+  private final ServiceToMatchExpr _serviceToMatchExpr = new ServiceToMatchExpr(ImmutableMap.of());
+
+  private final BddTestbed _tb = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
+
+  @Test
+  public void testCpmiAnyObject() {
+    Service service = new CpmiAnyObject(Uid.of("1"));
+    assertBddsEqual(service.accept(_serviceToMatchExpr), TrueExpr.INSTANCE);
+  }
+
+  @Test
+  public void testIcmp() {
+    Service service = new ServiceIcmp("icmp", 1, 2, Uid.of("1"));
+    Service serviceNoCode = new ServiceIcmp("icmp", 1, null, Uid.of("1"));
+    assertBddsEqual(
+        service.accept(_serviceToMatchExpr),
+        new MatchHeaderSpace(
+            HeaderSpace.builder()
+                .setIpProtocols(IpProtocol.ICMP)
+                .setIcmpTypes(1)
+                .setIcmpCodes(2)
+                .build()));
+    assertBddsEqual(
+        serviceNoCode.accept(_serviceToMatchExpr),
+        new MatchHeaderSpace(
+            HeaderSpace.builder().setIpProtocols(IpProtocol.ICMP).setIcmpTypes(1).build()));
+  }
+
+  @Test
+  public void testTcp() {
+    Service service = new ServiceTcp("tcp", "100-105,300", Uid.of("1"));
+    assertBddsEqual(
+        service.accept(_serviceToMatchExpr),
+        new MatchHeaderSpace(
+            HeaderSpace.builder()
+                .setIpProtocols(IpProtocol.TCP)
+                .setDstPorts(ImmutableList.of(new SubRange(100, 105), new SubRange(300)))
+                .build()));
+  }
+
+  @Test
+  public void testUdp() {
+    Service service = new ServiceUdp("udp", "222", Uid.of("1"));
+    assertBddsEqual(
+        service.accept(_serviceToMatchExpr),
+        new MatchHeaderSpace(
+            HeaderSpace.builder()
+                .setIpProtocols(IpProtocol.UDP)
+                .setDstPorts(new SubRange(222))
+                .build()));
+  }
+
+  private void assertBddsEqual(AclLineMatchExpr left, AclLineMatchExpr right) {
+    assertThat(_tb.toBDD(left), equalTo(_tb.toBDD(right)));
+  }
+}


### PR DESCRIPTION
Revamp `Service` conversion, NAT original-matching, and related tests.

----

* Return `AclLineMatchExpr` instead of `HeaderSpace` in a couple places
* Not implemented yet, but sets up for resolving `ServiceGroup`
* Add some direct tests of the visitor
* Consolidate some more conversion test constructs

