### PR TITLE
NumberSpace: remove dangerous and misleading not methods

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NumberSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NumberSpace.java
@@ -188,7 +188,7 @@ public abstract class NumberSpace<
 
   /** Compute the difference between two {@link NumberSpace}s */
   public final S difference(S other) {
-    return intersection(other.not(getThis()));
+    return toBuilder().excluding(other).build();
   }
 
   protected abstract DiscreteDomain<T> discreteDomain();
@@ -292,19 +292,18 @@ public abstract class NumberSpace<
   protected abstract B newBuilder();
 
   /**
-   * Take the complement of this space, bounded by existing lower and upper limits of the space.
-   * This can be used as a way to represent a set of excluded ranges as a positive space.
+   * Take the complement of this space, using the given {@link Range bounds}.
+   *
+   * <p>It is an error to provide a smaller bounds than this space represents.
    */
-  public final S not() {
-    if (_rangeset.isEmpty()) {
-      return empty();
-    }
-    return newBuilder().including(_rangeset.complement().subRangeSet(_rangeset.span())).build();
-  }
-
-  /** Take the complement of this space, bounded by some other {@link NumberSpace} */
-  public final S not(S within) {
-    return newBuilder().build(_rangeset.complement()).intersection(within);
+  public final S complement(Range<T> bounds) {
+    Range<T> canonicalBounds = bounds.canonical(discreteDomain());
+    checkArgument(
+        isEmpty() || canonicalBounds.encloses(_rangeset.span().canonical(discreteDomain())),
+        "Cannot take the complement of space %s within a smaller bounds %s.",
+        this,
+        bounds);
+    return newBuilder().build(_rangeset.complement().subRangeSet(canonicalBounds));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
@@ -158,25 +158,31 @@ public final class IntegerSpaceTest {
 
   @Test
   public void testComplement() {
-    IntegerSpace notPorts = PORTS.not(PORTS);
+    Range<Integer> u16 = Range.closed(0, 65535);
+    IntegerSpace ports = IntegerSpace.of(u16);
+    IntegerSpace notPorts = ports.complement(u16);
     assertTrue("Complement of full space is empty", notPorts.isEmpty());
+    assertThat("Complement of empty should be all", EMPTY.complement(u16), equalTo(ports));
 
-    IntegerSpace portsWithExclusion = PORTS.toBuilder().excluding(new SubRange(10, 20)).build();
+    // Non-empty complement
+    IntegerSpace u8 = IntegerSpace.of(Range.closed(0, 255));
+    assertThat(u8.complement(u16), equalTo(IntegerSpace.of(Range.closed(256, 65535))));
+    IntegerSpace middle = IntegerSpace.of(Range.closed(10, 20));
     assertThat(
-        portsWithExclusion.not(),
-        equalTo(IntegerSpace.builder().including(new SubRange(10, 20)).build()));
+        middle.complement(u16),
+        equalTo(
+            IntegerSpace.builder()
+                .including(Range.closed(0, 9))
+                .including(Range.closed(21, 65535))
+                .build()));
+  }
 
-    // A bit contrived, but: a complement within a smaller space can produce a valid result
-    IntegerSpace small = _b.including(new SubRange(12, 15)).build();
-    assertThat(portsWithExclusion.not(small), equalTo(small));
-
-    // Test empty intersections
-    assertThat(
-        portsWithExclusion.not(IntegerSpace.builder().including(new SubRange(40, 50)).build()),
-        equalTo(EMPTY));
-    assertThat(portsWithExclusion.not(EMPTY), equalTo(EMPTY));
-
-    assertThat(EMPTY.not(), equalTo(EMPTY));
+  @Test
+  public void testComplementRejectsSmaller() {
+    _expected.expect(IllegalArgumentException.class);
+    _expected.expectMessage(
+        "Cannot take the complement of space 10-100 within a smaller bounds [5..5].");
+    IntegerSpace.of(Range.closed(10, 100)).complement(Range.singleton(5));
   }
 
   @Test


### PR DESCRIPTION
Replace with a straightforward complement-within-bounds function.