### PR TITLE
validation for NODE_NAME variable type

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/InputValidationUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/InputValidationUtils.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.answers.AutoCompleteUtils.autoCompleteSource
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.CompletionMetadata;
@@ -140,6 +141,8 @@ public final class InputValidationUtils {
             completionMetadata,
             nodeRolesData,
             referenceLibrary);
+      case NODE_NAME:
+        return validateNodeName(query, completionMetadata.getNodes().keySet());
       case NODE_SPEC:
         return ParboiledInputValidator.validate(
             Grammar.NODE_SPECIFIER, query, completionMetadata, nodeRolesData, referenceLibrary);
@@ -275,6 +278,16 @@ public final class InputValidationUtils {
       return new InputValidationNotes(Validity.VALID, pfx.toString());
     } catch (Exception e) {
       return new InputValidationNotes(Validity.INVALID, e.getMessage());
+    }
+  }
+
+  @VisibleForTesting
+  static InputValidationNotes validateNodeName(String query, Set<String> snapshotHostnames) {
+    // TODO: distinguish between no-match and syntactically invalid queries
+    if (snapshotHostnames.contains(query.toLowerCase())) {
+      return new InputValidationNotes(Validity.VALID, query);
+    } else {
+      return new InputValidationNotes(Validity.NO_MATCH, "");
     }
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/InputValidationUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/InputValidationUtilsTest.java
@@ -260,4 +260,38 @@ public class InputValidationUtilsTest {
     assertEquals(
         Validity.INVALID, validateQuery("icmp", Type.SINGLE_APPLICATION_SPEC).getValidity());
   }
+
+  @Test
+  public void testNodeName() {
+    CompletionMetadata completionMetadata =
+        CompletionMetadata.builder().setNodes(ImmutableSet.of("n1")).build();
+
+    // node exists --> VALID
+    {
+      InputValidationNotes result =
+          InputValidationUtils.validate(
+              Type.NODE_NAME, "n1", completionMetadata, emptyNodeRolesData, emptyReferenceLibrary);
+      assertEquals(Validity.VALID, result.getValidity());
+    }
+
+    // check is case-insensitive
+    {
+      InputValidationNotes result =
+          InputValidationUtils.validate(
+              Type.NODE_NAME, "N1", completionMetadata, emptyNodeRolesData, emptyReferenceLibrary);
+      assertEquals(Validity.VALID, result.getValidity());
+    }
+
+    // node does not exist --> NO_MATCH
+    {
+      InputValidationNotes result =
+          InputValidationUtils.validate(
+              Type.NODE_NAME,
+              "asdf",
+              completionMetadata,
+              emptyNodeRolesData,
+              emptyReferenceLibrary);
+      assertEquals(Validity.NO_MATCH, result.getValidity());
+    }
+  }
 }


### PR DESCRIPTION
Previously, all queries for NODE_NAME were considered VALID. Now only matching names are valid, all other queries are NO_MATCH. We could/should distinguish between NO_MATCH and INVALID, but punting on that for now.