### PR TITLE
PAN: fix application and service references outside current `vsys`

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -2856,7 +2856,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   public void exitSrs_application(Srs_applicationContext ctx) {
     for (Variable_list_itemContext var : variables(ctx.variable_list())) {
       String name = getText(var);
-      _currentSecurityRule.getApplications().add(name);
+      _currentSecurityRule.addApplication(name);
       // Use constructed object name so same-named refs across vsys are unique
       String uniqueName = computeObjectName(_currentVsys, name);
       referenceApplicationOrGroupLike(name, uniqueName, SECURITY_RULE_APPLICATION, var);

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOrApplicationGroupReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOrApplicationGroupReference.java
@@ -1,0 +1,27 @@
+package org.batfish.representation.palo_alto;
+
+import javax.annotation.Nonnull;
+
+public class ApplicationOrApplicationGroupReference
+    implements Comparable<ApplicationOrApplicationGroupReference>, Reference {
+  public ApplicationOrApplicationGroupReference(String name) {
+    _name = name;
+  }
+
+  @Override
+  public <T, U> T accept(ReferenceVisitor<T, U> visitor, U arg) {
+    return visitor.visitApplicationOrApplicationGroupReference(this, arg);
+  }
+
+  @Override
+  public int compareTo(@Nonnull ApplicationOrApplicationGroupReference o) {
+    return _name.compareTo(o._name);
+  }
+
+  /** Return the name of the referenced Application or ApplicationGroup */
+  public String getName() {
+    return _name;
+  }
+
+  private final String _name;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOrApplicationGroupReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOrApplicationGroupReference.java
@@ -2,6 +2,7 @@ package org.batfish.representation.palo_alto;
 
 import javax.annotation.Nonnull;
 
+/** Datamodel class that represents a reference to an applicaiton or an applicaiton-group. */
 public class ApplicationOrApplicationGroupReference
     implements Comparable<ApplicationOrApplicationGroupReference>, Reference {
   public ApplicationOrApplicationGroupReference(String name) {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOrApplicationGroupReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOrApplicationGroupReference.java
@@ -2,8 +2,8 @@ package org.batfish.representation.palo_alto;
 
 import javax.annotation.Nonnull;
 
-/** Datamodel class that represents a reference to an applicaiton or an applicaiton-group. */
-public class ApplicationOrApplicationGroupReference
+/** Datamodel class that represents a reference to an application or an application-group. */
+public final class ApplicationOrApplicationGroupReference
     implements Comparable<ApplicationOrApplicationGroupReference>, Reference {
   public ApplicationOrApplicationGroupReference(String name) {
     _name = name;
@@ -15,15 +15,32 @@ public class ApplicationOrApplicationGroupReference
   }
 
   @Override
-  public int compareTo(@Nonnull ApplicationOrApplicationGroupReference o) {
+  public int compareTo(ApplicationOrApplicationGroupReference o) {
     return _name.compareTo(o._name);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ApplicationOrApplicationGroupReference)) {
+      return false;
+    }
+    return _name.equals(((ApplicationOrApplicationGroupReference) o).getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return _name.hashCode();
   }
 
   /** Return the name of the referenced Application or ApplicationGroup */
   @Override
+  @Nonnull
   public String getName() {
     return _name;
   }
 
-  private final String _name;
+  @Nonnull private final String _name;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOrApplicationGroupReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOrApplicationGroupReference.java
@@ -20,6 +20,7 @@ public class ApplicationOrApplicationGroupReference
   }
 
   /** Return the name of the referenced Application or ApplicationGroup */
+  @Override
   public String getName() {
     return _name;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -941,7 +941,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     Streams.concat(
             _sharedGateways.values().stream(),
             _virtualSystems.values().stream(),
-            // Duplicates object names from panorama namespace should overwrite shared namespace
+            // Duplicate object names from panorama namespace should overwrite those in shared
+            // namespace
             Stream.of(_shared, _panorama).filter(Objects::nonNull))
         .forEach(
             namespace -> {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1776,7 +1776,6 @@ public class PaloAltoConfiguration extends VendorConfiguration {
         // fall-through
       case SHARED:
       default:
-        assert vsys.getNamespaceType() == NamespaceType.SHARED;
         return Optional.empty();
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -941,7 +941,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     Streams.concat(
             _sharedGateways.values().stream(),
             _virtualSystems.values().stream(),
-            Stream.of(_panorama, _shared).filter(Objects::nonNull))
+            // Duplicates object names from panorama namespace should overwrite shared namespace
+            Stream.of(_shared, _panorama).filter(Objects::nonNull))
         .forEach(
             namespace -> {
               loggingServers.addAll(namespace.getSyslogServerAddresses());
@@ -1567,11 +1568,12 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     for (ServiceOrServiceGroupReference service : services) {
       String serviceName = service.getName();
 
-      // Check for matching object before using built-ins
-      String vsysName = service.getVsysName(this, vsys);
-      if (vsysName != null) {
-        // Service object found
+      Optional<Vsys> maybeContainingVsys = getVsysForReference(service, vsys);
 
+      // Check for matching object before using built-ins
+      if (maybeContainingVsys.isPresent()) {
+        // Service object found
+        String vsysName = maybeContainingVsys.get().getName();
         AclLineMatchExpr serviceMatch =
             permittedByAcl(
                 computeServiceGroupMemberAclName(vsysName, serviceName),
@@ -1618,42 +1620,50 @@ public class PaloAltoConfiguration extends VendorConfiguration {
    * If no corresponding application/group is found, then {@link Optional#empty()} is returned.
    */
   private Optional<AclLineMatchExpr> aclLineMatchExprForApplicationOrGroup(
-      String name,
+      ApplicationOrApplicationGroupReference reference,
       SecurityRule rule,
       Vsys vsys,
       Map<String, AclLineMatchExpr> appOverrideAclsMap,
       boolean applicationDefaultService) {
-    String vsysName = vsys.getName();
+    String name = reference.getName();
 
     // Assume all traffic matches some application under the "any" definition
     if (name.equals(CATCHALL_APPLICATION_NAME)) {
       return Optional.of(new TrueExpr(matchApplicationAnyTraceElement()));
     }
 
-    ApplicationGroup group = vsys.getApplicationGroups().get(name);
-    if (group != null) {
-      return Optional.of(
-          new OrMatchExpr(
-              group
-                  .getDescendantObjects(vsys.getApplications(), vsys.getApplicationGroups())
-                  .stream()
-                  // Don't add trace for children; we've already flattened intermediate app groups
-                  .map(
-                      a ->
-                          aclLineMatchExprForApplication(
-                              a, appOverrideAclsMap, null, applicationDefaultService))
-                  .collect(ImmutableList.toImmutableList()),
-              matchApplicationGroupTraceElement(name, vsysName, _filename)));
-    }
+    Optional<Vsys> maybeContainingVsys = getVsysForReference(reference, vsys);
+    if (maybeContainingVsys.isPresent()) {
+      Vsys containingVsys = maybeContainingVsys.get();
+      String vsysName = containingVsys.getName();
+      ApplicationGroup group = containingVsys.getApplicationGroups().get(name);
+      if (group != null) {
+        return Optional.of(
+            new OrMatchExpr(
+                group
+                    .getDescendantObjects(
+                        containingVsys.getApplications(), containingVsys.getApplicationGroups())
+                    .stream()
+                    // Don't add trace for children; we've already flattened intermediate app groups
+                    .map(
+                        a ->
+                            aclLineMatchExprForApplication(
+                                a, appOverrideAclsMap, null, applicationDefaultService))
+                    .collect(ImmutableList.toImmutableList()),
+                matchApplicationGroupTraceElement(name, vsysName, _filename)));
+      }
 
-    Application a = vsys.getApplications().get(name);
-    if (a != null) {
-      return Optional.of(
-          aclLineMatchExprForApplication(
-              a,
-              appOverrideAclsMap,
-              matchApplicationObjectTraceElement(name, vsysName, _filename),
-              applicationDefaultService));
+      Application a = containingVsys.getApplications().get(name);
+      if (a != null) {
+        return Optional.of(
+            aclLineMatchExprForApplication(
+                a,
+                appOverrideAclsMap,
+                matchApplicationObjectTraceElement(name, vsysName, _filename),
+                applicationDefaultService));
+      }
+      // If the reference is contained by a vsys, should match an application or group above
+      assert false;
     }
 
     Optional<Application> builtIn = ApplicationBuiltIn.getBuiltInApplication(name);
@@ -1725,6 +1735,51 @@ public class PaloAltoConfiguration extends VendorConfiguration {
         .collect(ImmutableList.toImmutableList());
   }
 
+  private static final ReferenceInVsys REFERENCE_IN_VSYS = new ReferenceInVsys();
+
+  /** Visitor that determines if a {@link Reference} exists in the specified {@link Vsys}. */
+  public static class ReferenceInVsys implements ReferenceVisitor<Boolean, Vsys> {
+    @Override
+    public Boolean visitServiceOrServiceGroupReference(
+        ServiceOrServiceGroupReference reference, Vsys vsys) {
+      return vsys.getServices().containsKey(reference.getName())
+          || vsys.getServiceGroups().containsKey(reference.getName());
+    }
+
+    @Override
+    public Boolean visitApplicationOrApplicationGroupReference(
+        ApplicationOrApplicationGroupReference reference, Vsys vsys) {
+      return vsys.getApplications().containsKey(reference.getName())
+          || vsys.getApplicationGroups().containsKey(reference.getName());
+    }
+  }
+
+  /**
+   * Return the {@link Vsys} this {@link Reference} is attached to. Handles checking the starting
+   * Vsys, shared Vsys, and Panorama Vsys if applicable.
+   */
+  @Nonnull
+  @SuppressWarnings("fallthrough")
+  Optional<Vsys> getVsysForReference(Reference ref, Vsys vsys) {
+    if (REFERENCE_IN_VSYS.visit(ref, vsys)) {
+      return Optional.of(vsys);
+    }
+    switch (vsys.getNamespaceType()) {
+      case LEAF:
+        if (_panorama != null) {
+          return getVsysForReference(ref, _panorama);
+        }
+        // fall-through
+      case PANORAMA:
+        if (_shared != null) {
+          return getVsysForReference(ref, _shared);
+        }
+        // fall-through
+      default:
+        return Optional.empty();
+    }
+  }
+
   /** Converts interface address {@code String} to {@link IpSpace} */
   @Nullable
   @SuppressWarnings("fallthrough")
@@ -1751,13 +1806,13 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     }
     switch (vsys.getNamespaceType()) {
       case LEAF:
-        if (_shared != null) {
-          return interfaceAddressToConcreteInterfaceAddress(address, _shared, w);
-        }
-        // fall-through
-      case SHARED:
         if (_panorama != null) {
           return interfaceAddressToConcreteInterfaceAddress(address, _panorama, w);
+        }
+        // fall-through
+      case PANORAMA:
+        if (_shared != null) {
+          return interfaceAddressToConcreteInterfaceAddress(address, _shared, w);
         }
         // fall-through
       default:
@@ -1793,13 +1848,13 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     }
     switch (vsys.getNamespaceType()) {
       case LEAF:
-        if (_shared != null) {
-          return ruleEndpointToIpSpace(endpoint, _shared, w);
-        }
-        // fall-through
-      case SHARED:
         if (_panorama != null) {
           return ruleEndpointToIpSpace(endpoint, _panorama, w);
+        }
+        // fall-through
+      case PANORAMA:
+        if (_shared != null) {
+          return ruleEndpointToIpSpace(endpoint, _shared, w);
         }
         // fall-through
       default:
@@ -1879,13 +1934,13 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     }
     switch (vsys.getNamespaceType()) {
       case LEAF:
-        if (_shared != null) {
-          return getRuleEndpointTraceElement(endpoint, _shared, filename);
-        }
-        // fall-through
-      case SHARED:
         if (_panorama != null) {
           return getRuleEndpointTraceElement(endpoint, _panorama, filename);
+        }
+        // fall-through
+      case PANORAMA:
+        if (_shared != null) {
+          return getRuleEndpointTraceElement(endpoint, _shared, filename);
         }
         // fall-through
       default:
@@ -1923,13 +1978,13 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     }
     switch (vsys.getNamespaceType()) {
       case LEAF:
-        if (_shared != null) {
-          return ruleEndpointToIpRangeSet(endpoint, _shared, w);
-        }
-        // fall-through
-      case SHARED:
         if (_panorama != null) {
           return ruleEndpointToIpRangeSet(endpoint, _panorama, w);
+        }
+        // fall-through
+      case PANORAMA:
+        if (_shared != null) {
+          return ruleEndpointToIpRangeSet(endpoint, _shared, w);
         }
         // fall-through
       default:
@@ -2190,9 +2245,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     }
     String serviceName = service.getName();
     // Check for matching object before using built-ins
-    String vsysName = service.getVsysName(this, vsys);
+    Optional<Vsys> maybeContainingVsys = getVsysForReference(service, vsys);
 
-    if (vsysName != null) {
+    if (maybeContainingVsys.isPresent()) {
+      String vsysName = maybeContainingVsys.get().getName();
       return Optional.of(
           new PacketMatchExpr(
               permittedByAcl(computeServiceGroupMemberAclName(vsysName, serviceName))));
@@ -2816,13 +2872,15 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     // TODO support applying device-group to specific vsys
     // https://github.com/batfish/batfish/issues/5910
 
-    // Create the target vsys (it shouldn't already exist)
+    // Create the target vsyses (shouldn't already exist)
     Vsys target = new Vsys(PANORAMA_VSYS_NAME, NamespaceType.PANORAMA);
     assert _panorama == null;
     _panorama = target;
+    Vsys targetShared = new Vsys(SHARED_VSYS_NAME, NamespaceType.SHARED);
+    assert _shared == null;
+    _shared = targetShared;
 
-    // Apply shared config first, since it is overwritten by device-groups applied after it
-    applyVsys(shared, target);
+    applyVsys(shared, targetShared);
 
     List<DeviceGroup> inheritedDeviceGroups = new ArrayList<>();
     inheritedDeviceGroups.add(template);

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Reference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Reference.java
@@ -1,0 +1,13 @@
+package org.batfish.representation.palo_alto;
+
+import java.io.Serializable;
+
+/**
+ * Datamodel interface representing a structure reference in Palo Alto. e.g. an application-group
+ * reference from a security rule.
+ */
+public interface Reference extends Serializable {
+  <T, U> T accept(ReferenceVisitor<T, U> visitor, U arg);
+
+  String getName();
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Reference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Reference.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.palo_alto;
 
 import java.io.Serializable;
+import javax.annotation.Nonnull;
 
 /**
  * Datamodel interface representing a structure reference in Palo Alto. e.g. an application-group
@@ -9,5 +10,6 @@ import java.io.Serializable;
 public interface Reference extends Serializable {
   <T, U> T accept(ReferenceVisitor<T, U> visitor, U arg);
 
+  @Nonnull
   String getName();
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ReferenceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ReferenceVisitor.java
@@ -1,6 +1,6 @@
 package org.batfish.representation.palo_alto;
 
-/** Visitor for {@link Reference} */
+/** Visitor for {@link Reference} that takes in an argument. */
 public interface ReferenceVisitor<T, U> {
   default T visit(Reference reference, U arg) {
     return reference.accept(this, arg);

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ReferenceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ReferenceVisitor.java
@@ -1,0 +1,13 @@
+package org.batfish.representation.palo_alto;
+
+/** Visitor for {@link Reference} */
+public interface ReferenceVisitor<T, U> {
+  default T visit(Reference reference, U arg) {
+    return reference.accept(this, arg);
+  }
+
+  T visitServiceOrServiceGroupReference(ServiceOrServiceGroupReference reference, U arg);
+
+  T visitApplicationOrApplicationGroupReference(
+      ApplicationOrApplicationGroupReference reference, U arg);
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ReferenceVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ReferenceVisitor.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.palo_alto;
 
-/** Visitor for {@link Reference} that takes in an argument. */
+/**
+ * Visitor for {@link Reference} that takes a generic argument of type {@code U} and returns a
+ * generic value of type {@code T}.
+ */
 public interface ReferenceVisitor<T, U> {
   default T visit(Reference reference, U arg) {
     return reference.accept(this, arg);

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/SecurityRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/SecurityRule.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.palo_alto;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -48,7 +49,7 @@ public final class SecurityRule implements Serializable {
   @Nonnull private final SortedSet<ServiceOrServiceGroupReference> _service;
 
   // Applications
-  @Nonnull private final SortedSet<String> _applications;
+  @Nonnull private final SortedSet<ApplicationOrApplicationGroupReference> _applications;
 
   // Rule type
   @Nullable private RuleType _ruleType;
@@ -81,9 +82,13 @@ public final class SecurityRule implements Serializable {
     return _action;
   }
 
+  public void addApplication(String application) {
+    _applications.add(new ApplicationOrApplicationGroupReference(application));
+  }
+
   @Nonnull
-  public SortedSet<String> getApplications() {
-    return _applications;
+  public SortedSet<ApplicationOrApplicationGroupReference> getApplications() {
+    return ImmutableSortedSet.copyOf(_applications);
   }
 
   @Nullable

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceOrServiceGroupReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceOrServiceGroupReference.java
@@ -1,13 +1,15 @@
 package org.batfish.representation.palo_alto;
 
-import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ServiceOrServiceGroupReference
-    implements Serializable, Comparable<ServiceOrServiceGroupReference> {
+    implements Comparable<ServiceOrServiceGroupReference>, Reference {
 
-  private final String _name;
+  @Override
+  public <T, U> T accept(ReferenceVisitor<T, U> visitor, U arg) {
+    return visitor.visitServiceOrServiceGroupReference(this, arg);
+  }
 
   public ServiceOrServiceGroupReference(String name) {
     _name = name;
@@ -34,17 +36,19 @@ public class ServiceOrServiceGroupReference
     }
     switch (vsys.getNamespaceType()) {
       case LEAF:
-        if (pc.getShared() != null) {
-          return getVsysName(pc, pc.getShared());
-        }
-        // fall-through
-      case SHARED:
         if (pc.getPanorama() != null) {
           return getVsysName(pc, pc.getPanorama());
+        }
+        // fall-through
+      case PANORAMA:
+        if (pc.getShared() != null) {
+          return getVsysName(pc, pc.getShared());
         }
         // fall-through
       default:
         return null;
     }
   }
+
+  private final String _name;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceOrServiceGroupReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceOrServiceGroupReference.java
@@ -3,7 +3,7 @@ package org.batfish.representation.palo_alto;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class ServiceOrServiceGroupReference
+public final class ServiceOrServiceGroupReference
     implements Comparable<ServiceOrServiceGroupReference>, Reference {
 
   @Override
@@ -16,12 +16,29 @@ public class ServiceOrServiceGroupReference
   }
 
   @Override
-  public int compareTo(@Nonnull ServiceOrServiceGroupReference o) {
+  public int compareTo(ServiceOrServiceGroupReference o) {
     return _name.compareTo(o._name);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ServiceOrServiceGroupReference)) {
+      return false;
+    }
+    return _name.equals(((ServiceOrServiceGroupReference) o).getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return _name.hashCode();
   }
 
   /** Return the name of the referenced Service or ServiceGroup */
   @Override
+  @Nonnull
   public String getName() {
     return _name;
   }
@@ -51,5 +68,5 @@ public class ServiceOrServiceGroupReference
     }
   }
 
-  private final String _name;
+  @Nonnull private final String _name;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceOrServiceGroupReference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceOrServiceGroupReference.java
@@ -21,6 +21,7 @@ public class ServiceOrServiceGroupReference
   }
 
   /** Return the name of the referenced Service or ServiceGroup */
+  @Override
   public String getName() {
     return _name;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
@@ -422,6 +422,10 @@ public class PaloAltoSecurityRuleTest {
     }
   }
 
+  /**
+   * Test that trace elements contain structure data pointing to structures in the correct
+   * namespace.
+   */
   @Test
   public void testPanoramaRulebaseTracing() throws IOException {
     String hostname = "panorama-rulebase-tracing";
@@ -447,8 +451,8 @@ public class PaloAltoSecurityRuleTest {
                 c.getIpSpaces(),
                 c.getIpSpaceMetadata());
 
-    // TODO fix shared vs panorama...
     {
+      // Shared address object and service
       List<TraceTree> traces = trace.apply(iface1, rule1Flow);
       assertThat(
           traces,
@@ -466,6 +470,7 @@ public class PaloAltoSecurityRuleTest {
                   isTraceTree(matchServiceTraceElement()))));
     }
     {
+      // Device-group address object and service
       List<TraceTree> traces = trace.apply(iface1, rule2Flow);
       assertThat(
           traces,
@@ -483,6 +488,7 @@ public class PaloAltoSecurityRuleTest {
                   isTraceTree(matchServiceTraceElement()))));
     }
     {
+      // Shared application-group
       List<TraceTree> traces = trace.apply(iface1, rule3Flow);
       assertThat(
           traces,
@@ -501,6 +507,7 @@ public class PaloAltoSecurityRuleTest {
                               "app_group1", SHARED_VSYS_NAME, filename))))));
     }
     {
+      // Device-group application-group
       List<TraceTree> traces = trace.apply(iface1, rule4Flow);
       assertThat(
           traces,

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-namespace
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-namespace
@@ -1,0 +1,37 @@
+set deviceconfig system hostname panorama-namespace
+#
+#
+#
+# Panorama configuration
+#
+set shared address ADDRESS1 ip-netmask 192.168.1.1
+set shared service SERVICE1 protocol tcp port 1001
+set shared application-group APPGROUP1 members ping
+#
+#
+#
+# Managed-device configuration
+#
+set device-group DG1 description "test device-group 1"
+set device-group DG1 devices 00000001
+set device-group DG1 address ADDRESS2 ip-netmask 192.168.1.2
+set device-group DG1 service SERVICE2 protocol tcp port 1002
+set device-group DG1 application-group APPGROUP2 members icmp
+set device-group DG1 pre-rulebase security rules PRE_RULE_DG to any
+set device-group DG1 pre-rulebase security rules PRE_RULE_DG from any
+set device-group DG1 pre-rulebase security rules PRE_RULE_DG source [ ADDRESS1 ADDRESS2 ]
+set device-group DG1 pre-rulebase security rules PRE_RULE_DG destination any
+set device-group DG1 pre-rulebase security rules PRE_RULE_DG application [ APPGROUP1 APPGROUP2 ]
+set device-group DG1 pre-rulebase security rules PRE_RULE_DG service [ SERVICE1 SERVICE2 ]
+set device-group DG1 pre-rulebase security rules PRE_RULE_DG action allow
+#
+# Network configuration required to make device 00000001 allow traffic through
+set template T1 config devices localhost.localdomain vsys vsys1 zone Z1 network layer3 ethernet1/1
+set template T1 config devices localhost.localdomain vsys vsys1 zone Z2 network layer3 ethernet1/2
+set template T1 config devices localhost.localdomain vsys vsys1 import network interface [ ethernet1/1 ethernet1/2 ]
+set template T1 config devices localhost.localdomain network interface ethernet ethernet1/1 layer3 ip 10.0.1.1/24
+set template T1 config devices localhost.localdomain network interface ethernet ethernet1/2 layer3 ip 10.0.2.1/24
+set template T1 config devices localhost.localdomain network virtual-router default interface [ ethernet1/1 ethernet1/2 ]
+set template-stack TS1 templates T1
+set template-stack TS1 devices 00000001
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-rulebase-tracing
@@ -1,0 +1,65 @@
+set deviceconfig system hostname panorama-rulebase-tracing
+#
+#
+#
+# Panorama configuration
+#
+set shared address addr1 ip-netmask 1.1.1.10
+set shared service service1 protocol tcp port 1
+set shared application-group app_group1 members dns
+# Managed-device configuration
+#
+set device-group DG1 description "test device-group 1"
+set device-group DG1 devices 00000001
+set device-group DG1 address addr2 ip-netmask 1.1.4.10
+set device-group DG1 service service2 protocol tcp port 2
+set device-group DG1 application-group app_group2 members bgp
+#
+# Network configuration required to make device 00000001 allow traffic through
+set template T1 config devices localhost.localdomain vsys vsys1 zone z1 network layer3 ethernet1/1
+set template T1 config devices localhost.localdomain vsys vsys1 zone z2 network layer3 ethernet1/4
+set template T1 config devices localhost.localdomain vsys vsys1 import network interface [ ethernet1/1 ethernet1/4 ]
+set template T1 config devices localhost.localdomain network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
+set template T1 config devices localhost.localdomain network interface ethernet ethernet1/4 layer3 ip 1.1.4.1/24
+set template T1 config devices localhost.localdomain network virtual-router default interface [ ethernet1/1 ethernet1/4 ]
+set template-stack TS1 templates T1
+set template-stack TS1 devices 00000001
+#
+
+
+set device-group DG1 pre-rulebase security rules RULE1 from any
+set device-group DG1 pre-rulebase security rules RULE1 to any
+set device-group DG1 pre-rulebase security rules RULE1 source addr1
+set device-group DG1 pre-rulebase security rules RULE1 source-user any
+set device-group DG1 pre-rulebase security rules RULE1 destination any
+set device-group DG1 pre-rulebase security rules RULE1 service service1
+set device-group DG1 pre-rulebase security rules RULE1 application any
+set device-group DG1 pre-rulebase security rules RULE1 action deny
+
+set device-group DG1 pre-rulebase security rules RULE2 from any
+set device-group DG1 pre-rulebase security rules RULE2 to any
+set device-group DG1 pre-rulebase security rules RULE2 source addr2
+set device-group DG1 pre-rulebase security rules RULE2 source-user any
+set device-group DG1 pre-rulebase security rules RULE2 destination any
+set device-group DG1 pre-rulebase security rules RULE2 service service2
+set device-group DG1 pre-rulebase security rules RULE2 application any
+set device-group DG1 pre-rulebase security rules RULE2 action deny
+
+set device-group DG1 pre-rulebase security rules RULE3 from any
+set device-group DG1 pre-rulebase security rules RULE3 to any
+set device-group DG1 pre-rulebase security rules RULE3 source any
+set device-group DG1 pre-rulebase security rules RULE3 source-user any
+set device-group DG1 pre-rulebase security rules RULE3 destination any
+set device-group DG1 pre-rulebase security rules RULE3 service application-default
+set device-group DG1 pre-rulebase security rules RULE3 application app_group1
+set device-group DG1 pre-rulebase security rules RULE3 action allow
+
+set device-group DG1 pre-rulebase security rules RULE4 from any
+set device-group DG1 pre-rulebase security rules RULE4 to any
+set device-group DG1 pre-rulebase security rules RULE4 source any
+set device-group DG1 pre-rulebase security rules RULE4 source-user any
+set device-group DG1 pre-rulebase security rules RULE4 destination any
+set device-group DG1 pre-rulebase security rules RULE4 service application-default
+set device-group DG1 pre-rulebase security rules RULE4 application app_group2
+set device-group DG1 pre-rulebase security rules RULE4 action allow
+

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-rulebase-tracing
@@ -7,6 +7,9 @@ set deviceconfig system hostname panorama-rulebase-tracing
 set shared address addr1 ip-netmask 1.1.1.10
 set shared service service1 protocol tcp port 1
 set shared application-group app_group1 members dns
+#
+#
+#
 # Managed-device configuration
 #
 set device-group DG1 description "test device-group 1"


### PR DESCRIPTION
* Update security rule conversion to permit references to shared and panorama applications and services
* Split up panorama and shared objects in VS representation (rather than putting all objects in panorama)
* Change ordering of shared and panorama data in many places to prefer panorama
  * (Not really an issue until this PR split panorama and shared objects)

