### PR TITLE
A10: extract virtual port ACL names

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Lexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Lexer.g4
@@ -13,6 +13,7 @@ tokens {
 }
 
 // A10 keywords
+ACCESS_LIST: 'access-list';
 ACTIVATE: 'activate';
 ACTIVE: 'active';
 ADDRESS: 'address';

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_common.g4
@@ -10,6 +10,8 @@ single_quoted_string: SINGLE_QUOTE text = quoted_text? SINGLE_QUOTE;
 word_content: (double_quoted_string | single_quoted_string | WORD)+;
 word: WORD_SEPARATOR word_content;
 
+access_list_name: word;
+
 aflex_name: word;
 
 health_check_name: word;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_slb_virtual_server.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_slb_virtual_server.g4
@@ -40,7 +40,8 @@ ssvs_port: PORT port_number virtual_server_port_type (RANGE port_range_value)? N
 
 ssvsp_definition
 :
-   ssvspd_aflex
+   ssvspd_access_list
+   | ssvspd_aflex
    | ssvspd_bucket_count
    | ssvspd_conn_limit
    | ssvspd_disable
@@ -53,6 +54,8 @@ ssvsp_definition
    | ssvspd_stats_data_enable
    | ssvspd_template
 ;
+
+ssvspd_access_list: ACCESS_LIST NAME access_list_name NEWLINE;
 
 ssvspd_aflex: AFLEX aflex_name NEWLINE;
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -1715,6 +1715,21 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
   }
 
   @Override
+  public void exitSsvspd_access_list(A10Parser.Ssvspd_access_listContext ctx) {
+    // TODO verify ACL exists and add struct refs
+    toString(ctx, ctx.access_list_name()).ifPresent(_currentVirtualServerPort::setAccessList);
+  }
+
+  private @Nonnull Optional<String> toString(
+      ParserRuleContext messageCtx, A10Parser.Access_list_nameContext ctx) {
+    return toStringWithLengthInSpace(
+        messageCtx, ctx.word(), ACCESS_LIST_NAME_LENGTH_RANGE, "access-list name");
+  }
+
+  private static final IntegerSpace ACCESS_LIST_NAME_LENGTH_RANGE =
+      IntegerSpace.of(Range.closed(1, 16));
+
+  @Override
   public void exitSsvspd_aflex(A10Parser.Ssvspd_aflexContext ctx) {
     toString(ctx, ctx.aflex_name()).ifPresent(_currentVirtualServerPort::setAflex);
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/VirtualServerPort.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/VirtualServerPort.java
@@ -46,6 +46,15 @@ public class VirtualServerPort implements Serializable {
   }
 
   @Nullable
+  public String getAccessList() {
+    return _accessList;
+  }
+
+  public void setAccessList(String accessList) {
+    _accessList = accessList;
+  }
+
+  @Nullable
   public String getAflex() {
     return _aflex;
   }
@@ -133,6 +142,7 @@ public class VirtualServerPort implements Serializable {
     _range = range;
   }
 
+  @Nullable private String _accessList;
   @Nullable private String _aflex;
   @Nullable private Integer _bucketCount;
   @Nullable private Boolean _defSelectionIfPrefFailed;

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -1092,6 +1092,7 @@ public class A10GrammarTest {
       Map<VirtualServerPort.PortAndType, VirtualServerPort> server2Ports = server2.getPorts();
       assertThat(server2Ports.keySet(), contains(tcp80));
       VirtualServerPort server2Port80 = server2Ports.get(tcp80);
+      assertThat(server2Port80.getAccessList(), equalTo("ACL_NAME"));
       assertThat(server2Port80.getAflex(), equalTo("AFLEX_SCRIPT1"));
       assertThat(server2Port80.getBucketCount(), equalTo(100));
       assertTrue(server2Port80.getDefSelectionIfPrefFailed());
@@ -1111,6 +1112,7 @@ public class A10GrammarTest {
       Map<VirtualServerPort.PortAndType, VirtualServerPort> server3Ports = server3.getPorts();
       assertThat(server3Ports.keySet(), containsInAnyOrder(udp81, tcpProxy101, http102, https103));
       VirtualServerPort server3Port81 = server3Ports.get(udp81);
+      assertNull(server3Port81.getAccessList());
       assertNull(server3Port81.getAflex());
       assertNull(server3Port81.getBucketCount());
       assertNull(server3Port81.getDefSelectionIfPrefFailed());

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/virtual_server
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/virtual_server
@@ -31,6 +31,8 @@ slb virtual-server VS2 10.0.0.102
   stats-data-enable
   vrid 1
   port 80 tcp range 10
+    ! TODO define ACL when those are supported
+    access-list name ACL_NAME
     bucket-count 100
     conn-limit 1000
     def-selection-if-pref-failed


### PR DESCRIPTION
Not doing anything with this at the moment. Can add references + validation after ACLs are extracted.