### PR TITLE
IBatfish: Another load config that refuses to initialize snapshot

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/e2e/l1/asymmetric/L1AsymmetricTest.java
+++ b/projects/allinone/src/test/java/org/batfish/e2e/l1/asymmetric/L1AsymmetricTest.java
@@ -27,6 +27,7 @@ public class L1AsymmetricTest {
                 .setLayer1TopologyPrefix(prefix + "/batfish")
                 .build(),
             _folder);
+    batfish.loadConfigurations(batfish.getSnapshot());
     return batfish.getTopologyProvider().getInitialLayer3Topology(batfish.getSnapshot());
   }
 

--- a/projects/allinone/src/test/java/org/batfish/e2e/layer2ntc/Layer2NtcTest.java
+++ b/projects/allinone/src/test/java/org/batfish/e2e/layer2ntc/Layer2NtcTest.java
@@ -36,6 +36,7 @@ public class Layer2NtcTest {
                 .setLayer1TopologyPrefix(prefix + '/' + nameOfBatfishFolderContainingL1)
                 .build(),
             _folder);
+    batfish.loadConfigurations(batfish.getSnapshot());
     return batfish.getTopologyProvider().getInitialLayer3Topology(batfish.getSnapshot());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -131,8 +131,17 @@ public interface IBatfish extends IPluginConsumer {
   InitInfoAnswerElement initInfoBgpAdvertisements(
       NetworkSnapshot snapshot, boolean summary, boolean verboseError);
 
-  /** Returns the configurations for given snapshot. */
+  /**
+   * Returns the configurations for given snapshot. Parses and serializes them from snapshot input
+   * if needed.
+   */
   SortedMap<String, Configuration> loadConfigurations(NetworkSnapshot snapshot);
+
+  /**
+   * Returns the configurations for given snapshot, which was parsed and serialized before. The
+   * returned optional is empty if the snapshot was not serialized before.
+   */
+  Optional<SortedMap<String, Configuration>> loadSerializedConfigurations(NetworkSnapshot snapshot);
 
   /** Returns the vendor configurations of a given snapshot */
   Map<String, VendorConfiguration> loadVendorConfigurations(NetworkSnapshot snapshot);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -138,10 +138,11 @@ public interface IBatfish extends IPluginConsumer {
   SortedMap<String, Configuration> loadConfigurations(NetworkSnapshot snapshot);
 
   /**
-   * Returns the configurations for given snapshot, which was parsed and serialized before. The
-   * returned optional is empty if the snapshot was not serialized before.
+   * Returns the configurations for given snapshot that have been processed (parsed, serialized,
+   * etc.) before. The returned optional is empty if the snapshot configurations have not been
+   * processed.
    */
-  Optional<SortedMap<String, Configuration>> loadSerializedConfigurations(NetworkSnapshot snapshot);
+  Optional<SortedMap<String, Configuration>> getProcessedConfigurations(NetworkSnapshot snapshot);
 
   /** Returns the vendor configurations of a given snapshot */
   Map<String, VendorConfiguration> loadVendorConfigurations(NetworkSnapshot snapshot);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -263,6 +263,12 @@ public class IBatfishTestAdapter implements IBatfish {
   }
 
   @Override
+  public Optional<SortedMap<String, Configuration>> loadSerializedConfigurations(
+      NetworkSnapshot snapshot) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public Map<String, VendorConfiguration> loadVendorConfigurations(NetworkSnapshot snapshot) {
     throw new UnsupportedOperationException();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -263,7 +263,7 @@ public class IBatfishTestAdapter implements IBatfish {
   }
 
   @Override
-  public Optional<SortedMap<String, Configuration>> loadSerializedConfigurations(
+  public Optional<SortedMap<String, Configuration>> getProcessedConfigurations(
       NetworkSnapshot snapshot) {
     throw new UnsupportedOperationException();
   }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1225,11 +1225,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
       configurations = _storage.loadConfigurations(snapshot.getNetwork(), snapshot.getSnapshot());
       if (configurations != null) {
         _logger.debugf("Loaded configurations for %s off disk", snapshot);
-      } else {
-        if (parseIfNeeded) {
-          // Otherwise, we have to parse the configurations. Fall back to old, hacky code.
-          configurations = actuallyParseConfigurations(snapshot);
-        }
+      } else if (parseIfNeeded) {
+        // Otherwise, we have to parse the configurations. Fall back to old, hacky code.
+        configurations = actuallyParseConfigurations(snapshot);
       }
       if (configurations != null) {
         // Apply things like blacklist and aggregations before installing in the cache.

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1197,7 +1197,18 @@ public class Batfish extends PluginConsumer implements IBatfish {
   }
 
   @Override
+  public Optional<SortedMap<String, Configuration>> loadSerializedConfigurations(
+      NetworkSnapshot snapshot) {
+    return loadConfigurations(snapshot, false);
+  }
+
+  @Override
   public SortedMap<String, Configuration> loadConfigurations(NetworkSnapshot snapshot) {
+    return loadConfigurations(snapshot, true).get();
+  }
+
+  private Optional<SortedMap<String, Configuration>> loadConfigurations(
+      NetworkSnapshot snapshot, boolean parseIfNeeded) {
     Span span = GlobalTracer.get().buildSpan("Load configurations").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
@@ -1206,7 +1217,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
       SortedMap<String, Configuration> configurations =
           _cachedConfigurations.getIfPresent(snapshot);
       if (configurations != null) {
-        return configurations;
+        return Optional.of(configurations);
       }
       _logger.debugf("Loading configurations for %s, cache miss", snapshot);
 
@@ -1215,14 +1226,19 @@ public class Batfish extends PluginConsumer implements IBatfish {
       if (configurations != null) {
         _logger.debugf("Loaded configurations for %s off disk", snapshot);
       } else {
-        // Otherwise, we have to parse the configurations. Fall back to old, hacky code.
-        configurations = actuallyParseConfigurations(snapshot);
+        if (parseIfNeeded) {
+          // Otherwise, we have to parse the configurations. Fall back to old, hacky code.
+          configurations = actuallyParseConfigurations(snapshot);
+        }
       }
-      // Apply things like blacklist and aggregations before installing in the cache.
-      postProcessSnapshot(snapshot, configurations);
+      if (configurations != null) {
+        // Apply things like blacklist and aggregations before installing in the cache.
+        postProcessSnapshot(snapshot, configurations);
+        _cachedConfigurations.put(snapshot, configurations);
+      }
 
-      _cachedConfigurations.put(snapshot, configurations);
-      return configurations;
+      return Optional.ofNullable(configurations);
+
     } finally {
       span.finish();
     }

--- a/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
@@ -209,7 +209,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
 
   private @Nonnull Map<String, Configuration> getConfigurations(NetworkSnapshot snapshot) {
     return _batfish
-        .loadSerializedConfigurations(snapshot)
+        .getProcessedConfigurations(snapshot)
         .orElseThrow(
             () ->
                 new IllegalArgumentException(

--- a/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
@@ -207,11 +207,20 @@ public final class TopologyProviderImpl implements TopologyProvider {
           .maximumSize(MAX_CACHED_SNAPSHOTS)
           .build(CacheLoader.from(this::computeVxlanTopology));
 
+  private @Nonnull Map<String, Configuration> getConfigurations(NetworkSnapshot snapshot) {
+    return _batfish
+        .loadSerializedConfigurations(snapshot)
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Snapshot '" + snapshot + "' has not been parsed/serialized"));
+  }
+
   private @Nonnull IpOwners computeIpOwners(NetworkSnapshot snapshot) {
     Span span = GlobalTracer.get().buildSpan("TopologyProviderImpl::computeIpOwners").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      return new IpOwners(_batfish.loadConfigurations(snapshot));
+      return new IpOwners(getConfigurations(snapshot));
     } finally {
       span.finish();
     }
@@ -233,7 +242,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
       return Layer1TopologiesFactory.create(
           getRawLayer1PhysicalTopology(networkSnapshot).orElse(Layer1Topology.EMPTY),
           loadSynthesizedLayer1Topology(networkSnapshot).orElse(Layer1Topology.EMPTY),
-          _batfish.loadConfigurations(networkSnapshot));
+          getConfigurations(networkSnapshot));
     } finally {
       span.finish();
     }
@@ -245,7 +254,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
         GlobalTracer.get().buildSpan("TopologyProviderImpl::computeInitialIpsecTopology").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      return TopologyUtil.computeIpsecTopology(_batfish.loadConfigurations(networkSnapshot));
+      return TopologyUtil.computeIpsecTopology(getConfigurations(networkSnapshot));
     } finally {
       span.finish();
     }
@@ -271,13 +280,13 @@ public final class TopologyProviderImpl implements TopologyProvider {
       Layer1Topologies l1 = getLayer1Topologies(networkSnapshot);
       if (L3Adjacencies.USE_NEW_METHOD) {
         return BroadcastL3Adjacencies.create(
-            l1, VxlanTopology.EMPTY, _batfish.loadConfigurations(networkSnapshot));
+            l1, VxlanTopology.EMPTY, getConfigurations(networkSnapshot));
       }
       if (l1.getCombinedL1().isEmpty()) {
         return GlobalBroadcastNoPointToPoint.instance();
       }
 
-      Map<String, Configuration> configs = _batfish.loadConfigurations(networkSnapshot);
+      Map<String, Configuration> configs = getConfigurations(networkSnapshot);
       return HybridL3Adjacencies.create(
           l1,
           computeLayer2Topology(l1.getActiveLogicalL1(), VxlanTopology.EMPTY, configs),
@@ -307,7 +316,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
         GlobalTracer.get().buildSpan("TopologyProviderImpl::computeRawLayer3Topology").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      Map<String, Configuration> configurations = _batfish.loadConfigurations(networkSnapshot);
+      Map<String, Configuration> configurations = getConfigurations(networkSnapshot);
       L3Adjacencies adjacencies = getInitialL3Adjacencies(networkSnapshot);
       return TopologyUtil.computeRawLayer3Topology(adjacencies, configurations);
     } finally {
@@ -321,7 +330,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
       return OspfTopologyUtils.computeOspfTopology(
-          NetworkConfigurations.of(_batfish.loadConfigurations(snapshot)),
+          NetworkConfigurations.of(getConfigurations(snapshot)),
           getInitialLayer3Topology(snapshot));
     } finally {
       span.finish();
@@ -333,8 +342,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
       return OspfTopologyUtils.computeOspfTopology(
-          NetworkConfigurations.of(_batfish.loadConfigurations(snapshot)),
-          getLayer3Topology(snapshot));
+          NetworkConfigurations.of(getConfigurations(snapshot)), getLayer3Topology(snapshot));
     }
   }
 
@@ -343,7 +351,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
         GlobalTracer.get().buildSpan("TopologyProviderImpl::computeInitialTunnelTopology").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      return TopologyUtil.computeInitialTunnelTopology(_batfish.loadConfigurations(snapshot));
+      return TopologyUtil.computeInitialTunnelTopology(getConfigurations(snapshot));
     } finally {
       span.finish();
     }
@@ -353,7 +361,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
     Span span = GlobalTracer.get().buildSpan("TopologyProviderImpl::computeVxlanTopology").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      return VxlanTopologyUtils.computeVxlanTopology(_batfish.loadConfigurations(snapshot));
+      return VxlanTopologyUtils.computeVxlanTopology(getConfigurations(snapshot));
     } finally {
       span.finish();
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5565,6 +5565,7 @@ public final class CiscoGrammarTest {
 
     // Overlay edge present in initial tunnel topology
     NetworkSnapshot snapshot = batfish.getSnapshot();
+    batfish.loadConfigurations(snapshot);
     assertThat(
         batfish.getTopologyProvider().getInitialTunnelTopology(snapshot).asEdgeSet(),
         containsInAnyOrder(overlayEdge, overlayEdge.reverse()));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -847,6 +847,7 @@ public final class CumulusNcluGrammarTest {
                 .setLayer1TopologyPrefix(TESTRIGS_PREFIX + testrigName)
                 .build(),
             _folder);
+    batfish.loadConfigurations(batfish.getSnapshot());
 
     // Expect an l3 edge to come up on the peer link interface
     Edge edge =

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -894,6 +894,7 @@ public final class FlatJuniperGrammarTest {
                 .setConfigurationFiles(resourcePrefix, fw, r1, r2, sw)
                 .build(),
             _folder);
+    batfish.loadConfigurations(batfish.getSnapshot());
 
     // check layer-2 adjacencies for L3 interfaces
     L3Adjacencies adjacencies =
@@ -931,6 +932,7 @@ public final class FlatJuniperGrammarTest {
                 .setConfigurationFiles(resourcePrefix, "r1", "r2")
                 .build(),
             _folder);
+    batfish.loadConfigurations(batfish.getSnapshot());
 
     Layer1Topology layer1LogicalTopology =
         batfish.getTopologyProvider().getLayer1LogicalTopology(batfish.getSnapshot()).get();

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -217,6 +217,7 @@ public class BatfishTest {
             .setHostsFiles(testrigResourcePrefix, ImmutableSet.of("c1.json", "c2.json"));
     Batfish batfish =
         BatfishTestUtils.getBatfishFromTestrigText(testrigTextBuilder.build(), _folder);
+    batfish.loadConfigurations(batfish.getSnapshot());
 
     assertThat(
         batfish.getTopologyProvider().getRawLayer3Topology(batfish.getSnapshot()).getEdges(),


### PR DESCRIPTION
A variant of Batfish::loadConfiguration that will not parse uninitialized snapshots. Call it from topology provider, which helps make sure that topology provider does not try to initialize snapshots. Topology provider is not expected to work for uninitialized snapshots.  