### PR TITLE
RangesIpSpace: an IpSpace implementation suitable for IP address ranges

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractIpSpaceContainsIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractIpSpaceContainsIp.java
@@ -59,6 +59,11 @@ public abstract class AbstractIpSpaceContainsIp implements GenericIpSpaceVisitor
   }
 
   @Override
+  public final Boolean visitRangesIpSpace(RangesIpSpace rangesIpSpace) {
+    return rangesIpSpace.containsIp(_ip);
+  }
+
+  @Override
   public final Boolean visitUniverseIpSpace(UniverseIpSpace universeIpSpace) {
     return true;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
@@ -24,7 +24,7 @@ import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
  * An ACL-based {@link IpSpace}. An IP is permitted if it is in the space the ACL represents, or
  * denied if it is not.
  */
-public class AclIpSpace extends IpSpace {
+public final class AclIpSpace extends IpSpace {
 
   public static class Builder {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIpSpace.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.ObjectStreamException;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
-public class EmptyIpSpace extends IpSpace {
+public final class EmptyIpSpace extends IpSpace {
 
   public static final EmptyIpSpace INSTANCE = new EmptyIpSpace();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpIpSpace.java
@@ -9,7 +9,7 @@ import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
-public class IpIpSpace extends IpSpace {
+public final class IpIpSpace extends IpSpace {
   // Soft values: let it be garbage collected in times of pressure.
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   //   (12 bytes seems smallest possible entry (long + int), would be 12 MiB total).

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpaceReference.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpaceReference.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
-public class IpSpaceReference extends IpSpace {
+public final class IpSpaceReference extends IpSpace {
   private static final String PROP_DESCRIPTION = "description";
   private static final String PROP_NAME = "name";
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardIpSpace.java
@@ -9,7 +9,7 @@ import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
-public class IpWildcardIpSpace extends IpSpace {
+public final class IpWildcardIpSpace extends IpSpace {
   // Soft values: let it be garbage collected in times of pressure.
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   //   (12 bytes seems smallest possible entry (long + int), would be 12 MiB total).

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RangesIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RangesIpSpace.java
@@ -1,0 +1,153 @@
+package org.batfish.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Range;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
+
+/**
+ * An {@link IpSpace} that is a set of ranges of IP addresses. Suitable for collections of {@link
+ * Ip}, {@link Prefix}, and/or ranges of {@link Ip} addresses (e.g., as in {@link
+ * org.batfish.datamodel.transformation.AssignIpAddressFromPool}).
+ */
+public final class RangesIpSpace extends IpSpace {
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public boolean containsIp(Ip ip) {
+    return _space.contains(ip.asLong());
+  }
+
+  @Override
+  public @Nonnull IpSpace complement() {
+    if (isEmpty()) {
+      return UniverseIpSpace.INSTANCE;
+    }
+    LongSpace complement = LongSpace.builder().including(ALL).excluding(_space).build();
+    return create(complement);
+  }
+
+  public static @Nonnull RangesIpSpace empty() {
+    return EMPTY;
+  }
+
+  @JsonProperty(PROP_SPACE)
+  public LongSpace getSpace() {
+    return _space;
+  }
+
+  @JsonIgnore
+  public boolean isEmpty() {
+    return _space.isEmpty();
+  }
+
+  public static @Nonnull RangesIpSpace union(RangesIpSpace left, RangesIpSpace right) {
+    return RangesIpSpace.create(
+        LongSpace.builder().including(left._space).including(right._space).build());
+  }
+
+  public static class Builder {
+    private final @Nonnull LongSpace.Builder _builder;
+
+    private Builder() {
+      _builder = LongSpace.builder();
+    }
+
+    public Builder excluding(Ip ip) {
+      _builder.excluding(ip.asLong());
+      return this;
+    }
+
+    public Builder excluding(Prefix prefix) {
+      _builder.excluding(prefixRange(prefix));
+      return this;
+    }
+
+    public Builder excluding(RangesIpSpace space) {
+      _builder.excluding(space._space);
+      return this;
+    }
+
+    public Builder including(Ip ip) {
+      _builder.including(ip.asLong());
+      return this;
+    }
+
+    public Builder including(Prefix prefix) {
+      _builder.including(prefixRange(prefix));
+      return this;
+    }
+
+    public Builder including(RangesIpSpace space) {
+      _builder.including(space._space);
+      return this;
+    }
+
+    public RangesIpSpace build() {
+      return create(_builder.build());
+    }
+  }
+
+  // Internal impl details
+
+  @JsonCreator
+  @VisibleForTesting
+  static RangesIpSpace create(@JsonProperty(PROP_SPACE) LongSpace space) {
+    return new RangesIpSpace(space);
+  }
+
+  private RangesIpSpace(LongSpace space) {
+    _space = space;
+  }
+
+  @Override
+  public <R> R accept(GenericIpSpaceVisitor<R> visitor) {
+    return visitor.visitRangesIpSpace(this);
+  }
+
+  @Override
+  protected int compareSameClass(IpSpace o) {
+    RangesIpSpace other = (RangesIpSpace) o;
+    if (_space.equals(other._space)) {
+      return 0;
+    }
+    LongSpace onlyThis = LongSpace.builder().including(_space).excluding(other._space).build();
+    if (onlyThis.isEmpty()) {
+      return -1;
+    }
+    LongSpace onlyOther = LongSpace.builder().including(other._space).excluding(_space).build();
+    if (onlyOther.isEmpty()) {
+      return 1;
+    }
+    return onlyThis.least().compareTo(onlyOther.least());
+  }
+
+  private static Range<Long> prefixRange(Prefix p) {
+    return Range.closed(p.getStartIp().asLong(), p.getEndIp().asLong());
+  }
+
+  @Override
+  protected boolean exprEquals(Object o) {
+    return _space.equals(((RangesIpSpace) o)._space);
+  }
+
+  @Override
+  public int hashCode() {
+    return _space.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(getClass()).add(PROP_SPACE, _space).toString();
+  }
+
+  private static final String PROP_SPACE = "space";
+  private final LongSpace _space;
+  private static final Range<Long> ALL = prefixRange(Prefix.ZERO);
+  private static final RangesIpSpace EMPTY = create(LongSpace.EMPTY);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UniverseIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UniverseIpSpace.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.ObjectStreamException;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
-public class UniverseIpSpace extends IpSpace {
+public final class UniverseIpSpace extends IpSpace {
 
   public static final UniverseIpSpace INSTANCE = new UniverseIpSpace();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/GenericIpSpaceVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/GenericIpSpaceVisitor.java
@@ -8,6 +8,7 @@ import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.PrefixIpSpace;
+import org.batfish.datamodel.RangesIpSpace;
 import org.batfish.datamodel.UniverseIpSpace;
 
 public interface GenericIpSpaceVisitor<R> {
@@ -29,6 +30,8 @@ public interface GenericIpSpaceVisitor<R> {
   R visitIpWildcardSetIpSpace(IpWildcardSetIpSpace ipWildcardSetIpSpace);
 
   R visitPrefixIpSpace(PrefixIpSpace prefixIpSpace);
+
+  R visitRangesIpSpace(RangesIpSpace rangesIpSpace);
 
   R visitUniverseIpSpace(UniverseIpSpace universeIpSpace);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceDereferencer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceDereferencer.java
@@ -13,6 +13,7 @@ import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.PrefixIpSpace;
+import org.batfish.datamodel.RangesIpSpace;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.CircularReferenceException;
 import org.batfish.datamodel.acl.UndefinedReferenceException;
@@ -145,6 +146,11 @@ public class IpSpaceDereferencer implements GenericIpSpaceVisitor<IpSpace> {
   @Override
   public IpSpace visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
     return prefixIpSpace;
+  }
+
+  @Override
+  public IpSpace visitRangesIpSpace(RangesIpSpace rangesIpSpace) {
+    return rangesIpSpace;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceRenamer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceRenamer.java
@@ -10,6 +10,7 @@ import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.PrefixIpSpace;
+import org.batfish.datamodel.RangesIpSpace;
 import org.batfish.datamodel.UniverseIpSpace;
 
 /**
@@ -61,6 +62,11 @@ public class IpSpaceRenamer implements Function<IpSpace, IpSpace> {
     @Override
     public IpSpace visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
       return prefixIpSpace;
+    }
+
+    @Override
+    public IpSpace visitRangesIpSpace(RangesIpSpace rangesIpSpace) {
+      return rangesIpSpace;
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/IpSpaceToBDDTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/IpSpaceToBDDTest.java
@@ -1,5 +1,7 @@
 package org.batfish.common.bdd;
 
+import static org.batfish.common.bdd.BDDMatchers.isOne;
+import static org.batfish.common.bdd.BDDMatchers.isZero;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -19,6 +21,7 @@ import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RangesIpSpace;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -143,6 +146,20 @@ public class IpSpaceToBDDTest {
     BDD ipBDD = ip.toIpSpace().accept(ipSpaceToBDD);
     BDD referenceBDD = reference.accept(ipSpaceToBDD);
     assertThat(referenceBDD, equalTo(ipBDD));
+  }
+
+  @Test
+  public void testRangesIpSpace() {
+    Ip ip = Ip.parse("1.2.3.4");
+    Prefix prefix = Prefix.parse("2.0.0.0/8");
+    RangesIpSpace space = RangesIpSpace.builder().including(ip).including(prefix).build();
+    IpSpaceToBDD ipSpaceToBDD = new IpSpaceToBDD(_ipAddrBdd);
+    BDD spaceBDD = ipSpaceToBDD.visit(space);
+    BDD equivalentBDD = ipSpaceToBDD.toBDD(ip).or(ipSpaceToBDD.toBDD(prefix));
+    assertThat(spaceBDD, equalTo(equivalentBDD));
+
+    assertThat(ipSpaceToBDD.visit(RangesIpSpace.empty()), isZero());
+    assertThat(ipSpaceToBDD.visit(RangesIpSpace.builder().including(Prefix.ZERO).build()), isOne());
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AbstractIpSpaceContainsIpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AbstractIpSpaceContainsIpTest.java
@@ -64,6 +64,13 @@ public class AbstractIpSpaceContainsIpTest {
   }
 
   @Test
+  public void testVisitRangesIpSpace() {
+    RangesIpSpace ipSpace = RangesIpSpace.builder().including(IP1).build();
+    assertTrue(containsIp(IP1).visitRangesIpSpace(ipSpace));
+    assertFalse(containsIp(IP2).visitRangesIpSpace(ipSpace));
+  }
+
+  @Test
   public void visitUniverseIpSpace() {
     assertTrue(containsIp(IP1).visitUniverseIpSpace(UniverseIpSpace.INSTANCE));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RangesIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RangesIpSpaceTest.java
@@ -1,0 +1,149 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.google.common.testing.EqualsTester;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class RangesIpSpaceTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            RangesIpSpace.create(LongSpace.of(5)), RangesIpSpace.create(LongSpace.of(5)))
+        .addEqualityGroup(RangesIpSpace.create(LongSpace.of(6)))
+        .testEquals();
+  }
+
+  @Test
+  public void testIsEmpty() {
+    assertTrue(RangesIpSpace.empty().isEmpty());
+
+    RangesIpSpace space =
+        RangesIpSpace.builder()
+            .including(Prefix.parse("10.0.0.0/8"))
+            .excluding(Prefix.parse("10.0.0.0/24"))
+            .build();
+    assertFalse(space.isEmpty());
+  }
+
+  @Test
+  public void testComplement() {
+    assertThat(RangesIpSpace.empty().complement(), equalTo(UniverseIpSpace.INSTANCE));
+
+    // make a partial space, check one in and on out
+    RangesIpSpace space =
+        RangesIpSpace.builder()
+            .including(Prefix.parse("10.0.0.0/8"))
+            .excluding(Prefix.parse("10.0.0.0/24"))
+            .build();
+    assertFalse(space.containsIp(Ip.parse("10.0.0.1")));
+    assertTrue(space.containsIp(Ip.parse("10.0.1.1")));
+
+    // Complement is a RangesIpSpace with opposite containment
+    IpSpace complement = space.complement();
+    assertThat(complement, instanceOf(RangesIpSpace.class));
+    RangesIpSpace complementRange = (RangesIpSpace) complement;
+    assertTrue(complementRange.containsIp(Ip.parse("10.0.0.1")));
+    assertFalse(complementRange.containsIp(Ip.parse("10.0.1.1")));
+
+    // space union complement is everything.
+    assertThat(
+        RangesIpSpace.union(space, complementRange),
+        equalTo(RangesIpSpace.builder().including(Prefix.ZERO).build()));
+
+    // complement twice is equal to space
+    assertThat(complementRange.complement(), equalTo(space));
+  }
+
+  @Test
+  public void testContainsIp() {
+    RangesIpSpace space =
+        RangesIpSpace.builder()
+            .including(Prefix.parse("1.0.0.0/24"))
+            .including(Ip.parse("2.1.2.3"))
+            .build();
+    assertFalse(space.containsIp(Ip.ZERO));
+    assertFalse(space.containsIp(Ip.MAX));
+
+    assertFalse(space.containsIp(Ip.parse("0.255.255.255")));
+    assertTrue(space.containsIp(Ip.parse("1.0.0.0")));
+    assertTrue(space.containsIp(Ip.parse("1.0.0.128")));
+    assertTrue(space.containsIp(Ip.parse("1.0.0.255")));
+    assertFalse(space.containsIp(Ip.parse("1.0.1.0")));
+
+    assertFalse(space.containsIp(Ip.parse("2.1.2.2")));
+    assertTrue(space.containsIp(Ip.parse("2.1.2.3")));
+    assertFalse(space.containsIp(Ip.parse("2.1.2.4")));
+  }
+
+  @Test
+  public void testBuilding() {
+    // Include and exclude same type give empty
+    RangesIpSpace ip3 = RangesIpSpace.builder().including(Prefix.parse("3.0.0.0/8")).build();
+    assertTrue(
+        RangesIpSpace.builder()
+            .including(Ip.parse("1.2.3.4"))
+            .excluding(Ip.parse("1.2.3.4"))
+            .including(Prefix.parse("2.0.0.0/8"))
+            .excluding(Prefix.parse("2.0.0.0/8"))
+            .including(ip3)
+            .excluding(ip3)
+            .build()
+            .isEmpty());
+
+    RangesIpSpace space =
+        RangesIpSpace.builder()
+            .including(Prefix.parse("1.2.3.0/24"))
+            .excluding(Ip.parse("1.2.3.4"))
+            .including(Prefix.parse("2.0.0.0/24"))
+            .excluding(Prefix.parse("2.0.0.0/8"))
+            .build();
+    assertThat(
+        space.getSpace(),
+        equalTo(
+            LongSpace.builder()
+                .including(Range.closed(Ip.parse("1.2.3.0").asLong(), Ip.parse("1.2.3.3").asLong()))
+                .including(
+                    Range.closed(Ip.parse("1.2.3.5").asLong(), Ip.parse("1.2.3.255").asLong()))
+                .build()));
+  }
+
+  @Test
+  public void testSerialization() {
+    RangesIpSpace space =
+        RangesIpSpace.builder()
+            .including(Prefix.parse("10.0.0.0/8"))
+            .excluding(Prefix.parse("10.0.0.0/24"))
+            .build();
+    assertThat(BatfishObjectMapper.clone(space, IpSpace.class), equalTo(space));
+    assertThat(SerializationUtils.clone(space), equalTo(space));
+  }
+
+  @Test
+  public void testSorting() {
+    List<RangesIpSpace> space =
+        ImmutableList.of(
+            RangesIpSpace.empty(),
+            RangesIpSpace.builder().including(Ip.parse("1.2.3.4")).build(),
+            RangesIpSpace.builder().including(Ip.parse("1.2.3.4")).build(),
+            RangesIpSpace.builder().including(Ip.parse("1.2.3.5")).build(),
+            RangesIpSpace.builder().including(Prefix.parse("2.0.0.0/24")).build(),
+            RangesIpSpace.builder().including(Ip.parse("2.0.0.1")).build(),
+            RangesIpSpace.builder().including(Prefix.parse("0.0.0.0/3")).build());
+    assertThat(
+        space.stream().sorted().collect(Collectors.toList()),
+        equalTo(Lists.reverse(space).stream().sorted().collect(Collectors.toList())));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -47,6 +47,7 @@ import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.Mlag;
 import org.batfish.datamodel.PrefixIpSpace;
+import org.batfish.datamodel.RangesIpSpace;
 import org.batfish.datamodel.Route6FilterList;
 import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.SwitchportMode;
@@ -281,6 +282,11 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
 
     @Override
     public Void visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
+      return null;
+    }
+
+    @Override
+    public Void visitRangesIpSpace(RangesIpSpace rangesIpSpace) {
       return null;
     }
 


### PR DESCRIPTION
There are a number of places within Batfish where we need an IpSpace
corresponding to a set of IP addresses, a set of Prefixes, a set of Ranges, or
a combination of the above.

Today, we have two strategies for this: IpWildcardSetIpSpace or AclIpSpace.
Both of these are memory-intensive, encoding-intensive, and have O(n)
membership checks. Instead, introduce an IpSpace backed by a LongSpace. The
resulting structure merges contiguous ranges, stores them efficiently in a
a RangeSet, and provides logarithmic lookup of an IP address.

Not connected anywhere yet.