### PR TITLE
Remove Reason from RouteAdvertisement

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -56,7 +56,6 @@ import org.batfish.dataplane.rib.EigrpRib;
 import org.batfish.dataplane.rib.RibDelta;
 import org.batfish.dataplane.rib.RibDelta.Builder;
 import org.batfish.dataplane.rib.RouteAdvertisement;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 /** An instance of an EigrpProcess as constructed and used by {@link VirtualRouter} */
 @ParametersAreNonnullByDefault
@@ -209,7 +208,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
                 builder.add(outputRoute);
                 _externalRib.mergeRouteGetDelta(outputRoute);
               } else {
-                builder.remove(outputRoute, Reason.WITHDRAW);
+                builder.remove(outputRoute);
                 _externalRib.removeRouteGetDelta(outputRoute);
               }
             });

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -71,7 +71,6 @@ import org.batfish.dataplane.rib.OspfIntraAreaRib;
 import org.batfish.dataplane.rib.OspfRib;
 import org.batfish.dataplane.rib.RibDelta;
 import org.batfish.dataplane.rib.RouteAdvertisement;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 /** An OSPF routing process, a dataplane version of {@link OspfProcess} */
 @ParametersAreNonnullByDefault
@@ -494,7 +493,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   private static <R extends AbstractRoute, T extends R> RibDelta<R> processRouteAdvertisement(
       RouteAdvertisement<T> ra, AbstractRib<R> rib) {
     if (ra.isWithdrawn()) {
-      return rib.removeRouteGetDelta(ra.getRoute(), ra.getReason());
+      return rib.removeRouteGetDelta(ra.getRoute());
     } else {
       return rib.mergeRouteGetDelta(ra.getRoute());
     }
@@ -675,7 +674,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
         interAreaDelta.from(
             processRouteAdvertisement(
                 RouteAdvertisement.<OspfInterAreaRoute>builder()
-                    .setReason(routeAdvertisement.getReason())
+                    .setWithdrawn(routeAdvertisement.isWithdrawn())
                     .setRoute(interAreaRoute)
                     .build(),
                 _interAreaRib));
@@ -1140,7 +1139,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
 
     return Optional.of(
         RouteAdvertisement.<OspfInterAreaRoute>builder()
-            .setReason(Reason.ADD)
+            .setWithdrawn(false)
             .setRoute(
                 OspfInterAreaRoute.builder()
                     .setNetwork(Prefix.ZERO)

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RouteDependencyTracker.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RouteDependencyTracker.java
@@ -10,7 +10,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.dataplane.rib.AbstractRib;
 import org.batfish.dataplane.rib.RibDelta;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 @ParametersAreNonnullByDefault
 public final class RouteDependencyTracker<
@@ -53,7 +52,7 @@ public final class RouteDependencyTracker<
     }
     RibDelta.Builder<R> b = RibDelta.builder();
     for (R depRoute : dependents) {
-      b.from(rib.removeRouteGetDelta(depRoute, Reason.WITHDRAW));
+      b.from(rib.removeRouteGetDelta(depRoute));
     }
     // Now the route is gone and will have no dependents
     _routeDependents.remove(route);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -109,7 +109,6 @@ import org.batfish.dataplane.rib.RibDelta.Builder;
 import org.batfish.dataplane.rib.RipInternalRib;
 import org.batfish.dataplane.rib.RipRib;
 import org.batfish.dataplane.rib.RouteAdvertisement;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 import org.batfish.dataplane.rib.StaticRib;
 
 public final class VirtualRouter {
@@ -297,8 +296,8 @@ public final class VirtualRouter {
         .forEach(
             r -> {
               @SuppressWarnings("unchecked") // Ok to upcast to R since immutable.
-              RouteAdvertisement<R> sanitized = (RouteAdvertisement<R>) r.sanitizeForExport();
-              queue.add(sanitized);
+              RouteAdvertisement<R> cast = (RouteAdvertisement<R>) r;
+              queue.add(cast);
             });
   }
 
@@ -532,8 +531,7 @@ public final class VirtualRouter {
         /*
          * If the route is not in the RIB, this has no effect. But might add some overhead (TODO)
          */
-        _mainRibRouteDeltaBuilder.from(
-            _mainRib.removeRouteGetDelta(annotateRoute(sr), Reason.WITHDRAW));
+        _mainRibRouteDeltaBuilder.from(_mainRib.removeRouteGetDelta(annotateRoute(sr)));
       }
     }
   }
@@ -989,7 +987,7 @@ public final class VirtualRouter {
                     .setNonRouting(false)
                     .build();
             if (withdraw) {
-              deltaBuilder.remove(newRoute, Reason.WITHDRAW);
+              deltaBuilder.remove(newRoute);
             } else {
               IsisLevelRib levelStagingRib =
                   routeLevel == IsisLevel.LEVEL_1 ? _isisL1StagingRib : _isisL2StagingRib;
@@ -1153,7 +1151,7 @@ public final class VirtualRouter {
                       IsisRoute r = newRoute.get();
                       if (ra.isWithdrawn()) {
                         _isisL2StagingRib.removeRoute(r);
-                        upgradedRoutes.remove(newRoute.get(), ra.getReason());
+                        upgradedRoutes.remove(newRoute.get());
                       } else {
                         _isisL2StagingRib.mergeRoute(r);
                         upgradedRoutes.add(newRoute.get());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/IsisProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/IsisProtocolHelper.java
@@ -51,7 +51,7 @@ public class IsisProtocolHelper {
             ra -> {
               IsisRoute newRoute = ra.getRoute().toBuilder().setOverload(true).build();
               if (ra.isWithdrawn()) {
-                deltaWithOverloadTrue.remove(newRoute, ra.getReason());
+                deltaWithOverloadTrue.remove(newRoute);
               } else {
                 deltaWithOverloadTrue.add(newRoute);
               }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -17,7 +17,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.ResolutionRestriction;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 /**
  * Implements general RIB (Routing Information Base) semantics. RIB stores routes for different
@@ -228,25 +227,19 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    * Remove given route from the RIB
    *
    * @param route route to remove
-   * @param reason The reason for route removal (will propagate to the returned delta)
    * @return a {@link RibDelta} object indicating that the route was removed or @{code null} if the
    *     route was not present in the RIB
    */
   @Nonnull
-  public RibDelta<R> removeRouteGetDelta(R route, Reason reason) {
+  public RibDelta<R> removeRouteGetDelta(R route) {
     // Remove the backup route first, then remove route from rib
     removeBackupRoute(route);
-    RibDelta<R> delta = _tree.removeRouteGetDelta(route, reason);
+    RibDelta<R> delta = _tree.removeRouteGetDelta(route);
     if (!delta.isEmpty()) {
       // A change to routes has been made
       _allRoutes = null;
     }
     return delta;
-  }
-
-  @Nonnull
-  public RibDelta<R> removeRouteGetDelta(R route) {
-    return removeRouteGetDelta(route, Reason.WITHDRAW);
   }
 
   /**
@@ -256,7 +249,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    * @return True if the route was located and removed
    */
   public boolean removeRoute(R route) {
-    return !removeRouteGetDelta(route, Reason.WITHDRAW).isEmpty();
+    return !removeRouteGetDelta(route).isEmpty();
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -29,7 +29,6 @@ import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.route.nh.NextHopVisitor;
 import org.batfish.datamodel.route.nh.NextHopVrf;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 /**
  * A generic BGP RIB containing the common properties among the RIBs for different types of BGP
@@ -160,8 +159,8 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
 
   @Nonnull
   @Override
-  public RibDelta<R> removeRouteGetDelta(R route, Reason reason) {
-    RibDelta<R> delta = super.removeRouteGetDelta(route, reason);
+  public RibDelta<R> removeRouteGetDelta(R route) {
+    RibDelta<R> delta = super.removeRouteGetDelta(route);
     if (!delta.isEmpty()) {
       delta.getPrefixes().forEach(this::selectBestPath);
       delta

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -23,7 +23,6 @@ import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.route.nh.NextHopIp;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DirectedAcyclicGraph;
 
@@ -96,7 +95,7 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
           _ribResolutionTrie.removeNextHopIp(nextHopIp);
         }
       }
-      return processSideEffects(route, Rib.super.removeRouteGetDelta(route, Reason.WITHDRAW));
+      return processSideEffects(route, Rib.super.removeRouteGetDelta(route));
     }
 
     /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RouteAdvertisement.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RouteAdvertisement.java
@@ -4,10 +4,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.common.BatfishException;
 
 /**
  * A wrapper around a route object representing a route advertisement action (send/withdraw) and the
@@ -16,30 +16,20 @@ import org.batfish.common.BatfishException;
 @ParametersAreNonnullByDefault
 public final class RouteAdvertisement<T> {
   @Nonnull private final T _route;
-  @Nonnull private final Reason _reason;
+  private final boolean _withdrawn;
 
   private transient int _hashCode = 0;
-
-  /** Reason for the advertisement */
-  public enum Reason {
-    /** The route was added */
-    ADD,
-    /** The route was replaced by a better route */
-    REPLACE,
-    /** The route was removed */
-    WITHDRAW
-  }
 
   /**
    * Create a new route advertisement
    *
    * @param route route object that is advertised
-   * @param reason The {@link Reason} indicating if the route was added or withdrawn and why
+   * @param withdrawn Whether the advertisement withdraws the route (if false, it adds the route)
    */
   @VisibleForTesting
-  RouteAdvertisement(T route, Reason reason) {
+  RouteAdvertisement(T route, boolean withdrawn) {
     _route = route;
-    _reason = reason;
+    _withdrawn = withdrawn;
   }
 
   /**
@@ -49,19 +39,15 @@ public final class RouteAdvertisement<T> {
    */
   public RouteAdvertisement(T route) {
     _route = route;
-    _reason = Reason.ADD;
+    _withdrawn = false;
   }
 
   public static <T> RouteAdvertisement<T> adding(T route) {
-    return new RouteAdvertisement<>(route, Reason.ADD);
-  }
-
-  public static <T> RouteAdvertisement<T> replacing(T route) {
-    return new RouteAdvertisement<>(route, Reason.REPLACE);
+    return new RouteAdvertisement<>(route, false);
   }
 
   public static <T> RouteAdvertisement<T> withdrawing(T route) {
-    return new RouteAdvertisement<>(route, Reason.WITHDRAW);
+    return new RouteAdvertisement<>(route, true);
   }
 
   /** Get the underlying route that's being advertised (or withdrawn) */
@@ -70,27 +56,13 @@ public final class RouteAdvertisement<T> {
     return _route;
   }
 
-  @Nonnull
-  public Reason getReason() {
-    return _reason;
-  }
-
   /**
    * Check if this route is being withdrawn
    *
    * @return true if the route is being withdrawn
    */
   public boolean isWithdrawn() {
-    switch (_reason) {
-      case WITHDRAW:
-      case REPLACE:
-        return true;
-      case ADD:
-        return false;
-      default:
-        throw new BatfishException(
-            String.format("Unrecognized RouteAdvertisement reason: %s", _reason));
-    }
+    return _withdrawn;
   }
 
   @Override
@@ -104,22 +76,20 @@ public final class RouteAdvertisement<T> {
     RouteAdvertisement<?> that = (RouteAdvertisement<?>) o;
     return (_hashCode == that._hashCode || _hashCode == 0 || that._hashCode == 0)
         && _route.equals(that._route)
-        && _reason == that._reason;
+        && _withdrawn == that._withdrawn;
   }
 
   @Override
   public int hashCode() {
-    int h = _hashCode;
-    if (h == 0) {
-      h = 31 * _route.hashCode() + _reason.hashCode();
-      _hashCode = h;
-    }
-    return _hashCode;
+    return Objects.hash(_route, _withdrawn);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("route", _route).add("reason", _reason).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("route", _route)
+        .add("withdrawn", _withdrawn)
+        .toString();
   }
 
   @Nonnull
@@ -129,13 +99,13 @@ public final class RouteAdvertisement<T> {
 
   @Nonnull
   public Builder<T> toBuilder() {
-    return RouteAdvertisement.<T>builder().setRoute(_route).setReason(_reason);
+    return RouteAdvertisement.<T>builder().setRoute(_route).setWithdrawn(_withdrawn);
   }
 
   /** Builder for {@link RouteAdvertisement} */
   public static final class Builder<T> {
     private T _route;
-    private Reason _reason = Reason.ADD;
+    private boolean _withdrawn = false;
 
     private Builder() {}
 
@@ -144,26 +114,15 @@ public final class RouteAdvertisement<T> {
       return this;
     }
 
-    public Builder<T> setReason(Reason reason) {
-      _reason = reason;
+    public Builder<T> setWithdrawn(boolean withdrawn) {
+      _withdrawn = withdrawn;
       return this;
     }
 
     @Nonnull
     public RouteAdvertisement<T> build() {
       checkArgument(_route != null, "Route advertisement missing the route");
-      return new RouteAdvertisement<>(_route, _reason);
+      return new RouteAdvertisement<>(_route, _withdrawn);
     }
-  }
-
-  /**
-   * Returns a version of this route advertisement with REPLACE changed to WITHDRAW. Replace is a
-   * local operation but always looks like withdraw to neighbors.
-   */
-  public RouteAdvertisement<T> sanitizeForExport() {
-    if (_reason != Reason.REPLACE) {
-      return this;
-    }
-    return new RouteAdvertisement<T>(_route, Reason.WITHDRAW);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -86,7 +87,6 @@ import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.dataplane.rib.Rib;
 import org.batfish.dataplane.rib.RibDelta;
 import org.batfish.dataplane.rib.RouteAdvertisement;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -825,7 +825,7 @@ public class BgpRoutingProcessTest {
             .collect(ImmutableList.toImmutableList());
 
     // Initially, there should only be adds.
-    deltaAdverts.forEach(advert -> assertThat(advert.getReason(), equalTo(Reason.ADD)));
+    deltaAdverts.forEach(advert -> assertFalse(advert.isWithdrawn()));
     return deltaAdverts;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -10,9 +10,8 @@ import static org.batfish.dataplane.ibdp.OspfRoutingProcess.filterInterAreaRoute
 import static org.batfish.dataplane.ibdp.OspfRoutingProcess.getIfaceAddressesForIntraAreaRoutes;
 import static org.batfish.dataplane.ibdp.OspfRoutingProcess.transformInterAreaRoutesOnExportNonABR;
 import static org.batfish.dataplane.ibdp.OspfRoutingProcess.transformIntraAreaRoutesOnExport;
-import static org.batfish.dataplane.rib.RouteAdvertisement.Reason.ADD;
-import static org.batfish.matchers.RouteAdvertisementMatchers.hasReason;
 import static org.batfish.matchers.RouteAdvertisementMatchers.hasRoute;
+import static org.batfish.matchers.RouteAdvertisementMatchers.isAdding;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -346,7 +345,7 @@ public class OspfRoutingProcessTest {
     // Must not crash on non-existent interface
     RibDelta<OspfIntraAreaRoute> delta = _routingProcess.initializeRoutesByArea(AREA0_CONFIG);
     // All routes were added
-    assertTrue(delta.getActions().allMatch(r -> r.getReason() == ADD));
+    assertTrue(delta.getActions().noneMatch(RouteAdvertisement::isWithdrawn));
 
     /*
       Requirements:
@@ -452,8 +451,7 @@ public class OspfRoutingProcessTest {
                 nextHopIp)
             .get(),
         allOf(
-            hasRoute(allOf(hasPrefix(Prefix.ZERO), hasNextHopIp(equalTo(nextHopIp)))),
-            hasReason(ADD)));
+            hasRoute(allOf(hasPrefix(Prefix.ZERO), hasNextHopIp(equalTo(nextHopIp)))), isAdding()));
     // STUB area
     assertThat(
         computeDefaultInterAreaRouteToInject(
@@ -464,8 +462,7 @@ public class OspfRoutingProcessTest {
                 nextHopIp)
             .get(),
         allOf(
-            hasRoute(allOf(hasPrefix(Prefix.ZERO), hasNextHopIp(equalTo(nextHopIp)))),
-            hasReason(ADD)));
+            hasRoute(allOf(hasPrefix(Prefix.ZERO), hasNextHopIp(equalTo(nextHopIp)))), isAdding()));
   }
 
   @Test
@@ -491,7 +488,7 @@ public class OspfRoutingProcessTest {
         contains(
             allOf(
                 hasRoute(allOf(hasPrefix(Prefix.ZERO), hasNextHopIp(equalTo(nextHopIp)))),
-                hasReason(ADD))));
+                isAdding())));
 
     // Any subsequent calls for the same edge -- no need to inject default route
     for (int i = 0; i < 10; i++) {
@@ -512,7 +509,7 @@ public class OspfRoutingProcessTest {
         contains(
             allOf(
                 hasRoute(allOf(hasPrefix(Prefix.ZERO), hasNextHopIp(equalTo(nextHopIp)))),
-                hasReason(ADD))));
+                isAdding())));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -92,7 +92,6 @@ import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.dataplane.rib.RibDelta;
 import org.batfish.dataplane.rib.RouteAdvertisement;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 import org.junit.Test;
 
 /** Tests of {@link VirtualRouter} */
@@ -488,7 +487,7 @@ public class VirtualRouterTest {
     assertThat(q, hasSize(1));
 
     // Repeats are allowed; So existing route + 1 add + 1 remove = 3 total
-    builder.remove(sr2, Reason.WITHDRAW);
+    builder.remove(sr2);
     VirtualRouter.queueDelta(q, builder.build());
     assertThat(q, hasSize(3));
   }
@@ -516,7 +515,7 @@ public class VirtualRouterTest {
     RibDelta.Builder<AbstractRoute> builder = RibDelta.builder();
 
     // Test queueing empty deltas
-    builder.add(sr1).remove(sr2, Reason.WITHDRAW);
+    builder.add(sr1).remove(sr2);
     VirtualRouter.queueDelta(q, builder.build());
 
     // Check queuing order.

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -30,7 +30,6 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopIp;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -185,7 +184,7 @@ public class AbstractRibTest {
   }
 
   /**
-   * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip, int,
+   * Ensure that {@link org.batfish.datamodel.GenericRibReadOnly#longestPrefixMatch(Ip, int,
    * org.batfish.datamodel.ResolutionRestriction)} returns correct routes when the RIB is non-empty
    */
   @Test
@@ -358,13 +357,13 @@ public class AbstractRibTest {
 
     // Check only route r remains
     assertThat(_rib.getTypedRoutes(), contains(r));
-    assertThat(actions, contains(new RouteAdvertisement<>(_mostGeneralRoute, Reason.WITHDRAW)));
+    assertThat(actions, contains(RouteAdvertisement.withdrawing(_mostGeneralRoute)));
 
     // Remove route r
     d = _rib.removeRouteGetDelta(r);
     actions = d.getActions().collect(Collectors.toList());
     assertThat(_rib.getTypedRoutes(), empty());
-    assertThat(actions, contains(new RouteAdvertisement<>(r, Reason.WITHDRAW)));
+    assertThat(actions, contains(RouteAdvertisement.withdrawing(r)));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -666,7 +666,7 @@ public class RibTest {
     assertThat(
         rib.mergeRouteGetDelta(betterRoute).getActions().collect(ImmutableList.toImmutableList()),
         containsInAnyOrder(
-            RouteAdvertisement.replacing(worseRoute), RouteAdvertisement.adding(betterRoute)));
+            RouteAdvertisement.withdrawing(worseRoute), RouteAdvertisement.adding(betterRoute)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTreeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTreeTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.equalTo;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 import org.junit.Test;
 
 public final class RibTreeTest {
@@ -34,13 +33,6 @@ public final class RibTreeTest {
     RibDelta<StaticRoute> addR2 = ribTree.mergeRoute(r2);
     assertThat(addR2, equalTo(RibDelta.adding(r2)));
     RibDelta<StaticRoute> addR3 = ribTree.mergeRoute(r3);
-    assertThat(
-        addR3,
-        equalTo(
-            RibDelta.builder()
-                .remove(r1, Reason.REPLACE)
-                .remove(r2, Reason.REPLACE)
-                .add(r3)
-                .build()));
+    assertThat(addR3, equalTo(RibDelta.builder().remove(r1).remove(r2).add(r3).build()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/matchers/RouteAdvertisementMatchers.java
+++ b/projects/batfish/src/test/java/org/batfish/matchers/RouteAdvertisementMatchers.java
@@ -6,20 +6,16 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.dataplane.rib.RouteAdvertisement;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
-import org.batfish.matchers.RouteAdvertisementMatchersImpl.HasReason;
 import org.batfish.matchers.RouteAdvertisementMatchersImpl.HasRoute;
+import org.batfish.matchers.RouteAdvertisementMatchersImpl.IsWithdrawn;
 import org.hamcrest.Matcher;
 
 /** Matchers for {@link RouteAdvertisement} */
 @ParametersAreNonnullByDefault
 public final class RouteAdvertisementMatchers {
-  /**
-   * Provides a matcher that matches when the {@code reason} is equal to the {@link
-   * RouteAdvertisement}'s reason.
-   */
-  public static @Nonnull HasReason hasReason(Reason reason) {
-    return new HasReason(equalTo(reason));
+  /** Provides a matcher that matches a {@link RouteAdvertisement} that adds its route. */
+  public static @Nonnull IsWithdrawn isAdding() {
+    return new IsWithdrawn(equalTo(false));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/matchers/RouteAdvertisementMatchersImpl.java
+++ b/projects/batfish/src/test/java/org/batfish/matchers/RouteAdvertisementMatchersImpl.java
@@ -3,22 +3,21 @@ package org.batfish.matchers;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.dataplane.rib.RouteAdvertisement;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
 @ParametersAreNonnullByDefault
 public final class RouteAdvertisementMatchersImpl {
 
-  static final class HasReason
-      extends FeatureMatcher<RouteAdvertisement<? extends AbstractRouteDecorator>, Reason> {
-    HasReason(Matcher<? super Reason> subMatcher) {
-      super(subMatcher, "A RouteAdvertisement with reason:", "reason");
+  static final class IsWithdrawn
+      extends FeatureMatcher<RouteAdvertisement<? extends AbstractRouteDecorator>, Boolean> {
+    IsWithdrawn(Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "A RouteAdvertisement with withdrawn:", "withdrawn");
     }
 
     @Override
-    protected Reason featureValueOf(RouteAdvertisement<? extends AbstractRouteDecorator> actual) {
-      return actual.getReason();
+    protected Boolean featureValueOf(RouteAdvertisement<? extends AbstractRouteDecorator> actual) {
+      return actual.isWithdrawn();
     }
   }
 


### PR DESCRIPTION
Removes the `Reason` enum in `RouteAdvertisement`, replacing the `_reason` field with a boolean `_withdrawn` field. The `Reason` enum contained two values indicating a withdrawal, `WITHDRAW` and `REPLACE`, but Batfish never discriminated between a `WITHDRAW` advertisement and a `REPLACE` advertisement, except to "sanitize" `REPLACE` to `WITHDRAW` upon export.