### PR TITLE
CollectIpSpaceReferences: avoid recursion for traversing Transformations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -199,10 +199,10 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
           };
       enqueue.accept(t);
       while (!queue.isEmpty()) {
-        t = queue.remove();
-        visit(t.getGuard());
-        enqueue.accept(t.getAndThen());
-        enqueue.accept(t.getOrElse());
+        Transformation tx = queue.remove();
+        visit(tx.getGuard());
+        enqueue.accept(tx.getAndThen());
+        enqueue.accept(tx.getOrElse());
       }
     }
 


### PR DESCRIPTION
Transformations can be very deep, so recursion can cause stack overflow. Use the heap (via work queue) instead.