### PR TITLE
FibEntry: only track top level route for now

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibEntry.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibEntry.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -25,7 +26,10 @@ public final class FibEntry implements Serializable {
     checkArgument(
         !resolutionSteps.isEmpty(), "FIB resolution steps must contain at least one route");
     _action = action;
-    _resolutionSteps = resolutionSteps;
+    // TODO: currently only keeping the top level route. Until there is another use case for
+    //       resolution steps, the rest are not used.
+    // _resolutionSteps = ImmutableList.copyOf(resolutionSteps);
+    _resolutionSteps = ImmutableList.of(resolutionSteps.get(0));
   }
 
   /** The action to take when this entry is matched. */
@@ -33,9 +37,14 @@ public final class FibEntry implements Serializable {
     return _action;
   }
 
-  /** A chain of routes that explains how the top route was resolved */
-  @Nonnull
-  public List<AbstractRoute> getResolutionSteps() {
+  /**
+   * A chain of routes that explains how the top route was resolved.
+   *
+   * <p>TODO: this is not used anywhere, and it is more efficient not to store all routes. If
+   * needed, fix constructor and change visibility.
+   */
+  @SuppressWarnings("unused")
+  private @Nonnull List<AbstractRoute> getResolutionSteps() {
     return _resolutionSteps;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
@@ -170,7 +169,7 @@ public final class FibImpl implements Fib {
               return new FibNextVrf(nextHopVrf.getVrfName());
             }
           }.visit(route.getNextHop());
-      entriesBuilder.add(new FibEntry(fibAction, ImmutableList.copyOf(stack)));
+      entriesBuilder.add(new FibEntry(fibAction, stack));
       return;
     }
     stack.push(route);


### PR DESCRIPTION
The resolution steps will likely be needed later, but right now only the top
level route is used.