### PR TITLE
A10: initial `interface` VS model

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Parser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Parser.g4
@@ -1,14 +1,16 @@
 parser grammar A10Parser;
 
-import A10_common;
+import
+  A10_common,
+  A10_interface;
 
 options {
    superClass = 'org.batfish.grammar.BatfishParser';
    tokenVocab = A10Lexer;
 }
 
-a10_configuration: NEWLINE? statement+ EOF;
+a10_configuration: NEWLINE? statement+ NEWLINE* EOF;
 
-statement: s_hostname;
+statement: s_hostname | s_interface;
 
 s_hostname: HOSTNAME hostname NEWLINE;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_common.g4
@@ -4,6 +4,28 @@ options {
     tokenVocab = A10Lexer;
 }
 
-hostname: WORD;
+quoted_text: QUOTED_TEXT;
+double_quoted_string: DOUBLE_QUOTE text = quoted_text? DOUBLE_QUOTE;
+single_quoted_string: SINGLE_QUOTE text = quoted_text? SINGLE_QUOTE;
+word_content: (double_quoted_string | single_quoted_string | WORD)+;
+word: WORD_SEPARATOR word_content;
+
+hostname: word;
+
+interface_name_str: word;
+
+ip_prefix: ip_address (subnet_mask | ip_slash_prefix);
+
+ip_address: IP_ADDRESS;
+
+ip_slash_prefix: IP_SLASH_PREFIX;
+
+subnet_mask: SUBNET_MASK;
 
 null_rest_of_line: ~NEWLINE* NEWLINE;
+
+uint8: UINT8;
+
+uint16: UINT16;
+
+uint32: UINT32;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_interface.g4
@@ -1,0 +1,38 @@
+parser grammar A10_interface;
+
+import A10_common;
+
+options {
+    tokenVocab = A10Lexer;
+}
+
+s_interface: INTERFACE si_definition;
+
+si_definition: sid_ethernet | sid_loopback;
+
+sid_ethernet: ETHERNET num = ethernet_number NEWLINE sid*;
+
+sid_loopback: LOOPBACK num = loopback_number NEWLINE sid*;
+
+sid: (sid_disable | sid_enable | sid_ip | sid_mtu | sid_name);
+
+sid_enable: ENABLE NEWLINE;
+
+sid_disable: DISABLE NEWLINE;
+
+sid_ip: IP sidi_address;
+
+sidi_address: ADDRESS ip_prefix NEWLINE;
+
+sid_mtu: MTU interface_mtu NEWLINE;
+
+sid_name: NAME interface_name_str NEWLINE;
+
+// 1-40? assuming 40 is max for now
+ethernet_number: uint8;
+
+// 0-10
+loopback_number: uint8;
+
+// 434-1500
+interface_mtu: uint16;

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -1,15 +1,24 @@
 package org.batfish.vendor.a10.grammar;
 
+import static org.batfish.vendor.a10.grammar.A10Lexer.WORD;
+
+import com.google.common.collect.Range;
+import com.google.common.primitives.Ints;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.Ip;
 import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.SilentSyntaxListener;
 import org.batfish.grammar.UnrecognizedLineToken;
@@ -17,7 +26,9 @@ import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
 import org.batfish.vendor.a10.grammar.A10Parser.A10_configurationContext;
 import org.batfish.vendor.a10.grammar.A10Parser.HostnameContext;
 import org.batfish.vendor.a10.grammar.A10Parser.S_hostnameContext;
+import org.batfish.vendor.a10.grammar.A10Parser.WordContext;
 import org.batfish.vendor.a10.representation.A10Configuration;
+import org.batfish.vendor.a10.representation.Interface;
 
 /** Given a parse tree, builds a {@link A10Configuration}. */
 public final class A10ConfigurationBuilder extends A10ParserBaseListener
@@ -99,38 +110,170 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
     toString(ctx, ctx.hostname()).ifPresent(_configuration::setHostname);
   }
 
+  @Override
+  public void enterSid_ethernet(A10Parser.Sid_ethernetContext ctx) {
+    Optional<Integer> num = toInteger(ctx.num);
+    num.ifPresent(
+        n ->
+            _currentInterface =
+                _configuration
+                    .getInterfacesEthernet()
+                    .computeIfAbsent(n, number -> new Interface(Interface.Type.ETHERNET, n)));
+    if (!num.isPresent()) {
+      _currentInterface = new Interface(Interface.Type.ETHERNET, -1); // dummy
+    }
+  }
+
+  @Override
+  public void exitSid_ethernet(A10Parser.Sid_ethernetContext ctx) {
+    _currentInterface = null;
+  }
+
+  @Override
+  public void enterSid_loopback(A10Parser.Sid_loopbackContext ctx) {
+    Optional<Integer> num = toInteger(ctx.num);
+    num.ifPresent(
+        n ->
+            _currentInterface =
+                _configuration
+                    .getInterfacesLoopback()
+                    .computeIfAbsent(n, number -> new Interface(Interface.Type.LOOPBACK, n)));
+    if (!num.isPresent()) {
+      _currentInterface = new Interface(Interface.Type.LOOPBACK, -1); // dummy
+    }
+  }
+
+  @Override
+  public void exitSid_loopback(A10Parser.Sid_loopbackContext ctx) {
+    _currentInterface = null;
+  }
+
+  @Override
+  public void exitSid_enable(A10Parser.Sid_enableContext ctx) {
+    _currentInterface.setEnabled(true);
+  }
+
+  @Override
+  public void exitSid_disable(A10Parser.Sid_disableContext ctx) {
+    _currentInterface.setEnabled(false);
+  }
+
+  @Override
+  public void exitSid_mtu(A10Parser.Sid_mtuContext ctx) {
+    toInteger(ctx.interface_mtu()).ifPresent(mtu -> _currentInterface.setMtu(mtu));
+  }
+
+  @Override
+  public void exitSidi_address(A10Parser.Sidi_addressContext ctx) {
+    _currentInterface.setIpAddress(toInterfaceAddress(ctx.ip_prefix()));
+  }
+
+  @Override
+  public void exitSid_name(A10Parser.Sid_nameContext ctx) {
+    toString(ctx, ctx.interface_name_str()).ifPresent(n -> _currentInterface.setName(n));
+  }
+
+  private @Nonnull ConcreteInterfaceAddress toInterfaceAddress(A10Parser.Ip_prefixContext ctx) {
+    ;
+    if (ctx.subnet_mask() != null) {
+      return ConcreteInterfaceAddress.create(toIp(ctx.ip_address()), toIp(ctx.subnet_mask()));
+    }
+    assert ctx.ip_slash_prefix() != null;
+    return ConcreteInterfaceAddress.parse(
+        ctx.ip_address().getText() + ctx.ip_slash_prefix().getText());
+  }
+
+  private @Nonnull Ip toIp(A10Parser.Ip_addressContext ctx) {
+    return Ip.parse(ctx.getText());
+  }
+
+  private @Nonnull Ip toIp(A10Parser.Subnet_maskContext ctx) {
+    return Ip.parse(ctx.getText());
+  }
+
+  private @Nonnull Optional<Integer> toInteger(A10Parser.Interface_mtuContext ctx) {
+    return toIntegerInSpace(ctx, ctx.uint16(), INTERFACE_MTU_RANGE, "interface mtu");
+  }
+
+  private @Nonnull Optional<Integer> toInteger(A10Parser.Ethernet_numberContext ctx) {
+    return toIntegerInSpace(
+        ctx, ctx.uint8(), INTERFACE_NUMBER_ETHERNET_RANGE, "interface ethernet number");
+  }
+
+  private @Nonnull Optional<Integer> toInteger(A10Parser.Loopback_numberContext ctx) {
+    return toIntegerInSpace(
+        ctx, ctx.uint8(), INTERFACE_NUMBER_LOOPBACK_RANGE, "interface loopback number");
+  }
+
+  private @Nonnull Optional<Integer> toIntegerInSpace(
+      ParserRuleContext messageCtx, A10Parser.Uint8Context ctx, IntegerSpace space, String name) {
+    return toIntegerInSpace(messageCtx, ctx.getText(), space, name);
+  }
+
+  private @Nonnull Optional<Integer> toIntegerInSpace(
+      ParserRuleContext messageCtx, A10Parser.Uint16Context ctx, IntegerSpace space, String name) {
+    return toIntegerInSpace(messageCtx, ctx.getText(), space, name);
+  }
+
+  private @Nonnull Optional<Integer> toIntegerInSpace(
+      ParserRuleContext messageCtx, A10Parser.Uint32Context ctx, IntegerSpace space, String name) {
+    return toIntegerInSpace(messageCtx, ctx.getText(), space, name);
+  }
+
+  /**
+   * Convert a {@link String} to an {@link Integer} if it represents a number that is contained in
+   * the provided {@code space}, or else {@link Optional#empty}.
+   */
+  private @Nonnull Optional<Integer> toIntegerInSpace(
+      ParserRuleContext messageCtx, String str, IntegerSpace space, String name) {
+    Integer num = Ints.tryParse(str);
+    if (num == null || !space.contains(num)) {
+      warn(messageCtx, String.format("Expected %s in range %s, but got '%d'", name, space, num));
+      return Optional.empty();
+    }
+    return Optional.of(num);
+  }
+
   /**
    * Return the text of the provided {@code ctx} if its length is within the provided {@link
    * IntegerSpace lengthSpace}, or else {@link Optional#empty}.
    */
   private @Nonnull Optional<String> toStringWithLengthInSpace(
-      ParserRuleContext messageCtx, ParserRuleContext ctx, IntegerSpace lengthSpace, String name) {
-    String text = ctx.getText();
+      ParserRuleContext messageCtx, WordContext ctx, IntegerSpace lengthSpace, String name) {
+    String text = toString(ctx);
     if (!lengthSpace.contains(text.length())) {
       warn(
           messageCtx,
           String.format(
-              "Expected %s with length in range %s, but got '%s'", text, lengthSpace, name));
+              "Expected %s with length in range %s, but got '%s'", name, lengthSpace, text));
       return Optional.empty();
     }
     return Optional.of(text);
   }
 
   private @Nonnull Optional<String> toString(ParserRuleContext messageCtx, HostnameContext ctx) {
-    return toString(messageCtx, ctx, "hostname", HOSTNAME_PATTERN);
+    return toString(messageCtx, ctx.word(), "hostname", HOSTNAME_PATTERN);
   }
 
   private @Nonnull Optional<String> toString(
-      ParserRuleContext messageCtx, ParserRuleContext ctx, String type, Pattern pattern) {
+      ParserRuleContext messageCtx, A10Parser.Interface_name_strContext ctx) {
+    return toStringWithLengthInSpace(
+        messageCtx, ctx.word(), INTERFACE_NAME_LENGTH_RANGE, "interface name");
+  }
+
+  private @Nonnull Optional<String> toString(
+      ParserRuleContext messageCtx, WordContext ctx, String type, Pattern pattern) {
     return toString(messageCtx, ctx, type, s -> pattern.matcher(s).matches());
   }
 
   private @Nonnull Optional<String> toString(
-      ParserRuleContext messageCtx,
-      ParserRuleContext ctx,
-      String type,
-      Predicate<String> predicate) {
-    String text = ctx.getText();
+      ParserRuleContext messageCtx, WordContext ctx, String type, Predicate<String> predicate) {
+    String text = toString(ctx);
+    return toString(messageCtx, text, type, predicate);
+  }
+
+  private @Nonnull Optional<String> toString(
+      ParserRuleContext messageCtx, String text, String type, Predicate<String> predicate) {
     if (!predicate.test(text)) {
       warn(messageCtx, String.format("Illegal value for %s", type));
       return Optional.empty();
@@ -138,9 +281,45 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
     return Optional.of(text);
   }
 
+  private static @Nonnull String toString(WordContext ctx) {
+    return ctx.word_content().children.stream()
+        .map(
+            child -> {
+              if (child instanceof A10Parser.Double_quoted_stringContext) {
+                return toString(((A10Parser.Double_quoted_stringContext) child).text);
+              } else if (child instanceof A10Parser.Single_quoted_stringContext) {
+                return toString(((A10Parser.Single_quoted_stringContext) child).text);
+              } else {
+                assert child instanceof TerminalNode;
+                int type = ((TerminalNode) child).getSymbol().getType();
+                assert type == WORD;
+                return child.getText();
+              }
+            })
+        .collect(Collectors.joining(""));
+  }
+
+  private static @Nonnull String toString(@Nullable A10Parser.Quoted_textContext text) {
+    if (text == null) {
+      return "";
+    }
+    // Device appears to just remove backslashes from quoted strings
+    return text.getText().replaceAll("\\\\", "");
+  }
+
+  private static final IntegerSpace INTERFACE_MTU_RANGE = IntegerSpace.of(Range.closed(434, 1500));
+  private static final IntegerSpace INTERFACE_NUMBER_ETHERNET_RANGE =
+      IntegerSpace.of(Range.closed(1, 40));
+  private static final IntegerSpace INTERFACE_NUMBER_LOOPBACK_RANGE =
+      IntegerSpace.of(Range.closed(0, 10));
+  private static final IntegerSpace INTERFACE_NAME_LENGTH_RANGE =
+      IntegerSpace.of(Range.closed(1, 63));
+
   private static final Pattern HOSTNAME_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+$");
 
   @Nonnull private A10Configuration _configuration;
+
+  private Interface _currentInterface;
 
   @Nonnull private A10CombinedParser _parser;
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -174,7 +174,6 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
   }
 
   private @Nonnull ConcreteInterfaceAddress toInterfaceAddress(A10Parser.Ip_prefixContext ctx) {
-    ;
     if (ctx.subnet_mask() != null) {
       return ConcreteInterfaceAddress.create(toIp(ctx.ip_address()), toIp(ctx.subnet_mask()));
     }

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -106,6 +106,11 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
   public void enterA10_configuration(A10_configurationContext ctx) {}
 
   @Override
+  public void exitA10_configuration(A10_configurationContext ctx) {
+    _configuration.finalizeStructures();
+  }
+
+  @Override
   public void exitS_hostname(S_hostnameContext ctx) {
     toString(ctx, ctx.hostname()).ifPresent(_configuration::setHostname);
   }
@@ -268,11 +273,6 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
   private @Nonnull Optional<String> toString(
       ParserRuleContext messageCtx, WordContext ctx, String type, Predicate<String> predicate) {
     String text = toString(ctx);
-    return toString(messageCtx, text, type, predicate);
-  }
-
-  private @Nonnull Optional<String> toString(
-      ParserRuleContext messageCtx, String text, String type, Predicate<String> predicate) {
     if (!predicate.test(text)) {
       warn(messageCtx, String.format("Illegal value for %s", type));
       return Optional.empty();

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/package-info.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.vendor.a10.grammar;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -1,7 +1,9 @@
 package org.batfish.vendor.a10.representation;
 
 import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.batfish.common.VendorConversionException;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -12,11 +14,22 @@ import org.batfish.vendor.VendorConfiguration;
 /** Datamodel class representing an A10 device configuration. */
 public final class A10Configuration extends VendorConfiguration {
 
-  public A10Configuration() {}
+  public A10Configuration() {
+    _interfacesEthernet = new HashMap<>();
+    _interfacesLoopback = new HashMap<>();
+  }
 
   @Override
   public String getHostname() {
     return _hostname;
+  }
+
+  public Map<Integer, Interface> getInterfacesEthernet() {
+    return _interfacesEthernet;
+  }
+
+  public Map<Integer, Interface> getInterfacesLoopback() {
+    return _interfacesLoopback;
   }
 
   @Override
@@ -42,5 +55,7 @@ public final class A10Configuration extends VendorConfiguration {
 
   private Configuration _c;
   private String _hostname;
+  private final Map<Integer, Interface> _interfacesEthernet;
+  private final Map<Integer, Interface> _interfacesLoopback;
   private ConfigurationFormat _vendor;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -1,5 +1,9 @@
 package org.batfish.vendor.a10.representation;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.vendor.a10.representation.Interface.DEFAULT_MTU;
+
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
@@ -43,6 +47,7 @@ public final class A10Configuration extends VendorConfiguration {
     _vendor = format;
   }
 
+  @VisibleForTesting
   public static boolean getInterfaceEnabledEffective(Interface iface) {
     Boolean enabled = iface.getEnabled();
     if (enabled != null) {
@@ -55,6 +60,11 @@ public final class A10Configuration extends VendorConfiguration {
       default:
         return false;
     }
+  }
+
+  @VisibleForTesting
+  public static int getInterfaceMtuEffective(Interface iface) {
+    return firstNonNull(iface.getMtu(), DEFAULT_MTU);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -1,6 +1,7 @@
 package org.batfish.vendor.a10.representation;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,20 @@ public final class A10Configuration extends VendorConfiguration {
     _vendor = format;
   }
 
+  public static boolean getInterfaceEnabledEffective(Interface iface) {
+    Boolean enabled = iface.getEnabled();
+    if (enabled != null) {
+      return enabled;
+    }
+    switch (iface.getType()) {
+      case LOOPBACK:
+        return true;
+      case ETHERNET:
+      default:
+        return false;
+    }
+  }
+
   @Override
   public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
     String hostname = getHostname();
@@ -53,9 +68,20 @@ public final class A10Configuration extends VendorConfiguration {
     return ImmutableList.of(_c);
   }
 
+  /**
+   * Finalize configuration after it is finished being built. Does things like making structures
+   * immutable.
+   *
+   * <p>This should only be called once, at the end of parsing and extraction.
+   */
+  public void finalizeStructures() {
+    _interfacesEthernet = ImmutableMap.copyOf(_interfacesEthernet);
+    _interfacesLoopback = ImmutableMap.copyOf(_interfacesLoopback);
+  }
+
   private Configuration _c;
   private String _hostname;
-  private final Map<Integer, Interface> _interfacesEthernet;
-  private final Map<Integer, Interface> _interfacesLoopback;
+  private Map<Integer, Interface> _interfacesEthernet;
+  private Map<Integer, Interface> _interfacesLoopback;
   private ConfigurationFormat _vendor;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Interface.java
@@ -21,19 +21,6 @@ public final class Interface implements Serializable {
     return _enabled;
   }
 
-  public boolean getEnabledEffective() {
-    if (_enabled != null) {
-      return _enabled;
-    }
-    switch (_type) {
-      case LOOPBACK:
-        return true;
-      case ETHERNET:
-      default:
-        return false;
-    }
-  }
-
   @Nullable
   public ConcreteInterfaceAddress getIpAddress() {
     return _ipAddress;

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Interface.java
@@ -1,7 +1,5 @@
 package org.batfish.vendor.a10.representation;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,10 +27,6 @@ public final class Interface implements Serializable {
   @Nullable
   public Integer getMtu() {
     return _mtu;
-  }
-
-  public int getMtuEffective() {
-    return firstNonNull(_mtu, DEFAULT_MTU);
   }
 
   @Nullable

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Interface.java
@@ -1,0 +1,92 @@
+package org.batfish.vendor.a10.representation;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+
+/** Datamodel class representing a configured A10 interface. */
+public final class Interface implements Serializable {
+  public enum Type {
+    ETHERNET,
+    LOOPBACK,
+  }
+
+  public static final int DEFAULT_MTU = 1500;
+
+  @Nullable
+  public Boolean getEnabled() {
+    return _enabled;
+  }
+
+  public boolean getEnabledEffective() {
+    if (_enabled != null) {
+      return _enabled;
+    }
+    switch (_type) {
+      case LOOPBACK:
+        return true;
+      case ETHERNET:
+      default:
+        return false;
+    }
+  }
+
+  @Nullable
+  public ConcreteInterfaceAddress getIpAddress() {
+    return _ipAddress;
+  }
+
+  @Nullable
+  public Integer getMtu() {
+    return _mtu;
+  }
+
+  public int getMtuEffective() {
+    return firstNonNull(_mtu, DEFAULT_MTU);
+  }
+
+  @Nullable
+  public String getName() {
+    return _name;
+  }
+
+  public int getNumber() {
+    return _number;
+  }
+
+  @Nonnull
+  public Type getType() {
+    return _type;
+  }
+
+  public void setEnabled(boolean enabled) {
+    _enabled = enabled;
+  }
+
+  public void setIpAddress(ConcreteInterfaceAddress ipAddress) {
+    _ipAddress = ipAddress;
+  }
+
+  public void setMtu(Integer mtu) {
+    _mtu = mtu;
+  }
+
+  public void setName(String name) {
+    _name = name;
+  }
+
+  public Interface(Type type, int number) {
+    _number = number;
+    _type = type;
+  }
+
+  @Nullable private Boolean _enabled;
+  @Nonnull private final Type _type;
+  @Nullable private ConcreteInterfaceAddress _ipAddress;
+  @Nullable private Integer _mtu;
+  @Nullable private String _name;
+  private final int _number;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/package-info.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.vendor.a10.representation;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -1,15 +1,22 @@
 package org.batfish.vendor.a10.grammar;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.matchers.ParseWarningMatchers.hasComment;
+import static org.batfish.common.matchers.WarningsMatchers.hasParseWarnings;
 import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.ConfigurationFormat.A10_ACOS;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasConfigurationFormat;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -23,6 +30,7 @@ import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.runtime.SnapshotRuntimeData;
 import org.batfish.config.Settings;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
@@ -30,6 +38,7 @@ import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.vendor.ConversionContext;
 import org.batfish.vendor.a10.representation.A10Configuration;
+import org.batfish.vendor.a10.representation.Interface;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -108,5 +117,69 @@ public class A10GrammarTest {
     assertThat(c, notNullValue());
     // Should be lower-cased
     assertThat(c.getHostname(), equalTo("hostname"));
+  }
+
+  @Test
+  public void testInterfacesExtraction() {
+    String hostname = "interfaces";
+    A10Configuration c = parseVendorConfig(hostname);
+
+    Map<Integer, Interface> eths = c.getInterfacesEthernet();
+    Map<Integer, Interface> loops = c.getInterfacesLoopback();
+    assertThat(eths.keySet(), containsInAnyOrder(1, 9));
+    assertThat(loops.keySet(), containsInAnyOrder(0, 10));
+
+    Interface eth1 = eths.get(1);
+    Interface eth9 = eths.get(9);
+    assertTrue(eth1.getEnabled());
+    assertTrue(eth1.getEnabledEffective());
+    assertThat(eth1.getIpAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.1.1/24")));
+    assertThat(eth1.getMtu(), equalTo(1234));
+    assertThat(eth1.getMtuEffective(), equalTo(1234));
+    assertThat(eth1.getName(), equalTo("this is a comp\"licat'ed name"));
+    assertThat(eth1.getNumber(), equalTo(1));
+    assertThat(eth1.getType(), equalTo(Interface.Type.ETHERNET));
+
+    assertFalse(eth9.getEnabled());
+    // Ethernet is disabled by default
+    assertFalse(eth9.getEnabledEffective());
+    assertThat(eth9.getIpAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.2.1/24")));
+    assertNull(eth9.getMtu());
+    assertThat(eth9.getMtuEffective(), equalTo(Interface.DEFAULT_MTU));
+    assertThat(eth9.getName(), equalTo("baz"));
+    assertThat(eth9.getNumber(), equalTo(9));
+    assertThat(eth9.getType(), equalTo(Interface.Type.ETHERNET));
+
+    Interface loop0 = loops.get(0);
+    Interface loop10 = loops.get(10);
+    assertNull(loop0.getEnabled());
+    // Loopback is enabled by default
+    assertTrue(loop0.getEnabledEffective());
+    assertThat(loop0.getIpAddress(), equalTo(ConcreteInterfaceAddress.parse("192.168.0.1/32")));
+    assertThat(loop0.getNumber(), equalTo(0));
+    assertThat(loop0.getType(), equalTo(Interface.Type.LOOPBACK));
+
+    assertNull(loop10.getIpAddress());
+  }
+
+  @Test
+  public void testInterfaceWarn() throws IOException {
+    String filename = "interface_warn";
+    Batfish batfish = getBatfishForConfigurationNames(filename);
+    Warnings warnings =
+        getOnlyElement(
+            batfish
+                .loadParseVendorConfigurationAnswerElement(batfish.getSnapshot())
+                .getWarnings()
+                .values());
+    assertThat(
+        warnings,
+        hasParseWarnings(
+            containsInAnyOrder(
+                hasComment(
+                    "Expected interface name with length in range 1-63, but got"
+                        + " '1234567890123456789012345678901234567890123456789012345678901234'"),
+                hasComment("Expected interface loopback number in range 0-10, but got '11'"),
+                hasComment("Expected interface ethernet number in range 1-40, but got '0'"))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -132,7 +132,6 @@ public class A10GrammarTest {
     Interface eth1 = eths.get(1);
     Interface eth9 = eths.get(9);
     assertTrue(eth1.getEnabled());
-    assertTrue(eth1.getEnabledEffective());
     assertThat(eth1.getIpAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.1.1/24")));
     assertThat(eth1.getMtu(), equalTo(1234));
     assertThat(eth1.getMtuEffective(), equalTo(1234));
@@ -141,8 +140,6 @@ public class A10GrammarTest {
     assertThat(eth1.getType(), equalTo(Interface.Type.ETHERNET));
 
     assertFalse(eth9.getEnabled());
-    // Ethernet is disabled by default
-    assertFalse(eth9.getEnabledEffective());
     assertThat(eth9.getIpAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.2.1/24")));
     assertNull(eth9.getMtu());
     assertThat(eth9.getMtuEffective(), equalTo(Interface.DEFAULT_MTU));
@@ -153,8 +150,6 @@ public class A10GrammarTest {
     Interface loop0 = loops.get(0);
     Interface loop10 = loops.get(10);
     assertNull(loop0.getEnabled());
-    // Loopback is enabled by default
-    assertTrue(loop0.getEnabledEffective());
     assertThat(loop0.getIpAddress(), equalTo(ConcreteInterfaceAddress.parse("192.168.0.1/32")));
     assertThat(loop0.getNumber(), equalTo(0));
     assertThat(loop0.getType(), equalTo(Interface.Type.LOOPBACK));

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -134,7 +134,6 @@ public class A10GrammarTest {
     assertTrue(eth1.getEnabled());
     assertThat(eth1.getIpAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.1.1/24")));
     assertThat(eth1.getMtu(), equalTo(1234));
-    assertThat(eth1.getMtuEffective(), equalTo(1234));
     assertThat(eth1.getName(), equalTo("this is a comp\"licat'ed name"));
     assertThat(eth1.getNumber(), equalTo(1));
     assertThat(eth1.getType(), equalTo(Interface.Type.ETHERNET));
@@ -142,7 +141,6 @@ public class A10GrammarTest {
     assertFalse(eth9.getEnabled());
     assertThat(eth9.getIpAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.2.1/24")));
     assertNull(eth9.getMtu());
-    assertThat(eth9.getMtuEffective(), equalTo(Interface.DEFAULT_MTU));
     assertThat(eth9.getName(), equalTo("baz"));
     assertThat(eth9.getNumber(), equalTo(9));
     assertThat(eth9.getType(), equalTo(Interface.Type.ETHERNET));

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
@@ -1,6 +1,10 @@
 package org.batfish.vendor.a10.representation;
 
 import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceEnabledEffective;
+import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceMtuEffective;
+import static org.batfish.vendor.a10.representation.Interface.DEFAULT_MTU;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -25,5 +29,14 @@ public class A10ConfigurationTest {
     assertTrue(getInterfaceEnabledEffective(eth));
     eth.setEnabled(false);
     assertFalse(getInterfaceEnabledEffective(eth));
+  }
+
+  @Test
+  public void testGetInterfaceMtuEffective() {
+    Interface eth = new Interface(Interface.Type.ETHERNET, 1);
+
+    assertThat(getInterfaceMtuEffective(eth), equalTo(DEFAULT_MTU));
+    eth.setMtu(1234);
+    assertThat(getInterfaceMtuEffective(eth), equalTo(1234));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
@@ -1,0 +1,29 @@
+package org.batfish.vendor.a10.representation;
+
+import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceEnabledEffective;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Tests of {@link A10Configuration}. */
+public class A10ConfigurationTest {
+  @Test
+  public void testGetInterfaceEnabledEffective() {
+    Interface ethNullEnabled = new Interface(Interface.Type.ETHERNET, 1);
+    Interface loopNullEnabled = new Interface(Interface.Type.LOOPBACK, 1);
+
+    // Defaults
+    // Ethernet is disabled by default
+    assertFalse(getInterfaceEnabledEffective(ethNullEnabled));
+    // Loopback is enabled by default
+    assertTrue(getInterfaceEnabledEffective(loopNullEnabled));
+
+    // Explicit enabled value set
+    Interface eth = new Interface(Interface.Type.ETHERNET, 1);
+    eth.setEnabled(true);
+    assertTrue(getInterfaceEnabledEffective(eth));
+    eth.setEnabled(false);
+    assertFalse(getInterfaceEnabledEffective(eth));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/BUILD
@@ -1,0 +1,35 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    resources = [
+        "//projects/batfish/src/test/resources:log4j_config",
+    ],
+    tags = ["cpu:4"],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/batfish/src/main/java/org/batfish/vendor/a10/representation",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:junit_junit",
+        "@maven//:org_antlr_antlr4_runtime",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/interface_warn
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/interface_warn
@@ -1,0 +1,12 @@
+!BATFISH_FORMAT: a10_acos
+hostname interface_warn
+!
+interface ethernet 1
+  ! name is too long
+  name 1234567890123456789012345678901234567890123456789012345678901234
+!
+! Bad interface numbers
+interface ethernet 0
+!
+interface loopback 11
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/interfaces
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/interfaces
@@ -1,0 +1,19 @@
+!BATFISH_FORMAT: a10_acos
+hostname interfaces
+!
+interface ethernet 1
+  ip address 10.0.1.1 /24
+  name "this is a comp\"l"'icat\'ed 'name
+  mtu 1234
+  enable
+!
+interface ethernet 9
+  ip address 10.0.2.1 255.255.255.0
+  name baz
+  disable
+!
+interface loopback 0
+  ip address 192.168.0.1 255.255.255.255
+!
+interface loopback 10
+!


### PR DESCRIPTION
* Add support for extracting `ethernet` and `loopback` interfaces as well as a few common properties
* Add support for some class of string quoting in names (e.g. `"foo "and' bar'` == `"foo and bar"`)
