### PR TITLE
Batfish: simplify some IpSpaces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -30,6 +30,8 @@ import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.hsrp.HsrpGroup;
@@ -502,7 +504,7 @@ public final class IpOwners {
    */
   private static Map<String, Map<String, Map<String, IpSpace>>> computeIfaceOwnedIpSpaces(
       Map<Ip, Map<String, Map<String, Set<String>>>> ipIfaceOwners) {
-    Map<String, Map<String, Map<String, AclIpSpace.Builder>>> builders = new HashMap<>();
+    Map<String, Map<String, Map<String, IpWildcardSetIpSpace.Builder>>> builders = new HashMap<>();
     ipIfaceOwners.forEach(
         (ip, nodeMap) ->
             nodeMap.forEach(
@@ -514,8 +516,8 @@ public final class IpOwners {
                                     builders
                                         .computeIfAbsent(node, k -> new HashMap<>())
                                         .computeIfAbsent(vrf, k -> new HashMap<>())
-                                        .computeIfAbsent(iface, k -> AclIpSpace.builder())
-                                        .thenPermitting(ip.toIpSpace())))));
+                                        .computeIfAbsent(iface, k -> IpWildcardSetIpSpace.builder())
+                                        .including(IpWildcard.create(ip))))));
     return toImmutableMap(
         builders,
         Entry::getKey, /* node */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpRange.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpRange.java
@@ -3,6 +3,8 @@ package org.batfish.datamodel;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -55,9 +57,13 @@ public final class IpRange {
         high);
     ImmutableList.Builder<Prefix> prefixes = ImmutableList.builder();
     collectPrefixes(low, high, prefixes);
-    return AclIpSpace.builder()
-        .thenPermitting(prefixes.build().stream().map(Prefix::toIpSpace))
-        .build();
+    List<Prefix> prefixList = prefixes.build();
+    if (prefixList.size() == 1) {
+      return prefixList.get(0).toIpSpace();
+    }
+    return IpWildcardSetIpSpace.create(
+        ImmutableSet.of(),
+        prefixList.stream().map(IpWildcard::create).collect(ImmutableSet.toImmutableSet()));
   }
 
   private IpRange() {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -212,10 +212,10 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
     if (_prefixLength >= Prefix.MAX_PREFIX_LENGTH - 1) {
       return toIpSpace();
     }
-    return AclIpSpace.builder()
-        .thenRejecting(getStartIp().toIpSpace())
-        .thenRejecting(getEndIp().toIpSpace())
-        .thenPermitting(toIpSpace())
+    return IpWildcardSetIpSpace.builder()
+        .excluding(IpWildcard.create(getStartIp()))
+        .excluding(IpWildcard.create(getEndIp()))
+        .including(IpWildcard.create(this))
         .build();
   }
 


### PR DESCRIPTION
- Specific simple AclIpSpaces can be IpWildcardSetIpSpace instead
- Create fewer IpWildcardSetIpSpaces of size 1