### PR TITLE
Interface dependencies: for AGGREGATED/REDUNDANT interfaces, exclude neighbors of other types

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
@@ -3,10 +3,11 @@ package org.batfish.datamodel.interface_dependency;
 import static org.batfish.datamodel.Interface.DependencyType.AGGREGATE;
 import static org.batfish.datamodel.Interface.DependencyType.BIND;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.graph.Network;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
@@ -20,7 +21,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Node;
 import org.batfish.common.topology.Layer1Topologies;
 import org.batfish.common.topology.Layer1Topology;
@@ -98,7 +98,7 @@ public class InterfaceDependencies {
               }
 
               // non-local dependencies
-              Set<Layer1Node> neighbors = getL1Neighbors(iface);
+              Collection<Layer1Node> neighbors = getL1Neighbors(iface);
               if (neighbors.size() == 1) {
                 /* if the neighbor is inactive, iface must be too. e.g. if all member interfaces are up, but the
                  * neighbor is admin-down, iface will be down
@@ -212,33 +212,38 @@ public class InterfaceDependencies {
     _depGraph.addEdge(src, tgt, new DependencyEdge(depType));
   }
 
-  private @Nullable Layer1Topology getLayer1Topology(Interface iface) {
+  private Collection<Layer1Node> getL1Neighbors(Interface iface) {
+    Layer1Node layer1Node = new Layer1Node(iface.getOwner().getHostname(), iface.getName());
     switch (iface.getInterfaceType()) {
       case PHYSICAL:
-        return _layer1Topologies.getCombinedL1();
+        return adjacentNodes(_layer1Topologies.getCombinedL1(), layer1Node);
       case AGGREGATED:
       case REDUNDANT:
-        return _layer1Topologies.getLogicalL1();
+        // the logical L1 contains physical nodes and AGGREGATED/REDUNDANT nodes. filter them out.
+        return adjacentNodes(_layer1Topologies.getLogicalL1(), layer1Node).stream()
+            .filter(
+                node ->
+                    _configs
+                            .get(node.getHostname())
+                            .getAllInterfaces()
+                            .get(node.getInterfaceName())
+                            .getInterfaceType()
+                        == iface.getInterfaceType())
+            .collect(ImmutableList.toImmutableList());
       default:
-        return null;
+        return ImmutableList.of();
     }
   }
 
-  private Set<Layer1Node> getL1Neighbors(Interface iface) {
-    @Nullable Layer1Topology l1Topology = getLayer1Topology(iface);
-    if (l1Topology == null) {
+  private static Set<Layer1Node> adjacentNodes(Layer1Topology topology, Layer1Node node) {
+    if (!topology.getGraph().nodes().contains(node)) {
       return ImmutableSet.of();
     }
-    Network<Layer1Node, Layer1Edge> l1Graph = l1Topology.getGraph();
-    Layer1Node layer1Node = new Layer1Node(iface.getOwner().getHostname(), iface.getName());
-    if (!l1Graph.nodes().contains(layer1Node)) {
-      return ImmutableSet.of();
-    }
-    return l1Graph.adjacentNodes(layer1Node);
+    return topology.getGraph().adjacentNodes(node);
   }
 
   private @Nullable NodeInterfacePair getL1Neighbor(Interface iface) {
-    Set<Layer1Node> neighbors = getL1Neighbors(iface);
+    Collection<Layer1Node> neighbors = getL1Neighbors(iface);
     if (neighbors.isEmpty()) {
       return null;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
@@ -3,11 +3,9 @@ package org.batfish.datamodel.interface_dependency;
 import static org.batfish.datamodel.Interface.DependencyType.AGGREGATE;
 import static org.batfish.datamodel.Interface.DependencyType.BIND;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
@@ -98,7 +96,7 @@ public class InterfaceDependencies {
               }
 
               // non-local dependencies
-              Collection<Layer1Node> neighbors = getL1Neighbors(iface);
+              Set<Layer1Node> neighbors = getL1Neighbors(iface);
               if (neighbors.size() == 1) {
                 /* if the neighbor is inactive, iface must be too. e.g. if all member interfaces are up, but the
                  * neighbor is admin-down, iface will be down
@@ -212,7 +210,7 @@ public class InterfaceDependencies {
     _depGraph.addEdge(src, tgt, new DependencyEdge(depType));
   }
 
-  private Collection<Layer1Node> getL1Neighbors(Interface iface) {
+  private Set<Layer1Node> getL1Neighbors(Interface iface) {
     Layer1Node layer1Node = new Layer1Node(iface.getOwner().getHostname(), iface.getName());
     switch (iface.getInterfaceType()) {
       case PHYSICAL:
@@ -229,9 +227,9 @@ public class InterfaceDependencies {
                             .get(node.getInterfaceName())
                             .getInterfaceType()
                         == iface.getInterfaceType())
-            .collect(ImmutableList.toImmutableList());
+            .collect(ImmutableSet.toImmutableSet());
       default:
-        return ImmutableList.of();
+        return ImmutableSet.of();
     }
   }
 
@@ -243,7 +241,7 @@ public class InterfaceDependencies {
   }
 
   private @Nullable NodeInterfacePair getL1Neighbor(Interface iface) {
-    Collection<Layer1Node> neighbors = getL1Neighbors(iface);
+    Set<Layer1Node> neighbors = getL1Neighbors(iface);
     if (neighbors.isEmpty()) {
       return null;
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/interface_dependencies/InterfaceDependenciesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/interface_dependencies/InterfaceDependenciesTest.java
@@ -375,6 +375,66 @@ public class InterfaceDependenciesTest {
         getInterfacesToDeactivate(configs, layer1Topologies), contains(NodeInterfacePair.of(pc1)));
   }
 
+  /**
+   * The logical L1 topology will assign physical nodes as neighbors of an LACP interface. We should
+   * exclude those when looking for an unambiguous neighbor.
+   */
+  @Test
+  public void testGetInterfacesToDeactivate_LACP_PhysicalNeighborsInLogicalL1() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    Configuration n1 = cb.setHostname("n1").build();
+    Vrf v1 = nf.vrfBuilder().setOwner(n1).build();
+    // member interface
+    Interface m1 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.PHYSICAL)
+            .setOwner(n1)
+            .setVrf(v1)
+            .setName("m1")
+            .build();
+    // port-channel interface
+    Interface pc1 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.AGGREGATED)
+            .setOwner(n1)
+            .setVrf(v1)
+            .setName("pc1")
+            .setDependencies(ImmutableList.of(new Dependency(m1.getName(), AGGREGATE)))
+            .build();
+
+    Configuration n2 = cb.setHostname("n2").build();
+    Vrf v2 = nf.vrfBuilder().setOwner(n2).build();
+    // neighbor of the member interface
+    Interface m2 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.PHYSICAL)
+            .setOwner(n2)
+            .setVrf(v2)
+            .setName("m2")
+            .build();
+    // port-channel interface
+    Interface pc2 =
+        nf.interfaceBuilder()
+            .setType(InterfaceType.AGGREGATED)
+            .setOwner(n2)
+            .setVrf(v2)
+            .setName("pc2")
+            .setDependencies(ImmutableList.of(new Dependency(m2.getName(), AGGREGATE)))
+            .build();
+
+    Map<String, Configuration> configs =
+        ImmutableMap.of(n1.getHostname(), n1, n2.getHostname(), n2);
+    Layer1Topologies layer1Topologies =
+        layer1Topologies(
+            new Layer1Topology(l1Edge(m1, m2)),
+            new Layer1Topology(l1Edge(m1, m2), l1Edge(m1, pc2), l1Edge(pc1, m2), l1Edge(pc1, pc2)));
+
+    assertThat(getInterfacesToDeactivate(configs, layer1Topologies), empty());
+  }
+
   /** An LACP interface without a neighbor can be active if it's on the network boundary. */
   @Test
   public void testGetInterfacesToDeactivate_LACP_on_network_boundary() {


### PR DESCRIPTION
We use the logical L1 topology for AGGREGATED/REDUNDANT interfaces, which includes edges to physical nodes (i.e. the
neighbors of their member interfaces). Exclude those when looking for a unique neighbor.

After #7435 