### PR TITLE
PacketPolicyToBdd: fix missing default state

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1999,6 +1999,10 @@ public final class BDDReachabilityAnalysisFactoryTest {
             edge(
                 new PacketPolicyStatement(n1.getHostname(), vrf.getName(), "pbr", 0),
                 new PacketPolicyAction(n1.getHostname(), vrf.getName(), "pbr", Drop.instance()),
+                IDENTITY),
+            edge(
+                new PacketPolicyAction(n1.getHostname(), vrf.getName(), "pbr", Drop.instance()),
+                new NodeDropAclIn(n1.getHostname()),
                 IDENTITY)));
   }
 


### PR DESCRIPTION
1. Missing default action because we used _edges.add instead of addEdge
2. Update tests to check both edges and actions.
3. Add invariant assertion (not in production)