### PR TITLE
Copy originator IP to EVPN route correctly

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -2224,7 +2224,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         .setMetric(route.getMetric())
         .setNextHopInterface(route.getNextHopInterface())
         .setNextHopIp(route.getNextHopIp())
-        .setOriginatorIp(route.getNextHopIp())
+        .setOriginatorIp(route.getOriginatorIp())
         .setOriginMechanism(route.getOriginMechanism())
         .setOriginType(route.getOriginType())
         .setProtocol(route.getProtocol())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
@@ -59,6 +59,7 @@ public class EvpnType5AristaTest {
     batfish.computeDataPlane(batfish.getSnapshot()); // compute and cache the dataPlane
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
     String vrf1 = "vrf1";
+    Ip originatorIp = Ip.parse("12.12.12.2"); // IP of BGP route originator
     Prefix prefix = Prefix.parse("12.12.12.0/24"); // prefix of the connected route in vrf1
 
     // Neither VRF should have any BGP or EVPN routes in the main RIB.
@@ -96,7 +97,7 @@ public class EvpnType5AristaTest {
             .setNextHop(NextHopDiscard.instance())
             .setSrcProtocol(RoutingProtocol.CONNECTED)
             .setReceivedFromIp(Ip.ZERO)
-            .setOriginatorIp(Ip.AUTO) // TODO Is this valid, even on the original BGP route?
+            .setOriginatorIp(originatorIp)
             .build();
     assertThat(exportedEvpnRoute, equalTo(expectedEvpnRoute));
   }


### PR DESCRIPTION
Not sure how we both missed this, but this is why the EVPN route in the test supposedly had originator IP `Ip.AUTO`.