### PR TITLE
A10 enable proxy-arp for real and virtual addresses

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
@@ -37,10 +37,12 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
 
   /** Builder for {@link KernelRoute} */
   public static final class Builder extends AbstractRouteBuilder<Builder, KernelRoute> {
+
     @Nonnull
     @Override
     public KernelRoute build() {
-      return new KernelRoute(getNetwork(), getAdmin(), getTag(), _requiredOwnedIp);
+      return new KernelRoute(
+          getNetwork(), getAdmin(), getTag(), _requiredOwnedIp, getNonForwarding());
     }
 
     @Nonnull
@@ -52,6 +54,10 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
     public @Nonnull Builder setRequiredOwnedIp(@Nullable Ip requiredOwnedIp) {
       _requiredOwnedIp = requiredOwnedIp;
       return this;
+    }
+
+    private Builder() {
+      setNonForwarding(true);
     }
 
     private @Nullable Ip _requiredOwnedIp;
@@ -71,11 +77,13 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
       @JsonProperty(PROP_REQUIRED_OWNED_IP) @Nullable Ip requiredOwnedIp,
       @JsonProperty(PROP_TAG) long tag) {
     checkArgument(network != null, "Cannot create kernel route: missing %s", PROP_NETWORK);
-    return new KernelRoute(network, adminCost, tag, requiredOwnedIp);
+    // Since nonForwarding is not jackson serialized, just use default value
+    return new KernelRoute(network, adminCost, tag, requiredOwnedIp, true);
   }
 
-  private KernelRoute(Prefix network, int admin, long tag, @Nullable Ip requiredOwnedIp) {
-    super(network, admin, tag, false, true);
+  private KernelRoute(
+      Prefix network, int admin, long tag, @Nullable Ip requiredOwnedIp, boolean nonForwarding) {
+    super(network, admin, tag, false, nonForwarding);
     _requiredOwnedIp = requiredOwnedIp;
   }
 
@@ -105,6 +113,7 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
   public Builder toBuilder() {
     return builder()
         .setNetwork(getNetwork())
+        .setNonForwarding(getNonForwarding())
         .setRequiredOwnedIp(getRequiredOwnedIp())
         .setTag(getTag());
   }
@@ -119,12 +128,13 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
     KernelRoute rhs = (KernelRoute) o;
     return _network.equals(rhs._network)
         && _tag == rhs._tag
-        && Objects.equals(_requiredOwnedIp, rhs._requiredOwnedIp);
+        && Objects.equals(_requiredOwnedIp, rhs._requiredOwnedIp)
+        && getNonForwarding() == rhs.getNonForwarding();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_network, _tag, _requiredOwnedIp);
+    return Objects.hash(_network, _tag, _requiredOwnedIp, getNonForwarding());
   }
 
   @Override
@@ -134,6 +144,7 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
         .add("_network", _network)
         .add("_tag", _tag)
         .add("_requiredOwnedIp", _requiredOwnedIp)
+        .add("_nonForwarding", getNonForwarding())
         .toString();
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/KernelRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/KernelRouteTest.java
@@ -19,6 +19,7 @@ public final class KernelRouteTest {
         .addEqualityGroup(builder.setNetwork(Prefix.ZERO).build())
         .addEqualityGroup((builder.setTag(5L).build()))
         .addEqualityGroup((builder.setRequiredOwnedIp(Ip.ZERO).build()))
+        .addEqualityGroup(builder.setNonForwarding(false).build())
         .testEquals();
   }
 
@@ -29,6 +30,7 @@ public final class KernelRouteTest {
             .setNetwork(Prefix.ZERO)
             .setTag(5L)
             .setRequiredOwnedIp(Ip.ZERO)
+            // skip setNonForwarding since its value is not jackson-serialized
             .build();
     assertEquals(route, BatfishObjectMapper.clone(route, KernelRoute.class));
   }
@@ -40,6 +42,7 @@ public final class KernelRouteTest {
             .setNetwork(Prefix.ZERO)
             .setTag(5L)
             .setRequiredOwnedIp(Ip.ZERO)
+            .setNonForwarding(false)
             .build();
     assertEquals(route, SerializationUtils.clone(route));
   }

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -30,6 +30,8 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSwitchPortMode;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.isProxyArp;
+import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.datamodel.matchers.StaticRouteMatchers.hasRecursive;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
@@ -39,7 +41,9 @@ import static org.batfish.main.BatfishTestUtils.getBatfish;
 import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceName;
 import static org.batfish.vendor.a10.representation.A10Conversion.DEFAULT_VRRP_A_PRIORITY;
 import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_FLOATING_IP;
+import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_INTERFACE_PROXY_ARP_IP;
 import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_NAT_POOL;
+import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_NAT_POOL_PROXY_ARP_IP;
 import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_VIRTUAL_SERVER_FLAGGED;
 import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_VIRTUAL_SERVER_UNFLAGGED;
 import static org.batfish.vendor.a10.representation.A10Conversion.SNAT_PORT_POOL_START;
@@ -98,10 +102,12 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConnectedRouteMetadata;
 import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.KernelRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SwitchportMode;
@@ -773,7 +779,8 @@ public class A10GrammarTest {
                 isActive(),
                 hasDescription("this is a comp\"licat'ed name"),
                 hasHumanName("Ethernet 1"),
-                hasMtu(1234))));
+                hasMtu(1234),
+                isProxyArp())));
 
     assertThat(
         c,
@@ -786,7 +793,8 @@ public class A10GrammarTest {
                 isActive(false),
                 hasDescription("baz"),
                 hasHumanName("Ethernet 9"),
-                hasMtu(DEFAULT_MTU))));
+                hasMtu(DEFAULT_MTU),
+                isProxyArp())));
 
     assertThat(
         c,
@@ -797,7 +805,8 @@ public class A10GrammarTest {
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(contains(ConcreteInterfaceAddress.parse("192.168.0.1/32"))),
                 hasDescription(nullValue()),
-                hasHumanName("Loopback 0"))));
+                hasHumanName("Loopback 0"),
+                isProxyArp(equalTo(false)))));
 
     assertThat(
         c,
@@ -808,7 +817,8 @@ public class A10GrammarTest {
                 hasSwitchPortMode(SwitchportMode.NONE),
                 hasAllAddresses(empty()),
                 hasDescription(nullValue()),
-                hasHumanName("Loopback 10"))));
+                hasHumanName("Loopback 10"),
+                isProxyArp(equalTo(false)))));
   }
 
   @Test
@@ -1934,30 +1944,93 @@ public class A10GrammarTest {
                 .setTag(KERNEL_ROUTE_TAG_NAT_POOL)
                 .build(),
             KernelRoute.builder()
+                .setNetwork(Prefix.strict("10.10.10.10/32"))
+                .setRequiredOwnedIp(Ip.parse("10.10.10.10"))
+                .setNonForwarding(false)
+                .setTag(KERNEL_ROUTE_TAG_NAT_POOL_PROXY_ARP_IP)
+                .build(),
+            KernelRoute.builder()
                 .setNetwork(Prefix.strict("10.0.0.0/24"))
                 .setRequiredOwnedIp(Ip.parse("10.0.0.11"))
                 .setTag(KERNEL_ROUTE_TAG_NAT_POOL)
                 .build(),
             KernelRoute.builder()
+                .setNetwork(Prefix.strict("10.0.0.11/32"))
+                .setRequiredOwnedIp(Ip.parse("10.0.0.11"))
+                .setNonForwarding(false)
+                .setTag(KERNEL_ROUTE_TAG_NAT_POOL_PROXY_ARP_IP)
+                .build(),
+            KernelRoute.builder()
                 .setNetwork(Prefix.strict("10.0.5.1/32"))
                 .setRequiredOwnedIp(Ip.parse("10.0.5.1"))
+                .setNonForwarding(false)
                 .setTag(KERNEL_ROUTE_TAG_VIRTUAL_SERVER_UNFLAGGED)
                 .build(),
             KernelRoute.builder()
                 .setNetwork(Prefix.strict("10.0.6.1/32"))
                 .setRequiredOwnedIp(Ip.parse("10.0.6.1"))
+                .setNonForwarding(false)
                 .setTag(KERNEL_ROUTE_TAG_VIRTUAL_SERVER_FLAGGED)
                 .build(),
             KernelRoute.builder()
                 .setNetwork(Prefix.strict("10.0.9.1/32"))
                 .setRequiredOwnedIp(Ip.parse("10.0.9.1"))
+                .setNonForwarding(false)
                 .setTag(KERNEL_ROUTE_TAG_FLOATING_IP)
                 .build(),
             KernelRoute.builder()
                 .setNetwork(Prefix.strict("10.0.9.2/32"))
                 .setRequiredOwnedIp(Ip.parse("10.0.9.2"))
+                .setNonForwarding(false)
                 .setTag(KERNEL_ROUTE_TAG_FLOATING_IP)
+                .build(),
+            KernelRoute.builder()
+                .setNetwork(Prefix.strict("10.0.0.10/32"))
+                .setTag(KERNEL_ROUTE_TAG_INTERFACE_PROXY_ARP_IP)
+                .setNonForwarding(false)
+                .build(),
+            KernelRoute.builder()
+                .setNetwork(Prefix.strict("10.100.0.1/32"))
+                .setTag(KERNEL_ROUTE_TAG_INTERFACE_PROXY_ARP_IP)
+                .setNonForwarding(false)
+                .build(),
+            KernelRoute.builder()
+                .setNetwork(Prefix.strict("192.168.255.1/32"))
+                .setTag(KERNEL_ROUTE_TAG_INTERFACE_PROXY_ARP_IP)
+                .setNonForwarding(false)
                 .build()));
+  }
+
+  @Test
+  public void testKernelRoutesProxyArp() throws IOException {
+    String hostname = "kernel_routes";
+    Configuration c = parseConfig(hostname);
+
+    Batfish batfish = getBatfish(ImmutableSortedMap.of(c.getHostname(), c), _folder);
+    NetworkSnapshot snapshot = batfish.getSnapshot();
+    batfish.computeDataPlane(snapshot);
+    ForwardingAnalysis fa = batfish.loadDataPlane(snapshot).getForwardingAnalysis();
+
+    IpSpace e1Replies = fa.getArpReplies().get(hostname).get(getInterfaceName(Type.ETHERNET, 1));
+    IpSpace e2Replies = fa.getArpReplies().get(hostname).get(getInterfaceName(Type.ETHERNET, 2));
+
+    Ip e1Address = Ip.parse("10.0.0.10");
+    Ip e2Address = Ip.parse("10.100.0.1");
+    Ip floatingIp = Ip.parse("10.0.9.1");
+    Ip natPoolIp = Ip.parse("10.0.0.11");
+    Ip vsIp = Ip.parse("10.0.5.1");
+
+    assertThat(e1Replies, containsIp(e1Address));
+    assertThat(e1Replies, containsIp(e2Address));
+    assertThat(e1Replies, containsIp(floatingIp));
+    assertThat(e1Replies, containsIp(natPoolIp));
+    assertThat(e1Replies, containsIp(vsIp));
+
+    assertThat(e2Replies, containsIp(e1Address));
+    assertThat(e2Replies, containsIp(e2Address));
+    assertThat(e2Replies, containsIp(floatingIp));
+    assertThat(e2Replies, containsIp(natPoolIp));
+    assertThat(e2Replies, containsIp(vsIp));
   }
 
   @Test
@@ -2042,6 +2115,7 @@ public class A10GrammarTest {
                 .setNetwork(Prefix.strict("10.0.2.1/32"))
                 .setRequiredOwnedIp(Ip.parse("10.0.2.1"))
                 .setTag(KERNEL_ROUTE_TAG_FLOATING_IP)
+                .setNonForwarding(false)
                 .build(),
             KernelRoute.builder()
                 .setNetwork(Prefix.strict("10.0.3.0/24"))
@@ -2052,6 +2126,19 @@ public class A10GrammarTest {
                 .setNetwork(Prefix.strict("10.0.4.1/32"))
                 .setRequiredOwnedIp(Ip.parse("10.0.4.1"))
                 .setTag(KERNEL_ROUTE_TAG_VIRTUAL_SERVER_UNFLAGGED)
+                .setNonForwarding(false)
+                .build(),
+            KernelRoute.builder()
+                .setNetwork(Prefix.strict("10.0.3.1/32"))
+                .setRequiredOwnedIp(Ip.parse("10.0.3.1"))
+                .setTag(KERNEL_ROUTE_TAG_NAT_POOL_PROXY_ARP_IP)
+                .setNonForwarding(false)
+                .build(),
+            KernelRoute.builder()
+                .setNetwork(Prefix.strict("10.0.3.2/32"))
+                .setRequiredOwnedIp(Ip.parse("10.0.3.2"))
+                .setTag(KERNEL_ROUTE_TAG_NAT_POOL_PROXY_ARP_IP)
+                .setNonForwarding(false)
                 .build()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConfigurationTest.java
@@ -1,13 +1,10 @@
 package org.batfish.vendor.a10.representation;
 
-import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceEnabledEffective;
 import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceHumanName;
 import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceMtuEffective;
 import static org.batfish.vendor.a10.representation.Interface.DEFAULT_MTU;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -23,25 +20,6 @@ import org.junit.Test;
 
 /** Tests of {@link A10Configuration}. */
 public class A10ConfigurationTest {
-  @Test
-  public void testGetInterfaceEnabledEffective() {
-    Interface ethNullEnabled = new Interface(Interface.Type.ETHERNET, 1);
-    Interface loopNullEnabled = new Interface(Interface.Type.LOOPBACK, 1);
-
-    // Defaults
-    // Ethernet is disabled by default
-    assertFalse(getInterfaceEnabledEffective(ethNullEnabled));
-    // Loopback is enabled by default
-    assertTrue(getInterfaceEnabledEffective(loopNullEnabled));
-
-    // Explicit enabled value set
-    Interface eth = new Interface(Interface.Type.ETHERNET, 1);
-    eth.setEnabled(true);
-    assertTrue(getInterfaceEnabledEffective(eth));
-    eth.setEnabled(false);
-    assertFalse(getInterfaceEnabledEffective(eth));
-  }
-
   @Test
   public void testGetInterfaceMtuEffective() {
     Interface eth = new Interface(Interface.Type.ETHERNET, 1);

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/kernel_routes
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/kernel_routes
@@ -11,10 +11,25 @@ vrrp-a vrid 0
   floating-ip 10.0.9.2
 !
 
+vrrp-a peer-group
+  peer 192.168.255.2
+!
+
 interface ethernet 1
   ip address 10.0.0.10 255.255.255.0
   enable
 !
+
+interface ethernet 2
+  ip address 10.100.0.1 255.255.255.0
+  enable
+!
+
+interface ethernet 3
+  ip address 192.168.255.1 /30
+  enable
+!
+
 !
 ip nat pool POOL1 10.10.10.10 10.10.10.10 netmask /32
 ! overlaps with interface subnet, but not interface address


### PR DESCRIPTION
- enable proxy-arp on non-loopback l3 interfaces
- allow kernel routes to be forwarding so they may be used by proxy-arp
- make virutal-server and floating-ip kernel routes forwarding
- add forwarding /32 kernel routes for each nat pool ip
  - use separate tag so they won't be redistributed
- add forwarding /32 kernel routes for interface ips
  - needed because a10 interface addresses do not generate local routes