### PR TITLE
CheckPoint: v0 `service-other` support

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
@@ -36,7 +36,7 @@ public final class CheckPointManagementTraceElementCreators {
 
   @VisibleForTesting
   public static TraceElement serviceOtherTraceElement(ServiceOther service) {
-    return TraceElement.of(String.format("Matched service-other %s", service.getName()));
+    return TraceElement.of(String.format("Matched service-other '%s'", service.getName()));
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
@@ -21,6 +21,11 @@ public final class CheckPointManagementTraceElementCreators {
   }
 
   @VisibleForTesting
+  public static TraceElement serviceOtherTraceElement(ServiceOther service) {
+    return TraceElement.of(String.format("Matched service-other %s", service.getName()));
+  }
+
+  @VisibleForTesting
   public static TraceElement serviceTcpTraceElement(ServiceTcp service) {
     return TraceElement.of(String.format("Matched service-tcp %s", service.getName()));
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceOther.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceOther.java
@@ -1,0 +1,71 @@
+package org.batfish.vendor.check_point_management;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class ServiceOther extends TypedManagementObject implements Service {
+  @Override
+  public <T> T accept(ServiceVisitor<T> visitor) {
+    return visitor.visitServiceOther(this);
+  }
+
+  /** Docs: IP protocol number. */
+  public int getIpProtocol() {
+    return _ipProtocol;
+  }
+
+  /** Docs: A string in INSPECT syntax on packet matching. */
+  public @Nullable String getMatch() {
+    return _match;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!baseEquals(o)) {
+      return false;
+    }
+    ServiceOther other = (ServiceOther) o;
+    return _ipProtocol == other._ipProtocol && Objects.equals(_match, other._match);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(baseHashcode(), _ipProtocol, _match);
+  }
+
+  @Override
+  public String toString() {
+    return baseToStringHelper().add(PROP_IP_PROTOCOL, _ipProtocol).toString();
+  }
+
+  @JsonCreator
+  private static @Nonnull ServiceOther create(
+      @JsonProperty(PROP_NAME) @Nullable String name,
+      @JsonProperty(PROP_IP_PROTOCOL) @Nullable Integer ipProtocol,
+      @JsonProperty(PROP_MATCH) @Nullable String match,
+      @JsonProperty(PROP_UID) @Nullable Uid uid) {
+    checkArgument(name != null, "Missing %s", PROP_NAME);
+    checkArgument(ipProtocol != null, "Missing %s", PROP_IP_PROTOCOL);
+    checkArgument(uid != null, "Missing %s", PROP_UID);
+    return new ServiceOther(name, ipProtocol, match, uid);
+  }
+
+  @VisibleForTesting
+  public ServiceOther(String name, int ipProtocol, @Nullable String match, Uid uid) {
+    super(name, uid);
+    _ipProtocol = ipProtocol;
+    _match = match;
+  }
+
+  private static final String PROP_IP_PROTOCOL = "ip-protocol";
+  private static final String PROP_MATCH = "match";
+
+  private final int _ipProtocol;
+  private final @Nullable String _match;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceOther.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceOther.java
@@ -41,7 +41,10 @@ public final class ServiceOther extends TypedManagementObject implements Service
 
   @Override
   public String toString() {
-    return baseToStringHelper().add(PROP_IP_PROTOCOL, _ipProtocol).toString();
+    return baseToStringHelper()
+        .add(PROP_IP_PROTOCOL, _ipProtocol)
+        .add(PROP_MATCH, _match)
+        .toString();
   }
 
   @JsonCreator

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceVisitor.java
@@ -12,6 +12,8 @@ public interface ServiceVisitor<T> {
 
   T visitServiceIcmp(ServiceIcmp serviceIcmp);
 
+  T visitServiceOther(ServiceOther serviceOther);
+
   T visitServiceTcp(ServiceTcp serviceTcp);
 
   T visitServiceUdp(ServiceUdp serviceUdp);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/TypedManagementObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/TypedManagementObject.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
   @JsonSubTypes.Type(value = RulebaseAction.class, name = "RulebaseAction"),
   @JsonSubTypes.Type(value = ServiceGroup.class, name = "service-group"),
   @JsonSubTypes.Type(value = ServiceIcmp.class, name = "service-icmp"),
+  @JsonSubTypes.Type(value = ServiceOther.class, name = "service-other"),
   @JsonSubTypes.Type(value = ServiceTcp.class, name = "service-tcp"),
   @JsonSubTypes.Type(value = ServiceUdp.class, name = "service-udp"),
 })

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceOtherTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceOtherTest.java
@@ -1,0 +1,49 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link ServiceOther}. */
+public final class ServiceOtherTest {
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"GARBAGE\":0,"
+            + "\"type\":\"service-other\","
+            + "\"uid\":\"1\","
+            + "\"name\":\"foo\","
+            + "\"ip-protocol\":17,"
+            + "\"match\":\"uh_dport > 33000\""
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, TypedManagementObject.class),
+        equalTo(new ServiceOther("foo", 17, "uh_dport > 33000", Uid.of("1"))));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    ServiceOther obj = new ServiceOther("foo", 86, "bar", Uid.of("1"));
+    assertEquals(obj, SerializationUtils.clone(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    ServiceOther obj = new ServiceOther("foo", 86, null, Uid.of("1"));
+    new EqualsTester()
+        .addEqualityGroup(obj, new ServiceOther("foo", 86, null, Uid.of("1")))
+        .addEqualityGroup(new ServiceOther("bar", 86, null, Uid.of("1")))
+        .addEqualityGroup(new ServiceOther("bar", 87, null, Uid.of("1")))
+        .addEqualityGroup(new ServiceOther("bar", 87, "foo", Uid.of("1")))
+        .addEqualityGroup(new ServiceOther("bar", 87, "foo", Uid.of("2")))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceToMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/ServiceToMatchExprTest.java
@@ -127,7 +127,7 @@ public final class ServiceToMatchExprTest {
   @Test
   public void testOther() {
     String match = "uh_dport > 33000, (IPV4_VER (ip_ttl < 30))";
-    ServiceOther service = new ServiceOther("udp", 17, match, Uid.of("1"));
+    ServiceOther service = new ServiceOther("udp", IpProtocol.UDP.number(), match, Uid.of("1"));
     AclLineMatchExpr expr = _serviceToMatchExpr.visit(service);
     assertBddsEqual(
         expr,


### PR DESCRIPTION
Very basic, initial handling of `service-other`. Will need to do a lot more work around actually parsing the `match` strings.

Based on https://github.com/batfish/batfish/pull/7353
