### PR TITLE
Include best routes in EVPN routes question

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -146,7 +146,7 @@ public class RoutesAnswerer extends Answerer {
                 matchingVrfsByNode,
                 network,
                 protocolSpec,
-                ImmutableSet.of(BACKUP),
+                ImmutableSet.of(BEST, BACKUP),
                 question.getPrefixMatchType()));
         rows.sort(BGP_COMPARATOR);
         break;


### PR DESCRIPTION
For some not-completely-understood reason, EVPN backup routes no longer include best routes as of recent PRs. Therefore the question should now include both best and backup routes by default to get the same results.