### PR TITLE
FRR: rewrite BGP grammar for recovery, fix crash

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
@@ -9,17 +9,20 @@ options {
 s_bgp
 :
   ROUTER BGP autonomous_system (VRF vrf_name)? NEWLINE
-  (
-    sb_address_family
-  | sb_always_compare_med
-  | sb_bgp
-  | sb_neighbor
-  | sb_network
-  | sb_no
-  | sb_redistribute
-  | sb_timers
-  | sbafi_neighbor
-  )*
+  bgp_inner*
+;
+
+bgp_inner
+:
+  sb_address_family
+| sb_always_compare_med
+| sb_bgp
+| sb_neighbor
+| sb_network
+| sb_no
+| sb_redistribute
+| sb_timers
+| sbafi_neighbor
 ;
 
 sb_bgp
@@ -58,7 +61,6 @@ sbnob_default
   (
      sbnobd_ipv4_unicast
   )
-  NEWLINE
 ;
 
 sbb_confederation
@@ -106,7 +108,7 @@ sbb_cluster_id
 
 sb_neighbor
 :
-  NEIGHBOR (sbn_ip | sbn_ip6 | sbn_name) NEWLINE
+  NEIGHBOR (sbn_ip | sbn_ip6 | sbn_name)
 ;
 
 sb_address_family
@@ -125,26 +127,32 @@ sbaf
 sbaf_ipv4_unicast
 :
   IPV4 UNICAST NEWLINE
-  (
-    sbafi_aggregate_address
-    | sbafi_import
-    // Skeptical that max-paths belongs here.
-    // Adding for now to prevent jumping out of parser context.
-    | sbafi_maximum_paths
-    | sbafi_network
-    | sbafi_neighbor
-    | sbafi_no
-    | sbafi_redistribute
-  )*
+  sbafi_inner*
+;
+
+sbafi_inner
+:
+  sbafi_aggregate_address
+| sbafi_import
+// Skeptical that max-paths belongs here.
+// Adding for now to prevent jumping out of parser context.
+| sbafi_maximum_paths
+| sbafi_network
+| sbafi_neighbor
+| sbafi_no
+| sbafi_redistribute
 ;
 
 sbaf_ipv6_unicast
 :
   IPV6 UNICAST NEWLINE
-  (
-    sbafi6_import
-    |  sbafi6_null_tail
-  )*
+  sbafi6_inner*
+;
+
+sbafi6_inner
+:
+  sbafi6_import
+| sbafi6_null_tail
 ;
 
 sbafi6_import
@@ -166,12 +174,15 @@ sbafi6_null_tail
 sbaf_l2vpn_evpn
 :
   L2VPN EVPN NEWLINE
-  (
-       sbafl_advertise
-     | sbafl_advertise_all_vni
-     | sbafl_advertise_default_gw
-     | sbafl_neighbor
-  )*
+  sbafl_inner*
+;
+
+sbafl_inner
+:
+  sbafl_advertise
+| sbafl_advertise_all_vni
+| sbafl_advertise_default_gw
+| sbafl_neighbor
 ;
 
 sbafl_neighbor
@@ -308,72 +319,72 @@ sbn_interface
 
 sbn_peer_group_decl
 :
-  PEER_GROUP
+  PEER_GROUP NEWLINE
 ;
 
 sbn_property
 :
  sbnp_advertisement_interval
+| sbnp_bfd
 | sbnp_description
 | sbnp_ebgp_multihop
-| sbnp_peer_group
-| sbnp_bfd
-| sbnp_password
-| sbnp_remote_as
-| sbnp_update_source
 | sbnp_local_as
+| sbnp_password
+| sbnp_peer_group
+| sbnp_remote_as
 | sbnp_timers
+| sbnp_update_source
 ;
 
 sbnp_advertisement_interval
 :
-   ADVERTISEMENT_INTERVAL uint32
+   ADVERTISEMENT_INTERVAL uint32 NEWLINE
 ;
 
 
 sbnp_bfd
 :
-  BFD word*
+  BFD word* NEWLINE
 ;
 
 sbnp_description
 :
-  DESCRIPTION REMARK_TEXT
+  DESCRIPTION REMARK_TEXT NEWLINE
 ;
 
 sbnp_ebgp_multihop
 :
-  EBGP_MULTIHOP (num = uint32)?
-;
-
-sbnp_password
-:
-  PASSWORD REMARK_TEXT
-;
-
-sbnp_peer_group
-:
-  PEER_GROUP name = word
-;
-
-sbnp_remote_as
-:
-  REMOTE_AS (autonomous_system | EXTERNAL | INTERNAL)
-;
-
-sbnp_update_source
-:
-  UPDATE_SOURCE (ip = IP_ADDRESS | name = word)
+  EBGP_MULTIHOP (num = uint32)? NEWLINE
 ;
 
 sbnp_local_as
 :
-  LOCAL_AS asn = autonomous_system (NO_PREPEND REPLACE_AS?)?
+  LOCAL_AS asn = autonomous_system (NO_PREPEND REPLACE_AS?)? NEWLINE
+;
+
+sbnp_password
+:
+  PASSWORD REMARK_TEXT NEWLINE
+;
+
+sbnp_peer_group
+:
+  PEER_GROUP name = word NEWLINE
+;
+
+sbnp_remote_as
+:
+  REMOTE_AS (autonomous_system | EXTERNAL | INTERNAL) NEWLINE
 ;
 
 sbnp_timers
 :
-  TIMERS CONNECT uint32
+  TIMERS CONNECT uint32 NEWLINE
+;
+
+sbnp_update_source
+:
+  UPDATE_SOURCE (ip = IP_ADDRESS | name = word) NEWLINE
 ;
 
 sb_network
@@ -394,7 +405,6 @@ sbafi_neighbor
   | sbafin_soft_reconfiguration
   | sbafin_route_map
   )
-  NEWLINE
 ;
 
 sbafi_no
@@ -417,57 +427,47 @@ sbafinon_activate
 
 sbafin_activate
 :
-  ACTIVATE
+  ACTIVATE NEWLINE
 ;
 
 sbafin_allowas_in
 :
-  ALLOWAS_IN count = UINT8
+  ALLOWAS_IN count = UINT8 NEWLINE
 ;
 
 sbafin_default_originate
 :
-  DEFAULT_ORIGINATE
+  DEFAULT_ORIGINATE NEWLINE
 ;
 
 sbafin_next_hop_self
 :
-  NEXT_HOP_SELF (FORCE | ALL)?
+  NEXT_HOP_SELF (FORCE | ALL)? NEWLINE
 ;
 
 sbafin_route_reflector_client
 :
-  ROUTE_REFLECTOR_CLIENT
+  ROUTE_REFLECTOR_CLIENT NEWLINE
 ;
 
 sbafin_send_community
 :
-  SEND_COMMUNITY EXTENDED?
+  SEND_COMMUNITY EXTENDED? NEWLINE
 ;
 
 sbafin_soft_reconfiguration
 :
-  SOFT_RECONFIGURATION INBOUND
+  SOFT_RECONFIGURATION INBOUND NEWLINE
 ;
 
 sbafin_route_map
 :
-  ROUTE_MAP name=word (IN | OUT)
-;
-
-sbn_bfd
-:
-  BFD word*
-;
-
-sbn_password
-:
-  PASSWORD REMARK_TEXT
+  ROUTE_MAP name=word (IN | OUT) NEWLINE
 ;
 
 sbnobd_ipv4_unicast
 :
-    IPV4_UNICAST
+    IPV4_UNICAST NEWLINE
 ;
 
 sb_timers

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -545,7 +545,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     if (oldRedistributionPolicy != null) {
       _w.addWarning(
           ctx,
-          ctx.getStart().getText(),
+          getFullText(ctx),
           _parser,
           String.format(
               "overwriting BgpRedistributionPolicy for vrf %s, protocol %s",
@@ -781,16 +781,13 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     } else if (ctx.name != null) {
       name = ctx.name.getText();
     } else {
-      throw new BatfishException("neightbor name or address");
+      throw new BatfishException("neighbor name or address");
     }
 
     BgpNeighbor bgpNeighbor = _currentBgpVrf.getNeighbors().get(name);
     if (bgpNeighbor == null) {
       _w.addWarning(
-          ctx,
-          ctx.getStart().getText(),
-          _parser,
-          String.format("neighbor %s does not exist", name));
+          ctx, getFullText(ctx), _parser, String.format("neighbor %s does not exist", name));
     } else {
       _currentBgpNeighborIpv4UnicastAddressFamily = bgpNeighbor.getIpv4UnicastAddressFamily();
       if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
@@ -821,10 +818,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     BgpNeighbor bgpNeighbor = _currentBgpVrf.getNeighbors().get(name);
     if (bgpNeighbor == null) {
       _w.addWarning(
-          ctx,
-          ctx.getStart().getText(),
-          _parser,
-          String.format("neighbor %s does not exist", name));
+          ctx, getFullText(ctx), _parser, String.format("neighbor %s does not exist", name));
     } else {
       _currentBgpNeighborIpv4UnicastAddressFamily = bgpNeighbor.getIpv4UnicastAddressFamily();
       if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
@@ -1037,7 +1031,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     if (oldRedistributionPolicy != null) {
       _w.addWarning(
           ctx,
-          ctx.getStart().getText(),
+          getFullText(ctx),
           _parser,
           String.format(
               "overwriting BgpRedistributionPolicy for vrf %s, protocol %s",
@@ -1326,6 +1320,9 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
 
   @Override
   public void exitSbafin_route_map(Sbafin_route_mapContext ctx) {
+    if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
+      return;
+    }
     String name = ctx.name.getText();
     CumulusStructureUsage usage;
     if (ctx.IN() != null) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -2,6 +2,7 @@ package org.batfish.grammar.cumulus_frr;
 
 import static org.batfish.common.matchers.ParseWarningMatchers.hasComment;
 import static org.batfish.common.matchers.ParseWarningMatchers.hasText;
+import static org.batfish.common.matchers.WarningsMatchers.hasParseWarning;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
@@ -465,21 +466,21 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnAdvertiseAllVni() {
+  public void testBgpAddressFamilyL2vpnEvpnAdvertiseAllVni() {
     parseLines(
         "router bgp 1", "address-family l2vpn evpn", "advertise-all-vni", "exit-address-family");
     assertTrue(_frr.getBgpProcess().getDefaultVrf().getL2VpnEvpn().getAdvertiseAllVni());
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnAdvertiseDefaultGw() {
+  public void testBgpAddressFamilyL2vpnEvpnAdvertiseDefaultGw() {
     parseLines(
         "router bgp 1", "address-family l2vpn evpn", "advertise-default-gw", "exit-address-family");
     assertTrue(_frr.getBgpProcess().getDefaultVrf().getL2VpnEvpn().getAdvertiseDefaultGw());
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnAdvertiseIpv4Unicast() {
+  public void testBgpAddressFamilyL2vpnEvpnAdvertiseIpv4Unicast() {
     parseLines(
         "router bgp 1",
         "address-family l2vpn evpn",
@@ -489,7 +490,7 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnAdvertiseIpv4UnicastRouteMap() {
+  public void testBgpAddressFamilyL2vpnEvpnAdvertiseIpv4UnicastRouteMap() {
     parseLines(
         "router bgp 1",
         "address-family l2vpn evpn",
@@ -507,7 +508,7 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnAdvertiseIpv6Unicast() {
+  public void testBgpAddressFamilyL2vpnEvpnAdvertiseIpv6Unicast() {
     parseLines(
         "router bgp 1",
         "address-family l2vpn evpn",
@@ -524,7 +525,7 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnNeighborActivate() {
+  public void testBgpAddressFamilyL2vpnEvpnNeighborActivate() {
     parseLines(
         "router bgp 1",
         "neighbor n interface description a",
@@ -539,7 +540,7 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnNeighborRouteMap() {
+  public void testBgpAddressFamilyL2vpnEvpnNeighborRouteMap() {
     parseLines(
         "router bgp 1",
         " neighbor n interface description a",
@@ -565,7 +566,7 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnNeighborRouteReflectorClient() {
+  public void testBgpAddressFamilyL2vpnEvpnNeighborRouteReflectorClient() {
     parseLines(
         "router bgp 1",
         "neighbor n interface description a",
@@ -577,7 +578,7 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
-  public void testBgpAdressFamilyL2vpnEvpnMultipleDefinitions() {
+  public void testBgpAddressFamilyL2vpnEvpnMultipleDefinitions() {
     parseLines(
         "router bgp 1",
         " neighbor n interface description a",
@@ -1727,6 +1728,20 @@ public class CumulusFrrGrammarTest {
     assertThat(
         _config.getBgpProcess().getDefaultVrf().getNetworks(),
         equalTo(ImmutableMap.of(network, new BgpNetwork(network, "FOO"))));
+  }
+
+  /** FRR does not crash if undeclared peer-group has a route-map configured. */
+  @Test
+  public void testIp4vUnicastRoutemap_error() {
+    parseLines(
+        "router bgp 10000",
+        "address-family ipv4 unicast",
+        "neighbor N route-map R in",
+        "exit-address-family");
+    assertThat(
+        _warnings,
+        hasParseWarning(
+            allOf(hasComment("neighbor N does not exist"), hasText("neighbor N route-map R in"))));
   }
 
   @Test


### PR DESCRIPTION
1. sbafi_route_map was missing a null check
2. The BGP grammar was not written well to work with recovery,
   so an unrecognized line early in router bgp might take out all the
   rest of the lines. This exposed (1) and triggered a crash for an
   unrelated line.
3. Improve error messages.
4. Reorder rules alphabetically when safe.