### PR TITLE
Tweak redflag APIs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -134,15 +134,11 @@ public class Warnings implements Serializable {
     _pedanticWarnings.add(new Warning(msg, tag));
   }
 
-  public void redFlag(String msg) {
-    redFlag(msg, TAG_RED_FLAG);
-  }
-
-  public void redFlag(String msg, String tag) {
+  public void redFlag(String format, Object... args) {
     if (!_redFlagRecord) {
       return;
     }
-    _redFlagWarnings.add(new Warning(msg, tag));
+    _redFlagWarnings.add(new Warning(String.format(format, args), TAG_RED_FLAG));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -134,11 +134,11 @@ public class Warnings implements Serializable {
     _pedanticWarnings.add(new Warning(msg, tag));
   }
 
-  public void redFlag(String format, Object... args) {
+  public void redFlag(String msg) {
     if (!_redFlagRecord) {
       return;
     }
-    _redFlagWarnings.add(new Warning(String.format(format, args), TAG_RED_FLAG));
+    _redFlagWarnings.add(new Warning(msg, TAG_RED_FLAG));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/WarningsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/WarningsTest.java
@@ -1,5 +1,6 @@
 package org.batfish.common;
 
+import static org.batfish.common.Warnings.TAG_RED_FLAG;
 import static org.batfish.common.Warnings.TAG_UNIMPLEMENTED;
 import static org.batfish.common.matchers.WarningsMatchers.hasPedanticWarnings;
 import static org.batfish.common.matchers.WarningsMatchers.hasRedFlags;
@@ -17,19 +18,19 @@ public class WarningsTest {
     Warnings ws = new Warnings(true, true, true);
     String message1 = "message1";
     String message2 = "message2";
-    String tag1 = "tag1";
-    String tag2 = "tag2";
 
     // Add one warning twice and another once
-    ws.redFlag(message1, tag1);
-    ws.redFlag(message2, tag2);
-    ws.redFlag(message1, tag1);
+    ws.redFlag(message1);
+    ws.redFlag(message2);
+    ws.redFlag(message1);
 
     // Only unique warnings should show up
     assertThat(
         ws,
         hasRedFlags(
-            contains(equalTo(new Warning(message1, tag1)), equalTo(new Warning(message2, tag2)))));
+            contains(
+                equalTo(new Warning(message1, TAG_RED_FLAG)),
+                equalTo(new Warning(message2, TAG_RED_FLAG)))));
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -518,7 +518,7 @@ public class F5BigipConfiguration extends VendorConfiguration {
       return Optional.empty();
     }
     if (snat.getIpv4Origins().isEmpty()) {
-      _w.redFlag("Cannot SNAT for snat '%s' without origins", snat.getName());
+      _w.redFlag(String.format("Cannot SNAT for snat '%s' without origins", snat.getName()));
       return Optional.empty();
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2361,7 +2361,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     }
 
     if (peer.getPeerAddress() == null) {
-      _w.redFlag("Missing peer-address for peer %s; disabling it", peer.getName());
+      _w.redFlag(String.format("Missing peer-address for peer %s; disabling it", peer.getName()));
       return;
     }
 


### PR DESCRIPTION
Makes it slightly easier to use redFlag. 

The method with the tag removed in this PR was being used only in two places, and incorrectly in both (as `(format, args)` instead of `(msg, tag)`). 