### PR TITLE
Update OriginMechanism javadoc

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OriginMechanism.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OriginMechanism.java
@@ -9,7 +9,10 @@ public enum OriginMechanism {
   GENERATED,
   /** Learned from a peer. */
   LEARNED,
-  /** Locally originated via a {@code network} statement. */
+  /**
+   * Locally originated via a {@code network} statement on a vendor with an independent network
+   * policy.
+   */
   NETWORK,
   /**
    * Locally originated via a {@code redistribute} statement; or via export from main RIB on devices

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OriginMechanism.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OriginMechanism.java
@@ -12,8 +12,9 @@ public enum OriginMechanism {
   /** Locally originated via a {@code network} statement. */
   NETWORK,
   /**
-   * Locally originated via a {@code redistribute} statement, or via export from main RIB on devices
-   * that do so.
+   * Locally originated via a {@code redistribute} statement; or via export from main RIB on devices
+   * that do so; or via a {@code network} statement on vendors with a redistribution policy but
+   * without an independent network policy.
    */
   REDISTRIBUTE;
 }


### PR DESCRIPTION
- OK to use REDISTRIBUTE for network statements on vendors without an
independent network policy