### PR TITLE
FRR: Implement `neighbor WORD passive`

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -346,6 +346,8 @@ OSPF: 'ospf';
 
 OUT: 'out';
 
+PASSIVE: 'passive';
+
 PASSIVE_INTERFACE
 :
   'passive-interface' -> pushMode(M_Default_Or_Word)

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
@@ -334,6 +334,7 @@ sbn_property
 | sbnp_remote_as
 | sbnp_timers
 | sbnp_update_source
+| sbnp_passive
 ;
 
 sbnp_advertisement_interval
@@ -385,6 +386,11 @@ sbnp_timers
 sbnp_update_source
 :
   UPDATE_SOURCE (ip = IP_ADDRESS | name = word) NEWLINE
+;
+
+sbnp_passive
+:
+  PASSIVE NEWLINE
 ;
 
 sb_network

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -1650,6 +1650,11 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
+  public void testCumulusFrrNeightborPassive() {
+    parse("router bgp 10000\nneighbor N passive\n");
+  }
+
+  @Test
   public void testBgpNeighborEbgpMultihopPeerGroup() {
     _warnings = new Warnings(false, true, false);
     parseLines(


### PR DESCRIPTION
```
neighbor SERVERS passive  [bgp_inner s_bgp statement cumulus_frr_configu...  This syntax is unrecognized
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>