### PR TITLE
ARP replies include all vrf-owned IPs under proxy-arp

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -381,10 +381,10 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
    * <br>
    * 1) PERMIT IPs belonging to the interface.<br>
    * 2) PERMIT any statically configured arp IPs.<br>
-   * 3) (Proxy-ARP) DENY any IP for which there is a longest-prefix match entry in the FIB that goes
+   * 3) (Proxy-ARP) PERMIT any other owned IPs of the VRF of the interface.<br>
+   * 4) (Proxy-ARP) DENY any IP for which there is a longest-prefix match entry in the FIB that goes
    * through the interface.<br>
-   * 4) (Proxy-ARP) PERMIT any other IP routable via the VRF of the interface.<br>
-   * 5) (Proxy-ARP) PERMIT any other owned IPs of the VRF of the interface.
+   * 5) (Proxy-ARP) PERMIT any other IP routable via the VRF of the interface.
    */
   @VisibleForTesting
   static @Nonnull Map<String, Map<String, IpSpace>> computeArpReplies(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -538,16 +538,16 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
     interfaceArpReplies.thenPermitting(iface.getAdditionalArpIps());
 
     if (iface.getProxyArp()) {
+      /* Accept all vrf-owned IPs */
+      // TODO: There may be room for optimization, since this generally overlaps with both IPs owned
+      //       by this interface as well as IPs routable for this VRF.
+      interfaceArpReplies.thenPermitting(vrfOwnedIps);
+
       /* Reject IPs routed through this interface */
       interfaceArpReplies.thenRejecting(ipsRoutedThroughInterface);
 
       /* Accept all other routable IPs */
       interfaceArpReplies.thenPermitting(routableIpsForThisVrf);
-
-      /* Accept all vrf-owned IPs */
-      // TODO: There may be room for optimization, since this generally overlaps with both IPs owned
-      //       by this interface as well as IPs routable for this VRF.
-      interfaceArpReplies.thenPermitting(vrfOwnedIps);
     }
 
     return interfaceArpReplies.build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -475,7 +475,7 @@ public class ForwardingAnalysisImplTest {
     Interface iNoAddresses = _ib.build();
     ConcreteInterfaceAddress address =
         ConcreteInterfaceAddress.create(P1.getFirstHostIp(), P1.getPrefixLength());
-    // address not read, just set for clariy
+    // address not read, just set for clarity
     Interface iAddress = _ib.setAddress(address).build();
     Map<String, Interface> activeInterfaces =
         ImmutableMap.of(iNoAddresses.getName(), iNoAddresses, iAddress.getName(), iAddress);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -200,7 +200,7 @@ public class ForwardingAnalysisImplTest {
             .setAddress(ConcreteInterfaceAddress.create(P1.getFirstHostIp(), P1.getPrefixLength()))
             .setProxyArp(true)
             .build();
-    Ip nonRoutedOwnedIp = Ip.parse("5.5.5.5");
+    Ip nonRoutedOwnedIp = Ip.parse("1.0.0.2"); // In P1, neither first nor last host IP.
     ConcreteInterfaceAddress nonRoutedOwnedAddress =
         ConcreteInterfaceAddress.create(nonRoutedOwnedIp, Prefix.MAX_PREFIX_LENGTH);
     Interface i1B =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -479,7 +479,7 @@ public class ForwardingAnalysisImplTest {
     Interface iAddress = _ib.setAddress(address).build();
     Map<String, Interface> activeInterfaces =
         ImmutableMap.of(iNoAddresses.getName(), iNoAddresses, iAddress.getName(), iAddress);
-    // Note there is no key for iNoAddress
+    // Note there is no key for iNoAddresses
     Map<String, Set<Ip>> interfaceOwnedIps =
         ImmutableMap.of(iAddress.getName(), ImmutableSet.of(P1.getFirstHostIp()));
     Map<String, IpSpace> ownedIpsByVrf = computeOwnedIpsByVrf(activeInterfaces, interfaceOwnedIps);


### PR DESCRIPTION
- needed to remove kernel route hack for A10 nat pool addresses