### PR TITLE
Palo Alto: filter NAT rules on HA devices

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -283,6 +283,8 @@ GROUP19: 'group19';
 
 GROUP20: 'group20';
 
+GROUP_ID: 'group-id';
+
 HALF: 'half';
 
 HA: 'ha';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -21,6 +21,8 @@ ACCEPT_SUMMARY: 'accept-summary';
 
 ACTION: 'action';
 
+ACTIVE_ACTIVE: 'active-active';
+
 ACTIVE_ACTIVE_DEVICE_BINDING: 'active-active-device-binding';
 
 ADDRESS: 'address';
@@ -177,6 +179,8 @@ DEVICES: 'devices';
 
 DEVICE_GROUP: 'device-group';
 
+DEVICE_ID: 'device-id';
+
 DEVICECONFIG: 'deviceconfig';
 
 DH_GROUP: 'dh-group';
@@ -265,6 +269,8 @@ GR_DELAY: 'gr-delay';
 
 GRACEFUL_RESTART: 'graceful-restart';
 
+GROUP: 'group';
+
 GROUP1: 'group1';
 
 GROUP2: 'group2';
@@ -288,6 +294,8 @@ HASH: 'hash';
 HELLO_INTERVAL: 'hello-interval';
 
 HELPER_ENABLE: 'helper-enable';
+
+HIGH_AVAILABILITY: 'high-availability';
 
 HIP_PROFILES: 'hip-profiles';
 
@@ -412,6 +420,8 @@ MEMBERS: 'members';
 METRIC: 'metric';
 
 MGT_CONFIG: 'mgt-config';
+
+MODE: 'mode';
 
 MOVE: 'move';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -21,6 +21,8 @@ ACCEPT_SUMMARY: 'accept-summary';
 
 ACTION: 'action';
 
+ACTIVE_ACTIVE_DEVICE_BINDING: 'active-active-device-binding';
+
 ADDRESS: 'address';
 
 ADDRESS_GROUP: 'address-group';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_deviceconfig.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_deviceconfig.g4
@@ -6,14 +6,61 @@ options {
     tokenVocab = PaloAltoLexer;
 }
 
+active_active_device_id
+:
+  // 0 or 1
+  uint8
+;
+
+ha_group_id
+:
+  // 1-63
+  uint8
+;
+
 s_deviceconfig
 :
     DEVICECONFIG
     (
-        sd_null
+        sd_high_availability
+        | sd_null
         | sd_system
     )
 ;
+
+sd_high_availability
+:
+    HIGH_AVAILABILITY
+    (
+      sdha_group
+    )
+;
+
+sdha_group
+:
+    GROUP id = ha_group_id
+    (
+      sdhag_mode
+    )
+;
+
+sdhag_mode
+:
+    MODE
+    (
+      sdhagm_active_active
+    )
+;
+
+sdhagm_active_active
+:
+    ACTIVE_ACTIVE
+    (
+      sdhagmaa_device_id
+    )
+;
+
+sdhagmaa_device_id: DEVICE_ID id = active_active_device_id;
 
 sd_null
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_deviceconfig.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_deviceconfig.g4
@@ -38,11 +38,14 @@ sd_high_availability
 
 sdha_group
 :
-    GROUP id = ha_group_id
+    GROUP
     (
-      sdhag_mode
+      sdhag_group_id
+      | sdhag_mode
     )
 ;
+
+sdhag_group_id: GROUP_ID id = ha_group_id;
 
 sdhag_mode
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_nat.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_nat.g4
@@ -20,7 +20,8 @@ srn_definition
 :
     name = variable
     (
-        srn_destination_translation
+        srn_active_active_device_binding
+        | srn_destination_translation
         | srn_source_translation
         | srn_to
         | srn_from
@@ -29,6 +30,18 @@ srn_definition
         | srn_service
         | srn_disabled
     )?
+;
+
+active_active_device_binding_val
+:
+    uint8 // 0 or 1
+    | BOTH
+    | PRIMARY
+;
+
+srn_active_active_device_binding
+:
+    ACTIVE_ACTIVE_DEVICE_BINDING bind = active_active_device_binding_val
 ;
 
 srn_destination_translation

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -297,6 +297,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Srao_toContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Src_or_dst_list_itemContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srespr_devicesContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sresprd_hostnameContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Srn_active_active_device_bindingContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srn_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srn_destinationContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srn_destination_translationContext;
@@ -2544,6 +2545,13 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
         String uniqueName = computeObjectName(_currentVsys, zoneName);
         referenceStructure(ZONE, uniqueName, APPLICATION_OVERRIDE_RULE_TO_ZONE, getLine(var.start));
       }
+    }
+  }
+
+  @Override
+  public void exitSrn_active_active_device_binding(Srn_active_active_device_bindingContext ctx) {
+    if (ctx.bind.BOTH() == null) {
+      warn(ctx, "Batfish currently models this as active-active-device-binding both");
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/HighAvailability.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/HighAvailability.java
@@ -1,0 +1,21 @@
+package org.batfish.representation.palo_alto;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/** Datamodel class representing high-availability configuration for a PaloAlto device. */
+public final class HighAvailability implements Serializable {
+  /** The high-availability device id (number) assigned to this device. */
+  @Nullable
+  public Integer getDeviceId() {
+    return _deviceId;
+  }
+
+  public void setDeviceId(@Nullable Integer deviceId) {
+    _deviceId = deviceId;
+  }
+
+  // TODO: relocate this once we flesh out datamodel to better represent
+  // active-active/active-passive hierarchy
+  @Nullable private Integer _deviceId;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/NatRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/NatRule.java
@@ -11,6 +11,16 @@ import javax.annotation.Nullable;
 /** PAN NAT rule configuration */
 public final class NatRule implements Serializable {
 
+  public enum ActiveActiveDeviceBinding {
+    BOTH,
+    PRIMARY,
+    ONE,
+    ZERO
+  }
+
+  // For HA systems, determines which system the rule is installed on
+  @Nullable private ActiveActiveDeviceBinding _activeActiveDeviceBinding;
+
   // Name of the rule
   @Nonnull private final String _name;
 
@@ -37,6 +47,16 @@ public final class NatRule implements Serializable {
     _source = new LinkedList<>();
     _destination = new LinkedList<>();
     _disabled = false;
+  }
+
+  @Nullable
+  public ActiveActiveDeviceBinding getActiveActiveDeviceBinding() {
+    return _activeActiveDeviceBinding;
+  }
+
+  public void setActiveActiveDeviceBinding(
+      @Nullable ActiveActiveDeviceBinding activeActiveDeviceBinding) {
+    _activeActiveDeviceBinding = activeActiveDeviceBinding;
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -458,12 +458,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
   /** Generate PacketPolicy name using the given zone's name and vsys name */
   public static String computePacketPolicyName(Zone zone) {
-    return computePacketPolicyName(zone.getVsys().getName(), zone.getName());
-  }
-
-  /** Generate PacketPolicy name using the given zone's name and vsys name */
-  public static String computePacketPolicyName(String vsys, String zone) {
-    return String.format("~%s~%s~PACKET_POLICY~", vsys, zone);
+    return String.format("~%s~%s~PACKET_POLICY~", zone.getVsys().getName(), zone.getName());
   }
 
   /**
@@ -500,7 +495,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
    * should not necessarily be converted to VI -- there may be other reasons not to convert.
    */
   private boolean checkNatRuleValid(NatRule rule, boolean fileWarnings) {
-    // Check if rule is applicable for this device id (for high-availability devices)
+    // Check if rule is applicable for this device (for high-availability devices)
     NatRule.ActiveActiveDeviceBinding binding = rule.getActiveActiveDeviceBinding();
     Integer id = getOrCreateHighAvailability().getDeviceId();
     if (id != null && (binding == null || !deviceBindingAndIdCompatible(binding, id))) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3857,7 +3857,6 @@ public final class PaloAltoGrammarTest {
   public void testHighAvailability() {
     String hostname = "high-availability";
     PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
-    Vsys vsys = c.getVirtualSystems().get(DEFAULT_VSYS_NAME);
     assertNotNull(c.getHighAvailability());
     assertThat(c.getHighAvailability().getDeviceId(), equalTo(1));
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2395,7 +2395,7 @@ public final class PaloAltoGrammarTest {
                 hasComment("Batfish currently models this as active-active-device-binding both")),
             hasComment("Expected active-active-device-binding in range 0-1, but got '2'")));
 
-    // Make sure the active-active-device-binding isn't overwritten by an invalid number
+    // Make sure the active-active-device-binding isn't set to an invalid number
     Map<String, NatRule> natRules =
         c.getVirtualSystems().get(DEFAULT_VSYS_NAME).getRulebase().getNatRules();
     assertThat(natRules, hasKey("NATRULE2"));

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2392,7 +2392,14 @@ public final class PaloAltoGrammarTest {
         containsInAnyOrder(
             allOf(
                 ParseWarningMatchers.hasText("active-active-device-binding primary"),
-                hasComment("Batfish currently models this as active-active-device-binding both"))));
+                hasComment("Batfish currently models this as active-active-device-binding both")),
+            hasComment("Expected active-active-device-binding in range 0-1, but got '2'")));
+
+    // Make sure the active-active-device-binding isn't overwritten by an invalid number
+    Map<String, NatRule> natRules =
+        c.getVirtualSystems().get(DEFAULT_VSYS_NAME).getRulebase().getNatRules();
+    assertThat(natRules, hasKey("NATRULE2"));
+    assertNull(natRules.get("NATRULE2").getActiveActiveDeviceBinding());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -130,6 +130,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -3836,6 +3838,41 @@ public final class PaloAltoGrammarTest {
             .get("RULE1")
             .getTags(),
         contains("TAG"));
+  }
+
+  @Test
+  public void testHighAvailability() {
+    String hostname = "high-availability";
+    PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
+    Vsys vsys = c.getVirtualSystems().get(DEFAULT_VSYS_NAME);
+    assertNotNull(c.getHighAvailability());
+    assertThat(c.getHighAvailability().getDeviceId(), equalTo(1));
+  }
+
+  @Test
+  public void testNatHighAvailability() {
+    String hostname = "nat-high-availability";
+    PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
+    assertNotNull(c.getHighAvailability());
+    assertThat(c.getHighAvailability().getDeviceId(), equalTo(1));
+
+    Vsys vsys = c.getVirtualSystems().get(DEFAULT_VSYS_NAME);
+    Map<String, NatRule> rules = vsys.getRulebase().getNatRules();
+    assertThat(
+        rules.keySet(), contains("RULE_0", "RULE_1", "RULE_BOTH", "RULE_PRIMARY", "RULE_NONE"));
+    assertThat(
+        rules.get("RULE_0").getActiveActiveDeviceBinding(),
+        equalTo(NatRule.ActiveActiveDeviceBinding.ZERO));
+    assertThat(
+        rules.get("RULE_1").getActiveActiveDeviceBinding(),
+        equalTo(NatRule.ActiveActiveDeviceBinding.ONE));
+    assertThat(
+        rules.get("RULE_BOTH").getActiveActiveDeviceBinding(),
+        equalTo(NatRule.ActiveActiveDeviceBinding.BOTH));
+    assertThat(
+        rules.get("RULE_PRIMARY").getActiveActiveDeviceBinding(),
+        equalTo(NatRule.ActiveActiveDeviceBinding.PRIMARY));
+    assertNull(rules.get("RULE_NONE").getActiveActiveDeviceBinding());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -157,6 +157,7 @@ import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.common.matchers.ParseWarningMatchers;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.runtime.SnapshotRuntimeData;
 import org.batfish.config.Settings;
@@ -2380,6 +2381,18 @@ public final class PaloAltoGrammarTest {
             String.format(
                 "Could not convert RuleEndpoint range to IpSpace: %s",
                 new RuleEndpoint(IP_RANGE, "11.11.11.13-11.11.11.12"))));
+  }
+
+  @Test
+  public void testRulebaseParseWarning() {
+    PaloAltoConfiguration c = parsePaloAltoConfig("rulebase-warning");
+    List<ParseWarning> parseWarnings = c.getWarnings().getParseWarnings();
+    assertThat(
+        parseWarnings,
+        containsInAnyOrder(
+            allOf(
+                ParseWarningMatchers.hasText("active-active-device-binding primary"),
+                hasComment("Batfish currently models this as active-active-device-binding both"))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
@@ -12,6 +12,7 @@ import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejectsByDefault;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.checkIntrazoneValidityAndWarn;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.deviceBindingAndIdCompatible;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.generateCrossZoneCalls;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.generateCrossZoneCallsFromExternal;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.generateCrossZoneCallsFromLayer3;
@@ -703,5 +704,22 @@ public final class PaloAltoConfigurationTest {
     rule.getTo().add("C");
     assertFalse(checkIntrazoneValidityAndWarn(rule, w));
     assertThat(w, hasRedFlag(hasText(containsString("Skipping invalid intrazone security rule"))));
+  }
+
+  @Test
+  public void testDeviceBindingAndIdCompatible() {
+    // Both applies to any device id
+    assertTrue(deviceBindingAndIdCompatible(NatRule.ActiveActiveDeviceBinding.BOTH, 0));
+    assertTrue(deviceBindingAndIdCompatible(NatRule.ActiveActiveDeviceBinding.BOTH, 1));
+
+    // Zero only applies to 0
+    assertTrue(deviceBindingAndIdCompatible(NatRule.ActiveActiveDeviceBinding.ZERO, 0));
+    assertFalse(deviceBindingAndIdCompatible(NatRule.ActiveActiveDeviceBinding.ZERO, 1));
+
+    // One only applies to 1
+    assertFalse(deviceBindingAndIdCompatible(NatRule.ActiveActiveDeviceBinding.ONE, 0));
+    assertTrue(deviceBindingAndIdCompatible(NatRule.ActiveActiveDeviceBinding.ONE, 1));
+
+    // TODO test PRIMARY once that is better supported
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/high-availability
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/high-availability
@@ -1,0 +1,32 @@
+set deviceconfig system hostname high-availability
+#
+set deviceconfig high-availability group group-id 1
+set deviceconfig high-availability group mode active-active device-id 1
+# set deviceconfig high-availability group mode active-active session-owner-selection first-packet session-setup first-packet
+# set deviceconfig high-availability group mode active-active tentative-hold-time 10
+# set deviceconfig high-availability group description "My Group Description"
+# set deviceconfig high-availability group peer-ip 192.168.0.1
+# set deviceconfig high-availability group state-synchronization ha2-keep-alive enabled yes
+# set deviceconfig high-availability group election-option heartbeat-backup no
+# set deviceconfig high-availability group election-option preemptive no
+# set deviceconfig high-availability group election-option timers aggressive
+# set deviceconfig high-availability group election-option device-priority 200
+# set deviceconfig high-availability group peer-ip-backup 192.168.10.1
+# set deviceconfig high-availability group monitoring link-monitoring link-group GROUP1 interface [ ethernet1/23 ethernet1/24 ]
+# set deviceconfig high-availability group monitoring link-monitoring link-group GROUP1 failure-condition all
+# set deviceconfig high-availability group monitoring link-monitoring link-group GROUP2 interface [ ethernet1/21 ethernet1/22 ]
+# set deviceconfig high-availability group monitoring link-monitoring link-group GROUP2 failure-condition all
+# set deviceconfig high-availability group monitoring link-monitoring enabled no
+# set deviceconfig high-availability group monitoring path-monitoring enabled no
+# set deviceconfig high-availability group configuration-synchronization enabled yes
+# set deviceconfig high-availability interface ha1 ip-address 192.168.0.2
+# set deviceconfig high-availability interface ha1 netmask 255.255.255.0
+# set deviceconfig high-availability interface ha1-backup port ha1-b
+# set deviceconfig high-availability interface ha1-backup ip-address 192.168.10.2
+# set deviceconfig high-availability interface ha1-backup netmask 255.255.255.0
+# set deviceconfig high-availability interface ha2 ip-address 192.168.20.2
+# set deviceconfig high-availability interface ha2 netmask 255.255.255.0
+# set deviceconfig high-availability interface ha2-backup
+# set deviceconfig high-availability interface ha3
+# set deviceconfig high-availability enabled yes
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nat-high-availability
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nat-high-availability
@@ -1,0 +1,58 @@
+set deviceconfig system hostname nat-high-availability
+!
+set deviceconfig high-availability group group-id 1
+set deviceconfig high-availability group mode active-active device-id 1
+!
+
+! TODO matching and not-matching device-ids
+
+set network interface ethernet ethernet1/1 layer3 ip 192.168.1.1/24
+set network interface ethernet ethernet1/2 layer3 ip 10.0.2.1/24
+set zone INSIDE network layer3 ethernet1/1
+set zone OUTSIDE network layer3 ethernet1/2
+set network virtual-router default interface [ ethernet1/1 ethernet1/2 ]
+
+set service SERVICE_0 protocol tcp port 1234
+set service SERVICE_1 protocol tcp port 2345
+set service SERVICE_BOTH protocol tcp port 3456
+set service SERVICE_PRIMARY protocol tcp port 4567
+set service SERVICE_NONE protocol tcp port 5678
+
+# Device-binding 0 - not applicable
+set rulebase nat rules RULE_0 to OUTSIDE
+set rulebase nat rules RULE_0 from INSIDE
+set rulebase nat rules RULE_0 source any
+set rulebase nat rules RULE_0 destination any
+set rulebase nat rules RULE_0 service SERVICE_0
+set rulebase nat rules RULE_0 active-active-device-binding 0
+
+# Device-binding 1 - applicable
+set rulebase nat rules RULE_1 to OUTSIDE
+set rulebase nat rules RULE_1 from INSIDE
+set rulebase nat rules RULE_1 source any
+set rulebase nat rules RULE_1 destination any
+set rulebase nat rules RULE_1 service SERVICE_1
+set rulebase nat rules RULE_1 active-active-device-binding 1
+
+# Device-binding BOTH - applicable
+set rulebase nat rules RULE_BOTH to OUTSIDE
+set rulebase nat rules RULE_BOTH from INSIDE
+set rulebase nat rules RULE_BOTH source any
+set rulebase nat rules RULE_BOTH destination any
+set rulebase nat rules RULE_BOTH service SERVICE_BOTH
+set rulebase nat rules RULE_BOTH active-active-device-binding both
+
+# Device-binding PRIMARY - not handled
+set rulebase nat rules RULE_PRIMARY to OUTSIDE
+set rulebase nat rules RULE_PRIMARY from INSIDE
+set rulebase nat rules RULE_PRIMARY source any
+set rulebase nat rules RULE_PRIMARY destination any
+set rulebase nat rules RULE_PRIMARY service SERVICE_PRIMARY
+set rulebase nat rules RULE_PRIMARY active-active-device-binding primary
+
+# Device-binding missing, TODO warn?
+set rulebase nat rules RULE_NONE to OUTSIDE
+set rulebase nat rules RULE_NONE from INSIDE
+set rulebase nat rules RULE_NONE source any
+set rulebase nat rules RULE_NONE destination any
+set rulebase nat rules RULE_NONE service SERVICE_NONE

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-warning
@@ -26,4 +26,4 @@ set rulebase nat rules NATRULE1 destination [ 10.0.1.1 10.0.2.11-10.0.2.1 ]
 set rulebase nat rules NATRULE1 source-translation dynamic-ip-and-port translated-address 192.168.1.101-192.168.1.1
 set rulebase nat rules NATRULE1 service service-http
 # Unsupported active-active-device-binding mode
-set rulebase nat rules NATRULE1 active-active-device-binding 1
+set rulebase nat rules NATRULE1 active-active-device-binding primary

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-warning
@@ -27,3 +27,10 @@ set rulebase nat rules NATRULE1 source-translation dynamic-ip-and-port translate
 set rulebase nat rules NATRULE1 service service-http
 # Unsupported active-active-device-binding mode
 set rulebase nat rules NATRULE1 active-active-device-binding primary
+
+set rulebase nat rules NATRULE2 to z1
+set rulebase nat rules NATRULE2 from any
+set rulebase nat rules NATRULE2 source any
+set rulebase nat rules NATRULE2 destination 10.0.1.1
+# Device id outside of allowed range [0,1]
+set rulebase nat rules NATRULE2 active-active-device-binding 2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-warning
@@ -25,3 +25,5 @@ set rulebase nat rules NATRULE1 destination [ 10.0.1.1 10.0.2.11-10.0.2.1 ]
 # Invalid range
 set rulebase nat rules NATRULE1 source-translation dynamic-ip-and-port translated-address 192.168.1.101-192.168.1.1
 set rulebase nat rules NATRULE1 service service-http
+# Unsupported active-active-device-binding mode
+set rulebase nat rules NATRULE1 active-active-device-binding 1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/source-nat-high-availability
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/source-nat-high-availability
@@ -1,0 +1,161 @@
+policy {
+  panorama {
+  }
+}
+config {
+  devices {
+    localhost.localdomain {
+      network {
+        interface {
+          ethernet {
+            ethernet1/1 {
+              layer3 {
+                units {
+                  ethernet1/1.1 {
+                    ip {
+                      10.1.0.3/16;
+                    }
+                  }
+                }
+              }
+            }
+            ethernet1/2 {
+              layer3 {
+                units {
+                  ethernet1/2.1 {
+                    ip {
+                      10.2.1.3/24;
+                    }
+                  }
+                  ethernet1/2.2 {
+                    ip {
+                      10.2.0.3/16;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        virtual-router {
+          vr1 {
+            interface [ ethernet1/1.1 ethernet1/2.1 ethernet1/2.2];
+          }
+        }
+      }
+      deviceconfig {
+        system {
+          hostname source-nat-high-availability;
+        }
+        high-availability {
+          group {
+            mode {
+              active-active {
+                device-id 1;
+              }
+             }
+          }
+        }
+      }
+      vsys {
+        vsys1 {
+          address {
+            SOURCE_ADDR_0 {
+              ip-netmask 10.1.0.1/32;
+            }
+            SOURCE_ADDR_1 {
+              ip-netmask 10.1.1.1/32;
+            }
+            SOURCE_ADDR_BOTH {
+              ip-netmask 10.1.2.1/32;
+            }
+            SOURCE_ADDR_NONE {
+              ip-netmask 10.1.3.1/32;
+            }
+            SERVER_NEW_ADDR {
+              ip-netmask 10.2.99.1/32;
+            }
+          }
+          rulebase {
+            nat {
+              rules {
+                SOURCE_NAT_0 {
+                  active-active-device-binding 0;
+                  source-translation {
+                    dynamic-ip-and-port {
+                      translated-address SERVER_NEW_ADDR;
+                    }
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR_0;
+                  destination any;
+                }
+                SOURCE_NAT_1 {
+                  active-active-device-binding 1;
+                  source-translation {
+                    dynamic-ip-and-port {
+                      translated-address SERVER_NEW_ADDR;
+                    }
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR_1;
+                  destination any;
+                }
+                SOURCE_NAT_BOTH {
+                  active-active-device-binding both;
+                  source-translation {
+                    dynamic-ip-and-port {
+                      translated-address SERVER_NEW_ADDR;
+                    }
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR_BOTH;
+                  destination any;
+                }
+                SOURCE_NAT_NONE {
+                  source-translation {
+                    dynamic-ip-and-port {
+                      translated-address SERVER_NEW_ADDR;
+                    }
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR_NONE;
+                  destination any;
+                }
+              }
+            }
+            security {
+              rules {
+                PERMIT_ALL {
+                  to any;
+                  from any;
+                  source any;
+                  destination any;
+                  application any;
+                  service any;
+                  action allow;
+                }
+              }
+            }
+          }
+          zone {
+            INSIDE {
+              network {
+                layer3 [ ethernet1/1.1];
+              }
+            }
+            OUTSIDE {
+              network {
+                layer3 [ ethernet1/2.1 ethernet1/2.2];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/parsing-tests/networks/unit-tests/configs/palo_alto/nat
+++ b/tests/parsing-tests/networks/unit-tests/configs/palo_alto/nat
@@ -16,7 +16,7 @@ policy {
       nat {
         rules {
           RULE_1 {
-            active-active-device-binding 0;
+            active-active-device-binding primary;
             destination-translation {
               translated-address 1.1.1.0/24;
             }

--- a/tests/parsing-tests/networks/unit-tests/configs/palo_alto/nat
+++ b/tests/parsing-tests/networks/unit-tests/configs/palo_alto/nat
@@ -16,6 +16,7 @@ policy {
       nat {
         rules {
           RULE_1 {
+            active-active-device-binding 0;
             destination-translation {
               translated-address 1.1.1.0/24;
             }

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -4085,7 +4085,7 @@
         "Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            45
+            46
           ]
         }
       },
@@ -4097,7 +4097,7 @@
         "Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            45
+            46
           ]
         }
       },
@@ -4109,9 +4109,9 @@
         "Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            34,
-            55,
-            59
+            35,
+            56,
+            60
           ]
         }
       },
@@ -4123,12 +4123,12 @@
         "Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            27,
-            33,
-            39,
-            51,
-            54,
-            58
+            28,
+            34,
+            40,
+            52,
+            55,
+            59
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -3371,10 +3371,10 @@
         "Source_Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            57,
             58,
             59,
-            60
+            60,
+            61
           ]
         }
       },
@@ -3384,8 +3384,8 @@
         "Source_Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            50,
-            51
+            51,
+            52
           ]
         }
       },
@@ -3395,9 +3395,9 @@
         "Source_Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            53,
             54,
-            55
+            55,
+            56
           ]
         }
       },
@@ -3407,7 +3407,7 @@
         "Source_Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            49
+            50
           ]
         }
       },
@@ -3420,13 +3420,14 @@
             18,
             19,
             20,
-            22,
+            21,
             23,
             24,
-            27,
+            25,
             28,
             29,
-            30
+            30,
+            31
           ]
         }
       },
@@ -3436,11 +3437,11 @@
         "Source_Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            32,
             33,
             34,
             35,
-            36
+            36,
+            37
           ]
         }
       },
@@ -3450,14 +3451,14 @@
         "Source_Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            38,
             39,
             40,
             41,
             42,
-            45,
+            43,
             46,
-            47
+            47,
+            48
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1312,7 +1312,7 @@
       {
         "Filename" : "configs/palo_alto/nat",
         "Line" : 19,
-        "Text" : "active-active-device-binding 0",
+        "Text" : "active-active-device-binding primary",
         "Parser_Context" : "[srn_active_active_device_binding srn_definition sr_nat_rules sr_nat rulebase_inner s_post_rulebase ss_common s_policy_panorama s_policy set_line_tail set_line palo_alto_configuration]",
         "Comment" : "Batfish currently models this as active-active-device-binding both"
       },

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1310,6 +1310,13 @@
         "Comment" : "This feature is not currently supported"
       },
       {
+        "Filename" : "configs/palo_alto/nat",
+        "Line" : 19,
+        "Text" : "active-active-device-binding 0",
+        "Parser_Context" : "[srn_active_active_device_binding srn_definition sr_nat_rules sr_nat rulebase_inner s_post_rulebase ss_common s_policy_panorama s_policy set_line_tail set_line palo_alto_configuration]",
+        "Comment" : "Batfish currently models this as active-active-device-binding both"
+      },
+      {
         "Filename" : "configs/route_policy_param",
         "Line" : 6,
         "Text" : "in $cust_v4_as_path",
@@ -1332,10 +1339,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 184 results",
+      "notes" : "Found 185 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 184
+      "numResults" : 185
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -66480,8 +66480,7 @@
             "                      (srn_active_active_device_binding",
             "                        ACTIVE_ACTIVE_DEVICE_BINDING:'active-active-device-binding'",
             "                        bind = (active_active_device_binding_val*",
-            "                          (uint8*",
-            "                            UINT8:'0'))))))))))))",
+            "                          PRIMARY:'primary')))))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",
             "    SET:'set'",
@@ -71406,7 +71405,7 @@
               "Comment" : "Batfish currently models this as active-active-device-binding both",
               "Line" : 19,
               "Parser_Context" : "[srn_active_active_device_binding srn_definition sr_nat_rules sr_nat rulebase_inner s_post_rulebase ss_common s_policy_panorama s_policy set_line_tail set_line palo_alto_configuration]",
-              "Text" : "active-active-device-binding 0"
+              "Text" : "active-active-device-binding primary"
             }
           ]
         },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -66477,6 +66477,30 @@
             "                    (srn_definition",
             "                      name = (variable*",
             "                        VARIABLE:'RULE_1')",
+            "                      (srn_active_active_device_binding",
+            "                        ACTIVE_ACTIVE_DEVICE_BINDING:'active-active-device-binding'",
+            "                        bind = (active_active_device_binding_val*",
+            "                          (uint8*",
+            "                            UINT8:'0'))))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line*",
+            "    SET:'set'",
+            "    (set_line_tail*",
+            "      (s_policy*",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (ss_common*",
+            "            (s_post_rulebase",
+            "              POST_RULEBASE:'post-rulebase'",
+            "              (rulebase_inner*",
+            "                (sr_nat*",
+            "                  NAT:'nat'",
+            "                  (sr_nat_rules*",
+            "                    RULES:'rules'",
+            "                    (srn_definition",
+            "                      name = (variable*",
+            "                        VARIABLE:'RULE_1')",
             "                      (srn_destination_translation",
             "                        DESTINATION_TRANSLATION:'destination-translation'",
             "                        (srndt_translated_address",
@@ -71376,6 +71400,16 @@
             }
           ]
         },
+        "configs/palo_alto/nat" : {
+          "Parse warnings" : [
+            {
+              "Comment" : "Batfish currently models this as active-active-device-binding both",
+              "Line" : 19,
+              "Parser_Context" : "[srn_active_active_device_binding srn_definition sr_nat_rules sr_nat rulebase_inner s_post_rulebase ss_common s_policy_panorama s_policy set_line_tail set_line palo_alto_configuration]",
+              "Text" : "active-active-device-binding 0"
+            }
+          ]
+        },
         "configs/route_policy_param" : {
           "Parse warnings" : [
             {
@@ -75926,31 +75960,31 @@
         "configs/palo_alto/nat" : {
           "nat rule" : {
             "MISSING_DESTINATION~panorama" : {
-              "definitionLines" : "57-60",
+              "definitionLines" : "58-61",
               "numReferrers" : 0
             },
             "MISSING_FROM~panorama" : {
-              "definitionLines" : "50-51",
+              "definitionLines" : "51-52",
               "numReferrers" : 0
             },
             "MISSING_SOURCE~panorama" : {
-              "definitionLines" : "53-55",
+              "definitionLines" : "54-56",
               "numReferrers" : 0
             },
             "MISSING_TO~panorama" : {
-              "definitionLines" : "49",
+              "definitionLines" : "50",
               "numReferrers" : 0
             },
             "RULE_1~panorama" : {
-              "definitionLines" : "18-20,22-24,27-30",
+              "definitionLines" : "18-21,23-25,28-31",
               "numReferrers" : 0
             },
             "RULE_2~panorama" : {
-              "definitionLines" : "32-36",
+              "definitionLines" : "33-37",
               "numReferrers" : 0
             },
             "RULE_3~panorama" : {
-              "definitionLines" : "38-42,45-47",
+              "definitionLines" : "39-43,46-48",
               "numReferrers" : 0
             }
           }
@@ -83133,91 +83167,91 @@
           "address-like" : {
             "ADDR1~panorama" : {
               "rulebase nat rules source-translation" : [
-                42
+                43
               ]
             },
             "DST_1~panorama" : {
               "rulebase nat rules destination" : [
-                47
+                48
               ]
             },
             "DST_2~panorama" : {
               "rulebase nat rules destination" : [
-                47
+                48
               ]
             },
             "DST_NAME~panorama" : {
               "rulebase nat rules destination" : [
-                36
+                37
               ]
             },
             "SRC_1~panorama" : {
               "rulebase nat rules source" : [
-                46
+                47
               ]
             },
             "SRC_2~panorama" : {
               "rulebase nat rules source" : [
-                46
+                47
               ]
             },
             "SRC_NAME~panorama" : {
               "rulebase nat rules source" : [
-                35,
-                60
+                36,
+                61
               ]
             }
           },
           "address-like or none" : {
             "1.1.1.0/24~panorama" : {
               "rulebase nat rules destination-translation" : [
-                20
+                21
               ]
             },
             "1.1.1.1~panorama" : {
               "rulebase nat rules source-translation" : [
-                42
+                43
               ]
             },
             "2.2.2.0/24~panorama" : {
               "rulebase nat rules source-translation" : [
-                24,
-                42
+                25,
+                43
               ]
             },
             "3.3.3.3-4.4.4.4~panorama" : {
               "rulebase nat rules source-translation" : [
-                42
+                43
               ]
             },
             "any~panorama" : {
               "rulebase nat rules destination" : [
-                30
+                31
               ],
               "rulebase nat rules source" : [
-                29
+                30
               ]
             }
           },
           "nat rule" : {
             "MISSING_DESTINATION~panorama" : {
               "rulebase nat rules" : [
-                57
+                58
               ]
             },
             "MISSING_FROM~panorama" : {
               "rulebase nat rules" : [
-                50
+                51
               ]
             },
             "MISSING_SOURCE~panorama" : {
               "rulebase nat rules" : [
-                53
+                54
               ]
             },
             "MISSING_TO~panorama" : {
               "rulebase nat rules" : [
-                49
+                50
               ]
             },
             "RULE_1~panorama" : {
@@ -83227,41 +83261,41 @@
             },
             "RULE_2~panorama" : {
               "rulebase nat rules" : [
-                32
+                33
               ]
             },
             "RULE_3~panorama" : {
               "rulebase nat rules" : [
-                38
+                39
               ]
             }
           },
           "zone" : {
             "FROM_1~panorama" : {
               "rulebase nat rules from" : [
-                45
+                46
               ]
             },
             "FROM_2~panorama" : {
               "rulebase nat rules from" : [
-                45
+                46
               ]
             },
             "FROM_ZONE~panorama" : {
               "rulebase nat rules from" : [
-                34,
-                55,
-                59
+                35,
+                56,
+                60
               ]
             },
             "TO_ZONE~panorama" : {
               "rulebase nat rules to" : [
-                27,
-                33,
-                39,
-                51,
-                54,
-                58
+                28,
+                34,
+                40,
+                52,
+                55,
+                59
               ]
             }
           }
@@ -85859,29 +85893,29 @@
           "zone" : {
             "FROM_1~panorama" : {
               "rulebase nat rules from" : [
-                45
+                46
               ]
             },
             "FROM_2~panorama" : {
               "rulebase nat rules from" : [
-                45
+                46
               ]
             },
             "FROM_ZONE~panorama" : {
               "rulebase nat rules from" : [
-                34,
-                55,
-                59
+                35,
+                56,
+                60
               ]
             },
             "TO_ZONE~panorama" : {
               "rulebase nat rules to" : [
-                27,
-                33,
-                39,
-                51,
-                54,
-                58
+                28,
+                34,
+                40,
+                52,
+                55,
+                59
               ]
             }
           }


### PR DESCRIPTION
* Track `high-availability` device id for PA devices
* Track device binding in PA NAT rules, and filter out inapplicable rules
