### PR TITLE
A10: handle hybrid vlan syntax

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_vlan.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_vlan.g4
@@ -18,7 +18,8 @@ svd_tagged: TAGGED vlan_iface_references NEWLINE;
 
 svd_untagged: UNTAGGED vlan_iface_references NEWLINE;
 
-vlan_iface_references: vlan_ifaces_range | vlan_ifaces_list;
+// Only ACOS 2.X allows more than one interface specifier here
+vlan_iface_references: (vlan_ifaces_range | vlan_ifaces_list)+;
 
 vlan_ifaces_range:
     // All(?) versions of ACOS

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -591,7 +591,8 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
     return TrunkGroup.Type.STATIC;
   }
 
-  Optional<List<InterfaceReference>> toInterfaceReferences(A10Parser.Vlan_ifaces_rangeContext ctx) {
+  private Optional<List<InterfaceReference>> toInterfaceReferences(
+      A10Parser.Vlan_ifaces_rangeContext ctx) {
     Interface.Type type = toInterfaceType(ctx);
     return toSubRange(ctx)
         .map(
@@ -607,7 +608,7 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
    * references for each interface. Returns {@link Optional#empty()} and adds warnings if the
    * context cannot be converted to a list of {@link InterfaceReference}s.
    */
-  Optional<List<InterfaceReference>> toInterfaceReferences(
+  private Optional<List<InterfaceReference>> toInterfaceReferences(
       A10Parser.Vlan_iface_referencesContext ctx, A10StructureUsage usage) {
     int line = ctx.start.getLine();
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -590,6 +591,17 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
     return TrunkGroup.Type.STATIC;
   }
 
+  Optional<List<InterfaceReference>> toInterfaceReferences(A10Parser.Vlan_ifaces_rangeContext ctx) {
+    Interface.Type type = toInterfaceType(ctx);
+    return toSubRange(ctx)
+        .map(
+            subRange ->
+                subRange
+                    .asStream()
+                    .mapToObj(i -> new InterfaceReference(type, i))
+                    .collect(ImmutableList.toImmutableList()));
+  }
+
   /**
    * Convert specified context into a list of {@link InterfaceReference} and add structure
    * references for each interface. Returns {@link Optional#empty()} and adds warnings if the
@@ -598,33 +610,30 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
   Optional<List<InterfaceReference>> toInterfaceReferences(
       A10Parser.Vlan_iface_referencesContext ctx, A10StructureUsage usage) {
     int line = ctx.start.getLine();
-    if (ctx.vlan_ifaces_list() != null) {
-      Optional<List<InterfaceReference>> maybeInterfaces = toInterfaces(ctx.vlan_ifaces_list());
-      maybeInterfaces.ifPresent(
-          ifaces ->
-              ifaces.forEach(
-                  iface ->
-                      _c.referenceStructure(
-                          A10StructureType.INTERFACE, getInterfaceName(iface), usage, line)));
-      return maybeInterfaces;
+
+    ImmutableList<Optional<List<InterfaceReference>>> references =
+        Stream.concat(
+                ctx.vlan_ifaces_list().stream().map(this::toInterfaces),
+                ctx.vlan_ifaces_range().stream().map(this::toInterfaceReferences))
+            .collect(ImmutableList.toImmutableList());
+    if (references.stream().anyMatch(maybeRefs -> !maybeRefs.isPresent())) {
+      // Already warned
+      return Optional.empty();
     }
-    assert ctx.vlan_ifaces_range() != null;
-    Interface.Type type = toInterfaceType(ctx.vlan_ifaces_range());
-    Optional<List<InterfaceReference>> maybeIfaces =
-        toSubRange(ctx.vlan_ifaces_range())
-            .map(
-                subRange ->
-                    subRange
-                        .asStream()
-                        .mapToObj(i -> new InterfaceReference(type, i))
-                        .collect(ImmutableList.toImmutableList()));
-    maybeIfaces.ifPresent(
-        ifaces ->
-            ifaces.forEach(
-                iface ->
-                    _c.referenceStructure(
-                        A10StructureType.INTERFACE, getInterfaceName(iface), usage, line)));
-    return maybeIfaces;
+    return Optional.of(
+        references.stream()
+            .flatMap(
+                maybeRef -> {
+                  // Guaranteed above
+                  assert maybeRef.isPresent();
+                  List<InterfaceReference> refs = maybeRef.get();
+                  refs.forEach(
+                      iface ->
+                          _c.referenceStructure(
+                              A10StructureType.INTERFACE, getInterfaceName(iface), usage, line));
+                  return refs.stream();
+                })
+            .collect(ImmutableList.toImmutableList()));
   }
 
   Interface.Type toInterfaceType(A10Parser.Vlan_ifaces_rangeContext ctx) {

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -354,8 +354,9 @@ public class A10GrammarTest {
     A10Configuration c = parseVendorConfig(hostname);
 
     Map<Integer, Vlan> vlans = c.getVlans();
-    assertThat(vlans.keySet(), containsInAnyOrder(2));
+    assertThat(vlans.keySet(), containsInAnyOrder(2, 3));
     Vlan vlan2 = vlans.get(2);
+    Vlan vlan3 = vlans.get(3);
 
     assertThat(vlan2.getNumber(), equalTo(2));
     assertThat(
@@ -364,6 +365,13 @@ public class A10GrammarTest {
             new InterfaceReference(Interface.Type.ETHERNET, 1),
             new InterfaceReference(Interface.Type.ETHERNET, 2)));
     assertThat(vlan2.getUntagged(), emptyIterable());
+    assertThat(vlan3.getTagged(), emptyIterable());
+    assertThat(
+        vlan3.getUntagged(),
+        containsInAnyOrder(
+            new InterfaceReference(Interface.Type.ETHERNET, 1),
+            new InterfaceReference(Interface.Type.ETHERNET, 3),
+            new InterfaceReference(Interface.Type.ETHERNET, 4)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/vlan_acos2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/vlan_acos2
@@ -5,7 +5,14 @@ hostname vlan_acos2
 vlan 2
  tagged ethernet 1 ethernet 2
 !
+vlan 3
+ untagged ethernet 1 ethernet 3 to 4
+!
 interface ethernet 1
 !
 interface ethernet 2
+!
+interface ethernet 3
+!
+interface ethernet 4
 !


### PR DESCRIPTION
Handle `vlan` syntax where interfaces are referenced by a list and range on the same line, which appears to be allowed in `acos v2`. Note: list and range references were previously allowed, but only on separate lines.

e.g.
```
vlan 3
 untagged ethernet 1 ethernet 3 to 4
!
```
(which corresponds to `Ethernet 1`, `Ethernet 3`, and `Ethernet 4`)