### PR TITLE
Sonic: Scaffolding for configdb deserialization

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/BUILD
@@ -1,0 +1,26 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("@batfish//skylark:pmd_test.bzl", "pmd_test")
+
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "sonic",
+    srcs = glob(
+        ["**/*.java"],
+        exclude = ["BUILD"],
+    ),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_fasterxml_jackson_core_jackson_databind",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_apache_commons_commons_lang3",
+    ],
+)
+
+pmd_test(
+    name = "pmd",
+    lib = ":sonic",
+)

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/ConfigDb.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/ConfigDb.java
@@ -1,0 +1,78 @@
+package org.batfish.vendor.sonic;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.util.BatfishObjectMapper;
+
+/**
+ * Represents ConfigDb for Sonic nodes.
+ *
+ * <p>See https://github.com/Azure/SONiC/wiki/Configuration
+ */
+@ParametersAreNonnullByDefault
+public class ConfigDb implements Serializable {
+
+  public enum ObjectType {
+    INTERFACE
+  }
+
+  Map<ObjectType, ConfigDbObject> _objects;
+
+  public ConfigDb(Map<ObjectType, ConfigDbObject> objects) {
+    _objects = ImmutableMap.copyOf(objects);
+  }
+
+  @JsonCreator
+  private static ConfigDb create(Map<String, JsonNode> objects) throws JsonProcessingException {
+    Map<ObjectType, ConfigDbObject> objectMap = new HashMap<>();
+    for (String key : objects.keySet()) {
+      try {
+        ObjectType objectType = Enum.valueOf(ObjectType.class, key);
+        switch (objectType) {
+          case INTERFACE:
+            objectMap.put(
+                ObjectType.INTERFACE,
+                BatfishObjectMapper.ignoreUnknownMapper()
+                    .treeToValue(objects.get(key), InterfaceDb.class));
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Deserialization not implemented for " + objectType);
+        }
+      } catch (IllegalArgumentException e) {
+        // ignore -- unknown object type
+      }
+    }
+    return new ConfigDb(objectMap);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ConfigDb)) {
+      return false;
+    }
+    ConfigDb configDb = (ConfigDb) o;
+    return Objects.equals(_objects, configDb._objects);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_objects);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("objects", _objects).toString();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/ConfigDbObject.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/ConfigDbObject.java
@@ -1,0 +1,5 @@
+package org.batfish.vendor.sonic;
+
+import java.io.Serializable;
+
+public interface ConfigDbObject extends Serializable {}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/InterfaceDb.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/InterfaceDb.java
@@ -1,0 +1,97 @@
+package org.batfish.vendor.sonic;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+
+@ParametersAreNonnullByDefault
+public class InterfaceDb implements ConfigDbObject {
+
+  static class Interface {
+    private @Nullable final ConcreteInterfaceAddress _v4Address;
+
+    public Interface(@Nullable ConcreteInterfaceAddress v4address) {
+      _v4Address = v4address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Interface)) {
+        return false;
+      }
+      Interface that = (Interface) o;
+      return Objects.equals(_v4Address, that._v4Address);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_v4Address);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("v4Address", _v4Address).toString();
+    }
+  }
+
+  private @Nonnull final Map<String, Interface> _interfaces;
+
+  public InterfaceDb(Map<String, Interface> interfaces) {
+    _interfaces = ImmutableMap.copyOf(interfaces);
+  }
+
+  @JsonCreator
+  private static InterfaceDb create(Map<String, Object> interfaces) {
+    Map<String, Interface> interfaceMap = new HashMap<>();
+    for (String key : interfaces.keySet()) {
+      String[] parts = key.split("\\|");
+      interfaceMap.computeIfAbsent(parts[0], i -> new Interface(null));
+      if (parts.length == 2) {
+        try {
+          ConcreteInterfaceAddress v4Address = ConcreteInterfaceAddress.parse(parts[1]);
+          interfaceMap.put(parts[0], new Interface(v4Address));
+        } catch (IllegalArgumentException e) {
+          // ignore -- could be v6 address
+        }
+      }
+    }
+    return new InterfaceDb(interfaceMap);
+  }
+
+  @Nonnull
+  public Map<String, Interface> getInterfaces() {
+    return _interfaces;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof InterfaceDb)) {
+      return false;
+    }
+    InterfaceDb that = (InterfaceDb) o;
+    return Objects.equals(_interfaces, that._interfaces);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_interfaces);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("interfaces", _interfaces).toString();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/BUILD
@@ -1,0 +1,28 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:private"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["Test*.java"],
+    ),
+    deps = [
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/batfish/src/main/java/org/batfish/vendor/sonic",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_fasterxml_jackson_core_jackson_databind",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/ConfigDbTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/ConfigDbTest.java
@@ -1,0 +1,39 @@
+package org.batfish.vendor.sonic;
+
+import static org.batfish.vendor.sonic.ConfigDb.ObjectType.INTERFACE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class ConfigDbTest {
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input = "{ \"GARBAGE\": 1, \"INTERFACE\": {}}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, ConfigDb.class),
+        equalTo(new ConfigDb(ImmutableMap.of(INTERFACE, new InterfaceDb(ImmutableMap.of())))));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    ConfigDb obj = new ConfigDb(ImmutableMap.of());
+    assertEquals(obj, SerializationUtils.clone(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(new ConfigDb(ImmutableMap.of()), new ConfigDb(ImmutableMap.of()))
+        .addEqualityGroup(
+            new ConfigDb(ImmutableMap.of(INTERFACE, new InterfaceDb(ImmutableMap.of()))))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/InterfaceDbTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/InterfaceDbTest.java
@@ -1,0 +1,61 @@
+package org.batfish.vendor.sonic;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.vendor.sonic.InterfaceDb.Interface;
+import org.junit.Test;
+
+public class InterfaceDbTest {
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input =
+        "{"
+            + "\"Ethernet136\": {},"
+            + "\"Ethernet136|0:0:0:0:0:ffff:ac13:5d00/127\": {},"
+            + "\"Ethernet136|172.19.93.0/31\": {},"
+            + "\"Ethernet137\": {}"
+            + "}";
+    assertThat(
+        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, InterfaceDb.class),
+        equalTo(
+            new InterfaceDb(
+                ImmutableMap.of(
+                    "Ethernet136",
+                    new Interface(ConcreteInterfaceAddress.parse("172.19.93.0/31")),
+                    "Ethernet137",
+                    new Interface(null)))));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    InterfaceDb obj = new InterfaceDb(ImmutableMap.of());
+    assertEquals(obj, SerializationUtils.clone(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    InterfaceDb obj = new InterfaceDb(ImmutableMap.of());
+    new EqualsTester()
+        .addEqualityGroup(obj, new InterfaceDb(ImmutableMap.of()))
+        .addEqualityGroup(new InterfaceDb(ImmutableMap.of("iface", new Interface(null))))
+        .testEquals();
+  }
+
+  @Test
+  public void testInterfaceEquals() {
+    Interface obj = new Interface(null);
+    new EqualsTester()
+        .addEqualityGroup(obj, new Interface(null))
+        .addEqualityGroup(new Interface(ConcreteInterfaceAddress.parse("1.1.1.1/24")))
+        .testEquals();
+  }
+}


### PR DESCRIPTION
The schema is here: https://github.com/Azure/SONiC/wiki/Configuration

One trick in deserialization is that object types are identified by key names (e.g., `AAA` and `INTERFACE`), and there isn't anything in the object definition that betrays object type. So, we have decide how to deserialize based on the key name. 