### PR TITLE
IBDP: do not recompute fibs and forwarding analysis at the end

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -78,13 +78,16 @@ final class IncrementalBdpEngine {
     _settings = settings;
   }
 
+  /**
+   * Returns the {@link PartialDataplane} corresponding to the given topology and nodes. FIBs,
+   * ForwardingAnalysis, and other internals are recomputed based on the updated state in the {@code
+   * nodes} and {@code vrs}.
+   */
   private PartialDataplane nextDataplane(
       TopologyContext currentTopologyContext,
       SortedMap<String, Node> nodes,
       List<VirtualRouter> vrs) {
     LOGGER.info("Updating dataplane");
-
-    // Force re-init of partial dataplane. Re-inits forwarding analysis, etc.
     computeFibs(vrs);
 
     return PartialDataplane.builder()

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -136,7 +136,6 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     _fibs = dataplane.getFibs();
     _forwardingAnalysis = dataplane.getForwardingAnalysis();
 
-    // Order of initialization matters:
     Map<String, Node> nodes = builder._nodes;
     _bgpRoutes = DataplaneUtil.computeBgpRoutes(nodes);
     _bgpBackupRoutes = DataplaneUtil.computeBgpBackupRoutes(nodes);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
@@ -76,14 +76,25 @@ public final class PartialDataplane implements DataPlane {
   }
 
   @Override
-  public SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
+  public @Nonnull SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
       getPrefixTracingInfoSummary() {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> getRibs() {
+  public @Nonnull SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
+      getRibs() {
     throw new UnsupportedOperationException();
+  }
+
+  // For invariant checking only.
+
+  public @Nonnull Topology getLayer3Topology() {
+    return _layer3Topology;
+  }
+
+  public @Nonnull L3Adjacencies getL3Adjacencies() {
+    return _l3Adjacencies;
   }
 
   //////////
@@ -127,6 +138,8 @@ public final class PartialDataplane implements DataPlane {
   @Nonnull private final Map<String, Map<String, Fib>> _fibs;
   @Nonnull private final ForwardingAnalysis _forwardingAnalysis;
   @Nonnull private final Table<String, String, Set<Layer2Vni>> _vniSettings;
+  @Nonnull private final Topology _layer3Topology;
+  @Nonnull private final L3Adjacencies _l3Adjacencies;
 
   private PartialDataplane(Builder builder) {
     checkArgument(builder._nodes != null, "Dataplane must have nodes to be constructed");
@@ -139,5 +152,7 @@ public final class PartialDataplane implements DataPlane {
     _forwardingAnalysis =
         computeForwardingAnalysis(_fibs, configs, builder._layer3Topology, builder._l3Adjacencies);
     _vniSettings = DataplaneUtil.computeVniSettings(nodes);
+    _l3Adjacencies = builder._l3Adjacencies;
+    _layer3Topology = builder._layer3Topology;
   }
 }


### PR DESCRIPTION
We can instead reuse the forwarding analysis used to build topologies.
Since the topologies haven't changed, and no route exchange has been
done, the FIBs and Forwarding Analysis cannot have changed.