### PR TITLE
A10: alternate trunk member syntax

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_trunk.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_trunk.g4
@@ -15,6 +15,8 @@ st_definition: std_ethernet | std_name;
 
 std_name: NAME name = interface_name_str NEWLINE;
 
-std_ethernet: trunk_ethernet_interface+ NEWLINE;
+std_ethernet: (trunk_ethernet_interface | trunk_ethernet_interface_range)+ NEWLINE;
 
 trunk_ethernet_interface: ETHERNET num = ethernet_number;
+
+trunk_ethernet_interface_range: ETHERNET num = ethernet_number TO to = ethernet_number;

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -913,7 +913,7 @@ public class A10GrammarTest {
 
     Map<Integer, Interface> eths = c.getInterfacesEthernet();
     Map<Integer, TrunkInterface> trunks = c.getInterfacesTrunk();
-    assertThat(eths.keySet(), containsInAnyOrder(1, 2, 3, 4));
+    assertThat(eths.keySet(), containsInAnyOrder(1, 2, 3, 4, 5));
     assertThat(trunks.keySet(), containsInAnyOrder(1, 2));
 
     // LACP trunk-group
@@ -942,7 +942,8 @@ public class A10GrammarTest {
         trunkIface2.getMembers(),
         containsInAnyOrder(
             new InterfaceReference(Interface.Type.ETHERNET, 2),
-            new InterfaceReference(Interface.Type.ETHERNET, 3)));
+            new InterfaceReference(Interface.Type.ETHERNET, 3),
+            new InterfaceReference(Interface.Type.ETHERNET, 5)));
   }
 
   /** Testing ACOS v2 trunk datamodel conversion */
@@ -1012,14 +1013,17 @@ public class A10GrammarTest {
             allOf(
                 hasInterfaceType(InterfaceType.AGGREGATED),
                 hasChannelGroup(nullValue()),
-                hasChannelGroupMembers(containsInAnyOrder("Ethernet2", "Ethernet3")))));
+                hasChannelGroupMembers(
+                    containsInAnyOrder("Ethernet2", "Ethernet3", "Ethernet5")))));
     assertThat(
         c.getAllInterfaces().get("Trunk2").getDependencies(),
         containsInAnyOrder(
             new org.batfish.datamodel.Interface.Dependency(
                 "Ethernet2", org.batfish.datamodel.Interface.DependencyType.AGGREGATE),
             new org.batfish.datamodel.Interface.Dependency(
-                "Ethernet3", org.batfish.datamodel.Interface.DependencyType.AGGREGATE)));
+                "Ethernet3", org.batfish.datamodel.Interface.DependencyType.AGGREGATE),
+            new org.batfish.datamodel.Interface.Dependency(
+                "Ethernet5", org.batfish.datamodel.Interface.DependencyType.AGGREGATE)));
   }
 
   /** Testing ACOS v2 trunk conversion warnings */
@@ -1112,7 +1116,10 @@ public class A10GrammarTest {
             containsInAnyOrder(
                 hasComment("Cannot configure timeout for non-existent trunk-group"),
                 hasComment("Expected trunk ports-threshold in range 2-8, but got '1'"),
-                hasComment("Expected trunk ports-threshold in range 2-8, but got '9'"))));
+                hasComment("Expected trunk ports-threshold in range 2-8, but got '9'"),
+                hasComment(
+                    "Invalid range for trunk interface reference, 'from' must not be greater than"
+                        + " 'to'."))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2
@@ -4,7 +4,7 @@ hostname trunk_acos2
 !
 ! Default (static?) trunk definition
 trunk 2
- ethernet 2 ethernet 3
+ ethernet 5 ethernet 2 to 3
  name trunk2Name
 !
 interface ethernet 1
@@ -22,6 +22,9 @@ interface ethernet 3
 interface ethernet 4
  lacp trunk 1 mode active
  lacp timeout short
+ enable
+!
+interface ethernet 5
  enable
 !
 lacp-trunk 1

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_warn
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2_warn
@@ -5,6 +5,18 @@ hostname trunk_acos2_warn
 interface ethernet 1
  lacp timeout short
 !
+!
+interface ethernet 2
+!
+interface ethernet 3
+!
+interface ethernet 4
+!
+!
+trunk 1
+ ! `from` is greater than `to`
+ ethernet 4 ethernet 3 to 2
+!
 lacp-trunk 1
  ports-threshold 1
  ports-threshold 9


### PR DESCRIPTION
Like for `VLAN` interface references, you can list interfaces or use the `ethernet # to #` syntax, or a combination of both when specifying `trunk` members.
