### PR TITLE
CheckPoint: better NAT rulebase merging

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/HasUid.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/HasUid.java
@@ -1,0 +1,8 @@
+package org.batfish.vendor.check_point_management;
+
+import javax.annotation.Nonnull;
+
+public interface HasUid {
+  @Nonnull
+  Uid getUid();
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/HasUid.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/HasUid.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management;
 
 import javax.annotation.Nonnull;
 
+/** An object that has a {@link Uid}. */
 public interface HasUid {
   @Nonnull
   Uid getUid();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ManagementObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ManagementObject.java
@@ -7,7 +7,7 @@ import java.io.Serializable;
 import javax.annotation.Nonnull;
 
 /** Abstract class representing a management object with a UID. */
-public abstract class ManagementObject implements Serializable {
+public abstract class ManagementObject implements HasUid, Serializable {
 
   protected static final String PROP_UID = "uid";
 
@@ -15,6 +15,7 @@ public abstract class ManagementObject implements Serializable {
     _uid = uid;
   }
 
+  @Override
   public final @Nonnull Uid getUid() {
     return _uid;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRuleOrSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatRuleOrSection.java
@@ -11,6 +11,6 @@ import java.io.Serializable;
   @JsonSubTypes.Type(value = NatRule.class, name = "nat-rule"),
   @JsonSubTypes.Type(value = NatSection.class, name = "nat-section")
 })
-public interface NatRuleOrSection extends Serializable {
+public interface NatRuleOrSection extends HasUid, Serializable {
   <T> T accept(NatRuleOrSectionVisitor<T> visitor);
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatSection.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -21,7 +20,6 @@ public final class NatSection extends NamedManagementObject implements NatRuleOr
     return _rulebase;
   }
 
-  @VisibleForTesting
   public NatSection(String name, List<NatRule> rulebase, Uid uid) {
     super(name, uid);
     _rulebase = rulebase;

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatSection.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatSection.java
@@ -22,7 +22,7 @@ public final class NatSection extends NamedManagementObject implements NatRuleOr
   }
 
   @VisibleForTesting
-  NatSection(String name, List<NatRule> rulebase, Uid uid) {
+  public NatSection(String name, List<NatRule> rulebase, Uid uid) {
     super(name, uid);
     _rulebase = rulebase;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParser.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParser.java
@@ -32,7 +32,6 @@ import org.batfish.vendor.check_point_management.CheckpointManagementConfigurati
 import org.batfish.vendor.check_point_management.Domain;
 import org.batfish.vendor.check_point_management.GatewaysAndServers;
 import org.batfish.vendor.check_point_management.ManagementDomain;
-import org.batfish.vendor.check_point_management.ManagementObject;
 import org.batfish.vendor.check_point_management.ManagementPackage;
 import org.batfish.vendor.check_point_management.ManagementServer;
 import org.batfish.vendor.check_point_management.NamedManagementObject;
@@ -273,8 +272,7 @@ public class CheckpointManagementParser {
     if (items.stream().anyMatch(NatRule.class::isInstance)) {
       // Shouldn't happen w/ well-formed data, but check to prevent bad casting below
       if (items.size() > 1) {
-        Uid uid =
-            first instanceof NatRule ? ((NatRule) first).getUid() : ((NatSection) first).getUid();
+        Uid uid = first.getUid();
         pvcae.addRedFlagWarning(
             RELPATH_CHECKPOINT_MANAGEMENT_DIR,
             new Warning(
@@ -306,7 +304,7 @@ public class CheckpointManagementParser {
   private static @Nonnull List<NatRuleOrSection> mergeNatRuleOrSections(
       Collection<NatRuleOrSection> items, ParseVendorConfigurationAnswerElement pvcae) {
     LinkedListMultimap<Uid, NatRuleOrSection> uidToParts = LinkedListMultimap.create();
-    items.forEach(i -> uidToParts.put(((ManagementObject) i).getUid(), i));
+    items.forEach(i -> uidToParts.put((i).getUid(), i));
     return uidToParts.keySet().stream()
         .map(uid -> mergeNatRuleOrSection(uidToParts.get(uid), pvcae))
         .collect(ImmutableList.toImmutableList());

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParser.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/CheckpointManagementParser.java
@@ -10,7 +10,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedListMultimap;
 import java.util.Collection;
 import java.util.HashMap;
@@ -33,11 +32,14 @@ import org.batfish.vendor.check_point_management.CheckpointManagementConfigurati
 import org.batfish.vendor.check_point_management.Domain;
 import org.batfish.vendor.check_point_management.GatewaysAndServers;
 import org.batfish.vendor.check_point_management.ManagementDomain;
+import org.batfish.vendor.check_point_management.ManagementObject;
 import org.batfish.vendor.check_point_management.ManagementPackage;
 import org.batfish.vendor.check_point_management.ManagementServer;
 import org.batfish.vendor.check_point_management.NamedManagementObject;
+import org.batfish.vendor.check_point_management.NatRule;
 import org.batfish.vendor.check_point_management.NatRuleOrSection;
 import org.batfish.vendor.check_point_management.NatRulebase;
+import org.batfish.vendor.check_point_management.NatSection;
 import org.batfish.vendor.check_point_management.ObjectPage;
 import org.batfish.vendor.check_point_management.Package;
 import org.batfish.vendor.check_point_management.TypedManagementObject;
@@ -246,35 +248,91 @@ public class CheckpointManagementParser {
           pvcae,
           null);
     }
-    return mergeNatRulebasePages(
+    return mergeNatRulebase(
         natRulebases.stream()
             .filter(rulebase -> rulebase.getUid().equals(uid))
-            .collect(ImmutableList.toImmutableList()));
+            .collect(ImmutableList.toImmutableList()),
+        pvcae);
   }
 
   /**
-   * Merge objects-dictionary and nat-rules from a list of pages of NAT rulebase data into a single
-   * {@link NatRulebase} object. The pages should be provided in order, and all for the same
-   * rulebase UID.
+   * Returns a single NatRuleOrSection representing the specified collection.
+   *
+   * <p>The specified collection of items should contain one of the following:
+   *
+   * <ul>
+   *   <li>1. a single NatRule (rules can't be split across pages)
+   *   <li>2. a single NatSection (contained fully on a single page)
+   *   <li>3. multiple NatSection (all with the same name and uid, with different rules)
+   * </ul>
    */
-  private static @Nonnull NatRulebase mergeNatRulebasePages(
-      Collection<NatRulebase> natRulebasePages) {
-    if (natRulebasePages.size() == 1) {
-      return Iterables.getOnlyElement(natRulebasePages);
+  private static @Nonnull NatRuleOrSection mergeNatRuleOrSection(
+      Collection<NatRuleOrSection> items, ParseVendorConfigurationAnswerElement pvcae) {
+    NatRuleOrSection first = items.iterator().next();
+    if (items.stream().anyMatch(NatRule.class::isInstance)) {
+      // Shouldn't happen w/ well-formed data, but check to prevent bad casting below
+      if (items.size() > 1) {
+        Uid uid =
+            first instanceof NatRule ? ((NatRule) first).getUid() : ((NatSection) first).getUid();
+        pvcae.addRedFlagWarning(
+            RELPATH_CHECKPOINT_MANAGEMENT_DIR,
+            new Warning(
+                String.format(
+                    "Cannot merge NatRule pages (for uid %s), ignoring instances after the"
+                        + " first",
+                    uid.getValue()),
+                "Checkpoint"));
+      }
+      return first;
     }
-    Map<Uid, TypedManagementObject> objectsDict = new HashMap<>();
-    natRulebasePages.stream()
-        .map(NatRulebase::getObjectsDictionary)
-        .map(Map::entrySet)
-        .flatMap(Collection::stream)
-        .forEach(e -> objectsDict.put(e.getKey(), e.getValue()));
-    List<NatRuleOrSection> rulebase =
-        natRulebasePages.stream()
-            .map(NatRulebase::getRulebase)
-            .flatMap(Collection::stream)
-            .collect(ImmutableList.toImmutableList());
+
+    NatSection firstSection = (NatSection) first;
+    return new NatSection(
+        firstSection.getName(),
+        items.stream()
+            .flatMap(s -> ((NatSection) s).getRulebase().stream())
+            .collect(ImmutableList.toImmutableList()),
+        firstSection.getUid());
+  }
+
+  /**
+   * Returns a list of unique Nat Rules and Nat Sections, generated from the specified collection of
+   * non-unique items; i.e. multiple partial Nat Sections can be specified and will be merged into a
+   * single Nat Section in the resulting list.
+   *
+   * <p>The items should be provided in order.
+   */
+  private static @Nonnull List<NatRuleOrSection> mergeNatRuleOrSections(
+      Collection<NatRuleOrSection> items, ParseVendorConfigurationAnswerElement pvcae) {
+    LinkedListMultimap<Uid, NatRuleOrSection> uidToChunks = LinkedListMultimap.create();
+    items.forEach(i -> uidToChunks.put(((ManagementObject) i).getUid(), i));
+    return uidToChunks.keySet().stream()
+        .map(uid -> mergeNatRuleOrSection(uidToChunks.get(uid), pvcae))
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /**
+   * Merges multiple pages of a <i>single</i> NAT rulebase and returns the resulting rulebase.
+   *
+   * <p>Assumes all supplied pages are for the same rulebase.
+   */
+  private static @Nonnull NatRulebase mergeNatRulebase(
+      Collection<NatRulebase> pages, ParseVendorConfigurationAnswerElement pvcae) {
+    assert !pages.isEmpty();
+    NatRulebase first = pages.iterator().next();
+    Uid uid = first.getUid();
+    Map<Uid, TypedManagementObject> objs = new HashMap<>();
+    pages.stream()
+        .flatMap(p -> p.getObjectsDictionary().entrySet().stream())
+        .forEach(o -> objs.put(o.getKey(), o.getValue()));
     return new NatRulebase(
-        ImmutableMap.copyOf(objectsDict), rulebase, natRulebasePages.iterator().next().getUid());
+        ImmutableMap.copyOf(objs),
+        mergeNatRuleOrSections(
+            pages.stream()
+                .flatMap(p -> p.getRulebase().stream())
+                .collect(ImmutableList.toImmutableList()),
+            pvcae),
+        uid);
   }
 
   /**


### PR DESCRIPTION
Handle merging NAT rulebases even when NatSections are split across pages. Similar to what we're doing for `AccessLayer` page merging https://github.com/batfish/batfish/pull/7370
