### PR TITLE
Arista: redo ip route grammar

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/AristaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/AristaLexer.g4
@@ -3045,6 +3045,8 @@ NTP: 'ntp';
 
 NULL: 'null';
 
+NULL0: [Nn] [Uu] [Ll] [Ll] ' '* '0';
+
 NV: 'nv';
 
 OBJECT: 'object';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/AristaParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/AristaParser.g4
@@ -1048,41 +1048,20 @@ s_ip_route
 ip_route_tail
 :
    (
-      (
-         address = IP_ADDRESS mask = IP_ADDRESS
-      )
-      | prefix = IP_PREFIX
+     (address = IP_ADDRESS mask = IP_ADDRESS)
+     | prefix = IP_PREFIX
    )
    (
-      nexthopip = IP_ADDRESS
-      | nexthopprefix = IP_PREFIX
-      | GLOBAL
-      | nexthopint = interface_name_unstructured
-   )*
+      null0 = NULL0
+      | nexthopip = IP_ADDRESS (nexthopint = interface_name_unstructured)?
+      | nexthopint = interface_name_unstructured (nexthopip = IP_ADDRESS)?
+   )
    (
-      (
-         (
-            ADMIN_DIST
-            | ADMIN_DISTANCE
-         )? distance = dec
-      )
-      |
-      (
-         METRIC metric = dec
-      )
-      |
-      (
-         TAG tag = dec
-      )
-      | perm = PERMANENT
-      |
-      (
-         TRACK track = dec
-      )
-      |
-      (
-         NAME variable
-      )
+     distance = dec
+     | METRIC metric = dec
+     | NAME variable
+     | TAG tag = dec
+     | TRACK track = dec
    )* NEWLINE
 ;
 
@@ -1940,25 +1919,6 @@ rmc_null
    (
       MAXIMUM
    ) null_rest_of_line
-;
-
-route_tail
-:
-   iface = variable destination = IP_ADDRESS mask = IP_ADDRESS gateway = IP_ADDRESS
-   (
-      (
-         (
-            distance = dec+
-         )?
-         (
-            TRACK track = dec+
-         )?
-      )
-      |
-      (
-         TUNNELED
-      )
-   ) NEWLINE
 ;
 
 router_multicast_stanza
@@ -2838,11 +2798,6 @@ s_role
    NO? ROLE null_rest_of_line
 ;
 
-s_route
-:
-   ROUTE route_tail
-;
-
 s_router_vrrp
 :
    NO? ROUTER VRRP NEWLINE
@@ -3438,7 +3393,6 @@ stanza
    | s_redundancy
    | s_rf
    | s_role
-   | s_route
    | s_router_ospf
    | s_router_ospfv3
    | s_router_rip

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/Conversions.java
@@ -70,8 +70,6 @@ import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.isis.IsisLevelSettings;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
-import org.batfish.datamodel.route.nh.NextHop;
-import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.Conjunction;
@@ -970,16 +968,9 @@ public class Conversions {
   }
 
   static org.batfish.datamodel.StaticRoute toStaticRoute(Configuration c, StaticRoute staticRoute) {
-    String nextHopInterface = staticRoute.getNextHopInterface();
-    NextHop nh;
-    if (nextHopInterface != null && nextHopInterface.toLowerCase().startsWith("null")) {
-      nh = NextHopDiscard.instance();
-    } else {
-      nh = NextHop.legacyConverter(nextHopInterface, staticRoute.getNextHopIp());
-    }
     return org.batfish.datamodel.StaticRoute.builder()
         .setNetwork(staticRoute.getPrefix())
-        .setNextHop(nh)
+        .setNextHop(staticRoute.getNextHop())
         .setAdministrativeCost(staticRoute.getDistance())
         .setTag(firstNonNull(staticRoute.getTag(), -1L))
         .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/StaticRoute.java
@@ -1,43 +1,32 @@
 package org.batfish.representation.arista;
 
 import java.io.Serializable;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.route.nh.NextHop;
 
 @ParametersAreNonnullByDefault
 public class StaticRoute implements Serializable {
 
-  private int _distance;
+  private final int _distance;
 
-  @Nullable private String _nextHopInterface;
+  private final @Nonnull NextHop _nextHop;
 
-  private Ip _nextHopIp;
+  private final @Nonnull Prefix _prefix;
 
-  private boolean _permanent;
+  private final @Nullable Long _tag;
 
-  private Prefix _prefix;
-
-  @Nullable private Long _tag;
-
-  @Nullable private Integer _track;
+  private final @Nullable Integer _track;
 
   public StaticRoute(
-      Prefix prefix,
-      Ip nextHopIp,
-      @Nullable String nextHopInterface,
-      int distance,
-      @Nullable Long tag,
-      @Nullable Integer track,
-      boolean permanent) {
+      Prefix prefix, NextHop nextHop, int distance, @Nullable Long tag, @Nullable Integer track) {
     _prefix = prefix;
-    _nextHopIp = nextHopIp;
-    _nextHopInterface = nextHopInterface;
+    _nextHop = nextHop;
     _distance = distance;
     _tag = tag;
     _track = track;
-    _permanent = permanent;
   }
 
   @Override
@@ -48,59 +37,31 @@ public class StaticRoute implements Serializable {
       return false;
     }
     StaticRoute rhs = (StaticRoute) o;
-    boolean res = _prefix.equals(rhs._prefix);
-    if (_nextHopIp != null) {
-      res = res && _nextHopIp.equals(rhs._nextHopIp);
-    } else {
-      res = res && rhs._nextHopIp == null;
-    }
-    if (_nextHopInterface != null) {
-      return res && _nextHopInterface.equals(rhs._nextHopInterface);
-    } else {
-      return res && rhs._nextHopInterface == null;
-    }
+    return _prefix.equals(rhs._prefix) && _nextHop.equals(rhs._nextHop);
   }
 
   public int getDistance() {
     return _distance;
   }
 
-  @Nullable
-  public String getNextHopInterface() {
-    return _nextHopInterface;
+  public @Nonnull NextHop getNextHop() {
+    return _nextHop;
   }
 
-  public Ip getNextHopIp() {
-    return _nextHopIp;
-  }
-
-  public boolean getPermanent() {
-    return _permanent;
-  }
-
-  public Prefix getPrefix() {
+  public @Nonnull Prefix getPrefix() {
     return _prefix;
   }
 
-  @Nullable
-  public Long getTag() {
+  public @Nullable Long getTag() {
     return _tag;
   }
 
-  @Nullable
-  public Integer getTrack() {
+  public @Nullable Integer getTrack() {
     return _track;
   }
 
   @Override
   public int hashCode() {
-    int code = _prefix.hashCode();
-    if (_nextHopInterface != null) {
-      code = code * 31 + _nextHopInterface.hashCode();
-    }
-    if (_nextHopIp != null) {
-      code = code * 31 + _nextHopIp.hashCode();
-    }
-    return code;
+    return _prefix.hashCode() * 31 + _nextHop.hashCode();
   }
 }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -2140,8 +2140,7 @@
             "        ROUTE:'route'",
             "        (ip_route_tail",
             "          prefix = IP_PREFIX:'1.2.3.32/29'",
-            "          nexthopint = (interface_name_unstructured*",
-            "            VARIABLE:'Null0')",
+            "          null0 = NULL0:'Null0'",
             "          NAME:'name'",
             "          (variable*",
             "            VARIABLE:'bippety'  <== mode:M_Name)",
@@ -71670,14 +71669,7 @@
             }
           }
         },
-        "configs/arista_ip_route" : {
-          "interface" : {
-            "Null0" : {
-              "definitionLines" : "5",
-              "numReferrers" : 1
-            }
-          }
-        },
+        "configs/arista_ip_route" : { },
         "configs/arista_misc" : {
           "ip access-list standard" : {
             "sshabc" : {
@@ -76975,15 +76967,6 @@
             "qos-pmap" : {
               "interface service-policy" : [
                 11
-              ]
-            }
-          }
-        },
-        "configs/arista_ip_route" : {
-          "interface" : {
-            "Null0" : {
-              "ip route next-hop interface" : [
-                5
               ]
             }
           }


### PR DESCRIPTION
Delete several unused options, make sure NexHop is required, remove legacy s_route.