### PR TITLE
BroadcastL3Adjacencies: connect untagged subinterfaces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/L3AdjacencyComputer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/broadcast/L3AdjacencyComputer.java
@@ -272,10 +272,8 @@ public class L3AdjacencyComputer {
             parentNip);
         return;
       } else if (i.getEncapsulationVlan() == null) {
-        LOGGER.warn(
-            "Not connecting L3 interface {} to parent {}: no encapsulation VLAN set",
-            nip,
-            parentNip);
+        LOGGER.debug("L3 interface {} connected to physical interface {} untagged", nip, parentNip);
+        Edges.connectL3Untagged(iface, parentIface);
         return;
       }
       LOGGER.debug(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/broadcast/L3AdjacencyComputerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/broadcast/L3AdjacencyComputerTest.java
@@ -518,7 +518,7 @@ public class L3AdjacencyComputerTest {
       assertThat(domain.getL3InterfacesForTest(), anEmptyMap());
     }
     {
-      // Subif is missing encapsulation vlan
+      // Subif handles untagged frames
       subif.setEncapsulationVlan(null);
       L3Interface iface = new L3Interface(NodeInterfacePair.of(subif));
       PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
@@ -529,9 +529,9 @@ public class L3AdjacencyComputerTest {
           c.getAllInterfaces(),
           ImmutableMap.of(physicalInterface.getIface(), physicalInterface),
           ImmutableMap.of(domain.getHostname(), domain));
-      assertThat(iface.getSendToInterfaceForTesting(), nullValue());
+      assertThat(iface.getSendToInterfaceForTesting(), sameInstance(physicalInterface));
       assertThat(iface.getSendToSwitchForTesting(), nullValue());
-      assertThat(physicalInterface.getL3InterfacesForTest(), anEmptyMap());
+      assertThat(physicalInterface.getL3InterfacesForTest().keySet(), contains(iface));
       assertThat(physicalInterface.getSwitchForTest(), nullValue());
       assertThat(domain.getPhysicalInterfacesForTest(), anEmptyMap());
       assertThat(domain.getL3InterfacesForTest(), anEmptyMap());


### PR DESCRIPTION
There is no requirement that the subinterface handling untagged frames has the
same name as the physical interface. E.g., Juniper the L3 config is on unit 0.
On Cisco you can control which subinterface handles untagged frames too, via
`encapsulation untagged`. So relax that check.