### PR TITLE
Track non-local interface dependencies

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/DependencyEdge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/DependencyEdge.java
@@ -1,0 +1,16 @@
+package org.batfish.datamodel.interface_dependency;
+
+import org.batfish.datamodel.Interface;
+import org.jgrapht.graph.DefaultEdge;
+
+final class DependencyEdge extends DefaultEdge {
+  private final Interface.DependencyType _dependencyType;
+
+  DependencyEdge(Interface.DependencyType dependencyType) {
+    _dependencyType = dependencyType;
+  }
+
+  public Interface.DependencyType getDependencyType() {
+    return _dependencyType;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
@@ -3,23 +3,23 @@ package org.batfish.datamodel.interface_dependency;
 import static org.batfish.datamodel.Interface.DependencyType.AGGREGATE;
 import static org.batfish.datamodel.Interface.DependencyType.BIND;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.graph.Network;
 import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Node;
 import org.batfish.common.topology.Layer1Topologies;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
-import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.jgrapht.Graph;
 import org.jgrapht.graph.SimpleDirectedGraph;
@@ -28,49 +28,173 @@ public class InterfaceDependencies {
   private static final NodeInterfacePair NON_EXISTENT_INTERFACE =
       NodeInterfacePair.of("non existent device", "non existent interface");
 
+  /**
+   * Compute the interfaces that should be deactivated because they depend on one or more missing or
+   * inactive interfaces.
+   */
   public static Set<NodeInterfacePair> getInterfacesToDeactivate(
       Map<String, Configuration> configs, Layer1Topologies layer1Topologies) {
-    return computeInterfacesToDeactivate(
-        computeInitiallyInactiveInterfaces(configs),
-        computeDependencyGraph(configs, layer1Topologies));
+    InterfaceDependencies deps = new InterfaceDependencies(configs, layer1Topologies);
+    deps.initialize();
+    deps.run();
+    return deps._interfacesToDeactivate;
   }
 
-  private static Set<NodeInterfacePair> computeInitiallyInactiveInterfaces(
-      Map<String, Configuration> configs) {
-    return configs.values().stream()
-        .flatMap(config -> config.getAllInterfaces().values().stream())
-        .filter(iface -> !iface.getActive())
-        .map(NodeInterfacePair::of)
-        .collect(ImmutableSet.toImmutableSet());
+  private final Map<String, Configuration> _configs;
+  private final Layer1Topologies _layer1Topologies;
+  private final Graph<NodeInterfacePair, DependencyEdge> _depGraph;
+  private final Set<NodeInterfacePair> _inactiveInterfaces = new HashSet<>();
+  private final Set<NodeInterfacePair> _interfacesToDeactivate = new HashSet<>();
+
+  private InterfaceDependencies(
+      Map<String, Configuration> configs, Layer1Topologies layer1Topologies) {
+    _configs = configs;
+    _layer1Topologies = layer1Topologies;
+
+    _depGraph = new SimpleDirectedGraph<>(DependencyEdge.class);
+    _depGraph.addVertex(NON_EXISTENT_INTERFACE);
   }
 
-  private static Set<NodeInterfacePair> computeInterfacesToDeactivate(
-      Set<NodeInterfacePair> initiallyInactiveInterfaces,
-      Graph<NodeInterfacePair, DependencyEdge> depGraph) {
-    Set<NodeInterfacePair> interfacesToDeactivate = new HashSet<>();
-    List<NodeInterfacePair> workList = new LinkedList<>();
-    workList.add(NON_EXISTENT_INTERFACE);
-    initiallyInactiveInterfaces.stream().filter(depGraph::containsVertex).forEach(workList::add);
+  private void initialize() {
+    for (Configuration config : _configs.values()) {
+      Map<String, Interface> allIfaces = config.getAllInterfaces();
+      for (Interface iface : allIfaces.values()) {
+        if (!iface.getActive()) {
+          _inactiveInterfaces.add(NodeInterfacePair.of(iface));
+          continue;
+        }
 
-    Predicate<NodeInterfacePair> isInactive =
-        (iface) ->
-            iface == NON_EXISTENT_INTERFACE
-                || initiallyInactiveInterfaces.contains(iface)
-                || interfacesToDeactivate.contains(iface);
+        // add edges for local dependencies
+        addDependencyEdges(iface);
+
+        // add edges for type-specific dependencies
+        switch (iface.getInterfaceType()) {
+          case PHYSICAL:
+            {
+              // non-local dependencies
+              @Nullable NodeInterfacePair neighbor = getL1Neighbor(iface);
+              if (neighbor != null) {
+                addDependencyEdge(neighbor, NodeInterfacePair.of(iface), BIND);
+              }
+              break;
+            }
+          case AGGREGATED:
+          case REDUNDANT:
+            {
+              // if the aggregate has no AGGREGATE dependencies, deactivate it.
+              if (iface.getDependencies().stream().noneMatch(dep -> dep.getType() == AGGREGATE)) {
+                _interfacesToDeactivate.add(NodeInterfacePair.of(iface));
+              }
+
+              // non-local dependencies
+              @Nullable NodeInterfacePair neighbor = getL1Neighbor(iface);
+              if (neighbor == null) {
+                /* aggregate has no neighbor. if any member interface has a neighbor, deactivate iface
+                 * assumption: if none of the member interfaces has a neighbor, this is the network
+                 * boundary. leave iface active so traffic can exit the network here. if any of the member
+                 * interfaces has a neighbor, then this is not the network bounadary, so this aggregate
+                 * needs a neighbor
+                 */
+                if (iface.getDependencies().stream()
+                    .anyMatch(
+                        dep ->
+                            dep.getType() == AGGREGATE
+                                && getL1Neighbor(allIfaces.get(dep.getInterfaceName())) != null)) {
+                  _interfacesToDeactivate.add(NodeInterfacePair.of(iface));
+                }
+              } else {
+                /* if the neighbor is inactive, iface must be too.
+                 * e.g. if all member interfaces are up, but the neighbor is admin-down, iface will
+                 * be down
+                 */
+                addDependencyEdge(neighbor, NodeInterfacePair.of(iface), BIND);
+              }
+              break;
+            }
+          default:
+            break;
+        }
+      }
+    }
+  }
+
+  private void addDependencyEdges(Interface iface) {
+    iface.getDependencies().forEach(dep -> addDependencyEdge(iface, dep));
+  }
+
+  private void addDependencyEdge(Interface tgtIface, Interface.Dependency dep) {
+    NodeInterfacePair tgt = NodeInterfacePair.of(tgtIface);
+    NodeInterfacePair src =
+        Optional.ofNullable(tgtIface.getOwner().getAllInterfaces().get(dep.getInterfaceName()))
+            .map(NodeInterfacePair::of)
+            .orElse(NON_EXISTENT_INTERFACE);
+    addDependencyEdge(src, tgt, dep.getType());
+  }
+
+  private void addDependencyEdge(
+      NodeInterfacePair src, NodeInterfacePair tgt, Interface.DependencyType depType) {
+    _depGraph.addVertex(src);
+    _depGraph.addVertex(tgt);
+    _depGraph.addEdge(src, tgt, new DependencyEdge(depType));
+  }
+
+  private @Nullable Layer1Topology getLayer1Topology(Interface iface) {
+    switch (iface.getInterfaceType()) {
+      case PHYSICAL:
+        return _layer1Topologies.getCombinedL1();
+      case AGGREGATED:
+      case REDUNDANT:
+        return _layer1Topologies.getLogicalL1();
+      default:
+        return null;
+    }
+  }
+
+  private @Nullable NodeInterfacePair getL1Neighbor(Interface iface) {
+    @Nullable Layer1Topology l1Topology = getLayer1Topology(iface);
+    if (l1Topology == null) {
+      return null;
+    }
+    Network<Layer1Node, Layer1Edge> l1Graph = l1Topology.getGraph();
+    Layer1Node layer1Node = new Layer1Node(iface.getOwner().getHostname(), iface.getName());
+    if (!l1Graph.nodes().contains(layer1Node)) {
+      return null;
+    }
+    Set<Layer1Node> neighbors = l1Graph.adjacentNodes(layer1Node);
+    if (neighbors.size() == 1) {
+      return Iterables.getOnlyElement(neighbors).asNodeInterfacePair();
+    }
+    return null;
+  }
+
+  private boolean isInactive(NodeInterfacePair nip) {
+    return nip == NON_EXISTENT_INTERFACE
+        || _inactiveInterfaces.contains(nip)
+        || _interfacesToDeactivate.contains(nip);
+  }
+
+  private void run() {
+    Queue<NodeInterfacePair> workQueue = new LinkedList<>();
+    workQueue.add(NON_EXISTENT_INTERFACE);
+    Stream.of(_inactiveInterfaces, _interfacesToDeactivate)
+        .flatMap(Set::stream)
+        .filter(_depGraph::containsVertex)
+        .forEach(workQueue::add);
+
     Consumer<NodeInterfacePair> deactivate =
         (iface) -> {
-          assert !isInactive.test(iface) : "deactivating already-inactive iface";
-          interfacesToDeactivate.add(iface);
-          workList.add(iface);
+          assert !isInactive(iface) : "deactivating already-inactive iface";
+          _interfacesToDeactivate.add(iface);
+          workQueue.add(iface);
         };
 
-    while (!workList.isEmpty()) {
-      NodeInterfacePair inactiveIface = workList.remove(0);
-      assert isInactive.test(inactiveIface) : "interface in workList has not been deactivated";
+    while (!workQueue.isEmpty()) {
+      NodeInterfacePair inactiveIface = workQueue.poll();
+      assert isInactive(inactiveIface) : "interface in workList has not been deactivated";
 
-      for (DependencyEdge outEdge : depGraph.outgoingEdgesOf(inactiveIface)) {
-        NodeInterfacePair tgtIface = depGraph.getEdgeTarget(outEdge);
-        if (isInactive.test(tgtIface)) {
+      for (DependencyEdge outEdge : _depGraph.outgoingEdgesOf(inactiveIface)) {
+        NodeInterfacePair tgtIface = _depGraph.getEdgeTarget(outEdge);
+        if (isInactive(tgtIface)) {
           // already deactivated
           continue;
         }
@@ -79,10 +203,10 @@ public class InterfaceDependencies {
             deactivate.accept(tgtIface);
             break;
           case AGGREGATE:
-            if (depGraph.incomingEdgesOf(tgtIface).stream()
+            if (_depGraph.incomingEdgesOf(tgtIface).stream()
                 .filter(edge -> edge.getDependencyType() == AGGREGATE)
-                .map(depGraph::getEdgeSource)
-                .allMatch(isInactive)) {
+                .map(_depGraph::getEdgeSource)
+                .allMatch(this::isInactive)) {
               // all the interfaces tgtIface depends upon are inactive. deactivate it.
               deactivate.accept(tgtIface);
             }
@@ -93,95 +217,5 @@ public class InterfaceDependencies {
         }
       }
     }
-    return interfacesToDeactivate;
   }
-
-  private static Graph<NodeInterfacePair, DependencyEdge> computeDependencyGraph(
-      Map<String, Configuration> configs, Layer1Topologies layer1Topologies) {
-    Graph<NodeInterfacePair, DependencyEdge> graph =
-        new SimpleDirectedGraph<>(DependencyEdge.class);
-    graph.addVertex(NON_EXISTENT_INTERFACE);
-
-    configs
-        .values()
-        .forEach(
-            config -> {
-              Map<String, Interface> configIfaces = config.getAllInterfaces();
-              configIfaces
-                  .values()
-                  .forEach(
-                      iface -> {
-                        NodeInterfacePair nip1 = NodeInterfacePair.of(iface);
-                        graph.addVertex(nip1);
-
-                        InterfaceType ifaceType = iface.getInterfaceType();
-
-                        // handle aggregate interfaces with no AGGREGATE dependencies
-                        if ((ifaceType == InterfaceType.REDUNDANT
-                                || ifaceType == InterfaceType.AGGREGATED)
-                            && iface.getDependencies().stream()
-                                .noneMatch(dep -> dep.getType() == AGGREGATE)) {
-                          // interface cannot come up without any AGGREGATE deps. add an edge that
-                          // will cause iface to be deactivated
-                          graph.addEdge(
-                              NON_EXISTENT_INTERFACE, nip1, new DependencyEdge(AGGREGATE));
-                        }
-
-                        // add local dependencies
-                        iface
-                            .getDependencies()
-                            .forEach(
-                                dep -> {
-                                  // if the depended-upon interface does not exist, the dependency
-                                  // is not satisfied
-                                  NodeInterfacePair nip2 =
-                                      Optional.ofNullable(configIfaces.get(dep.getInterfaceName()))
-                                          .map(NodeInterfacePair::of)
-                                          .orElse(NON_EXISTENT_INTERFACE);
-                                  graph.addVertex(nip2);
-                                  graph.addEdge(nip2, nip1, new DependencyEdge(dep.getType()));
-                                });
-
-                        // add non-local dependencies for PHYSICAL and AGGREGATED/REDUNDANT
-                        // interfaces only.
-                        @Nullable
-                        Layer1Topology layer1Topology =
-                            getLayer1Topology(layer1Topologies, ifaceType);
-                        if (layer1Topology == null) {
-                          return;
-                        }
-                        Layer1Node layer1Node =
-                            new Layer1Node(nip1.getHostname(), nip1.getInterface());
-                        if (!layer1Topology.getGraph().nodes().contains(layer1Node)) {
-                          return;
-                        }
-
-                        Set<Layer1Node> neighbors =
-                            layer1Topology.getGraph().adjacentNodes(layer1Node);
-                        if (neighbors.size() == 1) {
-                          NodeInterfacePair nip2 =
-                              Iterables.getOnlyElement(neighbors).asNodeInterfacePair();
-                          graph.addVertex(nip2);
-                          graph.addEdge(nip1, nip2, new DependencyEdge(BIND));
-                          graph.addEdge(nip2, nip1, new DependencyEdge(BIND));
-                        }
-                      });
-            });
-    return graph;
-  }
-
-  private static @Nullable Layer1Topology getLayer1Topology(
-      Layer1Topologies layer1Topologies, InterfaceType ifaceType) {
-    switch (ifaceType) {
-      case PHYSICAL:
-        return layer1Topologies.getCombinedL1();
-      case AGGREGATED:
-      case REDUNDANT:
-        return layer1Topologies.getLogicalL1();
-      default:
-        return null;
-    }
-  }
-
-  private InterfaceDependencies() {}
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
@@ -1,0 +1,172 @@
+package org.batfish.datamodel.interface_dependency;
+
+import static org.batfish.datamodel.Interface.DependencyType.AGGREGATE;
+import static org.batfish.datamodel.Interface.DependencyType.BIND;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import org.batfish.common.topology.L3Adjacencies;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.SimpleDirectedGraph;
+
+public class InterfaceDependencies {
+  private static final NodeInterfacePair NON_EXISTENT_INTERFACE =
+      NodeInterfacePair.of("non existent device", "non existent interface");
+
+  public static Set<NodeInterfacePair> getInterfacesToDeactivate(
+      Map<String, Configuration> configs, L3Adjacencies l3Adjacencies) {
+    return computeInterfacesToDeactivate(
+        computeInitiallyInactiveInterfaces(configs),
+        computeDependencyGraph(configs, l3Adjacencies));
+  }
+
+  private static Set<NodeInterfacePair> computeInitiallyInactiveInterfaces(
+      Map<String, Configuration> configs) {
+    return configs.values().stream()
+        .flatMap(config -> config.getAllInterfaces().values().stream())
+        .filter(iface -> !iface.getActive())
+        .map(NodeInterfacePair::of)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  private static Set<NodeInterfacePair> computeInterfacesToDeactivate(
+      Set<NodeInterfacePair> initiallyInactiveInterfaces,
+      Graph<NodeInterfacePair, DependencyEdge> depGraph) {
+    Set<NodeInterfacePair> interfacesToDeactivate = new HashSet<>();
+    List<NodeInterfacePair> workList = new LinkedList<>();
+    workList.add(NON_EXISTENT_INTERFACE);
+    initiallyInactiveInterfaces.stream().filter(depGraph::containsVertex).forEach(workList::add);
+
+    Predicate<NodeInterfacePair> isInactive =
+        (iface) ->
+            iface == NON_EXISTENT_INTERFACE
+                || initiallyInactiveInterfaces.contains(iface)
+                || interfacesToDeactivate.contains(iface);
+    Consumer<NodeInterfacePair> deactivate =
+        (iface) -> {
+          assert !isInactive.test(iface) : "deactivating already-inactive iface";
+          interfacesToDeactivate.add(iface);
+          workList.add(iface);
+        };
+
+    while (!workList.isEmpty()) {
+      NodeInterfacePair inactiveIface = workList.remove(0);
+      assert isInactive.test(inactiveIface) : "interface in workList has not been deactivated";
+
+      for (DependencyEdge outEdge : depGraph.outgoingEdgesOf(inactiveIface)) {
+        NodeInterfacePair tgtIface = depGraph.getEdgeTarget(outEdge);
+        if (isInactive.test(tgtIface)) {
+          // already deactivated
+          continue;
+        }
+        switch (outEdge.getDependencyType()) {
+          case BIND:
+            deactivate.accept(tgtIface);
+            break;
+          case AGGREGATE:
+            if (depGraph.incomingEdgesOf(tgtIface).stream()
+                .filter(edge -> edge.getDependencyType() == AGGREGATE)
+                .map(depGraph::getEdgeSource)
+                .allMatch(isInactive)) {
+              // all the interfaces tgtIface depends upon are inactive. deactivate it.
+              deactivate.accept(tgtIface);
+            }
+            break;
+          default:
+            throw new IllegalStateException(
+                "Unexpected Interface.DependencyType " + outEdge.getDependencyType().name());
+        }
+      }
+    }
+    return interfacesToDeactivate;
+  }
+
+  private static Graph<NodeInterfacePair, DependencyEdge> computeDependencyGraph(
+      Map<String, Configuration> configs, L3Adjacencies l3Adjacencies) {
+    Graph<NodeInterfacePair, DependencyEdge> graph =
+        new SimpleDirectedGraph<>(DependencyEdge.class);
+    graph.addVertex(NON_EXISTENT_INTERFACE);
+
+    configs
+        .values()
+        .forEach(
+            config -> {
+              Map<String, Interface> configIfaces = config.getAllInterfaces();
+              configIfaces
+                  .values()
+                  .forEach(
+                      iface -> {
+                        NodeInterfacePair nip1 = NodeInterfacePair.of(iface);
+                        graph.addVertex(nip1);
+
+                        InterfaceType ifaceType = iface.getInterfaceType();
+
+                        // handle aggregate interfaces with no AGGREGATE dependencies
+                        if ((ifaceType == InterfaceType.REDUNDANT
+                                || ifaceType == InterfaceType.AGGREGATED)
+                            && iface.getDependencies().stream()
+                                .noneMatch(dep -> dep.getType() == AGGREGATE)) {
+                          // interface cannot come up without any AGGREGATE deps. add an edge that
+                          // will cause iface to be deactivated
+                          graph.addEdge(
+                              NON_EXISTENT_INTERFACE, nip1, new DependencyEdge(AGGREGATE));
+                        }
+
+                        // add local dependencies
+                        iface
+                            .getDependencies()
+                            .forEach(
+                                dep -> {
+                                  // if the depended-upon interface does not exist, the dependency
+                                  // is not satisfied
+                                  NodeInterfacePair nip2 =
+                                      Optional.ofNullable(configIfaces.get(dep.getInterfaceName()))
+                                          .map(NodeInterfacePair::of)
+                                          .orElse(NON_EXISTENT_INTERFACE);
+                                  graph.addVertex(nip2);
+                                  graph.addEdge(nip2, nip1, new DependencyEdge(dep.getType()));
+                                });
+
+                        // add non-local dependencies for PHYSICAL and AGGREGATED/REDUNDANT
+                        // interfaces only.
+                        switch (ifaceType) {
+                          case PHYSICAL:
+                          case AGGREGATED:
+                          case REDUNDANT:
+                            /* Add a BIND dependency to the (single) l3 neighbor (if any). If either interface is down, the
+                             * other will be too.
+                             */
+                            try {
+                              l3Adjacencies
+                                  .pairedPointToPointL3Interface(nip1)
+                                  .ifPresent(
+                                      nip2 -> {
+                                        graph.addVertex(nip2);
+                                        graph.addEdge(nip1, nip2, new DependencyEdge(BIND));
+                                        graph.addEdge(nip2, nip1, new DependencyEdge(BIND));
+                                      });
+                            } catch (IllegalArgumentException e) {
+                              // iface is not an L3 interface.
+                            }
+                            break;
+                          default:
+                            break;
+                        }
+                      });
+            });
+    return graph;
+  }
+
+  private InterfaceDependencies() {}
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
@@ -133,6 +133,7 @@ public class InterfaceDependencies {
 
   private void addDependencyEdge(
       NodeInterfacePair src, NodeInterfacePair tgt, Interface.DependencyType depType) {
+    // ensure both vertices exist, otherwise addEdge will throw. it's ok to re-add a vertex.
     _depGraph.addVertex(src);
     _depGraph.addVertex(tgt);
     _depGraph.addEdge(src, tgt, new DependencyEdge(depType));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/interface_dependencies/InterfaceDependenciesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/interface_dependencies/InterfaceDependenciesTest.java
@@ -1,0 +1,339 @@
+package org.batfish.datamodel.interface_dependencies;
+
+import static org.batfish.datamodel.Interface.DependencyType.AGGREGATE;
+import static org.batfish.datamodel.Interface.DependencyType.BIND;
+import static org.batfish.datamodel.interface_dependency.InterfaceDependencies.getInterfacesToDeactivate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.L3Adjacencies;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.junit.Test;
+
+public class InterfaceDependenciesTest {
+  private static final class MockL3Adjacencies implements L3Adjacencies {
+    BiMap<NodeInterfacePair, NodeInterfacePair> _inSameBroadcastDomain;
+
+    MockL3Adjacencies(BiMap<NodeInterfacePair, NodeInterfacePair> inSameBroadcastDomain) {
+      _inSameBroadcastDomain = inSameBroadcastDomain;
+    }
+
+    @Override
+    public boolean inSameBroadcastDomain(NodeInterfacePair i1, NodeInterfacePair i2) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Nonnull
+    @Override
+    public Optional<NodeInterfacePair> pairedPointToPointL3Interface(NodeInterfacePair iface) {
+      NodeInterfacePair pairedIface = _inSameBroadcastDomain.get(iface);
+      if (pairedIface == null) {
+        pairedIface = _inSameBroadcastDomain.inverse().get(iface);
+      }
+      return Optional.ofNullable(pairedIface);
+    }
+  }
+
+  @Test
+  public void testGetInterfacesToDeactivate_p2p() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    Configuration n1 = cb.setHostname("n1").build();
+    Vrf v1 = nf.vrfBuilder().setOwner(n1).build();
+    Interface i1 =
+        nf.interfaceBuilder().setType(InterfaceType.PHYSICAL).setOwner(n1).setVrf(v1).build();
+
+    Configuration n2 = cb.setHostname("n2").build();
+    Vrf v2 = nf.vrfBuilder().setOwner(n2).build();
+    Interface i2 =
+        nf.interfaceBuilder().setType(InterfaceType.PHYSICAL).setOwner(n2).setVrf(v2).build();
+
+    Map<String, Configuration> configs =
+        ImmutableMap.of(n1.getHostname(), n1, n2.getHostname(), n2);
+    L3Adjacencies l3Adjacencies =
+        new MockL3Adjacencies(
+            ImmutableBiMap.of(NodeInterfacePair.of(i1), NodeInterfacePair.of(i2)));
+
+    // i2 is inactive and i1 and i2 are in the same p2p broadcast domain, so deactivate i1.
+    assertThat(getInterfacesToDeactivate(configs, l3Adjacencies), empty());
+
+    i2.setActive(false);
+    // i2 is inactive and i1 and i2 are in the same p2p broadcast domain, so deactivate i1.
+    assertThat(
+        getInterfacesToDeactivate(configs, l3Adjacencies), contains(NodeInterfacePair.of(i1)));
+  }
+
+  @Test
+  public void testGetInterfacesToDeactivate_aggregate() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    Configuration n1 = cb.setHostname("n1").build();
+    Vrf v1 = nf.vrfBuilder().setOwner(n1).build();
+
+    Interface i1 =
+        nf.interfaceBuilder().setType(InterfaceType.PHYSICAL).setOwner(n1).setVrf(v1).build();
+    Interface i2 =
+        nf.interfaceBuilder().setType(InterfaceType.PHYSICAL).setOwner(n1).setVrf(v1).build();
+    Interface i3 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.AGGREGATED)
+            .setOwner(n1)
+            .setVrf(v1)
+            .setDependencies(
+                ImmutableList.of(
+                    new Dependency(i1.getName(), AGGREGATE),
+                    new Dependency(i2.getName(), AGGREGATE)))
+            .build();
+
+    Map<String, Configuration> configs = ImmutableMap.of(n1.getHostname(), n1);
+    L3Adjacencies l3Adjacencies = new MockL3Adjacencies(ImmutableBiMap.of());
+
+    i1.setActive(false);
+    // only i1 is inactive, so i3 is up
+    assertThat(getInterfacesToDeactivate(configs, l3Adjacencies), empty());
+
+    i2.setActive(false);
+    // i1 and i2 are inactive, so i3 is down
+    assertThat(
+        getInterfacesToDeactivate(configs, l3Adjacencies), contains(NodeInterfacePair.of(i3)));
+  }
+
+  @Test
+  public void testGetInterfacesToDeactivate_bind() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    Configuration n1 = cb.setHostname("n1").build();
+    Vrf v1 = nf.vrfBuilder().setOwner(n1).build();
+
+    // i2 has a local BIND dependency on i1, e.g. i2 is a subinterface of i1
+    Interface i1 =
+        nf.interfaceBuilder().setType(InterfaceType.PHYSICAL).setOwner(n1).setVrf(v1).build();
+    Interface i2 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.LOGICAL)
+            .setOwner(n1)
+            .setVrf(v1)
+            .setDependencies(ImmutableList.of(new Dependency(i1.getName(), BIND)))
+            .build();
+
+    Map<String, Configuration> configs = ImmutableMap.of(n1.getHostname(), n1);
+    L3Adjacencies l3Adjacencies = new MockL3Adjacencies(ImmutableBiMap.of());
+
+    // only i1 is active, so i2 is up
+    assertThat(getInterfacesToDeactivate(configs, l3Adjacencies), empty());
+
+    i1.setActive(false);
+    // i1 and i2 are inactive, so i3 is down
+    assertThat(
+        getInterfacesToDeactivate(configs, l3Adjacencies), contains(NodeInterfacePair.of(i2)));
+  }
+
+  @Test
+  public void testGetInterfacesToDeactivate_missing_bind() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    Configuration n1 = cb.setHostname("n1").build();
+    Vrf v1 = nf.vrfBuilder().setOwner(n1).build();
+
+    // i2 has a BIND dependency on i1 and on a missing interface
+    Interface i1 = nf.interfaceBuilder().setOwner(n1).setVrf(v1).build();
+    Interface i2 =
+        nf.interfaceBuilder()
+            .setOwner(n1)
+            .setVrf(v1)
+            .setDependencies(
+                ImmutableList.of(
+                    new Dependency(i1.getName(), BIND), new Dependency("missing", BIND)))
+            .build();
+
+    Map<String, Configuration> configs = ImmutableMap.of(n1.getHostname(), n1);
+    L3Adjacencies l3Adjacencies = new MockL3Adjacencies(ImmutableBiMap.of());
+
+    // i2 is down due to missing BIND dependency
+    assertThat(
+        getInterfacesToDeactivate(configs, l3Adjacencies), contains(NodeInterfacePair.of(i2)));
+  }
+
+  @Test
+  public void testGetInterfacesToDeactivate_missing_aggregate() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    Configuration n1 = cb.setHostname("n1").build();
+    Vrf v1 = nf.vrfBuilder().setOwner(n1).build();
+
+    // i2 has a BIND dependency on i1 and on a missing interface
+    Interface i1 =
+        nf.interfaceBuilder()
+            .setOwner(n1)
+            .setVrf(v1)
+            .setDependencies(
+                ImmutableList.of(
+                    new Dependency("missing1", AGGREGATE), new Dependency("missing2", AGGREGATE)))
+            .build();
+
+    Map<String, Configuration> configs = ImmutableMap.of(n1.getHostname(), n1);
+    L3Adjacencies l3Adjacencies = new MockL3Adjacencies(ImmutableBiMap.of());
+
+    // both AGGREGATE deps are missing, so deactivate
+    assertThat(
+        getInterfacesToDeactivate(configs, l3Adjacencies), contains(NodeInterfacePair.of(i1)));
+
+    nf.interfaceBuilder().setOwner(n1).setVrf(v1).setName("missing1").build();
+    // one of the AGGREGATE deps is present (and active), so don't deactivate
+    assertThat(getInterfacesToDeactivate(configs, l3Adjacencies), empty());
+  }
+
+  /**
+   * Nodes N1 and N2 are connected via two physical edges forming a port-channel. If one of the
+   * physical interfaces on each edge is inactive, all of them will be deactivated, as will the
+   * port-channels themselves, and any subinterfaces of the port-channels.
+   */
+  @Test
+  public void testGetInterfacesToDeactivate_transitive1() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    Configuration n1 = cb.setHostname("n1").build();
+    Vrf v1 = nf.vrfBuilder().setOwner(n1).build();
+    // member interfaces
+    Interface m1 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.PHYSICAL)
+            .setOwner(n1)
+            .setVrf(v1)
+            .setName("m1")
+            .build();
+    Interface m3 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.PHYSICAL)
+            .setOwner(n1)
+            .setVrf(v1)
+            .setName("m3")
+            .build();
+    // port-channel interface
+    Interface pc1 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.AGGREGATED)
+            .setOwner(n1)
+            .setVrf(v1)
+            .setName("pc1")
+            .setDependencies(
+                ImmutableList.of(
+                    new Dependency(m1.getName(), AGGREGATE),
+                    new Dependency(m3.getName(), AGGREGATE)))
+            .build();
+    // port-channel subinterface
+    Interface pc1_1 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.AGGREGATE_CHILD)
+            .setOwner(n1)
+            .setVrf(v1)
+            .setName("pc1.1")
+            .setDependencies(ImmutableList.of(new Dependency(pc1.getName(), BIND)))
+            .build();
+
+    Configuration n2 = cb.setHostname("n2").build();
+    Vrf v2 = nf.vrfBuilder().setOwner(n2).build();
+    // member interfaces
+    Interface m2 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.PHYSICAL)
+            .setOwner(n2)
+            .setVrf(v2)
+            .setName("m2")
+            .build();
+    Interface m4 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.PHYSICAL)
+            .setOwner(n2)
+            .setVrf(v2)
+            .setName("m4")
+            .build();
+    // port-channel interface
+    Interface pc2 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.AGGREGATED)
+            .setOwner(n2)
+            .setVrf(v2)
+            .setName("pc2")
+            .setDependencies(
+                ImmutableList.of(
+                    new Dependency(m2.getName(), AGGREGATE),
+                    new Dependency(m4.getName(), AGGREGATE)))
+            .build();
+    // port-channel subinterface
+    Interface pc2_1 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.AGGREGATE_CHILD)
+            .setOwner(n2)
+            .setVrf(v2)
+            .setName("pc2.1")
+            .setDependencies(ImmutableList.of(new Dependency(pc2.getName(), BIND)))
+            .build();
+
+    Map<String, Configuration> configs =
+        ImmutableMap.of(n1.getHostname(), n1, n2.getHostname(), n2);
+    L3Adjacencies l3Adjacencies =
+        new MockL3Adjacencies(
+            ImmutableBiMap.of(
+                NodeInterfacePair.of(m1), NodeInterfacePair.of(m2), // m1 -- m2
+                NodeInterfacePair.of(m3), NodeInterfacePair.of(m4), // m3 -- m4
+                NodeInterfacePair.of(pc1), NodeInterfacePair.of(pc2) // pc1 -- pc2
+                ));
+
+    // m1 is inactive, so m2 becomes inactive too
+    m1.setActive(false);
+    assertThat(
+        getInterfacesToDeactivate(configs, l3Adjacencies), contains(NodeInterfacePair.of(m2)));
+
+    // m4 is inactive so m3 becomes inactive too. that brings down the port-channels and their
+    // subinterfaces
+    m4.setActive(false);
+    assertThat(
+        getInterfacesToDeactivate(configs, l3Adjacencies),
+        containsInAnyOrder(
+            NodeInterfacePair.of(m2),
+            NodeInterfacePair.of(m3),
+            NodeInterfacePair.of(pc1),
+            NodeInterfacePair.of(pc1_1),
+            NodeInterfacePair.of(pc2),
+            NodeInterfacePair.of(pc2_1)));
+
+    // now member interfaces are active but one of the port-channels is inactive.
+    // deactivate the other port-channel and both subinterfaces
+    m1.setActive(true);
+    m4.setActive(true);
+    pc1.setActive(false);
+    assertThat(
+        getInterfacesToDeactivate(configs, l3Adjacencies),
+        containsInAnyOrder(
+            NodeInterfacePair.of(pc1_1), NodeInterfacePair.of(pc2), NodeInterfacePair.of(pc2_1)));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2012,11 +2012,10 @@ public class Batfish extends PluginConsumer implements IBatfish {
       processManagementInterfaces(configurations);
     }
 
-    // compute a L3Adjacencies directly instead of getting it from _topologyProvider, since doing so
-    // will try to load
-    // configurations (which we're in the middle of loading now). We don't yet have the "real"
-    // configs, so the
-    // adjacencies we build now may not match what we get later.
+    /* compute a Layer1Topologies directly instead of getting it from _topologyProvider, since doing so would try to
+     * load configurations (which we're in the middle of loading now). We don't yet have the "real" configs, so the
+     * adjacencies we build now may not match what we get later.
+     */
     Layer1Topology synthesizedLayer1Topology;
     try {
       synthesizedLayer1Topology =

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -117,14 +117,12 @@ import org.batfish.common.plugin.PluginClientType;
 import org.batfish.common.plugin.PluginConsumer;
 import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.common.runtime.SnapshotRuntimeData;
-import org.batfish.common.topology.L3Adjacencies;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Topologies;
 import org.batfish.common.topology.Layer1TopologiesFactory;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.TopologyContainer;
 import org.batfish.common.topology.TopologyProvider;
-import org.batfish.common.topology.broadcast.BroadcastL3Adjacencies;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.common.util.isp.IspModelingUtils;
@@ -182,7 +180,6 @@ import org.batfish.datamodel.ospf.OspfTopologyUtils;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.vxlan.Layer2Vni;
-import org.batfish.datamodel.vxlan.VxlanTopology;
 import org.batfish.dataplane.TracerouteEngineImpl;
 import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.BatfishParseException;
@@ -1747,8 +1744,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @VisibleForTesting
   static void postProcessInterfaceDependencies(
-      Map<String, Configuration> configurations, L3Adjacencies l3Adjacencies) {
-    getInterfacesToDeactivate(configurations, l3Adjacencies)
+      Map<String, Configuration> configurations, Layer1Topologies layer1Topologies) {
+    getInterfacesToDeactivate(configurations, layer1Topologies)
         .forEach(
             iface ->
                 configurations
@@ -2032,10 +2029,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
             _topologyProvider.getRawLayer1PhysicalTopology(snapshot).orElse(Layer1Topology.EMPTY),
             synthesizedLayer1Topology,
             configurations);
-    BroadcastL3Adjacencies l3Adjacencies =
-        BroadcastL3Adjacencies.create(l1Topologies, VxlanTopology.EMPTY, configurations);
 
-    postProcessInterfaceDependencies(configurations, l3Adjacencies);
+    postProcessInterfaceDependencies(configurations, l1Topologies);
 
     // We do not process the edge blacklist here. Instead, we rely on these edges being explicitly
     // deleted from the Topology (aka list of edges) that is used along with configurations in

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -39,11 +39,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import javax.annotation.Nonnull;
 import org.apache.commons.io.IOUtils;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
@@ -51,6 +53,7 @@ import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.topology.IpOwners;
+import org.batfish.common.topology.L3Adjacencies;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Node;
 import org.batfish.common.topology.Layer1Topology;
@@ -79,6 +82,7 @@ import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.AnswerStatus;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.questions.TestQuestion;
 import org.batfish.identifiers.AnalysisId;
@@ -597,6 +601,19 @@ public class BatfishTest {
     assertThat(config1.activeInterfaceNames(), equalTo(ImmutableSet.of()));
   }
 
+  final class EmptyL3Adjacencies implements L3Adjacencies {
+    @Override
+    public boolean inSameBroadcastDomain(NodeInterfacePair i1, NodeInterfacePair i2) {
+      return false;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<NodeInterfacePair> pairedPointToPointL3Interface(NodeInterfacePair iface) {
+      return Optional.empty();
+    }
+  }
+
   @Test
   public void testPostProcessInterfaceDependenciesBind() {
     NetworkFactory nf = new NetworkFactory();
@@ -624,7 +641,7 @@ public class BatfishTest {
     ImmutableSet<String> inactiveIfaces = ImmutableSet.of("eth0", "eth1", "eth2");
 
     // Test
-    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1));
+    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), new EmptyL3Adjacencies());
 
     activeIfaces.forEach(
         name -> assertThat(c1.getAllInterfaces().get(name).getActive(), equalTo(true)));
@@ -647,7 +664,7 @@ public class BatfishTest {
         .setDependencies(ImmutableSet.of(new Dependency("NON_EXISTENT", DependencyType.BIND)))
         .build();
 
-    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1));
+    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), new EmptyL3Adjacencies());
 
     assertThat(c1.getAllInterfaces().values(), contains(allOf(hasName("eth1"), isActive(false))));
   }
@@ -689,7 +706,7 @@ public class BatfishTest {
     ImmutableSet<String> inactiveIfaces = ImmutableSet.of("eth0", "eth3", "eth4");
 
     // Test
-    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1));
+    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), new EmptyL3Adjacencies());
 
     activeIfaces.forEach(
         name -> assertThat(c1.getAllInterfaces().get(name).getActive(), equalTo(true)));

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -39,13 +39,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import javax.annotation.Nonnull;
 import org.apache.commons.io.IOUtils;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
@@ -53,9 +51,9 @@ import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.topology.IpOwners;
-import org.batfish.common.topology.L3Adjacencies;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Node;
+import org.batfish.common.topology.Layer1Topologies;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.util.isp.IspModelingUtils.ModeledNodes;
 import org.batfish.datamodel.AsPath;
@@ -82,7 +80,6 @@ import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.AnswerStatus;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.questions.TestQuestion;
 import org.batfish.identifiers.AnalysisId;
@@ -601,19 +598,6 @@ public class BatfishTest {
     assertThat(config1.activeInterfaceNames(), equalTo(ImmutableSet.of()));
   }
 
-  final class EmptyL3Adjacencies implements L3Adjacencies {
-    @Override
-    public boolean inSameBroadcastDomain(NodeInterfacePair i1, NodeInterfacePair i2) {
-      return false;
-    }
-
-    @Nonnull
-    @Override
-    public Optional<NodeInterfacePair> pairedPointToPointL3Interface(NodeInterfacePair iface) {
-      return Optional.empty();
-    }
-  }
-
   @Test
   public void testPostProcessInterfaceDependenciesBind() {
     NetworkFactory nf = new NetworkFactory();
@@ -641,7 +625,7 @@ public class BatfishTest {
     ImmutableSet<String> inactiveIfaces = ImmutableSet.of("eth0", "eth1", "eth2");
 
     // Test
-    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), new EmptyL3Adjacencies());
+    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), Layer1Topologies.empty());
 
     activeIfaces.forEach(
         name -> assertThat(c1.getAllInterfaces().get(name).getActive(), equalTo(true)));
@@ -664,7 +648,7 @@ public class BatfishTest {
         .setDependencies(ImmutableSet.of(new Dependency("NON_EXISTENT", DependencyType.BIND)))
         .build();
 
-    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), new EmptyL3Adjacencies());
+    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), Layer1Topologies.empty());
 
     assertThat(c1.getAllInterfaces().values(), contains(allOf(hasName("eth1"), isActive(false))));
   }
@@ -706,7 +690,7 @@ public class BatfishTest {
     ImmutableSet<String> inactiveIfaces = ImmutableSet.of("eth0", "eth3", "eth4");
 
     // Test
-    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), new EmptyL3Adjacencies());
+    postProcessInterfaceDependencies(ImmutableMap.of("c1", c1), Layer1Topologies.empty());
 
     activeIfaces.forEach(
         name -> assertThat(c1.getAllInterfaces().get(name).getActive(), equalTo(true)));


### PR DESCRIPTION
Previously, we tracked _local_ interface dependencies: e.g. a portchannel depends on at least one of its members interfaces being active, a subinterface depends on its superinterface being active, etc. This PR adds _non-local_ interface dependency tracking: for physical or LACP interfaces, if the `Layer1Topology` identifies a neighbor interface, depend on that neighbor being active. 
