### PR TITLE
CheckPoint: better format detection

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -39,7 +39,7 @@ public final class VendorConfigurationFormatDetector {
   private static final Pattern BLADE_NETWORK_PATTERN = Pattern.compile("(?m)^switch-type");
   private static final Pattern CADANT_NETWORK_PATTERN = Pattern.compile("(?m)^shelfname");
   private static final Pattern CHECK_POINT_GATEWAY_PATTERN =
-      Pattern.compile("(?m)^# Configuration of [\\w-]+\n# Language version: ");
+      Pattern.compile("(?m)^# Configuration of [\\w-]+\\R+# Language version: ");
   private static final Pattern CUMULUS_CONCATENATED_PATTERN =
       Pattern.compile("(?m)^# This file describes the network interfaces");
   private static final Pattern CUMULUS_NCLU_PATTERN = Pattern.compile("(?m)^net del all$");

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -32,19 +32,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class VendorConfigurationFormatDetectorTest {
   @Test
-  public void testNewlines() {
-    List<String> lines =
-        ImmutableList.of("#", "# Configuration of host_name-ch01-01", "# Language version: 13.4v1");
-
-    // Should be able to detect config format regardless of the type of line separator
-    List<String> lineSeparators = ImmutableList.of("\n", "\r\n");
-    for (String lineSeparator : lineSeparators) {
-      String line = String.join(lineSeparator, lines);
-      assertThat(identifyConfigurationFormat(line), equalTo(CHECK_POINT_GATEWAY));
-    }
-  }
-
-  @Test
   public void testA10() {
     String fileText =
         "!\n" + "!version 3.4.5-A6-B78, build 90 (Aug-5-2021,01:23)\n" + "hostname foo\n";
@@ -117,6 +104,19 @@ public class VendorConfigurationFormatDetectorTest {
             + "set installer policy check-for-updates-period 3\n"
             + "set hostname check_point\n";
     assertThat(identifyConfigurationFormat(fileText), equalTo(CHECK_POINT_GATEWAY));
+  }
+
+  @Test
+  public void testCheckPointNewlines() {
+    List<String> lines =
+        ImmutableList.of("#", "# Configuration of host_name-ch01-01", "# Language version: 13.4v1");
+
+    // Should be able to detect config format regardless of the type of line separator
+    List<String> lineSeparators = ImmutableList.of("\n", "\r\n");
+    for (String lineSeparator : lineSeparators) {
+      String line = String.join(lineSeparator, lines);
+      assertThat(identifyConfigurationFormat(line), equalTo(CHECK_POINT_GATEWAY));
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,6 +31,19 @@ import org.junit.runners.JUnit4;
 /** Tests of {@link VendorConfigurationFormatDetector}. */
 @RunWith(JUnit4.class)
 public class VendorConfigurationFormatDetectorTest {
+  @Test
+  public void testNewlines() {
+    List<String> lines =
+        ImmutableList.of("#", "# Configuration of host_name-ch01-01", "# Language version: 13.4v1");
+
+    // Should be able to detect config format regardless of the type of line separator
+    List<String> lineSeparators = ImmutableList.of("\n", "\r\n");
+    for (String lineSeparator : lineSeparators) {
+      String line = String.join(lineSeparator, lines);
+      assertThat(identifyConfigurationFormat(line), equalTo(CHECK_POINT_GATEWAY));
+    }
+  }
+
   @Test
   public void testA10() {
     String fileText =


### PR DESCRIPTION
Allow different types of newline chars in CheckPoint format detection logic.
