### PR TITLE
CheckPoint mgmt service-other match grammar

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/AstNode.java
@@ -1,6 +1,8 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import java.io.Serializable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** A node that may be placed on the value stack while parsing a service-other match expression. */
+@ParametersAreNonnullByDefault
 public interface AstNode extends Serializable {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/AstNode.java
@@ -1,0 +1,3 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+public interface AstNode {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/AstNode.java
@@ -1,3 +1,6 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
-public interface AstNode {}
+import java.io.Serializable;
+
+/** A node that may be placed on the value stack while parsing a service-other match expression. */
+public interface AstNode extends Serializable {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BUILD
@@ -4,22 +4,22 @@ load("@batfish//skylark:pmd_test.bzl", "pmd_test")
 package(default_visibility = ["//visibility:public"])
 
 java_library(
-    name = "representation",
+    name = "parboiled",
     srcs = glob(
-        ["*.java"],
+        ["**/*.java"],
         exclude = ["BUILD"],
     ),
     deps = [
         "//projects/batfish-common-protocol:common",
-        "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management",
-        "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_parboiled_parboiled_core",
+        "@maven//:org_parboiled_parboiled_java",
     ],
 )
 
 pmd_test(
     name = "pmd",
-    lib = ":representation",
+    lib = ":parboiled",
 )

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNode.java
@@ -1,8 +1,10 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a boolean expression. */
+@ParametersAreNonnullByDefault
 public abstract class BooleanExprAstNode implements AstNode {
 
   public @Nonnull BooleanExprAstNode or(BooleanExprAstNode disjunct) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public abstract class BooleanExprAstNode implements AstNode {
+
+  public @Nonnull BooleanExprAstNode or(BooleanExprAstNode disjunct) {
+    return new DisjunctionAstNode(this, disjunct);
+  }
+
+  public @Nonnull BooleanExprAstNode and(BooleanExprAstNode conjunct) {
+    return new ConjunctionAstNode(this, conjunct);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} representing a boolean expression. */
 public abstract class BooleanExprAstNode implements AstNode {
 
   public @Nonnull BooleanExprAstNode or(BooleanExprAstNode disjunct) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNode.java
@@ -1,4 +1,7 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
 /** An {@link AstNode} representing a comparator. */
+@ParametersAreNonnullByDefault
 public interface ComparatorAstNode extends AstNode {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNode.java
@@ -1,3 +1,4 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
+/** An {@link AstNode} representing a comparator. */
 public interface ComparatorAstNode extends AstNode {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNode.java
@@ -1,0 +1,3 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+public interface ComparatorAstNode extends AstNode {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNode.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** An {@link AstNode} representing a conjunction of boolean expressions. */
 public final class ConjunctionAstNode extends BooleanExprAstNode {
 
   ConjunctionAstNode(BooleanExprAstNode... conjuncts) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNode.java
@@ -4,8 +4,10 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a conjunction of boolean expressions. */
+@ParametersAreNonnullByDefault
 public final class ConjunctionAstNode extends BooleanExprAstNode {
 
   ConjunctionAstNode(BooleanExprAstNode... conjuncts) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNode.java
@@ -1,0 +1,42 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class ConjunctionAstNode extends BooleanExprAstNode {
+
+  ConjunctionAstNode(BooleanExprAstNode... conjuncts) {
+    _conjuncts = ImmutableList.copyOf(conjuncts);
+  }
+
+  ConjunctionAstNode(Iterable<BooleanExprAstNode> conjuncts) {
+    _conjuncts = ImmutableList.copyOf(conjuncts);
+  }
+
+  @Nonnull
+  @Override
+  public BooleanExprAstNode and(BooleanExprAstNode conjunct) {
+    return new ConjunctionAstNode(
+        ImmutableList.<BooleanExprAstNode>builder().addAll(_conjuncts).add(conjunct).build());
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof ConjunctionAstNode)) {
+      return false;
+    }
+    ConjunctionAstNode that = (ConjunctionAstNode) o;
+    return _conjuncts.equals(that._conjuncts);
+  }
+
+  @Override
+  public int hashCode() {
+    return _conjuncts.hashCode();
+  }
+
+  private final @Nonnull List<BooleanExprAstNode> _conjuncts;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNode.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** An {@link AstNode} representing a disjunction of boolean expressions. */
 public final class DisjunctionAstNode extends BooleanExprAstNode {
 
   DisjunctionAstNode(BooleanExprAstNode... disjuncts) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNode.java
@@ -4,8 +4,10 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a disjunction of boolean expressions. */
+@ParametersAreNonnullByDefault
 public final class DisjunctionAstNode extends BooleanExprAstNode {
 
   DisjunctionAstNode(BooleanExprAstNode... disjuncts) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNode.java
@@ -1,0 +1,42 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class DisjunctionAstNode extends BooleanExprAstNode {
+
+  DisjunctionAstNode(BooleanExprAstNode... disjuncts) {
+    _disjuncts = ImmutableList.copyOf(disjuncts);
+  }
+
+  DisjunctionAstNode(Iterable<BooleanExprAstNode> disjuncts) {
+    _disjuncts = ImmutableList.copyOf(disjuncts);
+  }
+
+  @Nonnull
+  @Override
+  public BooleanExprAstNode or(BooleanExprAstNode disjunct) {
+    return new DisjunctionAstNode(
+        ImmutableList.<BooleanExprAstNode>builder().addAll(_disjuncts).add(disjunct).build());
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof DisjunctionAstNode)) {
+      return false;
+    }
+    DisjunctionAstNode that = (DisjunctionAstNode) o;
+    return _disjuncts.equals(that._disjuncts);
+  }
+
+  @Override
+  public int hashCode() {
+    return _disjuncts.hashCode();
+  }
+
+  private final @Nonnull List<BooleanExprAstNode> _disjuncts;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNode.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+/** An {@link AstNode} representing a boolean function of the destination port. */
 @ParametersAreNonnullByDefault
 public class DportAstNode extends BooleanExprAstNode {
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNode.java
@@ -1,0 +1,34 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class DportAstNode extends BooleanExprAstNode {
+
+  public DportAstNode(ComparatorAstNode comparator, Uint16AstNode value) {
+    _comparator = comparator;
+    _value = value;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof DportAstNode)) {
+      return false;
+    }
+    DportAstNode that = (DportAstNode) o;
+    return _comparator.equals(that._comparator) && _value.equals(that._value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_comparator, _value);
+  }
+
+  private final @Nonnull ComparatorAstNode _comparator;
+  private final @Nonnull Uint16AstNode _value;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNode.java
@@ -1,11 +1,14 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * An {@link AstNode} that is the result of parsing an empty match expression. Should be treated as
  * {@code true} in evaluation.
  */
+@ParametersAreNonnullByDefault
 public final class EmptyAstNode extends BooleanExprAstNode {
 
   public static @Nonnull EmptyAstNode instance() {
@@ -13,6 +16,16 @@ public final class EmptyAstNode extends BooleanExprAstNode {
   }
 
   private static final EmptyAstNode INSTANCE = new EmptyAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof EmptyAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0xF3858ECF; // randomly generated
+  }
 
   private EmptyAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNode.java
@@ -2,6 +2,10 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/**
+ * An {@link AstNode} that is the result of parsing an empty match expression. Should be treated as
+ * {@code true} in evaluation.
+ */
 public final class EmptyAstNode extends BooleanExprAstNode {
 
   public static @Nonnull EmptyAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class EmptyAstNode extends BooleanExprAstNode {
+
+  public static @Nonnull EmptyAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final EmptyAstNode INSTANCE = new EmptyAstNode();
+
+  private EmptyAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class EqualsAstNode implements ComparatorAstNode {
+
+  public static @Nonnull EqualsAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final EqualsAstNode INSTANCE = new EqualsAstNode();
+
+  private EqualsAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} representing the {@code equals} comparator. */
 public final class EqualsAstNode implements ComparatorAstNode {
 
   public static @Nonnull EqualsAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNode.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the {@code equals} comparator. */
+@ParametersAreNonnullByDefault
 public final class EqualsAstNode implements ComparatorAstNode {
 
   public static @Nonnull EqualsAstNode instance() {
@@ -10,6 +13,16 @@ public final class EqualsAstNode implements ComparatorAstNode {
   }
 
   private static final EqualsAstNode INSTANCE = new EqualsAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof EqualsAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0x5C7938D4; // randomly generated
+  }
 
   private EqualsAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNode.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} resulting from a failure to parse the match expression. */
+@ParametersAreNonnullByDefault
 public final class ErrorAstNode extends BooleanExprAstNode {
 
   public static @Nonnull ErrorAstNode instance() {
@@ -10,6 +13,16 @@ public final class ErrorAstNode extends BooleanExprAstNode {
   }
 
   private static final ErrorAstNode INSTANCE = new ErrorAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof ErrorAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0xF40A5BCD; // randomly generated
+  }
 
   private ErrorAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class ErrorAstNode extends BooleanExprAstNode {
+
+  public static @Nonnull ErrorAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final ErrorAstNode INSTANCE = new ErrorAstNode();
+
+  private ErrorAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} resulting from a failure to parse the match expression. */
 public final class ErrorAstNode extends BooleanExprAstNode {
 
   public static @Nonnull ErrorAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class GreaterThanAstNode implements ComparatorAstNode {
+
+  public static @Nonnull GreaterThanAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final GreaterThanAstNode INSTANCE = new GreaterThanAstNode();
+
+  private GreaterThanAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNode.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the {@code greater-than} comparator. */
+@ParametersAreNonnullByDefault
 public final class GreaterThanAstNode implements ComparatorAstNode {
 
   public static @Nonnull GreaterThanAstNode instance() {
@@ -10,6 +13,16 @@ public final class GreaterThanAstNode implements ComparatorAstNode {
   }
 
   private static final GreaterThanAstNode INSTANCE = new GreaterThanAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof GreaterThanAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0x8E7FAD85; // randomly generated
+  }
 
   private GreaterThanAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} representing the {@code greater-than} comparator. */
 public final class GreaterThanAstNode implements ComparatorAstNode {
 
   public static @Nonnull GreaterThanAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNode.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the {@code greater-than-or-equals} comparator. */
+@ParametersAreNonnullByDefault
 public final class GreaterThanOrEqualsAstNode implements ComparatorAstNode {
 
   public static @Nonnull GreaterThanOrEqualsAstNode instance() {
@@ -10,6 +13,16 @@ public final class GreaterThanOrEqualsAstNode implements ComparatorAstNode {
   }
 
   private static final GreaterThanOrEqualsAstNode INSTANCE = new GreaterThanOrEqualsAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof GreaterThanOrEqualsAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0x73732991; // randomly generated
+  }
 
   private GreaterThanOrEqualsAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} representing the {@code greater-than-or-equals} comparator. */
 public final class GreaterThanOrEqualsAstNode implements ComparatorAstNode {
 
   public static @Nonnull GreaterThanOrEqualsAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class GreaterThanOrEqualsAstNode implements ComparatorAstNode {
+
+  public static @Nonnull GreaterThanOrEqualsAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final GreaterThanOrEqualsAstNode INSTANCE = new GreaterThanOrEqualsAstNode();
+
+  private GreaterThanOrEqualsAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
@@ -2,6 +2,10 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/**
+ * An {@link AstNode} representing the condition that the packet direction is classified as {@code
+ * incoming}.
+ */
 public final class IncomingAstNode extends BooleanExprAstNode {
 
   public static @Nonnull IncomingAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class IncomingAstNode extends BooleanExprAstNode {
+
+  public static @Nonnull IncomingAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final IncomingAstNode INSTANCE = new IncomingAstNode();
+
+  private IncomingAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
@@ -1,11 +1,14 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * An {@link AstNode} representing the condition that the packet direction is classified as {@code
  * incoming}.
  */
+@ParametersAreNonnullByDefault
 public final class IncomingAstNode extends BooleanExprAstNode {
 
   public static @Nonnull IncomingAstNode instance() {
@@ -13,6 +16,16 @@ public final class IncomingAstNode extends BooleanExprAstNode {
   }
 
   private static final IncomingAstNode INSTANCE = new IncomingAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof IncomingAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0xB6D251E7; // randomly generated
+  }
 
   private IncomingAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNode.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the {@code less-than} comparator. */
+@ParametersAreNonnullByDefault
 public final class LessThanAstNode implements ComparatorAstNode {
 
   public static @Nonnull LessThanAstNode instance() {
@@ -10,6 +13,16 @@ public final class LessThanAstNode implements ComparatorAstNode {
   }
 
   private static final LessThanAstNode INSTANCE = new LessThanAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof LessThanAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0x59B7C219; // randomly generated
+  }
 
   private LessThanAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class LessThanAstNode implements ComparatorAstNode {
+
+  public static @Nonnull LessThanAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final LessThanAstNode INSTANCE = new LessThanAstNode();
+
+  private LessThanAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} representing the {@code less-than} comparator. */
 public final class LessThanAstNode implements ComparatorAstNode {
 
   public static @Nonnull LessThanAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class LessThanOrEqualsAstNode implements ComparatorAstNode {
+
+  public static @Nonnull LessThanOrEqualsAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final LessThanOrEqualsAstNode INSTANCE = new LessThanOrEqualsAstNode();
+
+  private LessThanOrEqualsAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNode.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the {@code less-than-or-equals} comparator. */
+@ParametersAreNonnullByDefault
 public final class LessThanOrEqualsAstNode implements ComparatorAstNode {
 
   public static @Nonnull LessThanOrEqualsAstNode instance() {
@@ -10,6 +13,16 @@ public final class LessThanOrEqualsAstNode implements ComparatorAstNode {
   }
 
   private static final LessThanOrEqualsAstNode INSTANCE = new LessThanOrEqualsAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof LessThanOrEqualsAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0xB6CB113F; // randomly generated
+  }
 
   private LessThanOrEqualsAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} representing the {@code less-than-or-equals} comparator. */
 public final class LessThanOrEqualsAstNode implements ComparatorAstNode {
 
   public static @Nonnull LessThanOrEqualsAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
@@ -2,6 +2,10 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/**
+ * An {@link AstNode} representing the condition that the packet direction is classified as {@code
+ * outgoing}.
+ */
 public final class OutgoingAstNode extends BooleanExprAstNode {
 
   public static @Nonnull OutgoingAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class OutgoingAstNode extends BooleanExprAstNode {
+
+  public static @Nonnull OutgoingAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final OutgoingAstNode INSTANCE = new OutgoingAstNode();
+
+  private OutgoingAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
@@ -1,11 +1,14 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * An {@link AstNode} representing the condition that the packet direction is classified as {@code
  * outgoing}.
  */
+@ParametersAreNonnullByDefault
 public final class OutgoingAstNode extends BooleanExprAstNode {
 
   public static @Nonnull OutgoingAstNode instance() {
@@ -13,6 +16,16 @@ public final class OutgoingAstNode extends BooleanExprAstNode {
   }
 
   private static final OutgoingAstNode INSTANCE = new OutgoingAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof OutgoingAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0x3FA69E8B; // randomly generated
+  }
 
   private OutgoingAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExpr.java
@@ -11,6 +11,10 @@ import org.parboiled.parserunners.TracingParseRunner;
 import org.parboiled.support.ParsingResult;
 
 /** Parser for the {@code match} field of a CheckPoint service of type {@code service-other}. */
+@SuppressWarnings({
+  "checkstyle:methodname", // this class uses idiomatic names
+  "WeakerAccess", // access of Rule methods is needed for parser auto-generation.
+})
 public class ServiceOtherMatchExpr extends BaseParser<AstNode> {
 
   Rule TopLevel() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExpr.java
@@ -6,8 +6,8 @@ import javax.annotation.Nonnull;
 import org.parboiled.BaseParser;
 import org.parboiled.Parboiled;
 import org.parboiled.Rule;
-import org.parboiled.parserunners.AbstractParseRunner;
-import org.parboiled.parserunners.TracingParseRunner;
+import org.parboiled.parserunners.BasicParseRunner;
+import org.parboiled.parserunners.ParseRunner;
 import org.parboiled.support.ParsingResult;
 
 /** Parser for the {@code match} field of a CheckPoint service of type {@code service-other}. */
@@ -175,7 +175,7 @@ public class ServiceOtherMatchExpr extends BaseParser<AstNode> {
   static @Nonnull AstNode parse(
       String input, Function<ServiceOtherMatchExpr, Rule> inputRuleGetter) {
     ServiceOtherMatchExpr parser = instance();
-    AbstractParseRunner<AstNode> runner = new TracingParseRunner<>(inputRuleGetter.apply(parser));
+    ParseRunner<AstNode> runner = new BasicParseRunner<>(inputRuleGetter.apply(parser));
     ParsingResult<AstNode> result = runner.run(input);
     if (!result.matched) {
       return ErrorAstNode.instance();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExpr.java
@@ -1,0 +1,192 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import org.parboiled.BaseParser;
+import org.parboiled.Parboiled;
+import org.parboiled.Rule;
+import org.parboiled.parserunners.AbstractParseRunner;
+import org.parboiled.parserunners.TracingParseRunner;
+import org.parboiled.support.ParsingResult;
+
+/** Parser for the {@code match} field of a CheckPoint service of type {@code service-other}. */
+public class ServiceOtherMatchExpr extends BaseParser<AstNode> {
+
+  Rule TopLevel() {
+    return Sequence(
+        WhiteSpace(), FirstOf(Conjunction(), push(EmptyAstNode.instance())), WhiteSpace(), EOI);
+  }
+
+  Rule Conjunction() {
+    return Sequence(
+        Disjunction(),
+        ZeroOrMore(
+            ",",
+            Disjunction(),
+            push(((BooleanExprAstNode) pop(1)).and((BooleanExprAstNode) pop()))));
+  }
+
+  Rule Disjunction() {
+    return Sequence(
+        Disjunct(),
+        ZeroOrMore(
+            "or", Disjunct(), push(((BooleanExprAstNode) pop(1)).or((BooleanExprAstNode) pop()))));
+  }
+
+  Rule Disjunct() {
+    return FirstOf(ParentheticalBooleanExpr(), AtomicBooleanExpr());
+  }
+
+  Rule ParentheticalBooleanExpr() {
+    return Sequence("(", Conjunction(), ")");
+  }
+
+  Rule AtomicBooleanExpr() {
+    return FirstOf(DirectionExpr(), DportExpr(), UhDportExpr(), Tcp(), Udp(), UnhandledExpr());
+  }
+
+  Rule DportExpr() {
+    return Sequence(
+        "dport",
+        Comparator(),
+        Uint16Expr(),
+        push(new DportAstNode((ComparatorAstNode) pop(1), (Uint16AstNode) pop())));
+  }
+
+  Rule UhDportExpr() {
+    return Sequence(
+        "uh_dport",
+        Comparator(),
+        Uint16Expr(),
+        push(new UhDportAstNode((ComparatorAstNode) pop(1), (Uint16AstNode) pop())));
+  }
+
+  Rule Uint16Expr() {
+    return FirstOf(LowUdpPort(), Uint16());
+  }
+
+  Rule LowUdpPort() {
+    return Sequence("LOW_UDP_PORT", push(Uint16AstNode.of(LOW_UDP_PORT)));
+  }
+
+  Rule Uint16() {
+    return Sequence(Number(), push(Uint16AstNode.of(match())), WhiteSpace());
+  }
+
+  Rule Comparator() {
+    return FirstOf(Equals(), LessThanOrEquals(), LessThan(), GreaterThanOrEquals(), GreaterThan());
+  }
+
+  Rule Equals() {
+    return Sequence("=", push(EqualsAstNode.instance()));
+  }
+
+  Rule GreaterThanOrEquals() {
+    return Sequence(">=", push(GreaterThanOrEqualsAstNode.instance()));
+  }
+
+  Rule LessThanOrEquals() {
+    return Sequence("<=", push(LessThanOrEqualsAstNode.instance()));
+  }
+
+  Rule LessThan() {
+    return Sequence("<", push(LessThanAstNode.instance()));
+  }
+
+  Rule GreaterThan() {
+    return Sequence(">", push(GreaterThanAstNode.instance()));
+  }
+
+  Rule Tcp() {
+    return Sequence("tcp", push(TcpAstNode.instance()));
+  }
+
+  Rule Udp() {
+    return Sequence("udp", push(UdpAstNode.instance()));
+  }
+
+  Rule DirectionExpr() {
+    return Sequence("direction", "=", FirstOf(Incoming(), Outgoing()));
+  }
+
+  Rule Incoming() {
+    return Sequence("0", push(IncomingAstNode.instance()));
+  }
+
+  Rule Outgoing() {
+    return Sequence("1", push(OutgoingAstNode.instance()));
+  }
+
+  Rule UnhandledExpr() {
+    return Sequence(
+        FirstOf(CallExpr(), InExpr(), UnhandledComparisonExpr(), UnhandledWord()),
+        push(UnhandledAstNode.instance()));
+  }
+
+  Rule InExpr() {
+    return Sequence(
+        "<", UnhandledWord(), ZeroOrMore(",", UnhandledWord()), ">", "in", UnhandledWord());
+  }
+
+  Rule UnhandledComparisonExpr() {
+    return Sequence(UnhandledWord(), Comparator(), ACTION(pop() != null), UnhandledWord());
+  }
+
+  Rule CallExpr() {
+    return Sequence(
+        UnhandledWord(),
+        "(",
+        Optional(
+            Sequence(
+                Conjunction(),
+                ACTION(pop() != null),
+                ZeroOrMore(",", Conjunction(), ACTION(pop() != null)))),
+        ")");
+  }
+
+  Rule UnhandledWord() {
+    return Sequence(OneOrMore(NoneOf(" (),=<>")), WhiteSpace());
+  }
+
+  Rule WhiteSpace() {
+    return ZeroOrMore(AnyOf(" "));
+  }
+
+  /** [0-9]+ */
+  Rule Number() {
+    return OneOrMore(Digit());
+  }
+
+  /** [0-9] */
+  Rule Digit() {
+    return CharRange('0', '9');
+  }
+
+  public static @Nonnull BooleanExprAstNode parse(String input) {
+    return (BooleanExprAstNode) parse(input, ServiceOtherMatchExpr::TopLevel);
+  }
+
+  @VisibleForTesting
+  static @Nonnull AstNode parse(
+      String input, Function<ServiceOtherMatchExpr, Rule> inputRuleGetter) {
+    ServiceOtherMatchExpr parser = instance();
+    AbstractParseRunner<AstNode> runner = new TracingParseRunner<>(inputRuleGetter.apply(parser));
+    ParsingResult<AstNode> result = runner.run(input);
+    if (!result.matched) {
+      return ErrorAstNode.instance();
+    }
+    return result.resultValue;
+  }
+
+  static ServiceOtherMatchExpr instance() {
+    return Parboiled.createParser(ServiceOtherMatchExpr.class);
+  }
+
+  @Override
+  protected Rule fromStringLiteral(String string) {
+    return Sequence(String(string), WhiteSpace());
+  }
+
+  @VisibleForTesting static final int LOW_UDP_PORT = 1024;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class TcpAstNode extends BooleanExprAstNode {
+
+  public static @Nonnull TcpAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final TcpAstNode INSTANCE = new TcpAstNode();
+
+  private TcpAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the condition that the packet protocol is TCP. */
+@ParametersAreNonnullByDefault
 public final class TcpAstNode extends BooleanExprAstNode {
 
   public static @Nonnull TcpAstNode instance() {
@@ -10,6 +13,16 @@ public final class TcpAstNode extends BooleanExprAstNode {
   }
 
   private static final TcpAstNode INSTANCE = new TcpAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof TcpAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0xE11BD082; // randomly generated
+  }
 
   private TcpAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} representing the condition that the packet protocol is TCP. */
 public final class TcpAstNode extends BooleanExprAstNode {
 
   public static @Nonnull TcpAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/** An {@link AstNode} representing the condition that the packet protocol is UDP. */
 public final class UdpAstNode extends BooleanExprAstNode {
 
   public static @Nonnull UdpAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the condition that the packet protocol is UDP. */
+@ParametersAreNonnullByDefault
 public final class UdpAstNode extends BooleanExprAstNode {
 
   public static @Nonnull UdpAstNode instance() {
@@ -10,6 +13,16 @@ public final class UdpAstNode extends BooleanExprAstNode {
   }
 
   private static final UdpAstNode INSTANCE = new UdpAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof UdpAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0xD423CF19; // randomly generated
+  }
 
   private UdpAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class UdpAstNode extends BooleanExprAstNode {
+
+  public static @Nonnull UdpAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final UdpAstNode INSTANCE = new UdpAstNode();
+
+  private UdpAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNode.java
@@ -1,0 +1,34 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class UhDportAstNode extends BooleanExprAstNode {
+
+  public UhDportAstNode(ComparatorAstNode comparator, Uint16AstNode value) {
+    _comparator = comparator;
+    _value = value;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof UhDportAstNode)) {
+      return false;
+    }
+    UhDportAstNode that = (UhDportAstNode) o;
+    return _comparator.equals(that._comparator) && _value.equals(that._value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_comparator, _value);
+  }
+
+  private final @Nonnull ComparatorAstNode _comparator;
+  private final @Nonnull Uint16AstNode _value;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNode.java
@@ -5,8 +5,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+/**
+ * An {@link AstNode} representing a boolean function of the destination port conjoined with
+ * condition that the protocol is UDP.
+ */
 @ParametersAreNonnullByDefault
-public class UhDportAstNode extends BooleanExprAstNode {
+public final class UhDportAstNode extends BooleanExprAstNode {
 
   public UhDportAstNode(ComparatorAstNode comparator, Uint16AstNode value) {
     _comparator = comparator;

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
@@ -3,8 +3,10 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a 16-bit unsigned integer. */
+@ParametersAreNonnullByDefault
 public final class Uint16AstNode implements AstNode {
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
@@ -31,7 +31,7 @@ public final class Uint16AstNode implements AstNode {
   }
 
   static Uint16AstNode of(int value) {
-    checkArgument(0 <= value && value <= 0xFFFF, "Invalid 16-bit integer: %s", value);
+    checkArgument(0 <= value && value <= 0xFFFF, "Invalid unsigned 16-bit integer: %s", value);
     return new Uint16AstNode(value);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
@@ -27,11 +27,11 @@ public final class Uint16AstNode implements AstNode {
 
   public static Uint16AstNode of(String valueStr) {
     int value = Integer.parseInt(valueStr);
-    checkArgument(0 <= value && value <= 0xFFFF, "Invalid 16-bit integer: %s", valueStr);
     return of(value);
   }
 
   static Uint16AstNode of(int value) {
+    checkArgument(0 <= value && value <= 0xFFFF, "Invalid 16-bit integer: %s", value);
     return new Uint16AstNode(value);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
@@ -1,0 +1,40 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import javax.annotation.Nullable;
+
+public class Uint16AstNode implements AstNode {
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof Uint16AstNode)) {
+      return false;
+    }
+    Uint16AstNode that = (Uint16AstNode) o;
+    return _value == that._value;
+  }
+
+  @Override
+  public int hashCode() {
+    return _value;
+  }
+
+  public static Uint16AstNode of(String valueStr) {
+    int value = Integer.parseInt(valueStr);
+    checkArgument(0 <= value && value <= 0xFFFF, "Invalid 16-bit integer: %s", valueStr);
+    return of(value);
+  }
+
+  static Uint16AstNode of(int value) {
+    return new Uint16AstNode(value);
+  }
+
+  private Uint16AstNode(int value) {
+    _value = value;
+  }
+
+  private final int _value;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
@@ -4,7 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import javax.annotation.Nullable;
 
-public class Uint16AstNode implements AstNode {
+/** An {@link AstNode} representing a 16-bit unsigned integer. */
+public final class Uint16AstNode implements AstNode {
 
   @Override
   public boolean equals(@Nullable Object o) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
@@ -26,8 +26,7 @@ public final class Uint16AstNode implements AstNode {
   }
 
   public static Uint16AstNode of(String valueStr) {
-    int value = Integer.parseInt(valueStr);
-    return of(value);
+    return of(Integer.parseInt(valueStr));
   }
 
   static Uint16AstNode of(int value) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
@@ -1,0 +1,14 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+public final class UnhandledAstNode extends BooleanExprAstNode {
+
+  public static @Nonnull UnhandledAstNode instance() {
+    return INSTANCE;
+  }
+
+  private static final UnhandledAstNode INSTANCE = new UnhandledAstNode();
+
+  private UnhandledAstNode() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
@@ -2,6 +2,10 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
 
+/**
+ * An {@link AstNode} representing a boolean constraint that Batfish is incapable of evaluating. May
+ * be evaluated as {@code true} or {@code false} depending on context.
+ */
 public final class UnhandledAstNode extends BooleanExprAstNode {
 
   public static @Nonnull UnhandledAstNode instance() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
@@ -1,11 +1,14 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * An {@link AstNode} representing a boolean constraint that Batfish is incapable of evaluating. May
  * be evaluated as {@code true} or {@code false} depending on context.
  */
+@ParametersAreNonnullByDefault
 public final class UnhandledAstNode extends BooleanExprAstNode {
 
   public static @Nonnull UnhandledAstNode instance() {
@@ -13,6 +16,16 @@ public final class UnhandledAstNode extends BooleanExprAstNode {
   }
 
   private static final UnhandledAstNode INSTANCE = new UnhandledAstNode();
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return this == obj || obj instanceof UnhandledAstNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0xD26A9570; // randomly generated
+  }
 
   private UnhandledAstNode() {}
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/BUILD
@@ -1,0 +1,23 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:private"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["Test*.java"],
+    ),
+    deps = [
+        "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNodeTest.java
@@ -1,0 +1,30 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+/** Test of {@link ConjunctionAstNode}. */
+public final class ConjunctionAstNodeTest {
+
+  @Test
+  public void testEquals() {
+    ConjunctionAstNode obj = new ConjunctionAstNode();
+    new EqualsTester()
+        .addEqualityGroup(obj, new ConjunctionAstNode())
+        .addEqualityGroup(new ConjunctionAstNode(TcpAstNode.instance()))
+        .testEquals();
+  }
+
+  @Test
+  public void testAnd() {
+    assertThat(
+        new ConjunctionAstNode().and(TcpAstNode.instance()),
+        equalTo(new ConjunctionAstNode(TcpAstNode.instance())));
+    assertThat(
+        TcpAstNode.instance().and(UdpAstNode.instance()),
+        equalTo(new ConjunctionAstNode(TcpAstNode.instance(), UdpAstNode.instance())));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNodeTest.java
@@ -4,10 +4,17 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
 /** Test of {@link ConjunctionAstNode}. */
 public final class ConjunctionAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    ConjunctionAstNode obj = new ConjunctionAstNode();
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
 
   @Test
   public void testEquals() {

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNodeTest.java
@@ -1,0 +1,30 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+/** Test of {@link DisjunctionAstNode}. */
+public final class DisjunctionAstNodeTest {
+
+  @Test
+  public void testEquals() {
+    DisjunctionAstNode obj = new DisjunctionAstNode();
+    new EqualsTester()
+        .addEqualityGroup(obj, new DisjunctionAstNode())
+        .addEqualityGroup(new DisjunctionAstNode(TcpAstNode.instance()))
+        .testEquals();
+  }
+
+  @Test
+  public void testOr() {
+    assertThat(
+        new DisjunctionAstNode().or(TcpAstNode.instance()),
+        equalTo(new DisjunctionAstNode(TcpAstNode.instance())));
+    assertThat(
+        TcpAstNode.instance().or(UdpAstNode.instance()),
+        equalTo(new DisjunctionAstNode(TcpAstNode.instance(), UdpAstNode.instance())));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNodeTest.java
@@ -4,10 +4,17 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
 /** Test of {@link DisjunctionAstNode}. */
 public final class DisjunctionAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    DisjunctionAstNode obj = new DisjunctionAstNode();
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
 
   @Test
   public void testEquals() {

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNodeTest.java
@@ -1,10 +1,20 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
 /** Test of {@link DportAstNode}. */
 public final class DportAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    DportAstNode obj = new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1));
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
 
   @Test
   public void testEquals() {

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNodeTest.java
@@ -1,0 +1,18 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+/** Test of {@link DportAstNode}. */
+public final class DportAstNodeTest {
+
+  @Test
+  public void testEquals() {
+    DportAstNode obj = new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1));
+    new EqualsTester()
+        .addEqualityGroup(obj, new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(new DportAstNode(LessThanOrEqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(2)))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNodeTest.java
@@ -1,0 +1,24 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link EmptyAstNode}. */
+public final class EmptyAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(SerializationUtils.clone(EmptyAstNode.instance()), equalTo(EmptyAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(EmptyAstNode.instance(), EmptyAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNodeTest.java
@@ -1,0 +1,25 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link EqualsAstNode}. */
+public final class EqualsAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(
+        SerializationUtils.clone(EqualsAstNode.instance()), equalTo(EqualsAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(EqualsAstNode.instance(), EqualsAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNodeTest.java
@@ -1,0 +1,24 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link ErrorAstNode}. */
+public final class ErrorAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(SerializationUtils.clone(ErrorAstNode.instance()), equalTo(ErrorAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(ErrorAstNode.instance(), ErrorAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNodeTest.java
@@ -1,0 +1,26 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link GreaterThanAstNode}. */
+public final class GreaterThanAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(
+        SerializationUtils.clone(GreaterThanAstNode.instance()),
+        equalTo(GreaterThanAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(GreaterThanAstNode.instance(), GreaterThanAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNodeTest.java
@@ -1,0 +1,27 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link GreaterThanOrEqualsAstNode}. */
+public final class GreaterThanOrEqualsAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(
+        SerializationUtils.clone(GreaterThanOrEqualsAstNode.instance()),
+        equalTo(GreaterThanOrEqualsAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            GreaterThanOrEqualsAstNode.instance(), GreaterThanOrEqualsAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNodeTest.java
@@ -1,0 +1,25 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link IncomingAstNode}. */
+public final class IncomingAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(
+        SerializationUtils.clone(IncomingAstNode.instance()), equalTo(IncomingAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(IncomingAstNode.instance(), IncomingAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNodeTest.java
@@ -1,0 +1,25 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link LessThanAstNode}. */
+public final class LessThanAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(
+        SerializationUtils.clone(LessThanAstNode.instance()), equalTo(LessThanAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(LessThanAstNode.instance(), LessThanAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNodeTest.java
@@ -1,0 +1,26 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link LessThanOrEqualsAstNode}. */
+public final class LessThanOrEqualsAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(
+        SerializationUtils.clone(LessThanOrEqualsAstNode.instance()),
+        equalTo(LessThanOrEqualsAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(LessThanOrEqualsAstNode.instance(), LessThanOrEqualsAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNodeTest.java
@@ -1,0 +1,25 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link OutgoingAstNode}. */
+public final class OutgoingAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(
+        SerializationUtils.clone(OutgoingAstNode.instance()), equalTo(OutgoingAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(OutgoingAstNode.instance(), OutgoingAstNode.instance())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExprTest.java
@@ -1,0 +1,158 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.batfish.vendor.check_point_management.parsing.parboiled.ServiceOtherMatchExpr.LOW_UDP_PORT;
+import static org.batfish.vendor.check_point_management.parsing.parboiled.ServiceOtherMatchExpr.parse;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/** Test of {@link ServiceOtherMatchExpr}. */
+public final class ServiceOtherMatchExprTest {
+
+  @Test
+  public void testEmpty() {
+    assertThat(parse(""), equalTo(EmptyAstNode.instance()));
+    assertThat(parse(" "), equalTo(EmptyAstNode.instance()));
+  }
+
+  @Test
+  public void testUnhandledWord() {
+    assertThat(parse("blah"), equalTo(UnhandledAstNode.instance()));
+    assertThat(parse("1"), equalTo(UnhandledAstNode.instance()));
+  }
+
+  @Test
+  public void testUnhandledComparisonExpr() {
+    assertThat(parse("foo=bar"), equalTo(UnhandledAstNode.instance()));
+    assertThat(parse("foo = bar"), equalTo(UnhandledAstNode.instance()));
+  }
+
+  @Test
+  public void testCallExpr() {
+    assertThat(
+        parse("SERVICE_HANDLER(ADP_SQL_CMDS_ID, adp_mssql_monitor_code)"),
+        equalTo(UnhandledAstNode.instance()));
+    assertThat(parse("IPV4_VER (ip_ttl < 30)"), equalTo(UnhandledAstNode.instance()));
+  }
+
+  @Test
+  public void testError() {
+    assertThat(parse("("), equalTo(ErrorAstNode.instance()));
+  }
+
+  @Test
+  public void testDport() {
+    assertThat(
+        parse("dport < 5"),
+        equalTo(new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))));
+  }
+
+  @Test
+  public void testUhDport() {
+    assertThat(
+        parse("uh_dport < 5"),
+        equalTo(new UhDportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))));
+  }
+
+  @Test
+  public void testDisjunction() {
+    // 2 items
+    assertThat(
+        parse("dport < 5 or dport>1"),
+        equalTo(
+            new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))
+                .or(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(1)))));
+
+    // 3 items
+    assertThat(
+        parse("dport < 5 or dport>1 or dport>2"),
+        equalTo(
+            new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))
+                .or(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(1)))
+                .or(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(2)))));
+  }
+
+  @Test
+  public void testConjunction() {
+    // 2 items
+    assertThat(
+        parse("dport < 5 , dport>1"),
+        equalTo(
+            new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))
+                .and(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(1)))));
+
+    // 3 items
+    assertThat(
+        parse("dport < 5, foo= bar,dport>2"),
+        equalTo(
+            new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))
+                .and(UnhandledAstNode.instance())
+                .and(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(2)))));
+  }
+
+  @Test
+  public void testComparator() {
+    assertThat(parse("<", ServiceOtherMatchExpr::Comparator), equalTo(LessThanAstNode.instance()));
+    assertThat(
+        parse(">", ServiceOtherMatchExpr::Comparator), equalTo(GreaterThanAstNode.instance()));
+    assertThat(
+        parse("<=", ServiceOtherMatchExpr::Comparator),
+        equalTo(LessThanOrEqualsAstNode.instance()));
+    assertThat(
+        parse(">=", ServiceOtherMatchExpr::Comparator),
+        equalTo(GreaterThanOrEqualsAstNode.instance()));
+    assertThat(parse("=", ServiceOtherMatchExpr::Comparator), equalTo(EqualsAstNode.instance()));
+  }
+
+  @Test
+  public void testUint16Expr() {
+    assertThat(parse("5", ServiceOtherMatchExpr::Uint16Expr), equalTo(Uint16AstNode.of(5)));
+    assertThat(
+        parse("LOW_UDP_PORT", ServiceOtherMatchExpr::Uint16Expr),
+        equalTo(Uint16AstNode.of(LOW_UDP_PORT)));
+  }
+
+  @Test
+  public void testDirectionExpr() {
+    assertThat(parse("direction=0"), equalTo(IncomingAstNode.instance()));
+    assertThat(parse("direction = 1"), equalTo(OutgoingAstNode.instance()));
+  }
+
+  @Test
+  public void testTcp() {
+    assertThat(parse("tcp"), equalTo(TcpAstNode.instance()));
+  }
+
+  @Test
+  public void testUdp() {
+    assertThat(parse("udp"), equalTo(UdpAstNode.instance()));
+  }
+
+  @Test
+  public void testParentheticalBooleanExpr() {
+    assertThat(parse("(tcp)"), equalTo(TcpAstNode.instance()));
+    assertThat(parse("( tcp,udp )"), equalTo(TcpAstNode.instance().and(UdpAstNode.instance())));
+    assertThat(
+        parse("tcp or ( tcp,udp )"),
+        equalTo(TcpAstNode.instance().or(TcpAstNode.instance().and(UdpAstNode.instance()))));
+    assertThat(
+        parse("tcp or ( tcp,udp or tcp )"),
+        equalTo(
+            TcpAstNode.instance()
+                .or(TcpAstNode.instance().and(UdpAstNode.instance().or(TcpAstNode.instance())))));
+    assertThat(parse("(IPV4_VER (ip_ttl < 30))"), equalTo(UnhandledAstNode.instance()));
+    assertThat(
+        parse("tcp, (IPV4_VER (ip_ttl < 30))"),
+        equalTo(TcpAstNode.instance().and(UnhandledAstNode.instance())));
+  }
+
+  @Test
+  public void testInExpr() {
+    assertThat(
+        parse("<src, dst, dport> in mgcp_dynamic_port"), equalTo(UnhandledAstNode.instance()));
+    assertThat(
+        parse("tcp,<src, dst, dport>in mgcp_dynamic_port , udp"),
+        equalTo(TcpAstNode.instance().and(UnhandledAstNode.instance()).and(UdpAstNode.instance())));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNodeTest.java
@@ -1,0 +1,22 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link TcpAstNode}. */
+public final class TcpAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(SerializationUtils.clone(TcpAstNode.instance()), equalTo(TcpAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester().addEqualityGroup(TcpAstNode.instance(), TcpAstNode.instance()).testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNodeTest.java
@@ -1,0 +1,22 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link UdpAstNode}. */
+public final class UdpAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(SerializationUtils.clone(UdpAstNode.instance()), equalTo(UdpAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester().addEqualityGroup(UdpAstNode.instance(), UdpAstNode.instance()).testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNodeTest.java
@@ -1,10 +1,20 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
 /** Test of {@link UhDportAstNode}. */
 public final class UhDportAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    UhDportAstNode obj = new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1));
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
 
   @Test
   public void testEquals() {

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNodeTest.java
@@ -1,0 +1,19 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+/** Test of {@link UhDportAstNode}. */
+public final class UhDportAstNodeTest {
+
+  @Test
+  public void testEquals() {
+    UhDportAstNode obj = new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1));
+    new EqualsTester()
+        .addEqualityGroup(obj, new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(
+            new UhDportAstNode(LessThanOrEqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(2)))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNodeTest.java
@@ -1,0 +1,47 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Test of {@link Uint16AstNode}. */
+public final class Uint16AstNodeTest {
+
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  @Test
+  public void testOfValid() {
+    assertThat(Uint16AstNode.of("1"), equalTo(Uint16AstNode.of(1)));
+  }
+
+  @Test
+  public void testOfInvalidNotNumber() {
+    _thrown.expect(IllegalArgumentException.class);
+    Uint16AstNode.of("-1");
+  }
+
+  @Test
+  public void testOfInvalidLow() {
+    _thrown.expect(IllegalArgumentException.class);
+    Uint16AstNode.of("-1");
+  }
+
+  @Test
+  public void testOfInvalidHigh() {
+    _thrown.expect(IllegalArgumentException.class);
+    Uint16AstNode.of("100000");
+  }
+
+  @Test
+  public void testEquals() {
+    Uint16AstNode obj = Uint16AstNode.of(1);
+    new EqualsTester()
+        .addEqualityGroup(obj, Uint16AstNode.of(1))
+        .addEqualityGroup(Uint16AstNode.of(2))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNodeTest.java
@@ -21,7 +21,7 @@ public final class Uint16AstNodeTest {
   @Test
   public void testOfInvalidNotNumber() {
     _thrown.expect(IllegalArgumentException.class);
-    Uint16AstNode.of("-1");
+    Uint16AstNode.of("foo");
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNodeTest.java
@@ -1,0 +1,26 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+/** Test of {@link UnhandledAstNode}. */
+public final class UnhandledAstNodeTest {
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(
+        SerializationUtils.clone(UnhandledAstNode.instance()),
+        equalTo(UnhandledAstNode.instance()));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(UnhandledAstNode.instance(), UnhandledAstNode.instance())
+        .testEquals();
+  }
+}


### PR DESCRIPTION
- add parboiled grammar and tests for parsing `match` field of `service-other` object