### PR TITLE
A10: recognize subnet masks as valid ip addresses

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/StaticRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/StaticRouteMatchers.java
@@ -1,0 +1,42 @@
+package org.batfish.datamodel.matchers;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.StaticRoute;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+@ParametersAreNonnullByDefault
+public final class StaticRouteMatchers {
+
+  /**
+   * Provides a matcher that matches when the supplied {@code subMatcher} matches {@link
+   * StaticRoute#getRecursive()}.
+   */
+  public static @Nonnull Matcher<StaticRoute> hasRecursive(Matcher<? super Boolean> subMatcher) {
+    return new HasRecursive(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches when the supplied value matches {@link
+   * StaticRoute#getRecursive()}.
+   */
+  public static @Nonnull Matcher<StaticRoute> hasRecursive(boolean value) {
+    return hasRecursive(equalTo(value));
+  }
+
+  private static final class HasRecursive extends FeatureMatcher<StaticRoute, Boolean> {
+    HasRecursive(@Nonnull Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "A StaticRoute with recursive:", "recursive");
+    }
+
+    @Override
+    protected Boolean featureValueOf(StaticRoute actual) {
+      return actual.getRecursive();
+    }
+  }
+
+  private StaticRouteMatchers() {}
+}

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_common.g4
@@ -30,7 +30,7 @@ ip_prefix: ip_address ip_netmask;
 
 ip_netmask: subnet_mask | ip_slash_prefix;
 
-ip_address: IP_ADDRESS;
+ip_address: IP_ADDRESS | SUBNET_MASK;
 
 ip_slash_prefix: IP_SLASH_PREFIX;
 

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/static_route_convert
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/static_route_convert
@@ -4,6 +4,8 @@ hostname static_route_convert
 interface ethernet 1
  ip address 10.100.4.100 /24
 !
+ip route 0.0.0.0 /0 10.100.4.4
+!
 ip route 10.100.0.0 /16 10.100.4.1
 ip route 10.100.0.0 /16 10.100.4.2 1
 !


### PR DESCRIPTION
Fixes a bug where static routes that happened to be valid masks would not parse.

Also cleaned up test to not depend on route equality but instead simply
test the properties of interest.