### PR TITLE
CheckPoint: merge `AccessLayer` pages

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParser.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParser.java
@@ -11,6 +11,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.LinkedListMultimap;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -25,12 +26,16 @@ import org.batfish.common.Warning;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.vendor.check_point_management.AccessLayer;
+import org.batfish.vendor.check_point_management.AccessRule;
+import org.batfish.vendor.check_point_management.AccessRuleOrSection;
+import org.batfish.vendor.check_point_management.AccessSection;
 import org.batfish.vendor.check_point_management.CheckpointManagementConfiguration;
 import org.batfish.vendor.check_point_management.Domain;
 import org.batfish.vendor.check_point_management.GatewaysAndServers;
 import org.batfish.vendor.check_point_management.ManagementDomain;
 import org.batfish.vendor.check_point_management.ManagementPackage;
 import org.batfish.vendor.check_point_management.ManagementServer;
+import org.batfish.vendor.check_point_management.NamedManagementObject;
 import org.batfish.vendor.check_point_management.NatRuleOrSection;
 import org.batfish.vendor.check_point_management.NatRulebase;
 import org.batfish.vendor.check_point_management.ObjectPage;
@@ -74,6 +79,120 @@ public class CheckpointManagementParser {
         });
     return new CheckpointManagementConfiguration(
         buildServersMap(domainFileMap, packageFileMap, pvcae));
+  }
+
+  /** Read Access Layer data. */
+  private static @Nonnull List<AccessLayer> readAccessLayers(
+      Package pakij,
+      String domainName,
+      Map<String, String> packageFiles,
+      ParseVendorConfigurationAnswerElement pvcae,
+      String serverName) {
+    return mergeAccessLayers(
+        firstNonNull(
+            tryParseCheckpointPackageFile(
+                packageFiles,
+                new TypeReference<List<AccessLayer>>() {},
+                pvcae,
+                serverName,
+                domainName,
+                pakij.getName(),
+                RELPATH_CHECKPOINT_SHOW_ACCESS_RULEBASE),
+            ImmutableList.of()),
+        pvcae);
+  }
+
+  /**
+   * Returns a single AccessRuleOrSection representing the specified collection.
+   *
+   * <p>The specified collection of items should contain one of the following:
+   *
+   * <ul>
+   *   <li>1. a single AccessRule (rules can't be split across pages)
+   *   <li>2. a single AccessSection (contained fully on a single page)
+   *   <li>3. multiple AccessSection (all with the same name and uid, with different rules)
+   * </ul>
+   */
+  private static @Nonnull AccessRuleOrSection mergeRuleOrSection(
+      Collection<AccessRuleOrSection> items, ParseVendorConfigurationAnswerElement pvcae) {
+    AccessRuleOrSection first = items.iterator().next();
+    if (items.stream().anyMatch(AccessRule.class::isInstance)) {
+      // Shouldn't happen w/ well-formed data, but check to prevent bad casting below
+      if (items.size() > 1) {
+        pvcae.addRedFlagWarning(
+            RELPATH_CHECKPOINT_MANAGEMENT_DIR,
+            new Warning(
+                String.format(
+                    "Cannot merge AccessRule pages (for uid %s), ignoring instances after the"
+                        + " first",
+                    ((AccessRule) first).getUid().getValue()),
+                "Checkpoint"));
+      }
+      return first;
+    }
+
+    AccessSection firstSection = (AccessSection) first;
+    return new AccessSection(
+        firstSection.getName(),
+        items.stream()
+            .flatMap(s -> ((AccessSection) s).getRulebase().stream())
+            .collect(ImmutableList.toImmutableList()),
+        firstSection.getUid());
+  }
+
+  /**
+   * Returns a list of unique Access Rules and Access Sections, generated from the specified
+   * collection of non-unique items; i.e. multiple partial Access Sections can be specified and will
+   * be merged into a single Access Section in the resulting list.
+   *
+   * <p>The items should be provided in order.
+   */
+  private static @Nonnull List<AccessRuleOrSection> mergeRuleOrSections(
+      Collection<AccessRuleOrSection> items, ParseVendorConfigurationAnswerElement pvcae) {
+    LinkedListMultimap<Uid, AccessRuleOrSection> uidToChunks = LinkedListMultimap.create();
+    items.forEach(i -> uidToChunks.put(((NamedManagementObject) i).getUid(), i));
+    return uidToChunks.keySet().stream()
+        .map(uid -> mergeRuleOrSection(uidToChunks.get(uid), pvcae))
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /**
+   * Merges multiple pages of a <i>single</i> Access Layer and returns the resulting Access Layer.
+   *
+   * <p>Assumes all supplied pages are for the same AccessLayer.
+   */
+  private static @Nonnull AccessLayer mergeAccessLayer(
+      Collection<AccessLayer> pages, ParseVendorConfigurationAnswerElement pvcae) {
+    Uid uid = pages.iterator().next().getUid();
+    String name = pages.iterator().next().getName();
+    Map<Uid, NamedManagementObject> objs = new HashMap<>();
+    pages.stream()
+        .flatMap(p -> p.getObjectsDictionary().entrySet().stream())
+        .forEach(o -> objs.put(o.getKey(), o.getValue()));
+    return new AccessLayer(
+        objs,
+        mergeRuleOrSections(
+            pages.stream()
+                .flatMap(p -> p.getRulebase().stream())
+                .collect(ImmutableList.toImmutableList()),
+            pvcae),
+        uid,
+        name);
+  }
+
+  /**
+   * Merges multiple pages of non-unique Access Layers.
+   *
+   * <p>The pages should be provided in order.
+   */
+  @VisibleForTesting
+  static @Nonnull List<AccessLayer> mergeAccessLayers(
+      Collection<AccessLayer> pages, ParseVendorConfigurationAnswerElement pvcae) {
+    LinkedListMultimap<Uid, AccessLayer> uidToPages = LinkedListMultimap.create();
+    pages.forEach(p -> uidToPages.put(p.getUid(), p));
+    return uidToPages.keySet().stream()
+        .map(uid -> mergeAccessLayer(uidToPages.get(uid), pvcae))
+        .collect(ImmutableList.toImmutableList());
   }
 
   /** Read NAT rulebase data. */
@@ -309,16 +428,7 @@ public class CheckpointManagementParser {
       // name. In the future we may want to encode that name in base64 so we can guarantee
       // the same package name can be retrieved from JSON and directory name.
       List<AccessLayer> accessLayers =
-          firstNonNull(
-              tryParseCheckpointPackageFile(
-                  packageFiles,
-                  new TypeReference<List<AccessLayer>>() {},
-                  pvcae,
-                  serverName,
-                  domainName,
-                  pakij.getName(),
-                  RELPATH_CHECKPOINT_SHOW_ACCESS_RULEBASE),
-              ImmutableList.of());
+          readAccessLayers(pakij, domainName, packageFiles, pvcae, serverName);
       NatRulebase natRulebase = readNatRulebase(pakij, domainName, packageFiles, pvcae, serverName);
       ManagementPackage mgmtPackage = new ManagementPackage(accessLayers, natRulebase, pakij);
       packagesBuilder.put(mgmtPackage.getPackage().getUid(), mgmtPackage);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParser.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParser.java
@@ -163,14 +163,16 @@ public class CheckpointManagementParser {
    */
   private static @Nonnull AccessLayer mergeAccessLayer(
       Collection<AccessLayer> pages, ParseVendorConfigurationAnswerElement pvcae) {
-    Uid uid = pages.iterator().next().getUid();
-    String name = pages.iterator().next().getName();
+    assert !pages.isEmpty();
+    AccessLayer first = pages.iterator().next();
+    Uid uid = first.getUid();
+    String name = first.getName();
     Map<Uid, NamedManagementObject> objs = new HashMap<>();
     pages.stream()
         .flatMap(p -> p.getObjectsDictionary().entrySet().stream())
         .forEach(o -> objs.put(o.getKey(), o.getValue()));
     return new AccessLayer(
-        objs,
+        ImmutableMap.copyOf(objs),
         mergeRuleOrSections(
             pages.stream()
                 .flatMap(p -> p.getRulebase().stream())

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/BUILD
@@ -13,6 +13,7 @@ junit_tests(
     ),
     deps = [
         "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers",
         "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management",
         "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing",
         "@maven//:com_fasterxml_jackson_core_jackson_core",

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParserTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParserTest.java
@@ -472,7 +472,6 @@ public final class CheckpointManagementParserTest {
   public void testMergeAccessLayersAccessSectionSplit() {
     ParseVendorConfigurationAnswerElement pvcae = new ParseVendorConfigurationAnswerElement();
     Uid uidAny = Uid.of("0");
-    Uid uid1 = Uid.of("1");
     Uid uid2 = Uid.of("2");
     Uid uidTcp = Uid.of("3");
     Uid uidUdp = Uid.of("4");
@@ -481,7 +480,6 @@ public final class CheckpointManagementParserTest {
     Uid uidRule3 = Uid.of("7");
     Uid uidSection1 = Uid.of("8");
     Uid uidBogus = Uid.of("999");
-    String name1 = "1";
     String name2 = "2";
     CpmiAnyObject any = new CpmiAnyObject(uidAny);
     ServiceTcp tcp = new ServiceTcp("tcp", "1234", uidTcp);
@@ -504,28 +502,21 @@ public final class CheckpointManagementParserTest {
             .setUid(uidRule3)
             .setAction(uidBogus)
             .build();
-    AccessLayer al1a =
-        new AccessLayer(ImmutableMap.of(uidAny, any), ImmutableList.of(rule1, rule2), uid1, name1);
-    AccessLayer al1b =
-        new AccessLayer(ImmutableMap.of(uidAny, any), ImmutableList.of(rule3), uid1, name1);
-    AccessLayer al1 =
-        new AccessLayer(
-            ImmutableMap.of(uidAny, any), ImmutableList.of(rule1, rule2, rule3), uid1, name1);
 
-    AccessLayer al2a =
+    AccessLayer ala =
         new AccessLayer(
             ImmutableMap.of(uidAny, any, uidTcp, tcp),
             ImmutableList.of(new AccessSection("section1", ImmutableList.of(rule1), uidSection1)),
             uid2,
             name2);
-    AccessLayer al2b =
+    AccessLayer alb =
         new AccessLayer(
             ImmutableMap.of(uidAny, any, uidUdp, udp),
             ImmutableList.of(
                 new AccessSection("section1", ImmutableList.of(rule2), uidSection1), rule3),
             uid2,
             name2);
-    AccessLayer al2 =
+    AccessLayer al =
         new AccessLayer(
             ImmutableMap.of(uidAny, any, uidTcp, tcp, uidUdp, udp),
             ImmutableList.of(
@@ -533,9 +524,7 @@ public final class CheckpointManagementParserTest {
             uid2,
             name2);
 
-    assertThat(
-        mergeAccessLayers(ImmutableList.of(al1a, al1b, al2a, al2b), pvcae),
-        equalTo(ImmutableList.of(al1, al2)));
+    assertThat(mergeAccessLayers(ImmutableList.of(ala, alb), pvcae), equalTo(ImmutableList.of(al)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParserTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParserTest.java
@@ -1,5 +1,7 @@
 package org.batfish.vendor.check_point_management.parsing;
 
+import static org.batfish.common.BfConsts.RELPATH_CHECKPOINT_MANAGEMENT_DIR;
+import static org.batfish.common.matchers.WarningMatchers.hasText;
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.RELPATH_CHECKPOINT_SHOW_GATEWAYS_AND_SERVERS;
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.RELPATH_CHECKPOINT_SHOW_GROUPS;
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.RELPATH_CHECKPOINT_SHOW_NAT_RULEBASE;
@@ -8,8 +10,10 @@ import static org.batfish.vendor.check_point_management.parsing.CheckpointManage
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.RELPATH_CHECKPOINT_SHOW_SERVICES_UDP;
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.RELPATH_CHECKPOINT_SHOW_SERVICE_GROUPS;
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.buildObjectsList;
+import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.mergeAccessLayers;
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.readGatewaysAndServers;
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.readNatRulebase;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNull;
@@ -21,6 +25,9 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
+import org.batfish.vendor.check_point_management.AccessLayer;
+import org.batfish.vendor.check_point_management.AccessRule;
+import org.batfish.vendor.check_point_management.AccessSection;
 import org.batfish.vendor.check_point_management.AllInstallationTargets;
 import org.batfish.vendor.check_point_management.CpmiAnyObject;
 import org.batfish.vendor.check_point_management.Domain;
@@ -397,6 +404,166 @@ public final class CheckpointManagementParserTest {
                         Uid.of("6"),
                         Uid.of("0"))),
                 Uid.of("0"))));
+  }
+
+  @Test
+  public void testMergeAccessLayers() {
+    ParseVendorConfigurationAnswerElement pvcae = new ParseVendorConfigurationAnswerElement();
+    Uid uidAny = Uid.of("0");
+    Uid uid1 = Uid.of("1");
+    Uid uid2 = Uid.of("2");
+    Uid uidTcp = Uid.of("3");
+    Uid uidUdp = Uid.of("4");
+    Uid uidRule1 = Uid.of("5");
+    Uid uidRule2 = Uid.of("6");
+    Uid uidRule3 = Uid.of("7");
+    Uid uidBogus = Uid.of("999");
+    String name1 = "1";
+    String name2 = "2";
+    CpmiAnyObject any = new CpmiAnyObject(uidAny);
+    ServiceTcp tcp = new ServiceTcp("tcp", "1234", uidTcp);
+    ServiceUdp udp = new ServiceUdp("udp", "1234", uidUdp);
+    AccessRule rule1 =
+        AccessRule.testBuilder(uidAny)
+            .setName("rule1")
+            .setUid(uidRule1)
+            .setAction(uidBogus)
+            .build();
+    AccessRule rule2 =
+        AccessRule.testBuilder(uidAny)
+            .setName("rule2")
+            .setUid(uidRule2)
+            .setAction(uidBogus)
+            .build();
+    AccessRule rule3 =
+        AccessRule.testBuilder(uidAny)
+            .setName("rule3")
+            .setUid(uidRule3)
+            .setAction(uidBogus)
+            .build();
+    AccessLayer al1a =
+        new AccessLayer(ImmutableMap.of(uidAny, any), ImmutableList.of(rule1, rule2), uid1, name1);
+    AccessLayer al1b =
+        new AccessLayer(ImmutableMap.of(uidAny, any), ImmutableList.of(rule3), uid1, name1);
+    AccessLayer al1 =
+        new AccessLayer(
+            ImmutableMap.of(uidAny, any), ImmutableList.of(rule1, rule2, rule3), uid1, name1);
+
+    AccessLayer al2a =
+        new AccessLayer(
+            ImmutableMap.of(uidAny, any, uidTcp, tcp), ImmutableList.of(rule1), uid2, name2);
+    AccessLayer al2b =
+        new AccessLayer(
+            ImmutableMap.of(uidAny, any, uidUdp, udp), ImmutableList.of(rule2), uid2, name2);
+    AccessLayer al2 =
+        new AccessLayer(
+            ImmutableMap.of(uidAny, any, uidTcp, tcp, uidUdp, udp),
+            ImmutableList.of(rule1, rule2),
+            uid2,
+            name2);
+
+    assertThat(
+        mergeAccessLayers(ImmutableList.of(al1a, al1b, al2a, al2b), pvcae),
+        equalTo(ImmutableList.of(al1, al2)));
+  }
+
+  /** Test merging AccessLayers when their children (AccessSections) are split across pages. */
+  @Test
+  public void testMergeAccessLayersAccessSectionSplit() {
+    ParseVendorConfigurationAnswerElement pvcae = new ParseVendorConfigurationAnswerElement();
+    Uid uidAny = Uid.of("0");
+    Uid uid1 = Uid.of("1");
+    Uid uid2 = Uid.of("2");
+    Uid uidTcp = Uid.of("3");
+    Uid uidUdp = Uid.of("4");
+    Uid uidRule1 = Uid.of("5");
+    Uid uidRule2 = Uid.of("6");
+    Uid uidRule3 = Uid.of("7");
+    Uid uidSection1 = Uid.of("8");
+    Uid uidBogus = Uid.of("999");
+    String name1 = "1";
+    String name2 = "2";
+    CpmiAnyObject any = new CpmiAnyObject(uidAny);
+    ServiceTcp tcp = new ServiceTcp("tcp", "1234", uidTcp);
+    ServiceUdp udp = new ServiceUdp("udp", "1234", uidUdp);
+    AccessRule rule1 =
+        AccessRule.testBuilder(uidAny)
+            .setName("rule1")
+            .setUid(uidRule1)
+            .setAction(uidBogus)
+            .build();
+    AccessRule rule2 =
+        AccessRule.testBuilder(uidAny)
+            .setName("rule2")
+            .setUid(uidRule2)
+            .setAction(uidBogus)
+            .build();
+    AccessRule rule3 =
+        AccessRule.testBuilder(uidAny)
+            .setName("rule3")
+            .setUid(uidRule3)
+            .setAction(uidBogus)
+            .build();
+    AccessLayer al1a =
+        new AccessLayer(ImmutableMap.of(uidAny, any), ImmutableList.of(rule1, rule2), uid1, name1);
+    AccessLayer al1b =
+        new AccessLayer(ImmutableMap.of(uidAny, any), ImmutableList.of(rule3), uid1, name1);
+    AccessLayer al1 =
+        new AccessLayer(
+            ImmutableMap.of(uidAny, any), ImmutableList.of(rule1, rule2, rule3), uid1, name1);
+
+    AccessLayer al2a =
+        new AccessLayer(
+            ImmutableMap.of(uidAny, any, uidTcp, tcp),
+            ImmutableList.of(new AccessSection("section1", ImmutableList.of(rule1), uidSection1)),
+            uid2,
+            name2);
+    AccessLayer al2b =
+        new AccessLayer(
+            ImmutableMap.of(uidAny, any, uidUdp, udp),
+            ImmutableList.of(
+                new AccessSection("section1", ImmutableList.of(rule2), uidSection1), rule3),
+            uid2,
+            name2);
+    AccessLayer al2 =
+        new AccessLayer(
+            ImmutableMap.of(uidAny, any, uidTcp, tcp, uidUdp, udp),
+            ImmutableList.of(
+                new AccessSection("section1", ImmutableList.of(rule1, rule2), uidSection1), rule3),
+            uid2,
+            name2);
+
+    assertThat(
+        mergeAccessLayers(ImmutableList.of(al1a, al1b, al2a, al2b), pvcae),
+        equalTo(ImmutableList.of(al1, al2)));
+  }
+
+  @Test
+  public void testMergeAccessLayersWarning() {
+    ParseVendorConfigurationAnswerElement pvcae = new ParseVendorConfigurationAnswerElement();
+    Uid uidAny = Uid.of("0");
+    Uid uid1 = Uid.of("1");
+    Uid uidRule1 = Uid.of("5");
+    Uid uidBogus = Uid.of("999");
+    String name1 = "1";
+    CpmiAnyObject any = new CpmiAnyObject(uidAny);
+    AccessRule rule1 =
+        AccessRule.testBuilder(uidAny)
+            .setName("rule1")
+            .setUid(uidRule1)
+            .setAction(uidBogus)
+            .build();
+    AccessLayer al1a =
+        new AccessLayer(ImmutableMap.of(uidAny, any), ImmutableList.of(rule1), uid1, name1);
+    AccessLayer al1b =
+        new AccessLayer(ImmutableMap.of(uidAny, any), ImmutableList.of(rule1), uid1, name1);
+    assertThat(
+        mergeAccessLayers(ImmutableList.of(al1a, al1b), pvcae), equalTo(ImmutableList.of(al1a)));
+    assertThat(
+        pvcae.getWarnings().get(RELPATH_CHECKPOINT_MANAGEMENT_DIR).getRedFlagWarnings(),
+        contains(
+            hasText(
+                "Cannot merge AccessRule pages (for uid 5), ignoring instances after the first")));
   }
 
   /** Convert JSON object text into ObjectPage JSON */


### PR DESCRIPTION
Handle merging `AccessLayer` pages in access-rulebase json input files.

----

Handles merging both:
1. top-level rulebase split across pages
2. rulebase within `AccessSection`s under the top-level rulebase

