### PR TITLE
A10: filter which interfaces have VRRP info

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -336,7 +336,7 @@ public final class A10Configuration extends VendorConfiguration {
                     virtualAddress -> virtualAddress,
                     unused -> connectedRouteMetadata));
     _c.getAllInterfaces().values().stream()
-        .filter(A10Configuration::vrrpAAppliesToInterface)
+        .filter(A10Conversion::vrrpAAppliesToInterface)
         .forEach(
             iface -> {
               iface.setAllAddresses(
@@ -395,16 +395,8 @@ public final class A10Configuration extends VendorConfiguration {
                     vrid, toVrrpGroupBuilder(_vrrpA.getVrids().get(vrid), virtualAddresses)));
     // Create and assign the final VRRP groups on each interface with a concrete IPv4 address.
     _c.getAllInterfaces().values().stream()
-        .filter(A10Configuration::vrrpAAppliesToInterface)
+        .filter(A10Conversion::vrrpAAppliesToInterface)
         .forEach(i -> i.setVrrpGroups(toVrrpGroups(i, vrrpGroupBuildersBuilder.build())));
-  }
-
-  @VisibleForTesting
-  static boolean vrrpAAppliesToInterface(org.batfish.datamodel.Interface iface) {
-    if (iface.getInterfaceType() == InterfaceType.LOOPBACK) {
-      return false;
-    }
-    return iface.getConcreteAddress() != null;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Conversion.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Conversion.java
@@ -24,6 +24,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.NamedPort;
@@ -321,5 +322,16 @@ public class A10Conversion {
         (vrid, vrrpGroupBuilder) ->
             builder.put(vrid, vrrpGroupBuilder.setSourceAddress(sourceAddress).build()));
     return builder.build();
+  }
+
+  /**
+   * Returns a boolean indicating if the specified VI interface should have VRRP-A configuration
+   * associated with it.
+   */
+  static boolean vrrpAAppliesToInterface(org.batfish.datamodel.Interface iface) {
+    if (iface.getInterfaceType() == InterfaceType.LOOPBACK) {
+      return false;
+    }
+    return iface.getConcreteAddress() != null;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
@@ -9,8 +9,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.batfish.datamodel.ConcreteInterfaceAddress;
-import org.batfish.datamodel.InterfaceType;
 import org.junit.Test;
 
 /** Tests of {@link A10Configuration}. */
@@ -52,35 +50,5 @@ public class A10ConfigurationTest {
         getInterfaceHumanName(new Interface(Interface.Type.LOOPBACK, 9)), equalTo("Loopback 9"));
     assertThat(
         getInterfaceHumanName(new Interface(Interface.Type.VE, 9)), equalTo("VirtualEthernet 9"));
-  }
-
-  @Test
-  public void testVrrpAAppliesToInterface() {
-    org.batfish.datamodel.Interface.Builder ifaceBuilder =
-        org.batfish.datamodel.Interface.builder().setName("placeholder");
-    // No concrete address
-    assertFalse(
-        A10Configuration.vrrpAAppliesToInterface(
-            ifaceBuilder.setType(InterfaceType.PHYSICAL).setAddress(null).build()));
-    // Loopback interface
-    assertFalse(
-        A10Configuration.vrrpAAppliesToInterface(
-            ifaceBuilder
-                .setType(InterfaceType.LOOPBACK)
-                .setAddress(ConcreteInterfaceAddress.parse("10.10.10.10/32"))
-                .build()));
-
-    assertTrue(
-        A10Configuration.vrrpAAppliesToInterface(
-            ifaceBuilder
-                .setType(InterfaceType.PHYSICAL)
-                .setAddress(ConcreteInterfaceAddress.parse("10.10.10.10/32"))
-                .build()));
-    assertTrue(
-        A10Configuration.vrrpAAppliesToInterface(
-            ifaceBuilder
-                .setType(InterfaceType.AGGREGATED)
-                .setAddress(ConcreteInterfaceAddress.parse("10.10.10.10/24"))
-                .build()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConversionTest.java
@@ -11,6 +11,7 @@ import static org.batfish.vendor.a10.representation.A10Conversion.toMatchConditi
 import static org.batfish.vendor.a10.representation.A10Conversion.toProtocol;
 import static org.batfish.vendor.a10.representation.A10Conversion.toVrrpGroupBuilder;
 import static org.batfish.vendor.a10.representation.A10Conversion.toVrrpGroups;
+import static org.batfish.vendor.a10.representation.A10Conversion.vrrpAAppliesToInterface;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -27,6 +28,7 @@ import org.batfish.datamodel.BddTestbed;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.SubRange;
@@ -269,5 +271,35 @@ public class A10ConversionTest {
                     .setVirtualAddresses(Ip.parse("1.1.1.1"))
                     .setSourceAddress(sourceAddress)
                     .build())));
+  }
+
+  @Test
+  public void testVrrpAAppliesToInterface() {
+    org.batfish.datamodel.Interface.Builder ifaceBuilder =
+        org.batfish.datamodel.Interface.builder().setName("placeholder");
+    // No concrete address
+    assertFalse(
+        vrrpAAppliesToInterface(
+            ifaceBuilder.setType(InterfaceType.PHYSICAL).setAddress(null).build()));
+    // Loopback interface
+    assertFalse(
+        vrrpAAppliesToInterface(
+            ifaceBuilder
+                .setType(InterfaceType.LOOPBACK)
+                .setAddress(ConcreteInterfaceAddress.parse("10.10.10.10/32"))
+                .build()));
+
+    assertTrue(
+        vrrpAAppliesToInterface(
+            ifaceBuilder
+                .setType(InterfaceType.PHYSICAL)
+                .setAddress(ConcreteInterfaceAddress.parse("10.10.10.10/32"))
+                .build()));
+    assertTrue(
+        vrrpAAppliesToInterface(
+            ifaceBuilder
+                .setType(InterfaceType.AGGREGATED)
+                .setAddress(ConcreteInterfaceAddress.parse("10.10.10.10/24"))
+                .build()));
   }
 }


### PR DESCRIPTION
Further filter down the interfaces that have VRRP group info attached to them (i.e. don't set VRRP group info for loopback interfaces)
