### PR TITLE
BgpProtocolHelper: tags are non-transitive

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -410,9 +410,10 @@ public final class BgpProtocolHelper {
                   .add(asSetToPrepend)
                   .addAll(routeAsPath.getAsSets())
                   .build()));
-      // Tags are non-transitive
-      routeBuilder.setTag(null);
     }
+
+    // Tags are non-transitive
+    routeBuilder.setTag(null);
 
     // Skip setting our own next hop if it has already been set by the routing policy
     if (routeBuilder.getNextHopIp().equals(UNSET_ROUTE_NEXT_HOP_IP)) {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -190,6 +190,8 @@ public class BgpProtocolHelperTest {
     Builder builder = _baseBgpRouteBuilder.setTag(MAX_TAG);
     transformBgpRoutePostExport(builder, true, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO);
     assertThat("Tag is cleared", builder.getTag(), equalTo(UNSET_ROUTE_TAG));
+
+    builder.setTag(MAX_TAG);
     transformBgpRoutePostExport(builder, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO);
     assertThat("Tag is cleared", builder.getTag(), equalTo(UNSET_ROUTE_TAG));
   }


### PR DESCRIPTION
It does not depend on whether the session is eBGP