### PR TITLE
CheckPoint service-other tracing

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -138,11 +138,16 @@ public final class AclLineMatchExprs {
   }
 
   public static @Nonnull AclLineMatchExpr matchDstPort(IntegerSpace portSpace) {
+    return matchDstPort(portSpace, null);
+  }
+
+  public static @Nonnull AclLineMatchExpr matchDstPort(
+      IntegerSpace portSpace, @Nullable TraceElement traceElement) {
     checkArgument(
         0 <= portSpace.least() && portSpace.greatest() <= 0xFFFF,
         "Invalid port space: %s",
         portSpace);
-    return match(HeaderSpace.builder().setDstPorts(portSpace.getSubRanges()).build());
+    return match(HeaderSpace.builder().setDstPorts(portSpace.getSubRanges()).build(), traceElement);
   }
 
   public static AclLineMatchExpr matchDstPrefix(String prefix) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
@@ -192,7 +192,7 @@ public final class BooleanExprAstNodeToAclLineMatchExpr
 
   @VisibleForTesting
   static @Nonnull TraceElement inspectTraceElement(String inspectText) {
-    return TraceElement.of(String.format("Matched INSPECT expression '%s'", inspectText));
+    return TraceElement.of(String.format("Matched: '%s'", inspectText));
   }
 
   private static @Nonnull TraceElement unhandledInspectTraceElement(HasInspectText hasInspectText) {
@@ -201,8 +201,7 @@ public final class BooleanExprAstNodeToAclLineMatchExpr
 
   @VisibleForTesting
   static @Nonnull TraceElement unhandledInspectTraceElement(String inspectText) {
-    return TraceElement.of(
-        String.format("Assumed matched unsupported INSPECT expression '%s'", inspectText));
+    return TraceElement.of(String.format("Assumed matched since unsupported: '%s'", inspectText));
   }
 
   private static final BooleanExprAstNodeToAclLineMatchExpr INSTANCE =

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
@@ -81,11 +81,9 @@ public final class BooleanExprAstNodeToAclLineMatchExpr
   @Override
   public @Nonnull AclLineMatchExpr visitDportAstNode(
       DportAstNode dportAstNode, Boolean permitUnsupported) {
-    return and(
-        inspectTraceElement(dportAstNode),
-        matchDstPort(
-            portRangeToIntegerSpace(
-                dportAstNode.getComparator(), dportAstNode.getValue().getValue())));
+    return matchDstPort(
+        portRangeToIntegerSpace(dportAstNode.getComparator(), dportAstNode.getValue().getValue()),
+        inspectTraceElement(dportAstNode));
   }
 
   @Override
@@ -117,13 +115,13 @@ public final class BooleanExprAstNodeToAclLineMatchExpr
   @Override
   public @Nonnull AclLineMatchExpr visitTcpAstNode(
       TcpAstNode tcpAstNode, Boolean permitUnsupported) {
-    return and(inspectTraceElement(tcpAstNode.getInspectText()), matchIpProtocol(TCP));
+    return matchIpProtocol(TCP, inspectTraceElement(tcpAstNode.getInspectText()));
   }
 
   @Override
   public @Nonnull AclLineMatchExpr visitUdpAstNode(
       UdpAstNode udpAstNode, Boolean permitUnsupported) {
-    return and(inspectTraceElement(udpAstNode.getInspectText()), matchIpProtocol(UDP));
+    return matchIpProtocol(UDP, inspectTraceElement(udpAstNode.getInspectText()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExpr.java
@@ -193,7 +193,7 @@ public final class BooleanExprAstNodeToAclLineMatchExpr
   }
 
   @VisibleForTesting
-  public static @Nonnull TraceElement inspectTraceElement(String inspectText) {
+  static @Nonnull TraceElement inspectTraceElement(String inspectText) {
     return TraceElement.of(String.format("Matched INSPECT expression '%s'", inspectText));
   }
 
@@ -202,7 +202,7 @@ public final class BooleanExprAstNodeToAclLineMatchExpr
   }
 
   @VisibleForTesting
-  public static @Nonnull TraceElement unhandledInspectTraceElement(String inspectText) {
+  static @Nonnull TraceElement unhandledInspectTraceElement(String inspectText) {
     return TraceElement.of(
         String.format("Assumed matched unsupported INSPECT expression '%s'", inspectText));
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
@@ -40,6 +40,11 @@ public final class CheckPointManagementTraceElementCreators {
   }
 
   @VisibleForTesting
+  public static TraceElement serviceOtherMatchTraceElement(String matchText) {
+    return TraceElement.of(String.format("Matched INSPECT expression: '%s'", matchText));
+  }
+
+  @VisibleForTesting
   public static TraceElement serviceTcpTraceElement(ServiceTcp service) {
     return TraceElement.of(String.format("Matched service-tcp '%s'", service.getName()));
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CheckPointManagementTraceElementCreators.java
@@ -41,7 +41,7 @@ public final class CheckPointManagementTraceElementCreators {
 
   @VisibleForTesting
   public static TraceElement serviceOtherMatchTraceElement(String matchText) {
-    return TraceElement.of(String.format("Matched INSPECT expression: '%s'", matchText));
+    return TraceElement.of(String.format("Matched the 'match' expression: '%s'", matchText));
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNode.java
@@ -7,9 +7,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing a boolean function of the destination port. */
 @ParametersAreNonnullByDefault
-public class DportAstNode implements BooleanExprAstNode {
+public class DportAstNode extends VariableInspectTextBooleanExprAstNode {
 
-  public DportAstNode(ComparatorAstNode comparator, Uint16AstNode value) {
+  public DportAstNode(String inspectText, ComparatorAstNode comparator, Uint16AstNode value) {
+    super(inspectText);
     _comparator = comparator;
     _value = value;
   }
@@ -29,9 +30,7 @@ public class DportAstNode implements BooleanExprAstNode {
 
   @Override
   public boolean equals(@Nullable Object o) {
-    if (this == o) {
-      return true;
-    } else if (!(o instanceof DportAstNode)) {
+    if (!baseEquals(o)) {
       return false;
     }
     DportAstNode that = (DportAstNode) o;
@@ -40,7 +39,7 @@ public class DportAstNode implements BooleanExprAstNode {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_comparator, _value);
+    return Objects.hash(baseHashCode(), _comparator, _value);
   }
 
   private final @Nonnull ComparatorAstNode _comparator;

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/HasInspectText.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/HasInspectText.java
@@ -1,0 +1,10 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import javax.annotation.Nonnull;
+
+/** An object with associated text in the INSPECT language. */
+public interface HasInspectText {
+
+  @Nonnull
+  String getInspectText();
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNode.java
@@ -1,6 +1,5 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -9,10 +8,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * incoming}.
  */
 @ParametersAreNonnullByDefault
-public final class IncomingAstNode implements BooleanExprAstNode {
+public final class IncomingAstNode extends VariableInspectTextBooleanExprAstNode {
 
-  public static @Nonnull IncomingAstNode instance() {
-    return INSTANCE;
+  public IncomingAstNode(String inspectText) {
+    super(inspectText);
   }
 
   @Override
@@ -20,17 +19,13 @@ public final class IncomingAstNode implements BooleanExprAstNode {
     return visitor.visitIncomingAstNode(this, arg);
   }
 
-  private static final IncomingAstNode INSTANCE = new IncomingAstNode();
-
   @Override
   public boolean equals(@Nullable Object obj) {
-    return this == obj || obj instanceof IncomingAstNode;
+    return baseEquals(obj);
   }
 
   @Override
   public int hashCode() {
-    return 0xB6D251E7; // randomly generated
+    return baseHashCode();
   }
-
-  private IncomingAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNode.java
@@ -1,6 +1,5 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -9,10 +8,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * outgoing}.
  */
 @ParametersAreNonnullByDefault
-public final class OutgoingAstNode implements BooleanExprAstNode {
+public final class OutgoingAstNode extends VariableInspectTextBooleanExprAstNode {
 
-  public static @Nonnull OutgoingAstNode instance() {
-    return INSTANCE;
+  public OutgoingAstNode(String inspectText) {
+    super(inspectText);
   }
 
   @Override
@@ -20,17 +19,13 @@ public final class OutgoingAstNode implements BooleanExprAstNode {
     return visitor.visitOutgoingAstNode(this, arg);
   }
 
-  private static final OutgoingAstNode INSTANCE = new OutgoingAstNode();
-
   @Override
   public boolean equals(@Nullable Object obj) {
-    return this == obj || obj instanceof OutgoingAstNode;
+    return baseEquals(obj);
   }
 
   @Override
   public int hashCode() {
-    return 0x3FA69E8B; // randomly generated
+    return baseHashCode();
   }
-
-  private OutgoingAstNode() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExpr.java
@@ -52,18 +52,15 @@ public class ServiceOtherMatchExpr extends BaseParser<AstNode> {
 
   Rule DportExpr() {
     return Sequence(
-        "dport",
-        Comparator(),
-        Uint16Expr(),
-        push(new DportAstNode((ComparatorAstNode) pop(1), (Uint16AstNode) pop())));
+        Sequence("dport", Comparator(), Uint16Expr()),
+        push(new DportAstNode(match().trim(), (ComparatorAstNode) pop(1), (Uint16AstNode) pop())));
   }
 
   Rule UhDportExpr() {
     return Sequence(
-        "uh_dport",
-        Comparator(),
-        Uint16Expr(),
-        push(new UhDportAstNode((ComparatorAstNode) pop(1), (Uint16AstNode) pop())));
+        Sequence("uh_dport", Comparator(), Uint16Expr()),
+        push(
+            new UhDportAstNode(match().trim(), (ComparatorAstNode) pop(1), (Uint16AstNode) pop())));
   }
 
   Rule Uint16Expr() {
@@ -111,15 +108,15 @@ public class ServiceOtherMatchExpr extends BaseParser<AstNode> {
   }
 
   Rule DirectionExpr() {
-    return Sequence("direction", "=", FirstOf(Incoming(), Outgoing()));
+    return FirstOf(Incoming(), Outgoing());
   }
 
   Rule Incoming() {
-    return Sequence("0", push(IncomingAstNode.instance()));
+    return Sequence(Sequence("direction", "=", "0"), push(new IncomingAstNode(match().trim())));
   }
 
   Rule Outgoing() {
-    return Sequence("1", push(OutgoingAstNode.instance()));
+    return Sequence(Sequence("direction", "=", "1"), push(new OutgoingAstNode(match().trim())));
   }
 
   Rule UnhandledExpr() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/TcpAstNode.java
@@ -6,7 +6,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the condition that the packet protocol is TCP. */
 @ParametersAreNonnullByDefault
-public final class TcpAstNode implements BooleanExprAstNode {
+public final class TcpAstNode implements BooleanExprAstNode, HasInspectText {
 
   public static @Nonnull TcpAstNode instance() {
     return INSTANCE;
@@ -15,6 +15,11 @@ public final class TcpAstNode implements BooleanExprAstNode {
   @Override
   public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
     return visitor.visitTcpAstNode(this, arg);
+  }
+
+  @Override
+  public @Nonnull String getInspectText() {
+    return "tcp";
   }
 
   private static final TcpAstNode INSTANCE = new TcpAstNode();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UdpAstNode.java
@@ -6,7 +6,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** An {@link AstNode} representing the condition that the packet protocol is UDP. */
 @ParametersAreNonnullByDefault
-public final class UdpAstNode implements BooleanExprAstNode {
+public final class UdpAstNode implements BooleanExprAstNode, HasInspectText {
 
   public static @Nonnull UdpAstNode instance() {
     return INSTANCE;
@@ -15,6 +15,11 @@ public final class UdpAstNode implements BooleanExprAstNode {
   @Override
   public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
     return visitor.visitUdpAstNode(this, arg);
+  }
+
+  @Override
+  public @Nonnull String getInspectText() {
+    return "udp";
   }
 
   private static final UdpAstNode INSTANCE = new UdpAstNode();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNode.java
@@ -10,9 +10,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * condition that the protocol is UDP.
  */
 @ParametersAreNonnullByDefault
-public final class UhDportAstNode implements BooleanExprAstNode {
+public final class UhDportAstNode extends VariableInspectTextBooleanExprAstNode {
 
-  public UhDportAstNode(ComparatorAstNode comparator, Uint16AstNode value) {
+  public UhDportAstNode(String inspectText, ComparatorAstNode comparator, Uint16AstNode value) {
+    super(inspectText);
     _comparator = comparator;
     _value = value;
   }
@@ -32,9 +33,7 @@ public final class UhDportAstNode implements BooleanExprAstNode {
 
   @Override
   public boolean equals(@Nullable Object o) {
-    if (this == o) {
-      return true;
-    } else if (!(o instanceof UhDportAstNode)) {
+    if (!baseEquals(o)) {
       return false;
     }
     UhDportAstNode that = (UhDportAstNode) o;
@@ -43,7 +42,7 @@ public final class UhDportAstNode implements BooleanExprAstNode {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_comparator, _value);
+    return Objects.hash(baseHashCode(), _comparator, _value);
   }
 
   private final @Nonnull ComparatorAstNode _comparator;

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/UnhandledAstNode.java
@@ -1,7 +1,5 @@
 package org.batfish.vendor.check_point_management.parsing.parboiled;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -11,11 +9,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * be evaluated as {@code true} or {@code false} depending on context.
  */
 @ParametersAreNonnullByDefault
-public final class UnhandledAstNode implements BooleanExprAstNode {
-
-  public @Nonnull String getUnhandledText() {
-    return _unhandledText;
-  }
+public final class UnhandledAstNode extends VariableInspectTextBooleanExprAstNode {
 
   @Override
   public <T, U> T accept(BooleanExprAstNodeVisitor<T, U> visitor, U arg) {
@@ -24,32 +18,24 @@ public final class UnhandledAstNode implements BooleanExprAstNode {
 
   @Override
   public boolean equals(@Nullable Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (!(obj instanceof UnhandledAstNode)) {
-      return false;
-    }
-    UnhandledAstNode that = (UnhandledAstNode) obj;
-    return _unhandledText.equals(that._unhandledText);
+    return baseEquals(obj);
   }
 
   @Override
   public int hashCode() {
-    return _unhandledText.hashCode();
+    return baseHashCode();
   }
 
   @Override
   public String toString() {
-    return toStringHelper(this).add("_unhandledText", _unhandledText).toString();
+    return baseToStringHelper().toString();
   }
 
   public static @Nonnull UnhandledAstNode of(String unhandledText) {
     return new UnhandledAstNode(unhandledText);
   }
 
-  private UnhandledAstNode(String unhandledText) {
-    _unhandledText = unhandledText;
+  private UnhandledAstNode(String inspectText) {
+    super(inspectText);
   }
-
-  private final @Nonnull String _unhandledText;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/VariableInspectTextBooleanExprAstNode.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing/parboiled/VariableInspectTextBooleanExprAstNode.java
@@ -1,0 +1,41 @@
+package org.batfish.vendor.check_point_management.parsing.parboiled;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+import com.google.common.base.MoreObjects.ToStringHelper;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** A {@link BooleanExprAstNode} creatable from any of a class of equivalent INSPECT expressions. */
+public abstract class VariableInspectTextBooleanExprAstNode
+    implements BooleanExprAstNode, HasInspectText {
+
+  protected VariableInspectTextBooleanExprAstNode(String inspectText) {
+    _inspectText = inspectText;
+  }
+
+  @Override
+  public final @Nonnull String getInspectText() {
+    return _inspectText;
+  }
+
+  protected boolean baseEquals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!getClass().isInstance(o)) {
+      return false;
+    }
+    VariableInspectTextBooleanExprAstNode that = (VariableInspectTextBooleanExprAstNode) o;
+    return _inspectText.equals(that._inspectText);
+  }
+
+  protected int baseHashCode() {
+    return _inspectText.hashCode();
+  }
+
+  protected @Nonnull ToStringHelper baseToStringHelper() {
+    return toStringHelper(this).add("_inspectText", _inspectText);
+  }
+
+  private final @Nonnull String _inspectText;
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExprTest.java
@@ -10,16 +10,26 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstPort;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIpProtocol;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.applications.PortsApplication.MAX_PORT_NUMBER;
+import static org.batfish.datamodel.matchers.TraceTreeMatchers.isTraceTree;
 import static org.batfish.vendor.check_point_management.BooleanExprAstNodeToAclLineMatchExpr.convert;
+import static org.batfish.vendor.check_point_management.BooleanExprAstNodeToAclLineMatchExpr.inspectTraceElement;
 import static org.batfish.vendor.check_point_management.BooleanExprAstNodeToAclLineMatchExpr.portRangeToIntegerSpace;
+import static org.batfish.vendor.check_point_management.BooleanExprAstNodeToAclLineMatchExpr.unhandledInspectTraceElement;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
+import java.util.List;
 import org.batfish.datamodel.BddTestbed;
+import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclTracer;
+import org.batfish.datamodel.trace.TraceTree;
 import org.batfish.vendor.check_point_management.parsing.parboiled.ConjunctionAstNode;
 import org.batfish.vendor.check_point_management.parsing.parboiled.DisjunctionAstNode;
 import org.batfish.vendor.check_point_management.parsing.parboiled.DportAstNode;
@@ -48,6 +58,17 @@ public final class BooleanExprAstNodeToAclLineMatchExprTest {
     assertThat(_tb.toBDD(left), equalTo(_tb.toBDD(right)));
   }
 
+  private static final Flow TEST_FLOW =
+      Flow.builder()
+          .setIngressNode("node")
+          .setSrcPort(12345)
+          .setDstPort(23456)
+          .setIpProtocol(IpProtocol.TCP)
+          .setIngressInterface("eth1")
+          .setSrcIp(Ip.parse("10.0.1.2"))
+          .setDstIp(Ip.parse("10.0.2.2"))
+          .build();
+
   @Test
   public void testConvertConjunction() {
     assertBddsEqual(convert(new ConjunctionAstNode(), true), TRUE);
@@ -57,9 +78,16 @@ public final class BooleanExprAstNodeToAclLineMatchExprTest {
         convert(
             new ConjunctionAstNode(
                 UdpAstNode.instance(),
-                new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1))),
+                new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1))),
             false),
         and(matchIpProtocol(UDP), matchDstPort(1)));
+
+    // tracing
+    AclLineMatchExpr expr = convert(new ConjunctionAstNode(UnhandledAstNode.of("foo")), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr, TEST_FLOW, "eth1", ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(unhandledInspectTraceElement("foo")));
   }
 
   @Test
@@ -71,19 +99,39 @@ public final class BooleanExprAstNodeToAclLineMatchExprTest {
         convert(
             new DisjunctionAstNode(
                 UdpAstNode.instance(),
-                new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1))),
+                new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1))),
             true),
         or(matchIpProtocol(UDP), matchDstPort(1)));
+
+    // tracing
+    AclLineMatchExpr expr = convert(new DisjunctionAstNode(UnhandledAstNode.of("foo")), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr, TEST_FLOW, "eth1", ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(unhandledInspectTraceElement("foo")));
   }
 
   @Test
   public void testConvertDport() {
     assertBddsEqual(
-        convert(new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)), true),
+        convert(new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1)), true),
         matchDstPort(1));
     assertBddsEqual(
-        convert(new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)), false),
+        convert(new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1)), false),
         matchDstPort(1));
+
+    // tracing
+    AclLineMatchExpr expr =
+        convert(new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1)), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr,
+            TEST_FLOW.toBuilder().setDstPort(1).build(),
+            "eth1",
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(inspectTraceElement("foo")));
   }
 
   @Test
@@ -101,43 +149,101 @@ public final class BooleanExprAstNodeToAclLineMatchExprTest {
   @Test
   public void testConvertIncoming() {
     // TODO: support direction
-    assertBddsEqual(convert(IncomingAstNode.instance(), true), TRUE);
-    assertBddsEqual(convert(IncomingAstNode.instance(), false), FALSE);
+    assertBddsEqual(convert(new IncomingAstNode("foo"), true), TRUE);
+    assertBddsEqual(convert(new IncomingAstNode("foo"), false), FALSE);
+
+    // tracing
+    AclLineMatchExpr expr = convert(new IncomingAstNode("foo"), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr, TEST_FLOW, "eth1", ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(unhandledInspectTraceElement("foo")));
   }
 
   @Test
   public void testConvertOutgoing() {
     // TODO: support direction
-    assertBddsEqual(convert(OutgoingAstNode.instance(), true), TRUE);
-    assertBddsEqual(convert(OutgoingAstNode.instance(), false), FALSE);
+    assertBddsEqual(convert(new OutgoingAstNode("foo"), true), TRUE);
+    assertBddsEqual(convert(new OutgoingAstNode("foo"), false), FALSE);
+
+    // tracing
+    AclLineMatchExpr expr = convert(new OutgoingAstNode("foo"), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr, TEST_FLOW, "eth1", ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(unhandledInspectTraceElement("foo")));
   }
 
   @Test
   public void testConvertTcp() {
     assertBddsEqual(convert(TcpAstNode.instance(), true), matchIpProtocol(TCP));
     assertBddsEqual(convert(TcpAstNode.instance(), false), matchIpProtocol(TCP));
+
+    // tracing
+    AclLineMatchExpr expr = convert(TcpAstNode.instance(), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr,
+            TEST_FLOW.toBuilder().setIpProtocol(TCP).build(),
+            "eth1",
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(inspectTraceElement("tcp")));
   }
 
   @Test
   public void testConvertUdp() {
     assertBddsEqual(convert(UdpAstNode.instance(), true), matchIpProtocol(UDP));
     assertBddsEqual(convert(UdpAstNode.instance(), false), matchIpProtocol(UDP));
+
+    // tracing
+    AclLineMatchExpr expr = convert(UdpAstNode.instance(), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr,
+            TEST_FLOW.toBuilder().setIpProtocol(UDP).build(),
+            "eth1",
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(inspectTraceElement("udp")));
   }
 
   @Test
   public void testConvertUhDport() {
     assertBddsEqual(
-        convert(new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)), true),
+        convert(new UhDportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1)), true),
         and(matchIpProtocol(UDP), matchDstPort(1)));
     assertBddsEqual(
-        convert(new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)), false),
+        convert(new UhDportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1)), false),
         and(matchIpProtocol(UDP), matchDstPort(1)));
+
+    // tracing
+    AclLineMatchExpr expr =
+        convert(new UhDportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1)), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr,
+            TEST_FLOW.toBuilder().setIpProtocol(UDP).setDstPort(1).build(),
+            "eth1",
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(inspectTraceElement("foo")));
   }
 
   @Test
   public void testConvertUnhandled() {
     assertBddsEqual(convert(UnhandledAstNode.of("foo"), true), TRUE);
     assertBddsEqual(convert(UnhandledAstNode.of("foo"), false), FALSE);
+
+    // tracing
+    AclLineMatchExpr expr = convert(UnhandledAstNode.of("foo"), true);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            expr, TEST_FLOW, "eth1", ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+    assertThat(trace.get(0), isTraceTree(unhandledInspectTraceElement("foo")));
   }
 
   @Test
@@ -191,5 +297,18 @@ public final class BooleanExprAstNodeToAclLineMatchExprTest {
     assertThat(
         portRangeToIntegerSpace(LessThanOrEqualsAstNode.instance(), -5),
         equalTo(IntegerSpace.EMPTY));
+  }
+
+  @Test
+  public void testInspectTraceElement() {
+    assertThat(
+        inspectTraceElement("foo"), equalTo(TraceElement.of("Matched INSPECT expression 'foo'")));
+  }
+
+  @Test
+  public void testUnhandledInspectTraceElement() {
+    assertThat(
+        unhandledInspectTraceElement("foo"),
+        equalTo(TraceElement.of("Assumed matched unsupported INSPECT expression 'foo'")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/BooleanExprAstNodeToAclLineMatchExprTest.java
@@ -301,14 +301,13 @@ public final class BooleanExprAstNodeToAclLineMatchExprTest {
 
   @Test
   public void testInspectTraceElement() {
-    assertThat(
-        inspectTraceElement("foo"), equalTo(TraceElement.of("Matched INSPECT expression 'foo'")));
+    assertThat(inspectTraceElement("foo"), equalTo(TraceElement.of("Matched: 'foo'")));
   }
 
   @Test
   public void testUnhandledInspectTraceElement() {
     assertThat(
         unhandledInspectTraceElement("foo"),
-        equalTo(TraceElement.of("Assumed matched unsupported INSPECT expression 'foo'")));
+        equalTo(TraceElement.of("Assumed matched since unsupported: 'foo'")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/DportAstNodeTest.java
@@ -12,17 +12,20 @@ public final class DportAstNodeTest {
 
   @Test
   public void testJavaSerialization() {
-    DportAstNode obj = new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1));
+    DportAstNode obj = new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1));
     assertThat(SerializationUtils.clone(obj), equalTo(obj));
   }
 
   @Test
   public void testEquals() {
-    DportAstNode obj = new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1));
+    DportAstNode obj = new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1));
     new EqualsTester()
-        .addEqualityGroup(obj, new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)))
-        .addEqualityGroup(new DportAstNode(LessThanOrEqualsAstNode.instance(), Uint16AstNode.of(1)))
-        .addEqualityGroup(new DportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(2)))
+        .addEqualityGroup(
+            obj, new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(new DportAstNode("bar", EqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(
+            new DportAstNode("foo", LessThanOrEqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(new DportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(2)))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/IncomingAstNodeTest.java
@@ -12,14 +12,16 @@ public final class IncomingAstNodeTest {
 
   @Test
   public void testJavaSerialization() {
-    assertThat(
-        SerializationUtils.clone(IncomingAstNode.instance()), equalTo(IncomingAstNode.instance()));
+    IncomingAstNode obj = new IncomingAstNode("foo");
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
   }
 
   @Test
   public void testEquals() {
+    IncomingAstNode obj = new IncomingAstNode("foo");
     new EqualsTester()
-        .addEqualityGroup(IncomingAstNode.instance(), IncomingAstNode.instance())
+        .addEqualityGroup(obj, new IncomingAstNode("foo"))
+        .addEqualityGroup(new IncomingAstNode("bar"))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/OutgoingAstNodeTest.java
@@ -12,14 +12,16 @@ public final class OutgoingAstNodeTest {
 
   @Test
   public void testJavaSerialization() {
-    assertThat(
-        SerializationUtils.clone(OutgoingAstNode.instance()), equalTo(OutgoingAstNode.instance()));
+    OutgoingAstNode obj = new OutgoingAstNode("foo");
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
   }
 
   @Test
   public void testEquals() {
+    OutgoingAstNode obj = new OutgoingAstNode("foo");
     new EqualsTester()
-        .addEqualityGroup(OutgoingAstNode.instance(), OutgoingAstNode.instance())
+        .addEqualityGroup(obj, new OutgoingAstNode("foo"))
+        .addEqualityGroup(new OutgoingAstNode("bar"))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExprTest.java
@@ -49,14 +49,15 @@ public final class ServiceOtherMatchExprTest {
   public void testDport() {
     assertThat(
         parse("dport < 5"),
-        equalTo(new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))));
+        equalTo(new DportAstNode("dport < 5", LessThanAstNode.instance(), Uint16AstNode.of(5))));
   }
 
   @Test
   public void testUhDport() {
     assertThat(
         parse("uh_dport < 5"),
-        equalTo(new UhDportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))));
+        equalTo(
+            new UhDportAstNode("uh_dport < 5", LessThanAstNode.instance(), Uint16AstNode.of(5))));
   }
 
   @Test
@@ -65,16 +66,20 @@ public final class ServiceOtherMatchExprTest {
     assertThat(
         parse("dport < 5 or dport>1"),
         equalTo(
-            new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))
-                .or(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(1)))));
+            new DportAstNode("dpot < 5", LessThanAstNode.instance(), Uint16AstNode.of(5))
+                .or(
+                    new DportAstNode(
+                        "dport>1", GreaterThanAstNode.instance(), Uint16AstNode.of(1)))));
 
     // 3 items
     assertThat(
         parse("dport < 5 or dport>1 or dport>2"),
         equalTo(
-            new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))
-                .or(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(1)))
-                .or(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(2)))));
+            new DportAstNode("dport < 5", LessThanAstNode.instance(), Uint16AstNode.of(5))
+                .or(new DportAstNode("dport>1", GreaterThanAstNode.instance(), Uint16AstNode.of(1)))
+                .or(
+                    new DportAstNode(
+                        "dport>2", GreaterThanAstNode.instance(), Uint16AstNode.of(2)))));
   }
 
   @Test
@@ -83,16 +88,20 @@ public final class ServiceOtherMatchExprTest {
     assertThat(
         parse("dport < 5 , dport>1"),
         equalTo(
-            new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))
-                .and(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(1)))));
+            new DportAstNode("dport < 5", LessThanAstNode.instance(), Uint16AstNode.of(5))
+                .and(
+                    new DportAstNode(
+                        "dport>1", GreaterThanAstNode.instance(), Uint16AstNode.of(1)))));
 
     // 3 items
     assertThat(
         parse("dport < 5, foo= bar,dport>2"),
         equalTo(
-            new DportAstNode(LessThanAstNode.instance(), Uint16AstNode.of(5))
+            new DportAstNode("dport < 5", LessThanAstNode.instance(), Uint16AstNode.of(5))
                 .and(UnhandledAstNode.of("foo= bar"))
-                .and(new DportAstNode(GreaterThanAstNode.instance(), Uint16AstNode.of(2)))));
+                .and(
+                    new DportAstNode(
+                        "dport>2", GreaterThanAstNode.instance(), Uint16AstNode.of(2)))));
   }
 
   @Test
@@ -119,8 +128,8 @@ public final class ServiceOtherMatchExprTest {
 
   @Test
   public void testDirectionExpr() {
-    assertThat(parse("direction=0"), equalTo(IncomingAstNode.instance()));
-    assertThat(parse("direction = 1"), equalTo(OutgoingAstNode.instance()));
+    assertThat(parse("direction=0"), equalTo(new IncomingAstNode("direction=0")));
+    assertThat(parse("direction = 1"), equalTo(new OutgoingAstNode("direction = 1")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/ServiceOtherMatchExprTest.java
@@ -66,7 +66,7 @@ public final class ServiceOtherMatchExprTest {
     assertThat(
         parse("dport < 5 or dport>1"),
         equalTo(
-            new DportAstNode("dpot < 5", LessThanAstNode.instance(), Uint16AstNode.of(5))
+            new DportAstNode("dport < 5", LessThanAstNode.instance(), Uint16AstNode.of(5))
                 .or(
                     new DportAstNode(
                         "dport>1", GreaterThanAstNode.instance(), Uint16AstNode.of(1)))));

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/parsing/parboiled/UhDportAstNodeTest.java
@@ -12,18 +12,20 @@ public final class UhDportAstNodeTest {
 
   @Test
   public void testJavaSerialization() {
-    UhDportAstNode obj = new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1));
+    UhDportAstNode obj = new UhDportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1));
     assertThat(SerializationUtils.clone(obj), equalTo(obj));
   }
 
   @Test
   public void testEquals() {
-    UhDportAstNode obj = new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1));
+    UhDportAstNode obj = new UhDportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1));
     new EqualsTester()
-        .addEqualityGroup(obj, new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(1)))
         .addEqualityGroup(
-            new UhDportAstNode(LessThanOrEqualsAstNode.instance(), Uint16AstNode.of(1)))
-        .addEqualityGroup(new UhDportAstNode(EqualsAstNode.instance(), Uint16AstNode.of(2)))
+            obj, new UhDportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(new UhDportAstNode("bar", EqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(
+            new UhDportAstNode("foo", LessThanOrEqualsAstNode.instance(), Uint16AstNode.of(1)))
+        .addEqualityGroup(new UhDportAstNode("foo", EqualsAstNode.instance(), Uint16AstNode.of(2)))
         .testEquals();
   }
 }


### PR DESCRIPTION
- store exact INSPECT text in `AstNode`s for which there are multiple equivalent inputs
- implement tracing of service-other, with element structure:
  - service-other name
    - protocol
    - match expression
      - leaf boolean expressions