### PR TITLE
Rename FlowEvaluator and FlowResult

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketPolicyEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/PacketPolicyEvaluator.java
@@ -19,9 +19,9 @@ import org.batfish.datamodel.visitors.FibActionVisitor;
  * Evaluates a {@link PacketPolicy} against a given {@link Flow}.
  *
  * <p>To evaluate an entire policy, see {@link #evaluate(Flow, String, String, PacketPolicy, Map,
- * Map, Map)} which will return a {@link FlowResult}.
+ * Map, Map)} which will return a {@link PacketPolicyResult}.
  */
-public final class FlowEvaluator {
+public final class PacketPolicyEvaluator {
 
   private final @Nonnull Map<String, IpAccessList> _availableAcls;
   private final @Nonnull Map<String, IpSpace> _namedIpSpaces;
@@ -136,7 +136,7 @@ public final class FlowEvaluator {
     }
   }
 
-  private FlowEvaluator(
+  private PacketPolicyEvaluator(
       Flow originalFlow,
       String srcInterface,
       String srcInterfaceVrf,
@@ -156,17 +156,17 @@ public final class FlowEvaluator {
     return _currentFlow.build();
   }
 
-  private FlowResult evaluate(PacketPolicy policy) {
+  private PacketPolicyResult evaluate(PacketPolicy policy) {
     Action action =
         policy.getStatements().stream()
             .map(_stmtEvaluator::visit)
             .filter(Objects::nonNull)
             .findFirst()
             .orElse(policy.getDefaultAction().getAction());
-    return new FlowResult(getTransformedFlow(), action);
+    return new PacketPolicyResult(getTransformedFlow(), action);
   }
 
-  public static FlowResult evaluate(
+  public static PacketPolicyResult evaluate(
       Flow f,
       String srcInterface,
       String srcInterfaceVrf,
@@ -174,16 +174,20 @@ public final class FlowEvaluator {
       Map<String, IpAccessList> availableAcls,
       Map<String, IpSpace> namedIpSpaces,
       Map<String, Fib> fibs) {
-    return new FlowEvaluator(f, srcInterface, srcInterfaceVrf, availableAcls, namedIpSpaces, fibs)
+    return new PacketPolicyEvaluator(
+            f, srcInterface, srcInterfaceVrf, availableAcls, namedIpSpaces, fibs)
         .evaluate(policy);
   }
 
-  /** Combination of final (possibly transformed) {@link Flow} and the action taken */
-  public static final class FlowResult {
+  /**
+   * Combination of final (possibly transformed) {@link Flow} and the action taken by the evaluated
+   * {@link PacketPolicy}
+   */
+  public static final class PacketPolicyResult {
     private final Flow _finalFlow;
     private final Action _action;
 
-    FlowResult(Flow finalFlow, Action action) {
+    PacketPolicyResult(Flow finalFlow, Action action) {
       _finalFlow = finalFlow;
       _action = action;
     }
@@ -204,7 +208,7 @@ public final class FlowEvaluator {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      FlowResult that = (FlowResult) o;
+      PacketPolicyResult that = (PacketPolicyResult) o;
       return Objects.equals(getFinalFlow(), that.getFinalFlow())
           && Objects.equals(getAction(), that.getAction());
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyEvaluatorTest.java
@@ -25,15 +25,15 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.TrueExpr;
-import org.batfish.datamodel.packet_policy.FlowEvaluator.FlowResult;
+import org.batfish.datamodel.packet_policy.PacketPolicyEvaluator.PacketPolicyResult;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationStep;
 import org.junit.Before;
 import org.junit.Test;
 import org.parboiled.common.ImmutableList;
 
-/** Tests of {@link FlowEvaluator} */
-public final class FlowEvaluatorTest {
+/** Tests of {@link PacketPolicyEvaluator} */
+public final class PacketPolicyEvaluatorTest {
 
   private Flow _flow;
   private Return _defaultAction;
@@ -57,8 +57,8 @@ public final class FlowEvaluatorTest {
   @Test
   public void evaluateReturn() {
     FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
-    FlowResult r =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult r =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -74,8 +74,8 @@ public final class FlowEvaluatorTest {
   @Test
   public void evaluateIfWithMatch() {
     FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
-    FlowResult r =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult r =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -92,8 +92,8 @@ public final class FlowEvaluatorTest {
   @Test
   public void evaluateIfNoMatch() {
     FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
-    FlowResult r =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult r =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -112,11 +112,12 @@ public final class FlowEvaluatorTest {
   public void testFlowResultEquality() {
     new EqualsTester()
         .addEqualityGroup(
-            new FlowResult(_flow, Drop.instance()), new FlowResult(_flow, Drop.instance()))
+            new PacketPolicyResult(_flow, Drop.instance()),
+            new PacketPolicyResult(_flow, Drop.instance()))
         .addEqualityGroup(
-            new FlowResult(
+            new PacketPolicyResult(
                 _flow.toBuilder().setIngressNode("differentNode").build(), Drop.instance()))
-        .addEqualityGroup(new FlowResult(_flow, new FibLookup(new LiteralVrfName("avrf"))))
+        .addEqualityGroup(new PacketPolicyResult(_flow, new FibLookup(new LiteralVrfName("avrf"))))
         .addEqualityGroup(new Object())
         .testEquals();
   }
@@ -138,8 +139,8 @@ public final class FlowEvaluatorTest {
             _defaultAction);
 
     // Test:
-    FlowResult result =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult result =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -158,8 +159,8 @@ public final class FlowEvaluatorTest {
     // Setup policy
     PacketPolicy policy = new PacketPolicy("policyName", ImmutableList.of(), _defaultAction);
     // Test:
-    FlowResult result =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult result =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -178,8 +179,8 @@ public final class FlowEvaluatorTest {
     String aclName = "acl1";
     String ipSpaceName = "ipSpace1";
     FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
-    FlowResult r =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult r =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -208,8 +209,8 @@ public final class FlowEvaluatorTest {
   @Test
   public void testTrue() {
     FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
-    FlowResult r =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult r =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -227,8 +228,8 @@ public final class FlowEvaluatorTest {
   @Test
   public void testFalse() {
     FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
-    FlowResult r =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult r =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -251,8 +252,8 @@ public final class FlowEvaluatorTest {
             Transformation.always()
                 .apply(TransformationStep.assignDestinationIp(natIp, natIp))
                 .build());
-    FlowResult r =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult r =
+        PacketPolicyEvaluator.evaluate(
             _flow,
             "Eth0",
             "otherVrf",
@@ -311,8 +312,8 @@ public final class FlowEvaluatorTest {
 
     {
       // Lookup in interface VRF
-      FlowResult r =
-          FlowEvaluator.evaluate(
+      PacketPolicyResult r =
+          PacketPolicyEvaluator.evaluate(
               _flow,
               srcIface,
               vrfName,
@@ -328,8 +329,8 @@ public final class FlowEvaluatorTest {
     }
     {
       // Lookup in interface VRF, no match
-      FlowResult r =
-          FlowEvaluator.evaluate(
+      PacketPolicyResult r =
+          PacketPolicyEvaluator.evaluate(
               _flow,
               srcIface,
               vrfName,
@@ -346,8 +347,8 @@ public final class FlowEvaluatorTest {
 
     {
       // Lookup in a different VRF
-      FlowResult r =
-          FlowEvaluator.evaluate(
+      PacketPolicyResult r =
+          PacketPolicyEvaluator.evaluate(
               _flow,
               srcIface,
               vrfName,
@@ -365,8 +366,8 @@ public final class FlowEvaluatorTest {
     {
       // Lookup in original VRF with NEXT VR route -- should match nextVrfIface
       Flow flow = _flow.toBuilder().setDstIp(nextVrIp).build();
-      FlowResult r =
-          FlowEvaluator.evaluate(
+      PacketPolicyResult r =
+          PacketPolicyEvaluator.evaluate(
               flow,
               srcIface,
               vrfName,
@@ -386,8 +387,8 @@ public final class FlowEvaluatorTest {
   public void testConjunction() {
     FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
     {
-      FlowResult result =
-          FlowEvaluator.evaluate(
+      PacketPolicyResult result =
+          PacketPolicyEvaluator.evaluate(
               _flow,
               "Eth0",
               "otherVrf",
@@ -403,8 +404,8 @@ public final class FlowEvaluatorTest {
     }
 
     {
-      FlowResult result =
-          FlowEvaluator.evaluate(
+      PacketPolicyResult result =
+          PacketPolicyEvaluator.evaluate(
               _flow,
               "Eth0",
               "otherVrf",

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -119,9 +119,9 @@ import org.batfish.datamodel.packet_policy.ActionVisitor;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
 import org.batfish.datamodel.packet_policy.FibLookupOverrideLookupIp;
-import org.batfish.datamodel.packet_policy.FlowEvaluator;
-import org.batfish.datamodel.packet_policy.FlowEvaluator.FlowResult;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.PacketPolicyEvaluator;
+import org.batfish.datamodel.packet_policy.PacketPolicyEvaluator.PacketPolicyResult;
 import org.batfish.datamodel.packet_policy.VrfExprNameExtractor;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.transformation.Transformation;
@@ -610,8 +610,8 @@ class FlowTracer {
 
     // Policy is present. If this point is reached, processPBR will return true.
     Configuration owner = incomingInterface.getOwner();
-    FlowResult result =
-        FlowEvaluator.evaluate(
+    PacketPolicyResult result =
+        PacketPolicyEvaluator.evaluate(
             _currentFlow,
             incomingInterface.getName(),
             incomingInterface.getVrfName(),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -262,9 +262,9 @@ import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.packet_policy.FibLookup;
 import org.batfish.datamodel.packet_policy.FibLookupOverrideLookupIp;
-import org.batfish.datamodel.packet_policy.FlowEvaluator;
 import org.batfish.datamodel.packet_policy.IngressInterfaceVrf;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.PacketPolicyEvaluator;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.route.nh.NextHopIp;
@@ -2325,7 +2325,7 @@ public final class CiscoNxosGrammarTest {
     FibLookup regularFibLookup = new FibLookup(IngressInterfaceVrf.instance());
     // Accepted flow sent to 2.2.2.2
     assertThat(
-        FlowEvaluator.evaluate(
+        PacketPolicyEvaluator.evaluate(
                 acceptedFlow,
                 "eth0",
                 DEFAULT_VRF_NAME,
@@ -2344,7 +2344,7 @@ public final class CiscoNxosGrammarTest {
 
     // Rejected flow delegated to regular FIB lookup
     assertThat(
-        FlowEvaluator.evaluate(
+        PacketPolicyEvaluator.evaluate(
                 rejectedFlow,
                 "eth0",
                 DEFAULT_VRF_NAME,

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -210,10 +210,10 @@ import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
 import org.batfish.datamodel.packet_policy.FibLookupOverrideLookupIp;
-import org.batfish.datamodel.packet_policy.FlowEvaluator;
 import org.batfish.datamodel.packet_policy.IngressInterfaceVrf;
 import org.batfish.datamodel.packet_policy.LiteralVrfName;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.PacketPolicyEvaluator;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
@@ -3622,7 +3622,7 @@ public final class XrGrammarTest {
 
     // Permitted by non-ABF line
     assertThat(
-        FlowEvaluator.evaluate(
+        PacketPolicyEvaluator.evaluate(
                 permittedNoAbf,
                 gigE0,
                 DEFAULT_VRF_NAME,
@@ -3635,7 +3635,7 @@ public final class XrGrammarTest {
 
     // Permitted by ABF line (nexthop specified but not vrf)
     assertThat(
-        FlowEvaluator.evaluate(
+        PacketPolicyEvaluator.evaluate(
                 permittedAbfNoVrf,
                 gigE0,
                 DEFAULT_VRF_NAME,
@@ -3656,7 +3656,7 @@ public final class XrGrammarTest {
 
     // Permitted by ABF line (nexthop AND vrf specified)
     assertThat(
-        FlowEvaluator.evaluate(
+        PacketPolicyEvaluator.evaluate(
                 permittedAbfWithVrf,
                 gigE0,
                 DEFAULT_VRF_NAME,
@@ -3675,7 +3675,7 @@ public final class XrGrammarTest {
 
     // Denied by explicit deny line
     assertThat(
-        FlowEvaluator.evaluate(
+        PacketPolicyEvaluator.evaluate(
                 denied,
                 gigE0,
                 DEFAULT_VRF_NAME,
@@ -3687,7 +3687,7 @@ public final class XrGrammarTest {
         equalTo(Drop.instance()));
     // Similar to denied flow, but not matching source IP or dest port
     assertThat(
-        FlowEvaluator.evaluate(
+        PacketPolicyEvaluator.evaluate(
                 denied.toBuilder().setSrcIp(Ip.parse("10.0.0.2")).build(),
                 gigE0,
                 DEFAULT_VRF_NAME,
@@ -3698,7 +3698,7 @@ public final class XrGrammarTest {
             .getAction(),
         equalTo(regularFibLookup));
     assertThat(
-        FlowEvaluator.evaluate(
+        PacketPolicyEvaluator.evaluate(
                 denied.toBuilder().setDstPort(23).build(),
                 gigE0,
                 DEFAULT_VRF_NAME,

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -96,9 +96,9 @@ import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.packet_policy.Action;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
-import org.batfish.datamodel.packet_policy.FlowEvaluator;
 import org.batfish.datamodel.packet_policy.IngressInterfaceVrf;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.PacketPolicyEvaluator;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.route.nh.NextHopIp;
@@ -1520,8 +1520,8 @@ public class CheckPointGatewayGrammarTest {
     Action fibLookup = new FibLookup(IngressInterfaceVrf.instance());
     BiFunction<Flow, Flow, Void> testFunction =
         (testFlow, expectedFlow) -> {
-          FlowEvaluator.FlowResult eth0PolicyResult =
-              FlowEvaluator.evaluate(
+          PacketPolicyEvaluator.PacketPolicyResult eth0PolicyResult =
+              PacketPolicyEvaluator.evaluate(
                   testFlow,
                   eth0.getName(),
                   eth0.getVrfName(),
@@ -1529,8 +1529,8 @@ public class CheckPointGatewayGrammarTest {
                   c.getIpAccessLists(),
                   c.getIpSpaces(),
                   fibs);
-          FlowEvaluator.FlowResult eth1PolicyResult =
-              FlowEvaluator.evaluate(
+          PacketPolicyEvaluator.PacketPolicyResult eth1PolicyResult =
+              PacketPolicyEvaluator.evaluate(
                   testFlow,
                   eth1.getName(),
                   eth1.getVrfName(),
@@ -1823,8 +1823,8 @@ public class CheckPointGatewayGrammarTest {
     // Function to test that a given flow is transformed to the expected result flow
     TriFunction<Flow, Flow, Action, Void> testFunction =
         (testFlow, expectedFlow, expectedAction) -> {
-          FlowEvaluator.FlowResult eth0PolicyResult =
-              FlowEvaluator.evaluate(
+          PacketPolicyEvaluator.PacketPolicyResult eth0PolicyResult =
+              PacketPolicyEvaluator.evaluate(
                   testFlow,
                   eth0.getName(),
                   eth0.getVrfName(),
@@ -1832,8 +1832,8 @@ public class CheckPointGatewayGrammarTest {
                   c.getIpAccessLists(),
                   c.getIpSpaces(),
                   fibs);
-          FlowEvaluator.FlowResult eth1PolicyResult =
-              FlowEvaluator.evaluate(
+          PacketPolicyEvaluator.PacketPolicyResult eth1PolicyResult =
+              PacketPolicyEvaluator.evaluate(
                   testFlow,
                   eth1.getName(),
                   eth1.getVrfName(),


### PR DESCRIPTION
These classes are specific to evaluation of a `PacketPolicy`, so renamed them to make that clear.