### PR TITLE
A10: inherit `trunk` `VLAN` settings from its `members`

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -213,8 +213,8 @@ public final class A10Configuration extends VendorConfiguration {
     newIface.setDeclaredNames(ImmutableList.of(name));
 
     // VLANs
-    boolean vlanConfigured = hasVlanSettings(iface);
-    if (vlanConfigured) {
+    boolean vlanIsConfigured = hasVlanSettings(iface);
+    if (vlanIsConfigured) {
       setVlanSettings(iface, newIface);
     }
 
@@ -255,7 +255,7 @@ public final class A10Configuration extends VendorConfiguration {
                 .collect(ImmutableSet.toImmutableSet()));
 
         // If this trunk doesn't have VLAN configured directly (e.g. ACOS v2), inherit it
-        if (!vlanConfigured) {
+        if (!vlanIsConfigured) {
           if (vlanSettingsDifferent(memberNames)) {
             _w.redFlag(
                 String.format(

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -240,12 +240,22 @@ public final class A10Configuration extends VendorConfiguration {
           if (vlanSettingsDifferent(memberNames)) {
             _w.redFlag(
                 String.format(
-                    "VLAN settings for members of %s are different, ignoring VLAN settings",
+                    "VLAN settings for members of %s are different, ignoring their VLAN settings",
                     trunkName));
           } else {
             // All members have the same VLAN settings, so just use the first
             String firstMemberName = memberNames.iterator().next();
             setVlanSettings(_ifaceNametoIface.get(firstMemberName), newIface);
+          }
+        } else {
+          org.batfish.datamodel.Interface.Builder dummy = org.batfish.datamodel.Interface.builder();
+          if (memberNames.stream()
+              .anyMatch(memberName -> setVlanSettings(_ifaceNametoIface.get(memberName), dummy))) {
+            _w.redFlag(
+                String.format(
+                    "Cannot configure VLAN settings on %s as well as its members. Member VLAN"
+                        + " settings will be ignored.",
+                    trunkName));
           }
         }
       }

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -234,8 +234,7 @@ public final class A10Configuration extends VendorConfiguration {
                             member, org.batfish.datamodel.Interface.DependencyType.AGGREGATE))
                 .collect(ImmutableSet.toImmutableSet()));
 
-        // If this trunk doesn't have VLAN settings configured directly (e.g. ACOS v2), inherit
-        // settings
+        // If this trunk doesn't have VLAN configured directly (e.g. ACOS v2), inherit it
         if (!hasVlanSettings) {
           if (vlanSettingsDifferent(memberNames)) {
             _w.redFlag(

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -30,6 +30,7 @@ import static org.batfish.vendor.a10.representation.A10StructureType.INTERFACE;
 import static org.batfish.vendor.a10.representation.A10StructureUsage.VLAN_TAGGED_INTERFACE;
 import static org.batfish.vendor.a10.representation.A10StructureUsage.VLAN_UNTAGGED_INTERFACE;
 import static org.batfish.vendor.a10.representation.Interface.DEFAULT_MTU;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -689,7 +690,13 @@ public class A10GrammarTest {
         warnings,
         hasRedFlags(
             containsInAnyOrder(
-                WarningMatchers.hasText("Trunk 2 does not contain any member interfaces"))));
+                WarningMatchers.hasText("Trunk 2 does not contain any member interfaces"),
+                WarningMatchers.hasText(
+                    containsString(
+                        "VLAN settings for members of Trunk 1 are different, ignoring VLAN"
+                            + " settings")),
+                WarningMatchers.hasText(
+                    "Trunk member Ethernet 10 does not exist, cannot add to Trunk 1"))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -693,7 +693,7 @@ public class A10GrammarTest {
                 WarningMatchers.hasText("Trunk 2 does not contain any member interfaces"),
                 WarningMatchers.hasText(
                     containsString(
-                        "VLAN settings for members of Trunk 1 are different, ignoring VLAN"
+                        "VLAN settings for members of Trunk 1 are different, ignoring their VLAN"
                             + " settings")),
                 WarningMatchers.hasText(
                     "Trunk member Ethernet 10 does not exist, cannot add to Trunk 1"))));
@@ -725,6 +725,25 @@ public class A10GrammarTest {
                 hasComment("This interface is already a member of trunk-group 3"),
                 hasComment("Cannot add an interface with a configured IP address to a trunk-group"),
                 hasComment("Cannot configure an IP address on a trunk-group member"))));
+  }
+
+  @Test
+  public void testTrunkConversionWarn() throws IOException {
+    String hostname = "trunk_convert_warn";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Warnings warnings =
+        batfish
+            .loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot())
+            .getWarnings()
+            .get(hostname);
+
+    assertThat(
+        warnings,
+        hasRedFlags(
+            containsInAnyOrder(
+                WarningMatchers.hasText(
+                    "Cannot configure VLAN settings on Trunk 1 as well as its members. Member VLAN"
+                        + " settings will be ignored."))));
   }
 
   /** Testing ACOS v2 syntax */

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -306,12 +306,22 @@ public class A10GrammarTest {
                 hasSwitchPortMode(SwitchportMode.TRUNK),
                 hasAllowedVlans(IntegerSpace.of(2)),
                 hasNativeVlan(nullValue()))));
+    // Trunk3 only gets VLAN settings directly configured on it (ignore member settings)
+    assertThat(
+        c,
+        hasInterface(
+            "Trunk3",
+            allOf(
+                hasInterfaceType(InterfaceType.AGGREGATED),
+                hasSwitchPortMode(SwitchportMode.TRUNK),
+                hasAllowedVlans(IntegerSpace.EMPTY),
+                hasNativeVlan(equalTo(5)))));
   }
 
-  /** Testing ACOS v2 trunk VLANs */
+  /** Testing ACOS v2 trunk VLAN conversion */
   @Test
   public void testTrunkVlanAcos2Conversion() {
-    String hostname = "trunk_vlan_acos2_convert";
+    String hostname = "trunk_acos2_convert";
     Configuration c = parseConfig(hostname);
 
     // Trunk1 inherits member VLAN settings

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -308,6 +308,35 @@ public class A10GrammarTest {
                 hasNativeVlan(nullValue()))));
   }
 
+  /** Testing ACOS v2 trunk VLANs */
+  @Test
+  public void testTrunkVlanAcos2Conversion() {
+    String hostname = "trunk_vlan_acos2_convert";
+    Configuration c = parseConfig(hostname);
+
+    // Trunk1 inherits member VLAN settings
+    assertThat(
+        c,
+        hasInterface(
+            "Trunk1",
+            allOf(
+                hasInterfaceType(InterfaceType.AGGREGATED),
+                hasSwitchPortMode(SwitchportMode.TRUNK),
+                hasAllowedVlans(IntegerSpace.of(2)),
+                hasNativeVlan(equalTo(3)))));
+
+    // Trunk2's members have different VLAN settings, which are ignored
+    assertThat(
+        c,
+        hasInterface(
+            "Trunk2",
+            allOf(
+                hasInterfaceType(InterfaceType.AGGREGATED),
+                hasSwitchPortMode(SwitchportMode.NONE),
+                hasAllowedVlans(IntegerSpace.EMPTY),
+                hasNativeVlan(nullValue()))));
+  }
+
   /** Testing ACOS v2 VLAN syntax */
   @Test
   public void testVlanAcos2Extraction() {

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_convert
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_convert
@@ -1,6 +1,6 @@
 !BATFISH_FORMAT: a10_acos
 !version 2.7.2, build 123 (Aug-5-2021,01:23)
-hostname trunk_vlan_acos2_convert
+hostname trunk_acos2_convert
 !
 trunk 1
  ethernet 1 ethernet 2

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_convert_warn
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_convert_warn
@@ -2,7 +2,7 @@
 !version 2.7.2, build 123 (Aug-5-2021,01:23)
 hostname trunk_acos2_convert_warn
 !
-! Different VLAN settings for eth 1 and 2, eth 10 does not exist
+! Different VLAN settings for eth 1 and 2; eth 10 does not exist
 trunk 1
  ethernet 1 ethernet 2 ethernet 10
 !

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_convert_warn
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_convert_warn
@@ -2,7 +2,20 @@
 !version 2.7.2, build 123 (Aug-5-2021,01:23)
 hostname trunk_acos2_convert_warn
 !
+! Different VLAN settings for eth 1 and 2, eth 10 does not exist
+trunk 1
+ ethernet 1 ethernet 2 ethernet 10
+!
 ! Empty trunk
 trunk 2
  name trunk2Name
+!
+vlan 2
+ tagged ethernet 2
+vlan 3
+ tagged ethernet 1
+!
+interface ethernet 1
+!
+interface ethernet 2
 !

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_convert_warn
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_convert_warn
@@ -1,0 +1,17 @@
+!BATFISH_FORMAT: a10_acos
+hostname trunk_convert_warn
+!
+vlan 2
+ tagged trunk 1
+!
+! Can't configure VLAN settings on a trunk member directly
+vlan 3
+ tagged ethernet 1
+!
+interface ethernet 1
+ trunk-group 1
+interface ethernet 2
+ trunk-group 1
+!
+interface trunk 1
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_vlan_acos2_convert
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_vlan_acos2_convert
@@ -1,0 +1,27 @@
+!BATFISH_FORMAT: a10_acos
+!version 2.7.2, build 123 (Aug-5-2021,01:23)
+hostname trunk_vlan_acos2_convert
+!
+trunk 1
+ ethernet 1 ethernet 2
+!
+! Eth3 & 4 have different VLAN settings, which is invalid for the same trunk
+trunk 2
+ ethernet 3 ethernet 4
+!
+vlan 2
+ tagged ethernet 1 ethernet 2
+vlan 3
+ untagged ethernet 1 ethernet 2
+vlan 4
+ tagged ethernet 3
+ untagged ethernet 4
+!
+interface ethernet 1
+!
+interface ethernet 2
+!
+interface ethernet 3
+!
+interface ethernet 4
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_vlan_convert
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_vlan_convert
@@ -7,6 +7,15 @@ vlan 2
 vlan 3
  untagged trunk 1
 !
+!
+! Can't configured VLAN settings on a trunk and its members
+vlan 4
+ untagged ethernet 4
+!
+vlan 5
+ untagged trunk 3
+!
+!
 interface ethernet 1
  trunk-group 1
 !
@@ -16,7 +25,12 @@ interface ethernet 2
 interface ethernet 3
  trunk-group 2
 !
+interface ethernet 4
+ trunk-group 3
+!
 interface trunk 1
 !
 interface trunk 2
+!
+interface trunk 3
 !


### PR DESCRIPTION
### Some context

#### ACOS v2.x
`trunk`s appear to be a distinct object type, different from `interface`s.

`show config` prints `trunk` configuration, followed by `vlan` config, and finally `interface` config.

A `vlan` which applies to a trunk is configured by applying to each trunk member, e.g.:
```
trunk 1
 ethernet 1 ethernet 2
!
vlan 2
 tagged ethernet 1 ethernet 2
!
interface ethernet 1
!
interface ethernet 2
!
```

#### ACOS v4.x / v5.x
`trunk`s appear to just be a type of `interface`.

`show config` prints `vlan` config, followed by `interface` config (including `trunk` interfaces).

A `vlan` which applies to a trunk is configured simply by associating with the trunk itself, not its members:
```
vlan 2
 tagged trunk 1
!
interface ethernet 1
 trunk-group 1
!
interface ethernet 2
 trunk-group 1
!
interface trunk 1
!
```
----

In this PR:
* Add inheritance of VLAN settings from members (ignore and warn if members don't have the same settings)
* Warn if a trunk *and* its members have VLAN settings
* Factor out adding VLAN settings to VI interface (builder) into a helper
* Add check for missing `trunk` `members` (ignore them and add a warning for now)
