### PR TITLE
IspModeling: Remove hostname from SnapshotConnection

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModelingUtils.java
@@ -427,7 +427,6 @@ public final class IspModelingUtils {
       IspInterface ispInterface =
           new IspInterface(ispIfaceName, LINK_LOCAL_ADDRESS, snapshotL1node, null);
       return new SnapshotConnection(
-          snapshotHostname,
           ImmutableList.of(ispInterface),
           IspBgpUnnumberedPeer.create((BgpUnnumberedPeerConfig) bgpPeerConfig, ispIfaceName));
     }
@@ -445,7 +444,6 @@ public final class IspModelingUtils {
       IspInterface ispInterface =
           new IspInterface(ispIfaceName, ispInterfaceAddress, snapshotL1node, null);
       return new SnapshotConnection(
-          snapshotHostname,
           ImmutableList.of(ispInterface),
           IspBgpActivePeer.create((BgpActivePeerConfig) bgpPeerConfig));
     }
@@ -498,10 +496,7 @@ public final class IspModelingUtils {
     }
     if (bgpPeerInfo.getIspAttachment() == null) {
       return Optional.of(
-          new SnapshotConnection(
-              snapshotBgpHost.getHostname(),
-              ImmutableList.of(),
-              IspBgpActivePeer.create(snapshotBgpPeer)));
+          new SnapshotConnection(ImmutableList.of(), IspBgpActivePeer.create(snapshotBgpPeer)));
     }
 
     IspAttachment ispAttachment = bgpPeerInfo.getIspAttachment();
@@ -583,9 +578,7 @@ public final class IspModelingUtils {
     IspInterface ispInterface =
         new IspInterface(ispIfaceName, ispInterfaceAddress, snapshotL1node, vlanTag);
     return new SnapshotConnection(
-        snapshotAttachmentHostname,
-        ImmutableList.of(ispInterface),
-        IspBgpActivePeer.create(snapshotBgpPeer));
+        ImmutableList.of(ispInterface), IspBgpActivePeer.create(snapshotBgpPeer));
   }
 
   private static ModeledNodes createInternetAndIspNodes(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/SnapshotConnection.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/SnapshotConnection.java
@@ -8,18 +8,12 @@ import javax.annotation.Nonnull;
 /** Represents one connection (interface(s), BGP peer) this ISP has to the snapshot */
 final class SnapshotConnection {
 
-  private @Nonnull final String _snapshotHostname;
   private @Nonnull final List<IspInterface> _interfaces;
   private @Nonnull final IspBgpPeer _bgpPeer;
 
-  SnapshotConnection(String snapshotHostname, List<IspInterface> interfaces, IspBgpPeer bgpPeer) {
-    _snapshotHostname = snapshotHostname;
+  SnapshotConnection(List<IspInterface> interfaces, IspBgpPeer bgpPeer) {
     _interfaces = interfaces;
     _bgpPeer = bgpPeer;
-  }
-
-  public @Nonnull String getSnapshotHostname() {
-    return _snapshotHostname;
   }
 
   public @Nonnull List<IspInterface> getInterfaces() {
@@ -36,20 +30,17 @@ final class SnapshotConnection {
       return false;
     }
     SnapshotConnection that = (SnapshotConnection) o;
-    return _snapshotHostname.equals(that._snapshotHostname)
-        && _interfaces.equals(that._interfaces)
-        && _bgpPeer.equals(that._bgpPeer);
+    return _interfaces.equals(that._interfaces) && _bgpPeer.equals(that._bgpPeer);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_snapshotHostname, _interfaces, _bgpPeer);
+    return Objects.hash(_interfaces, _bgpPeer);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("snapshotHostname", _snapshotHostname)
         .add("interfaces", _interfaces)
         .add("bgpPeerConfig", _bgpPeer)
         .toString();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelTest.java
@@ -21,7 +21,6 @@ public class IspModelTest {
             builder
                 .setSnapshotConnections(
                     new SnapshotConnection(
-                        "a",
                         ImmutableList.of(),
                         IspBgpActivePeer.create(
                             BgpActivePeerConfig.builder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelingUtilsTest.java
@@ -158,7 +158,6 @@ public class IspModelingUtilsTest {
             .build();
     _snapshotConnection =
         new SnapshotConnection(
-            _snapshotHostname,
             ImmutableList.of(
                 new IspInterface(
                     ispToSnapshotInterfaceName(_snapshotHostname, _snapshotInterfaceName),
@@ -401,7 +400,6 @@ public class IspModelingUtilsTest {
             .setAsn(_ispAsn)
             .setSnapshotConnections(
                 new SnapshotConnection(
-                    _snapshotHostname,
                     ImmutableList.of(
                         new IspInterface(
                             ispIfaceName,
@@ -668,7 +666,6 @@ public class IspModelingUtilsTest {
         equalTo(
             ImmutableList.of(
                 new SnapshotConnection(
-                    configuration.getHostname(),
                     ImmutableList.of(
                         new IspInterface(
                             ispIfaceName,
@@ -707,7 +704,6 @@ public class IspModelingUtilsTest {
             ImmutableList.of(
                 _snapshotConnection,
                 new SnapshotConnection(
-                    _snapshotHostname,
                     ImmutableList.of(
                         new IspInterface(
                             ispIfaceName,
@@ -748,9 +744,7 @@ public class IspModelingUtilsTest {
         snapshotConnection.get(),
         equalTo(
             new SnapshotConnection(
-                _snapshotHostname,
-                ImmutableList.of(),
-                IspBgpActivePeer.create(_snapshotActivePeer))));
+                ImmutableList.of(), IspBgpActivePeer.create(_snapshotActivePeer))));
   }
 
   @Test
@@ -773,7 +767,6 @@ public class IspModelingUtilsTest {
         snapshotConnection.get(),
         equalTo(
             new SnapshotConnection(
-                _snapshotHostname,
                 ImmutableList.of(
                     new IspInterface(
                         ispToSnapshotInterfaceName(_snapshotHostname, attachIface.getName()),
@@ -801,7 +794,6 @@ public class IspModelingUtilsTest {
         snapshotConnection.get(),
         equalTo(
             new SnapshotConnection(
-                _snapshotHostname,
                 ImmutableList.of(
                     new IspInterface(
                         ispToSnapshotInterfaceName(_snapshotHostname, _snapshotInterfaceName),
@@ -1345,7 +1337,6 @@ public class IspModelingUtilsTest {
                     .setSnapshotConnections(
                         _snapshotConnection,
                         new SnapshotConnection(
-                            c2.getHostname(),
                             ImmutableList.of(
                                 new IspInterface(
                                     ispToSnapshotInterfaceName(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/SnapshotConnectionTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/SnapshotConnectionTest.java
@@ -23,18 +23,16 @@ public class SnapshotConnectionTest {
                 .build());
     new EqualsTester()
         .addEqualityGroup(
-            new SnapshotConnection("a", ImmutableList.of(), ispBgpActivePeer),
-            new SnapshotConnection("a", ImmutableList.of(), ispBgpActivePeer))
-        .addEqualityGroup(new SnapshotConnection("other", ImmutableList.of(), ispBgpActivePeer))
+            new SnapshotConnection(ImmutableList.of(), ispBgpActivePeer),
+            new SnapshotConnection(ImmutableList.of(), ispBgpActivePeer))
+        .addEqualityGroup(new SnapshotConnection(ImmutableList.of(), ispBgpActivePeer))
         .addEqualityGroup(
             new SnapshotConnection(
-                "a",
                 ImmutableList.of(
                     new IspInterface("name", LINK_LOCAL_ADDRESS, new Layer1Node("1", "2"), null)),
                 ispBgpActivePeer))
         .addEqualityGroup(
             new SnapshotConnection(
-                "a",
                 ImmutableList.of(),
                 IspBgpActivePeer.create(
                     BgpActivePeerConfig.builder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/SnapshotConnectionTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/SnapshotConnectionTest.java
@@ -25,7 +25,6 @@ public class SnapshotConnectionTest {
         .addEqualityGroup(
             new SnapshotConnection(ImmutableList.of(), ispBgpActivePeer),
             new SnapshotConnection(ImmutableList.of(), ispBgpActivePeer))
-        .addEqualityGroup(new SnapshotConnection(ImmutableList.of(), ispBgpActivePeer))
         .addEqualityGroup(
             new SnapshotConnection(
                 ImmutableList.of(


### PR DESCRIPTION
The field doesn't make sense anymore since there can be two different snapshot hosts involved, and it was not being used anyway.