### PR TITLE
IpWildcardSetIpSpace: improve efficiency

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IpsecUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IpsecUtil.java
@@ -506,8 +506,7 @@ public class IpsecUtil {
           nonNattedInterfaceAddresses.stream()
               .map(address -> IpWildcard.create(address.getPrefix()))
               .collect(ImmutableSet.toImmutableSet());
-      IpWildcardSetIpSpace ipSpace =
-          IpWildcardSetIpSpace.builder().including(whitelist).excluding(blacklist).build();
+      IpWildcardSetIpSpace ipSpace = IpWildcardSetIpSpace.create(blacklist, whitelist);
       interfaces.stream()
           .flatMap(i -> sourceNatPoolIps(i.getOutgoingTransformation()))
           .forEach(currentPoolIp -> builder.put(currentPoolIp, ipSpace));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -7,14 +7,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
-import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.Stack;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
@@ -328,31 +326,28 @@ public final class FibImpl implements Fib {
      * to the builder) and return an IpSpace of IPs matched by any prefix in that subtrie. To create
      * the matching Ips of the prefix, whitelist the prefix and blacklist the IPs matched by
      * subtrie prefixes (i.e. longer prefixes).
-     *
-     * We build ImmutableSortedSets because IpWildcardSetIpSpace uses them internally, and this
-     * avoids making an extra copy.
      */
     _root.fold(
-        new FoldOperator<FibEntry, SortedSet<IpWildcard>>() {
+        new FoldOperator<FibEntry, Set<IpWildcard>>() {
           @Nonnull
           @Override
-          public SortedSet<IpWildcard> fold(
+          public Set<IpWildcard> fold(
               Prefix prefix,
               Set<FibEntry> elems,
-              @Nullable SortedSet<IpWildcard> leftPrefixes,
-              @Nullable SortedSet<IpWildcard> rightPrefixes) {
-            SortedSet<IpWildcard> subTriePrefixes;
+              @Nullable Set<IpWildcard> leftPrefixes,
+              @Nullable Set<IpWildcard> rightPrefixes) {
+            Set<IpWildcard> subTriePrefixes;
             boolean leftEmpty = leftPrefixes == null || leftPrefixes.isEmpty();
             boolean rightEmpty = rightPrefixes == null || rightPrefixes.isEmpty();
             if (leftEmpty && rightEmpty) {
-              subTriePrefixes = ImmutableSortedSet.of();
+              subTriePrefixes = ImmutableSet.of();
             } else if (leftEmpty) {
               subTriePrefixes = rightPrefixes;
             } else if (rightEmpty) {
               subTriePrefixes = leftPrefixes;
             } else {
               subTriePrefixes =
-                  ImmutableSortedSet.<IpWildcard>naturalOrder()
+                  ImmutableSet.<IpWildcard>builder()
                       .addAll(leftPrefixes)
                       .addAll(rightPrefixes)
                       .build();
@@ -369,10 +364,10 @@ public final class FibImpl implements Fib {
             } else {
               // Ips matching prefix are those in prefix and not in any subtrie prefixes.
               builder.put(
-                  prefix, new IpWildcardSetIpSpace(subTriePrefixes, ImmutableSortedSet.of(wc)));
+                  prefix, IpWildcardSetIpSpace.create(subTriePrefixes, ImmutableSet.of(wc)));
             }
 
-            return ImmutableSortedSet.of(wc);
+            return ImmutableSet.of(wc);
           }
         });
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -2,14 +2,12 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Ordering.natural;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -634,13 +632,13 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                   nodeEntry.getValue(),
                   Entry::getKey, // vrf
                   vrfEntry ->
-                      new IpWildcardSetIpSpace(
-                          ImmutableSortedSet.of(),
+                      IpWildcardSetIpSpace.create(
+                          ImmutableSet.of(),
                           vrfEntry.getValue().allEntries().stream()
-                              .map(
-                                  fibEntry ->
-                                      IpWildcard.create(fibEntry.getTopLevelRoute().getNetwork()))
-                              .collect(ImmutableSortedSet.toImmutableSortedSet(natural())))));
+                              .map(fibEntry -> fibEntry.getTopLevelRoute().getNetwork())
+                              .distinct()
+                              .map(IpWildcard::create)
+                              .collect(ImmutableSet.toImmutableSet()))));
     } finally {
       span.finish();
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AbstractIpSpaceContainsIpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AbstractIpSpaceContainsIpTest.java
@@ -50,7 +50,7 @@ public class AbstractIpSpaceContainsIpTest {
   @Test
   public void testVisitIpWildcardSetIpSpace() {
     IpWildcardSetIpSpace ipSpace =
-        new IpWildcardSetIpSpace(
+        IpWildcardSetIpSpace.create(
             ImmutableSet.of(IpWildcard.create(IP2)), ImmutableSet.of(IpWildcard.create(IP1)));
     assertTrue(containsIp(IP1).visitIpWildcardSetIpSpace(ipSpace));
     assertFalse(containsIp(IP2).visitIpWildcardSetIpSpace(ipSpace));


### PR DESCRIPTION
1. Intern equivalent instances.
2. Only sort on JSON where it is needed.
3. Skip builders in simple cases, as this elides a copy.