### PR TITLE
A10: set `ve` interface VLAN

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -181,6 +181,7 @@ public final class A10Configuration extends VendorConfiguration {
     }
     newIface.setDeclaredNames(names.build());
 
+    // VLANs
     newIface.setSwitchportMode(SwitchportMode.NONE);
     List<Vlan> taggedVlans = getTaggedVlans(iface);
     Optional<Vlan> untaggedVlan = getUntaggedVlan(iface);
@@ -198,7 +199,11 @@ public final class A10Configuration extends VendorConfiguration {
                   .map(v -> new SubRange(v.getNumber()))
                   .collect(ImmutableList.toImmutableList())));
     }
+    if (iface.getType() == Interface.Type.VE) {
+      newIface.setVlan(iface.getNumber());
+    }
 
+    // Aggregates and members
     if (iface instanceof TrunkInterface) {
       TrunkInterface trunkIface = (TrunkInterface) iface;
       ImmutableSet<String> memberNames =

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -20,6 +20,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSwitchPortMode;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
@@ -274,6 +275,7 @@ public class A10GrammarTest {
             "VirtualEthernet 2",
             allOf(
                 hasInterfaceType(InterfaceType.VLAN),
+                hasVlan(2),
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.100.2.1/24"))))));
   }


### PR DESCRIPTION
Set the VLAN ID for `VLAN` `router-interface`s (`VirtualEthernet` interfaces).
