### PR TITLE
A10: Support ACOS v2 trunk definition

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Parser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Parser.g4
@@ -4,6 +4,7 @@ import
   A10_common,
   A10_interface,
   A10_rba,
+  A10_trunk,
   A10_vlan;
 
 options {
@@ -18,6 +19,7 @@ statement
    s_hostname
    | s_interface
    | s_rba
+   | s_trunk
    | s_vlan
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_trunk.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_trunk.g4
@@ -1,0 +1,20 @@
+parser grammar A10_trunk;
+
+import A10_common;
+
+options {
+    tokenVocab = A10Lexer;
+}
+
+// ACOS 2.X style trunk definition
+s_trunk: TRUNK trunk_number NEWLINE st_definition*;
+
+// TODO determine other allowed syntax here
+// presumably overlaps some with `interface trunk` syntax
+st_definition: std_ethernet | std_name;
+
+std_name: NAME name = interface_name_str NEWLINE;
+
+std_ethernet: trunk_ethernet_interface+ NEWLINE;
+
+trunk_ethernet_interface: ETHERNET num = ethernet_number;

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -458,6 +458,70 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
     toString(ctx, ctx.user_tag()).ifPresent(ut -> _currentTrunkGroup.setUserTag(ut));
   }
 
+  @Override
+  public void enterS_trunk(A10Parser.S_trunkContext ctx) {
+    Optional<Integer> maybeNum = toInteger(ctx.trunk_number());
+    _currentTrunk =
+        maybeNum
+            .map(
+                n -> {
+                  TrunkInterface trunkInterface =
+                      _c.getInterfacesTrunk()
+                          .computeIfAbsent(
+                              n, num -> new TrunkInterface(num, TrunkGroup.Type.STATIC));
+                  String trunkName = getInterfaceName(trunkInterface);
+                  _c.defineStructure(A10StructureType.INTERFACE, trunkName, ctx);
+                  _c.referenceStructure(
+                      A10StructureType.INTERFACE,
+                      trunkName,
+                      A10StructureUsage.INTERFACE_SELF_REF,
+                      ctx.start.getLine());
+                  return trunkInterface;
+                })
+            .orElseGet(() -> new TrunkInterface(-1, TrunkGroup.Type.STATIC)); // dummy
+  }
+
+  @Override
+  public void exitS_trunk(A10Parser.S_trunkContext ctx) {
+    _currentTrunk = null;
+  }
+
+  @Override
+  public void exitStd_name(A10Parser.Std_nameContext ctx) {
+    toString(ctx, ctx.name).ifPresent(n -> _currentTrunk.setName(n));
+  }
+
+  @Override
+  public void exitStd_ethernet(A10Parser.Std_ethernetContext ctx) {
+    int line = ctx.start.getLine();
+    Optional<List<InterfaceReference>> maybeIfaces = toInterfaces(ctx);
+    maybeIfaces.ifPresent(
+        ifaces -> {
+          ifaces.forEach(
+              iface -> {
+                _c.referenceStructure(
+                    A10StructureType.INTERFACE,
+                    getInterfaceName(iface),
+                    A10StructureUsage.TRUNK_INTERFACE,
+                    line);
+                _currentTrunk.getMembers().add(iface);
+              });
+        });
+  }
+
+  Optional<List<InterfaceReference>> toInterfaces(A10Parser.Std_ethernetContext ctx) {
+    ImmutableList.Builder<InterfaceReference> ifaces = ImmutableList.builder();
+    for (A10Parser.Trunk_ethernet_interfaceContext iface : ctx.trunk_ethernet_interface()) {
+      Optional<Integer> maybeNum = toInteger(iface.num);
+      if (!maybeNum.isPresent()) {
+        // Already warned
+        return Optional.empty();
+      }
+      ifaces.add(new InterfaceReference(Interface.Type.ETHERNET, maybeNum.get()));
+    }
+    return Optional.of(ifaces.build());
+  }
+
   TrunkGroup.Mode toMode(A10Parser.Trunk_modeContext ctx) {
     if (ctx.ACTIVE() != null) {
       return TrunkGroup.Mode.ACTIVE;
@@ -739,6 +803,9 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
   @Nonnull private A10Configuration _c;
 
   private Interface _currentInterface;
+
+  // Current trunk for ACOS v2 trunk stanza
+  private TrunkInterface _currentTrunk;
 
   private TrunkGroup _currentTrunkGroup;
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -213,11 +213,23 @@ public final class A10Configuration extends VendorConfiguration {
                       new org.batfish.datamodel.Interface.Dependency(
                           member, org.batfish.datamodel.Interface.DependencyType.AGGREGATE))
               .collect(ImmutableSet.toImmutableSet()));
+      if (memberNames.isEmpty()) {
+        _w.redFlag(
+            String.format(
+                "Trunk %s does not contain any member interfaces", trunkIface.getNumber()));
+      }
     }
-    TrunkGroup trunkGroup = iface.getTrunkGroup();
-    if (trunkGroup != null) {
-      newIface.setChannelGroup(getInterfaceName(Interface.Type.TRUNK, trunkGroup.getNumber()));
-      // TODO determine if switchport settings need to be propagated to member interfaces
+
+    if (iface.getType() == Interface.Type.ETHERNET) {
+      InterfaceReference ifaceRef = new InterfaceReference(iface.getType(), iface.getNumber());
+      _interfacesTrunk.values().stream()
+          .filter(t -> t.getMembers().contains(ifaceRef))
+          .findFirst()
+          .ifPresent(
+              t -> {
+                newIface.setChannelGroup(getInterfaceName(Interface.Type.TRUNK, t.getNumber()));
+                // TODO determine if switchport settings need to be propagated to member interfaces
+              });
     }
     newIface.build();
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10StructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10StructureUsage.java
@@ -6,6 +6,8 @@ import org.batfish.vendor.StructureUsage;
 public enum A10StructureUsage implements StructureUsage {
   INTERFACE_SELF_REF("interface"),
   INTERFACE_TRUNK_GROUP("interface trunk-group"),
+  // ACOS v2 member of a trunk
+  TRUNK_INTERFACE("trunk interface"),
   VLAN_ROUTER_INTERFACE("vlan router-interface"),
   VLAN_TAGGED_INTERFACE("vlan tagged interface"),
   VLAN_UNTAGGED_INTERFACE("vlan untagged interface");

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2
@@ -2,7 +2,20 @@
 !version 2.7.2, build 123 (Aug-5-2021,01:23)
 hostname trunk_acos2
 !
+! Default (static?) trunk definition
+trunk 2
+ ethernet 2 ethernet 3
+ name trunk2Name
+!
 interface ethernet 1
+ ! LACP trunk definition
  lacp trunk 1 mode active
  lacp timeout short
+ enable
+!
+interface ethernet 2
+ enable
+!
+interface ethernet 3
+ enable
 !

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_convert_warn
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_convert_warn
@@ -1,0 +1,8 @@
+!BATFISH_FORMAT: a10_acos
+!version 2.7.2, build 123 (Aug-5-2021,01:23)
+hostname trunk_acos2_convert_warn
+!
+! Empty trunk
+trunk 2
+ name trunk2Name
+!


### PR DESCRIPTION
Add support for ACOS v2 trunk definitions.

Also, update interface conversion to use trunks as source of truth for aggregate membership, to make conversion compatible with v2 datamodel (which _only_ populates default trunk information in the trunk itself, not in the interfaces).
