### PR TITLE
CP: Automatic static NAT rule support

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -408,6 +408,8 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
       outgoingTransformations.addAll(
           getOutgoingTransformations(
               iface, outgoingTransformationFuncsForExternalIfaces, warnings));
+      mergeTransformations(outgoingTransformations.build())
+          .ifPresent(iface::setOutgoingTransformation);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -6,9 +6,10 @@ import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.batfish.datamodel.FirewallSessionInterfaceInfo.Action.POST_NAT_FIB_LOOKUP;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.aclName;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toIpAccessLists;
-import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.applyOutgoingTransformations;
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.automaticHideRuleTransformationFunction;
+import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.automaticStaticRuleTransformation;
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.getManualNatRules;
+import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.getOutgoingTransformations;
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.manualRuleTransformation;
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.mergeTransformations;
 import static org.batfish.vendor.check_point_management.AddressSpaceToIpSpaceMetadata.toIpSpaceMetadata;
@@ -17,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +72,6 @@ import org.batfish.vendor.check_point_management.ManagementDomain;
 import org.batfish.vendor.check_point_management.ManagementPackage;
 import org.batfish.vendor.check_point_management.ManagementServer;
 import org.batfish.vendor.check_point_management.NamedManagementObject;
-import org.batfish.vendor.check_point_management.NatMethod;
 import org.batfish.vendor.check_point_management.NatRulebase;
 import org.batfish.vendor.check_point_management.NatSettings;
 import org.batfish.vendor.check_point_management.ServiceToMatchExpr;
@@ -313,24 +314,70 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(ImmutableList.toImmutableList());
-    // Apply manual transformations to incoming traffic
-    mergeTransformations(manualRuleTransformations)
-        .ifPresent(
-            transformation ->
-                _c.getActiveInterfaces()
-                    .values()
-                    .forEach(iface -> iface.setIncomingTransformation(transformation)));
 
-    // Convert automatic hide rules
+    // Find automatic NAT rules
+    List<HasNatSettings> autoHideNatObjects = new ArrayList<>();
+    List<HasNatSettings> autoStaticNatObjects = new ArrayList<>();
+    objects.values().stream()
+        .filter(HasNatSettings.class::isInstance)
+        .map(HasNatSettings.class::cast)
+        .forEach(
+            hasNatSettings -> {
+              NatSettings natSettings = hasNatSettings.getNatSettings();
+              if (!natSettings.getAutoRule()) {
+                return;
+              }
+              if (natSettings.getMethod() == null) {
+                // TODO What does null method mean?
+                warnings.redFlag(
+                    String.format(
+                        "NAT settings on %s %s will be ignored: No NAT method set",
+                        hasNatSettings.getClass(), hasNatSettings.getName()));
+                return;
+              }
+              switch (natSettings.getMethod()) {
+                case HIDE:
+                  autoHideNatObjects.add(hasNatSettings);
+                  return;
+                case STATIC:
+                  autoStaticNatObjects.add(hasNatSettings);
+                  return;
+                default:
+                  warnings.redFlag(
+                      String.format(
+                          "NAT method %s not recognized: NAT settings on %s %s will be ignored",
+                          natSettings.getMethod(),
+                          hasNatSettings.getClass(),
+                          hasNatSettings.getName()));
+              }
+            });
+
+    // If there are no automatic rules, we don't have to check if interfaces are external
+    boolean autoRulesPresent = !autoHideNatObjects.isEmpty() || !autoStaticNatObjects.isEmpty();
+    if (!autoRulesPresent && manualRuleTransformations.isEmpty()) {
+      // short circuit if there are no NAT rules
+      return;
+    }
+
+    // Convert automatic static rules (need inbound and outbound versions)
+    List<Transformation> internalToExternalAutoStaticTransformations =
+        autoStaticNatObjects.stream()
+            .map(
+                hasNatSettings -> automaticStaticRuleTransformation(hasNatSettings, true, warnings))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(ImmutableList.toImmutableList());
+    List<Transformation> externalToInternalAutoStaticTransformations =
+        autoStaticNatObjects.stream()
+            .map(
+                hasNatSettings ->
+                    automaticStaticRuleTransformation(hasNatSettings, false, warnings))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(ImmutableList.toImmutableList());
+    // Convert automatic hide rules (these transformations are functions of the egress iface IP)
     List<Function<Ip, Transformation>> outgoingTransformationFuncsForExternalIfaces =
-        objects.values().stream()
-            .filter(HasNatSettings.class::isInstance)
-            .map(HasNatSettings.class::cast)
-            .filter(
-                hasNatSettings -> {
-                  NatSettings natSettings = hasNatSettings.getNatSettings();
-                  return natSettings.getAutoRule() && natSettings.getMethod() == NatMethod.HIDE;
-                })
+        autoHideNatObjects.stream()
             // TODO: consult generated rules for automatic hide rule ordering
             .map(
                 hasNatSettings ->
@@ -339,21 +386,40 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(ImmutableList.toImmutableList());
-    // Apply automatic hide rules to traffic going out external interfaces
-    _c.getActiveInterfaces().values().stream()
-        .filter(
-            iface ->
-                // TODO If an interface is declared in the gateway configuration but not in the
-                //      management info, should it be considered external for NAT purposes?
-                gateway.getInterfaces().stream()
-                    .filter(i -> iface.getName().equals(i.getName()))
-                    .findAny()
-                    .map(gatewayIface -> gatewayIface.getTopology().getLeadsToInternet())
-                    .orElse(false))
-        .forEach(
-            iface ->
-                applyOutgoingTransformations(
-                    iface, outgoingTransformationFuncsForExternalIfaces, warnings));
+
+    // Apply transformations to interfaces
+    Optional<Transformation> manualTransformation = mergeTransformations(manualRuleTransformations);
+    for (org.batfish.datamodel.Interface iface : _c.getActiveInterfaces().values()) {
+      if (!autoRulesPresent || !isExternal(iface, gateway)) {
+        manualTransformation.ifPresent(iface::setIncomingTransformation);
+        continue;
+      }
+      // This is an external interface, and automatic rules are present.
+      // External interfaces need the usual incoming transformation resulting from manual
+      // rules, plus the external-to-internal auto static rules
+      ImmutableList.Builder<Transformation> incomingTransformations = ImmutableList.builder();
+      manualTransformation.ifPresent(incomingTransformations::add);
+      incomingTransformations.addAll(externalToInternalAutoStaticTransformations);
+      mergeTransformations(incomingTransformations.build())
+          .ifPresent(iface::setIncomingTransformation);
+      // Outgoing transformation applies static rules first, then hide rules
+      ImmutableList.Builder<Transformation> outgoingTransformations = ImmutableList.builder();
+      outgoingTransformations.addAll(internalToExternalAutoStaticTransformations);
+      outgoingTransformations.addAll(
+          getOutgoingTransformations(
+              iface, outgoingTransformationFuncsForExternalIfaces, warnings));
+    }
+  }
+
+  private static boolean isExternal(
+      org.batfish.datamodel.Interface iface, GatewayOrServer gateway) {
+    // TODO If an interface is declared in the gateway configuration but not in the
+    //      management info, should it be considered external for NAT purposes?
+    return gateway.getInterfaces().stream()
+        .filter(i -> iface.getName().equals(i.getName()))
+        .findAny()
+        .map(gatewayIface -> gatewayIface.getTopology().getLeadsToInternet())
+        .orElse(false);
   }
 
   private @Nonnull Optional<ManagementPackage> findAccessPackage(

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
@@ -436,11 +436,13 @@ public class CheckpointNatConversions {
    * settings on the given {@link HasNatSettings}. Returns an empty optional and files warnings if
    * the NAT settings cannot be converted.
    *
-   * @param toExternal Whether the generated transformation needs to apply to traffic destined out
-   *     (internal to external traffic) or in (external to internal traffic).
+   * @param srcNat Whether the generated transformation should do source NAT. If {@code true}, the
+   *     transformation will match traffic from the original IP and translate its source to the
+   *     translated IP. Otherwise, it will match traffic destined for the translated IP and
+   *     translate it back to the original IP.
    */
   static @Nonnull Optional<Transformation> automaticStaticRuleTransformation(
-      HasNatSettings hasNatSettings, boolean toExternal, Warnings warnings) {
+      HasNatSettings hasNatSettings, boolean srcNat, Warnings warnings) {
     if (!(hasNatSettings instanceof Host)) {
       // TODO Support automatic static NAT on constructs other than hosts
       warnings.redFlag(
@@ -481,7 +483,7 @@ public class CheckpointNatConversions {
               hasNatSettings.getClass(), hasNatSettings.getName()));
       return Optional.empty();
     }
-    return toExternal
+    return srcNat
         ? Optional.of(when(matchSrc(hostIp)).apply(assignSourceIp(translatedIp)).build())
         : Optional.of(when(matchDst(translatedIp)).apply(assignDestinationIp(hostIp)).build());
   }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversionsTest.java
@@ -448,14 +448,15 @@ public final class CheckpointNatConversionsTest {
     NatSettings natSettings = new NatSettings(true, null, "All", natIp, NatMethod.STATIC);
     Host host = new Host(hostIp, natSettings, "host", UID);
     Warnings warnings = new Warnings(true, true, true);
-    Optional<Transformation> toExternal = automaticStaticRuleTransformation(host, true, warnings);
-    Optional<Transformation> toInternal = automaticStaticRuleTransformation(host, false, warnings);
-    assertTrue(toExternal.isPresent() && toInternal.isPresent());
+    Optional<Transformation> srcTransform = automaticStaticRuleTransformation(host, true, warnings);
+    Optional<Transformation> dstTransform =
+        automaticStaticRuleTransformation(host, false, warnings);
+    assertTrue(srcTransform.isPresent() && dstTransform.isPresent());
     assertThat(
-        toExternal.get(),
+        srcTransform.get(),
         equalTo(Transformation.when(matchSrc(hostIp)).apply(assignSourceIp(natIp)).build()));
     assertThat(
-        toInternal.get(),
+        dstTransform.get(),
         equalTo(Transformation.when(matchDst(natIp)).apply(assignDestinationIp(hostIp)).build()));
     assertThat(warnings.getRedFlagWarnings(), empty()); // Neither call generated warnings
   }


### PR DESCRIPTION
Applies automatic static NAT rules on external interfaces:
- Outgoing transformation applies source NAT to matching outbound traffic
- Incoming transformation applies dest NAT to matching inbound traffic

Automatic static NAT, as currently implemented, does not impact transformations on non-external interfaces.

In theory, there is be a bug where static NAT rules could get applied to external-to-external traffic. Unlikely to affect any traffic in practice because external-to-external traffic isn't likely to have an internal source IP or a dest IP matching a static rule's translated IP.

Still to do:
- Support automatic static NAT rules on objects other than hosts
- Support `install-on` values other than `"All"`