### PR TITLE
CP: Apply NAT auto hide rules on all interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -369,7 +369,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
             .map(Optional::get)
             .collect(ImmutableList.toImmutableList());
     // Convert automatic hide rules (these transformations are functions of the egress iface IP)
-    List<Function<Ip, Transformation>> outgoingTransformationFuncsForExternalIfaces =
+    List<Function<Ip, Transformation>> autoHideTransformationFuncs =
         autoHideNatObjects.stream()
             // TODO: consult generated rules for automatic hide rule ordering
             .map(
@@ -394,7 +394,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
     // TODO: Prevent any outgoing transformation if the packet matched a manual NAT rule on ingress.
     // If there are no egress-iface-specific transformations, all outgoing transformations are the
     // same: source translation for automatic static rules
-    if (outgoingTransformationFuncsForExternalIfaces.isEmpty()) {
+    if (autoHideTransformationFuncs.isEmpty()) {
       mergeTransformations(autoStaticSrcTransformations)
           .ifPresent(
               t ->
@@ -407,25 +407,12 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
         // Automatic static rules take precedence over automatic hide rules
         ImmutableList.Builder<Transformation> outgoingTransformations = ImmutableList.builder();
         outgoingTransformations.addAll(autoStaticSrcTransformations);
-        if (isExternal(iface, gateway)) {
-          outgoingTransformations.addAll(
-              getOutgoingTransformations(iface, outgoingTransformationFuncsForExternalIfaces));
-        }
+        outgoingTransformations.addAll(
+            getOutgoingTransformations(iface, autoHideTransformationFuncs));
         mergeTransformations(outgoingTransformations.build())
             .ifPresent(iface::setOutgoingTransformation);
       }
     }
-  }
-
-  private static boolean isExternal(
-      org.batfish.datamodel.Interface iface, GatewayOrServer gateway) {
-    // TODO If an interface is declared in the gateway configuration but not in the
-    //      management info, should it be considered external for NAT purposes?
-    return gateway.getInterfaces().stream()
-        .filter(i -> iface.getName().equals(i.getName()))
-        .findAny()
-        .map(gatewayIface -> gatewayIface.getTopology().getLeadsToInternet())
-        .orElse(false);
   }
 
   private @Nonnull Optional<ManagementPackage> findAccessPackage(

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
@@ -366,10 +366,10 @@ public class CheckpointNatConversions {
   }
 
   /**
-   * Returns a function that takes in an external interface's IP and returns the {@link
-   * Transformation} that should be applied to outgoing traffic on that interface to reflect the NAT
-   * settings on the given {@link HasNatSettings}. Returns an empty optional and files warnings if
-   * the NAT settings cannot be converted.
+   * Returns a function that takes in an interface's IP and returns the {@link Transformation} that
+   * should be applied to outgoing traffic on that interface to reflect the NAT settings on the
+   * given {@link HasNatSettings}. Returns an empty optional and files warnings if the NAT settings
+   * cannot be converted.
    */
   static @Nonnull Optional<Function<Ip, Transformation>> automaticHideRuleTransformationFunction(
       HasNatSettings hasNatSettings,


### PR DESCRIPTION
Automatic hide rules do not only apply to traffic going out external interfaces.