### PR TITLE
A10: better VI interface names

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasEncapsulationVlan
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasFirewallSessionInterfaceInfo;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasHsrpGroup;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasHsrpVersion;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasHumanName;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasInterfaceType;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasIsis;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasMlagId;
@@ -285,6 +286,22 @@ public final class InterfaceMatchers {
    */
   public static @Nonnull Matcher<Interface> hasHsrpVersion(@Nullable String expectedHsrpVersion) {
     return new HasHsrpVersion(equalTo(expectedHsrpVersion));
+  }
+
+  /**
+   * Provides a matcher that matches if the {@link Interface}'s human name is {@code
+   * expectedHumanName}.
+   */
+  public static Matcher<Interface> hasHumanName(String expectedHumanName) {
+    return hasHumanName(equalTo(expectedHumanName));
+  }
+
+  /**
+   * Provides a matcher that matches if the {@link Interface}'s human name matches the given
+   * subMatcher.
+   */
+  public static Matcher<Interface> hasHumanName(Matcher<? super String> subMatcher) {
+    return new HasHumanName(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -292,7 +292,7 @@ public final class InterfaceMatchers {
    * Provides a matcher that matches if the {@link Interface}'s human name is {@code
    * expectedHumanName}.
    */
-  public static Matcher<Interface> hasHumanName(String expectedHumanName) {
+  public static @Nonnull Matcher<Interface> hasHumanName(String expectedHumanName) {
     return hasHumanName(equalTo(expectedHumanName));
   }
 
@@ -300,7 +300,7 @@ public final class InterfaceMatchers {
    * Provides a matcher that matches if the {@link Interface}'s human name matches the given
    * subMatcher.
    */
-  public static Matcher<Interface> hasHumanName(Matcher<? super String> subMatcher) {
+  public static @Nonnull Matcher<Interface> hasHumanName(Matcher<? super String> subMatcher) {
     return new HasHumanName(subMatcher);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -218,6 +218,17 @@ final class InterfaceMatchersImpl {
     }
   }
 
+  static final class HasHumanName extends FeatureMatcher<Interface, String> {
+    HasHumanName(@Nonnull Matcher<? super String> subMatcher) {
+      super(subMatcher, "An Interface with human name:", "human name");
+    }
+
+    @Override
+    protected String featureValueOf(Interface actual) {
+      return actual.getHumanName();
+    }
+  }
+
   static final class HasIsis extends FeatureMatcher<Interface, IsisInterfaceSettings> {
     HasIsis(@Nonnull Matcher<? super IsisInterfaceSettings> subMatcher) {
       super(subMatcher, "An Interface with isis:", "isis");

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -124,13 +124,13 @@ public final class A10Configuration extends VendorConfiguration {
   @Nonnull
   public static String getInterfaceName(Interface.Type type, int num) {
     if (type == Interface.Type.VE) {
-      return String.format("VirtualEthernet %s", num);
+      return String.format("VirtualEthernet%s", num);
     }
 
     String typeStr = type.toString();
-    // Only the first letter should be capitalized, like in A10 `show` data
+    // Only the first letter should be capitalized, similar to A10 `show` data
     return String.format(
-        "%s%s %s", typeStr.substring(0, 1), typeStr.substring(1).toLowerCase(), num);
+        "%s%s%s", typeStr.substring(0, 1), typeStr.substring(1).toLowerCase(), num);
   }
 
   @Override
@@ -175,11 +175,9 @@ public final class A10Configuration extends VendorConfiguration {
             .setName(name)
             .setVrf(vrf)
             .setOwner(_c);
-    ImmutableList.Builder<String> names = ImmutableList.<String>builder().add(name);
-    if (iface.getName() != null && !name.equals(iface.getName())) {
-      names.add(iface.getName());
-    }
-    newIface.setDeclaredNames(names.build());
+    // A10 interface `name` is more like a description than an actual name
+    newIface.setDescription(iface.getName());
+    newIface.setDeclaredNames(ImmutableList.of(name));
 
     // VLANs
     newIface.setSwitchportMode(SwitchportMode.NONE);
@@ -221,7 +219,8 @@ public final class A10Configuration extends VendorConfiguration {
       if (memberNames.isEmpty()) {
         _w.redFlag(
             String.format(
-                "Trunk %s does not contain any member interfaces", trunkIface.getNumber()));
+                "%s does not contain any member interfaces",
+                getInterfaceName(Interface.Type.TRUNK, trunkIface.getNumber())));
       }
     }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -133,6 +133,23 @@ public final class A10Configuration extends VendorConfiguration {
         "%s%s%s", typeStr.substring(0, 1), typeStr.substring(1).toLowerCase(), num);
   }
 
+  @Nonnull
+  public static String getInterfaceHumanName(Interface iface) {
+    return getInterfaceHumanName(iface.getType(), iface.getNumber());
+  }
+
+  @Nonnull
+  public static String getInterfaceHumanName(Interface.Type type, int num) {
+    if (type == Interface.Type.VE) {
+      return String.format("VirtualEthernet %s", num);
+    }
+
+    String typeStr = type.toString();
+    // Only the first letter should be capitalized, similar to A10 `show` data
+    return String.format(
+        "%s%s %s", typeStr.substring(0, 1), typeStr.substring(1).toLowerCase(), num);
+  }
+
   @Override
   public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
     String hostname = getHostname();
@@ -177,6 +194,7 @@ public final class A10Configuration extends VendorConfiguration {
             .setOwner(_c);
     // A10 interface `name` is more like a description than an actual name
     newIface.setDescription(iface.getName());
+    newIface.setHumanName(getInterfaceHumanName(iface));
     newIface.setDeclaredNames(ImmutableList.of(name));
 
     // VLANs

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -16,7 +16,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasChannelGroup;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasChannelGroupMembers;
-import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDeclaredNames;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
@@ -44,7 +44,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import java.io.IOException;
 import java.util.Arrays;
@@ -247,7 +246,7 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "Ethernet 1",
+            "Ethernet1",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
                 hasSwitchPortMode(SwitchportMode.TRUNK),
@@ -256,7 +255,7 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "Ethernet 2",
+            "Ethernet2",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
                 hasSwitchPortMode(SwitchportMode.TRUNK),
@@ -265,7 +264,7 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "Ethernet 3",
+            "Ethernet3",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
                 hasSwitchPortMode(SwitchportMode.TRUNK),
@@ -274,7 +273,7 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "VirtualEthernet 2",
+            "VirtualEthernet2",
             allOf(
                 hasInterfaceType(InterfaceType.VLAN),
                 hasVlan(2),
@@ -290,7 +289,7 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "Trunk 1",
+            "Trunk1",
             allOf(
                 hasInterfaceType(InterfaceType.AGGREGATED),
                 hasSwitchPortMode(SwitchportMode.TRUNK),
@@ -299,7 +298,7 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "Trunk 2",
+            "Trunk2",
             allOf(
                 hasInterfaceType(InterfaceType.AGGREGATED),
                 hasSwitchPortMode(SwitchportMode.TRUNK),
@@ -485,46 +484,46 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "Ethernet 1",
+            "Ethernet1",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.1.1/24"))),
                 isActive(),
-                hasDeclaredNames(ImmutableList.of("Ethernet 1", "this is a comp\"licat'ed name")),
+                hasDescription("this is a comp\"licat'ed name"),
                 hasMtu(1234))));
 
     assertThat(
         c,
         hasInterface(
-            "Ethernet 9",
+            "Ethernet9",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.2.1/24"))),
                 isActive(false),
-                hasDeclaredNames(ImmutableList.of("Ethernet 9", "baz")),
+                hasDescription("baz"),
                 hasMtu(DEFAULT_MTU))));
 
     assertThat(
         c,
         hasInterface(
-            "Loopback 0",
+            "Loopback0",
             allOf(
                 hasInterfaceType(InterfaceType.LOOPBACK),
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("192.168.0.1/32"))),
-                hasDeclaredNames(ImmutableList.of("Loopback 0")))));
+                hasDescription(nullValue()))));
 
     assertThat(
         c,
         hasInterface(
-            "Loopback 10",
+            "Loopback10",
             allOf(
                 hasInterfaceType(InterfaceType.LOOPBACK),
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(empty()),
-                hasDeclaredNames(ImmutableList.of("Loopback 10")))));
+                hasDescription(nullValue()))));
   }
 
   @Test
@@ -618,60 +617,60 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "Ethernet 1",
+            "Ethernet1",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
-                hasChannelGroup("Trunk 1"),
+                hasChannelGroup("Trunk1"),
                 hasChannelGroupMembers(empty()),
                 hasAllAddresses(empty()))));
     assertThat(
         c,
         hasInterface(
-            "Trunk 1",
+            "Trunk1",
             allOf(
                 hasInterfaceType(InterfaceType.AGGREGATED),
                 hasChannelGroup(nullValue()),
-                hasChannelGroupMembers(containsInAnyOrder("Ethernet 1")))));
+                hasChannelGroupMembers(containsInAnyOrder("Ethernet1")))));
     assertThat(
-        c.getAllInterfaces().get("Trunk 1").getDependencies(),
+        c.getAllInterfaces().get("Trunk1").getDependencies(),
         containsInAnyOrder(
             new org.batfish.datamodel.Interface.Dependency(
-                "Ethernet 1", org.batfish.datamodel.Interface.DependencyType.AGGREGATE)));
+                "Ethernet1", org.batfish.datamodel.Interface.DependencyType.AGGREGATE)));
 
     // Default trunk
     assertThat(
         c,
         hasInterface(
-            "Ethernet 2",
+            "Ethernet2",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
-                hasChannelGroup("Trunk 2"),
+                hasChannelGroup("Trunk2"),
                 hasChannelGroupMembers(empty()),
                 hasAllAddresses(empty()))));
     assertThat(
         c,
         hasInterface(
-            "Ethernet 3",
+            "Ethernet3",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
-                hasChannelGroup("Trunk 2"),
+                hasChannelGroup("Trunk2"),
                 hasChannelGroupMembers(empty()),
                 hasAllAddresses(empty()))));
     assertThat(
         c,
         hasInterface(
-            "Trunk 2",
+            "Trunk2",
             allOf(
                 hasInterfaceType(InterfaceType.AGGREGATED),
                 hasChannelGroup(nullValue()),
-                hasChannelGroupMembers(containsInAnyOrder("Ethernet 2", "Ethernet 3")))));
+                hasChannelGroupMembers(containsInAnyOrder("Ethernet2", "Ethernet3")))));
     assertThat(
-        c.getAllInterfaces().get("Trunk 2").getDependencies(),
+        c.getAllInterfaces().get("Trunk2").getDependencies(),
         containsInAnyOrder(
             new org.batfish.datamodel.Interface.Dependency(
-                "Ethernet 2", org.batfish.datamodel.Interface.DependencyType.AGGREGATE),
+                "Ethernet2", org.batfish.datamodel.Interface.DependencyType.AGGREGATE),
             new org.batfish.datamodel.Interface.Dependency(
-                "Ethernet 3", org.batfish.datamodel.Interface.DependencyType.AGGREGATE)));
+                "Ethernet3", org.batfish.datamodel.Interface.DependencyType.AGGREGATE)));
   }
 
   /** Testing ACOS v2 trunk conversion warnings */
@@ -689,7 +688,7 @@ public class A10GrammarTest {
         warnings,
         hasRedFlags(
             containsInAnyOrder(
-                WarningMatchers.hasText("Trunk 2 does not contain any member interfaces"))));
+                WarningMatchers.hasText("Trunk2 does not contain any member interfaces"))));
   }
 
   @Test
@@ -747,38 +746,38 @@ public class A10GrammarTest {
     assertThat(
         c,
         hasInterface(
-            "Ethernet 1",
+            "Ethernet1",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
-                hasChannelGroup("Trunk 1"),
+                hasChannelGroup("Trunk1"),
                 hasChannelGroupMembers(empty()),
                 hasAllAddresses(empty()))));
 
     assertThat(
         c,
         hasInterface(
-            "Ethernet 2",
+            "Ethernet2",
             allOf(
                 hasInterfaceType(InterfaceType.PHYSICAL),
-                hasChannelGroup("Trunk 1"),
+                hasChannelGroup("Trunk1"),
                 hasChannelGroupMembers(empty()),
                 hasAllAddresses(empty()))));
 
     assertThat(
         c,
         hasInterface(
-            "Trunk 1",
+            "Trunk1",
             allOf(
                 hasInterfaceType(InterfaceType.AGGREGATED),
                 hasChannelGroup(nullValue()),
-                hasChannelGroupMembers(containsInAnyOrder("Ethernet 1", "Ethernet 2")),
+                hasChannelGroupMembers(containsInAnyOrder("Ethernet1", "Ethernet2")),
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.1.1/24"))))));
     assertThat(
-        c.getAllInterfaces().get("Trunk 1").getDependencies(),
+        c.getAllInterfaces().get("Trunk1").getDependencies(),
         containsInAnyOrder(
             new org.batfish.datamodel.Interface.Dependency(
-                "Ethernet 1", org.batfish.datamodel.Interface.DependencyType.AGGREGATE),
+                "Ethernet1", org.batfish.datamodel.Interface.DependencyType.AGGREGATE),
             new org.batfish.datamodel.Interface.Dependency(
-                "Ethernet 2", org.batfish.datamodel.Interface.DependencyType.AGGREGATE)));
+                "Ethernet2", org.batfish.datamodel.Interface.DependencyType.AGGREGATE)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -17,6 +17,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasChannelGroup;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasChannelGroupMembers;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasHumanName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
@@ -491,6 +492,7 @@ public class A10GrammarTest {
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.1.1/24"))),
                 isActive(),
                 hasDescription("this is a comp\"licat'ed name"),
+                hasHumanName("Ethernet 1"),
                 hasMtu(1234))));
 
     assertThat(
@@ -503,6 +505,7 @@ public class A10GrammarTest {
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.2.1/24"))),
                 isActive(false),
                 hasDescription("baz"),
+                hasHumanName("Ethernet 9"),
                 hasMtu(DEFAULT_MTU))));
 
     assertThat(
@@ -513,7 +516,8 @@ public class A10GrammarTest {
                 hasInterfaceType(InterfaceType.LOOPBACK),
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("192.168.0.1/32"))),
-                hasDescription(nullValue()))));
+                hasDescription(nullValue()),
+                hasHumanName("Loopback 0"))));
 
     assertThat(
         c,
@@ -523,7 +527,8 @@ public class A10GrammarTest {
                 hasInterfaceType(InterfaceType.LOOPBACK),
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(empty()),
-                hasDescription(nullValue()))));
+                hasDescription(nullValue()),
+                hasHumanName("Loopback 10"))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.batfish.vendor.a10.representation;
 
 import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceEnabledEffective;
+import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceHumanName;
 import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceMtuEffective;
 import static org.batfish.vendor.a10.representation.Interface.DEFAULT_MTU;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,5 +39,16 @@ public class A10ConfigurationTest {
     assertThat(getInterfaceMtuEffective(eth), equalTo(DEFAULT_MTU));
     eth.setMtu(1234);
     assertThat(getInterfaceMtuEffective(eth), equalTo(1234));
+  }
+
+  @Test
+  public void testGetInterfaceHumanName() {
+    assertThat(
+        getInterfaceHumanName(new Interface(Interface.Type.ETHERNET, 9)), equalTo("Ethernet 9"));
+    assertThat(getInterfaceHumanName(new Interface(Interface.Type.TRUNK, 9)), equalTo("Trunk 9"));
+    assertThat(
+        getInterfaceHumanName(new Interface(Interface.Type.LOOPBACK, 9)), equalTo("Loopback 9"));
+    assertThat(
+        getInterfaceHumanName(new Interface(Interface.Type.VE, 9)), equalTo("VirtualEthernet 9"));
   }
 }


### PR DESCRIPTION
* Remove space from VI interface names for A10 devices to make using them w/ Batfish/Pybatfish slightly easier
* Use the original format as the human name
* Use A10 interface "name" as VI interface description, since that appears to be the intended use-case
