### PR TITLE
BGP support network policy independent of redistribution policy

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -56,7 +56,7 @@ public class BgpProcess implements Serializable {
       checkArgument(_localAdminCost != null, "Missing %s", PROP_LOCAL_ADMIN_COST);
       checkArgument(
           _networkPolicy == null || _redistributionPolicy != null,
-          "Impossible to have independent %s without %s",
+          "Impossible to have %s without %s",
           PROP_INDEPENDENT_NETWORK_POLICY,
           PROP_REDISTRIBUTION_POLICY);
       BgpProcess bgpProcess =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -511,6 +511,7 @@ public class BgpProcess implements Serializable {
   public void setIndependentNetworkPolicy(@Nullable String independentNetworkPolicy) {
     _independentNetworkPolicy = independentNetworkPolicy;
   }
+
   /**
    * Name of the redistribution policy for this process. This policy is expected to be set only on
    * vendors that export BGP from their BGP RIBs (Cisco-like behavior).

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -591,7 +591,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       if (!independentNetworkPolicy.isPresent()) {
         LOGGER.debug(
             "Undefined BGP independent network policy {}. Skipping redistribution",
-            _process.getIndependentNetworkPolicy());
+            independentNetworkPolicyName);
       } else {
         mainRibDelta
             .getActions()


### PR DESCRIPTION
On some device type (e.g. A10, FRR, NXOS), BGP `network` statements
redistribute routes into BGP independently of `redistribute` statements.
This means an IGP route could result in up to two BGP entries if it is
matched by both a `network` statement and a `redistribute` statement.

This PR adds datamodel and iBDP support for such independent policies.
Previously, you could only get up to one BGP entry for an IGP route.