### PR TITLE
Arista: Use a VS redistribution source enum

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -6221,7 +6221,7 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   @Override
   public void exitRedistribute_connected_is_stanza(Redistribute_connected_is_stanzaContext ctx) {
     IsisProcess proc = currentVrf().getIsisProcess();
-    RoutingProtocol sourceProtocol = RoutingProtocol.CONNECTED;
+    RedistributionSourceProtocol sourceProtocol = RedistributionSourceProtocol.CONNECTED;
     IsisRedistributionPolicy r = new IsisRedistributionPolicy(sourceProtocol);
     proc.getRedistributionPolicies().put(sourceProtocol, r);
     if (ctx.metric != null) {
@@ -6248,7 +6248,7 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   @Override
   public void exitRedistribute_static_is_stanza(Redistribute_static_is_stanzaContext ctx) {
     IsisProcess proc = currentVrf().getIsisProcess();
-    RoutingProtocol sourceProtocol = RoutingProtocol.STATIC;
+    RedistributionSourceProtocol sourceProtocol = RedistributionSourceProtocol.STATIC;
     IsisRedistributionPolicy r = new IsisRedistributionPolicy(sourceProtocol);
     proc.getRedistributionPolicies().put(sourceProtocol, r);
     if (ctx.metric != null) {
@@ -7153,7 +7153,7 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
     Ip ip = toIp(ctx.ip);
     Ip mask = toIp(ctx.mask);
     Prefix prefix = Prefix.create(ip, mask);
-    RoutingProtocol sourceProtocol = RoutingProtocol.ISIS_L1;
+    RedistributionSourceProtocol sourceProtocol = RedistributionSourceProtocol.ISIS_L1;
     IsisRedistributionPolicy r = new IsisRedistributionPolicy(sourceProtocol);
     r.setSummaryPrefix(prefix);
     _currentIsisProcess.getRedistributionPolicies().put(sourceProtocol, r);

--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -903,6 +903,7 @@ import org.batfish.representation.arista.Prefix6List;
 import org.batfish.representation.arista.Prefix6ListLine;
 import org.batfish.representation.arista.PrefixList;
 import org.batfish.representation.arista.PrefixListLine;
+import org.batfish.representation.arista.RedistributionSourceProtocol;
 import org.batfish.representation.arista.RipProcess;
 import org.batfish.representation.arista.RouteMap;
 import org.batfish.representation.arista.RouteMapClause;
@@ -6458,7 +6459,7 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   @Override
   public void exitRo_redistribute_bgp_arista(Ro_redistribute_bgp_aristaContext ctx) {
     OspfProcess proc = _currentOspfProcess;
-    RoutingProtocol sourceProtocol = RoutingProtocol.BGP;
+    RedistributionSourceProtocol sourceProtocol = RedistributionSourceProtocol.BGP_ANY;
     OspfRedistributionPolicy r = new OspfRedistributionPolicy(sourceProtocol);
     proc.getRedistributionPolicies().put(sourceProtocol, r);
     if (ctx.map != null) {
@@ -6473,7 +6474,7 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   @Override
   public void exitRo_redistribute_connected(Ro_redistribute_connectedContext ctx) {
     OspfProcess proc = _currentOspfProcess;
-    RoutingProtocol sourceProtocol = RoutingProtocol.CONNECTED;
+    RedistributionSourceProtocol sourceProtocol = RedistributionSourceProtocol.CONNECTED;
     OspfRedistributionPolicy r = new OspfRedistributionPolicy(sourceProtocol);
     proc.getRedistributionPolicies().put(sourceProtocol, r);
     if (ctx.metric != null) {
@@ -6507,7 +6508,7 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   @Override
   public void exitRo_redistribute_static(Ro_redistribute_staticContext ctx) {
     OspfProcess proc = _currentOspfProcess;
-    RoutingProtocol sourceProtocol = RoutingProtocol.STATIC;
+    RedistributionSourceProtocol sourceProtocol = RedistributionSourceProtocol.STATIC;
     OspfRedistributionPolicy r = new OspfRedistributionPolicy(sourceProtocol);
     proc.getRedistributionPolicies().put(sourceProtocol, r);
     if (ctx.metric != null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -1331,6 +1331,7 @@ public final class AristaConfiguration extends VendorConfiguration {
                     RoutingProtocol.ISIS_EL2,
                     RoutingProtocol.ISIS_L1,
                     RoutingProtocol.ISIS_L2));
+        break;
       case STATIC:
         ospfExportConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.STATIC));
         break;

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -18,6 +18,7 @@ import static org.batfish.representation.arista.AristaConversions.toBgpAggregate
 import static org.batfish.representation.arista.AristaConversions.toCommunityMatchExpr;
 import static org.batfish.representation.arista.AristaConversions.toCommunitySet;
 import static org.batfish.representation.arista.AristaConversions.toCommunitySetMatchExpr;
+import static org.batfish.representation.arista.AristaConversions.toOspfRedistributionProtocols;
 import static org.batfish.representation.arista.Conversions.computeDistributeListPolicies;
 import static org.batfish.representation.arista.Conversions.convertCryptoMapSet;
 import static org.batfish.representation.arista.Conversions.extractSourceNatIpSpaceFromAcl;
@@ -1311,34 +1312,9 @@ public final class AristaConfiguration extends VendorConfiguration {
     RedistributionSourceProtocol protocol = policy.getSourceProtocol();
     // All redistribution must match the specified protocol.
     Conjunction ospfExportConditions = new Conjunction();
-    switch (protocol) {
-      case BGP_ANY:
-        ospfExportConditions
-            .getConjuncts()
-            .add(
-                new MatchProtocol(
-                    RoutingProtocol.AGGREGATE, RoutingProtocol.BGP, RoutingProtocol.IBGP));
-        break;
-      case CONNECTED:
-        ospfExportConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.CONNECTED));
-        break;
-      case ISIS_ANY:
-        ospfExportConditions
-            .getConjuncts()
-            .add(
-                new MatchProtocol(
-                    RoutingProtocol.ISIS_EL1,
-                    RoutingProtocol.ISIS_EL2,
-                    RoutingProtocol.ISIS_L1,
-                    RoutingProtocol.ISIS_L2));
-        break;
-      case STATIC:
-        ospfExportConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.STATIC));
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "Unknown/invalid redistribution source protocol for OSPF" + protocol);
-    }
+    ospfExportConditions
+        .getConjuncts()
+        .add(new MatchProtocol(toOspfRedistributionProtocols(protocol)));
 
     ImmutableList.Builder<Statement> ospfExportStatements = ImmutableList.builder();
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -1335,7 +1335,8 @@ public final class AristaConfiguration extends VendorConfiguration {
         ospfExportConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.STATIC));
         break;
       default:
-        throw new IllegalArgumentException("Unknown redistribution source protocol " + protocol);
+        throw new IllegalArgumentException(
+            "Unknown/invalid redistribution source protocol for OSPF" + protocol);
     }
 
     ImmutableList.Builder<Statement> ospfExportStatements = ImmutableList.builder();

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -1308,20 +1308,34 @@ public final class AristaConfiguration extends VendorConfiguration {
   }
 
   private If convertOspfRedistributionPolicy(OspfRedistributionPolicy policy, OspfProcess proc) {
-    RoutingProtocol protocol = policy.getSourceProtocol();
+    RedistributionSourceProtocol protocol = policy.getSourceProtocol();
     // All redistribution must match the specified protocol.
     Conjunction ospfExportConditions = new Conjunction();
-    if (protocol == RoutingProtocol.ISIS_ANY) {
-      ospfExportConditions
-          .getConjuncts()
-          .add(
-              new MatchProtocol(
-                  RoutingProtocol.ISIS_EL1,
-                  RoutingProtocol.ISIS_EL2,
-                  RoutingProtocol.ISIS_L1,
-                  RoutingProtocol.ISIS_L2));
-    } else {
-      ospfExportConditions.getConjuncts().add(new MatchProtocol(protocol));
+    switch (protocol) {
+      case BGP_ANY:
+        ospfExportConditions
+            .getConjuncts()
+            .add(
+                new MatchProtocol(
+                    RoutingProtocol.AGGREGATE, RoutingProtocol.BGP, RoutingProtocol.IBGP));
+        break;
+      case CONNECTED:
+        ospfExportConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.CONNECTED));
+        break;
+      case ISIS_ANY:
+        ospfExportConditions
+            .getConjuncts()
+            .add(
+                new MatchProtocol(
+                    RoutingProtocol.ISIS_EL1,
+                    RoutingProtocol.ISIS_EL2,
+                    RoutingProtocol.ISIS_L1,
+                    RoutingProtocol.ISIS_L2));
+      case STATIC:
+        ospfExportConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.STATIC));
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown redistribution source protocol " + protocol);
     }
 
     ImmutableList.Builder<Statement> ospfExportStatements = ImmutableList.builder();

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -929,5 +929,29 @@ final class AristaConversions {
     return CommunitySet.empty();
   }
 
+  @Nonnull
+  static Collection<RoutingProtocol> toOspfRedistributionProtocols(
+      RedistributionSourceProtocol protocol) {
+    switch (protocol) {
+      case BGP_ANY:
+        return ImmutableList.of(
+            RoutingProtocol.AGGREGATE, RoutingProtocol.BGP, RoutingProtocol.IBGP);
+      case CONNECTED:
+        return ImmutableList.of(RoutingProtocol.CONNECTED);
+      case ISIS_ANY:
+        return ImmutableList.of(
+            RoutingProtocol.ISIS_EL1,
+            RoutingProtocol.ISIS_EL2,
+            RoutingProtocol.ISIS_L1,
+            RoutingProtocol.ISIS_L2);
+      case STATIC:
+        return ImmutableList.of(RoutingProtocol.STATIC);
+      case ISIS_L1:
+      default:
+        throw new IllegalArgumentException(
+            "Unknown/invalid redistribution source protocol for OSPF" + protocol);
+    }
+  }
+
   private AristaConversions() {} // prevent instantiation of utility class.
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/BUILD
@@ -12,6 +12,7 @@ java_library(
     deps = [
         "//projects/batfish-common-protocol:common",
         "@batfish//projects/bdd",
+        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:org_apache_commons_commons_lang3",

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/BUILD
@@ -12,7 +12,6 @@ java_library(
     deps = [
         "//projects/batfish-common-protocol:common",
         "@batfish//projects/bdd",
-        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:org_apache_commons_commons_lang3",

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/IsisProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/IsisProcess.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
 import org.batfish.datamodel.IsoAddress;
-import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.isis.IsisLevel;
 
 public class IsisProcess implements Serializable {
@@ -13,7 +12,7 @@ public class IsisProcess implements Serializable {
 
   private IsoAddress _netAddress;
 
-  private Map<RoutingProtocol, IsisRedistributionPolicy> _redistributionPolicies;
+  private Map<RedistributionSourceProtocol, IsisRedistributionPolicy> _redistributionPolicies;
 
   public IsisProcess() {
     _redistributionPolicies = new TreeMap<>();
@@ -27,7 +26,7 @@ public class IsisProcess implements Serializable {
     return _netAddress;
   }
 
-  public Map<RoutingProtocol, IsisRedistributionPolicy> getRedistributionPolicies() {
+  public Map<RedistributionSourceProtocol, IsisRedistributionPolicy> getRedistributionPolicies() {
     return _redistributionPolicies;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/IsisRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/IsisRedistributionPolicy.java
@@ -20,7 +20,7 @@ public class IsisRedistributionPolicy extends RedistributionPolicy {
 
   private Prefix _summaryPrefix;
 
-  public IsisRedistributionPolicy(RoutingProtocol sourceProtocol) {
+  public IsisRedistributionPolicy(RedistributionSourceProtocol sourceProtocol) {
     super(sourceProtocol, RoutingProtocol.ISIS_ANY);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/OspfProcess.java
@@ -14,7 +14,6 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfMetricType;
 
@@ -78,7 +77,7 @@ public class OspfProcess implements Serializable {
 
   private Set<String> _passiveInterfaces;
 
-  private Map<RoutingProtocol, OspfRedistributionPolicy> _redistributionPolicies;
+  private Map<RedistributionSourceProtocol, OspfRedistributionPolicy> _redistributionPolicies;
 
   private double _referenceBandwidth;
 
@@ -117,7 +116,7 @@ public class OspfProcess implements Serializable {
     _passiveInterfaces = new HashSet<>();
     _stubs = new HashMap<>();
     _wildcardNetworks = new TreeSet<>();
-    _redistributionPolicies = new EnumMap<>(RoutingProtocol.class);
+    _redistributionPolicies = new EnumMap<>(RedistributionSourceProtocol.class);
     _summaries = new TreeMap<>();
   }
 
@@ -230,7 +229,7 @@ public class OspfProcess implements Serializable {
     return _passiveInterfaces;
   }
 
-  public Map<RoutingProtocol, OspfRedistributionPolicy> getRedistributionPolicies() {
+  public Map<RedistributionSourceProtocol, OspfRedistributionPolicy> getRedistributionPolicies() {
     return _redistributionPolicies;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/OspfRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/OspfRedistributionPolicy.java
@@ -15,7 +15,7 @@ public class OspfRedistributionPolicy extends RedistributionPolicy {
 
   private Long _tag;
 
-  public OspfRedistributionPolicy(RoutingProtocol sourceProtocol) {
+  public OspfRedistributionPolicy(RedistributionSourceProtocol sourceProtocol) {
     super(sourceProtocol, RoutingProtocol.OSPF);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/RedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/RedistributionPolicy.java
@@ -11,11 +11,12 @@ public abstract class RedistributionPolicy implements Serializable {
 
   protected String _routeMap;
 
-  protected final RoutingProtocol _sourceProtocol;
+  protected final RedistributionSourceProtocol _sourceProtocol;
 
   protected final Map<String, Object> _specialAttributes;
 
-  public RedistributionPolicy(RoutingProtocol sourceProtocol, RoutingProtocol destinationProtocol) {
+  public RedistributionPolicy(
+      RedistributionSourceProtocol sourceProtocol, RoutingProtocol destinationProtocol) {
     _sourceProtocol = sourceProtocol;
     _destinationProtocol = destinationProtocol;
     _specialAttributes = new TreeMap<>();
@@ -29,7 +30,7 @@ public abstract class RedistributionPolicy implements Serializable {
     return _routeMap;
   }
 
-  public RoutingProtocol getSourceProtocol() {
+  public RedistributionSourceProtocol getSourceProtocol() {
     return _sourceProtocol;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/RedistributionSourceProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/RedistributionSourceProtocol.java
@@ -1,0 +1,49 @@
+package org.batfish.representation.arista;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.batfish.common.BatfishException;
+
+/**
+ * Source protocol for redistribution, used to express redistribution for OSPF, RIP, and ISIS. BGP
+ * is handled by {@link org.batfish.representation.arista.eos.AristaRedistributeType}.
+ */
+public enum RedistributionSourceProtocol {
+  CONNECTED("connected"),
+  BGP_ANY("bgp"),
+  ISIS_ANY("isis"),
+  STATIC("static");
+
+  private static final Map<String, RedistributionSourceProtocol> _map = buildMap();
+
+  private static Map<String, RedistributionSourceProtocol> buildMap() {
+    ImmutableMap.Builder<String, RedistributionSourceProtocol> map = ImmutableMap.builder();
+    for (RedistributionSourceProtocol protocol : RedistributionSourceProtocol.values()) {
+      String protocolName = protocol._protocolName.toLowerCase();
+      map.put(protocolName, protocol);
+    }
+    return map.build();
+  }
+
+  @JsonCreator
+  public static RedistributionSourceProtocol fromProtocolName(String name) {
+    RedistributionSourceProtocol protocol = _map.get(name.toLowerCase());
+    if (protocol == null) {
+      throw new BatfishException("No redistribution source protocol with name: \"" + name + "\"");
+    }
+    return protocol;
+  }
+
+  private final String _protocolName;
+
+  RedistributionSourceProtocol(String protocolName) {
+    _protocolName = protocolName;
+  }
+
+  @JsonValue
+  public String protocolName() {
+    return _protocolName;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/RedistributionSourceProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/RedistributionSourceProtocol.java
@@ -1,11 +1,5 @@
 package org.batfish.representation.arista;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import org.batfish.common.BatfishException;
-
 /**
  * Source protocol for redistribution, used to express redistribution for OSPF, RIP, and ISIS. BGP
  * is handled by {@link org.batfish.representation.arista.eos.AristaRedistributeType}.
@@ -17,33 +11,12 @@ public enum RedistributionSourceProtocol {
   ISIS_L1("isisL1"),
   STATIC("static");
 
-  private static final Map<String, RedistributionSourceProtocol> _map = buildMap();
-
-  private static Map<String, RedistributionSourceProtocol> buildMap() {
-    ImmutableMap.Builder<String, RedistributionSourceProtocol> map = ImmutableMap.builder();
-    for (RedistributionSourceProtocol protocol : RedistributionSourceProtocol.values()) {
-      String protocolName = protocol._protocolName.toLowerCase();
-      map.put(protocolName, protocol);
-    }
-    return map.build();
-  }
-
-  @JsonCreator
-  public static RedistributionSourceProtocol fromProtocolName(String name) {
-    RedistributionSourceProtocol protocol = _map.get(name.toLowerCase());
-    if (protocol == null) {
-      throw new BatfishException("No redistribution source protocol with name: \"" + name + "\"");
-    }
-    return protocol;
-  }
-
   private final String _protocolName;
 
   RedistributionSourceProtocol(String protocolName) {
     _protocolName = protocolName;
   }
 
-  @JsonValue
   public String protocolName() {
     return _protocolName;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/RedistributionSourceProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/RedistributionSourceProtocol.java
@@ -14,6 +14,7 @@ public enum RedistributionSourceProtocol {
   CONNECTED("connected"),
   BGP_ANY("bgp"),
   ISIS_ANY("isis"),
+  ISIS_L1("isisL1"),
   STATIC("static");
 
   private static final Map<String, RedistributionSourceProtocol> _map = buildMap();

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/RipRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/RipRedistributionPolicy.java
@@ -12,7 +12,7 @@ public class RipRedistributionPolicy extends RedistributionPolicy {
 
   private Long _metric;
 
-  public RipRedistributionPolicy(RoutingProtocol sourceProtocol) {
+  public RipRedistributionPolicy(RedistributionSourceProtocol sourceProtocol) {
     super(sourceProtocol, RoutingProtocol.RIP);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/arista/AristaConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/arista/AristaConversionsTest.java
@@ -1,7 +1,9 @@
 package org.batfish.representation.arista;
 
 import static org.batfish.representation.arista.AristaConversions.getAsnSpace;
+import static org.batfish.representation.arista.AristaConversions.toOspfRedistributionProtocols;
 import static org.batfish.representation.arista.Conversions.toRouteFilterList;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -10,6 +12,7 @@ import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.representation.arista.eos.AristaBgpPeerFilter;
 import org.batfish.representation.arista.eos.AristaBgpPeerFilterLine;
 import org.batfish.representation.arista.eos.AristaBgpV4DynamicNeighbor;
@@ -86,5 +89,25 @@ public class AristaConversionsTest {
         equalTo(
             new VendorStructureId(
                 "file", AristaStructureType.PREFIX_LIST.getDescription(), "name")));
+  }
+
+  @Test
+  public void testToOspfRedistributionProtocols() {
+    assertThat(
+        toOspfRedistributionProtocols(RedistributionSourceProtocol.BGP_ANY),
+        containsInAnyOrder(RoutingProtocol.BGP, RoutingProtocol.AGGREGATE, RoutingProtocol.IBGP));
+    assertThat(
+        toOspfRedistributionProtocols(RedistributionSourceProtocol.CONNECTED),
+        containsInAnyOrder(RoutingProtocol.CONNECTED));
+    assertThat(
+        toOspfRedistributionProtocols(RedistributionSourceProtocol.ISIS_ANY),
+        containsInAnyOrder(
+            RoutingProtocol.ISIS_L1,
+            RoutingProtocol.ISIS_L2,
+            RoutingProtocol.ISIS_EL1,
+            RoutingProtocol.ISIS_EL2));
+    assertThat(
+        toOspfRedistributionProtocols(RedistributionSourceProtocol.STATIC),
+        containsInAnyOrder(RoutingProtocol.STATIC));
   }
 }


### PR DESCRIPTION
Also fix a bug along the way. When redistribution source is VS BGP, then VI sources can be BGP, iBGP, or AGGREGATE. 