### PR TITLE
FRR: Remove private AS support

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrLexer.g4
@@ -396,6 +396,8 @@ REDISTRIBUTE: 'redistribute';
 
 REMOTE_AS: 'remote-as';
 
+REMOVE_PRIVATE_AS: 'remove-private-AS';
+
 REPLACE_AS: 'replace-as';
 
 RIP: 'rip';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/Frr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/Frr_bgp.g4
@@ -405,6 +405,7 @@ sbafi_neighbor
   | sbafin_allowas_in
   | sbafin_default_originate
   | sbafin_next_hop_self
+  | sbafin_remove_private_as
   | sbafin_route_reflector_client
   | sbafin_send_community
   | sbafin_soft_reconfiguration
@@ -449,6 +450,12 @@ sbafin_next_hop_self
 :
   NEXT_HOP_SELF (FORCE | ALL)? NEWLINE
 ;
+
+sbafin_remove_private_as
+:
+  REMOVE_PRIVATE_AS (ALL REPLACE_AS?)? NEWLINE
+;
+
 
 sbafin_route_reflector_client
 :

--- a/projects/batfish/src/main/java/org/batfish/grammar/frr/FrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/frr/FrrConfigurationBuilder.java
@@ -150,6 +150,7 @@ import org.batfish.grammar.frr.FrrParser.Sbafin_activateContext;
 import org.batfish.grammar.frr.FrrParser.Sbafin_allowas_inContext;
 import org.batfish.grammar.frr.FrrParser.Sbafin_default_originateContext;
 import org.batfish.grammar.frr.FrrParser.Sbafin_next_hop_selfContext;
+import org.batfish.grammar.frr.FrrParser.Sbafin_remove_private_asContext;
 import org.batfish.grammar.frr.FrrParser.Sbafin_route_mapContext;
 import org.batfish.grammar.frr.FrrParser.Sbafin_route_reflector_clientContext;
 import org.batfish.grammar.frr.FrrParser.Sbafino_neighborContext;
@@ -204,6 +205,7 @@ import org.batfish.representation.cumulus.BgpL2vpnEvpnAddressFamily;
 import org.batfish.representation.cumulus.BgpNeighbor;
 import org.batfish.representation.cumulus.BgpNeighbor.RemoteAs;
 import org.batfish.representation.cumulus.BgpNeighborIpv4UnicastAddressFamily;
+import org.batfish.representation.cumulus.BgpNeighborIpv4UnicastAddressFamily.RemovePrivateAsMode;
 import org.batfish.representation.cumulus.BgpNeighborL2vpnEvpnAddressFamily;
 import org.batfish.representation.cumulus.BgpNeighborSourceAddress;
 import org.batfish.representation.cumulus.BgpNeighborSourceInterface;
@@ -1124,6 +1126,21 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     // http://docs.frrouting.org/en/latest/bgp.html#clicmd-[no]neighborPEERnext-hop-self[all].
     if (ctx.FORCE() != null || ctx.ALL() != null) {
       _currentBgpNeighborIpv4UnicastAddressFamily.setNextHopSelfAll(true);
+    }
+  }
+
+  @Override
+  public void exitSbafin_remove_private_as(Sbafin_remove_private_asContext ctx) {
+    if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
+      return;
+    }
+    if (ctx.REPLACE_AS() != null) {
+      _currentBgpNeighborIpv4UnicastAddressFamily.setRemovePrivateAsMode(
+          RemovePrivateAsMode.REPLACE_AS);
+    } else if (ctx.ALL() != null) {
+      _currentBgpNeighborIpv4UnicastAddressFamily.setRemovePrivateAsMode(RemovePrivateAsMode.ALL);
+    } else {
+      _currentBgpNeighborIpv4UnicastAddressFamily.setRemovePrivateAsMode(RemovePrivateAsMode.BASIC);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpNeighborIpv4UnicastAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpNeighborIpv4UnicastAddressFamily.java
@@ -6,9 +6,18 @@ import javax.annotation.Nullable;
 
 /** IPv4 unicast BGP configuration for a neighbor (or peer group) */
 public class BgpNeighborIpv4UnicastAddressFamily implements Serializable {
+
+  public enum RemovePrivateAsMode {
+    NONE,
+    BASIC,
+    ALL,
+    REPLACE_AS,
+  }
+
   @Nullable private Boolean _activated;
   @Nullable private Integer _allowAsIn;
   @Nullable private Boolean _defaultOriginate;
+  @Nullable private RemovePrivateAsMode _removePrivateAsMode;
   @Nullable private Boolean _routeReflectorClient;
   @Nullable private Boolean _nextHopSelf;
   @Nullable private Boolean _nextHopSelfAll;
@@ -23,6 +32,14 @@ public class BgpNeighborIpv4UnicastAddressFamily implements Serializable {
 
   public void setActivated(@Nullable Boolean activated) {
     _activated = activated;
+  }
+
+  public @Nullable RemovePrivateAsMode getRemovePrivateAsMode() {
+    return _removePrivateAsMode;
+  }
+
+  public void setRemovePrivateAsMode(RemovePrivateAsMode removePrivateAsMode) {
+    _removePrivateAsMode = removePrivateAsMode;
   }
 
   /** Whether the neighbor is a route reflector client */
@@ -65,6 +82,10 @@ public class BgpNeighborIpv4UnicastAddressFamily implements Serializable {
 
     if (_defaultOriginate == null) {
       _defaultOriginate = other.getDefaultOriginate();
+    }
+
+    if (_removePrivateAsMode == null) {
+      _removePrivateAsMode = other.getRemovePrivateAsMode();
     }
 
     if (_routeReflectorClient == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -17,6 +17,7 @@ import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.bgp.VniConfig.importRtPatternForAnyAs;
 import static org.batfish.datamodel.routing_policy.Common.generateSuppressionPolicy;
 import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
+import static org.batfish.datamodel.routing_policy.statement.Statements.RemovePrivateAs;
 import static org.batfish.representation.cumulus.BgpProcess.BGP_UNNUMBERED_IP;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.CUMULUS_CLAG_DOMAIN_ID;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.LOOPBACK_INTERFACE_NAME;
@@ -136,6 +137,7 @@ import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.datamodel.vxlan.Vni;
+import org.batfish.representation.cumulus.BgpNeighborIpv4UnicastAddressFamily.RemovePrivateAsMode;
 import org.batfish.vendor.VendorStructureId;
 
 /** Utilities that convert Cumulus-specific representations to vendor-independent model. */
@@ -666,6 +668,15 @@ public final class CumulusConversions {
               ImmutableList.of()));
 
       peerExportPolicy.addStatement(REJECT_DEFAULT_ROUTE);
+    }
+
+    // remove private as if set
+    // TODO(handle different types of RemovePrivateAs)
+    if (neighbor.getIpv4UnicastAddressFamily() != null
+        && neighbor.getIpv4UnicastAddressFamily().getRemovePrivateAsMode() != null
+        && neighbor.getIpv4UnicastAddressFamily().getRemovePrivateAsMode()
+            != RemovePrivateAsMode.NONE) {
+      peerExportPolicy.addStatement(RemovePrivateAs.toStaticStatement());
     }
 
     BooleanExpr peerExportConditions = computePeerExportConditions(neighbor, bgpVrf);

--- a/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
@@ -103,6 +103,7 @@ import org.batfish.representation.cumulus.BgpInterfaceNeighbor;
 import org.batfish.representation.cumulus.BgpIpNeighbor;
 import org.batfish.representation.cumulus.BgpNeighbor;
 import org.batfish.representation.cumulus.BgpNeighbor.RemoteAs;
+import org.batfish.representation.cumulus.BgpNeighborIpv4UnicastAddressFamily.RemovePrivateAsMode;
 import org.batfish.representation.cumulus.BgpNeighborSourceAddress;
 import org.batfish.representation.cumulus.BgpNeighborSourceInterface;
 import org.batfish.representation.cumulus.BgpNetwork;
@@ -785,6 +786,44 @@ public class FrrGrammarTest {
                     .setAdmin(20)
                     .setLocalPreference(100)
                     .build())));
+  }
+
+  @Test
+  public void testBgpAddressFamilyNeighborRemovePrivateAs() {
+    parseLines(
+        "router bgp 1",
+        "  neighbor N1 interface description N",
+        "  neighbor N2 interface description N",
+        "  neighbor N3 interface description N",
+        "  address-family ipv4 unicast",
+        "    neighbor N1 remove-private-AS",
+        "    neighbor N2 remove-private-AS all",
+        "    neighbor N3 remove-private-AS all replace-as",
+        "  exit-address-family");
+    assertThat(
+        _frr.getBgpProcess()
+            .getDefaultVrf()
+            .getNeighbors()
+            .get("N1")
+            .getIpv4UnicastAddressFamily()
+            .getRemovePrivateAsMode(),
+        equalTo(RemovePrivateAsMode.BASIC));
+    assertThat(
+        _frr.getBgpProcess()
+            .getDefaultVrf()
+            .getNeighbors()
+            .get("N2")
+            .getIpv4UnicastAddressFamily()
+            .getRemovePrivateAsMode(),
+        equalTo(RemovePrivateAsMode.ALL));
+    assertThat(
+        _frr.getBgpProcess()
+            .getDefaultVrf()
+            .getNeighbors()
+            .get("N3")
+            .getIpv4UnicastAddressFamily()
+            .getRemovePrivateAsMode(),
+        equalTo(RemovePrivateAsMode.REPLACE_AS));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/BgpNeighborIpv4UnicastAddressFamilyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/BgpNeighborIpv4UnicastAddressFamilyTest.java
@@ -4,9 +4,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.batfish.representation.cumulus.BgpNeighborIpv4UnicastAddressFamily.RemovePrivateAsMode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,6 +25,7 @@ public class BgpNeighborIpv4UnicastAddressFamilyTest {
     _withSettings.setActivated(true);
     _withSettings.setAllowAsIn(5);
     _withSettings.setDefaultOriginate(true);
+    _withSettings.setRemovePrivateAsMode(RemovePrivateAsMode.REPLACE_AS);
     _withSettings.setRouteReflectorClient(false);
   }
 
@@ -33,6 +36,7 @@ public class BgpNeighborIpv4UnicastAddressFamilyTest {
     assertTrue(_empty.getActivated());
     assertEquals(_empty.getAllowAsIn().intValue(), 5);
     assertTrue(_empty.getDefaultOriginate());
+    assertEquals(_empty.getRemovePrivateAsMode(), RemovePrivateAsMode.REPLACE_AS);
     assertFalse(_empty.getRouteReflectorClient());
   }
 
@@ -43,6 +47,7 @@ public class BgpNeighborIpv4UnicastAddressFamilyTest {
     assertThat(_empty.getActivated(), nullValue());
     assertThat(_empty.getAllowAsIn(), nullValue());
     assertThat(_empty.getDefaultOriginate(), nullValue());
+    assertNull(_empty.getRemovePrivateAsMode());
     assertThat(_empty.getRouteReflectorClient(), nullValue());
   }
 
@@ -53,6 +58,8 @@ public class BgpNeighborIpv4UnicastAddressFamilyTest {
     assertThat(_withSettings.getActivated(), equalTo(_withSettings.getActivated()));
     assertThat(_withSettings.getAllowAsIn(), equalTo(_withSettings.getAllowAsIn()));
     assertThat(_withSettings.getDefaultOriginate(), equalTo(_withSettings.getDefaultOriginate()));
+    assertThat(
+        _withSettings.getRemovePrivateAsMode(), equalTo(_withSettings.getRemovePrivateAsMode()));
     assertThat(
         _withSettings.getRouteReflectorClient(), equalTo(_withSettings.getRouteReflectorClient()));
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -728,8 +728,6 @@ public final class CumulusConversionsTest {
     org.batfish.datamodel.BgpProcess newProc =
         org.batfish.datamodel.BgpProcess.testBgpProcess(Ip.parse("10.0.0.1"));
 
-    CumulusConcatenatedConfiguration vsConfig = new CumulusConcatenatedConfiguration();
-
     {
       // remove private as is not set
       Configuration viConfig =
@@ -739,7 +737,8 @@ public final class CumulusConversionsTest {
 
       generateBgpCommonPeerConfig(
           viConfig,
-          vsConfig,
+          _oob,
+          _frr,
           neighbor,
           10000L,
           new BgpVrf("vrf"),
@@ -766,7 +765,8 @@ public final class CumulusConversionsTest {
 
       generateBgpCommonPeerConfig(
           viConfig,
-          vsConfig,
+          _oob,
+          _frr,
           neighbor,
           10000L,
           new BgpVrf("vrf"),

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -16,6 +16,7 @@ import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
 import static org.batfish.datamodel.routing_policy.Common.SUMMARY_ONLY_SUPPRESSION_POLICY_NAME;
 import static org.batfish.datamodel.routing_policy.statement.Statements.ExitAccept;
+import static org.batfish.datamodel.routing_policy.statement.Statements.RemovePrivateAs;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.LOOPBACK_INTERFACE_NAME;
 import static org.batfish.representation.cumulus.CumulusConversions.DEFAULT_MAX_MED;
 import static org.batfish.representation.cumulus.CumulusConversions.GENERATED_DEFAULT_ROUTE;
@@ -128,6 +129,7 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.representation.cumulus.BgpNeighbor.RemoteAs;
+import org.batfish.representation.cumulus.BgpNeighborIpv4UnicastAddressFamily.RemovePrivateAsMode;
 import org.batfish.vendor.VendorStructureId;
 import org.junit.Before;
 import org.junit.Test;
@@ -712,6 +714,74 @@ public final class CumulusConversionsTest {
             .getStatements()
             .get(1),
         equalTo(REJECT_DEFAULT_ROUTE));
+  }
+
+  @Test
+  public void testGenerateBgpCommonPeerConfig_removePrivateAs() {
+    Ip peerIp = Ip.parse("10.0.0.2");
+    BgpIpNeighbor neighbor = new BgpIpNeighbor("BgpNeighbor", peerIp);
+    neighbor.setRemoteAs(RemoteAs.internal());
+    BgpNeighborIpv4UnicastAddressFamily ipv4UnicastAddressFamily =
+        new BgpNeighborIpv4UnicastAddressFamily();
+    neighbor.setIpv4UnicastAddressFamily(ipv4UnicastAddressFamily);
+
+    org.batfish.datamodel.BgpProcess newProc =
+        org.batfish.datamodel.BgpProcess.testBgpProcess(Ip.parse("10.0.0.1"));
+
+    CumulusConcatenatedConfiguration vsConfig = new CumulusConcatenatedConfiguration();
+
+    {
+      // remove private as is not set
+      Configuration viConfig =
+          _nf.configurationBuilder()
+              .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED)
+              .build();
+
+      generateBgpCommonPeerConfig(
+          viConfig,
+          vsConfig,
+          neighbor,
+          10000L,
+          new BgpVrf("vrf"),
+          newProc,
+          BgpActivePeerConfig.builder().setPeerAddress(peerIp),
+          new Warnings());
+
+      assertTrue(
+          viConfig
+              .getRoutingPolicies()
+              .get(generatedBgpPeerExportPolicyName("vrf", neighbor.getName()))
+              .getStatements()
+              .stream()
+              .noneMatch(s -> s.equals(RemovePrivateAs.toStaticStatement())));
+    }
+    {
+      // remove private as is set
+      ipv4UnicastAddressFamily.setRemovePrivateAsMode(RemovePrivateAsMode.BASIC);
+
+      Configuration viConfig =
+          _nf.configurationBuilder()
+              .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED)
+              .build();
+
+      generateBgpCommonPeerConfig(
+          viConfig,
+          vsConfig,
+          neighbor,
+          10000L,
+          new BgpVrf("vrf"),
+          newProc,
+          BgpActivePeerConfig.builder().setPeerAddress(peerIp),
+          new Warnings());
+
+      assertTrue(
+          viConfig
+              .getRoutingPolicies()
+              .get(generatedBgpPeerExportPolicyName("vrf", neighbor.getName()))
+              .getStatements()
+              .stream()
+              .anyMatch(s -> s.equals(RemovePrivateAs.toStaticStatement())));
+    }
   }
 
   @Test


### PR DESCRIPTION
Fixes #7679 

Added at `router bgp 1` -> `address-family` -> `neighbor ... remove-private-AS`