### PR TITLE
Rows: preserve insertion order

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/Row.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/Row.java
@@ -4,9 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,7 +26,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.common.BatfishException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
@@ -48,7 +45,7 @@ import org.batfish.datamodel.questions.Exclusion;
  * key is the column name and the value (currently) is JsonNode.
  */
 @ParametersAreNonnullByDefault
-public class Row implements Comparable<Row>, Serializable {
+public class Row implements Serializable {
 
   public abstract static class RowBuilder {
 
@@ -185,25 +182,6 @@ public class Row implements Comparable<Row>, Serializable {
   /** Returns a {@link TypedRowBuilder} object for Row */
   public static TypedRowBuilder builder(Map<String, ColumnMetadata> columns) {
     return new TypedRowBuilder(columns);
-  }
-
-  /**
-   * Compares two Rows. The current implementation ignores primary keys of the table and compares
-   * everything, mainly to provide consistent ordering of answers. This will need to change when we
-   * start using the primary keys for something.
-   *
-   * @param o The other Row to compare against.
-   * @return The result of the comparison
-   */
-  @Override
-  public int compareTo(Row o) {
-    try {
-      String myStr = getAsString();
-      String oStr = o.getAsString();
-      return myStr.compareTo(oStr);
-    } catch (JsonProcessingException e) {
-      throw new BatfishException("Exception in row comparison", e);
-    }
   }
 
   @Override
@@ -395,17 +373,5 @@ public class Row implements Comparable<Row>, Serializable {
 
   public boolean hasNonNull(String column) {
     return _data.hasNonNull(column);
-  }
-
-  private volatile String _asString;
-
-  @JsonIgnore
-  private String getAsString() throws JsonProcessingException {
-    String asString = _asString;
-    if (asString == null) {
-      asString = BatfishObjectMapper.writeString(_data);
-      _asString = asString;
-    }
-    return asString;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/Rows.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/Rows.java
@@ -2,25 +2,26 @@ package org.batfish.datamodel.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multiset;
-import com.google.common.collect.TreeMultiset;
 import java.io.Serializable;
 import java.util.Iterator;
-import java.util.Objects;
+import javax.annotation.Nonnull;
 
 /** Represents data rows insider {@link TableAnswerElement} */
 public class Rows implements Serializable {
 
-  private Multiset<Row> _data;
+  private final Multiset<Row> _data;
 
   public Rows() {
-    this(null);
+    _data = LinkedHashMultiset.create();
   }
 
-  @JsonCreator
-  public Rows(Multiset<Row> data) {
-    _data = data == null ? TreeMultiset.create() : data;
+  @VisibleForTesting
+  public Rows(@Nonnull Multiset<Row> rows) {
+    _data = ImmutableMultiset.copyOf(rows);
   }
 
   public Rows add(Row row) {
@@ -45,7 +46,6 @@ public class Rows implements Serializable {
    *
    * @return An ImmutableMultiset
    */
-  @JsonValue
   public Multiset<Row> getData() {
     return ImmutableMultiset.copyOf(_data);
   }
@@ -65,6 +65,17 @@ public class Rows implements Serializable {
 
   @Override
   public String toString() {
-    return Objects.toString(_data);
+    return _data.toString();
+  }
+
+  // Jackson serializes a Multiset as a list of items.
+  @JsonCreator
+  private Rows(Iterable<Row> data) {
+    _data = ImmutableMultiset.copyOf(data);
+  }
+
+  @JsonValue
+  private Iterable<Row> asJsonValue() {
+    return _data;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/RowsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/RowsTest.java
@@ -1,0 +1,61 @@
+package org.batfish.datamodel.table;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.testing.EqualsTester;
+import java.util.List;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public final class RowsTest {
+
+  @Test
+  public void testEquals() {
+    Row r1 = Row.of("val", 1);
+    Row r2 = Row.of("val", 2);
+    new EqualsTester()
+        .addEqualityGroup(new Rows().add(r1), new Rows().add(r1))
+        .addEqualityGroup(new Rows().add(r1).add(r1), new Rows().add(r1).add(r1))
+        .addEqualityGroup(new Rows().add(r1).add(r2), new Rows().add(r2).add(r1))
+        .testEquals();
+  }
+
+  @Test
+  public void testIterationAndSerializationPreservation() {
+    // Rows are insertion-ordered, with duplicates appearing next to their first instance.
+    List<Row> outOfOrderRows =
+        ImmutableList.of(Row.of("val", 1), Row.of("val", 2), Row.of("val", 1));
+    List<Row> inOrderRows = ImmutableList.of(Row.of("val", 1), Row.of("val", 1), Row.of("val", 2));
+
+    {
+      Rows rows = new Rows();
+      outOfOrderRows.forEach(rows::add);
+      assertThat(ImmutableList.copyOf(rows.iterator()), equalTo(inOrderRows));
+      // Survives cloning
+      assertThat(
+          ImmutableList.copyOf(SerializationUtils.clone(rows).iterator()), equalTo(inOrderRows));
+      assertThat(
+          ImmutableList.copyOf(BatfishObjectMapper.clone(rows, Rows.class).iterator()),
+          equalTo(inOrderRows));
+    }
+
+    // Reverse insertion.
+    {
+      List<Row> reversedRows = Lists.reverse(inOrderRows);
+      Rows reverse = new Rows();
+      reversedRows.forEach(reverse::add);
+      assertThat(ImmutableList.copyOf(reverse.iterator()), equalTo(reversedRows));
+      // Survives cloning
+      assertThat(
+          ImmutableList.copyOf(SerializationUtils.clone(reverse).iterator()),
+          equalTo(reversedRows));
+      assertThat(
+          ImmutableList.copyOf(BatfishObjectMapper.clone(reverse, Rows.class).iterator()),
+          equalTo(reversedRows));
+    }
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/ipsecsessionstatus/IpsecSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ipsecsessionstatus/IpsecSessionStatusAnswerer.java
@@ -8,9 +8,9 @@ import static org.batfish.datamodel.questions.IpsecSessionStatus.IPSEC_SESSION_E
 import static org.batfish.datamodel.questions.IpsecSessionStatus.MISSING_END_POINT;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.graph.ValueGraph;
 import java.util.List;
@@ -91,7 +91,6 @@ class IpsecSessionStatusAnswerer extends Answerer {
         ipsecSessionInfos.stream()
             .filter(ipsecSessionInfo -> statuses.contains(ipsecSessionInfo.getIpsecSessionStatus()))
             .map(IpsecSessionStatusAnswerer::toRow)
-            .sorted()
             .collect(ImmutableList.toImmutableList()));
     return answerElement;
   }
@@ -102,7 +101,7 @@ class IpsecSessionStatusAnswerer extends Answerer {
       ValueGraph<IpsecPeerConfigId, IpsecSession> ipsecTopology,
       Set<String> initiatorNodes,
       Set<String> responderNodes) {
-    Multiset<IpsecSessionInfo> ipsecSessionInfos = HashMultiset.create();
+    Multiset<IpsecSessionInfo> ipsecSessionInfos = LinkedHashMultiset.create();
 
     for (IpsecPeerConfigId node : ipsecTopology.nodes()) {
       IpsecPeerConfig ipsecPeerConfig = networkConfigurations.getIpsecPeerConfig(node);


### PR DESCRIPTION
Prior to this PR, Rows was sorted for determinism, using a completely
arbitrary sort.

Preserving insertion order enables answerers to provide a better,
useful default result order.