### PR TITLE
CheckPoint: add more details for `Service` tracing

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -191,9 +191,15 @@ public final class AclLineMatchExprs {
   }
 
   public static @Nonnull AclLineMatchExpr matchIcmpType(int icmpType) {
+    return matchIcmpType(icmpType, null);
+  }
+
+  public static @Nonnull AclLineMatchExpr matchIcmpType(
+      int icmpType, @Nullable TraceElement traceElement) {
     checkArgument(0 <= icmpType && icmpType <= 255, "Invalid ICMP type: %s", icmpType);
     return new MatchHeaderSpace(
-        HeaderSpace.builder().setIcmpTypes(ImmutableList.of(SubRange.singleton(icmpType))).build());
+        HeaderSpace.builder().setIcmpTypes(ImmutableList.of(SubRange.singleton(icmpType))).build(),
+        traceElement);
   }
 
   public static @Nonnull AclLineMatchExpr matchIpProtocol(int ipProtocolNumber) {
@@ -208,8 +214,13 @@ public final class AclLineMatchExprs {
   }
 
   public static @Nonnull AclLineMatchExpr matchIpProtocol(IpProtocol ipProtocol) {
+    return matchIpProtocol(ipProtocol, null);
+  }
+
+  public static @Nonnull AclLineMatchExpr matchIpProtocol(
+      IpProtocol ipProtocol, @Nullable TraceElement traceElement) {
     return new MatchHeaderSpace(
-        HeaderSpace.builder().setIpProtocols(ImmutableList.of(ipProtocol)).build());
+        HeaderSpace.builder().setIpProtocols(ImmutableList.of(ipProtocol)).build(), traceElement);
   }
 
   public static @Nonnull AclLineMatchExpr matchPacketLength(IntegerSpace packetLengthSpace) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
@@ -93,20 +93,24 @@ public class ServiceToMatchExpr implements ServiceVisitor<AclLineMatchExpr> {
             destPortTraceElement(portDefinition)));
   }
 
-  private static TraceElement ipProtocolTraceElement(IpProtocol ipProtocol) {
+  @VisibleForTesting
+  static TraceElement ipProtocolTraceElement(IpProtocol ipProtocol) {
     return TraceElement.of(String.format("Matched IP protocol %s", ipProtocol));
   }
 
-  private static TraceElement destPortTraceElement(String portDefinition) {
+  @VisibleForTesting
+  static TraceElement destPortTraceElement(String portDefinition) {
     return TraceElement.of(
         String.format("Matched destination port definition '%s'", portDefinition));
   }
 
-  private static TraceElement icmpCodeTraceElement(int code) {
+  @VisibleForTesting
+  static TraceElement icmpCodeTraceElement(int code) {
     return TraceElement.of(String.format("Matched ICMP code %s", code));
   }
 
-  private static TraceElement icmpTypeTraceElement(int type) {
+  @VisibleForTesting
+  static TraceElement icmpTypeTraceElement(int type) {
     return TraceElement.of(String.format("Matched ICMP type %s", type));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
@@ -100,8 +100,7 @@ public class ServiceToMatchExpr implements ServiceVisitor<AclLineMatchExpr> {
 
   @VisibleForTesting
   static TraceElement destPortTraceElement(String portDefinition) {
-    return TraceElement.of(
-        String.format("Matched destination port definition '%s'", portDefinition));
+    return TraceElement.of(String.format("Matched destination port '%s'", portDefinition));
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceToMatchExpr.java
@@ -9,6 +9,7 @@ import static org.batfish.vendor.check_point_management.CheckPointManagementTrac
 import static org.batfish.vendor.check_point_management.CheckPointManagementTraceElementCreators.serviceUdpTraceElement;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -20,9 +21,12 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.TrueExpr;
 
 /** Generates an {@link AclLineMatchExpr} for the specified {@link Service}. */
@@ -45,31 +49,65 @@ public class ServiceToMatchExpr implements ServiceVisitor<AclLineMatchExpr> {
 
   @Override
   public AclLineMatchExpr visitServiceIcmp(ServiceIcmp serviceIcmp) {
-    HeaderSpace.Builder hsb = HeaderSpace.builder();
-    hsb.setIpProtocols(IpProtocol.ICMP);
-    hsb.setIcmpTypes(serviceIcmp.getIcmpType());
-    Optional.ofNullable(serviceIcmp.getIcmpCode()).ifPresent(hsb::setIcmpCodes);
-    return AclLineMatchExprs.match(hsb.build(), serviceIcmpTraceElement(serviceIcmp));
+    ImmutableList.Builder<AclLineMatchExpr> exprs = ImmutableList.builder();
+    int type = serviceIcmp.getIcmpType();
+
+    exprs.add(
+        AclLineMatchExprs.matchIpProtocol(
+            IpProtocol.ICMP, ipProtocolTraceElement(IpProtocol.ICMP)));
+    exprs.add(AclLineMatchExprs.matchIcmpType(type, icmpTypeTraceElement(type)));
+    Optional.ofNullable(serviceIcmp.getIcmpCode())
+        .ifPresent(
+            code ->
+                exprs.add(
+                    AclLineMatchExprs.match(
+                        HeaderSpace.builder().setIcmpCodes(code).build(),
+                        icmpCodeTraceElement(code))));
+
+    return new AndMatchExpr(exprs.build(), serviceIcmpTraceElement(serviceIcmp));
   }
 
   @Override
   public AclLineMatchExpr visitServiceTcp(ServiceTcp serviceTcp) {
-    return AclLineMatchExprs.match(
-        HeaderSpace.builder()
-            .setIpProtocols(IpProtocol.TCP)
-            .setDstPorts(portStringToIntegerSpace(serviceTcp.getPort()).getSubRanges())
-            .build(),
-        serviceTcpTraceElement(serviceTcp));
+    String portDefinition = serviceTcp.getPort();
+    return AclLineMatchExprs.and(
+        serviceTcpTraceElement(serviceTcp),
+        AclLineMatchExprs.matchIpProtocol(IpProtocol.TCP, ipProtocolTraceElement(IpProtocol.TCP)),
+        new MatchHeaderSpace(
+            HeaderSpace.builder()
+                .setDstPorts(portStringToIntegerSpace(portDefinition).getSubRanges())
+                .build(),
+            destPortTraceElement(portDefinition)));
   }
 
   @Override
   public AclLineMatchExpr visitServiceUdp(ServiceUdp serviceUdp) {
-    return AclLineMatchExprs.match(
-        HeaderSpace.builder()
-            .setIpProtocols(IpProtocol.UDP)
-            .setDstPorts(portStringToIntegerSpace(serviceUdp.getPort()).getSubRanges())
-            .build(),
-        serviceUdpTraceElement(serviceUdp));
+    String portDefinition = serviceUdp.getPort();
+    return AclLineMatchExprs.and(
+        serviceUdpTraceElement(serviceUdp),
+        AclLineMatchExprs.matchIpProtocol(IpProtocol.UDP, ipProtocolTraceElement(IpProtocol.UDP)),
+        new MatchHeaderSpace(
+            HeaderSpace.builder()
+                .setDstPorts(portStringToIntegerSpace(portDefinition).getSubRanges())
+                .build(),
+            destPortTraceElement(portDefinition)));
+  }
+
+  private static TraceElement ipProtocolTraceElement(IpProtocol ipProtocol) {
+    return TraceElement.of(String.format("Matched IP protocol %s", ipProtocol));
+  }
+
+  private static TraceElement destPortTraceElement(String portDefinition) {
+    return TraceElement.of(
+        String.format("Matched destination port definition '%s'", portDefinition));
+  }
+
+  private static TraceElement icmpCodeTraceElement(int code) {
+    return TraceElement.of(String.format("Matched ICMP code %s", code));
+  }
+
+  private static TraceElement icmpTypeTraceElement(int type) {
+    return TraceElement.of(String.format("Matched ICMP type %s", type));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceToMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceToMatchExprTest.java
@@ -4,6 +4,13 @@ import static org.batfish.datamodel.applications.PortsApplication.MAX_PORT_NUMBE
 import static org.batfish.datamodel.matchers.TraceTreeMatchers.isTraceTree;
 import static org.batfish.vendor.check_point_management.CheckPointManagementTraceElementCreators.serviceCpmiAnyTraceElement;
 import static org.batfish.vendor.check_point_management.CheckPointManagementTraceElementCreators.serviceGroupTraceElement;
+import static org.batfish.vendor.check_point_management.CheckPointManagementTraceElementCreators.serviceIcmpTraceElement;
+import static org.batfish.vendor.check_point_management.CheckPointManagementTraceElementCreators.serviceTcpTraceElement;
+import static org.batfish.vendor.check_point_management.CheckPointManagementTraceElementCreators.serviceUdpTraceElement;
+import static org.batfish.vendor.check_point_management.ServiceToMatchExpr.destPortTraceElement;
+import static org.batfish.vendor.check_point_management.ServiceToMatchExpr.icmpCodeTraceElement;
+import static org.batfish.vendor.check_point_management.ServiceToMatchExpr.icmpTypeTraceElement;
+import static org.batfish.vendor.check_point_management.ServiceToMatchExpr.ipProtocolTraceElement;
 import static org.batfish.vendor.check_point_management.ServiceToMatchExpr.portRangeStringToIntegerSpace;
 import static org.batfish.vendor.check_point_management.ServiceToMatchExpr.portStringToIntegerSpace;
 import static org.hamcrest.Matchers.equalTo;
@@ -81,10 +88,10 @@ public final class ServiceToMatchExprTest {
     assertThat(
         trace.get(0),
         isTraceTree(
-            "Matched service-icmp 'icmp'",
-            isTraceTree("Matched IP protocol ICMP"),
-            isTraceTree("Matched ICMP type 1"),
-            isTraceTree("Matched ICMP code 2")));
+            serviceIcmpTraceElement(service),
+            isTraceTree(ipProtocolTraceElement(IpProtocol.ICMP)),
+            isTraceTree(icmpTypeTraceElement(1)),
+            isTraceTree(icmpCodeTraceElement(2))));
   }
 
   @Test
@@ -110,9 +117,9 @@ public final class ServiceToMatchExprTest {
     assertThat(
         trace.get(0),
         isTraceTree(
-            "Matched service-icmp 'icmp'",
-            isTraceTree("Matched IP protocol ICMP"),
-            isTraceTree("Matched ICMP type 1")));
+            serviceIcmpTraceElement(serviceNoCode),
+            isTraceTree(ipProtocolTraceElement(IpProtocol.ICMP)),
+            isTraceTree(icmpTypeTraceElement(1))));
   }
 
   @Test
@@ -137,9 +144,9 @@ public final class ServiceToMatchExprTest {
     assertThat(
         trace.get(0),
         isTraceTree(
-            "Matched service-tcp 'tcp'",
-            isTraceTree("Matched IP protocol TCP"),
-            isTraceTree("Matched destination port definition '100-105,300'")));
+            serviceTcpTraceElement(service),
+            isTraceTree(ipProtocolTraceElement(IpProtocol.TCP)),
+            isTraceTree(destPortTraceElement("100-105,300"))));
 
     assertBddsEqual(
         _serviceToMatchExpr.visit(new ServiceTcp("tcp", ">5", Uid.of("1"))),
@@ -173,9 +180,9 @@ public final class ServiceToMatchExprTest {
     assertThat(
         trace.get(0),
         isTraceTree(
-            "Matched service-udp 'udp'",
-            isTraceTree("Matched IP protocol UDP"),
-            isTraceTree("Matched destination port definition '222'")));
+            serviceUdpTraceElement(service),
+            isTraceTree(ipProtocolTraceElement(IpProtocol.UDP)),
+            isTraceTree(destPortTraceElement("222"))));
   }
 
   @Test
@@ -240,9 +247,9 @@ public final class ServiceToMatchExprTest {
                 isTraceTree(
                     serviceGroupTraceElement(group3),
                     isTraceTree(
-                        "Matched service-udp 'service3'",
-                        isTraceTree("Matched IP protocol UDP"),
-                        isTraceTree("Matched destination port definition '300'"))))));
+                        serviceUdpTraceElement(service3),
+                        isTraceTree(ipProtocolTraceElement(IpProtocol.UDP)),
+                        isTraceTree(destPortTraceElement("300")))))));
   }
 
   @Test


### PR DESCRIPTION
Now, a service trace might look like this:
```
* Matched service-group 'group1'
   * Matched service-group 'group2'
      * Matched service-icmp 'icmp'
         * Matched IP protocol ICMP
         * Matched ICMP type 1
         * Matched ICMP code 2
```
or
```
* Matched service-tcp 'tcp'
   * Matched IP protocol TCP
   * Matched destination port '100-105,300'
```
