### PR TITLE
FRR: Make `allowas-in <num>` to be optional

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/Frr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/Frr_bgp.g4
@@ -437,7 +437,7 @@ sbafin_activate
 
 sbafin_allowas_in
 :
-  ALLOWAS_IN count = UINT8 NEWLINE
+  ALLOWAS_IN (count = UINT8)? NEWLINE
 ;
 
 sbafin_default_originate

--- a/projects/batfish/src/main/java/org/batfish/grammar/frr/FrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/frr/FrrConfigurationBuilder.java
@@ -1097,7 +1097,14 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
       // TODO: remove this silent ignore from here and other places
       return;
     }
-    _currentBgpNeighborIpv4UnicastAddressFamily.setAllowAsIn(Integer.parseInt(ctx.count.getText()));
+    if (ctx.count != null) {
+      _currentBgpNeighborIpv4UnicastAddressFamily.setAllowAsIn(
+          Integer.parseInt(ctx.count.getText()));
+    } else {
+      // If `allowas-in <num>` <num> is ommited, then
+      // use a default value which is currently 3 in FRR.
+      _currentBgpNeighborIpv4UnicastAddressFamily.setAllowAsIn(3);
+    }
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
@@ -667,6 +667,24 @@ public class FrrGrammarTest {
   }
 
   @Test
+  public void testBgpAddressFamilyNeighborAllowAsInDefault() {
+    parseLines(
+        "router bgp 1",
+        "neighbor N interface description N",
+        "address-family ipv4 unicast",
+        "neighbor N allowas-in",
+        "exit-address-family");
+    assertThat(
+        _frr.getBgpProcess()
+            .getDefaultVrf()
+            .getNeighbors()
+            .get("N")
+            .getIpv4UnicastAddressFamily()
+            .getAllowAsIn(),
+        equalTo(3));
+  }
+
+  @Test
   public void testBgpAddressFamilyNeighborDefaultOriginate_parsing() {
     parseLines(
         "router bgp 1",


### PR DESCRIPTION
FRR accepts this command without a number as well.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Closes https://github.com/batfish/batfish/issues/7680