### PR TITLE
CheckPoint: better Access Layer/Section naming

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -96,11 +96,6 @@ public final class CheckPointGatewayConversions {
     return valid;
   }
 
-  @VisibleForTesting
-  static String getAclName(AccessSection section) {
-    return String.format("%s (%s)", section.getUid().getValue(), section.getName());
-  }
-
   /**
    * Returns a {@code Map} of names to {@link IpAccessList}s corresponding to specified {@link
    * AccessLayer}.
@@ -324,10 +319,10 @@ public final class CheckPointGatewayConversions {
   /** Returns the name we use for IpAccessList of AccessSection */
   public static String aclName(AccessSection accessSection) {
     String uid = accessSection.getUid().getValue();
+    // Using a generated name, so just use Uid as the name
     if (accessSection.getName().equals(AccessSection.generateName(accessSection.getUid()))) {
       return uid;
     }
-    // Not using generated name, so add user-defined name
     return String.format("%s (%s)", uid, accessSection.getName());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -313,7 +313,7 @@ public final class CheckPointGatewayConversions {
 
   /** Returns the name we use for IpAccessList of AccessLayer */
   public static String aclName(AccessLayer accessLayer) {
-    return String.format("%s (%s)", accessLayer.getName(), accessLayer.getUid().getValue());
+    return String.format("%s (%s)", accessLayer.getUid().getValue(), accessLayer.getName());
   }
 
   /** Returns the name we use for IpAccessList of AccessSection */

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -96,6 +96,11 @@ public final class CheckPointGatewayConversions {
     return valid;
   }
 
+  @VisibleForTesting
+  static String getAclName(AccessSection section) {
+    return String.format("%s (%s)", section.getUid().getValue(), section.getName());
+  }
+
   /**
    * Returns a {@code Map} of names to {@link IpAccessList}s corresponding to specified {@link
    * AccessLayer}.
@@ -313,12 +318,17 @@ public final class CheckPointGatewayConversions {
 
   /** Returns the name we use for IpAccessList of AccessLayer */
   public static String aclName(AccessLayer accessLayer) {
-    return accessLayer.getUid().getValue();
+    return String.format("%s (%s)", accessLayer.getName(), accessLayer.getUid().getValue());
   }
 
   /** Returns the name we use for IpAccessList of AccessSection */
   public static String aclName(AccessSection accessSection) {
-    return accessSection.getUid().getValue();
+    String uid = accessSection.getUid().getValue();
+    if (accessSection.getName().equals(AccessSection.generateName(accessSection.getUid()))) {
+      return uid;
+    }
+    // Not using generated name, so add user-defined name
+    return String.format("%s (%s)", uid, accessSection.getName());
   }
 
   private CheckPointGatewayConversions() {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/AccessSection.java
@@ -18,6 +18,10 @@ public final class AccessSection extends NamedManagementObject implements Access
     return _rulebase;
   }
 
+  public static String generateName(Uid uid) {
+    return "Section " + uid.getValue();
+  }
+
   @VisibleForTesting
   public AccessSection(String name, List<AccessRule> rulebase, Uid uid) {
     super(name, uid);
@@ -31,7 +35,7 @@ public final class AccessSection extends NamedManagementObject implements Access
       @JsonProperty(PROP_UID) @Nullable Uid uid) {
     checkArgument(rulebase != null, "Missing %s", PROP_RULEBASE);
     checkArgument(uid != null, "Missing %s", PROP_UID);
-    return new AccessSection(firstNonNull(name, "Section " + uid.getValue()), rulebase, uid);
+    return new AccessSection(firstNonNull(name, generateName(uid)), rulebase, uid);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
@@ -12,6 +12,7 @@ import static org.batfish.vendor.check_point_gateway.representation.CheckPointGa
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toMatchExpr;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -446,5 +447,28 @@ public final class CheckPointGatewayConversionsTest {
     assertFalse(checkValidHeaderSpaceInputs(addressSpace, service, service, warnings));
     assertFalse(checkValidHeaderSpaceInputs(addressSpace, addressSpace, addressSpace, warnings));
     assertTrue(checkValidHeaderSpaceInputs(addressSpace, addressSpace, service, warnings));
+  }
+
+  @Test
+  public void testAclNameAccessLayer() {
+    Uid uid = Uid.of("1234");
+    String name = "Named AccessLayer";
+    AccessLayer named = new AccessLayer(ImmutableMap.of(), ImmutableList.of(), uid, name);
+
+    assertThat(aclName(named), containsString(uid.getValue()));
+    assertThat(aclName(named), containsString(name));
+  }
+
+  @Test
+  public void testAclNameAccessSection() {
+    Uid uid = Uid.of("1234");
+    AccessSection unnamed =
+        new AccessSection(AccessSection.generateName(uid), ImmutableList.of(), uid);
+    String name = "Named AccessSection";
+    AccessSection named = new AccessSection(name, ImmutableList.of(), uid);
+
+    assertThat(aclName(unnamed), containsString(uid.getValue()));
+    assertThat(aclName(named), containsString(uid.getValue()));
+    assertThat(aclName(named), containsString(name));
   }
 }


### PR DESCRIPTION
Add the object name (if it exists) to the VI model construct.

e.g. a named AccessLayer would now be named something like `uid123456 (Layer Name)` and an unnamed AccessLayer would still be named `uid123456`.
