### PR TITLE
Arista: BGP no redistribute, route-map variant

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Arista_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Arista_bgp.g4
@@ -2651,22 +2651,22 @@ eos_rbinor_aggregate
 
 eos_rbinor_attached_host
 :
-  ATTACHED_HOST NEWLINE
+  ATTACHED_HOST (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_connected
 :
-  CONNECTED NEWLINE
+  CONNECTED (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_dynamic
 :
-  DYNAMIC NEWLINE
+  DYNAMIC (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_isis
 :
-  ISIS NEWLINE
+  ISIS (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_ospf
@@ -2680,12 +2680,12 @@ eos_rbinor_ospf
 
 eos_rbinor_ospf_any
 :
-  NEWLINE
+  (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_ospf_match
 :
-  MATCH (INTERNAL | EXTERNAL | NSSA_EXTERNAL) NEWLINE
+  MATCH (INTERNAL | EXTERNAL | NSSA_EXTERNAL) (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_ospf3
@@ -2701,12 +2701,12 @@ eos_rbinor_ospf3
 
 eos_rbinor_ospf3_any
 :
-  NEWLINE
+  (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_ospf3_match
 :
-  MATCH (INTERNAL | EXTERNAL | NSSA_EXTERNAL) NEWLINE
+  MATCH (INTERNAL | EXTERNAL | NSSA_EXTERNAL) (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_ospfv3
@@ -2722,12 +2722,12 @@ eos_rbinor_ospfv3
 
 eos_rbinor_rip
 :
-  RIP NEWLINE
+  RIP (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbinor_static
 :
-  STATIC NEWLINE
+  STATIC (ROUTE_MAP variable)? NEWLINE
 ;
 
 eos_rbino_router_id

--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -549,6 +549,7 @@ import org.batfish.grammar.arista.AristaParser.Eos_rbinon_route_to_peerContext;
 import org.batfish.grammar.arista.AristaParser.Eos_rbinon_send_communityContext;
 import org.batfish.grammar.arista.AristaParser.Eos_rbinon_shutdownContext;
 import org.batfish.grammar.arista.AristaParser.Eos_rbinon_update_sourceContext;
+import org.batfish.grammar.arista.AristaParser.Eos_rbinor_attached_hostContext;
 import org.batfish.grammar.arista.AristaParser.Eos_rbinor_connectedContext;
 import org.batfish.grammar.arista.AristaParser.Eos_rbinor_isisContext;
 import org.batfish.grammar.arista.AristaParser.Eos_rbinor_ospfContext;
@@ -3141,6 +3142,11 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   @Override
   public void exitEos_rbinon_update_source(Eos_rbinon_update_sourceContext ctx) {
     _currentAristaBgpNeighbor.setUpdateSource(null);
+  }
+
+  @Override
+  public void exitEos_rbinor_attached_host(Eos_rbinor_attached_hostContext ctx) {
+    _currentAristaBgpVrf.removeRedistributionPolicy(AristaRedistributeType.ATTACHED_HOST);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -4624,4 +4624,16 @@ public class AristaGrammarTest {
         vc.getWarnings().getParseWarnings(),
         contains(hasComment("Undefined ip prefix-list: OTHER")));
   }
+
+  /**
+   * Checks that both "no redistribute" variants (with and without route-map) are parsed and
+   * deletion actually happens
+   */
+  @Test
+  public void testBgpNoRedistribute() {
+    String hostname = "arista_bgp_no_redistribute";
+    AristaConfiguration vc = parseVendorConfig(hostname);
+
+    assertTrue(vc.getAristaBgp().getDefaultVrf().getRedistributionPolicies().isEmpty());
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_no_redistribute
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_no_redistribute
@@ -1,0 +1,74 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_bgp_no_redistribute
+!
+router bgp 65321
+  redistribute attached-host
+  no redistribute attached-host
+  no redistribute attached-host route-map RM
+
+  redistribute connected  
+  no redistribute connected
+  no redistribute connected route-map RM
+    
+  redistribute dynamic
+  no redistribute dynamic
+  no redistribute dynamic route-map RM
+  
+  redistribute isis
+  no redistribute isis
+  no redistribute isis route-map RM
+  
+  redistribute ospf
+  no redistribute ospf
+  no redistribute ospf route-map RM
+  
+  redistribute ospf match internal
+  no redistribute ospf match internal
+  no redistribute ospf match internal route-map RM
+  
+  redistribute ospf match external
+  no redistribute ospf match external
+  no redistribute ospf match external route-map RM
+  
+  redistribute ospf match nssa-external
+  no redistribute ospf match nssa-external
+  no redistribute ospf match nssa-external route-map RM
+  
+  redistribute ospf3
+  no redistribute ospf3
+  no redistribute ospf3 route-map RM
+  
+  redistribute ospf3 match internal
+  no redistribute ospf3 match internal
+  no redistribute ospf3 match internal route-map RM
+  
+  redistribute ospf3 match external
+  no redistribute ospf3 match external
+  no redistribute ospf3 match external route-map RM
+  
+  redistribute ospf3 match nssa-external
+  no redistribute ospf3 match nssa-external
+  no redistribute ospf3 match nssa-external route-map RM
+
+! positive version of ospfv3 is not supported
+  no redistribute ospfv3
+  no redistribute ospfv3 route-map RM
+  
+  no redistribute ospfv3 match internal
+  no redistribute ospfv3 match internal route-map RM
+  
+  no redistribute ospfv3 match external
+  no redistribute ospfv3 match external route-map RM
+  
+  no redistribute ospfv3 match nssa-external
+  no redistribute ospfv3 match nssa-external route-map RM
+  
+  redistribute rip
+  no redistribute rip
+  no redistribute rip route-map RM
+
+  redistribute static
+  no redistribute static
+  no redistribute static route-map RM
+


### PR DESCRIPTION
1. "no redistribute" syntax permits route-map specification (which is ignored by the box). 
2. add tests
3. add missing extractor logic for "no redistribute attached-host"