### PR TITLE
FRR: `maximum-paths` fixes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -300,6 +300,8 @@ LOG_NEIGHBOR_CHANGES: 'log-neighbor-changes';
 
 LINE: 'line';
 
+IBGP: 'ibgp';
+
 MAXIMUM_PATHS: 'maximum-paths';
 
 MAX_MED: 'max-med';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
@@ -134,8 +134,6 @@ sbafi_inner
 :
   sbafi_aggregate_address
 | sbafi_import
-// Skeptical that max-paths belongs here.
-// Adding for now to prevent jumping out of parser context.
 | sbafi_maximum_paths
 | sbafi_network
 | sbafi_neighbor
@@ -152,7 +150,13 @@ sbaf_ipv6_unicast
 sbafi6_inner
 :
   sbafi6_import
+| sbafi6_maximum_paths
 | sbafi6_null_tail
+;
+
+sbafi6_maximum_paths
+:
+  MAXIMUM_PATHS num = uint32 NEWLINE
 ;
 
 sbafi6_import

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
@@ -156,7 +156,7 @@ sbafi6_inner
 
 sbafi6_maximum_paths
 :
-  MAXIMUM_PATHS num = uint32 NEWLINE
+  MAXIMUM_PATHS (IBGP)? num = uint32 NEWLINE
 ;
 
 sbafi6_import
@@ -233,7 +233,7 @@ sbafi_import
 
 sbafi_maximum_paths
 :
-  MAXIMUM_PATHS num = uint32 NEWLINE
+  MAXIMUM_PATHS (IBGP)? num = uint32 NEWLINE
 ;
 
 sbafi_network

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -256,6 +256,23 @@ public class CumulusFrrGrammarTest {
     parse("router bgp 1\n address-family ipv4 unicast\n maximum-paths 4\nexit-address-family\n");
   }
 
+  @Test
+  public void testBgpAddressFamily_ipv6UnicastMaximumPaths() {
+    parse("router bgp 1\n address-family ipv6 unicast\n maximum-paths 4\nexit-address-family\n");
+  }
+
+  @Test
+  public void testBgpAddressFamily_ipv4UnicastMaximumPathsIbgp() {
+    parse(
+        "router bgp 1\n address-family ipv4 unicast\n maximum-paths ibgp 4\nexit-address-family\n");
+  }
+
+  @Test
+  public void testBgpAddressFamily_ipv6UnicastMaximumPathsIbgp() {
+    parse(
+        "router bgp 1\n address-family ipv6 unicast\n maximum-paths ibgp 4\nexit-address-family\n");
+  }
+
   /** Make sure that we warn when import statements are ignored but still do reference counting */
   @Test
   public void testBgpAddressFamilyIpv4UnicastImport() {


### PR DESCRIPTION
```
3  configs/leaf1.cfg  305             maximum-paths 64  [sbaf_ipv6_unicast sbaf sb_address_family bgp_...  This syntax is unrecognized
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>