### PR TITLE
Support EVPN to BGPv4 VRF leaking

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnToBgpv4VrfLeakConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnToBgpv4VrfLeakConfig.java
@@ -1,0 +1,104 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** VRF leaking config that leaks routes from a BGPv4 RIB into an EVPN RIB */
+public final class EvpnToBgpv4VrfLeakConfig implements Serializable {
+
+  /** Name of the source VRF from which to copy routes. The source VRF must have an EVPN RIB. */
+  @Nonnull
+  @JsonProperty(PROP_IMPORT_FROM_VRF)
+  public String getImportFromVrf() {
+    return _importFromVrf;
+  }
+
+  /**
+   * Name of the import policy to apply to imported routes when leaking. If {@code null} no policy
+   * is applied, all routes are allowed.
+   */
+  @Nullable
+  @JsonProperty(PROP_IMPORT_POLICY)
+  public String getImportPolicy() {
+    return _importPolicy;
+  }
+
+  public static @Nonnull Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof EvpnToBgpv4VrfLeakConfig)) {
+      return false;
+    }
+    EvpnToBgpv4VrfLeakConfig that = (EvpnToBgpv4VrfLeakConfig) o;
+    return _importFromVrf.equals(that._importFromVrf)
+        && Objects.equals(_importPolicy, that._importPolicy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_importFromVrf, _importPolicy);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(EvpnToBgpv4VrfLeakConfig.class)
+        .omitNullValues()
+        .add(PROP_IMPORT_FROM_VRF, _importFromVrf)
+        .add(PROP_IMPORT_POLICY, _importPolicy)
+        .toString();
+  }
+
+  private EvpnToBgpv4VrfLeakConfig(String importFromVrf, @Nullable String importPolicy) {
+    _importFromVrf = importFromVrf;
+    _importPolicy = importPolicy;
+  }
+
+  @JsonCreator
+  private static EvpnToBgpv4VrfLeakConfig create(
+      @Nullable @JsonProperty(PROP_IMPORT_FROM_VRF) String importFromVrf,
+      @Nullable @JsonProperty(PROP_IMPORT_POLICY) String importPolicy) {
+    return builder().setImportFromVrf(importFromVrf).setImportPolicy(importPolicy).build();
+  }
+
+  private static final String PROP_IMPORT_FROM_VRF = "importFromVrf";
+  private static final String PROP_IMPORT_POLICY = "importPolicy";
+
+  @Nonnull private final String _importFromVrf;
+  @Nullable private final String _importPolicy;
+
+  public static final class Builder {
+    public @Nonnull EvpnToBgpv4VrfLeakConfig build() {
+      checkArgument(_importFromVrf != null, "Missing %s", PROP_IMPORT_FROM_VRF);
+      return new EvpnToBgpv4VrfLeakConfig(_importFromVrf, _importPolicy);
+    }
+
+    public Builder setImportPolicy(@Nullable String importPolicy) {
+      _importPolicy = importPolicy;
+      return this;
+    }
+
+    @Nonnull
+    public Builder setImportFromVrf(@Nullable String importFromVrf) {
+      _importFromVrf = importFromVrf;
+      return this;
+    }
+
+    @Nullable private String _importPolicy;
+    @Nullable private String _importFromVrf;
+
+    private Builder() {}
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
@@ -124,6 +124,10 @@ public final class Names {
     return String.format("~BGP_PEER_IMPORT_POLICY_EVPN:%s:%s~", vrf, peer);
   }
 
+  public static String generatedEvpnToBgpv4VrfLeakPolicyName(String vrf) {
+    return String.format("~EVPN_TO_BGPV4_VRF_LEAK_POLICY:%s~", vrf);
+  }
+
   public static String generatedOspfDefaultRouteGenerationPolicyName(String vrf, String proc) {
     return String.format("~OSPF_DEFAULT_ROUTE_GENERATION_POLICY:%s:%s~", vrf, proc);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfLeakConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfLeakConfig.java
@@ -30,7 +30,10 @@ public class VrfLeakConfig implements Serializable {
   public void addBgpVrfLeakConfig(BgpVrfLeakConfig c) {
     checkArgument(_leakAsBgp, "BGP VRF leak configs cannot be configured unless leakAsBgp is set");
     _bgpVrfLeakConfigs =
-        ImmutableList.<BgpVrfLeakConfig>builder().addAll(_bgpVrfLeakConfigs).add(c).build();
+        ImmutableList.<BgpVrfLeakConfig>builderWithExpectedSize(_bgpVrfLeakConfigs.size() + 1)
+            .addAll(_bgpVrfLeakConfigs)
+            .add(c)
+            .build();
   }
 
   /** VRF leak configs describing how routes should leak from BGPv4 RIBs to EVPN RIBs. */
@@ -42,7 +45,8 @@ public class VrfLeakConfig implements Serializable {
 
   public void addBgpv4ToEvpnVrfLeakConfig(Bgpv4ToEvpnVrfLeakConfig c) {
     _bgpv4ToEvpnVrfLeakConfigs =
-        ImmutableList.<Bgpv4ToEvpnVrfLeakConfig>builder()
+        ImmutableList.<Bgpv4ToEvpnVrfLeakConfig>builderWithExpectedSize(
+                _bgpv4ToEvpnVrfLeakConfigs.size() + 1)
             .addAll(_bgpv4ToEvpnVrfLeakConfigs)
             .add(c)
             .build();
@@ -57,7 +61,8 @@ public class VrfLeakConfig implements Serializable {
 
   public void addEvpnToBgpv4VrfLeakConfig(EvpnToBgpv4VrfLeakConfig c) {
     _evpnToBgpv4VrfLeakConfigs =
-        ImmutableList.<EvpnToBgpv4VrfLeakConfig>builder()
+        ImmutableList.<EvpnToBgpv4VrfLeakConfig>builderWithExpectedSize(
+                _evpnToBgpv4VrfLeakConfigs.size() + 1)
             .addAll(_evpnToBgpv4VrfLeakConfigs)
             .add(c)
             .build();
@@ -94,7 +99,11 @@ public class VrfLeakConfig implements Serializable {
     checkArgument(
         !_leakAsBgp, "Main RIB VRF leak configs cannot be configured when leakAsBgp is set");
     _mainRibVrfLeakConfigs =
-        ImmutableList.<MainRibVrfLeakConfig>builder().addAll(_mainRibVrfLeakConfigs).add(c).build();
+        ImmutableList.<MainRibVrfLeakConfig>builderWithExpectedSize(
+                _mainRibVrfLeakConfigs.size() + 1)
+            .addAll(_mainRibVrfLeakConfigs)
+            .add(c)
+            .build();
   }
 
   public static @Nonnull Builder builder(boolean leakAsBgp) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfLeakConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfLeakConfig.java
@@ -48,6 +48,21 @@ public class VrfLeakConfig implements Serializable {
             .build();
   }
 
+  /** VRF leak configs describing how routes should leak from EVPN RIBs to BGPv4 RIBs. */
+  @JsonProperty(PROP_EVPN_TO_BGPV4_VRF_LEAK_CONFIGS)
+  @Nonnull
+  public List<EvpnToBgpv4VrfLeakConfig> getEvpnToBgpv4VrfLeakConfigs() {
+    return _evpnToBgpv4VrfLeakConfigs;
+  }
+
+  public void addEvpnToBgpv4VrfLeakConfig(EvpnToBgpv4VrfLeakConfig c) {
+    _evpnToBgpv4VrfLeakConfigs =
+        ImmutableList.<EvpnToBgpv4VrfLeakConfig>builder()
+            .addAll(_evpnToBgpv4VrfLeakConfigs)
+            .add(c)
+            .build();
+  }
+
   /**
    * Whether the node containing this leak configuration leaks routes between BGP RIBs or main RIBs.
    *
@@ -98,23 +113,29 @@ public class VrfLeakConfig implements Serializable {
     return _leakAsBgp == that._leakAsBgp
         && _bgpVrfLeakConfigs.equals(that._bgpVrfLeakConfigs)
         && _bgpv4ToEvpnVrfLeakConfigs.equals(that._bgpv4ToEvpnVrfLeakConfigs)
+        && _evpnToBgpv4VrfLeakConfigs.equals(that._evpnToBgpv4VrfLeakConfigs)
         && _mainRibVrfLeakConfigs.equals(that._mainRibVrfLeakConfigs);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        _leakAsBgp, _bgpVrfLeakConfigs, _bgpv4ToEvpnVrfLeakConfigs, _mainRibVrfLeakConfigs);
+        _leakAsBgp,
+        _bgpVrfLeakConfigs,
+        _bgpv4ToEvpnVrfLeakConfigs,
+        _evpnToBgpv4VrfLeakConfigs,
+        _mainRibVrfLeakConfigs);
   }
 
   public VrfLeakConfig(boolean leakAsBgp) {
-    this(leakAsBgp, ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+    this(leakAsBgp, ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
   }
 
   private VrfLeakConfig(
       boolean leakAsBgp,
       List<BgpVrfLeakConfig> bgpVrfLeakConfigs,
       List<Bgpv4ToEvpnVrfLeakConfig> bgpv4ToEvpnVrfLeakConfigs,
+      List<EvpnToBgpv4VrfLeakConfig> evpnToBgpv4VrfLeakConfigs,
       List<MainRibVrfLeakConfig> mainRibVrfLeakConfigs) {
     if (leakAsBgp) {
       checkArgument(
@@ -128,6 +149,7 @@ public class VrfLeakConfig implements Serializable {
     _leakAsBgp = leakAsBgp;
     _bgpVrfLeakConfigs = bgpVrfLeakConfigs;
     _bgpv4ToEvpnVrfLeakConfigs = bgpv4ToEvpnVrfLeakConfigs;
+    _evpnToBgpv4VrfLeakConfigs = evpnToBgpv4VrfLeakConfigs;
     _mainRibVrfLeakConfigs = mainRibVrfLeakConfigs;
   }
 
@@ -136,6 +158,8 @@ public class VrfLeakConfig implements Serializable {
       @Nullable @JsonProperty(PROP_BGP_VRF_LEAK_CONFIGS) List<BgpVrfLeakConfig> bgpVrfLeakConfigs,
       @Nullable @JsonProperty(PROP_BGPV4_TO_EVPN_VRF_LEAK_CONFIGS)
           List<Bgpv4ToEvpnVrfLeakConfig> bgpv4ToEvpnVrfLeakConfigs,
+      @Nullable @JsonProperty(PROP_EVPN_TO_BGPV4_VRF_LEAK_CONFIGS)
+          List<EvpnToBgpv4VrfLeakConfig> evpnToBgpv4VrfLeakConfigs,
       @Nullable @JsonProperty(PROP_LEAK_AS_BGP) Boolean leakAsBgp,
       @Nullable @JsonProperty(PROP_MAIN_RIB_VRF_LEAK_CONFIGS)
           List<MainRibVrfLeakConfig> mainRibVrfLeakConfigs) {
@@ -145,6 +169,9 @@ public class VrfLeakConfig implements Serializable {
         bgpv4ToEvpnVrfLeakConfigs == null
             ? ImmutableList.of()
             : ImmutableList.copyOf(bgpv4ToEvpnVrfLeakConfigs),
+        evpnToBgpv4VrfLeakConfigs == null
+            ? ImmutableList.of()
+            : ImmutableList.copyOf(evpnToBgpv4VrfLeakConfigs),
         mainRibVrfLeakConfigs == null
             ? ImmutableList.of()
             : ImmutableList.copyOf(mainRibVrfLeakConfigs));
@@ -152,12 +179,14 @@ public class VrfLeakConfig implements Serializable {
 
   private static final String PROP_BGP_VRF_LEAK_CONFIGS = "bgpVrfLeakConfigs";
   private static final String PROP_BGPV4_TO_EVPN_VRF_LEAK_CONFIGS = "bgpv4ToEvpnVrfLeakConfigs";
+  private static final String PROP_EVPN_TO_BGPV4_VRF_LEAK_CONFIGS = "evpnToBgpv4VrfLeakConfigs";
   private static final String PROP_LEAK_AS_BGP = "leakAsBgp";
   private static final String PROP_MAIN_RIB_VRF_LEAK_CONFIGS = "mainRibVrfLeakConfigs";
 
   private final boolean _leakAsBgp;
   private @Nonnull List<BgpVrfLeakConfig> _bgpVrfLeakConfigs;
   private @Nonnull List<Bgpv4ToEvpnVrfLeakConfig> _bgpv4ToEvpnVrfLeakConfigs;
+  private @Nonnull List<EvpnToBgpv4VrfLeakConfig> _evpnToBgpv4VrfLeakConfigs;
   private @Nonnull List<MainRibVrfLeakConfig> _mainRibVrfLeakConfigs;
 
   public static final class Builder {
@@ -175,6 +204,12 @@ public class VrfLeakConfig implements Serializable {
     }
 
     @Nonnull
+    public Builder addEvpnToBgpv4VrfLeakConfig(EvpnToBgpv4VrfLeakConfig c) {
+      _evpnToBgpv4VrfLeakConfigs.add(c);
+      return this;
+    }
+
+    @Nonnull
     public Builder addMainRibVrfLeakConfig(MainRibVrfLeakConfig c) {
       _mainRibVrfLeakConfigs.add(c);
       return this;
@@ -185,6 +220,7 @@ public class VrfLeakConfig implements Serializable {
           _leakAsBgp,
           _bgpVrfLeakConfigs.build(),
           _bgpv4ToEvpnVrfLeakConfigs.build(),
+          _evpnToBgpv4VrfLeakConfigs.build(),
           _mainRibVrfLeakConfigs.build());
     }
 
@@ -196,6 +232,8 @@ public class VrfLeakConfig implements Serializable {
     private @Nonnull ImmutableList.Builder<BgpVrfLeakConfig> _bgpVrfLeakConfigs =
         ImmutableList.builder();
     private @Nonnull ImmutableList.Builder<Bgpv4ToEvpnVrfLeakConfig> _bgpv4ToEvpnVrfLeakConfigs =
+        ImmutableList.builder();
+    private @Nonnull ImmutableList.Builder<EvpnToBgpv4VrfLeakConfig> _evpnToBgpv4VrfLeakConfigs =
         ImmutableList.builder();
     private @Nonnull ImmutableList.Builder<MainRibVrfLeakConfig> _mainRibVrfLeakConfigs =
         ImmutableList.builder();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnToBgpv4VrfLeakConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnToBgpv4VrfLeakConfigTest.java
@@ -1,0 +1,38 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class EvpnToBgpv4VrfLeakConfigTest {
+
+  @Test
+  public void testJavaSerialization() {
+    EvpnToBgpv4VrfLeakConfig val =
+        EvpnToBgpv4VrfLeakConfig.builder().setImportFromVrf("v").setImportPolicy("p").build();
+    assertThat(SerializationUtils.clone(val), equalTo(val));
+  }
+
+  @Test
+  public void testJsonSerialization() {
+    EvpnToBgpv4VrfLeakConfig val =
+        EvpnToBgpv4VrfLeakConfig.builder().setImportFromVrf("v").setImportPolicy("p").build();
+    assertThat(BatfishObjectMapper.clone(val, EvpnToBgpv4VrfLeakConfig.class), equalTo(val));
+  }
+
+  @Test
+  public void testEquals() {
+    EvpnToBgpv4VrfLeakConfig.Builder b = EvpnToBgpv4VrfLeakConfig.builder().setImportFromVrf("v1");
+    EvpnToBgpv4VrfLeakConfig val = b.build();
+    new EqualsTester()
+        .addEqualityGroup(val, b.build())
+        .addEqualityGroup(b.setImportFromVrf("v2").build())
+        .addEqualityGroup(b.setImportPolicy("p").build(), b.build())
+        .addEqualityGroup(b.setImportPolicy("p2").build())
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnToBgpv4VrfLeakConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnToBgpv4VrfLeakConfigTest.java
@@ -31,8 +31,7 @@ public class EvpnToBgpv4VrfLeakConfigTest {
     new EqualsTester()
         .addEqualityGroup(val, b.build())
         .addEqualityGroup(b.setImportFromVrf("v2").build())
-        .addEqualityGroup(b.setImportPolicy("p").build(), b.build())
-        .addEqualityGroup(b.setImportPolicy("p2").build())
+        .addEqualityGroup(b.setImportPolicy("p").build())
         .testEquals();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakConfigTest.java
@@ -24,6 +24,8 @@ public class VrfLeakConfigTest {
                   .setImportFromVrf("v")
                   .setSrcVrfRouteDistinguisher(RouteDistinguisher.from(0, 1L))
                   .build())
+          .addEvpnToBgpv4VrfLeakConfig(
+              EvpnToBgpv4VrfLeakConfig.builder().setImportFromVrf("v").build())
           .build();
   private static final VrfLeakConfig MAIN_RIB_LEAK_CONFIG =
       VrfLeakConfig.builder(false)
@@ -80,6 +82,11 @@ public class VrfLeakConfigTest {
                         .setImportFromVrf("v")
                         .setSrcVrfRouteDistinguisher(RouteDistinguisher.from(0, 1L))
                         .build())
+                .build())
+        .addEqualityGroup(
+            mainRibBuilder
+                .addEvpnToBgpv4VrfLeakConfig(
+                    EvpnToBgpv4VrfLeakConfig.builder().setImportFromVrf("v").build())
                 .build())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AnnotatedRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AnnotatedRouteMatchers.java
@@ -3,11 +3,22 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.equalTo;
 
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.matchers.AnnotatedRouteMatchersImpl.HasRoute;
 import org.batfish.datamodel.matchers.AnnotatedRouteMatchersImpl.HasSourceVrf;
+import org.hamcrest.Matcher;
 
 /** Matchers for testing {@link AnnotatedRoute} objects */
 public final class AnnotatedRouteMatchers {
+  /**
+   * Provides a matcher that matches when the supplied route matcher matches the {@link
+   * AnnotatedRoute}'s route.
+   */
+  public static @Nonnull <R extends AbstractRoute> HasRoute<R> hasRoute(
+      @Nonnull Matcher<? super R> routeMatcher) {
+    return new HasRoute<R>(routeMatcher);
+  }
 
   /**
    * Provides a matcher that matches when the supplied {@code expectedSourceVrf} is equal to the

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AnnotatedRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AnnotatedRouteMatchers.java
@@ -15,7 +15,7 @@ public final class AnnotatedRouteMatchers {
    * Provides a matcher that matches when the supplied route matcher matches the {@link
    * AnnotatedRoute}'s route.
    */
-  public static @Nonnull <R extends AbstractRoute> HasRoute<R> hasRoute(
+  public static @Nonnull <R extends AbstractRoute> Matcher<AnnotatedRoute<R>> hasRoute(
       @Nonnull Matcher<? super R> routeMatcher) {
     return new HasRoute<R>(routeMatcher);
   }
@@ -24,7 +24,8 @@ public final class AnnotatedRouteMatchers {
    * Provides a matcher that matches when the supplied {@code expectedSourceVrf} is equal to the
    * {@link AnnotatedRoute}'s source VRF.
    */
-  public static @Nonnull HasSourceVrf hasSourceVrf(@Nonnull String expectedSourceVrf) {
+  public static @Nonnull Matcher<AnnotatedRoute<?>> hasSourceVrf(
+      @Nonnull String expectedSourceVrf) {
     return new HasSourceVrf(equalTo(expectedSourceVrf));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AnnotatedRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AnnotatedRouteMatchersImpl.java
@@ -1,11 +1,24 @@
 package org.batfish.datamodel.matchers;
 
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
 final class AnnotatedRouteMatchersImpl {
+
+  static final class HasRoute<R extends AbstractRoute>
+      extends FeatureMatcher<AnnotatedRoute<R>, R> {
+    HasRoute(@Nonnull Matcher<? super R> subMatcher) {
+      super(subMatcher, "An AnnotatedRoute with route:", "route");
+    }
+
+    @Override
+    protected R featureValueOf(AnnotatedRoute<R> actual) {
+      return actual.getRoute();
+    }
+  }
 
   static final class HasSourceVrf extends FeatureMatcher<AnnotatedRoute<?>, String> {
     HasSourceVrf(@Nonnull Matcher<? super String> subMatcher) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -2293,7 +2293,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         .setMetric(route.getMetric())
         .setNextHopInterface(route.getNextHopInterface())
         .setNextHopIp(route.getNextHopIp())
-        .setOriginatorIp(route.getNextHopIp())
+        .setOriginatorIp(route.getOriginatorIp())
         .setOriginMechanism(route.getOriginMechanism())
         .setOriginType(route.getOriginType())
         .setProtocol(route.getProtocol())

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -2217,6 +2217,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   /** Convert a BGP v4 route to a EVPN type 5 route. */
   private static @Nonnull EvpnType5Route toEvpnType5Route(
       Bgpv4Route route, RouteDistinguisher rd, Set<ExtendedCommunity> rt) {
+    assert !(route.getNextHop() instanceof NextHopVrf);
     return EvpnType5Route.builder()
         .setNetwork(route.getNetwork())
         .setAsPath(route.getAsPath())
@@ -2224,8 +2225,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         .addCommunities(rt) // add route targets
         .setLocalPreference(route.getLocalPreference())
         .setMetric(route.getMetric())
-        .setNextHopInterface(route.getNextHopInterface())
-        .setNextHopIp(route.getNextHopIp())
+        .setNextHop(route.getNextHop())
         .setOriginatorIp(route.getOriginatorIp())
         .setOriginMechanism(route.getOriginMechanism())
         .setOriginType(route.getOriginType())
@@ -2285,14 +2285,14 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
 
   /** Convert an EVPN route to a BGPv4 route. */
   private static @Nonnull Bgpv4Route.Builder evpnRouteToBgpv4Route(EvpnType5Route route) {
+    assert !(route.getNextHop() instanceof NextHopVrf);
     return Bgpv4Route.builder()
         .setNetwork(route.getNetwork())
         .setAsPath(route.getAsPath())
         .setCommunities(route.getCommunities())
         .setLocalPreference(route.getLocalPreference())
         .setMetric(route.getMetric())
-        .setNextHopInterface(route.getNextHopInterface())
-        .setNextHopIp(route.getNextHopIp())
+        .setNextHop(route.getNextHop())
         .setOriginatorIp(route.getOriginatorIp())
         .setOriginMechanism(route.getOriginMechanism())
         .setOriginType(route.getOriginType())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/BUILD
@@ -19,6 +19,7 @@ junit_tests(
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol:common_testlib",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/batfish/src/main/java/org/batfish/representation/arista",
         "//projects/batfish/src/main/java/org/batfish/representation/juniper",
         "//projects/batfish/src/test/java/org/batfish/dataplane/ibdp:testlib",
         "@maven//:com_fasterxml_jackson_core_jackson_core",

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
@@ -3,10 +3,11 @@ package org.batfish.dataplane;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.OriginMechanism.REDISTRIBUTE;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.AnnotatedRouteMatchers.hasRoute;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.instanceOf;
 
 import com.google.common.collect.ImmutableSet;
@@ -36,6 +37,7 @@ import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
+import org.batfish.representation.arista.AristaConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -48,10 +50,12 @@ public class EvpnType5AristaTest {
   @Test
   public void testType5RoutePresence() throws IOException {
     /*
-    Setup: Single node containing two VRFs.
+    Setup: Single node containing three VRFs.
     - Default VRF does not redistribute anything, but has an EVPN address family configured
     - Vrf vrf1 redistributes connected and exports EVPN with route-target 15004:15004
-    Should see the local BGPv4 route in vrf1 get exported into default VRF as an EVPN route.
+    - Vrf vrf2 imports EVPN with route-target 15004:15004
+    Should see the local BGPv4 route in vrf1 get exported into default VRF as an EVPN route, and then
+    imported from the default VRF into vrf2 as a BGPv4 route.
      */
     String hostname = "evpn-type5-arista";
     Batfish batfish =
@@ -59,29 +63,54 @@ public class EvpnType5AristaTest {
     batfish.computeDataPlane(batfish.getSnapshot()); // compute and cache the dataPlane
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
     String vrf1 = "vrf1";
+    String vrf2 = "vrf2";
     Ip originatorIp = Ip.parse("12.12.12.2"); // IP of BGP route originator
     Prefix prefix = Prefix.parse("12.12.12.0/24"); // prefix of the connected route in vrf1
 
-    // Neither VRF should have any BGP or EVPN routes in the main RIB.
+    // The connected route that vrf1 redistributes into BGP should be a connected route in vrf1, an
+    // EVPN route in the default VRF (so no appearance in main RIB), and a BGPv4 route in vrf2.
     SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> ribs = dp.getRibs().get(hostname);
-    ribs.values()
-        .forEach(rib -> assertThat(rib.getRoutes(), everyItem(instanceOf(ConnectedRoute.class))));
+    assertThat(ribs.get(DEFAULT_VRF_NAME).getRoutes(prefix), empty());
+    assertThat(
+        ribs.get(vrf1).getRoutes(prefix), contains(hasRoute(instanceOf(ConnectedRoute.class))));
+    assertThat(ribs.get(vrf2).getRoutes(prefix), contains(hasRoute(instanceOf(Bgpv4Route.class))));
 
     // Route-map sets attributes of vrf1's local BGP route. They should be copied to the EVPN route
     Community rmCommunity = StandardCommunity.of(12345);
     long rmAs = 54321;
 
-    // Only vrf1 should have BGP routes; exporting EVPN should not affect default VRF's BGP RIB.
+    // vrf1 should have a local BGPv4 route due to the network statement. The default VRF should
+    // have no BGPv4 routes (exporting EVPN from vrf1 should impact default VRF's EVPN RIB only).
     Map<String, Set<Bgpv4Route>> bgpRoutes = dp.getBgpRoutes().row(hostname);
     assertThat(bgpRoutes.get(DEFAULT_VRF_NAME), empty());
     Bgpv4Route vrf1BgpRoute = Iterables.getOnlyElement(bgpRoutes.get(vrf1));
     assertThat(vrf1BgpRoute, hasPrefix(prefix));
     assertThat(vrf1BgpRoute.getCommunities(), equalTo(CommunitySet.of(rmCommunity)));
     assertThat(vrf1BgpRoute.getAsPath(), equalTo(AsPath.ofSingletonAsSets(rmAs)));
+    // vrf2 should have a BGPv4 route because it imports the EVPN route target from the default VRF.
+    Bgpv4Route vrf2BgpRoute = Iterables.getOnlyElement(bgpRoutes.get(vrf2));
+    Bgpv4Route expectedVrf2BgpRoute =
+        Bgpv4Route.builder()
+            .setNetwork(prefix)
+            .setCommunities(ImmutableSet.of(rmCommunity, ExtendedCommunity.target(15004, 15004)))
+            .setAsPath(AsPath.ofSingletonAsSets(rmAs))
+            // REDISTRIBUTE rather than NETWORK because Arista has a combined network statement +
+            // redistribution policy (a route can't be originated via both mechanisms)
+            .setOriginMechanism(REDISTRIBUTE)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHop(NextHopDiscard.instance())
+            .setSrcProtocol(RoutingProtocol.CONNECTED)
+            .setReceivedFromIp(Ip.ZERO)
+            .setOriginatorIp(originatorIp)
+            .setWeight(AristaConfiguration.DEFAULT_LOCAL_BGP_WEIGHT)
+            .build();
+    assertThat(vrf2BgpRoute, equalTo(expectedVrf2BgpRoute));
 
     // Only default VRF should have an EVPN route.
     Map<String, Set<EvpnRoute<?, ?>>> evpnRoutes = dp.getEvpnRoutes().row(hostname);
     assertThat(evpnRoutes.get(vrf1), empty());
+    assertThat(evpnRoutes.get(vrf2), empty());
     EvpnRoute<?, ?> exportedEvpnRoute = Iterables.getOnlyElement(evpnRoutes.get(DEFAULT_VRF_NAME));
     EvpnType5Route expectedEvpnRoute =
         EvpnType5Route.builder()
@@ -98,6 +127,7 @@ public class EvpnType5AristaTest {
             .setSrcProtocol(RoutingProtocol.CONNECTED)
             .setReceivedFromIp(Ip.ZERO)
             .setOriginatorIp(originatorIp)
+            .setWeight(AristaConfiguration.DEFAULT_LOCAL_BGP_WEIGHT)
             .build();
     assertThat(exportedEvpnRoute, equalTo(expectedEvpnRoute));
   }

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testconfigs/evpn-type5-arista
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testconfigs/evpn-type5-arista
@@ -55,10 +55,6 @@ route-map SET_MAP permit 10
 !
 router bgp 65002
    router-id 10.10.10.1
-   neighbor 11.11.11.6 maximum-routes 12000
-   !
-   address-family evpn
-      neighbor 11.11.11.6 activate
    !
    vrf vrf1
       rd 192.168.255.1:15004

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testconfigs/evpn-type5-arista
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testconfigs/evpn-type5-arista
@@ -17,6 +17,7 @@ vlan 130
    name vrf1
 !
 vrf instance vrf1
+vrf instance vrf2
 !
 interface Ethernet1
    no switchport
@@ -26,6 +27,11 @@ interface Ethernet2
    no switchport
    vrf vrf1
    ip address 12.12.12.2/24
+!
+interface Ethernet3
+   no switchport
+   vrf vrf2
+   ip address 13.13.13.2/24
 !
 interface Loopback1
    ip address 10.10.10.1/32
@@ -41,6 +47,7 @@ interface Vxlan1
 !
 ip routing
 ip routing vrf vrf1
+ip routing vrf vrf2
 !
 route-map SET_MAP permit 10
    set community 12345
@@ -56,8 +63,10 @@ router bgp 65002
    vrf vrf1
       rd 192.168.255.1:15004
       route-target export evpn 15004:15004
-      neighbor 12.12.12.5 remote-as 65003
-      neighbor 12.12.12.5 maximum-routes 12000
       network 12.12.12.0/24 route-map SET_MAP
+   !
+   vrf vrf2
+      rd 192.168.255.2:15004
+      route-target import evpn 15004:15004
 !
 end


### PR DESCRIPTION
Supports EVPN import route targets.

Still to do: Examine and remove infrastructure that leaks EVPN to EVPN via import route targets, which is orthogonal.