### PR TITLE
FRR: Warn that TTL is not enforced if TTL number is ommited

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -1296,7 +1296,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
 
   @Override
   public void exitSbnp_ebgp_multihop(Sbnp_ebgp_multihopContext ctx) {
-    if (ctx.num != null) {
+    if (ctx.num == null) {
       warn(
           ctx.getParent(),
           "Neighbor recognized as ebgp-multihop, but distance limit is not enforced");


### PR DESCRIPTION
Because now it confuses.

```
ebgp-multihop 123  [sbn_property sbn_ip sb_neighbor bgp_inner s_b...  Neighbor recognized as ebgp-multihop, but dist
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>