### PR TITLE
NXOS BGP use independent network policy

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
@@ -100,6 +100,10 @@ public final class Names {
     return String.format("~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv%s~", ipv4 ? "4" : "6");
   }
 
+  public static String generatedBgpIndependentNetworkPolicyName(String vrf) {
+    return String.format("~BGP_INDEPENDENT_NETWORK_POLICY:%s~", vrf);
+  }
+
   public static String generatedBgpRedistributionPolicyName(String vrf) {
     return String.format("~BGP_REDISTRIBUTION_POLICY:%s~", vrf);
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_network_and_redistribute
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_network_and_redistribute
@@ -1,0 +1,24 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_bgp_network_and_redistribute
+feature bgp
+!
+
+interface Loopback0
+  ip address 10.1.1.1/32
+
+interface Ethernet0
+  no switchport
+  ip address 10.0.0.1/24
+  no shutdown
+
+route-map r permit 100
+
+ip route 10.0.0.0/24 null0
+
+router bgp 1
+  router-id 10.1.1.1
+  address-family ipv4 unicast
+    network 10.0.0.0/24
+    redistribute direct route-map r
+!


### PR DESCRIPTION
- use indendependent network policy for `network` statements instead of
  combined redistribution policy
- allows multiple BGP RIB entries to be produced from single route
  applicable to both a `network` and a `redistribute` statement per
  device behavior