### PR TITLE
Disambiguate VRRP groups using L3 adjacencies

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -43,7 +43,6 @@ import org.batfish.datamodel.tracking.DecrementPriority;
 import org.batfish.datamodel.tracking.TrackInterface;
 import org.junit.Before;
 import org.junit.Test;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /** Tests of {@link IpOwners}. */
 public class IpOwnersTest {
@@ -501,9 +500,10 @@ public class IpOwnersTest {
 
       @Override
       public Optional<NodeInterfacePair> pairedPointToPointL3Interface(NodeInterfacePair iface) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
       }
     }
+
     Configuration c =
         Configuration.builder()
             .setHostname("c")

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -5,7 +5,10 @@ import static org.batfish.common.topology.IpOwners.computeInterfaceHostSubnetIps
 import static org.batfish.common.topology.IpOwners.computeIpIfaceOwners;
 import static org.batfish.common.topology.IpOwners.computeIpVrfOwners;
 import static org.batfish.common.topology.IpOwners.extractHsrp;
+import static org.batfish.common.topology.IpOwners.extractVrrp;
+import static org.batfish.common.topology.IpOwners.partitionVrrpCandidates;
 import static org.batfish.common.topology.IpOwners.processHsrpGroups;
+import static org.batfish.common.topology.IpOwners.processVrrpGroups;
 import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -22,6 +25,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Table;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
@@ -32,11 +36,14 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.VrrpGroup;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.hsrp.HsrpGroup;
 import org.batfish.datamodel.tracking.DecrementPriority;
 import org.batfish.datamodel.tracking.TrackInterface;
 import org.junit.Before;
 import org.junit.Test;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /** Tests of {@link IpOwners}. */
 public class IpOwnersTest {
@@ -412,5 +419,128 @@ public class IpOwnersTest {
     // If VI model doesn't have references to undefined track groups we shouldn't crash
     // Also skip applying track action if that happens
     assertThat(computeHsrpPriority(i1, hsrpGroup), equalTo(basePriority));
+  }
+
+  @Test
+  public void testExtractVrrp() {
+    Table<ConcreteInterfaceAddress, Integer, Set<Interface>> groups = HashBasedTable.create();
+    Interface i =
+        Interface.builder()
+            .setName("name")
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+            .build();
+    extractVrrp(groups, i);
+    assertTrue(groups.isEmpty());
+
+    ConcreteInterfaceAddress ip1 = ConcreteInterfaceAddress.parse("1.1.1.1/28");
+    i.setVrrpGroups(
+        ImmutableSortedMap.of(1, VrrpGroup.builder().setVirtualAddress(ip1).setName(1).build()));
+    extractVrrp(groups, i);
+    assertThat(groups.get(ip1, 1), equalTo(ImmutableSet.of(i)));
+  }
+
+  @Test
+  public void testProcessVrrpGroups() {
+    Map<Ip, Map<String, Set<String>>> ipOwners = new HashMap<>();
+    Configuration c1 =
+        Configuration.builder()
+            .setHostname("c1")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    Configuration c2 =
+        Configuration.builder()
+            .setHostname("c2")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+
+    Table<ConcreteInterfaceAddress, Integer, Set<Interface>> groups = HashBasedTable.create();
+    Interface i1 =
+        Interface.builder()
+            .setOwner(c1)
+            .setName("i1")
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+            .build();
+    Interface i2 =
+        Interface.builder()
+            .setOwner(c2)
+            .setName("i2")
+            .setAddress(ConcreteInterfaceAddress.parse("2.3.4.5/24"))
+            .build();
+
+    ConcreteInterfaceAddress ip = ConcreteInterfaceAddress.parse("1.1.1.1/28");
+    i1.setVrrpGroups(
+        ImmutableSortedMap.of(
+            1, VrrpGroup.builder().setPriority(100).setName(1).setVirtualAddress(ip).build()));
+    i2.setVrrpGroups(
+        ImmutableSortedMap.of(
+            1, VrrpGroup.builder().setPriority(200).setName(1).setVirtualAddress(ip).build()));
+    extractVrrp(groups, i1);
+    extractVrrp(groups, i2);
+
+    // Test: expect c2/i2 to win
+    processVrrpGroups(ipOwners, groups, null);
+    assertThat(
+        ipOwners.get(ip.getIp()).get(c2.getHostname()), equalTo(ImmutableSet.of(i2.getName())));
+  }
+
+  @Test
+  public void testPartitionVrrpCandidates() {
+    class MockL3Adjacencies implements L3Adjacencies {
+
+      private final Map<NodeInterfacePair, NodeInterfacePair> _pairs;
+
+      public MockL3Adjacencies(ImmutableMap<NodeInterfacePair, NodeInterfacePair> pairs) {
+        _pairs = pairs;
+      }
+
+      @Override
+      public boolean inSameBroadcastDomain(NodeInterfacePair i1, NodeInterfacePair i2) {
+        return (_pairs.containsKey(i1) && _pairs.get(i1).equals(i2))
+            || (_pairs.containsKey(i2) && _pairs.get(i2).equals(i1));
+      }
+
+      @Override
+      public Optional<NodeInterfacePair> pairedPointToPointL3Interface(NodeInterfacePair iface) {
+        throw new NotImplementedException();
+      }
+    }
+    Configuration c =
+        Configuration.builder()
+            .setHostname("c")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    Interface i1 = Interface.builder().setName("i1").setOwner(c).build();
+    Interface i2 = Interface.builder().setName("i2").setOwner(c).build();
+
+    // common case of two interfaces in the same broadcast domain
+    assertThat(
+        partitionVrrpCandidates(
+            ImmutableSet.of(i1, i2),
+            new MockL3Adjacencies(
+                ImmutableMap.of(NodeInterfacePair.of(i1), NodeInterfacePair.of(i2)))),
+        equalTo(ImmutableSet.of(ImmutableSet.of(i1, i2))));
+
+    Interface i3 = Interface.builder().setName("i3").setOwner(c).build();
+    Interface i4 = Interface.builder().setName("i4").setOwner(c).build();
+
+    // two groups of two
+    assertThat(
+        partitionVrrpCandidates(
+            ImmutableSet.of(i1, i2, i3, i4),
+            new MockL3Adjacencies(
+                ImmutableMap.of(
+                    NodeInterfacePair.of(i1),
+                    NodeInterfacePair.of(i2),
+                    NodeInterfacePair.of(i3),
+                    NodeInterfacePair.of(i4)))),
+        equalTo(ImmutableSet.of(ImmutableSet.of(i1, i2), ImmutableSet.of(i3, i4))));
+
+    // one interface flying solo
+    assertThat(
+        partitionVrrpCandidates(
+            ImmutableSet.of(i1, i2, i3),
+            new MockL3Adjacencies(
+                ImmutableMap.of(NodeInterfacePair.of(i1), NodeInterfacePair.of(i2)))),
+        equalTo(ImmutableSet.of(ImmutableSet.of(i1, i2), ImmutableSet.of(i3))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -1461,7 +1461,7 @@ public final class TopologyUtilTest {
 
   /**
    * Tests that inactive and blacklisted interfaces are properly included or excluded from the
-   * output of {@link IpOwners#computeIpInterfaceOwners(Map, boolean)}
+   * output of {@link IpOwners#computeIpInterfaceOwners(Map, boolean, L3Adjacencies)}
    */
   @Test
   public void testIpInterfaceOwnersActiveInclusion() {
@@ -1475,13 +1475,13 @@ public final class TopologyUtilTest {
                 iface("shut-black", "1.1.1.1/32", false, true)));
 
     assertThat(
-        computeIpInterfaceOwners(nodeInterfaces, true),
+        computeIpInterfaceOwners(nodeInterfaces, true, null),
         equalTo(
             ImmutableMap.of(
                 Ip.parse("1.1.1.1"), ImmutableMap.of("node", ImmutableSet.of("active")))));
 
     assertThat(
-        computeIpInterfaceOwners(nodeInterfaces, false),
+        computeIpInterfaceOwners(nodeInterfaces, false, null),
         equalTo(
             ImmutableMap.of(
                 Ip.parse("1.1.1.1"),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/VrrpComputationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/VrrpComputationTest.java
@@ -109,7 +109,7 @@ public class VrrpComputationTest {
     Map<String, Configuration> configs = setupVrrpTestCase(true);
 
     Map<Ip, Map<String, Set<String>>> interfaceOwners =
-        computeIpInterfaceOwners(computeNodeInterfaces(configs), false);
+        computeIpInterfaceOwners(computeNodeInterfaces(configs), false, null);
 
     assertThat(
         interfaceOwners,

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -103,7 +103,10 @@ public class RoutesAnswerer extends Answerer {
     RoutingProtocolSpecifier protocolSpec = question.getRoutingProtocolSpecifier();
     String vrfRegex = question.getVrfs();
     Map<Ip, Set<String>> ipOwners =
-        computeIpNodeOwners(_batfish.loadConfigurations(snapshot), true);
+        computeIpNodeOwners(
+            _batfish.loadConfigurations(snapshot),
+            true,
+            _batfish.getTopologyProvider().getL3Adjacencies(snapshot));
     boolean bgpMultipathBest = expandedBgpRouteStatuses.contains(BEST);
     boolean bgpBackup = expandedBgpRouteStatuses.contains(BACKUP);
     Multiset<Row> rows;
@@ -225,12 +228,20 @@ public class RoutesAnswerer extends Answerer {
       case MAIN:
       default:
         dp = _batfish.loadDataPlane(snapshot);
-        ipOwners = computeIpNodeOwners(_batfish.loadConfigurations(snapshot), true);
+        ipOwners =
+            computeIpNodeOwners(
+                _batfish.loadConfigurations(snapshot),
+                true,
+                _batfish.getTopologyProvider().getL3Adjacencies(snapshot));
         routesGroupedByKeyInBase =
             groupRoutes(dp.getRibs(), matchingNodes, network, vrfRegex, protocolSpec, ipOwners);
 
         dp = _batfish.loadDataPlane(reference);
-        ipOwners = computeIpNodeOwners(_batfish.loadConfigurations(reference), true);
+        ipOwners =
+            computeIpNodeOwners(
+                _batfish.loadConfigurations(reference),
+                true,
+                _batfish.getTopologyProvider().getL3Adjacencies(snapshot));
         routesGroupedByKeyInDelta =
             groupRoutes(dp.getRibs(), matchingNodes, network, vrfRegex, protocolSpec, ipOwners);
 

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -47,7 +47,11 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.IBatfishTestAdapter;
+import org.batfish.common.plugin.IBatfishTestAdapter.TopologyProviderTestAdapter;
+import org.batfish.common.topology.L3Adjacencies;
+import org.batfish.common.topology.TopologyProvider;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.AnnotatedRoute;
@@ -494,6 +498,18 @@ public class RoutesAnswererTest {
     assertThat(textDesc, not(emptyString()));
   }
 
+  static class MockTopoloogyProvider extends TopologyProviderTestAdapter {
+
+    public MockTopoloogyProvider(IBatfish batfish) {
+      super(batfish);
+    }
+
+    @Override
+    public L3Adjacencies getL3Adjacencies(NetworkSnapshot snapshot) {
+      return null;
+    }
+  }
+
   static class MockBatfish extends IBatfishTestAdapter {
 
     private final NetworkConfigurations _configs;
@@ -520,6 +536,11 @@ public class RoutesAnswererTest {
     @Override
     public SpecifierContext specifierContext(NetworkSnapshot snapshot) {
       return MockSpecifierContext.builder().setConfigs(loadConfigurations(snapshot)).build();
+    }
+
+    @Override
+    public TopologyProvider getTopologyProvider() {
+      return new MockTopoloogyProvider(this);
     }
   }
 


### PR DESCRIPTION
1. Creates a new method that disambiguates VRRP IP ownership. Only used by RoutesAnswerer at the moment. 

2. Some refactoring for testability