### PR TITLE
CheckPoint: minor cleanup for traces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversions.java
@@ -175,7 +175,6 @@ public final class CheckPointGatewayConversions {
             .setMatchCondition(
                 toMatchExpr(rule, objs, serviceToMatchExpr, addressSpaceToMatchExpr, w))
             .setAction(toAction(objs.get(rule.getAction()), rule.getAction(), w))
-            // TODO trace element and structure ID
             .build());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
@@ -8,38 +8,39 @@ public final class CheckPointManagementTraceElementCreators {
   @VisibleForTesting
   public static TraceElement addressCpmiAnyTraceElement(boolean source) {
     return TraceElement.of(
-        String.format("Matched %s address network object Any", source ? "source" : "destination"));
+        String.format(
+            "Matched %s address network object 'Any'", source ? "source" : "destination"));
   }
 
   @VisibleForTesting
   public static TraceElement addressGroupTraceElement(Group group, boolean source) {
     return TraceElement.of(
         String.format(
-            "Matched %s address group %s", source ? "source" : "destination", group.getName()));
+            "Matched %s address group '%s'", source ? "source" : "destination", group.getName()));
   }
 
   @VisibleForTesting
   public static TraceElement serviceCpmiAnyTraceElement() {
-    return TraceElement.of("Matched service CpmiAny");
+    return TraceElement.of("Matched service object 'Any'");
   }
 
   @VisibleForTesting
   public static TraceElement serviceGroupTraceElement(ServiceGroup group) {
-    return TraceElement.of(String.format("Matched service-group %s", group.getName()));
+    return TraceElement.of(String.format("Matched service-group '%s'", group.getName()));
   }
 
   @VisibleForTesting
   public static TraceElement serviceIcmpTraceElement(ServiceIcmp service) {
-    return TraceElement.of(String.format("Matched service-icmp %s", service.getName()));
+    return TraceElement.of(String.format("Matched service-icmp '%s'", service.getName()));
   }
 
   @VisibleForTesting
   public static TraceElement serviceTcpTraceElement(ServiceTcp service) {
-    return TraceElement.of(String.format("Matched service-tcp %s", service.getName()));
+    return TraceElement.of(String.format("Matched service-tcp '%s'", service.getName()));
   }
 
   @VisibleForTesting
   public static TraceElement serviceUdpTraceElement(ServiceUdp service) {
-    return TraceElement.of(String.format("Matched service-udp %s", service.getName()));
+    return TraceElement.of(String.format("Matched service-udp '%s'", service.getName()));
   }
 }


### PR DESCRIPTION
* Enclose object names in `'`
* Remove stale `TODO`
* Fix `CpmiAnyObject` name in trace