### PR TITLE
A10: Set export BGP from BGP RIB

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -292,6 +292,7 @@ public final class A10Configuration extends VendorConfiguration {
     _c.setDeviceModel(DeviceModel.A10);
     _c.setDefaultCrossZoneAction(LineAction.DENY);
     _c.setDefaultInboundAction(LineAction.PERMIT);
+    _c.setExportBgpFromBgpRib(true);
 
     // Generated default VRF
     Vrf vrf = new Vrf(DEFAULT_VRF_NAME);


### PR DESCRIPTION
We have been assuming A10 behaves this way, and we'd like to enforce a stricter invariant in BGP redistribution where `_exportFromBgpRib` must be set if and only if a BGP redistribution policy is present (which it already is in A10).