### PR TITLE
EVPN route cleanup: nonrouting/nonforwarding always true

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
@@ -32,7 +32,7 @@ public abstract class AbstractRouteBuilder<
     return _admin;
   }
 
-  public final S setAdmin(int admin) {
+  public S setAdmin(int admin) {
     _admin = admin;
     return getThis();
   }
@@ -135,7 +135,7 @@ public abstract class AbstractRouteBuilder<
   }
 
   @Nonnull
-  public final S setNonForwarding(boolean nonForwarding) {
+  public S setNonForwarding(boolean nonForwarding) {
     _nonForwarding = nonForwarding;
     return getThis();
   }
@@ -145,7 +145,7 @@ public abstract class AbstractRouteBuilder<
   }
 
   @Nonnull
-  public final S setNonRouting(boolean nonRouting) {
+  public S setNonRouting(boolean nonRouting) {
     _nonRouting = nonRouting;
     return getThis();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnRoute.java
@@ -28,6 +28,27 @@ public abstract class EvpnRoute<B extends Builder<B, R>, R extends BgpRoute<B, R
 
     @Nullable protected RouteDistinguisher _routeDistinguisher;
 
+    @Override
+    public final B setAdmin(int admin) {
+      // All EVPN routes have admin set to an arbitrary constant value because they never compete
+      // with non-EVPN routes
+      throw new IllegalArgumentException("Cannot set admin for an EvpnRoute");
+    }
+
+    @Nonnull
+    @Override
+    public final B setNonRouting(boolean nonRouting) {
+      // All EVPN routes have nonrouting set to true (they should never enter the main RIB)
+      throw new IllegalArgumentException("Cannot set nonRouting for an EvpnRoute");
+    }
+
+    @Nonnull
+    @Override
+    public final B setNonForwarding(boolean nonForwarding) {
+      // All EVPN routes have nonforwarding set to true (they should never enter the main RIB)
+      throw new IllegalArgumentException("Cannot set nonForwarding for an EvpnRoute");
+    }
+
     @Nullable
     public RouteDistinguisher getRouteDistinguisher() {
       return _routeDistinguisher;
@@ -69,8 +90,6 @@ public abstract class EvpnRoute<B extends Builder<B, R>, R extends BgpRoute<B, R
       @Nullable RoutingProtocol srcProtocol,
       long tag,
       int weight,
-      boolean nonForwarding,
-      boolean nonRouting,
       RouteDistinguisher routeDistinguisher) {
     super(
         network,
@@ -90,8 +109,8 @@ public abstract class EvpnRoute<B extends Builder<B, R>, R extends BgpRoute<B, R
         srcProtocol,
         tag,
         weight,
-        nonForwarding,
-        nonRouting);
+        true,
+        true);
     _routeDistinguisher = routeDistinguisher;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnRoute.java
@@ -32,21 +32,21 @@ public abstract class EvpnRoute<B extends Builder<B, R>, R extends BgpRoute<B, R
     public final B setAdmin(int admin) {
       // All EVPN routes have admin set to an arbitrary constant value because they never compete
       // with non-EVPN routes
-      throw new IllegalArgumentException("Cannot set admin for an EvpnRoute");
+      throw new UnsupportedOperationException("Cannot set admin for an EvpnRoute");
     }
 
     @Nonnull
     @Override
     public final B setNonRouting(boolean nonRouting) {
       // All EVPN routes have nonrouting set to true (they should never enter the main RIB)
-      throw new IllegalArgumentException("Cannot set nonRouting for an EvpnRoute");
+      throw new UnsupportedOperationException("Cannot set nonRouting for an EvpnRoute");
     }
 
     @Nonnull
     @Override
     public final B setNonForwarding(boolean nonForwarding) {
       // All EVPN routes have nonforwarding set to true (they should never enter the main RIB)
-      throw new IllegalArgumentException("Cannot set nonForwarding for an EvpnRoute");
+      throw new UnsupportedOperationException("Cannot set nonForwarding for an EvpnRoute");
     }
 
     @Nullable

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
@@ -59,8 +59,6 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
           _macAddress,
           getMetric(),
           _nextHop,
-          getNonForwarding(),
-          getNonRouting(),
           _originatorIp,
           _originMechanism,
           _originType,
@@ -150,8 +148,6 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
         macAddress,
         med,
         NextHop.legacyConverter(nextHopInterface, nextHopIp),
-        false,
-        false,
         originatorIp,
         originMechanism,
         originType,
@@ -173,8 +169,6 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
       @Nullable MacAddress macAddress,
       long med,
       NextHop nextHop,
-      boolean nonForwarding,
-      boolean nonRouting,
       Ip originatorIp,
       OriginMechanism originMechanism,
       OriginType originType,
@@ -202,8 +196,6 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
         srcProtocol,
         tag,
         weight,
-        nonForwarding,
-        nonRouting,
         routeDistinguisher);
     _ip = ip;
     _macAddress = macAddress;
@@ -233,8 +225,6 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
   public Builder toBuilder() {
     return builder()
         .setNetwork(getNetwork())
-        .setNonRouting(getNonRouting())
-        .setNonForwarding(getNonForwarding())
         .setAsPath(_asPath)
         .setClusterList(_clusterList)
         .setCommunities(_communities)
@@ -266,8 +256,6 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
     EvpnType2Route other = (EvpnType2Route) o;
     return (_hashCode == other._hashCode || _hashCode == 0 || other._hashCode == 0)
         && Objects.equals(_network, other._network)
-        && getNonRouting() == other.getNonRouting()
-        && getNonForwarding() == other.getNonForwarding()
         && Objects.equals(_ip, other._ip)
         && _localPreference == other._localPreference
         && Objects.equals(_macAddress, other._macAddress)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
@@ -56,8 +56,6 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
           _localPreference,
           getMetric(),
           _nextHop,
-          getNonForwarding(),
-          getNonRouting(),
           _originatorIp,
           _originMechanism,
           _originType,
@@ -134,8 +132,6 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
         localPreference,
         med,
         NextHop.legacyConverter(nextHopInterface, nextHopIp),
-        false,
-        false,
         originatorIp,
         originMechanism,
         originType,
@@ -156,8 +152,6 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
       long localPreference,
       long med,
       NextHop nextHop,
-      boolean nonForwarding,
-      boolean nonRouting,
       Ip originatorIp,
       OriginMechanism originMechanism,
       OriginType originType,
@@ -186,8 +180,6 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
         srcProtocol,
         tag,
         weight,
-        nonForwarding,
-        nonRouting,
         routeDistinguisher);
     _vniIp = vniIp;
   }
@@ -211,8 +203,6 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
   public Builder toBuilder() {
     return builder()
         .setNetwork(getNetwork())
-        .setNonRouting(getNonRouting())
-        .setNonForwarding(getNonForwarding())
         .setAsPath(_asPath)
         .setClusterList(_clusterList)
         .setCommunities(_communities)
@@ -243,8 +233,6 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
     EvpnType3Route other = (EvpnType3Route) o;
     return (_hashCode == other._hashCode || _hashCode == 0 || other._hashCode == 0)
         && Objects.equals(_network, other._network)
-        && getNonRouting() == other.getNonRouting()
-        && getNonForwarding() == other.getNonForwarding()
         && _localPreference == other._localPreference
         && _med == other._med
         && _receivedFromRouteReflectorClient == other._receivedFromRouteReflectorClient

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
@@ -55,8 +55,6 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
           getMetric(),
           getNetwork(),
           _nextHop,
-          getNonForwarding(),
-          getNonRouting(),
           _originatorIp,
           _originMechanism,
           _originType,
@@ -119,8 +117,6 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         med,
         network,
         NextHop.legacyConverter(nextHopInterface, nextHopIp),
-        false,
-        false,
         originatorIp,
         originMechanism,
         originType,
@@ -141,8 +137,6 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
       long med,
       Prefix network,
       NextHop nextHop,
-      boolean nonForwarding,
-      boolean nonRouting,
       Ip originatorIp,
       OriginMechanism originMechanism,
       OriginType originType,
@@ -170,8 +164,6 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         srcProtocol,
         tag,
         weight,
-        nonForwarding,
-        nonRouting,
         routeDistinguisher);
   }
 
@@ -185,8 +177,6 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
   public Builder toBuilder() {
     return builder()
         .setNetwork(getNetwork())
-        .setNonRouting(getNonRouting())
-        .setNonForwarding(getNonForwarding())
         .setAsPath(_asPath)
         .setClusterList(_clusterList)
         .setCommunities(_communities)
@@ -216,8 +206,6 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
     EvpnType5Route other = (EvpnType5Route) o;
     return (_hashCode == other._hashCode || _hashCode == 0 || other._hashCode == 0)
         && _network.equals(other._network)
-        && getNonRouting() == other.getNonRouting()
-        && getNonForwarding() == other.getNonForwarding()
         && _localPreference == other._localPreference
         && _med == other._med
         && _receivedFromRouteReflectorClient == other._receivedFromRouteReflectorClient

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType2RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType2RouteTest.java
@@ -85,8 +85,6 @@ public class EvpnType2RouteTest {
     new EqualsTester()
         .addEqualityGroup(erb.build(), erb.build())
         .addEqualityGroup(erb.setMacAddress(MacAddress.parse("00:11:22:33:44:55")))
-        .addEqualityGroup(erb.setNonRouting(true).build())
-        .addEqualityGroup(erb.setNonForwarding(true).build())
         .addEqualityGroup(erb.setAsPath(AsPath.ofSingletonAsSets(1L, 1L)).build())
         .addEqualityGroup(erb.setClusterList(ImmutableSet.of(1L)).build())
         .addEqualityGroup(erb.setCommunities(ImmutableSet.of(StandardCommunity.of(1L))).build())

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType3RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType3RouteTest.java
@@ -81,8 +81,6 @@ public class EvpnType3RouteTest {
             .setVniIp(Ip.parse("1.1.1.1"));
     new EqualsTester()
         .addEqualityGroup(erb.build(), erb.build())
-        .addEqualityGroup(erb.setNonRouting(true).build())
-        .addEqualityGroup(erb.setNonForwarding(true).build())
         .addEqualityGroup(erb.setAsPath(AsPath.ofSingletonAsSets(1L, 1L)).build())
         .addEqualityGroup(erb.setClusterList(ImmutableSet.of(1L)).build())
         .addEqualityGroup(erb.setCommunities(ImmutableSet.of(StandardCommunity.of(1L))).build())

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType5RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType5RouteTest.java
@@ -79,8 +79,6 @@ public class EvpnType5RouteTest {
     new EqualsTester()
         .addEqualityGroup(erb.build(), erb.build())
         .addEqualityGroup(erb.setNetwork(Prefix.parse("1.1.2.0/24")).build())
-        .addEqualityGroup(erb.setNonRouting(true).build())
-        .addEqualityGroup(erb.setNonForwarding(true).build())
         .addEqualityGroup(erb.setAsPath(AsPath.ofSingletonAsSets(1L, 1L)).build())
         .addEqualityGroup(erb.setClusterList(ImmutableSet.of(1L)).build())
         .addEqualityGroup(erb.setCommunities(ImmutableSet.of(StandardCommunity.of(1L))).build())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
@@ -86,7 +86,6 @@ public class EvpnType5AristaTest {
         EvpnType5Route.builder()
             .setNetwork(prefix)
             .setRouteDistinguisher(RouteDistinguisher.from(Ip.parse("192.168.255.1"), 15004))
-            .setNonRouting(true)
             .setCommunities(ImmutableSet.of(rmCommunity, ExtendedCommunity.target(15004, 15004)))
             .setAsPath(AsPath.ofSingletonAsSets(rmAs))
             // REDISTRIBUTE rather than NETWORK because Arista has a combined network statement +

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -142,10 +142,8 @@ public class BgpRoutingProcessTest {
     Ip ip = Ip.parse("1.1.1.1");
     ExtendedCommunity routeTarget = ExtendedCommunity.target(1, 1);
     RouteDistinguisher routeDistinguisher = RouteDistinguisher.from(ip, 1);
-    int admin = 20;
     EvpnType3Route route =
         initEvpnType3Route(
-            admin,
             Layer2Vni.testBuilder()
                 .setVlan(1)
                 .setVni(10001)
@@ -159,10 +157,8 @@ public class BgpRoutingProcessTest {
         route,
         equalTo(
             EvpnType3Route.builder()
-                .setAdmin(admin)
                 .setRouteDistinguisher(routeDistinguisher)
                 .setCommunities(ImmutableSet.of(routeTarget))
-                .setNonRouting(true)
                 .setProtocol(RoutingProtocol.BGP)
                 .setOriginMechanism(OriginMechanism.GENERATED)
                 .setOriginType(OriginType.EGP)
@@ -238,11 +234,9 @@ public class BgpRoutingProcessTest {
                 .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))
                 .setCommunities(ImmutableSet.of(ExtendedCommunity.target(65500, vni)))
                 .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
-                .setNonRouting(true)
                 .setOriginMechanism(OriginMechanism.GENERATED)
                 .setOriginType(OriginType.EGP)
                 .setProtocol(RoutingProtocol.BGP)
-                .setAdmin(20)
                 .setOriginatorIp(_bgpProcess.getRouterId())
                 .setNextHop(NextHopDiscard.instance())
                 .build()));
@@ -259,11 +253,9 @@ public class BgpRoutingProcessTest {
                 .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))
                 .setCommunities(ImmutableSet.of(ExtendedCommunity.target(65500, vni2)))
                 .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
-                .setNonRouting(true)
                 .setOriginMechanism(OriginMechanism.GENERATED)
                 .setOriginType(OriginType.EGP)
                 .setProtocol(RoutingProtocol.BGP)
-                .setAdmin(20)
                 .setOriginatorIp(_bgpProcess.getRouterId())
                 .setNextHop(NextHopDiscard.instance())
                 .build()));


### PR DESCRIPTION
EVPN routes never go in main RIBs, so they should all be nonrouting and
nonforwarding by definition. Hardcoded this in EvpnRoute and disabled
the setters in the builder. Also disabled the admin setter (EvpnRoute
admin was already hardcoded).