### PR TITLE
DataplaneUtil: parallelism and redundancy improvements

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
@@ -33,12 +33,12 @@ import org.batfish.datamodel.vxlan.Layer2Vni;
 /** Utility functions to convert dataplane {@link Node} into other structures */
 public final class DataplaneUtil {
 
-  static Map<String, Configuration> computeConfigurations(Map<String, Node> nodes) {
+  static @Nonnull Map<String, Configuration> computeConfigurations(Map<String, Node> nodes) {
     return nodes.entrySet().stream()
         .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getConfiguration()));
   }
 
-  static Map<String, Map<String, Fib>> computeFibs(Map<String, Node> nodes) {
+  static @Nonnull Map<String, Map<String, Fib>> computeFibs(Map<String, Node> nodes) {
     return toImmutableMap(
         nodes,
         Entry::getKey,
@@ -49,7 +49,7 @@ public final class DataplaneUtil {
                 VirtualRouter::getFib));
   }
 
-  static ForwardingAnalysis computeForwardingAnalysis(
+  static @Nonnull ForwardingAnalysis computeForwardingAnalysis(
       Map<String, Map<String, Fib>> fibs,
       Map<String, Configuration> configs,
       Topology layer3Topology,
@@ -59,7 +59,7 @@ public final class DataplaneUtil {
         configs, fibs, layer3Topology, computeLocationInfo(ipOwners, configs), ipOwners);
   }
 
-  static SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
+  static @Nonnull SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
       computeRibs(Map<String, Node> nodes) {
     return toImmutableSortedMap(
         nodes,
@@ -71,8 +71,7 @@ public final class DataplaneUtil {
                 VirtualRouter::getMainRib));
   }
 
-  @Nonnull
-  static Table<String, String, Set<Bgpv4Route>> computeBgpRoutes(List<VirtualRouter> vrs) {
+  static @Nonnull Table<String, String, Set<Bgpv4Route>> computeBgpRoutes(List<VirtualRouter> vrs) {
     return vrs.parallelStream()
         .filter(vr -> vr._bgpRoutingProcess != null)
         .collect(
@@ -102,8 +101,8 @@ public final class DataplaneUtil {
                             cell.getValue()))));
   }
 
-  @Nonnull
-  static Table<String, String, Set<EvpnRoute<?, ?>>> computeEvpnRoutes(List<VirtualRouter> vrs) {
+  static @Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> computeEvpnRoutes(
+      List<VirtualRouter> vrs) {
     return vrs.parallelStream()
         .filter(vr -> vr._bgpRoutingProcess != null)
         .collect(
@@ -113,8 +112,7 @@ public final class DataplaneUtil {
                 VirtualRouter::getEvpnRoutes));
   }
 
-  @Nonnull
-  static Table<String, String, Set<EvpnRoute<?, ?>>> computeEvpnBackupRoutes(
+  static @Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> computeEvpnBackupRoutes(
       Map<String, Node> nodes, Table<String, String, Set<EvpnRoute<?, ?>>> evpnRoutes) {
     return evpnRoutes.cellSet().parallelStream()
         .collect(
@@ -134,8 +132,8 @@ public final class DataplaneUtil {
                             cell.getValue()))));
   }
 
-  @Nonnull
-  static Table<String, String, Set<Layer2Vni>> computeVniSettings(Map<String, Node> nodes) {
+  static @Nonnull Table<String, String, Set<Layer2Vni>> computeVniSettings(
+      Map<String, Node> nodes) {
     ImmutableTable.Builder<String, String, Set<Layer2Vni>> result = ImmutableTable.builder();
     for (Node node : nodes.values()) {
       for (VirtualRouter vr : node.getVirtualRouters()) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -141,7 +141,6 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     Map<String, Node> nodes = builder._nodes;
     List<VirtualRouter> vrs =
         toListInRandomOrder(nodes.values().stream().flatMap(n -> n.getVirtualRouters().stream()));
-    ;
     _bgpRoutes = DataplaneUtil.computeBgpRoutes(vrs);
     _bgpBackupRoutes = DataplaneUtil.computeBgpBackupRoutes(nodes, _bgpRoutes);
     _evpnRoutes = DataplaneUtil.computeEvpnRoutes(vrs);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -2,10 +2,12 @@ package org.batfish.dataplane.ibdp;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
+import static org.batfish.common.util.StreamUtil.toListInRandomOrder;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Table;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -137,10 +139,13 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     _forwardingAnalysis = dataplane.getForwardingAnalysis();
 
     Map<String, Node> nodes = builder._nodes;
-    _bgpRoutes = DataplaneUtil.computeBgpRoutes(nodes);
-    _bgpBackupRoutes = DataplaneUtil.computeBgpBackupRoutes(nodes);
-    _evpnRoutes = DataplaneUtil.computeEvpnRoutes(nodes);
-    _evpnBackupRoutes = DataplaneUtil.computeEvpnBackupRoutes(nodes);
+    List<VirtualRouter> vrs =
+        toListInRandomOrder(nodes.values().stream().flatMap(n -> n.getVirtualRouters().stream()));
+    ;
+    _bgpRoutes = DataplaneUtil.computeBgpRoutes(vrs);
+    _bgpBackupRoutes = DataplaneUtil.computeBgpBackupRoutes(nodes, _bgpRoutes);
+    _evpnRoutes = DataplaneUtil.computeEvpnRoutes(vrs);
+    _evpnBackupRoutes = DataplaneUtil.computeEvpnBackupRoutes(nodes, _evpnRoutes);
     _ribs = DataplaneUtil.computeRibs(nodes);
     _prefixTracerSummary = computePrefixTracingInfo(nodes);
     _vniSettings = DataplaneUtil.computeVniSettings(nodes);


### PR DESCRIPTION
1. VirtualRouter#getBgpRoutes/getEvpnRoutes can be expensive.
   (The result is recomputed in most cases.) So only call it once,
   and use the prior result.
2. The Bgp/Evpn routes tables do not need empty cells.
3. Parallelize computation of tables, especially when the
   "cell value" function can be expensive.