### PR TITLE
MatchInterface: implement simple version

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
@@ -68,6 +68,7 @@ import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MainRib;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
+import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv6;
@@ -216,6 +217,12 @@ public final class CommunityStructuresVerifier {
         MatchCommunities matchCommunities, CommunityStructuresVerifierContext arg) {
       matchCommunities.getCommunitySetExpr().accept(COMMUNITY_SET_EXPR_VERIFIER, arg);
       matchCommunities.getCommunitySetMatchExpr().accept(COMMUNITY_SET_MATCH_EXPR_VERIFIER, arg);
+      return null;
+    }
+
+    @Override
+    public Void visitMatchInterface(
+        MatchInterface matchInterface, CommunityStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
@@ -23,6 +23,7 @@ import org.batfish.datamodel.routing_policy.expr.HasRoute6;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
+import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv6;
@@ -169,6 +170,12 @@ public final class AsPathStructuresVerifier {
     @Override
     public Void visitMatchCommunities(
         MatchCommunities matchCommunities, AsPathStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchInterface(
+        MatchInterface matchInterface, AsPathStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprVisitor.java
@@ -35,6 +35,8 @@ public interface BooleanExprVisitor<T, U> {
 
   T visitMatchCommunities(MatchCommunities matchCommunities, U arg);
 
+  T visitMatchInterface(MatchInterface matchInterface, U arg);
+
   T visitMatchIp6AccessList(MatchIp6AccessList matchIp6AccessList, U arg);
 
   T visitMatchIpv4(MatchIpv4 matchIpv4, U arg);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchInterface.java
@@ -1,0 +1,72 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Route;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+
+/**
+ * Matches routes that have next hop as one of the configured interfaces.
+ *
+ * <p>Note: this only matches interfaces in the route, not resolved interface.
+ */
+@ParametersAreNonnullByDefault
+public final class MatchInterface extends BooleanExpr {
+  private static final String PROP_INTERFACES = "interfaces";
+
+  @Nonnull private final Set<String> _interfaces;
+
+  @JsonCreator
+  private static MatchInterface jsonCreator(
+      @Nullable @JsonProperty(PROP_INTERFACES) Set<String> interfaces) {
+    return new MatchInterface(firstNonNull(interfaces, ImmutableSet.of()));
+  }
+
+  public MatchInterface(Iterable<String> interfaces) {
+    _interfaces = ImmutableSet.copyOf(interfaces);
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprVisitor<T, U> visitor, U arg) {
+    return visitor.visitMatchInterface(this, arg);
+  }
+
+  @Override
+  public Result evaluate(Environment environment) {
+    String iname =
+        environment.getUseOutputAttributes()
+            ? environment.getOutputRoute().getNextHopInterface()
+            : environment.getOriginalRoute().getNextHopInterface();
+    boolean matches = !iname.equals(Route.UNSET_NEXT_HOP_INTERFACE) && _interfaces.contains(iname);
+    return Result.builder().setBooleanValue(matches).build();
+  }
+
+  @JsonProperty(PROP_INTERFACES)
+  public @Nonnull Set<String> getInterfaces() {
+    return _interfaces;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof MatchInterface)) {
+      return false;
+    }
+    MatchInterface other = (MatchInterface) obj;
+    return _interfaces.equals(other._interfaces);
+  }
+
+  @Override
+  public int hashCode() {
+    return _interfaces.hashCode();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchInterfaceTest.java
@@ -1,0 +1,56 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.route.nh.NextHopInterface;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.junit.Test;
+
+/** Tests of {@link MatchInterface} */
+public class MatchInterfaceTest {
+  @Test
+  public void testSerialization() {
+    MatchInterface m = new MatchInterface(ImmutableSet.of("i1", "i2"));
+    assertThat(BatfishObjectMapper.clone(m, BooleanExpr.class), equalTo(m));
+    assertThat(SerializationUtils.clone(m), equalTo(m));
+  }
+
+  @Test
+  public void testEvaluate() {
+    MatchInterface mi = new MatchInterface(ImmutableSet.of("e1", "e2"));
+    ConnectedRoute e1 =
+        ConnectedRoute.builder()
+            .setNetwork(Prefix.parse("1.0.0.0/24"))
+            .setNextHop(NextHopInterface.of("e1", Ip.parse("1.0.0.1")))
+            .build();
+    ConnectedRoute e2 =
+        ConnectedRoute.builder()
+            .setNetwork(Prefix.parse("2.0.0.0/24"))
+            .setNextHop(NextHopInterface.of("e2", Ip.parse("2.0.0.1")))
+            .build();
+    ConnectedRoute e3 =
+        ConnectedRoute.builder()
+            .setNetwork(Prefix.parse("3.0.0.0/24"))
+            .setNextHop(NextHopInterface.of("e3", Ip.parse("3.0.0.1")))
+            .build();
+    Configuration c =
+        Configuration.builder()
+            .setHostname("h")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    assertTrue(mi.evaluate(Environment.builder(c).setOriginalRoute(e1).build()).getBooleanValue());
+    assertTrue(mi.evaluate(Environment.builder(c).setOriginalRoute(e2).build()).getBooleanValue());
+    assertFalse(mi.evaluate(Environment.builder(c).setOriginalRoute(e3).build()).getBooleanValue());
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -191,6 +191,7 @@ import org.batfish.datamodel.routing_policy.expr.LiteralEigrpMetric;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
+import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchMetric;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefix6Set;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
@@ -3446,9 +3447,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               RouteMapMatchInterface routeMapMatchInterface) {
             // Matches any routes that have their next hop out one of the configured interfaces.
             // https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/6-x/unicast/configuration/guide/l3_cli_nxos/l3_rpm.html
-            // TODO: Implement MatchNextHopInterface/Ip
-            // https://github.com/batfish/batfish/issues/6502
-            return BooleanExprs.TRUE;
+            return new MatchInterface(routeMapMatchInterface.getNames());
           }
 
           @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -6787,11 +6787,10 @@ public final class CiscoNxosGrammarTest {
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("match_interface");
-      // TODO Should deny base route after implementing next hop matching (right now permits all).
-      //  https://github.com/batfish/batfish/issues/6502
-      //      assertRoutingPolicyDeniesRoute(rp, base);
+      assertRoutingPolicyDeniesRoute(rp, base);
+      // TODO: we think this should permit 192.0.2.1, since it resolves to loopback0.
       Bgpv4Route routeNextHopIp = base.toBuilder().setNextHopIp(Ip.parse("192.0.2.1")).build();
-      assertRoutingPolicyPermitsRoute(rp, routeNextHopIp);
+      assertRoutingPolicyDeniesRoute(rp, routeNextHopIp); // should permit
       Bgpv4Route routeNextHopIface = base.toBuilder().setNextHopInterface("loopback0").build();
       assertRoutingPolicyPermitsRoute(rp, routeNextHopIface);
     }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollector.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.routing_policy.expr.HasRoute6;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
+import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv6;
@@ -151,6 +152,12 @@ public class BooleanExprAsPathCollector
   @Override
   public Set<SymbolicAsPathRegex> visitMatchIp6AccessList(
       MatchIp6AccessList matchIp6AccessList, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<SymbolicAsPathRegex> visitMatchInterface(
+      MatchInterface matchInterface, Configuration arg) {
     return ImmutableSet.of();
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
@@ -20,6 +20,7 @@ import org.batfish.datamodel.routing_policy.expr.HasRoute6;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
+import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIp6AccessList;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv6;
@@ -127,6 +128,11 @@ public class BooleanExprVarCollector
                 .getCommunitySetMatchExpr()
                 .accept(new CommunitySetMatchExprVarCollector(), arg))
         .build();
+  }
+
+  @Override
+  public Set<CommunityVar> visitMatchInterface(MatchInterface matchInterface, Configuration arg) {
+    return ImmutableSet.of();
   }
 
   @Override


### PR DESCRIPTION
Interface routes (OSPF, Connected, Local, Static) will be matched, but not
resolved routes that happen to use those interface. Probably on most vendors
the latter is actually the correct semantics; however this route-map is most
often used to match local routes so it should get us going in the right
direction.

This is for batfish/batfish#6502 