### PR TITLE
Remove combined EVPN RIB

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -231,7 +231,7 @@ public class BgpRoutingProcessTest {
 
     // The VRF/process that the neighbor is in
     assertThat(
-        defaultProc.getUpdatesForMainRib().getRoutesStream().collect(ImmutableSet.toImmutableSet()),
+        defaultProc.getEvpnType3Routes(),
         contains(
             EvpnType3Route.builder()
                 .setVniIp(localIp)
@@ -248,11 +248,7 @@ public class BgpRoutingProcessTest {
                 .build()));
     // Sibling VRF, for vni2
     assertThat(
-        node.getVirtualRouterOrThrow("vrf2")
-            .getBgpRoutingProcess()
-            .getUpdatesForMainRib()
-            .getRoutesStream()
-            .collect(ImmutableSet.toImmutableSet()),
+        node.getVirtualRouterOrThrow("vrf2").getBgpRoutingProcess().getEvpnType3Routes(),
         contains(
             EvpnType3Route.builder()
                 .setVniIp(localIp)


### PR DESCRIPTION
No reason to have type 3 and type 5 routes in the same RIB. Also:
- Split combined EVPN delta builder into type 3 and type 5 delta builders
- Remove remaining code queueing EVPN routes for main RIB