### PR TITLE
AclIpSpace: optimize complement of complement

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
@@ -120,6 +120,18 @@ public class AclIpSpace extends IpSpace {
     return of(Arrays.asList(lines));
   }
 
+  @Override
+  public IpSpace complement() {
+    if (_lines.size() == 2
+        && _lines.get(1).getAction() == LineAction.PERMIT
+        && _lines.get(1).getIpSpace() == UniverseIpSpace.INSTANCE) {
+      // This AclIpSpace is a complement already.
+      assert _lines.get(0).getAction() == LineAction.DENY;
+      return _lines.get(0).getIpSpace();
+    }
+    return super.complement();
+  }
+
   /**
    * Set-theoretic difference between two IpSpaces.<br>
    * If both arguments are {@code null}, returns {@code null}.<br>

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -33,6 +34,8 @@ public class AclIpSpaceTest {
     assertThat(notIpSpace, containsIp(Ip.parse("1.1.1.0")));
     assertThat(notIpSpace, not(containsIp(Ip.parse("1.1.0.0"))));
     assertThat(notIpSpace, containsIp(Ip.parse("1.0.0.0")));
+
+    assertThat(notIpSpace.complement(), sameInstance(_aclIpSpace));
   }
 
   @Test


### PR DESCRIPTION
Because AclIpSpace#intersection and AclIpSpace#difference both use complement,
it's not uncommon that we complement a complement. Optimize in this case to
the original AclIpSpace.