### PR TITLE
Checkpoint implement cluster virtual IP assignment

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrrpGroup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrrpGroup.java
@@ -2,9 +2,12 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
 import org.batfish.common.util.ComparableStructure;
 
 public class VrrpGroup extends ComparableStructure<Integer> {
+
+  public static final int MAX_PRIORITY = 255;
 
   public static class Builder {
     private int _name;
@@ -12,6 +15,8 @@ public class VrrpGroup extends ComparableStructure<Integer> {
     private int _priority;
 
     private ConcreteInterfaceAddress _virtualAddress;
+
+    private boolean _preempt;
 
     public VrrpGroup build() {
       return new VrrpGroup(this);
@@ -29,6 +34,11 @@ public class VrrpGroup extends ComparableStructure<Integer> {
 
     public Builder setVirtualAddress(ConcreteInterfaceAddress virtualAddress) {
       _virtualAddress = virtualAddress;
+      return this;
+    }
+
+    public @Nonnull Builder setPreempt(boolean preempt) {
+      _preempt = preempt;
       return this;
     }
   }
@@ -55,6 +65,7 @@ public class VrrpGroup extends ComparableStructure<Integer> {
 
   private VrrpGroup(Builder builder) {
     super(builder._name);
+    _preempt = builder._preempt;
     _priority = builder._priority;
     _virtualAddress = builder._virtualAddress;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -1,5 +1,6 @@
 package org.batfish.vendor.check_point_gateway.representation;
 
+import static com.google.common.collect.Maps.immutableEntry;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.batfish.datamodel.FirewallSessionInterfaceInfo.Action.POST_NAT_FIB_LOOKUP;
@@ -12,7 +13,7 @@ import static org.batfish.vendor.check_point_gateway.representation.CheckpointNa
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
+import com.google.common.collect.ImmutableSortedMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +21,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -31,6 +33,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.Interface.Builder;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceType;
@@ -40,6 +43,7 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.VrrpGroup;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopInterface;
@@ -52,6 +56,8 @@ import org.batfish.vendor.check_point_management.AccessLayer;
 import org.batfish.vendor.check_point_management.AddressSpace;
 import org.batfish.vendor.check_point_management.AddressSpaceToIpSpace;
 import org.batfish.vendor.check_point_management.CheckpointManagementConfiguration;
+import org.batfish.vendor.check_point_management.Cluster;
+import org.batfish.vendor.check_point_management.ClusterMember;
 import org.batfish.vendor.check_point_management.GatewayOrServer;
 import org.batfish.vendor.check_point_management.ManagementDomain;
 import org.batfish.vendor.check_point_management.ManagementPackage;
@@ -148,12 +154,47 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
     }
     ManagementDomain domain = maybeGatewayAndDomain.get().getKey();
     GatewayOrServer gateway = maybeGatewayAndDomain.get().getValue();
+    convertCluster(gateway, domain);
     // Find package
     Optional<ManagementPackage> maybePackage = findAccessPackage(domain, gateway);
     if (!maybePackage.isPresent()) {
       return;
     }
     convertPackage(maybePackage.get(), gateway, domain);
+  }
+
+  /** Populates cluster virtual IP metadata if this gateway is a member of a cluster. */
+  private void convertCluster(GatewayOrServer gateway, ManagementDomain domain) {
+    if (!(gateway instanceof ClusterMember)) {
+      return;
+    }
+    Class<? extends Cluster> clusterClass = ((ClusterMember) gateway).getClusterClass();
+    Optional<Entry<Cluster, Integer>> maybeClusterAndIndex =
+        domain.getGatewaysAndServers().values().stream()
+            .filter(clusterClass::isInstance)
+            .map(Cluster.class::cast)
+            .map(
+                cluster ->
+                    immutableEntry(
+                        cluster, cluster.getClusterMemberNames().indexOf(gateway.getName())))
+            .filter(clusterAndIndex -> clusterAndIndex.getValue() != -1)
+            .findFirst();
+    if (!maybeClusterAndIndex.isPresent()) {
+      _w.redFlag(
+          String.format(
+              "Could not find matching cluster of type %s for this gateway of type %s",
+              clusterClass.getSimpleName(), gateway.getClass().getSimpleName()));
+    } else {
+      Entry<Cluster, Integer> clusterAndIndex = maybeClusterAndIndex.get();
+      Cluster cluster = clusterAndIndex.getKey();
+      _clusterMemberIndex = clusterAndIndex.getValue();
+      _clusterInterfaces =
+          cluster.getInterfaces().stream()
+              .collect(
+                  ImmutableMap.toImmutableMap(
+                      org.batfish.vendor.check_point_management.Interface::getName,
+                      Function.identity()));
+    }
   }
 
   private void convertAccessLayers(
@@ -305,7 +346,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
                 .filter(gw -> ips.contains(gw.getIpv4Address()))
                 .findFirst();
         if (maybeGateway.isPresent()) {
-          return Optional.of(Maps.immutableEntry(domain, maybeGateway.get()));
+          return Optional.of(immutableEntry(domain, maybeGateway.get()));
         }
       }
     }
@@ -458,7 +499,34 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
     newIface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
             POST_NAT_FIB_LOOKUP, ImmutableList.of(ifaceName), null, null));
+
+    org.batfish.vendor.check_point_management.Interface clusterInterface =
+        Optional.ofNullable(_clusterInterfaces).orElse(ImmutableMap.of()).get(ifaceName);
+    if (clusterInterface != null) {
+      createClusterVrrpGroup(clusterInterface, newIface);
+    }
+
     newIface.build();
+  }
+
+  /** Create a VRRP group for the virtual IP the cluster associeates with this interface. */
+  private void createClusterVrrpGroup(
+      org.batfish.vendor.check_point_management.Interface clusterInterface, Builder newIface) {
+    Ip ip = clusterInterface.getIpv4Address();
+    if (ip == null) {
+      return;
+    }
+    Integer maskLength = clusterInterface.getIpv4MaskLength();
+    assert maskLength != null;
+    newIface.setVrrpGroups(
+        ImmutableSortedMap.of(
+            0,
+            VrrpGroup.builder()
+                .setVirtualAddress(ConcreteInterfaceAddress.create(ip, maskLength))
+                // prefer member with lowest cluster member index
+                .setPriority(VrrpGroup.MAX_PRIORITY - _clusterMemberIndex)
+                .setPreempt(true)
+                .build()));
   }
 
   /**
@@ -503,6 +571,11 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
   private Map<Prefix, StaticRoute> _staticRoutes;
 
   private transient Transformation _natTransformation;
+
+  private transient Map<String, org.batfish.vendor.check_point_management.Interface>
+      _clusterInterfaces;
+
+  private transient int _clusterMemberIndex;
 
   private ConfigurationFormat _vendor;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -184,17 +184,17 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
           String.format(
               "Could not find matching cluster of type %s for this gateway of type %s",
               clusterClass.getSimpleName(), gateway.getClass().getSimpleName()));
-    } else {
-      Entry<Cluster, Integer> clusterAndIndex = maybeClusterAndIndex.get();
-      Cluster cluster = clusterAndIndex.getKey();
-      _clusterMemberIndex = clusterAndIndex.getValue();
-      _clusterInterfaces =
-          cluster.getInterfaces().stream()
-              .collect(
-                  ImmutableMap.toImmutableMap(
-                      org.batfish.vendor.check_point_management.Interface::getName,
-                      Function.identity()));
+      return;
     }
+    Entry<Cluster, Integer> clusterAndIndex = maybeClusterAndIndex.get();
+    Cluster cluster = clusterAndIndex.getKey();
+    _clusterMemberIndex = clusterAndIndex.getValue();
+    _clusterInterfaces =
+        cluster.getInterfaces().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    org.batfish.vendor.check_point_management.Interface::getName,
+                    Function.identity()));
   }
 
   private void convertAccessLayers(

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ClusterMember.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ClusterMember.java
@@ -2,8 +2,10 @@ package org.batfish.vendor.check_point_management;
 
 import javax.annotation.Nonnull;
 
+/** A gateway that is a member of a {@link Cluster}. */
 public interface ClusterMember {
 
+  /** The specific class type of the {@link Cluster} of which this gateway may be a member. */
   @Nonnull
   Class<? extends Cluster> getClusterClass();
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ClusterMember.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ClusterMember.java
@@ -1,0 +1,9 @@
+package org.batfish.vendor.check_point_management;
+
+import javax.annotation.Nonnull;
+
+public interface ClusterMember {
+
+  @Nonnull
+  Class<? extends Cluster> getClusterClass();
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiClusterMember.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiClusterMember.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 
 /** Data model for an object of type {@code CpmiClusterMember}. */
-public final class CpmiClusterMember extends GatewayOrServer {
+public final class CpmiClusterMember extends GatewayOrServer implements ClusterMember {
 
   @JsonCreator
   private static @Nonnull CpmiClusterMember create(
@@ -28,7 +28,7 @@ public final class CpmiClusterMember extends GatewayOrServer {
   }
 
   @VisibleForTesting
-  CpmiClusterMember(
+  public CpmiClusterMember(
       @Nullable Ip ipv4Address,
       String name,
       List<Interface> interfaces,
@@ -50,5 +50,10 @@ public final class CpmiClusterMember extends GatewayOrServer {
   @Override
   public String toString() {
     return baseToStringHelper().toString();
+  }
+
+  @Override
+  public @Nonnull Class<? extends Cluster> getClusterClass() {
+    return CpmiGatewayCluster.class;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiGatewayCluster.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiGatewayCluster.java
@@ -37,7 +37,7 @@ public final class CpmiGatewayCluster extends Cluster {
   }
 
   @VisibleForTesting
-  CpmiGatewayCluster(
+  public CpmiGatewayCluster(
       List<String> clusterMemberNames,
       @Nullable Ip ipv4Address,
       String name,

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiVsxClusterMember.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiVsxClusterMember.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 
 /** Data model for an object of type {@code CpmiVsxClusterMember}. */
-public final class CpmiVsxClusterMember extends GatewayOrServer {
+public final class CpmiVsxClusterMember extends GatewayOrServer implements ClusterMember {
 
   @JsonCreator
   private static @Nonnull CpmiVsxClusterMember create(
@@ -50,5 +50,10 @@ public final class CpmiVsxClusterMember extends GatewayOrServer {
   @Override
   public String toString() {
     return baseToStringHelper().toString();
+  }
+
+  @Override
+  public @Nonnull Class<? extends Cluster> getClusterClass() {
+    return CpmiVsxClusterNetobj.class;
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/cluster_member
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/cluster_member
@@ -1,0 +1,13 @@
+#
+# Configuration of hostname
+# Language version: 13.4v1
+#
+# Exported by admin on Wed Jun 23 16:11:18 2021
+#
+set hostname cluster_member
+#
+set interface eth0 state on
+set interface eth0 ipv4-address 10.0.0.2 mask-length 24
+set interface eth1 state on
+set interface eth1 ipv4-address 1.0.0.1 mask-length 24
+#


### PR DESCRIPTION
- create a VRRP group for each participating cluster member interface
- assign priority that is higher the lower the member's index in
  cluster's cluster-member-names