### PR TITLE
CheckPoint: add warning for missing management config

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -164,6 +164,17 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
             .map(cmc -> (CheckpointManagementConfiguration) cmc);
     Optional<Entry<ManagementDomain, GatewayOrServer>> domainAndGateway =
         mgmtConfig.flatMap(this::findGatewayAndDomain);
+
+    if (!mgmtConfig.isPresent()) {
+      _w.redFlag(
+          "No CheckPoint management configuration found. This gateway will not have any management"
+              + " configuration applied, e.g. no ACLs or NAT rules.");
+    } else if (!domainAndGateway.isPresent()) {
+      _w.redFlag(
+          "No domain found for this gateway. This gateway will not have any domain configuration"
+              + " applied, e.g. no ACLs or NAT rules.");
+    }
+
     Optional<ManagementPackage> mgmtPackage =
         domainAndGateway.flatMap(e -> findAccessPackage(e.getKey(), e.getValue()));
     Map<Uid, NamedManagementObject> mgmtObjects =


### PR DESCRIPTION
Add a couple more warnings when there is no domain or management configuration.
