### PR TITLE
CumulusInterfaces: Make address list non-null

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -440,12 +440,10 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
     viIface.setDescription(iface.getDescription());
 
     InterfaceAddress primaryAdress =
-        (iface.getAddresses() == null || iface.getAddresses().isEmpty())
-            ? null
-            : iface.getAddresses().get(0);
+        iface.getAddresses().isEmpty() ? null : iface.getAddresses().get(0);
 
     ImmutableSet.Builder<InterfaceAddress> allAddresses = ImmutableSet.builder();
-    allAddresses.addAll(firstNonNull(iface.getAddresses(), ImmutableList.of()));
+    allAddresses.addAll(iface.getAddresses());
     firstNonNull(iface.getAddressVirtuals(), ImmutableMap.<MacAddress, Set<InterfaceAddress>>of())
         .values()
         .forEach(allAddresses::addAll);
@@ -549,7 +547,7 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
   void populateCommonInterfaceProperties(
       InterfacesInterface vsIface, org.batfish.datamodel.Interface viIface) {
     // addresses
-    if (vsIface.getAddresses() != null && !vsIface.getAddresses().isEmpty()) {
+    if (!vsIface.getAddresses().isEmpty()) {
       List<ConcreteInterfaceAddress> addresses = vsIface.getAddresses();
       ImmutableList.Builder<ConcreteInterfaceAddress> ownedAddressesBuilder =
           ImmutableList.builder();
@@ -857,7 +855,7 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
   }
 
   @Override
-  public List<ConcreteInterfaceAddress> getInterfaceAddresses(String ifaceName) {
+  public @Nonnull List<ConcreteInterfaceAddress> getInterfaceAddresses(String ifaceName) {
     checkArgument(
         _interfacesConfiguration.getInterfaces().containsKey(ifaceName),
         "Unknown interface " + ifaceName);

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -1408,8 +1408,7 @@ public final class CumulusConversions {
     // use ImmutableSet to preserve order and remove duplicates
     ImmutableSet.Builder<ConcreteInterfaceAddress> addressesBuilder = ImmutableSet.builder();
     if (oobConfig.hasInterface(ifaceName)) {
-      Optional.ofNullable(oobConfig.getInterfaceAddresses(ifaceName))
-          .ifPresent(addressesBuilder::addAll);
+      addressesBuilder.addAll(oobConfig.getInterfaceAddresses(ifaceName));
     }
     Optional.ofNullable(frrConfig.getInterfaces().get(ifaceName))
         .map(FrrInterface::getIpAddresses)

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfacesInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfacesInterface.java
@@ -34,7 +34,7 @@ import org.batfish.datamodel.MacAddress;
 @ParametersAreNonnullByDefault
 public final class InterfacesInterface implements Serializable {
 
-  private @Nullable List<ConcreteInterfaceAddress> _addresses;
+  private @Nonnull final List<ConcreteInterfaceAddress> _addresses;
   private @Nullable Map<MacAddress, Set<InterfaceAddress>> _addressVirtuals;
   private @Nullable InterfaceBridgeSettings _bridgeSettings;
   private @Nullable InterfaceClagSettings _clagSettings;
@@ -56,13 +56,11 @@ public final class InterfacesInterface implements Serializable {
 
   public InterfacesInterface(@Nonnull String name) {
     _name = name;
+    _addresses = new LinkedList<>();
     _postUpIpRoutes = ImmutableList.of();
   }
 
   public void addAddress(ConcreteInterfaceAddress address) {
-    if (_addresses == null) {
-      _addresses = new LinkedList<>();
-    }
     _addresses.add(address);
   }
 
@@ -82,7 +80,7 @@ public final class InterfacesInterface implements Serializable {
     return _clagSettings;
   }
 
-  @Nullable
+  @Nonnull
   public List<ConcreteInterfaceAddress> getAddresses() {
     return _addresses;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfacesInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfacesInterface.java
@@ -14,7 +14,6 @@ import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,7 +33,7 @@ import org.batfish.datamodel.MacAddress;
 @ParametersAreNonnullByDefault
 public final class InterfacesInterface implements Serializable {
 
-  private @Nonnull final List<ConcreteInterfaceAddress> _addresses;
+  private @Nonnull List<ConcreteInterfaceAddress> _addresses;
   private @Nullable Map<MacAddress, Set<InterfaceAddress>> _addressVirtuals;
   private @Nullable InterfaceBridgeSettings _bridgeSettings;
   private @Nullable InterfaceClagSettings _clagSettings;
@@ -56,12 +55,13 @@ public final class InterfacesInterface implements Serializable {
 
   public InterfacesInterface(@Nonnull String name) {
     _name = name;
-    _addresses = new LinkedList<>();
+    _addresses = ImmutableList.of();
     _postUpIpRoutes = ImmutableList.of();
   }
 
   public void addAddress(ConcreteInterfaceAddress address) {
-    _addresses.add(address);
+    _addresses =
+        ImmutableList.<ConcreteInterfaceAddress>builder().addAll(_addresses).add(address).build();
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/OutOfBandConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/OutOfBandConfiguration.java
@@ -2,6 +2,7 @@ package org.batfish.representation.cumulus;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 
 /**
@@ -13,6 +14,7 @@ public interface OutOfBandConfiguration {
 
   String getInterfaceVrf(String ifaceName);
 
+  @Nonnull
   List<ConcreteInterfaceAddress> getInterfaceAddresses(String ifaceName);
 
   boolean hasVrf(String vrfName);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
@@ -583,7 +583,7 @@ public class CumulusInterfacesGrammarTest {
     CumulusInterfacesConfiguration interfaces = parse(input);
     InterfacesInterface iface = interfaces.getInterfaces().get("eth0");
     assertEquals(iface.getLinkSpeed(), Integer.valueOf(10000));
-    assertNull(iface.getAddresses());
+    assertTrue(iface.getAddresses().isEmpty());
   }
 
   @Test
@@ -592,7 +592,7 @@ public class CumulusInterfacesGrammarTest {
     CumulusInterfacesConfiguration interfaces = parse(input);
     InterfacesInterface iface = interfaces.getInterfaces().get("eth0");
     assertEquals(iface.getLinkSpeed(), Integer.valueOf(10000));
-    assertNull(iface.getAddresses());
+    assertTrue(iface.getAddresses().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Earlier the address list could be null or empty (which mean the same thing), needlessly forcing a null-check everywhere.