### PR TITLE
CP NAT: Move to PacketPolicy

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -367,6 +367,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
                     new If(
                         new PacketMatchExpr(new DeniedByAcl(iface.getIncomingFilter().getName())),
                         ImmutableList.of(new Return(Drop.instance()))));
+                iface.setIncomingFilter(null);
               }
               ifacePolicyStatements.addAll(generalStatements);
               String packetPolicyName = packetPolicyName(iface.getName());

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
@@ -57,7 +57,7 @@ public class CheckpointNatConversions {
 
   @VisibleForTesting static final int NAT_PORT_FIRST = 10000;
   @VisibleForTesting static final int NAT_PORT_LAST = 60000;
-  @VisibleForTesting public static final Ip HIDE_BEHIND_GATEWAY_IP = Ip.parse("127.0.0.1");
+  @VisibleForTesting public static final Ip HIDE_BEHIND_GATEWAY_IP = Ip.ZERO;
 
   @VisibleForTesting
   static final TranslatedSourceToTransformationSteps TRANSLATED_SOURCE_TO_TRANSFORMATION_STEPS =

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -1795,24 +1795,6 @@ public class CheckPointGatewayGrammarTest {
               .setDstIp(otherIp)
               .setIngressNode(hostname)
               .build();
-      FlowEvaluator.FlowResult eth0PolicyResult =
-          FlowEvaluator.evaluate(
-              flow,
-              eth0.getName(),
-              eth0.getVrfName(),
-              eth0Policy,
-              c.getIpAccessLists(),
-              c.getIpSpaces(),
-              fibs);
-      FlowEvaluator.FlowResult eth1PolicyResult =
-          FlowEvaluator.evaluate(
-              flow,
-              eth1.getName(),
-              eth1.getVrfName(),
-              eth1Policy,
-              c.getIpAccessLists(),
-              c.getIpSpaces(),
-              fibs);
       testFunction.apply(
           flow, flow.toBuilder().setSrcIp(HIDE_BEHIND_GATEWAY_IP).build(), fibLookup);
     }


### PR DESCRIPTION
In master, there is currently a bug where a flow can match a manual rule at ingress and then match an automatic rule at egress. This was incorrect for multiple reasons:
- Once a manual rule has been matched, no automatic rules are applicable
- All rules should match on the original packet fields, but the egress transformation could have matched fields that were translated at ingress

This PR fixes the problem by converting all rules into a `PacketPolicy` that is applied on ingress. One wrinkle is that some automatic rules use a `hide-behind gateway` functionality to translate the source IP to the IP of the egress interface, which is unknown at ingress. To get around this, when such rules are matched at ingress, we translate the source IP to `0.0.0.0`. Then all interfaces have an outgoing transformation that transforms source `0.0.0.0` to the interface IP.