### PR TITLE
BGP only export best-path routes when not using add-path

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -2128,9 +2128,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   Stream<RouteAdvertisement<Bgpv4Route>> getRoutesToLeak() {
     return Stream.concat(
         _localDeltaPrev.getActions(),
-        _bgpv4DeltaPrevBestPath
-            .getActions()
-            .filter(r -> !_importedFromOtherVrfs.contains(r.getRoute())));
+        _bgpv4DeltaPrev.getActions().filter(r -> !_importedFromOtherVrfs.contains(r.getRoute())));
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -15,6 +15,7 @@ import static org.batfish.dataplane.rib.RibDelta.importDeltaToBuilder;
 import static org.batfish.dataplane.rib.RibDelta.importRibDelta;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -169,14 +170,18 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
 
   // outgoing RIB deltas for the current round (i.e., deltas generated in the previous round)
   @Nonnull private RibDelta<Bgpv4Route> _ebgpv4DeltaPrev = RibDelta.empty();
+  @Nonnull private RibDelta<Bgpv4Route> _ebgpv4DeltaPrevBestPath = RibDelta.empty();
   @Nonnull private RibDelta<Bgpv4Route> _bgpv4DeltaPrev = RibDelta.empty();
+  @Nonnull private RibDelta<Bgpv4Route> _bgpv4DeltaPrevBestPath = RibDelta.empty();
   // currently used for VRF-leaking only.
   @Nonnull private RibDelta<Bgpv4Route> _localDeltaPrev = RibDelta.empty();
 
   // copy of RIBs from prev round, for new links in the current round.
   // Nullable so they crash on improper use.
   private @Nullable Set<Bgpv4Route> _ebgpv4Prev;
+  private @Nullable Set<Bgpv4Route> _ebgpv4PrevBestPath;
   private @Nullable Set<Bgpv4Route> _bgpv4Prev;
+  private @Nullable Set<Bgpv4Route> _bgpv4PrevBestPath;
 
   /**
    * Routes in the main RIB at the end of the previous round. Unused if {@link #_exportFromBgpRib}
@@ -483,11 +488,15 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         _mainRibPrev = _mainRib.getTypedRoutes();
       }
       _bgpv4Prev = _bgpv4Rib.getTypedRoutes();
+      _bgpv4PrevBestPath = _bgpv4Rib.getBestPathRoutes();
       _ebgpv4Prev = _ebgpv4Rib.getTypedRoutes();
+      _ebgpv4PrevBestPath = _ebgpv4Rib.getBestPathRoutes();
     } else {
       assert _mainRibPrev == null;
       assert _bgpv4Prev == null;
+      assert _bgpv4PrevBestPath == null;
       assert _ebgpv4Prev == null;
+      assert _ebgpv4PrevBestPath == null;
     }
     _topology = topology;
     // TODO: compute edges that went down, remove routes we received from those neighbors
@@ -633,7 +642,9 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         // The reason we look at PREV values is because
         // endOfRound has been called BEFORE the isDirty check and we've already switched over.
         || !_ebgpv4DeltaPrev.isEmpty()
+        || !_ebgpv4DeltaPrevBestPath.isEmpty()
         || !_bgpv4DeltaPrev.isEmpty()
+        || !_bgpv4DeltaPrevBestPath.isEmpty()
         || !_mainRibDelta.isEmpty()
         || !_localDeltaPrev.isEmpty()
         // Delta builders
@@ -978,30 +989,51 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
      * 2. Advertise inactive: advertise best-path BGP routes to neighboring peers even if
      *    they are not active in the main RIB.
      */
+    Set<Bgpv4Route> bgpv4Prev;
+    RibDelta<Bgpv4Route> bgpv4DeltaPrev;
+    Set<Bgpv4Route> ebgpv4Prev;
+    RibDelta<Bgpv4Route> ebgpv4DeltaPrev;
+    if (session.getAdditionalPaths()) {
+      /*
+      TODO: https://github.com/batfish/batfish/issues/704
+         Add path is broken for all intents and purposes.
+         Need support for additional-paths based on https://tools.ietf.org/html/rfc7911
+         AND the combination of vendor-specific knobs, none of which are currently supported.
+      */
+      bgpv4Prev = _bgpv4Prev;
+      bgpv4DeltaPrev = _bgpv4DeltaPrev;
+      ebgpv4Prev = _ebgpv4Prev;
+      ebgpv4DeltaPrev = _ebgpv4DeltaPrev;
+    } else {
+      bgpv4Prev = _bgpv4PrevBestPath;
+      bgpv4DeltaPrev = _bgpv4DeltaPrevBestPath;
+      ebgpv4Prev = _ebgpv4PrevBestPath;
+      ebgpv4DeltaPrev = _ebgpv4DeltaPrevBestPath;
+    }
     if (session.getAdvertiseExternal()) {
       if (isNewSession) {
         bgpRibExports.from(
-            _ebgpv4Prev.stream().map(this::annotateRoute).map(RouteAdvertisement::new));
+            ebgpv4Prev.stream().map(this::annotateRoute).map(RouteAdvertisement::new));
       } else {
-        importDeltaToBuilder(bgpRibExports, _ebgpv4DeltaPrev, _vrfName);
+        importDeltaToBuilder(bgpRibExports, ebgpv4DeltaPrev, _vrfName);
       }
     }
 
     if (session.getAdvertiseInactive()) {
       if (isNewSession) {
         bgpRibExports.from(
-            _bgpv4Prev.stream().map(this::annotateRoute).map(RouteAdvertisement::new));
+            bgpv4Prev.stream().map(this::annotateRoute).map(RouteAdvertisement::new));
       } else {
-        importDeltaToBuilder(bgpRibExports, _bgpv4DeltaPrev, _vrfName);
+        importDeltaToBuilder(bgpRibExports, bgpv4DeltaPrev, _vrfName);
       }
     } else {
       // Default behavior
       Stream<RouteAdvertisement<AnnotatedRoute<Bgpv4Route>>> routes;
       if (isNewSession) {
-        routes = _bgpv4Prev.stream().map(this::annotateRoute).map(RouteAdvertisement::new);
+        routes = bgpv4Prev.stream().map(this::annotateRoute).map(RouteAdvertisement::new);
       } else {
         routes =
-            _bgpv4DeltaPrev
+            bgpv4DeltaPrev
                 .getActions()
                 .filter(r -> !r.isWithdrawn())
                 .map(
@@ -1018,16 +1050,6 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
                   // Received from 0.0.0.0 indicates local origination
                   (_exportFromBgpRib && Ip.ZERO.equals(r.getRoute().getRoute().getReceivedFromIp()))
                       || _mainRib.containsRoute(r.getRoute())));
-    }
-
-    /*
-    * TODO: https://github.com/batfish/batfish/issues/704
-       Add path is broken for all intents and purposes.
-       Need support for additional-paths based on https://tools.ietf.org/html/rfc7911
-       AND the combination of vendor-specific knobs, none of which are currently supported.
-    */
-    if (session.getAdditionalPaths()) {
-      importDeltaToBuilder(bgpRibExports, _bgpv4DeltaPrev, _vrfName);
     }
 
     /*
@@ -1907,7 +1929,9 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             // The reason we look at PREV values is because
             // endOfRound has been called BEFORE the isDirty check and we've already switched over.
             _ebgpv4DeltaPrev,
+            _ebgpv4DeltaPrevBestPath,
             _bgpv4DeltaPrev,
+            _bgpv4DeltaPrevBestPath,
             // Message queues
             _evpnType3IncomingRoutes,
             // Delta builders
@@ -1985,8 +2009,18 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
 
   public void endOfRound() {
     _bgpv4DeltaPrev = _bgpv4DeltaBuilder.build();
+    _bgpv4DeltaPrevBestPath =
+        getDeltaPrevBestPath(
+            _bgpv4DeltaPrev,
+            _bgpv4Rib,
+            firstNonNull(_bgpv4PrevBestPath, ImmutableSet.of())); // null during first round
     _bgpv4DeltaBuilder = RibDelta.builder();
     _ebgpv4DeltaPrev = _ebgpv4DeltaBuilder.build();
+    _ebgpv4DeltaPrevBestPath =
+        getDeltaPrevBestPath(
+            _ebgpv4DeltaPrev,
+            _ebgpv4Rib,
+            firstNonNull(_ebgpv4PrevBestPath, ImmutableSet.of())); // null during first round
     _ebgpv4DeltaBuilder = RibDelta.builder();
     _localDeltaPrev = _localDeltaBuilder.build();
     _localDeltaBuilder = RibDelta.builder();
@@ -1996,8 +2030,26 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     _mainRibPrev = null;
     _bgpv4Prev = null;
     _ebgpv4Prev = null;
+    _bgpv4PrevBestPath = null;
+    _ebgpv4PrevBestPath = null;
     // Main RIB delta for exporting directly from main RIB
     _mainRibDelta = RibDelta.empty();
+  }
+
+  /** Get BGP RIB previous best path delta from the rib and the previous best path routes. */
+  private @Nonnull RibDelta<Bgpv4Route> getDeltaPrevBestPath(
+      RibDelta<Bgpv4Route> delta, Bgpv4Rib rib, Set<Bgpv4Route> prevBestPathRoutes) {
+    // Under best-path:
+    // - If a route is to be advertised, it must be be the current best-path.
+    // - If a route is to be withdrawn, it must have been the best path in the last round.
+    return RibDelta.of(
+        delta
+            .getActions()
+            .filter(
+                adv ->
+                    (adv.isWithdrawn() && prevBestPathRoutes.contains(adv.getRoute()))
+                        || (!adv.isWithdrawn() && rib.isBestPath(adv.getRoute())))
+            .collect(ImmutableList.toImmutableList()));
   }
 
   /**
@@ -2076,7 +2128,9 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   Stream<RouteAdvertisement<Bgpv4Route>> getRoutesToLeak() {
     return Stream.concat(
         _localDeltaPrev.getActions(),
-        _bgpv4DeltaPrev.getActions().filter(r -> !_importedFromOtherVrfs.contains(r.getRoute())));
+        _bgpv4DeltaPrevBestPath
+            .getActions()
+            .filter(r -> !_importedFromOtherVrfs.contains(r.getRoute())));
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -841,6 +841,9 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       // consume exported routes
       RouteAdvertisement<Bgpv4Route> remoteRouteAdvert = exportedRoutes.next();
       Bgpv4Route remoteRoute = remoteRouteAdvert.getRoute();
+      if (remoteRoute.getNetwork().equals(Prefix.strict("10.1.0.0/24"))) {
+        assert Boolean.TRUE;
+      }
 
       Bgpv4Route.Builder transformedIncomingRouteBuilder =
           transformBgpRouteOnImport(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -841,9 +841,6 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       // consume exported routes
       RouteAdvertisement<Bgpv4Route> remoteRouteAdvert = exportedRoutes.next();
       Bgpv4Route remoteRoute = remoteRouteAdvert.getRoute();
-      if (remoteRoute.getNetwork().equals(Prefix.strict("10.1.0.0/24"))) {
-        assert Boolean.TRUE;
-      }
 
       Bgpv4Route.Builder transformedIncomingRouteBuilder =
           transformBgpRouteOnImport(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -186,6 +186,11 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
     }
   }
 
+  /** Whether a route is currently the best path for its prefix */
+  public final boolean isBestPath(R route) {
+    return route.equals(_bestPaths.get(route.getNetwork()));
+  }
+
   public Set<R> getBestPathRoutes() {
     return ImmutableSet.copyOf(_bestPaths.values());
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD
@@ -26,6 +26,7 @@ junit_tests(
     ]),
     resources = [
         "//projects/batfish/src/test/resources",
+        "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export",
         "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-topology-change",
     ],
     runtime_deps = [

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpBestPathExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpBestPathExportTest.java
@@ -133,6 +133,7 @@ public final class BgpBestPathExportTest {
    * - R3 starts iBGP sessions with R2 and R3
    * - R1 redistributes 10.1.0.0/24 to R2 and R3 with high local preference
    * - R2 and R3 redistribute 10.1.0.0/24 to R4 with low local preference
+   * - R4 starts eBGP session with R5
    * In round 2:
    * - R4 exports low local preference 10.1.0.0/24 to R5, erasing local preference and replacing NH
    * - R2 and R3 export high local preference 10.1.0.0/24 received from R1 to R4

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpBestPathExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpBestPathExportTest.java
@@ -1,0 +1,197 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHop;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.Set;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests of BGP best-path export logic. */
+public final class BgpBestPathExportTest {
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  /*
+   * Topology: {R1,R2} <=> R3 <=> R4 <=> R5
+   * All routers have BGP multipath enabled
+   * R5 has static routes to R1/2's subnets
+   * In round 1:
+   * - R1 and R2 redistribute routes for 10.1.0.0/24 to R3
+   * - The resulting BGP RIB routes on R3 are ECMP-equivalent
+   * - R4 redistributes static routes for R3/5's loopbacks to R5/3
+   * In round 2:
+   * - R3 and R5 start an iBGP session
+   * - R3 should only export a single best route for 10.1.0.0/24 to R5
+   */
+  @Test
+  public void testOnlyBestPathsExportedNewSession() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/bgp-best-path-export/new-session";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(snapshotPath, "r1", "r2", "r3", "r4", "r5")
+                .build(),
+            _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dataplane =
+        (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+    Set<Bgpv4Route> bgpRoutesOnR3 =
+        dataplane.getBgpRoutes().get("r3", Configuration.DEFAULT_VRF_NAME);
+    Set<Bgpv4Route> bgpRoutesOnR4 =
+        dataplane.getBgpRoutes().get("r4", Configuration.DEFAULT_VRF_NAME);
+    Set<Bgpv4Route> bgpRoutesOnR5 =
+        dataplane.getBgpRoutes().get("r5", Configuration.DEFAULT_VRF_NAME);
+    assertThat(
+        bgpRoutesOnR3.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            // should receive from R4
+            hasPrefix(Prefix.parse("5.5.5.5/32")),
+            // should have two paths for 10.1.0.0/24; one from R1, and one from R2
+            hasPrefix(Prefix.parse("10.1.0.0/24")),
+            hasPrefix(Prefix.parse("10.1.0.0/24"))));
+    assertThat(
+        bgpRoutesOnR4.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            // should be redistributing these
+            hasPrefix(Prefix.parse("3.3.3.3/32")), hasPrefix(Prefix.parse("5.5.5.5/32"))));
+    assertThat(
+        bgpRoutesOnR5.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            // should receive from R4
+            hasPrefix(Prefix.parse("3.3.3.3/32")),
+            hasPrefix(
+                // should only have received single best-path entry for 10.1.0.0/24 from R3
+                Prefix.parse("10.1.0.0/24"))));
+  }
+
+  /*
+   * Topology: {R1,R2} <=> R3 <=> R4
+   * All routers have BGP multipath enabled
+   * R4 has static routes to R1/2's subnets
+   * R3 and R4 have static routes to each other's loopback
+   * In round 1:
+   * - R1 and R2 redistribute routes for 10.1.0.0/24 to R3
+   * - The resulting BGP RIB routes on R3 are ECMP-equivalent
+   * - R3 and R4 start an iBGP session
+   * In round 2:
+   * - R3 should only export a single best route for 10.1.0.0/24 to R5
+   */
+  @Test
+  public void testOnlyBestPathsExportedOldSession() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/bgp-best-path-export/old-session";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(snapshotPath, "r1", "r2", "r3", "r4")
+                .build(),
+            _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dataplane =
+        (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+    Set<Bgpv4Route> bgpRoutesOnR3 =
+        dataplane.getBgpRoutes().get("r3", Configuration.DEFAULT_VRF_NAME);
+    Set<Bgpv4Route> bgpRoutesOnR4 =
+        dataplane.getBgpRoutes().get("r4", Configuration.DEFAULT_VRF_NAME);
+    assertThat(
+        bgpRoutesOnR3.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            // should have two paths for 10.1.0.0/24; one from R1, and one from R2
+            hasPrefix(Prefix.parse("10.1.0.0/24")), hasPrefix(Prefix.parse("10.1.0.0/24"))));
+    assertThat(
+        bgpRoutesOnR4.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            hasPrefix(
+                // should only have received single best-path entry for 10.1.0.0/24 from R3
+                Prefix.parse("10.1.0.0/24"))));
+  }
+
+  /*
+   * Topology: R1 <=> {R2,R3} <=> R4 <=> R5
+   * All routers have BGP multipath enabled
+   * R1-4 have static routes to each other's loopbacks
+   * R1-3 have static routes for 10.1.0.0/24
+   * R2 and R3 have higher than BGP admin distance for their 10.1.0.0/24 static route
+   * R2 and R3 redistribute 10.1.0.0/24 with weight 0
+   * R2 and R3 are route reflectors
+   * In round 1:
+   * - R1 starts iBGP sessions with R2 and R3
+   * - R3 starts iBGP sessions with R2 and R3
+   * - R1 redistributes 10.1.0.0/24 to R2 and R3 with high local preference
+   * - R2 and R3 redistribute 10.1.0.0/24 to R4 with low local preference
+   * In round 2:
+   * - R4 exports low local preference 10.1.0.0/24 to R5, erasing local preference and replacing NH
+   * - R2 and R3 export high local preference 10.1.0.0/24 received from R1 to R4
+   * - R4's resulting BGP RIB delta should have WITHDRAW of single best route from R2 or R3,
+   *   and ADD of new best route originating from R1
+   * In round 3:
+   * - R4's earlier BGP RIB for 10.1.0.0/24 should result in no-OP export delta, since transform
+   *   of old best route and new best route should be identical.
+   */
+  @Test
+  public void testOnlyPreviousBestPathsWithdrawn() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(snapshotPath, "r1", "r2", "r3", "r4", "r5")
+                .build(),
+            _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dataplane =
+        (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+    Set<Bgpv4Route> bgpRoutesOnR2 =
+        dataplane.getBgpRoutes().get("r2", Configuration.DEFAULT_VRF_NAME);
+    Set<Bgpv4Route> bgpRoutesOnR3 =
+        dataplane.getBgpRoutes().get("r3", Configuration.DEFAULT_VRF_NAME);
+    Set<Bgpv4Route> bgpRoutesOnR4 =
+        dataplane.getBgpRoutes().get("r4", Configuration.DEFAULT_VRF_NAME);
+    Set<Bgpv4Route> bgpRoutesOnR5 =
+        dataplane.getBgpRoutes().get("r5", Configuration.DEFAULT_VRF_NAME);
+    assertThat(
+        bgpRoutesOnR2.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            // should have single best path for 10.1.0.0/24 through R1
+            allOf(
+                hasPrefix(Prefix.parse("10.1.0.0/24")),
+                hasNextHop(NextHopIp.of(Ip.parse("1.1.1.1"))))));
+    assertThat(
+        bgpRoutesOnR3.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            // should have single best path for 10.1.0.0/24 through R1
+            allOf(
+                hasPrefix(Prefix.parse("10.1.0.0/24")),
+                hasNextHop(NextHopIp.of(Ip.parse("1.1.1.1"))))));
+    assertThat(
+        bgpRoutesOnR4.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            // should have two paths for 10.1.0.0/24; one through R2, and one through R3
+            // both should have next hop of R1
+            allOf(
+                hasPrefix(Prefix.parse("10.1.0.0/24")),
+                hasNextHop(NextHopIp.of(Ip.parse("1.1.1.1")))),
+            allOf(
+                hasPrefix(Prefix.parse("10.1.0.0/24")),
+                hasNextHop(NextHopIp.of(Ip.parse("1.1.1.1"))))));
+    assertThat(
+        bgpRoutesOnR5.stream().collect(ImmutableList.toImmutableList()),
+        containsInAnyOrder(
+            hasPrefix(
+                // should only have received single best-path entry for 10.1.0.0/24 from R4
+                Prefix.parse("10.1.0.0/24"))));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/BUILD
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/BUILD
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "bgp-best-path-export",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD"],
+    ),
+)

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r1
@@ -1,0 +1,28 @@
+hostname r1
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.13.0/31
+  description to r3
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.1.0/31
+  description NH for static route
+
+route-map REDISTRIBUTE_STATIC permit 10
+
+router bgp 1
+  router-id 1.1.1.1
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+    redistribute static route-map REDISTRIBUTE_STATIC
+  neighbor 10.0.13.1
+    remote-as 3
+    address-family ipv4 unicast
+
+ip route 10.1.0.0/24 10.0.1.1
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r2
@@ -1,0 +1,28 @@
+hostname r2
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.23.0/31
+  description to r3
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.2.0/31
+  description NH for static route
+
+route-map REDISTRIBUTE_STATIC permit 10
+
+router bgp 1
+  router-id 2.2.2.2
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+    redistribute static route-map REDISTRIBUTE_STATIC
+  neighbor 10.0.23.1
+    remote-as 3
+    address-family ipv4 unicast
+
+ip route 10.1.0.0/24 10.0.2.1
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r3
@@ -1,0 +1,51 @@
+hostname r3
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.13.1/31
+  description to r1
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.23.1/31
+  description to r2
+
+interface Ethernet3
+  no switchport
+  no shutdown
+  ip address 10.0.34.0/31
+  description to r4
+
+interface Loopback0
+  ip address 3.3.3.3/32
+
+ip prefix-list PL_R5 permit 5.5.5.5/32
+
+route-map ALLOW_R5 permit 10
+  match ip address prefix-list PL_R5
+
+route-map REJECT_ALL deny 10
+
+router bgp 3
+  router-id 3.3.3.3
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+  neighbor 10.0.13.0
+    remote-as 1
+    address-family ipv4 unicast
+  neighbor 10.0.23.0
+    remote-as 1
+    address-family ipv4 unicast
+  neighbor 10.0.34.1
+    remote-as 4
+    address-family ipv4 unicast
+    route-map ALLOW_R5 in
+    route-map REJECT_ALL out
+  neighbor 5.5.5.5
+    remote-as 3
+    update-source Loopback0
+    address-family ipv4 unicast
+    route-map REJECT_ALL in

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r4
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r4
@@ -1,0 +1,48 @@
+hostname r4
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.34.1/31
+  description to r3
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.45.0/31
+  description to r5
+
+route-map REDISTRIBUTE_STATIC permit 10
+
+route-map REJECT_ALL deny 10
+
+ip prefix-list PL_R3 permit 3.3.3.3/32
+
+route-map ALLOW_R3 permit 10
+  match ip address prefix-list PL_R3
+
+ip prefix-list PL_R5 permit 5.5.5.5/32
+
+route-map ALLOW_R5 permit 10
+  match ip address prefix-list PL_R5
+
+ip route 3.3.3.3/32 10.0.34.0
+ip route 5.5.5.5/32 10.0.45.1
+
+router bgp 4
+  router-id 4.4.4.4
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+    redistribute static route-map REDISTRIBUTE_STATIC
+  neighbor 10.0.34.0
+    remote-as 3
+    address-family ipv4 unicast
+    route-map REJECT_ALL in
+    route-map ALLOW_R5 out
+  neighbor 10.0.45.1
+    remote-as 3
+    address-family ipv4 unicast
+    route-map REJECT_ALL in
+    route-map ALLOW_R3 out
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r5
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/new-session/configs/r5
@@ -1,0 +1,37 @@
+hostname r5
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.45.1/31
+  description to r4
+
+interface Loopback0
+  ip address 5.5.5.5/32
+
+ip prefix-list PL_R3 permit 3.3.3.3/32
+
+route-map ALLOW_R3 permit 10
+  match ip address prefix-list PL_R3
+
+route-map REJECT_ALL deny 10
+
+ip route 10.0.13.0/31 3.3.3.3
+ip route 10.0.23.0/31 3.3.3.3
+
+router bgp 3
+  router-id 5.5.5.5
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+  neighbor 10.0.45.0
+    remote-as 4
+    address-family ipv4 unicast
+    route-map ALLOW_R3 in
+    route-map REJECT_ALL out
+  neighbor 3.3.3.3
+    remote-as 3
+    update-source Loopback0
+    address-family ipv4 unicast
+    route-map REJECT_ALL out
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/old-session/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/old-session/configs/r1
@@ -1,0 +1,28 @@
+hostname r1
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.13.0/31
+  description to r3
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.1.0/31
+  description NH for static route
+
+route-map REDISTRIBUTE_STATIC permit 10
+
+router bgp 1
+  router-id 1.1.1.1
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+    redistribute static route-map REDISTRIBUTE_STATIC
+  neighbor 10.0.13.1
+    remote-as 3
+    address-family ipv4 unicast
+
+ip route 10.1.0.0/24 10.0.1.1
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/old-session/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/old-session/configs/r2
@@ -1,0 +1,28 @@
+hostname r2
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.23.0/31
+  description to r3
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.2.0/31
+  description NH for static route
+
+route-map REDISTRIBUTE_STATIC permit 10
+
+router bgp 1
+  router-id 2.2.2.2
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+    redistribute static route-map REDISTRIBUTE_STATIC
+  neighbor 10.0.23.1
+    remote-as 3
+    address-family ipv4 unicast
+
+ip route 10.1.0.0/24 10.0.2.1
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/old-session/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/old-session/configs/r3
@@ -1,0 +1,43 @@
+hostname r3
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.13.1/31
+  description to r1
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.23.1/31
+  description to r2
+
+interface Ethernet3
+  no switchport
+  no shutdown
+  ip address 10.0.34.0/31
+  description to r4
+
+interface Loopback0
+  ip address 3.3.3.3/32
+
+ip route 4.4.4.4/32 10.0.34.1
+
+route-map REJECT_ALL deny 10
+
+router bgp 3
+  router-id 3.3.3.3
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+  neighbor 10.0.13.0
+    remote-as 1
+    address-family ipv4 unicast
+  neighbor 10.0.23.0
+    remote-as 1
+    address-family ipv4 unicast
+  neighbor 4.4.4.4
+    remote-as 3
+    update-source Loopback0
+    address-family ipv4 unicast
+    route-map REJECT_ALL in

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/old-session/configs/r4
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/old-session/configs/r4
@@ -1,0 +1,28 @@
+hostname r4
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.34.1/31
+  description to r3
+
+interface Loopback0
+  ip address 4.4.4.4/32
+
+route-map REJECT_ALL deny 10
+
+ip route 3.3.3.3/32 10.0.34.0
+ip route 10.0.13.0/31 3.3.3.3
+ip route 10.0.23.0/31 3.3.3.3
+
+router bgp 3
+  router-id 4.4.4.4
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+  neighbor 3.3.3.3
+    remote-as 3
+    update-source Loopback0
+    address-family ipv4 unicast
+    route-map REJECT_ALL out
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r1
@@ -1,0 +1,55 @@
+hostname r1
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.12.0/31
+  description to r2
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.13.0/31
+  description to r3
+
+interface Ethernet3
+  no switchport
+  no shutdown
+  ip address 10.0.1.0/31
+  description NH for static route
+
+interface Loopback0
+  ip address 1.1.1.1/32
+
+ip route 2.2.2.2/32 10.0.12.1
+ip route 3.3.3.3/32 10.0.13.1
+ip route 4.4.4.4/32 10.0.12.1
+ip route 4.4.4.4/32 10.0.13.1
+
+ip prefix-list PL_NET permit 10.1.0.0/24
+
+route-map REJECT_ALL deny 10
+
+route-map REDISTRIBUTE_STATIC permit 10
+  match ip address prefix-list PL_NET
+  set local-preference 500
+
+router bgp 1
+  router-id 1.1.1.1
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+    redistribute static route-map REDISTRIBUTE_STATIC
+  neighbor 2.2.2.2
+    remote-as 1
+    update-source Loopback0
+    address-family ipv4 unicast
+      route-map REJECT_ALL in
+  neighbor 3.3.3.3
+    remote-as 1
+    update-source Loopback0
+    address-family ipv4 unicast
+      route-map REJECT_ALL in
+
+ip route 10.1.0.0/24 10.0.1.1
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r2
@@ -1,0 +1,55 @@
+hostname r2
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.12.1/31
+  description to r1
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.24.0/31
+  description to r4
+
+interface Ethernet3
+  no switchport
+  no shutdown
+  ip address 10.0.2.0/31
+  description NH for static route
+
+interface Loopback0
+  ip address 2.2.2.2/32
+
+ip route 1.1.1.1/32 10.0.12.0
+ip route 4.4.4.4/32 10.0.24.1
+
+ip prefix-list PL_NET permit 10.1.0.0/24
+
+route-map REJECT_ALL deny 10
+
+route-map REDISTRIBUTE_STATIC permit 10
+  match ip address prefix-list PL_NET
+  set weight 0
+
+router bgp 1
+  router-id 2.2.2.2
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+    redistribute static route-map REDISTRIBUTE_STATIC
+  neighbor 1.1.1.1
+    remote-as 1
+    update-source Loopback0
+    address-family ipv4 unicast
+      route-reflector-client
+      route-map REJECT_ALL out
+  neighbor 4.4.4.4
+    remote-as 1
+    update-source Loopback0
+    address-family ipv4 unicast
+      route-reflector-client
+      route-map REJECT_ALL in
+
+ip route 10.1.0.0/24 10.0.2.1 250
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r3
@@ -1,0 +1,55 @@
+hostname r3
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.13.1/31
+  description to r1
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.34.0/31
+  description to r4
+
+interface Ethernet3
+  no switchport
+  no shutdown
+  ip address 10.0.3.0/31
+  description NH for static route
+
+interface Loopback0
+  ip address 3.3.3.3/32
+
+ip route 1.1.1.1/32 10.0.13.0
+ip route 4.4.4.4/32 10.0.34.1
+
+ip prefix-list PL_NET permit 10.1.0.0/24
+
+route-map REJECT_ALL deny 10
+
+route-map REDISTRIBUTE_STATIC permit 10
+  match ip address prefix-list PL_NET
+  set weight 0
+
+router bgp 1
+  router-id 3.3.3.3
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+    redistribute static route-map REDISTRIBUTE_STATIC
+  neighbor 1.1.1.1
+    remote-as 1
+    update-source Loopback0
+    address-family ipv4 unicast
+      route-reflector-client
+      route-map REJECT_ALL out
+  neighbor 4.4.4.4
+    remote-as 1
+    update-source Loopback0
+    address-family ipv4 unicast
+      route-reflector-client
+      route-map REJECT_ALL in
+
+ip route 10.1.0.0/24 10.0.3.1 250
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r4
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r4
@@ -1,0 +1,51 @@
+hostname r4
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.24.1/31
+  description to r2
+
+interface Ethernet2
+  no switchport
+  no shutdown
+  ip address 10.0.34.1/31
+  description to r3
+
+interface Ethernet3
+  no switchport
+  no shutdown
+  ip address 10.0.45.0/31
+  description to r5
+
+interface Loopback0
+  ip address 4.4.4.4/32
+
+route-map REJECT_ALL deny 10
+
+ip route 1.1.1.1/32 10.0.24.0
+ip route 1.1.1.1/32 10.0.34.0
+ip route 2.2.2.2/32 10.0.24.0
+ip route 3.3.3.3/32 10.0.34.0
+
+router bgp 1
+  router-id 4.4.4.4
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+  neighbor 2.2.2.2
+    remote-as 1
+    update-source Loopback0
+    address-family ipv4 unicast
+    route-map REJECT_ALL out
+  neighbor 3.3.3.3
+    remote-as 1
+    update-source Loopback0
+    address-family ipv4 unicast
+    route-map REJECT_ALL out
+  neighbor 10.0.45.1
+    remote-as 5
+    address-family ipv4 unicast
+    route-map REJECT_ALL in
+
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r5
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export/withdrawal/configs/r5
@@ -1,0 +1,19 @@
+hostname r5
+feature bgp
+
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 10.0.45.1/31
+  description to r4
+
+route-map REJECT_ALL deny 10
+
+router bgp 5
+  router-id 5.5.5.5
+  address-family ipv4 unicast
+    maximum-paths eibgp 5
+  neighbor 10.0.45.0
+    remote-as 1
+    address-family ipv4 unicast
+    route-map REJECT_ALL out


### PR DESCRIPTION
Under best path:
- To advertise an ADD, a route must currently be best
- To advertise a WITHDDRAW, a route must previously have been best