### PR TITLE
CP: Install access rules on correct gateways

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -173,7 +173,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
 
     // Initial management data conversion
     domainAndGateway.ifPresent(e -> convertCluster(e.getValue(), e.getKey()));
-    mgmtPackage.ifPresent(pakij -> convertPackage(pakij, mgmtObjects));
+    mgmtPackage.ifPresent(pakij -> convertPackage(pakij, mgmtObjects, domainAndGateway.get()));
 
     // Gateways don't have VRFs, so put everything in a generated default VRF
     Vrf vrf = new Vrf(VRF_NAME);
@@ -233,7 +233,9 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
   }
 
   private void convertAccessLayers(
-      List<AccessLayer> accessLayers, Map<Uid, NamedManagementObject> objects) {
+      List<AccessLayer> accessLayers,
+      Map<Uid, NamedManagementObject> objects,
+      Entry<ManagementDomain, GatewayOrServer> domainAndGateway) {
     // TODO support matching multiple access layers
     if (accessLayers.size() > 1) {
       _w.redFlag(
@@ -244,7 +246,8 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
     AddressSpaceToMatchExpr addressSpaceToMatchExpr = new AddressSpaceToMatchExpr(objects);
     for (AccessLayer al : accessLayers) {
       Map<String, IpAccessList> acl =
-          toIpAccessLists(al, objects, serviceToMatchExpr, addressSpaceToMatchExpr, _w);
+          toIpAccessLists(
+              al, objects, serviceToMatchExpr, addressSpaceToMatchExpr, domainAndGateway, _w);
       _c.getIpAccessLists().putAll(acl);
     }
     IpAccessList interfaceAcl =
@@ -298,9 +301,12 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
    * Convert constructs in the specified package to their VI model equivalent and add them to the VI
    * configuration. (Does not include NAT rulebase conversion.)
    */
-  private void convertPackage(ManagementPackage pakij, Map<Uid, NamedManagementObject> objects) {
+  private void convertPackage(
+      ManagementPackage pakij,
+      Map<Uid, NamedManagementObject> objects,
+      Entry<ManagementDomain, GatewayOrServer> domainAndGateway) {
     convertObjects(objects);
-    convertAccessLayers(pakij.getAccessLayers(), objects);
+    convertAccessLayers(pakij.getAccessLayers(), objects, domainAndGateway);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckpointNatConversions.java
@@ -35,6 +35,7 @@ import org.batfish.vendor.check_point_management.HasNatSettings;
 import org.batfish.vendor.check_point_management.HasNatSettingsVisitor;
 import org.batfish.vendor.check_point_management.Host;
 import org.batfish.vendor.check_point_management.ManagementDomain;
+import org.batfish.vendor.check_point_management.ManagementObject;
 import org.batfish.vendor.check_point_management.NamedManagementObject;
 import org.batfish.vendor.check_point_management.NatHideBehindGateway;
 import org.batfish.vendor.check_point_management.NatHideBehindIp;
@@ -51,6 +52,7 @@ import org.batfish.vendor.check_point_management.NatTranslatedSource;
 import org.batfish.vendor.check_point_management.NatTranslatedSourceVisitor;
 import org.batfish.vendor.check_point_management.Network;
 import org.batfish.vendor.check_point_management.Original;
+import org.batfish.vendor.check_point_management.PolicyTargets;
 import org.batfish.vendor.check_point_management.ServiceToMatchExpr;
 import org.batfish.vendor.check_point_management.TypedManagementObject;
 import org.batfish.vendor.check_point_management.Uid;
@@ -310,6 +312,12 @@ public class CheckpointNatConversions {
   /** Get a stream of the applicable NAT rules for the provided gateway. */
   static @Nonnull Stream<NatRule> getApplicableNatRules(
       NatRulebase natRulebase, Map.Entry<ManagementDomain, GatewayOrServer> domainAndGateway) {
+    Uid policyTargetsUid =
+        natRulebase.getObjectsDictionary().values().stream()
+            .filter(PolicyTargets.class::isInstance)
+            .map(ManagementObject::getUid)
+            .findAny()
+            .orElse(null);
     return natRulebase.getRulebase().stream()
         // Convert to stream of all rules
         .flatMap(
@@ -328,8 +336,7 @@ public class CheckpointNatConversions {
         .filter(NatRule::isEnabled)
         .filter(
             natRule ->
-                appliesToGateway(
-                    natRule.getInstallOn(), natRulebase.getObjectsDictionary(), domainAndGateway));
+                appliesToGateway(natRule.getInstallOn(), policyTargetsUid, domainAndGateway));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -1107,6 +1107,7 @@ public class CheckPointGatewayGrammarTest {
     CpmiAnyObject any = new CpmiAnyObject(cpmiAnyUid);
     Uid acceptUid = Uid.of("31");
     Uid dropUid = Uid.of("32");
+    Uid policyTargetsUid = Uid.of("33");
     Uid net1Uid = Uid.of("11");
     Uid net2Uid = Uid.of("12");
     // Attached to domain, NOT in access layer object dict
@@ -1134,6 +1135,7 @@ public class CheckPointGatewayGrammarTest {
                     net1Uid))
             .put(acceptUid, new RulebaseAction("Accept", acceptUid, "Accept"))
             .put(dropUid, new RulebaseAction("Drop", dropUid, "Drop"))
+            .put(policyTargetsUid, new PolicyTargets(policyTargetsUid))
             .build();
     ImmutableList<AccessRuleOrSection> rulebase =
         ImmutableList.of(
@@ -1141,11 +1143,13 @@ public class CheckPointGatewayGrammarTest {
                 .setAction(acceptUid)
                 .setDestination(ImmutableList.of(net2Uid))
                 .setSource(ImmutableList.of(net1Uid))
+                .setInstallOn(ImmutableList.of(policyTargetsUid))
                 .setUid(Uid.of("100"))
                 .setName("acceptNet1ToNet2")
                 .build(),
             AccessRule.testBuilder(cpmiAnyUid)
                 .setAction(dropUid)
+                .setInstallOn(ImmutableList.of(policyTargetsUid))
                 .setUid(Uid.of("101"))
                 .setName("dropAll")
                 .build());
@@ -1456,11 +1460,12 @@ public class CheckPointGatewayGrammarTest {
     Uid accessListUid = Uid.of(String.valueOf(uidGenerator.getAndIncrement()));
     AccessLayer accessLayer =
         new AccessLayer(
-            ImmutableMap.of(cpmiAnyUid, any, permitUid, permit),
+            ImmutableMap.of(cpmiAnyUid, any, permitUid, permit, policyTargetsUid, policyTargets),
             ImmutableList.of(
                 AccessRule.testBuilder(cpmiAnyUid)
                     .setUid(accessRuleUid)
                     .setAction(permitUid)
+                    .setInstallOn(ImmutableList.of(policyTargetsUid))
                     .build()),
             accessListUid,
             "accessLayer");
@@ -1741,20 +1746,19 @@ public class CheckPointGatewayGrammarTest {
     RulebaseAction permit = new RulebaseAction("Accept", permitUid, "");
     AccessLayer accessLayer =
         new AccessLayer(
-            ImmutableMap.of(
-                anyUid,
-                any,
-                natNetworkUid,
-                natNetwork,
-                noNatNetworkUid,
-                noNatNetwork,
-                permitUid,
-                permit),
+            ImmutableMap.<Uid, NamedManagementObject>builder()
+                .put(anyUid, any)
+                .put(natNetworkUid, natNetwork)
+                .put(noNatNetworkUid, noNatNetwork)
+                .put(permitUid, permit)
+                .put(policyTargetsUid, policyTargets)
+                .build(),
             ImmutableList.of(
                 AccessRule.testBuilder(anyUid)
                     .setUid(accessRuleUid)
                     .setAction(permitUid)
                     .setSource(ImmutableList.of(natNetworkUid, noNatNetworkUid))
+                    .setInstallOn(ImmutableList.of(policyTargetsUid))
                     .build()),
             alUid,
             "accessLayer");


### PR DESCRIPTION
Filters access rules by their `install-on` field with the same logic used to filter NAT rules.