### PR TITLE
A10 only put virtual-addresses on sync interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Conversion.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Conversion.java
@@ -517,14 +517,45 @@ public class A10Conversion {
   }
 
   /**
-   * Returns a boolean indicating if the specified VI interface should have VRRP-A configuration
-   * associated with it.
+   * Returns a boolean indicating if the specified VI interface should have VRRP configuration
+   * associated with it when vrrp-a is enabled.
    */
-  static boolean vrrpAppliesToInterface(org.batfish.datamodel.Interface iface) {
+  static boolean vrrpAEnabledAppliesToInterface(
+      org.batfish.datamodel.Interface iface, Set<Ip> peerIps) {
+    if (iface.getInterfaceType() == InterfaceType.LOOPBACK) {
+      return false;
+    }
+    return iface.getAllAddresses().stream()
+        .filter(ConcreteInterfaceAddress.class::isInstance)
+        .map(ConcreteInterfaceAddress.class::cast)
+        .map(ConcreteInterfaceAddress::getPrefix)
+        .anyMatch(prefix -> peerIps.stream().anyMatch(prefix::containsIp));
+  }
+
+  /**
+   * Returns a boolean indicating if the specified VI interface should have VRRP configuration
+   * associated with it when vrrp-a is disabled.
+   */
+  static boolean vrrpADisabledAppliesToInterface(org.batfish.datamodel.Interface iface) {
     if (iface.getInterfaceType() == InterfaceType.LOOPBACK) {
       return false;
     }
     return iface.getConcreteAddress() != null;
+  }
+
+  /**
+   * Returns a boolean indicating if the specified VI interface should have VRRP configuration
+   * associated with it when ha is enabled.
+   */
+  static boolean haAppliesToInterface(org.batfish.datamodel.Interface iface, Ip connMirrorIp) {
+    if (iface.getInterfaceType() == InterfaceType.LOOPBACK) {
+      return false;
+    }
+    return iface.getAllAddresses().stream()
+        .filter(ConcreteInterfaceAddress.class::isInstance)
+        .map(ConcreteInterfaceAddress.class::cast)
+        .map(ConcreteInterfaceAddress::getPrefix)
+        .anyMatch(prefix -> prefix.containsIp(connMirrorIp));
   }
 
   /** Convert the BGP process and associated routing policies, and attach them to the config. */

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -1969,7 +1969,7 @@ public class A10GrammarTest {
     assertThat(ha.getId(), equalTo(1));
     assertThat(ha.getSetId(), equalTo(2));
     assertThat(ha.getPreemptionEnable(), equalTo(Boolean.FALSE));
-    assertThat(ha.getConnMirror(), equalTo(Ip.parse("10.0.1.1")));
+    assertThat(ha.getConnMirror(), equalTo(Ip.parse("10.0.5.2")));
 
     assertThat(ha.getGroups(), hasKeys(1));
     HaGroup haGroup = ha.getGroups().get(1);

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/ha_acos2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/ha_acos2
@@ -28,7 +28,7 @@ ha id 1 set-id 2
 ha arp-retry 4
 ha group 1 priority 200
 ha check gateway 10.0.0.1
-ha conn-mirror ip 10.0.1.1
+ha conn-mirror ip 10.0.5.2
 ha interface ethernet 3 both vlan 4094
 ha interface ethernet 3 router-interface no-heartbeat
 no ha preemption-enable

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/vrrp-a-enabled
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/vrrp-a-enabled
@@ -12,6 +12,10 @@ vrrp-a vrid 1
   floating-ip 3.0.0.1
 !
 
+vrrp-a peer-group
+  peer 10.0.1.2
+!
+
 interface ethernet 1
   mtu 1500
   enable


### PR DESCRIPTION
- fixes bug where an interface would be master for its VRRP addresses if it did
  not share a LAN with paired LB interface
  - sync interface is guaranteed-ish to be on LAN with paired LB
    interface