### PR TITLE
Isp modeling: Misc cleanup

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspBgpActivePeer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspBgpActivePeer.java
@@ -42,20 +42,21 @@ final class IspBgpActivePeer extends IspBgpPeer {
 
   @Override
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof IspBgpActivePeer)) {
       return false;
     }
     IspBgpActivePeer that = (IspBgpActivePeer) o;
     return _peerAddress.equals(that._peerAddress)
         && _localIp.equals(that._localIp)
-        && _localAsn.equals(that._localAsn)
-        && _remoteAsn.equals(that._remoteAsn)
-        && (_ebgpMultiHop == that._ebgpMultiHop);
+        && super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_peerAddress, _localIp, _localAsn, _remoteAsn, _ebgpMultiHop);
+    return Objects.hash(_peerAddress, _localIp, super.hashCode());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspBgpPeer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspBgpPeer.java
@@ -1,6 +1,7 @@
 package org.batfish.common.util.isp;
 
 import com.google.common.base.MoreObjects;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /** Captures common settings used to create a BGP peer on the ISP node */
@@ -33,5 +34,24 @@ abstract class IspBgpPeer {
         .add("remoteAsn", _remoteAsn)
         .add("localAsn", _localAsn)
         .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof IspBgpPeer)) {
+      return false;
+    }
+    IspBgpPeer that = (IspBgpPeer) o;
+    return _localAsn.equals(that._localAsn)
+        && _remoteAsn.equals(that._remoteAsn)
+        && (_ebgpMultiHop == that._ebgpMultiHop);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_localAsn, _remoteAsn, _ebgpMultiHop);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspBgpUnnumberedPeer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspBgpUnnumberedPeer.java
@@ -33,19 +33,19 @@ final class IspBgpUnnumberedPeer extends IspBgpPeer {
 
   @Override
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof IspBgpUnnumberedPeer)) {
       return false;
     }
     IspBgpUnnumberedPeer that = (IspBgpUnnumberedPeer) o;
-    return _localIfaceName.equals(that._localIfaceName)
-        && _localAsn.equals(that._localAsn)
-        && _remoteAsn.equals(that._remoteAsn)
-        && (_ebgpMultiHop == that._ebgpMultiHop);
+    return _localIfaceName.equals(that._localIfaceName) && super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_localIfaceName, _localAsn, _remoteAsn, _ebgpMultiHop);
+    return Objects.hash(_localIfaceName, super.hashCode());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspInterface.java
@@ -40,6 +40,9 @@ final class IspInterface {
 
   @Override
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof IspInterface)) {
       return false;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModel.java
@@ -124,6 +124,9 @@ final class IspModel {
 
   @Override
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof IspModel)) {
       return false;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModelingUtils.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -526,12 +527,13 @@ public final class IspModelingUtils {
 
     // TODO: Enforce interface type constraint here
 
-    // TODO: search inactive interfaces too?
     Optional<ConcreteInterfaceAddress> snapshotBgpIfaceAddress =
-        snapshotBgpHost.getActiveInterfaces().values().stream()
+        snapshotBgpHost.getAllInterfaces().values().stream()
             .filter(iface -> iface.getVrfName().equalsIgnoreCase(bgpPeerVrf))
+            // prefer active interfaces
+            .sorted(Comparator.comparing(iface -> !iface.getActive()))
             .flatMap(iface -> iface.getAllConcreteAddresses().stream())
-            .filter(iface -> Objects.equals(iface.getIp(), snapshotBgpPeer.getLocalIp()))
+            .filter(addr -> Objects.equals(addr.getIp(), snapshotBgpPeer.getLocalIp()))
             .findFirst();
     if (!snapshotBgpIfaceAddress.isPresent()) {
       warnings.redFlag(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModelingUtils.java
@@ -427,7 +427,6 @@ public final class IspModelingUtils {
       IspInterface ispInterface =
           new IspInterface(ispIfaceName, LINK_LOCAL_ADDRESS, snapshotL1node, null);
       return new SnapshotConnection(
-          snapshotHostname,
           ImmutableList.of(ispInterface),
           IspBgpUnnumberedPeer.create((BgpUnnumberedPeerConfig) bgpPeerConfig, ispIfaceName));
     }
@@ -445,7 +444,6 @@ public final class IspModelingUtils {
       IspInterface ispInterface =
           new IspInterface(ispIfaceName, ispInterfaceAddress, snapshotL1node, null);
       return new SnapshotConnection(
-          snapshotHostname,
           ImmutableList.of(ispInterface),
           IspBgpActivePeer.create((BgpActivePeerConfig) bgpPeerConfig));
     }
@@ -498,10 +496,7 @@ public final class IspModelingUtils {
     }
     if (bgpPeerInfo.getIspAttachment() == null) {
       return Optional.of(
-          new SnapshotConnection(
-              snapshotBgpHost.getHostname(),
-              ImmutableList.of(),
-              IspBgpActivePeer.create(snapshotBgpPeer)));
+          new SnapshotConnection(ImmutableList.of(), IspBgpActivePeer.create(snapshotBgpPeer)));
     }
 
     IspAttachment ispAttachment = bgpPeerInfo.getIspAttachment();
@@ -583,9 +578,7 @@ public final class IspModelingUtils {
     IspInterface ispInterface =
         new IspInterface(ispIfaceName, ispInterfaceAddress, snapshotL1node, vlanTag);
     return new SnapshotConnection(
-        snapshotAttachmentHostname,
-        ImmutableList.of(ispInterface),
-        IspBgpActivePeer.create(snapshotBgpPeer));
+        ImmutableList.of(ispInterface), IspBgpActivePeer.create(snapshotBgpPeer));
   }
 
   private static ModeledNodes createInternetAndIspNodes(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/SnapshotConnection.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/SnapshotConnection.java
@@ -8,18 +8,12 @@ import javax.annotation.Nonnull;
 /** Represents one connection (interface(s), BGP peer) this ISP has to the snapshot */
 final class SnapshotConnection {
 
-  private @Nonnull final String _snapshotHostname;
   private @Nonnull final List<IspInterface> _interfaces;
   private @Nonnull final IspBgpPeer _bgpPeer;
 
-  SnapshotConnection(String snapshotHostname, List<IspInterface> interfaces, IspBgpPeer bgpPeer) {
-    _snapshotHostname = snapshotHostname;
+  SnapshotConnection(List<IspInterface> interfaces, IspBgpPeer bgpPeer) {
     _interfaces = interfaces;
     _bgpPeer = bgpPeer;
-  }
-
-  public @Nonnull String getSnapshotHostname() {
-    return _snapshotHostname;
   }
 
   public @Nonnull List<IspInterface> getInterfaces() {
@@ -32,24 +26,24 @@ final class SnapshotConnection {
 
   @Override
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof SnapshotConnection)) {
       return false;
     }
     SnapshotConnection that = (SnapshotConnection) o;
-    return _snapshotHostname.equals(that._snapshotHostname)
-        && _interfaces.equals(that._interfaces)
-        && _bgpPeer.equals(that._bgpPeer);
+    return _interfaces.equals(that._interfaces) && _bgpPeer.equals(that._bgpPeer);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_snapshotHostname, _interfaces, _bgpPeer);
+    return Objects.hash(_interfaces, _bgpPeer);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("snapshotHostname", _snapshotHostname)
         .add("interfaces", _interfaces)
         .add("bgpPeerConfig", _bgpPeer)
         .toString();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isp_configuration/BgpPeerInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isp_configuration/BgpPeerInfo.java
@@ -89,6 +89,9 @@ public class BgpPeerInfo {
 
   @Override
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof BgpPeerInfo)) {
       return false;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isp_configuration/IspAttachment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isp_configuration/IspAttachment.java
@@ -66,6 +66,9 @@ public class IspAttachment {
 
   @Override
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof IspAttachment)) {
       return false;
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspBgpActivePeerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspBgpActivePeerTest.java
@@ -1,0 +1,21 @@
+package org.batfish.common.util.isp;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.Ip;
+import org.junit.Test;
+
+public class IspBgpActivePeerTest {
+
+  @Test
+  public void testEquals() {
+    // test variation of fields unique to unnumbered peers -- the inherited fields are tested in the
+    // parent class
+    new EqualsTester()
+        .addEqualityGroup(
+            new IspBgpActivePeer(Ip.ZERO, Ip.FIRST_MULTICAST_IP, 1L, 2L, false),
+            new IspBgpActivePeer(Ip.ZERO, Ip.FIRST_MULTICAST_IP, 1L, 2L, false))
+        .addEqualityGroup(new IspBgpActivePeer(Ip.MAX, Ip.FIRST_MULTICAST_IP, 1L, 2L, false))
+        .addEqualityGroup(new IspBgpActivePeer(Ip.ZERO, Ip.MAX, 1L, 2L, false))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspBgpPeerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspBgpPeerTest.java
@@ -1,0 +1,20 @@
+package org.batfish.common.util.isp;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+public class IspBgpPeerTest {
+
+  @Test
+  public void testEquals() {
+    // test via unnumbered child class
+    new EqualsTester()
+        .addEqualityGroup(
+            new IspBgpUnnumberedPeer("iface", 1L, 2L, false),
+            new IspBgpUnnumberedPeer("iface", 1L, 2L, false))
+        .addEqualityGroup(new IspBgpUnnumberedPeer("iface", 9L, 2L, false))
+        .addEqualityGroup(new IspBgpUnnumberedPeer("iface", 1L, 9L, false))
+        .addEqualityGroup(new IspBgpUnnumberedPeer("iface", 1L, 2L, true))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspBgpUnnumberedTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspBgpUnnumberedTest.java
@@ -1,0 +1,19 @@
+package org.batfish.common.util.isp;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+public class IspBgpUnnumberedTest {
+
+  @Test
+  public void testEquals() {
+    // test variation of fields unique to unnumbered peers -- the inherited fields are tested in the
+    // parent class
+    new EqualsTester()
+        .addEqualityGroup(
+            new IspBgpUnnumberedPeer("iface", 1L, 2L, false),
+            new IspBgpUnnumberedPeer("iface", 1L, 2L, false))
+        .addEqualityGroup(new IspBgpUnnumberedPeer("other", 1L, 2L, false))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspInterfaceTest.java
@@ -1,0 +1,29 @@
+package org.batfish.common.util.isp;
+
+import static org.batfish.common.util.isp.IspModelingUtils.LINK_LOCAL_ADDRESS;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.common.topology.Layer1Node;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.junit.Test;
+
+public class IspInterfaceTest {
+
+  @Test
+  public void testEquals() {
+    Layer1Node layer1Node = new Layer1Node("host", "interface");
+    new EqualsTester()
+        .addEqualityGroup(
+            new IspInterface("name", LINK_LOCAL_ADDRESS, layer1Node, null),
+            new IspInterface("name", LINK_LOCAL_ADDRESS, new Layer1Node("host", "interface"), null))
+        .addEqualityGroup(new IspInterface("other", LINK_LOCAL_ADDRESS, layer1Node, null))
+        .addEqualityGroup(
+            new IspInterface(
+                "name", ConcreteInterfaceAddress.parse("1.1.1.1/24"), layer1Node, null))
+        .addEqualityGroup(
+            new IspInterface(
+                "name", LINK_LOCAL_ADDRESS, new Layer1Node("other", "interface"), null))
+        .addEqualityGroup(new IspInterface("name", LINK_LOCAL_ADDRESS, layer1Node, 23))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelTest.java
@@ -21,7 +21,6 @@ public class IspModelTest {
             builder
                 .setSnapshotConnections(
                     new SnapshotConnection(
-                        "a",
                         ImmutableList.of(),
                         IspBgpActivePeer.create(
                             BgpActivePeerConfig.builder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelingUtilsTest.java
@@ -158,7 +158,6 @@ public class IspModelingUtilsTest {
             .build();
     _snapshotConnection =
         new SnapshotConnection(
-            _snapshotHostname,
             ImmutableList.of(
                 new IspInterface(
                     ispToSnapshotInterfaceName(_snapshotHostname, _snapshotInterfaceName),
@@ -401,7 +400,6 @@ public class IspModelingUtilsTest {
             .setAsn(_ispAsn)
             .setSnapshotConnections(
                 new SnapshotConnection(
-                    _snapshotHostname,
                     ImmutableList.of(
                         new IspInterface(
                             ispIfaceName,
@@ -668,7 +666,6 @@ public class IspModelingUtilsTest {
         equalTo(
             ImmutableList.of(
                 new SnapshotConnection(
-                    configuration.getHostname(),
                     ImmutableList.of(
                         new IspInterface(
                             ispIfaceName,
@@ -707,7 +704,6 @@ public class IspModelingUtilsTest {
             ImmutableList.of(
                 _snapshotConnection,
                 new SnapshotConnection(
-                    _snapshotHostname,
                     ImmutableList.of(
                         new IspInterface(
                             ispIfaceName,
@@ -748,9 +744,7 @@ public class IspModelingUtilsTest {
         snapshotConnection.get(),
         equalTo(
             new SnapshotConnection(
-                _snapshotHostname,
-                ImmutableList.of(),
-                IspBgpActivePeer.create(_snapshotActivePeer))));
+                ImmutableList.of(), IspBgpActivePeer.create(_snapshotActivePeer))));
   }
 
   @Test
@@ -773,7 +767,6 @@ public class IspModelingUtilsTest {
         snapshotConnection.get(),
         equalTo(
             new SnapshotConnection(
-                _snapshotHostname,
                 ImmutableList.of(
                     new IspInterface(
                         ispToSnapshotInterfaceName(_snapshotHostname, attachIface.getName()),
@@ -801,7 +794,6 @@ public class IspModelingUtilsTest {
         snapshotConnection.get(),
         equalTo(
             new SnapshotConnection(
-                _snapshotHostname,
                 ImmutableList.of(
                     new IspInterface(
                         ispToSnapshotInterfaceName(_snapshotHostname, _snapshotInterfaceName),
@@ -1345,7 +1337,6 @@ public class IspModelingUtilsTest {
                     .setSnapshotConnections(
                         _snapshotConnection,
                         new SnapshotConnection(
-                            c2.getHostname(),
                             ImmutableList.of(
                                 new IspInterface(
                                     ispToSnapshotInterfaceName(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/SnapshotConnectionTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/SnapshotConnectionTest.java
@@ -23,18 +23,15 @@ public class SnapshotConnectionTest {
                 .build());
     new EqualsTester()
         .addEqualityGroup(
-            new SnapshotConnection("a", ImmutableList.of(), ispBgpActivePeer),
-            new SnapshotConnection("a", ImmutableList.of(), ispBgpActivePeer))
-        .addEqualityGroup(new SnapshotConnection("other", ImmutableList.of(), ispBgpActivePeer))
+            new SnapshotConnection(ImmutableList.of(), ispBgpActivePeer),
+            new SnapshotConnection(ImmutableList.of(), ispBgpActivePeer))
         .addEqualityGroup(
             new SnapshotConnection(
-                "a",
                 ImmutableList.of(
                     new IspInterface("name", LINK_LOCAL_ADDRESS, new Layer1Node("1", "2"), null)),
                 ispBgpActivePeer))
         .addEqualityGroup(
             new SnapshotConnection(
-                "a",
                 ImmutableList.of(),
                 IspBgpActivePeer.create(
                     BgpActivePeerConfig.builder()


### PR DESCRIPTION
1. Object equality in various places
2. testEquals where it wasn't there
3. Defer to parent equality in IspBgp{Active,Unnumbered}Peer
4. Consider inactive interfaces too while search for addresses to use on the ISP side
5. remove hostname from snapshot connection

No functional change (except for #4)