### PR TITLE
CheckPoint implement service-other match conversion

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AclLineMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AclLineMatchers.java
@@ -3,24 +3,27 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.equalTo;
 
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.matchers.AclLineMatchersImpl.HasTraceElement;
 import org.batfish.datamodel.matchers.AclLineMatchersImpl.IsExprAclLineThat;
 import org.hamcrest.Matcher;
 
-public class AclLineMatchers {
+public final class AclLineMatchers {
 
   /**
-   * Provides a matcher that matches {@link ExprAclLine}s that match the provided {@code
+   * Provides a matcher that matches an {@link ExprAclLine}s matched by the provided {@code
    * subMatcher}.
    */
-  public static IsExprAclLineThat isExprAclLineThat(
+  public static @Nonnull Matcher<AclLine> isExprAclLineThat(
       @Nonnull Matcher<? super ExprAclLine> subMatcher) {
     return new IsExprAclLineThat(subMatcher);
   }
 
-  public static HasTraceElement hasTraceElement(@Nonnull TraceElement traceElement) {
+  public static @Nonnull Matcher<AclLine> hasTraceElement(@Nonnull TraceElement traceElement) {
     return new HasTraceElement(equalTo(traceElement));
   }
+
+  private AclLineMatchers() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
@@ -1,0 +1,186 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.batfish.datamodel.IntegerSpace.PORTS;
+import static org.batfish.datamodel.IpProtocol.TCP;
+import static org.batfish.datamodel.IpProtocol.UDP;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstPort;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIpProtocol;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.batfish.datamodel.applications.PortsApplication.MAX_PORT_NUMBER;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.vendor.check_point_management.parsing.parboiled.BooleanExprAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.BooleanExprAstNodeVisitor;
+import org.batfish.vendor.check_point_management.parsing.parboiled.ComparatorAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.ComparatorAstNodeVisitor;
+import org.batfish.vendor.check_point_management.parsing.parboiled.ConjunctionAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.DisjunctionAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.DportAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.EmptyAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.EqualsAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.ErrorAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.GreaterThanAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.GreaterThanOrEqualsAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.IncomingAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.LessThanAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.LessThanOrEqualsAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.OutgoingAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.TcpAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.UdpAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.UhDportAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.UnhandledAstNode;
+
+/** Converter from {@link BooleanExprAstNode} to {@link AclLineMatchExpr}. */
+public final class BooleanExprAstNodeToAclLineMatchExpr
+    implements BooleanExprAstNodeVisitor<AclLineMatchExpr, Boolean> {
+
+  /**
+   * Converts the {@code booleanExprAstNode} to an {@link AclLineMatchExpr}.
+   *
+   * <p>Matches on unsupported features (e.g. L7, firewall state) are converted directly to the
+   * value of {@code permitUnsupported}. Matches on incoming direction are converted to {@code true}
+   * iff {@code incoming}. Matches on outgoing direction are converted to {@code false} iff not
+   * {@code incoming}.
+   */
+  public static @Nonnull AclLineMatchExpr convert(
+      BooleanExprAstNode booleanExprAstNode, boolean permitUnsupported) {
+    return INSTANCE.visit(booleanExprAstNode, permitUnsupported);
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitConjunctionAstNode(
+      ConjunctionAstNode conjunctionAstNode, Boolean permitUnsupported) {
+    return and(
+        conjunctionAstNode.getConjuncts().stream()
+            .map(conjunct -> visit(conjunct, permitUnsupported))
+            .collect(ImmutableList.toImmutableList()));
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitDisjunctionAstNode(
+      DisjunctionAstNode disjunctionAstNode, Boolean permitUnsupported) {
+    return or(
+        disjunctionAstNode.getDisjuncts().stream()
+            .map(disjunct -> visit(disjunct, permitUnsupported))
+            .collect(ImmutableList.toImmutableList()));
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitDportAstNode(
+      DportAstNode dportAstNode, Boolean permitUnsupported) {
+    return matchDstPort(
+        portRangeToIntegerSpace(dportAstNode.getComparator(), dportAstNode.getValue().getValue()));
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitEmptyAstNode(
+      EmptyAstNode emptyAstNode, Boolean permitUnsupported) {
+    return TRUE;
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitErrorAstNode(
+      ErrorAstNode errorAstNode, Boolean permitUnsupported) {
+    return FALSE;
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitIncomingAstNode(
+      IncomingAstNode incomingAstNode, Boolean permitUnsupported) {
+    // TODO: implement direction
+    return permitUnsupported ? TRUE : FALSE;
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitOutgoingAstNode(
+      OutgoingAstNode outgoingAstNode, Boolean permitUnsupported) {
+    // TODO: implement direction
+    return permitUnsupported ? TRUE : FALSE;
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitTcpAstNode(
+      TcpAstNode tcpAstNode, Boolean permitUnsupported) {
+    return matchIpProtocol(TCP);
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitUdpAstNode(
+      UdpAstNode udpAstNode, Boolean permitUnsupported) {
+    return matchIpProtocol(UDP);
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitUhDportAstNode(
+      UhDportAstNode uhDportAstNode, Boolean permitUnsupported) {
+    return and(
+        matchIpProtocol(UDP),
+        matchDstPort(
+            portRangeToIntegerSpace(
+                uhDportAstNode.getComparator(), uhDportAstNode.getValue().getValue())));
+  }
+
+  @Override
+  public @Nonnull AclLineMatchExpr visitUnhandledAstNode(
+      UnhandledAstNode unhandledAstNode, Boolean permitUnsupported) {
+    return permitUnsupported ? TRUE : FALSE;
+  }
+
+  /** Convert a port range represented by a comparator and a value to an {@link IntegerSpace}. */
+  @VisibleForTesting
+  static @Nonnull IntegerSpace portRangeToIntegerSpace(
+      ComparatorAstNode comparatorAstNode, int value) {
+    return COMPARATOR_AND_VALUE_TO_INTEGER_SPACE
+        .visit(comparatorAstNode, value)
+        .intersection(PORTS);
+  }
+
+  private static final ComparatorAndValueToIntegerSpace COMPARATOR_AND_VALUE_TO_INTEGER_SPACE =
+      new ComparatorAndValueToIntegerSpace();
+
+  private static final class ComparatorAndValueToIntegerSpace
+      implements ComparatorAstNodeVisitor<IntegerSpace, Integer> {
+
+    @Override
+    public @Nonnull IntegerSpace visitEqualsAstNode(EqualsAstNode equalsAstNode, Integer arg) {
+      return IntegerSpace.of(arg);
+    }
+
+    @Override
+    public @Nonnull IntegerSpace visitGreaterThanAstNode(
+        GreaterThanAstNode greaterThanAstNode, Integer arg) {
+      return IntegerSpace.of(new SubRange(arg + 1, MAX_PORT_NUMBER));
+    }
+
+    @Override
+    public @Nonnull IntegerSpace visitGreaterThanOrEqualsAstNode(
+        GreaterThanOrEqualsAstNode greaterThanOrEqualsAstNode, Integer arg) {
+      return IntegerSpace.of(new SubRange(arg, MAX_PORT_NUMBER));
+    }
+
+    @Override
+    public @Nonnull IntegerSpace visitLessThanAstNode(
+        LessThanAstNode lessThanAstNode, Integer arg) {
+      return IntegerSpace.of(new SubRange(0, arg - 1));
+    }
+
+    @Override
+    public @Nonnull IntegerSpace visitLessThanOrEqualsAstNode(
+        LessThanOrEqualsAstNode lessThanOrEqualsAstNode, Integer arg) {
+      return IntegerSpace.of(new SubRange(0, arg));
+    }
+  }
+
+  private static final BooleanExprAstNodeToAclLineMatchExpr INSTANCE =
+      new BooleanExprAstNodeToAclLineMatchExpr();
+
+  private BooleanExprAstNodeToAclLineMatchExpr() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
@@ -46,12 +46,14 @@ public final class BooleanExprAstNodeToAclLineMatchExpr
    * Converts the {@code booleanExprAstNode} to an {@link AclLineMatchExpr}.
    *
    * <p>Matches on unsupported features (e.g. L7, firewall state) are converted directly to the
-   * value of {@code permitUnsupported}. Matches on incoming direction are converted to {@code true}
-   * iff {@code incoming}. Matches on outgoing direction are converted to {@code false} iff not
-   * {@code incoming}.
+   * value of {@code permitUnsupported}. Matches on incoming/outgoing direction are currently
+   * treated as unsupported features.
    */
   public static @Nonnull AclLineMatchExpr convert(
       BooleanExprAstNode booleanExprAstNode, boolean permitUnsupported) {
+    // TODO: Support direction as follows:
+    //       Matches on incoming direction are converted to {@code true} iff {@code incoming}.
+    //       Matches on outgoing direction are converted to {@code false} iff not {@code incoming}.
     return INSTANCE.visit(booleanExprAstNode, permitUnsupported);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiAnyObject.java
@@ -21,8 +21,8 @@ public final class CpmiAnyObject extends TypedManagementObject implements Addres
   }
 
   @Override
-  public <T> T accept(ServiceVisitor<T> visitor) {
-    return visitor.visitCpmiAnyObject(this);
+  public <T, U> T accept(ServiceVisitor<T, U> visitor, U arg) {
+    return visitor.visitCpmiAnyObject(this, arg);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedServiceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/NatTranslatedServiceVisitor.java
@@ -1,7 +1,7 @@
 package org.batfish.vendor.check_point_management;
 
 /** Visitor for {@link NatTranslatedService} */
-public interface NatTranslatedServiceVisitor<T> extends ServiceVisitor<T> {
+public interface NatTranslatedServiceVisitor<T> extends ServiceVisitor<T, Void> {
   T visitOriginal(Original original);
 
   T visitService(Service service);

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/Service.java
@@ -8,5 +8,5 @@ public interface Service extends NatTranslatedService {
     return visitor.visitService(this);
   }
 
-  <T> T accept(ServiceVisitor<T> visitor);
+  <T, U> T accept(ServiceVisitor<T, U> visitor, U arg);
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceGroup.java
@@ -12,8 +12,8 @@ import javax.annotation.Nullable;
 
 public final class ServiceGroup extends TypedManagementObject implements Service {
   @Override
-  public <T> T accept(ServiceVisitor<T> visitor) {
-    return visitor.visitServiceGroup(this);
+  public <T, U> T accept(ServiceVisitor<T, U> visitor, U arg) {
+    return visitor.visitServiceGroup(this, arg);
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceIcmp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceIcmp.java
@@ -11,8 +11,8 @@ import javax.annotation.Nullable;
 
 public final class ServiceIcmp extends TypedManagementObject implements Service {
   @Override
-  public <T> T accept(ServiceVisitor<T> visitor) {
-    return visitor.visitServiceIcmp(this);
+  public <T, U> T accept(ServiceVisitor<T, U> visitor, U arg) {
+    return visitor.visitServiceIcmp(this, arg);
   }
 
   /** Docs: A number with no fractional part (integer). */

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceOther.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceOther.java
@@ -20,8 +20,8 @@ import org.batfish.vendor.check_point_management.parsing.parboiled.ServiceOtherM
  */
 public final class ServiceOther extends TypedManagementObject implements Service {
   @Override
-  public <T> T accept(ServiceVisitor<T> visitor) {
-    return visitor.visitServiceOther(this);
+  public <T, U> T accept(ServiceVisitor<T, U> visitor, U arg) {
+    return visitor.visitServiceOther(this, arg);
   }
 
   /** Docs: IP protocol number. */

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceTcp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceTcp.java
@@ -11,8 +11,8 @@ import javax.annotation.Nullable;
 
 public final class ServiceTcp extends TypedManagementObject implements Service {
   @Override
-  public <T> T accept(ServiceVisitor<T> visitor) {
-    return visitor.visitServiceTcp(this);
+  public <T, U> T accept(ServiceVisitor<T, U> visitor, U arg) {
+    return visitor.visitServiceTcp(this, arg);
   }
 
   /** Docs: Destination ports, a comma separated list of ports/ranges. */

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceUdp.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceUdp.java
@@ -11,8 +11,8 @@ import javax.annotation.Nullable;
 
 public final class ServiceUdp extends TypedManagementObject implements Service {
   @Override
-  public <T> T accept(ServiceVisitor<T> visitor) {
-    return visitor.visitServiceUdp(this);
+  public <T, U> T accept(ServiceVisitor<T, U> visitor, U arg) {
+    return visitor.visitServiceUdp(this, arg);
   }
 
   /** Docs: Destination ports, a comma separated list of ports/ranges. */

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/ServiceVisitor.java
@@ -1,22 +1,20 @@
 package org.batfish.vendor.check_point_management;
 
-/** Visitor for {@link Service} */
-public interface ServiceVisitor<T> {
-  default T visit(Service service) {
-    return service.accept(this);
+/** Visitor for {@link Service} that takes a generic argument and returns a generic value. */
+public interface ServiceVisitor<T, U> {
+  default T visit(Service service, U arg) {
+    return service.accept(this, arg);
   }
 
-  T visitCpmiAnyObject(CpmiAnyObject cpmiAnyObject);
+  T visitCpmiAnyObject(CpmiAnyObject cpmiAnyObject, U arg);
 
-  T visitServiceGroup(ServiceGroup serviceGroup);
+  T visitServiceGroup(ServiceGroup serviceGroup, U arg);
 
-  T visitServiceIcmp(ServiceIcmp serviceIcmp);
+  T visitServiceIcmp(ServiceIcmp serviceIcmp, U arg);
 
-  T visitServiceOther(ServiceOther serviceOther);
+  T visitServiceOther(ServiceOther serviceOther, U arg);
 
-  T visitServiceTcp(ServiceTcp serviceTcp);
+  T visitServiceTcp(ServiceTcp serviceTcp, U arg);
 
-  T visitServiceUdp(ServiceUdp serviceUdp);
-
-  // TODO Add ServiceOther when created
+  T visitServiceUdp(ServiceUdp serviceUdp, U arg);
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNode.java
@@ -5,13 +5,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a boolean expression. */
 @ParametersAreNonnullByDefault
-public abstract class BooleanExprAstNode implements AstNode {
+public interface BooleanExprAstNode extends AstNode {
 
-  public @Nonnull BooleanExprAstNode or(BooleanExprAstNode disjunct) {
+  <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg);
+
+  default @Nonnull BooleanExprAstNode or(BooleanExprAstNode disjunct) {
     return new DisjunctionAstNode(this, disjunct);
   }
 
-  public @Nonnull BooleanExprAstNode and(BooleanExprAstNode conjunct) {
+  default @Nonnull BooleanExprAstNode and(BooleanExprAstNode conjunct) {
     return new ConjunctionAstNode(this, conjunct);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/BooleanExprAstNodeVisitor.java
@@ -1,0 +1,37 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * A visitor of {@link BooleanExprAstNode} that takes a generic argument and returns a generic
+ * value.
+ */
+@ParametersAreNonnullByDefault
+public interface BooleanExprAstNodeVisitor<T, U> {
+
+  default T visit(BooleanExprAstNode booleanExprAstNode, U arg) {
+    return booleanExprAstNode.accept(this, arg);
+  }
+
+  T visitConjunctionAstNode(ConjunctionAstNode conjunctionAstNode, U arg);
+
+  T visitDisjunctionAstNode(DisjunctionAstNode disjunctionAstNode, U arg);
+
+  T visitDportAstNode(DportAstNode dportAstNode, U arg);
+
+  T visitEmptyAstNode(EmptyAstNode emptyAstNode, U arg);
+
+  T visitErrorAstNode(ErrorAstNode errorAstNode, U arg);
+
+  T visitIncomingAstNode(IncomingAstNode incomingAstNode, U arg);
+
+  T visitOutgoingAstNode(OutgoingAstNode outgoingAstNode, U arg);
+
+  T visitTcpAstNode(TcpAstNode tcpAstNode, U arg);
+
+  T visitUdpAstNode(UdpAstNode udpAstNode, U arg);
+
+  T visitUhDportAstNode(UhDportAstNode uhDportAstNode, U arg);
+
+  T visitUnhandledAstNode(UnhandledAstNode unhandledAstNode, U arg);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNode.java
@@ -4,4 +4,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a comparator. */
 @ParametersAreNonnullByDefault
-public interface ComparatorAstNode extends AstNode {}
+public interface ComparatorAstNode extends AstNode {
+
+  <T, U> T accept(ComparatorAstNodeVisitor<T, U> visitor, U value);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ComparatorAstNodeVisitor.java
@@ -1,0 +1,20 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+/**
+ * A visitor of {@link ComparatorAstNode} that takes a generic argument and returns a generic value.
+ */
+public interface ComparatorAstNodeVisitor<T, U> {
+  default T visit(ComparatorAstNode comparatorAstNode, U arg) {
+    return comparatorAstNode.accept(this, arg);
+  }
+
+  T visitEqualsAstNode(EqualsAstNode equalsAstNode, U arg);
+
+  T visitGreaterThanAstNode(GreaterThanAstNode greaterThanAstNode, U arg);
+
+  T visitGreaterThanOrEqualsAstNode(GreaterThanOrEqualsAstNode greaterThanOrEqualsAstNode, U arg);
+
+  T visitLessThanAstNode(LessThanAstNode lessThanAstNode, U arg);
+
+  T visitLessThanOrEqualsAstNode(LessThanOrEqualsAstNode lessThanOrEqualsAstNode, U arg);
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ConjunctionAstNode.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -10,9 +11,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a conjunction of boolean expressions. */
 @ParametersAreNonnullByDefault
-public final class ConjunctionAstNode extends BooleanExprAstNode {
+public final class ConjunctionAstNode implements BooleanExprAstNode {
 
-  ConjunctionAstNode(BooleanExprAstNode... conjuncts) {
+  @VisibleForTesting
+  public ConjunctionAstNode(BooleanExprAstNode... conjuncts) {
     _conjuncts = ImmutableList.copyOf(conjuncts);
   }
 
@@ -20,11 +22,20 @@ public final class ConjunctionAstNode extends BooleanExprAstNode {
     _conjuncts = ImmutableList.copyOf(conjuncts);
   }
 
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitConjunctionAstNode(this, arg);
+  }
+
   @Nonnull
   @Override
   public BooleanExprAstNode and(BooleanExprAstNode conjunct) {
     return new ConjunctionAstNode(
         ImmutableList.<BooleanExprAstNode>builder().addAll(_conjuncts).add(conjunct).build());
+  }
+
+  public @Nonnull List<BooleanExprAstNode> getConjuncts() {
+    return _conjuncts;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DisjunctionAstNode.java
@@ -1,5 +1,6 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -8,9 +9,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a disjunction of boolean expressions. */
 @ParametersAreNonnullByDefault
-public final class DisjunctionAstNode extends BooleanExprAstNode {
+public final class DisjunctionAstNode implements BooleanExprAstNode {
 
-  DisjunctionAstNode(BooleanExprAstNode... disjuncts) {
+  @VisibleForTesting
+  public DisjunctionAstNode(BooleanExprAstNode... disjuncts) {
     _disjuncts = ImmutableList.copyOf(disjuncts);
   }
 
@@ -18,11 +20,20 @@ public final class DisjunctionAstNode extends BooleanExprAstNode {
     _disjuncts = ImmutableList.copyOf(disjuncts);
   }
 
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitDisjunctionAstNode(this, arg);
+  }
+
   @Nonnull
   @Override
   public BooleanExprAstNode or(BooleanExprAstNode disjunct) {
     return new DisjunctionAstNode(
         ImmutableList.<BooleanExprAstNode>builder().addAll(_disjuncts).add(disjunct).build());
+  }
+
+  public @Nonnull List<BooleanExprAstNode> getDisjuncts() {
+    return _disjuncts;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNode.java
@@ -7,11 +7,24 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a boolean function of the destination port. */
 @ParametersAreNonnullByDefault
-public class DportAstNode extends BooleanExprAstNode {
+public class DportAstNode implements BooleanExprAstNode {
 
   public DportAstNode(ComparatorAstNode comparator, Uint16AstNode value) {
     _comparator = comparator;
     _value = value;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitDportAstNode(this, arg);
+  }
+
+  public @Nonnull ComparatorAstNode getComparator() {
+    return _comparator;
+  }
+
+  public @Nonnull Uint16AstNode getValue() {
+    return _value;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EmptyAstNode.java
@@ -9,10 +9,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * {@code true} in evaluation.
  */
 @ParametersAreNonnullByDefault
-public final class EmptyAstNode extends BooleanExprAstNode {
+public final class EmptyAstNode implements BooleanExprAstNode {
 
   public static @Nonnull EmptyAstNode instance() {
     return INSTANCE;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitEmptyAstNode(this, arg);
   }
 
   private static final EmptyAstNode INSTANCE = new EmptyAstNode();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/EqualsAstNode.java
@@ -12,6 +12,11 @@ public final class EqualsAstNode implements ComparatorAstNode {
     return INSTANCE;
   }
 
+  @Override
+  public <T, U> T accept(ComparatorAstNodeVisitor<T, U> visitor, U value) {
+    return visitor.visitEqualsAstNode(this, value);
+  }
+
   private static final EqualsAstNode INSTANCE = new EqualsAstNode();
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ErrorAstNode.java
@@ -6,10 +6,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} resulting from a failure to parse the match expression. */
 @ParametersAreNonnullByDefault
-public final class ErrorAstNode extends BooleanExprAstNode {
+public final class ErrorAstNode implements BooleanExprAstNode {
 
   public static @Nonnull ErrorAstNode instance() {
     return INSTANCE;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitErrorAstNode(this, arg);
   }
 
   private static final ErrorAstNode INSTANCE = new ErrorAstNode();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanAstNode.java
@@ -12,6 +12,11 @@ public final class GreaterThanAstNode implements ComparatorAstNode {
     return INSTANCE;
   }
 
+  @Override
+  public <T, U> T accept(ComparatorAstNodeVisitor<T, U> visitor, U value) {
+    return visitor.visitGreaterThanAstNode(this, value);
+  }
+
   private static final GreaterThanAstNode INSTANCE = new GreaterThanAstNode();
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/GreaterThanOrEqualsAstNode.java
@@ -12,6 +12,11 @@ public final class GreaterThanOrEqualsAstNode implements ComparatorAstNode {
     return INSTANCE;
   }
 
+  @Override
+  public <T, U> T accept(ComparatorAstNodeVisitor<T, U> visitor, U value) {
+    return visitor.visitGreaterThanOrEqualsAstNode(this, value);
+  }
+
   private static final GreaterThanOrEqualsAstNode INSTANCE = new GreaterThanOrEqualsAstNode();
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
@@ -9,10 +9,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * incoming}.
  */
 @ParametersAreNonnullByDefault
-public final class IncomingAstNode extends BooleanExprAstNode {
+public final class IncomingAstNode implements BooleanExprAstNode {
 
   public static @Nonnull IncomingAstNode instance() {
     return INSTANCE;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitIncomingAstNode(this, arg);
   }
 
   private static final IncomingAstNode INSTANCE = new IncomingAstNode();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanAstNode.java
@@ -12,6 +12,11 @@ public final class LessThanAstNode implements ComparatorAstNode {
     return INSTANCE;
   }
 
+  @Override
+  public <T, U> T accept(ComparatorAstNodeVisitor<T, U> visitor, U value) {
+    return visitor.visitLessThanAstNode(this, value);
+  }
+
   private static final LessThanAstNode INSTANCE = new LessThanAstNode();
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/LessThanOrEqualsAstNode.java
@@ -12,6 +12,11 @@ public final class LessThanOrEqualsAstNode implements ComparatorAstNode {
     return INSTANCE;
   }
 
+  @Override
+  public <T, U> T accept(ComparatorAstNodeVisitor<T, U> visitor, U value) {
+    return visitor.visitLessThanOrEqualsAstNode(this, value);
+  }
+
   private static final LessThanOrEqualsAstNode INSTANCE = new LessThanOrEqualsAstNode();
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
@@ -9,10 +9,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * outgoing}.
  */
 @ParametersAreNonnullByDefault
-public final class OutgoingAstNode extends BooleanExprAstNode {
+public final class OutgoingAstNode implements BooleanExprAstNode {
 
   public static @Nonnull OutgoingAstNode instance() {
     return INSTANCE;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitOutgoingAstNode(this, arg);
   }
 
   private static final OutgoingAstNode INSTANCE = new OutgoingAstNode();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
@@ -6,10 +6,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the condition that the packet protocol is TCP. */
 @ParametersAreNonnullByDefault
-public final class TcpAstNode extends BooleanExprAstNode {
+public final class TcpAstNode implements BooleanExprAstNode {
 
   public static @Nonnull TcpAstNode instance() {
     return INSTANCE;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitTcpAstNode(this, arg);
   }
 
   private static final TcpAstNode INSTANCE = new TcpAstNode();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
@@ -6,10 +6,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the condition that the packet protocol is UDP. */
 @ParametersAreNonnullByDefault
-public final class UdpAstNode extends BooleanExprAstNode {
+public final class UdpAstNode implements BooleanExprAstNode {
 
   public static @Nonnull UdpAstNode instance() {
     return INSTANCE;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitUdpAstNode(this, arg);
   }
 
   private static final UdpAstNode INSTANCE = new UdpAstNode();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNode.java
@@ -10,11 +10,24 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * condition that the protocol is UDP.
  */
 @ParametersAreNonnullByDefault
-public final class UhDportAstNode extends BooleanExprAstNode {
+public final class UhDportAstNode implements BooleanExprAstNode {
 
   public UhDportAstNode(ComparatorAstNode comparator, Uint16AstNode value) {
     _comparator = comparator;
     _value = value;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitUhDportAstNode(this, arg);
+  }
+
+  public @Nonnull ComparatorAstNode getComparator() {
+    return _comparator;
+  }
+
+  public @Nonnull Uint16AstNode getValue() {
+    return _value;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/Uint16AstNode.java
@@ -2,12 +2,17 @@ package org.batfish.vendor.check_point_management.parsing.parboiled;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a 16-bit unsigned integer. */
 @ParametersAreNonnullByDefault
 public final class Uint16AstNode implements AstNode {
+
+  public int getValue() {
+    return _value;
+  }
 
   @Override
   public boolean equals(@Nullable Object o) {
@@ -29,7 +34,8 @@ public final class Uint16AstNode implements AstNode {
     return of(Integer.parseInt(valueStr));
   }
 
-  static Uint16AstNode of(int value) {
+  @VisibleForTesting
+  public static Uint16AstNode of(int value) {
     checkArgument(0 <= value && value <= 0xFFFF, "Invalid unsigned 16-bit integer: %s", value);
     return new Uint16AstNode(value);
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
@@ -11,10 +11,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * be evaluated as {@code true} or {@code false} depending on context.
  */
 @ParametersAreNonnullByDefault
-public final class UnhandledAstNode extends BooleanExprAstNode {
+public final class UnhandledAstNode implements BooleanExprAstNode {
 
   public @Nonnull String getUnhandledText() {
     return _unhandledText;
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
+    return visitor.visitUnhandledAstNode(this, arg);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
@@ -547,7 +547,6 @@ public final class CheckPointGatewayConversionsTest {
 
   @Test
   public void testServicesToMatchExprOnlyUnknown() {
-    // TODO: rewrite
     // If the only service(s) are unknown/unhandled, then the rule shouldn't match
     assertThat(
         _tb.toBDD(
@@ -607,7 +606,7 @@ public final class CheckPointGatewayConversionsTest {
       assertBddsEqual(
           toAclLine(rule, TEST_OBJS, _serviceToMatchExpr, _addressSpaceToMatchExpr, new Warnings())
               .get(),
-          matchIpProtocol(1));
+          matchIpProtocol(SERVICE_OTHER_UNHANDLED.getIpProtocol()));
     }
     {
       AccessRule rule =

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConversionsTest.java
@@ -2,11 +2,14 @@ package org.batfish.vendor.check_point_gateway.representation;
 
 import static org.batfish.common.matchers.WarningMatchers.hasText;
 import static org.batfish.common.matchers.WarningsMatchers.hasRedFlags;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIpProtocol;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.accepts;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.aclName;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.checkValidHeaderSpaceInputs;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.servicesToMatchExpr;
+import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toAclLine;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toAction;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toAddressMatchExpr;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toIpAccessLists;
@@ -25,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
 import org.batfish.common.Warnings;
+import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.BddTestbed;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
@@ -53,6 +57,7 @@ import org.batfish.vendor.check_point_management.Network;
 import org.batfish.vendor.check_point_management.PolicyTargets;
 import org.batfish.vendor.check_point_management.RulebaseAction;
 import org.batfish.vendor.check_point_management.ServiceIcmp;
+import org.batfish.vendor.check_point_management.ServiceOther;
 import org.batfish.vendor.check_point_management.ServiceTcp;
 import org.batfish.vendor.check_point_management.ServiceToMatchExpr;
 import org.batfish.vendor.check_point_management.ServiceUdp;
@@ -75,12 +80,15 @@ public final class CheckPointGatewayConversionsTest {
   private static final Uid UID_UDP = Uid.of("16");
   private static final Uid UID_ICMP = Uid.of("17");
   private static final Uid UID_ICMP_NO_CODE = Uid.of("18");
+  private static final Uid UID_SERVICE_OTHER_UNHANDLED = Uid.of("19");
   private static final ServiceTcp SERVICE_TCP_RANGES =
       new ServiceTcp("tcp_ranges", "1-100,105-106", UID_TCP_RANGES);
   private static final ServiceUdp SERVICE_UDP = new ServiceUdp("udp", "1234", UID_UDP);
   private static final ServiceIcmp SERVICE_ICMP = new ServiceIcmp("icmp", 8, 3, UID_ICMP);
   private static final ServiceIcmp SERVICE_ICMP_NO_CODE =
       new ServiceIcmp("icmpNoCode", 8, null, UID_ICMP_NO_CODE);
+  private static final ServiceOther SERVICE_OTHER_UNHANDLED =
+      ServiceOther.of("serviceOtherUnhandled", 1, "unhandled", UID_SERVICE_OTHER_UNHANDLED);
   private static final Network NETWORK_0 =
       new Network(
           "net0",
@@ -113,6 +121,7 @@ public final class CheckPointGatewayConversionsTest {
           .put(UID_DROP, new RulebaseAction("Drop", UID_DROP, "Drop"))
           .put(UID_SERVICE_TCP_22, new ServiceTcp("service_tcp_22", "22", UID_SERVICE_TCP_22))
           .put(UID_SERVICE_UDP_222, new ServiceUdp("service_udp_222", "222", UID_SERVICE_UDP_222))
+          .put(UID_SERVICE_OTHER_UNHANDLED, SERVICE_OTHER_UNHANDLED)
           .put(UID_TCP_RANGES, SERVICE_TCP_RANGES)
           .put(UID_UDP, SERVICE_UDP)
           .put(UID_ICMP, SERVICE_ICMP)
@@ -278,6 +287,7 @@ public final class CheckPointGatewayConversionsTest {
             TEST_OBJS,
             _serviceToMatchExpr,
             _addressSpaceToMatchExpr,
+            true,
             w);
     assertThat(
         _tb.toBDD(matches),
@@ -301,6 +311,7 @@ public final class CheckPointGatewayConversionsTest {
             TEST_OBJS,
             _serviceToMatchExpr,
             _addressSpaceToMatchExpr,
+            true,
             w);
     assertThat(
         _tb.toBDD(negatedMatches),
@@ -321,6 +332,7 @@ public final class CheckPointGatewayConversionsTest {
             TEST_OBJS,
             _serviceToMatchExpr,
             _addressSpaceToMatchExpr,
+            true,
             w);
     assertThat(_tb.toBDD(mutliSvc), equalTo(_tb.toBDD(matchSvc).or(_tb.toBDD(matchUdpSvc))));
   }
@@ -512,7 +524,11 @@ public final class CheckPointGatewayConversionsTest {
     assertThat(
         _tb.toBDD(
             servicesToMatchExpr(
-                ImmutableList.of(UID_SERVICE_TCP_22, UID_NET0), TEST_OBJS, _serviceToMatchExpr, w)),
+                ImmutableList.of(UID_SERVICE_TCP_22, UID_NET0),
+                TEST_OBJS,
+                _serviceToMatchExpr,
+                true,
+                w)),
         equalTo(
             _tb.toBDD(
                 AclLineMatchExprs.match(
@@ -531,11 +547,12 @@ public final class CheckPointGatewayConversionsTest {
 
   @Test
   public void testServicesToMatchExprOnlyUnknown() {
+    // TODO: rewrite
     // If the only service(s) are unknown/unhandled, then the rule shouldn't match
     assertThat(
         _tb.toBDD(
             servicesToMatchExpr(
-                ImmutableList.of(UID_NET0), TEST_OBJS, _serviceToMatchExpr, new Warnings())),
+                ImmutableList.of(UID_NET0), TEST_OBJS, _serviceToMatchExpr, true, new Warnings())),
         equalTo(_tb.toBDD(FalseExpr.INSTANCE)));
   }
 
@@ -560,5 +577,56 @@ public final class CheckPointGatewayConversionsTest {
     assertThat(aclName(unnamed), containsString(uid.getValue()));
     assertThat(aclName(named), containsString(uid.getValue()));
     assertThat(aclName(named), containsString(name));
+  }
+
+  @Test
+  public void testToAclLine() {
+    {
+      AccessRule rule =
+          AccessRule.testBuilder(UID_CPMI_ANY)
+              .setUid(Uid.of("10"))
+              .setAction(UID_ACCEPT)
+              .setEnabled(false)
+              .setName("foo")
+              .build();
+      // disabled rule should yield empty result
+      assertThat(
+          toAclLine(rule, TEST_OBJS, _serviceToMatchExpr, _addressSpaceToMatchExpr, new Warnings()),
+          equalTo(Optional.empty()));
+    }
+    {
+      AccessRule rule =
+          AccessRule.testBuilder(UID_CPMI_ANY)
+              .setUid(Uid.of("10"))
+              .setAction(UID_ACCEPT)
+              .setEnabled(true)
+              .setName("foo")
+              .setService(ImmutableList.of(UID_SERVICE_OTHER_UNHANDLED))
+              .build();
+      // unhandled in ACCEPT context is translated to TRUE
+      assertBddsEqual(
+          toAclLine(rule, TEST_OBJS, _serviceToMatchExpr, _addressSpaceToMatchExpr, new Warnings())
+              .get(),
+          matchIpProtocol(1));
+    }
+    {
+      AccessRule rule =
+          AccessRule.testBuilder(UID_CPMI_ANY)
+              .setUid(Uid.of("10"))
+              .setAction(UID_DROP)
+              .setEnabled(true)
+              .setName("foo")
+              .setService(ImmutableList.of(UID_SERVICE_OTHER_UNHANDLED))
+              .build();
+      // unhandled in DROP context is translated to FALSE
+      assertBddsEqual(
+          toAclLine(rule, TEST_OBJS, _serviceToMatchExpr, _addressSpaceToMatchExpr, new Warnings())
+              .get(),
+          FALSE);
+    }
+  }
+
+  private void assertBddsEqual(AclLine left, AclLineMatchExpr right) {
+    assertThat(_tb.toBDD(left), equalTo(_tb.toBDD(right)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExprTest.java
@@ -1,0 +1,195 @@
+package org.batfish.vendor.check_point_management;
+
+import static org.batfish.datamodel.IntegerSpace.PORTS;
+import static org.batfish.datamodel.IpProtocol.TCP;
+import static org.batfish.datamodel.IpProtocol.UDP;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstPort;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIpProtocol;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.batfish.datamodel.applications.PortsApplication.MAX_PORT_NUMBER;
+import static org.batfish.vendor.check_point_management.BooleanExprAstNodeToAclLineMatchExpr.convert;
+import static org.batfish.vendor.check_point_management.BooleanExprAstNodeToAclLineMatchExpr.portRangeToIntegerSpace;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Range;
+import org.batfish.datamodel.BddTestbed;
+import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.vendor.check_point_management.parsing.parboiled.ConjunctionAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.DisjunctionAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.DportAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.EmptyAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.EqualsAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.ErrorAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.GreaterThanAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.GreaterThanOrEqualsAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.IncomingAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.LessThanAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.LessThanOrEqualsAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.OutgoingAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.TcpAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.UdpAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.UhDportAstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.Uint16AstNode;
+import org.batfish.vendor.check_point_management.parsing.parboiled.UnhandledAstNode;
+import org.junit.Test;
+
+/** Test of {@link BooleanExprAstNodeToAclLineMatchExpr}. */
+public final class BooleanExprAstNodeToAclLineMatchExprTest {
+
+  private final BddTestbed _tb = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
+
+  private void assertBddsEqual(AclLineMatchExpr left, AclLineMatchExpr right) {
+    assertThat(_tb.toBDD(left), equalTo(_tb.toBDD(right)));
+  }
+
+  @Test
+  public void testConvertConjunction() {
+    assertBddsEqual(convert(new ConjunctionAstNode(), true), TRUE);
+    assertBddsEqual(convert(new ConjunctionAstNode(UnhandledAstNode.of("foo")), true), TRUE);
+    assertBddsEqual(convert(new ConjunctionAstNode(UnhandledAstNode.of("foo")), false), FALSE);
+    assertBddsEqual(
+        convert(
+            new ConjunctionAstNode(
+                UdpAstNode.instance(),
+                new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1))),
+            false),
+        and(matchIpProtocol(UDP), matchDstPort(1)));
+  }
+
+  @Test
+  public void testConvertDisjunction() {
+    assertBddsEqual(convert(new DisjunctionAstNode(), true), FALSE);
+    assertBddsEqual(convert(new DisjunctionAstNode(UnhandledAstNode.of("foo")), true), TRUE);
+    assertBddsEqual(convert(new DisjunctionAstNode(UnhandledAstNode.of("foo")), false), FALSE);
+    assertBddsEqual(
+        convert(
+            new DisjunctionAstNode(
+                UdpAstNode.instance(),
+                new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1))),
+            true),
+        or(matchIpProtocol(UDP), matchDstPort(1)));
+  }
+
+  @Test
+  public void testConvertDport() {
+    assertBddsEqual(
+        convert(new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)), true),
+        matchDstPort(1));
+    assertBddsEqual(
+        convert(new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)), false),
+        matchDstPort(1));
+  }
+
+  @Test
+  public void testConvertEmpty() {
+    assertBddsEqual(convert(EmptyAstNode.instance(), true), TRUE);
+    assertBddsEqual(convert(EmptyAstNode.instance(), false), TRUE);
+  }
+
+  @Test
+  public void testConvertError() {
+    assertBddsEqual(convert(ErrorAstNode.instance(), true), FALSE);
+    assertBddsEqual(convert(ErrorAstNode.instance(), false), FALSE);
+  }
+
+  @Test
+  public void testConvertIncoming() {
+    // TODO: support direction
+    assertBddsEqual(convert(IncomingAstNode.instance(), true), TRUE);
+    assertBddsEqual(convert(IncomingAstNode.instance(), false), FALSE);
+  }
+
+  @Test
+  public void testConvertOutgoing() {
+    // TODO: support direction
+    assertBddsEqual(convert(OutgoingAstNode.instance(), true), TRUE);
+    assertBddsEqual(convert(OutgoingAstNode.instance(), false), FALSE);
+  }
+
+  @Test
+  public void testConvertTcp() {
+    assertBddsEqual(convert(TcpAstNode.instance(), true), matchIpProtocol(TCP));
+    assertBddsEqual(convert(TcpAstNode.instance(), false), matchIpProtocol(TCP));
+  }
+
+  @Test
+  public void testConvertUdp() {
+    assertBddsEqual(convert(UdpAstNode.instance(), true), matchIpProtocol(UDP));
+    assertBddsEqual(convert(UdpAstNode.instance(), false), matchIpProtocol(UDP));
+  }
+
+  @Test
+  public void testConvertUhDport() {
+    assertBddsEqual(
+        convert(new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)), true),
+        and(matchIpProtocol(UDP), matchDstPort(1)));
+    assertBddsEqual(
+        convert(new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)), false),
+        and(matchIpProtocol(UDP), matchDstPort(1)));
+  }
+
+  @Test
+  public void testConvertUnhandled() {
+    assertBddsEqual(convert(UnhandledAstNode.of("foo"), true), TRUE);
+    assertBddsEqual(convert(UnhandledAstNode.of("foo"), false), FALSE);
+  }
+
+  @Test
+  public void testPortRangeToIntegerSpaceEquals() {
+    assertThat(portRangeToIntegerSpace(EqualsAstNode.instance(), 5), equalTo(IntegerSpace.of(5)));
+    assertThat(portRangeToIntegerSpace(EqualsAstNode.instance(), -5), equalTo(IntegerSpace.EMPTY));
+    assertThat(
+        portRangeToIntegerSpace(EqualsAstNode.instance(), 100000), equalTo(IntegerSpace.EMPTY));
+  }
+
+  @Test
+  public void testPortRangeToIntegerSpaceGreaterThan() {
+    assertThat(
+        portRangeToIntegerSpace(GreaterThanAstNode.instance(), 5),
+        equalTo(IntegerSpace.of(Range.closed(6, MAX_PORT_NUMBER))));
+    assertThat(
+        portRangeToIntegerSpace(GreaterThanAstNode.instance(), 100000),
+        equalTo(IntegerSpace.EMPTY));
+    assertThat(
+        portRangeToIntegerSpace(GreaterThanAstNode.instance(), -5),
+        equalTo(IntegerSpace.of(Range.closed(0, MAX_PORT_NUMBER))));
+  }
+
+  @Test
+  public void testPortRangeToIntegerSpaceGreaterThanOrEquals() {
+    assertThat(
+        portRangeToIntegerSpace(GreaterThanOrEqualsAstNode.instance(), 5),
+        equalTo(IntegerSpace.of(Range.closed(5, MAX_PORT_NUMBER))));
+    assertThat(
+        portRangeToIntegerSpace(GreaterThanOrEqualsAstNode.instance(), 100000),
+        equalTo(IntegerSpace.EMPTY));
+    assertThat(portRangeToIntegerSpace(GreaterThanOrEqualsAstNode.instance(), -5), equalTo(PORTS));
+  }
+
+  @Test
+  public void testPortRangeToIntegerSpaceLessThan() {
+    assertThat(
+        portRangeToIntegerSpace(LessThanAstNode.instance(), 5),
+        equalTo(IntegerSpace.of(Range.closed(0, 4))));
+    assertThat(portRangeToIntegerSpace(LessThanAstNode.instance(), 100000), equalTo(PORTS));
+    assertThat(
+        portRangeToIntegerSpace(LessThanAstNode.instance(), -5), equalTo(IntegerSpace.EMPTY));
+  }
+
+  @Test
+  public void testPortRangeToIntegerSpaceLessThanOrEquals() {
+    assertThat(
+        portRangeToIntegerSpace(LessThanOrEqualsAstNode.instance(), 5),
+        equalTo(IntegerSpace.of(Range.closed(0, 5))));
+    assertThat(portRangeToIntegerSpace(LessThanOrEqualsAstNode.instance(), 100000), equalTo(PORTS));
+    assertThat(
+        portRangeToIntegerSpace(LessThanOrEqualsAstNode.instance(), -5),
+        equalTo(IntegerSpace.EMPTY));
+  }
+}


### PR DESCRIPTION
- compile service-other match ASTs into `AclLineMatchExpr`s
- for access-rules:
  - treat unhandled as true when action is ACCEPT
  - treat unhandled as false when action is DROP
- for nat-rules, treat unhandled as true
- follow-on work:
  - detailed tracing for service-other
  - support matching direction