### PR TITLE
FibEntry: remove getResolvedToRoute

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibEntry.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibEntry.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.collect.Iterables;
 import java.io.Serializable;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -44,11 +43,6 @@ public final class FibEntry implements Serializable {
   @Nonnull
   public AbstractRoute getTopLevelRoute() {
     return _resolutionSteps.get(0);
-  }
-
-  /** Return the final resolved route */
-  public AbstractRoute getResolvedToRoute() {
-    return Iterables.getLast(_resolutionSteps);
   }
 
   @Override


### PR DESCRIPTION
The only use was in IpsRoutedOutInterfacesFactory, and this is actually
redundant with information already in the FibAction.