### PR TITLE
Multifile parsing jobs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
@@ -68,8 +68,8 @@ public class ParseResult implements Serializable {
   }
 
   /**
-   * Get "global" (not file-specific) warnings. File-specific warnings (e.g., parse warnings) can be
-   * accessed via {@link #getFileResults()}.
+   * Get job-level (not file-specific) warnings. File-specific warnings (e.g., parse warnings) can
+   * be accessed via {@link #getFileResults()}.
    */
   @Nonnull
   public Warnings getWarnings() {

--- a/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
@@ -1,14 +1,17 @@
 package org.batfish.job;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.common.ParseTreeSentences;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.answers.ParseStatus;
-import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.job.ParseVendorConfigurationJob.FileResult;
 import org.batfish.vendor.VendorConfiguration;
 
 /** An intermediate class that holds a cacheable result of parsing input configuration files. */
@@ -16,31 +19,32 @@ import org.batfish.vendor.VendorConfiguration;
 public class ParseResult implements Serializable {
 
   @Nullable private final VendorConfiguration _config;
-  @Nonnull private final ParseTreeSentences _parseTreeSentences;
   @Nullable private final Throwable _failureCause;
-  @Nonnull private final String _filename;
+  @Nonnull private final Map<String, FileResult> _fileResults;
   @Nonnull private final ConfigurationFormat _format;
+  @Nonnull private final String _representativeFilename;
   @Nonnull private final ParseStatus _status;
   @Nonnull private final Warnings _warnings;
-  @Nonnull private final SilentSyntaxCollection _silentSyntax;
 
   public ParseResult(
       @Nullable VendorConfiguration config,
       @Nullable Throwable failureCause,
-      String filename,
+      Map<String, FileResult> fileResults,
       ConfigurationFormat format,
-      ParseTreeSentences parseTreeSentences,
+      String representativeFilename,
       ParseStatus status,
-      Warnings warnings,
-      SilentSyntaxCollection silentSyntax) {
+      Warnings warnings) {
+    checkArgument(
+        fileResults.containsKey(representativeFilename),
+        "Representative filename %s is missing from results",
+        representativeFilename);
     _config = config;
     _failureCause = failureCause;
-    _filename = filename;
+    _fileResults = ImmutableMap.copyOf(fileResults);
     _format = format;
-    _parseTreeSentences = parseTreeSentences;
+    _representativeFilename = representativeFilename;
     _status = status;
     _warnings = warnings;
-    _silentSyntax = silentSyntax;
   }
 
   @Nullable
@@ -54,8 +58,8 @@ public class ParseResult implements Serializable {
   }
 
   @Nonnull
-  public String getFilename() {
-    return _filename;
+  public Map<String, FileResult> getFileResults() {
+    return _fileResults;
   }
 
   @Nonnull
@@ -64,8 +68,8 @@ public class ParseResult implements Serializable {
   }
 
   @Nonnull
-  public ParseTreeSentences getParseTreeSentences() {
-    return _parseTreeSentences;
+  public String getRepresentativeFilename() {
+    return _representativeFilename;
   }
 
   @Nonnull
@@ -76,10 +80,5 @@ public class ParseResult implements Serializable {
   @Nonnull
   public Warnings getWarnings() {
     return _warnings;
-  }
-
-  @Nonnull
-  public SilentSyntaxCollection getSilentSyntax() {
-    return _silentSyntax;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
@@ -1,7 +1,5 @@
 package org.batfish.job;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.Map;
@@ -22,7 +20,6 @@ public class ParseResult implements Serializable {
   @Nullable private final Throwable _failureCause;
   @Nonnull private final Map<String, FileResult> _fileResults;
   @Nonnull private final ConfigurationFormat _format;
-  @Nonnull private final String _representativeFilename;
   @Nonnull private final ParseStatus _status;
   @Nonnull private final Warnings _warnings;
 
@@ -31,18 +28,12 @@ public class ParseResult implements Serializable {
       @Nullable Throwable failureCause,
       Map<String, FileResult> fileResults,
       ConfigurationFormat format,
-      String representativeFilename,
       ParseStatus status,
       Warnings warnings) {
-    checkArgument(
-        fileResults.containsKey(representativeFilename),
-        "Representative filename %s is missing from results",
-        representativeFilename);
     _config = config;
     _failureCause = failureCause;
     _fileResults = ImmutableMap.copyOf(fileResults);
     _format = format;
-    _representativeFilename = representativeFilename;
     _status = status;
     _warnings = warnings;
   }
@@ -65,11 +56,6 @@ public class ParseResult implements Serializable {
   @Nonnull
   public ConfigurationFormat getFormat() {
     return _format;
-  }
-
-  @Nonnull
-  public String getRepresentativeFilename() {
-    return _representativeFilename;
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
@@ -48,6 +48,10 @@ public class ParseResult implements Serializable {
     return _failureCause;
   }
 
+  /**
+   * Get results for individual files. File-level warnings and parse trees are contained in this
+   * map. Warnings not specific to a file are in {@link #getWarnings()}
+   */
   @Nonnull
   public Map<String, FileResult> getFileResults() {
     return _fileResults;
@@ -63,6 +67,10 @@ public class ParseResult implements Serializable {
     return _status;
   }
 
+  /**
+   * Get "global" (not file-specific) warnings. File-specific warnings (e.g., parse warnings) can be
+   * accessed via {@link #getFileResults()}.
+   */
   @Nonnull
   public Warnings getWarnings() {
     return _warnings;

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -736,8 +736,8 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
   }
 
   /**
-   * Returns a map from file name to its text content. There is one entry in the name for each file
-   * that it part of this parsing job.
+   * Returns a map from file name to its text content. The map has one entry for each file that is
+   * part of this parsing job.
    */
   public Map<String, String> getFileTexts() {
     return _fileTexts;

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -727,13 +727,15 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
   /**
    * For some existing APIs, e.g., {@link
    * org.batfish.vendor.VendorConfiguration#setFilename(java.lang.String)}, a single filename is
-   * expected. This filename will be used until we can upgrade those APIs.
+   * expected. This representative filename, corresponding to the main file, will be used until we
+   * can upgrade those APIs.
    */
   private String getRepresentativeFilename(
       Map<String, String> fileTexts, ConfigurationFormat format) {
     if (fileTexts.size() == 1) {
       return Iterables.getOnlyElement(fileTexts.keySet());
     }
+    assert format != ConfigurationFormat.UNKNOWN; // avoid unused warning
     // TODO: for multi-file cases, implement format-based representative
     throw new UnsupportedOperationException();
   }

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -13,12 +13,14 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.util.GlobalTracer;
+import java.io.Serializable;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.batfish.common.BatfishException;
 import org.batfish.common.NetworkSnapshot;
@@ -72,6 +74,7 @@ import org.batfish.vendor.a10.grammar.A10ControlPlaneExtractor;
 import org.batfish.vendor.check_point_gateway.grammar.CheckPointGatewayCombinedParser;
 import org.batfish.vendor.check_point_gateway.grammar.CheckPointGatewayControlPlaneExtractor;
 
+@ParametersAreNonnullByDefault
 public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigurationResult> {
 
   private static final Set<ConfigurationFormat> UNIMPLEMENTED_FORMATS =
@@ -87,13 +90,14 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           ConfigurationFormat.RUCKUS_ICX,
           ConfigurationFormat.VXWORKS);
 
-  public static class FileResult {
+  @ParametersAreNonnullByDefault
+  public static class FileResult implements Serializable {
     @Nonnull private ParseTreeSentences _parseTreeSentences;
     @Nonnull private final SilentSyntaxCollection _silentSyntax;
 
-    public FileResult() {
-      this._parseTreeSentences = new ParseTreeSentences();
-      this._silentSyntax = new SilentSyntaxCollection();
+    public FileResult(ParseTreeSentences parseTreeSentences, SilentSyntaxCollection silentSyntax) {
+      _parseTreeSentences = parseTreeSentences;
+      _silentSyntax = silentSyntax;
     }
 
     @Nonnull
@@ -143,7 +147,10 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
     _representativeFilename = representativeFilename;
     _fileResults =
         _fileTexts.keySet().stream()
-            .collect(ImmutableMap.toImmutableMap(f -> f, f -> new FileResult()));
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    f -> f,
+                    f -> new FileResult(new ParseTreeSentences(), new SilentSyntaxCollection())));
     _warnings = warnings;
     _expectedFormat = expectedFormat;
     _duplicateHostnames = duplicateHostnames;

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
@@ -220,11 +220,10 @@ public class ParseVendorConfigurationResult
     if (_vc == null) {
       return "<EMPTY OR UNSUPPORTED FORMAT>";
     } else if (_vc.getHostname() == null) {
-      return "<Indeterminate hostname in file(s): "
-          + jobFilenamesToString(_fileResults.keySet())
-          + ">";
+      return String.format(
+          "<Indeterminate hostname in file(s): %s>", jobFilenamesToString(_fileResults.keySet()));
     } else {
-      return "<" + _vc.getHostname() + ">";
+      return String.format("<%s>", _vc.getHostname());
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
@@ -1,6 +1,7 @@
 package org.batfish.job;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.job.ParseVendorConfigurationJob.jobFilenamesToString;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -8,7 +9,6 @@ import com.google.common.collect.Multimap;
 import java.io.File;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
@@ -36,6 +36,7 @@ public class ParseVendorConfigurationResult
 
   private VendorConfiguration _vc;
 
+  /** Job-level (not file-level) warnings */
   @Nonnull private final Warnings _warnings;
 
   public ParseVendorConfigurationResult(
@@ -103,7 +104,7 @@ public class ParseVendorConfigurationResult
       BatfishLogger logger,
       ParseVendorConfigurationAnswerElement answerElement) {
     appendHistory(logger);
-    String jobKey = _fileResults.keySet().stream().sorted().collect(Collectors.joining(","));
+    String jobKey = jobFilenamesToString(_fileResults.keySet());
     answerElement.getParseStatus().put(jobKey, _status);
     answerElement.getFileFormats().put(jobKey, _format);
     if (_vc != null) {
@@ -172,6 +173,10 @@ public class ParseVendorConfigurationResult
     }
   }
 
+  /**
+   * Returns the parsing results for individual files in the {@link ParseVendorConfigurationJob}, as
+   * a map from the filename to {@link FileResult}.
+   */
   public Map<String, FileResult> getFileResults() {
     return _fileResults;
   }
@@ -215,8 +220,8 @@ public class ParseVendorConfigurationResult
     if (_vc == null) {
       return "<EMPTY OR UNSUPPORTED FORMAT>";
     } else if (_vc.getHostname() == null) {
-      return "<Indeterminate hostname in "
-          + _fileResults.keySet().stream().sorted().collect(Collectors.joining(","))
+      return "<Indeterminate hostname in file(s): "
+          + jobFilenamesToString(_fileResults.keySet())
           + ">";
     } else {
       return "<" + _vc.getHostname() + ">";

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
@@ -215,7 +215,9 @@ public class ParseVendorConfigurationResult
     if (_vc == null) {
       return "<EMPTY OR UNSUPPORTED FORMAT>";
     } else if (_vc.getHostname() == null) {
-      return "<Indeterminate hostname in " + _fileResults + ">";
+      return "<Indeterminate hostname in "
+          + _fileResults.keySet().stream().sorted().collect(Collectors.joining(","))
+          + ">";
     } else {
       return "<" + _vc.getHostname() + ">";
     }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1644,8 +1644,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
               _settings,
               snapshot,
               ImmutableMap.of(vendorFile.getKey(), vendorFile.getValue()),
-              vendorFile.getKey(),
-              buildWarnings(_settings),
+              _settings.getLogger().getLogLevel(),
               expectedFormat,
               HashMultimap.create(),
               parseVendorConfigurationSpanContext);

--- a/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
+++ b/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
@@ -1,6 +1,7 @@
 package org.batfish.main.annotate;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.common.BatfishLogger.LEVEL_PEDANTIC;
 import static org.batfish.datamodel.answers.ParseStatus.FAILED;
 import static org.batfish.main.CliUtils.readAllFiles;
 import static org.batfish.main.CliUtils.relativize;
@@ -99,7 +100,6 @@ public final class Annotate {
       LOGGER.warn("Skipping {} because of preprocessing error: {}", inputText, e);
       return null;
     }
-    Warnings warnings = new Warnings(true, true, true);
     LOGGER.debug("Parsing: {}", inputFile);
     // parse the preprocessed text
     ParseVendorConfigurationResult parseResult =
@@ -107,8 +107,7 @@ public final class Annotate {
                 settings,
                 new NetworkSnapshot(new NetworkId("dummyNetwork"), new SnapshotId("dummySnapshot")),
                 ImmutableMap.of(inputFile.toString(), preprocessedText),
-                inputFile.toString(),
-                warnings,
+                LEVEL_PEDANTIC,
                 ConfigurationFormat.UNKNOWN,
                 ImmutableMultimap.of(),
                 null)
@@ -122,7 +121,7 @@ public final class Annotate {
     return annotatePreprocessedFile(
         preprocessedText,
         parseResult.getFileResults().get(inputFile.toString()).getSilentSyntax(),
-        warnings,
+        parseResult.getFileResults().get(inputFile.toString()).getWarnings(),
         getCommentHeader(parseResult.getConfigurationFormat()));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
+++ b/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
@@ -8,7 +8,6 @@ import static org.batfish.main.CliUtils.resolve;
 import static org.batfish.main.CliUtils.writeAllFiles;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.LinkedHashMultimap;
@@ -32,7 +31,6 @@ import org.batfish.grammar.silent_syntax.SilentSyntaxCollection.SilentSyntaxElem
 import org.batfish.identifiers.NetworkId;
 import org.batfish.identifiers.SnapshotId;
 import org.batfish.job.ParseVendorConfigurationJob;
-import org.batfish.job.ParseVendorConfigurationJob.VendorFile;
 import org.batfish.job.ParseVendorConfigurationResult;
 import org.batfish.main.preprocess.Preprocessor;
 
@@ -108,8 +106,8 @@ public final class Annotate {
         new ParseVendorConfigurationJob(
                 settings,
                 new NetworkSnapshot(new NetworkId("dummyNetwork"), new SnapshotId("dummySnapshot")),
-                ImmutableList.of(new VendorFile(inputFile.toString(), preprocessedText)),
-                null,
+                ImmutableMap.of(inputFile.toString(), preprocessedText),
+                inputFile.toString(),
                 warnings,
                 ConfigurationFormat.UNKNOWN,
                 ImmutableMultimap.of(),
@@ -123,7 +121,7 @@ public final class Annotate {
     LOGGER.debug("Annotating: {}", inputFile);
     return annotatePreprocessedFile(
         preprocessedText,
-        parseResult.getSilentSyntax(),
+        parseResult.getFileResults().get(inputFile.toString()).getSilentSyntax(),
         warnings,
         getCommentHeader(parseResult.getConfigurationFormat()));
   }

--- a/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
+++ b/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
@@ -8,6 +8,7 @@ import static org.batfish.main.CliUtils.resolve;
 import static org.batfish.main.CliUtils.writeAllFiles;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.LinkedHashMultimap;
@@ -31,6 +32,7 @@ import org.batfish.grammar.silent_syntax.SilentSyntaxCollection.SilentSyntaxElem
 import org.batfish.identifiers.NetworkId;
 import org.batfish.identifiers.SnapshotId;
 import org.batfish.job.ParseVendorConfigurationJob;
+import org.batfish.job.ParseVendorConfigurationJob.VendorFile;
 import org.batfish.job.ParseVendorConfigurationResult;
 import org.batfish.main.preprocess.Preprocessor;
 
@@ -106,8 +108,8 @@ public final class Annotate {
         new ParseVendorConfigurationJob(
                 settings,
                 new NetworkSnapshot(new NetworkId("dummyNetwork"), new SnapshotId("dummySnapshot")),
-                preprocessedText,
-                inputFile.toString(),
+                ImmutableList.of(new VendorFile(inputFile.toString(), preprocessedText)),
+                null,
                 warnings,
                 ConfigurationFormat.UNKNOWN,
                 ImmutableMultimap.of(),

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
@@ -1,6 +1,7 @@
 package org.batfish.job;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.BatfishLogger.LEVEL_DEBUG;
 import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.job.ParseVendorConfigurationJob.detectFormat;
 import static org.hamcrest.Matchers.equalTo;
@@ -11,7 +12,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import org.batfish.common.NetworkSnapshot;
-import org.batfish.common.Warnings;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.identifiers.NetworkId;
@@ -27,8 +27,7 @@ public class ParseVendorConfigurationJobTest {
             new Settings(),
             new NetworkSnapshot(new NetworkId("net"), new SnapshotId("ss")),
             ImmutableMap.of("filename", readResource(resourcePath, UTF_8)),
-            "filename",
-            new Warnings(),
+            LEVEL_DEBUG,
             ConfigurationFormat.HOST,
             ImmutableMultimap.of(),
             null)
@@ -60,8 +59,7 @@ public class ParseVendorConfigurationJobTest {
     ignored.setIgnoreFilesWithStrings(ImmutableList.of("\n"));
     for (String empty : empties) {
       assertThat(
-          detectFormat(
-              ImmutableMap.of("file", empty), "file", settings, ConfigurationFormat.UNKNOWN),
+          detectFormat(ImmutableMap.of("file", empty), settings, ConfigurationFormat.UNKNOWN),
           equalTo(ConfigurationFormat.EMPTY));
     }
   }
@@ -72,11 +70,10 @@ public class ParseVendorConfigurationJobTest {
     Settings settings = new Settings();
     settings.setIgnoreFilesWithStrings(ImmutableList.of("\n"));
     assertThat(
-        detectFormat(ImmutableMap.of("file", "\n"), "file", settings, ConfigurationFormat.UNKNOWN),
+        detectFormat(ImmutableMap.of("file", "\n"), settings, ConfigurationFormat.UNKNOWN),
         equalTo(ConfigurationFormat.EMPTY));
     assertThat(
-        detectFormat(
-            ImmutableMap.of("file", "\n\n\n"), "file", settings, ConfigurationFormat.UNKNOWN),
+        detectFormat(ImmutableMap.of("file", "\n\n\n"), settings, ConfigurationFormat.UNKNOWN),
         equalTo(ConfigurationFormat.EMPTY));
   }
 
@@ -84,7 +81,7 @@ public class ParseVendorConfigurationJobTest {
   @Test
   public void testDetectFormatEmptyBeatsFormat() {
     assertThat(
-        detectFormat(ImmutableMap.of("file", ""), "file", new Settings(), ConfigurationFormat.HOST),
+        detectFormat(ImmutableMap.of("file", ""), new Settings(), ConfigurationFormat.HOST),
         equalTo(ConfigurationFormat.EMPTY));
   }
 
@@ -95,15 +92,13 @@ public class ParseVendorConfigurationJobTest {
     Settings settings = new Settings();
     // Nothing ignored, is Cisco NX-OS.
     assertThat(
-        detectFormat(
-            ImmutableMap.of("file", fileText), "file", settings, ConfigurationFormat.UNKNOWN),
+        detectFormat(ImmutableMap.of("file", fileText), settings, ConfigurationFormat.UNKNOWN),
         equalTo(ConfigurationFormat.CISCO_NX));
 
     // "foo" ignored, file is ignored.
     settings.setIgnoreFilesWithStrings(ImmutableList.of("\n"));
     assertThat(
-        detectFormat(
-            ImmutableMap.of("file", fileText), "file", settings, ConfigurationFormat.UNKNOWN),
+        detectFormat(ImmutableMap.of("file", fileText), settings, ConfigurationFormat.UNKNOWN),
         equalTo(ConfigurationFormat.IGNORED));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warnings;
@@ -15,7 +16,6 @@ import org.batfish.config.Settings;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.identifiers.NetworkId;
 import org.batfish.identifiers.SnapshotId;
-import org.batfish.job.ParseVendorConfigurationJob.VendorFile;
 import org.junit.Test;
 
 /** Tests of {@link ParseVendorConfigurationJob}. */
@@ -26,8 +26,8 @@ public class ParseVendorConfigurationJobTest {
     return new ParseVendorConfigurationJob(
             new Settings(),
             new NetworkSnapshot(new NetworkId("net"), new SnapshotId("ss")),
-            ImmutableList.of(new VendorFile("filename", readResource(resourcePath, UTF_8))),
-            null,
+            ImmutableMap.of("filename", readResource(resourcePath, UTF_8)),
+            "filename",
             new Warnings(),
             ConfigurationFormat.HOST,
             ImmutableMultimap.of(),
@@ -61,10 +61,7 @@ public class ParseVendorConfigurationJobTest {
     for (String empty : empties) {
       assertThat(
           detectFormat(
-              ImmutableList.of(new VendorFile("file", empty)),
-              "file",
-              settings,
-              ConfigurationFormat.UNKNOWN),
+              ImmutableMap.of("file", empty), "file", settings, ConfigurationFormat.UNKNOWN),
           equalTo(ConfigurationFormat.EMPTY));
     }
   }
@@ -75,18 +72,11 @@ public class ParseVendorConfigurationJobTest {
     Settings settings = new Settings();
     settings.setIgnoreFilesWithStrings(ImmutableList.of("\n"));
     assertThat(
-        detectFormat(
-            ImmutableList.of(new VendorFile("file", "\n")),
-            "file",
-            settings,
-            ConfigurationFormat.UNKNOWN),
+        detectFormat(ImmutableMap.of("file", "\n"), "file", settings, ConfigurationFormat.UNKNOWN),
         equalTo(ConfigurationFormat.EMPTY));
     assertThat(
         detectFormat(
-            ImmutableList.of(new VendorFile("file", "\n\n\n")),
-            "file",
-            settings,
-            ConfigurationFormat.UNKNOWN),
+            ImmutableMap.of("file", "\n\n\n"), "file", settings, ConfigurationFormat.UNKNOWN),
         equalTo(ConfigurationFormat.EMPTY));
   }
 
@@ -94,11 +84,7 @@ public class ParseVendorConfigurationJobTest {
   @Test
   public void testDetectFormatEmptyBeatsFormat() {
     assertThat(
-        detectFormat(
-            ImmutableList.of(new VendorFile("file", "")),
-            "file",
-            new Settings(),
-            ConfigurationFormat.HOST),
+        detectFormat(ImmutableMap.of("file", ""), "file", new Settings(), ConfigurationFormat.HOST),
         equalTo(ConfigurationFormat.EMPTY));
   }
 
@@ -110,20 +96,14 @@ public class ParseVendorConfigurationJobTest {
     // Nothing ignored, is Cisco NX-OS.
     assertThat(
         detectFormat(
-            ImmutableList.of(new VendorFile("file", fileText)),
-            "file",
-            settings,
-            ConfigurationFormat.UNKNOWN),
+            ImmutableMap.of("file", fileText), "file", settings, ConfigurationFormat.UNKNOWN),
         equalTo(ConfigurationFormat.CISCO_NX));
 
     // "foo" ignored, file is ignored.
     settings.setIgnoreFilesWithStrings(ImmutableList.of("\n"));
     assertThat(
         detectFormat(
-            ImmutableList.of(new VendorFile("file", fileText)),
-            "file",
-            settings,
-            ConfigurationFormat.UNKNOWN),
+            ImmutableMap.of("file", fileText), "file", settings, ConfigurationFormat.UNKNOWN),
         equalTo(ConfigurationFormat.IGNORED));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
@@ -124,6 +124,6 @@ public class ParseVendorConfigurationResultTest {
     assertThat(answerWarnings, hasEntry(filenames.get(1), fileWarnings.get(1)));
 
     // Confirm that global warnings were applied
-    assertThat(answerWarnings, hasEntry("file1,file2", globalWarnings));
+    assertThat(answerWarnings, hasEntry("[file1, file2]", globalWarnings));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.batfish.common.BatfishLogger;
@@ -17,6 +18,7 @@ import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection.SilentSyntaxElem;
+import org.batfish.job.ParseVendorConfigurationJob.FileResult;
 import org.batfish.representation.cisco.CiscoConfiguration;
 import org.batfish.vendor.VendorConfiguration;
 import org.junit.Test;
@@ -42,14 +44,13 @@ public class ParseVendorConfigurationResultTest {
         new ParseVendorConfigurationResult(
             0,
             new BatfishLoggerHistory(),
+            ImmutableMap.of(filename, new FileResult(parseTree, silentSyntax)),
             filename,
             ConfigurationFormat.CISCO_IOS,
             config,
             warnings,
-            parseTree,
             ParseStatus.PASSED,
-            HashMultimap.create(),
-            silentSyntax);
+            HashMultimap.create());
 
     SortedMap<String, VendorConfiguration> configs = new TreeMap<>();
     ParseVendorConfigurationAnswerElement answerElement =

--- a/tests/basic/example-iptables-init.ref
+++ b/tests/basic/example-iptables-init.ref
@@ -85,7 +85,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in file: 'configs/r1.cfg'\n"
+              "text" : "No hostname set in [configs/r1.cfg]\n"
             }
           ]
         },
@@ -93,7 +93,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in file: 'configs/r2.cfg'\n"
+              "text" : "No hostname set in [configs/r2.cfg]\n"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in file: 'configs/r3.cfg'\n"
+              "text" : "No hostname set in [configs/r3.cfg]\n"
             }
           ]
         },
@@ -109,7 +109,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in file: 'configs/z1-firewall.cfg'\n"
+              "text" : "No hostname set in [configs/z1-firewall.cfg]\n"
             }
           ]
         },
@@ -117,7 +117,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in file: 'configs/z2-firewall.cfg'\n"
+              "text" : "No hostname set in [configs/z2-firewall.cfg]\n"
             }
           ]
         }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -70324,7 +70324,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in file: 'configs/cisco_style_acl1'\n"
+              "text" : "No hostname set in [configs/cisco_style_acl1]\n"
             }
           ]
         },
@@ -70332,7 +70332,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in file: 'configs/cisco_style_acl2'\n"
+              "text" : "No hostname set in [configs/cisco_style_acl2]\n"
             }
           ]
         },


### PR DESCRIPTION
For some vendors, configuration information for a device is spread across multiple files. Batfish has used concatenation as a means to turn them into single-file vendors, but concatenation is not a viable strategy for some vendors like SONiC with different file formats (JSON, text). 

This PR extends ParseVendorConfigurationJob to multi-file parsing. It logs file-specific warnings where applicable (e.g., parse warnings). File-agnostic warnings and the overall status is associated with the concatenation of the filenames.  

There is one unresolved gap: VendorConfiguration expects one filename. Here, a "representative" filename is used in this PR. The thinking is that the main file of the vendor will be used for the time being. This will be addressed in a future PR, along with making defined and reference structures file-aware. 

Single-file vendors should not be impacted by this PR.