### PR TITLE
A10: extract more health-check names and health-check-disable

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Lexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Lexer.g4
@@ -50,6 +50,7 @@ GRACEFUL_RESTART: 'graceful-restart';
 HELLO_INTERVAL: 'hello-interval';
 HA_GROUP_ID: 'ha-group-id';
 HEALTH_CHECK: 'health-check' -> pushMode(M_Word);
+HEALTH_CHECK_DISABLE: 'health-check-disable';
 HOSTNAME: 'hostname' -> pushMode(M_Word);
 HTTP: 'http';
 HTTPS: 'https';

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_slb_server.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_slb_server.g4
@@ -16,6 +16,8 @@ sss_definition
    sssd_conn_limit
    | sssd_disable
    | sssd_enable
+   | sssd_health_check
+   | sssd_health_check_disable
    | sssd_port
    | sssd_stats_data_disable
    | sssd_stats_data_enable
@@ -28,6 +30,10 @@ sssd_conn_limit: CONN_LIMIT connection_limit NEWLINE;
 sssd_disable: DISABLE NEWLINE;
 
 sssd_enable: ENABLE NEWLINE;
+
+sssd_health_check: HEALTH_CHECK health_check_name NEWLINE;
+
+sssd_health_check_disable: HEALTH_CHECK_DISABLE NEWLINE;
 
 sssd_stats_data_disable: STATS_DATA_DISABLE NEWLINE;
 
@@ -46,6 +52,8 @@ sssdp_definition
    sssdpd_conn_limit
    | sssdpd_disable
    | sssdpd_enable
+   | sssdpd_health_check
+   | sssdpd_health_check_disable
    | sssdpd_stats_data_disable
    | sssdpd_stats_data_enable
    | sssdpd_template
@@ -57,6 +65,10 @@ sssdpd_conn_limit: CONN_LIMIT connection_limit NEWLINE;
 sssdpd_disable: DISABLE NEWLINE;
 
 sssdpd_enable: ENABLE NEWLINE;
+
+sssdpd_health_check: HEALTH_CHECK health_check_name NEWLINE;
+
+sssdpd_health_check_disable: HEALTH_CHECK_DISABLE NEWLINE;
 
 sssdpd_stats_data_disable: STATS_DATA_DISABLE NEWLINE;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_slb_service_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_slb_service_group.g4
@@ -11,6 +11,7 @@ ss_service_group: SERVICE_GROUP service_group_name tcp_or_udp? NEWLINE sssg_defi
 sssg_definition
 :
    sssgd_health_check
+   | sssgd_health_check_disable
    | sssgd_member
    | sssgd_method
    | sssgd_stats_data_disable
@@ -18,6 +19,8 @@ sssg_definition
 ;
 
 sssgd_health_check: HEALTH_CHECK health_check_name NEWLINE;
+
+sssgd_health_check_disable: HEALTH_CHECK_DISABLE NEWLINE;
 
 // TODO support declaring a new server in this context, i.e. when IP address is provided as well
 sssgd_member: MEMBER slb_server_name port_number NEWLINE sssgdm_definition*;

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -1009,6 +1009,11 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
     toString(ctx, ctx.health_check_name()).ifPresent(_currentServiceGroup::setHealthCheck);
   }
 
+  @Override
+  public void exitSssgd_health_check_disable(A10Parser.Sssgd_health_check_disableContext ctx) {
+    _currentServiceGroup.setHealthCheckDisable(true);
+  }
+
   private @Nonnull Optional<String> toString(
       ParserRuleContext messageCtx, A10Parser.Health_check_nameContext ctx) {
     return toStringWithLengthInSpace(
@@ -1406,6 +1411,17 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
   }
 
   @Override
+  public void exitSssd_health_check(A10Parser.Sssd_health_checkContext ctx) {
+    // TODO add reject if invalid ref, and add ref once health checks are supported
+    toString(ctx, ctx.health_check_name()).ifPresent(_currentServer::setHealthCheck);
+  }
+
+  @Override
+  public void exitSssd_health_check_disable(A10Parser.Sssd_health_check_disableContext ctx) {
+    _currentServer.setHealthCheckDisable(true);
+  }
+
+  @Override
   public void exitSssd_stats_data_disable(A10Parser.Sssd_stats_data_disableContext ctx) {
     _currentServer.setStatsDataEnable(false);
   }
@@ -1466,6 +1482,17 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
   @Override
   public void exitSssdpd_enable(A10Parser.Sssdpd_enableContext ctx) {
     _currentServerPort.setEnable(true);
+  }
+
+  @Override
+  public void exitSssdpd_health_check(A10Parser.Sssdpd_health_checkContext ctx) {
+    // TODO add reject if invalid ref, and add ref once health checks are supported
+    toString(ctx, ctx.health_check_name()).ifPresent(_currentServerPort::setHealthCheck);
+  }
+
+  @Override
+  public void exitSssdpd_health_check_disable(A10Parser.Sssdpd_health_check_disableContext ctx) {
+    _currentServerPort.setHealthCheckDisable(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Server.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Server.java
@@ -87,6 +87,24 @@ public final class Server implements Serializable {
     _weight = weight;
   }
 
+  @Nullable
+  public String getHealthCheck() {
+    return _healthCheck;
+  }
+
+  public void setHealthCheck(String healthCheck) {
+    _healthCheck = healthCheck;
+  }
+
+  @Nullable
+  public Boolean getHealthCheckDisable() {
+    return _healthCheckDisable;
+  }
+
+  public void setHealthCheckDisable(boolean healthCheckDisable) {
+    _healthCheckDisable = healthCheckDisable;
+  }
+
   public Server(String name, ServerTarget target) {
     _name = name;
     _ports = new HashMap<>();
@@ -95,6 +113,8 @@ public final class Server implements Serializable {
 
   @Nullable private Integer _connLimit;
   @Nullable private Boolean _enable;
+  @Nullable private String _healthCheck;
+  @Nullable private Boolean _healthCheckDisable;
   @Nonnull private final String _name;
   @Nonnull private final Map<ServerPort.ServerPortAndType, ServerPort> _ports;
   @Nonnull private ServerTarget _target;

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/ServerPort.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/ServerPort.java
@@ -102,6 +102,24 @@ public class ServerPort implements Serializable {
     _weight = weight;
   }
 
+  @Nullable
+  public String getHealthCheck() {
+    return _healthCheck;
+  }
+
+  public void setHealthCheck(String healthCheck) {
+    _healthCheck = healthCheck;
+  }
+
+  @Nullable
+  public Boolean getHealthCheckDisable() {
+    return _healthCheckDisable;
+  }
+
+  public void setHealthCheckDisable(boolean healthCheckDisable) {
+    _healthCheckDisable = healthCheckDisable;
+  }
+
   public ServerPort(int number, Type type, @Nullable Integer range) {
     _number = number;
     _type = type;
@@ -110,6 +128,8 @@ public class ServerPort implements Serializable {
 
   @Nullable private Integer _connLimit;
   @Nullable private Boolean _enable;
+  @Nullable private String _healthCheck;
+  @Nullable private Boolean _healthCheckDisable;
   private final int _number;
   @Nullable private String _portTemplate;
   @Nullable private Integer _range;

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/ServiceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/ServiceGroup.java
@@ -70,6 +70,15 @@ public class ServiceGroup implements Serializable {
     _statsDataEnable = statsDataEnable;
   }
 
+  @Nullable
+  public Boolean getHealthCheckDisable() {
+    return _healthCheckDisable;
+  }
+
+  public void setHealthCheckDisable(boolean healthCheckDisable) {
+    _healthCheckDisable = healthCheckDisable;
+  }
+
   public ServiceGroup(String name, ServerPort.Type type) {
     _name = name;
     _type = type;
@@ -77,6 +86,7 @@ public class ServiceGroup implements Serializable {
   }
 
   @Nullable private String _healthCheck;
+  @Nullable private Boolean _healthCheckDisable;
   @Nonnull private final Map<ServiceGroupMember.NameAndPort, ServiceGroupMember> _members;
   @Nonnull private final String _name;
   @Nullable private Method _method;

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -1445,52 +1445,65 @@ public class A10GrammarTest {
     ServerPort.ServerPortAndType udp81 = new ServerPort.ServerPortAndType(81, ServerPort.Type.UDP);
 
     assertThat(c.getServers().keySet(), containsInAnyOrder("SERVER1", "SERVER2", "SERVER3"));
-    Server server1 = c.getServers().get("SERVER1");
-    Server server2 = c.getServers().get("SERVER2");
-    Server server3 = c.getServers().get("SERVER3");
 
-    assertNull(server1.getConnLimit());
-    assertNull(server1.getEnable());
-    assertThat(server1.getName(), equalTo("SERVER1"));
-    assertThat(server1.getPorts(), anEmptyMap());
-    assertNull(server1.getServerTemplate());
-    assertNull(server1.getStatsDataEnable());
-    assertThat(server1.getTarget(), equalTo(new ServerTargetAddress(Ip.parse("10.0.0.1"))));
-    assertNull(server1.getWeight());
+    {
+      Server server1 = c.getServers().get("SERVER1");
+      assertNull(server1.getConnLimit());
+      assertNull(server1.getEnable());
+      assertNull(server1.getHealthCheck());
+      assertNull(server1.getHealthCheckDisable());
+      assertThat(server1.getName(), equalTo("SERVER1"));
+      assertThat(server1.getPorts(), anEmptyMap());
+      assertNull(server1.getServerTemplate());
+      assertNull(server1.getStatsDataEnable());
+      assertThat(server1.getTarget(), equalTo(new ServerTargetAddress(Ip.parse("10.0.0.1"))));
+      assertNull(server1.getWeight());
+    }
 
-    assertThat(server2.getConnLimit(), equalTo(64000000));
-    assertTrue(server2.getEnable());
-    assertThat(server2.getName(), equalTo("SERVER2"));
-    assertThat(server2.getServerTemplate(), equalTo("SERVER_TEMPLATE"));
-    assertTrue(server2.getStatsDataEnable());
-    assertThat(server2.getTarget(), equalTo(new ServerTargetAddress(Ip.parse("10.0.0.2"))));
-    assertThat(server2.getWeight(), equalTo(1000));
-    Map<ServerPort.ServerPortAndType, ServerPort> server2Ports = server2.getPorts();
-    assertThat(server2Ports.keySet(), contains(tcp80));
-    ServerPort server2Port80 = server2Ports.get(tcp80);
-    assertThat(server2Port80.getConnLimit(), equalTo(10));
-    assertTrue(server2Port80.getEnable());
-    assertThat(server2Port80.getNumber(), equalTo(80));
-    assertThat(server2Port80.getPortTemplate(), equalTo("PORT_TEMPLATE"));
-    assertNull(server2Port80.getRange());
-    assertTrue(server2Port80.getStatsDataEnable());
-    assertThat(server2Port80.getType(), equalTo(ServerPort.Type.TCP));
-    assertThat(server2Port80.getWeight(), equalTo(999));
+    {
+      Server server2 = c.getServers().get("SERVER2");
+      assertThat(server2.getConnLimit(), equalTo(64000000));
+      assertTrue(server2.getEnable());
+      assertThat(server2.getHealthCheck(), equalTo("HEALTH_CHECK_NAME"));
+      assertThat(server2.getName(), equalTo("SERVER2"));
+      assertThat(server2.getServerTemplate(), equalTo("SERVER_TEMPLATE"));
+      assertTrue(server2.getStatsDataEnable());
+      assertThat(server2.getTarget(), equalTo(new ServerTargetAddress(Ip.parse("10.0.0.2"))));
+      assertThat(server2.getWeight(), equalTo(1000));
+      Map<ServerPort.ServerPortAndType, ServerPort> server2Ports = server2.getPorts();
+      assertThat(server2Ports.keySet(), contains(tcp80));
+      ServerPort server2Port80 = server2Ports.get(tcp80);
+      assertThat(server2Port80.getConnLimit(), equalTo(10));
+      assertTrue(server2Port80.getEnable());
+      assertThat(server2Port80.getHealthCheck(), equalTo("HEALTH_CHECK_NAME2"));
+      assertNull(server2Port80.getHealthCheckDisable());
+      assertThat(server2Port80.getNumber(), equalTo(80));
+      assertThat(server2Port80.getPortTemplate(), equalTo("PORT_TEMPLATE"));
+      assertNull(server2Port80.getRange());
+      assertTrue(server2Port80.getStatsDataEnable());
+      assertThat(server2Port80.getType(), equalTo(ServerPort.Type.TCP));
+      assertThat(server2Port80.getWeight(), equalTo(999));
+    }
 
-    assertFalse(server3.getEnable());
-    assertThat(server3.getName(), equalTo("SERVER3"));
-    assertFalse(server3.getStatsDataEnable());
-    Map<ServerPort.ServerPortAndType, ServerPort> server3Ports = server3.getPorts();
-    assertThat(server3Ports.keySet(), contains(udp81));
-    ServerPort server3Port81 = server3Ports.get(udp81);
-    assertNull(server3Port81.getConnLimit());
-    assertFalse(server3Port81.getEnable());
-    assertThat(server3Port81.getNumber(), equalTo(81));
-    assertNull(server3Port81.getPortTemplate());
-    assertThat(server3Port81.getRange(), equalTo(11));
-    assertFalse(server3Port81.getStatsDataEnable());
-    assertThat(server3Port81.getType(), equalTo(ServerPort.Type.UDP));
-    assertNull(server3Port81.getWeight());
+    {
+      Server server3 = c.getServers().get("SERVER3");
+      assertFalse(server3.getEnable());
+      assertThat(server3.getName(), equalTo("SERVER3"));
+      assertFalse(server3.getStatsDataEnable());
+      Map<ServerPort.ServerPortAndType, ServerPort> server3Ports = server3.getPorts();
+      assertThat(server3Ports.keySet(), contains(udp81));
+      ServerPort server3Port81 = server3Ports.get(udp81);
+      assertNull(server3Port81.getConnLimit());
+      assertFalse(server3Port81.getEnable());
+      assertNull(server3Port81.getHealthCheck());
+      assertTrue(server3Port81.getHealthCheckDisable());
+      assertThat(server3Port81.getNumber(), equalTo(81));
+      assertNull(server3Port81.getPortTemplate());
+      assertThat(server3Port81.getRange(), equalTo(11));
+      assertFalse(server3Port81.getStatsDataEnable());
+      assertThat(server3Port81.getType(), equalTo(ServerPort.Type.UDP));
+      assertNull(server3Port81.getWeight());
+    }
   }
 
   @Test
@@ -1526,6 +1539,7 @@ public class A10GrammarTest {
     {
       ServiceGroup sg1 = c.getServiceGroups().get("SG1");
       assertNull(sg1.getHealthCheck());
+      assertNull(sg1.getHealthCheckDisable());
       assertThat(sg1.getName(), equalTo("SG1"));
       assertNull(sg1.getStatsDataEnable());
       assertThat(sg1.getType(), equalTo(ServerPort.Type.TCP));
@@ -1556,6 +1570,7 @@ public class A10GrammarTest {
     {
       ServiceGroup sg3 = c.getServiceGroups().get("SG3");
       assertThat(sg3.getName(), equalTo("SG3"));
+      assertTrue(sg3.getHealthCheckDisable());
       assertThat(sg3.getMethod(), equalTo(ServiceGroup.Method.ROUND_ROBIN));
       assertFalse(sg3.getStatsDataEnable());
       assertThat(sg3.getType(), equalTo(ServerPort.Type.UDP));

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/server
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/server
@@ -5,9 +5,12 @@ slb server SERVER1 10.0.0.1
 !
 slb server SERVER2 10.0.0.102
   enable
+  ! TODO define health-checks when those are supported
+  health-check HEALTH_CHECK_NAME
   stats-data-enable
   template server SERVER_TEMPLATE
   port 80 tcp range 10
+    health-check HEALTH_CHECK_NAME2
     conn-limit 10
     enable
     stats-data-enable
@@ -19,8 +22,10 @@ slb server SERVER2 10.0.0.102
 !
 slb server SERVER3 10.0.0.3
   disable
+  health-check-disable
   stats-data-disable
   port 81 udp range 11
+    health-check-disable
     disable
     stats-data-disable
 !

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/service_group
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/service_group
@@ -30,6 +30,7 @@ slb service-group SG2 tcp
   stats-data-enable
 !
 slb service-group SG3 udp
+  health-check-disable
   stats-data-disable
   method round-robin
   member SERVER1 8080


### PR DESCRIPTION
Add more parsing and extraction for attaching and disabling health-checks for `server`s and `service-group`s.
