### PR TITLE
Arista local BGP route origin types based on source protocol

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -894,7 +894,9 @@ public final class AristaConfiguration extends VendorConfiguration {
 
     // Arista sets local routes' local preference to 0
     // actually, it is unset but treated like 0 in terms of BgpRib comparisons.
+    // All local routes have origin type IGP in Arista.
     redistributionPolicy.addStatement(new SetLocalPreference(new LiteralLong(0)));
+    redistributionPolicy.addStatement(new SetOrigin(new LiteralOrigin(OriginType.IGP, null)));
     redistributionPolicy.addStatement(new SetWeight(new LiteralInt(DEFAULT_LOCAL_BGP_WEIGHT)));
 
     // Only redistribute default route if `default-information originate` is set.
@@ -1006,9 +1008,8 @@ public final class AristaConfiguration extends VendorConfiguration {
                 redistributionPolicy.addStatement(
                     new If(
                         new Conjunction(exportNetworkConditions),
-                        ImmutableList.of(
-                            new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
-                            Statements.ExitAccept.toStaticStatement())));
+                        // no need to set origin type; it was set at beginning of redist policy
+                        ImmutableList.of(Statements.ExitAccept.toStaticStatement())));
               });
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -894,10 +894,16 @@ public final class AristaConfiguration extends VendorConfiguration {
 
     // Arista sets local routes' local preference to 0
     // actually, it is unset but treated like 0 in terms of BgpRib comparisons.
-    // All local routes have origin type IGP in Arista.
     redistributionPolicy.addStatement(new SetLocalPreference(new LiteralLong(0)));
-    redistributionPolicy.addStatement(new SetOrigin(new LiteralOrigin(OriginType.IGP, null)));
     redistributionPolicy.addStatement(new SetWeight(new LiteralInt(DEFAULT_LOCAL_BGP_WEIGHT)));
+
+    // Arista sets origin type differently depending on source protocol. Redistributed connected
+    // routes have origin type IGP and redistributed static routes have origin type incomplete.
+    // TODO: Check origin type for routes redistributed from other protocols
+    redistributionPolicy.addStatement(
+        new If(
+            new MatchProtocol(RoutingProtocol.CONNECTED),
+            ImmutableList.of(new SetOrigin(new LiteralOrigin(OriginType.IGP, null)))));
 
     // Only redistribute default route if `default-information originate` is set.
     //    BooleanExpr redistributeDefaultRoute =

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -660,7 +660,7 @@ public class AristaGrammarTest {
             .setAdmin(bgpAdmin)
             .setLocalPreference(0)
             .setNextHop(NextHopDiscard.instance())
-            .setOriginType(OriginType.INCOMPLETE)
+            .setOriginType(OriginType.IGP)
             .setOriginMechanism(OriginMechanism.REDISTRIBUTE)
             .setOriginatorIp(Ip.parse("10.10.10.1"))
             .setProtocol(RoutingProtocol.BGP)
@@ -1339,7 +1339,7 @@ public class AristaGrammarTest {
             .setNextHop(NextHopDiscard.instance())
             .setOriginatorIp(routerId)
             .setOriginMechanism(OriginMechanism.REDISTRIBUTE)
-            .setOriginType(OriginType.INCOMPLETE)
+            .setOriginType(OriginType.IGP)
             .setProtocol(RoutingProtocol.BGP)
             .setReceivedFromIp(Ip.ZERO) // indicates local origination
             .setSrcProtocol(RoutingProtocol.STATIC)

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/bgp_redistribution
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/bgp_redistribution
@@ -2,6 +2,10 @@
 !
 hostname bgp_redistribution
 !
+interface Ethernet1
+   no switchport
+   ip address 5.5.5.1/24
+!
 vrf definition VRF1
 vrf definition VRF2
 !
@@ -10,6 +14,8 @@ ip route vrf VRF2 1.1.1.1 255.255.255.255 null0
 ip route vrf VRF2 2.2.2.2 255.255.255.255 null0
 !
 router bgp 1
+  router-id 10.10.10.3
+  redistribute connected
   vrf VRF1
     router-id 10.10.10.1
     redistribute static


### PR DESCRIPTION
We were previously leaving `OriginType.INCOMPLETE` as the origin type for local routes that originated from a `redistribute` statement.