### PR TITLE
AbstractRib: remove removeRouteGetDelta(route, reason) API

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -1917,8 +1917,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     RibDelta<R> delta;
     BgpRib<R> rib = getRib(clazz, RibType.COMBINED);
     if (routeAdvertisement.isWithdrawn()) {
-      delta =
-          rib.removeRouteGetDelta(routeAdvertisement.getRoute(), routeAdvertisement.getReason());
+      delta = rib.removeRouteGetDelta(routeAdvertisement.getRoute());
     } else {
       delta = rib.mergeRouteGetDelta(routeAdvertisement.getRoute());
     }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -494,7 +494,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   private static <R extends AbstractRoute, T extends R> RibDelta<R> processRouteAdvertisement(
       RouteAdvertisement<T> ra, AbstractRib<R> rib) {
     if (ra.isWithdrawn()) {
-      return rib.removeRouteGetDelta(ra.getRoute(), ra.getReason());
+      return rib.removeRouteGetDelta(ra.getRoute());
     } else {
       return rib.mergeRouteGetDelta(ra.getRoute());
     }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RouteDependencyTracker.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RouteDependencyTracker.java
@@ -10,7 +10,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.dataplane.rib.AbstractRib;
 import org.batfish.dataplane.rib.RibDelta;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 @ParametersAreNonnullByDefault
 public final class RouteDependencyTracker<
@@ -53,7 +52,7 @@ public final class RouteDependencyTracker<
     }
     RibDelta.Builder<R> b = RibDelta.builder();
     for (R depRoute : dependents) {
-      b.from(rib.removeRouteGetDelta(depRoute, Reason.WITHDRAW));
+      b.from(rib.removeRouteGetDelta(depRoute));
     }
     // Now the route is gone and will have no dependents
     _routeDependents.remove(route);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -532,8 +532,7 @@ public final class VirtualRouter {
         /*
          * If the route is not in the RIB, this has no effect. But might add some overhead (TODO)
          */
-        _mainRibRouteDeltaBuilder.from(
-            _mainRib.removeRouteGetDelta(annotateRoute(sr), Reason.WITHDRAW));
+        _mainRibRouteDeltaBuilder.from(_mainRib.removeRouteGetDelta(annotateRoute(sr)));
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -228,25 +228,19 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    * Remove given route from the RIB
    *
    * @param route route to remove
-   * @param reason The reason for route removal (will propagate to the returned delta)
    * @return a {@link RibDelta} object indicating that the route was removed or @{code null} if the
    *     route was not present in the RIB
    */
   @Nonnull
-  public RibDelta<R> removeRouteGetDelta(R route, Reason reason) {
+  public RibDelta<R> removeRouteGetDelta(R route) {
     // Remove the backup route first, then remove route from rib
     removeBackupRoute(route);
-    RibDelta<R> delta = _tree.removeRouteGetDelta(route, reason);
+    RibDelta<R> delta = _tree.removeRouteGetDelta(route, Reason.WITHDRAW);
     if (!delta.isEmpty()) {
       // A change to routes has been made
       _allRoutes = null;
     }
     return delta;
-  }
-
-  @Nonnull
-  public RibDelta<R> removeRouteGetDelta(R route) {
-    return removeRouteGetDelta(route, Reason.WITHDRAW);
   }
 
   /**
@@ -256,7 +250,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    * @return True if the route was located and removed
    */
   public boolean removeRoute(R route) {
-    return !removeRouteGetDelta(route, Reason.WITHDRAW).isEmpty();
+    return !removeRouteGetDelta(route).isEmpty();
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -29,7 +29,6 @@ import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.route.nh.NextHopVisitor;
 import org.batfish.datamodel.route.nh.NextHopVrf;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 /**
  * A generic BGP RIB containing the common properties among the RIBs for different types of BGP
@@ -160,8 +159,8 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
 
   @Nonnull
   @Override
-  public RibDelta<R> removeRouteGetDelta(R route, Reason reason) {
-    RibDelta<R> delta = super.removeRouteGetDelta(route, reason);
+  public RibDelta<R> removeRouteGetDelta(R route) {
+    RibDelta<R> delta = super.removeRouteGetDelta(route);
     if (!delta.isEmpty()) {
       delta.getPrefixes().forEach(this::selectBestPath);
       delta

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -23,7 +23,6 @@ import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.route.nh.NextHopIp;
-import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DirectedAcyclicGraph;
 
@@ -96,7 +95,7 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
           _ribResolutionTrie.removeNextHopIp(nextHopIp);
         }
       }
-      return processSideEffects(route, Rib.super.removeRouteGetDelta(route, Reason.WITHDRAW));
+      return processSideEffects(route, Rib.super.removeRouteGetDelta(route));
     }
 
     /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -328,7 +328,7 @@ public final class RibDelta<R extends AbstractRouteDecorator> {
         (uRouteAdvertisement) -> {
           T tRoute = converter.apply(uRouteAdvertisement.getRoute());
           if (uRouteAdvertisement.isWithdrawn()) {
-            builder.from(importingRib.removeRouteGetDelta(tRoute, uRouteAdvertisement.getReason()));
+            builder.from(importingRib.removeRouteGetDelta(tRoute));
           } else {
             builder.from(importingRib.mergeRouteGetDelta(tRoute));
           }


### PR DESCRIPTION
It should not matter to a RIB whether the original reason for removal was a withdrawal or a replacement.