### PR TITLE
FRR: Allow more IPv4/IPv6 addresses to be specified for address-virtual

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesParser.g4
@@ -107,7 +107,7 @@ i_address_virtual
   (
     v4 = interface_address
     | v6 = interface_address6
-  ) NEWLINE
+  )+ NEWLINE
 ;
 
 i_alias

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
@@ -224,11 +224,13 @@ public final class CumulusInterfacesConfigurationBuilder extends CumulusInterfac
 
   @Override
   public void exitI_address_virtual(I_address_virtualContext ctx) {
-    if (ctx.v4 != null) {
-      _currentIface.setAddressVirtual(
-          MacAddress.parse(ctx.MAC_ADDRESS().getText()), toConcreteInterfaceAddress(ctx.v4));
-    } else {
-      assert ctx.v6 != null;
+    List<Interface_addressContext> v4 = ctx.interface_address();
+    v4.forEach(
+        address ->
+            _currentIface.setAddressVirtual(
+                MacAddress.parse(ctx.MAC_ADDRESS().getText()),
+                toConcreteInterfaceAddress(address)));
+    if (ctx.v6 != null) {
       // ignore v6
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
@@ -240,14 +240,19 @@ public class CumulusInterfacesGrammarTest {
 
   @Test
   public void testIfaceAddressVirtual() {
-    String input = "iface vlan1\n address-virtual 00:00:00:00:00:00 1.2.3.4/24\n";
+    String prefix1 = "10.0.0.254/24";
+    String prefix2 = "10.0.1.254/24";
+    String mac = "00:00:00:00:00:00";
+    String input = String.format("iface vlan1\n address-virtual %s %s %s\n", mac, prefix1, prefix2);
     InterfacesInterface iface = parse(input).getInterfaces().get("vlan1");
     assertThat(
         iface.getAddressVirtuals(),
         equalTo(
             ImmutableMap.of(
-                MacAddress.parse("00:00:00:00:00:00"),
-                ImmutableSet.of(ConcreteInterfaceAddress.parse("1.2.3.4/24")))));
+                MacAddress.parse(mac),
+                ImmutableSet.of(
+                    ConcreteInterfaceAddress.parse(prefix1),
+                    ConcreteInterfaceAddress.parse(prefix2)))));
   }
 
   @Test


### PR DESCRIPTION
It's a valid command like:

```
address-virtual 44:38:39:ff:ff:c8 10.0.0.254/24 10.0.1.254/24
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>