### PR TITLE
Fix Layer2Vni creation and usage

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer2Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer2Vni.java
@@ -141,7 +141,13 @@ public final class Layer2Vni implements Vni {
   @Override
   public int hashCode() {
     return Objects.hash(
-        _bumTransportMethod, _bumTransportIps, _sourceAddress, _udpPort, _vlan, _vni, _srcVrf);
+        _bumTransportMethod.ordinal(),
+        _bumTransportIps,
+        _sourceAddress,
+        _udpPort,
+        _vlan,
+        _vni,
+        _srcVrf);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -16,7 +16,6 @@ import static org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker.NO_PREFER
 import static org.batfish.datamodel.bgp.NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP;
 import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
-import static org.batfish.representation.arista.AristaConversions.getVrfForVlan;
 import static org.batfish.representation.arista.AristaConversions.toBgpAggregate;
 import static org.batfish.representation.arista.AristaConversions.toCommunityMatchExpr;
 import static org.batfish.representation.arista.AristaConversions.toCommunitySet;
@@ -2544,10 +2543,8 @@ public final class AristaConfiguration extends VendorConfiguration {
       _eosVxlan
           .getVlanVnis()
           .forEach(
-              (vlan, vni) -> {
-                org.batfish.datamodel.Vrf vrf = getVrfForVlan(c, vlan).orElse(c.getDefaultVrf());
-                vrf.addLayer2Vni(toL2Vni(_eosVxlan, vni, vlan, sourceIface));
-              });
+              (vlan, vni) ->
+                  c.getDefaultVrf().addLayer2Vni(toL2Vni(_eosVxlan, vni, vlan, sourceIface)));
       _eosVxlan
           .getVrfToVni()
           .forEach(

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -8,6 +8,7 @@ import static org.batfish.datamodel.Names.generatedBgpPeerImportPolicyName;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.Common.generateSuppressionPolicy;
 import static org.batfish.datamodel.routing_policy.statement.Statements.RemovePrivateAs;
+import static org.batfish.representation.arista.AristaConfiguration.DEFAULT_VRF_NAME;
 import static org.batfish.representation.arista.AristaConfiguration.MAX_ADMINISTRATIVE_COST;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -688,10 +689,6 @@ final class AristaConversions {
           continue;
         }
         for (Integer vlan : bundle.getVlans().enumerate()) {
-          Vrf vrfForVlan = getVrfForVlan(c, vlan).orElse(null);
-          if (vrfForVlan == null) {
-            continue;
-          }
           Integer vni = vlanToVni.get(vlan);
           if (vni == null) {
             continue;
@@ -702,7 +699,8 @@ final class AristaConversions {
                   .setImportRouteTarget(bundle.getRtImport().matchString())
                   .setRouteTarget(bundle.getRtExport())
                   .setRouteDistinguisher(bundle.getRd())
-                  .setVrf(vrfForVlan.getName())
+                  // TODO: remove vrf from Layer2Vni
+                  .setVrf(DEFAULT_VRF_NAME)
                   .build());
         }
       }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -176,14 +176,15 @@ public class BgpRoutingProcessTest {
         Layer2VniConfig.builder()
             .setVni(vni)
             .setVrf(DEFAULT_VRF_NAME)
-            .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))
+            .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 1))
             .setRouteTarget(ExtendedCommunity.target(65500, vni))
             .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(vni));
     Layer2VniConfig vniConfig1 = vniConfigBuilder.build();
     Layer2VniConfig vniConfig2 =
         vniConfigBuilder
             .setVni(vni2)
-            .setVrf(_vrf2.getName())
+            .setVrf(DEFAULT_VRF_NAME)
+            .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))
             .setRouteTarget(ExtendedCommunity.target(65500, vni2))
             .build();
     BgpActivePeerConfig evpnPeer =
@@ -207,7 +208,7 @@ public class BgpRoutingProcessTest {
             .setBumTransportMethod(UNICAST_FLOOD_GROUP)
             .setSourceAddress(localIp)
             .build());
-    _vrf2.addLayer2Vni(
+    _vrf.addLayer2Vni(
         testBuilder()
             .setVni(vni2)
             .setVlan(2)
@@ -225,10 +226,10 @@ public class BgpRoutingProcessTest {
     // The VRF/process that the neighbor is in
     assertThat(
         defaultProc.getEvpnType3Routes(),
-        contains(
+        containsInAnyOrder(
             EvpnType3Route.builder()
                 .setVniIp(localIp)
-                .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))
+                .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 1))
                 .setCommunities(ImmutableSet.of(ExtendedCommunity.target(65500, vni)))
                 .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
                 .setOriginMechanism(OriginMechanism.GENERATED)
@@ -236,11 +237,7 @@ public class BgpRoutingProcessTest {
                 .setProtocol(RoutingProtocol.BGP)
                 .setOriginatorIp(_bgpProcess.getRouterId())
                 .setNextHop(NextHopDiscard.instance())
-                .build()));
-    // Sibling VRF, for vni2
-    assertThat(
-        node.getVirtualRouterOrThrow("vrf2").getBgpRoutingProcess().getEvpnType3Routes(),
-        contains(
+                .build(),
             EvpnType3Route.builder()
                 .setVniIp(localIp)
                 .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -2215,13 +2215,13 @@ public class AristaGrammarTest {
       assertThat(vniSettings.getBumTransportIps(), empty());
     }
     {
-      Layer2Vni vniSettings = config.getVrfs().get("VRF_1").getLayer2Vnis().get(10001);
+      Layer2Vni vniSettings = config.getDefaultVrf().getLayer2Vnis().get(10001);
       assertThat(
           vniSettings.getBumTransportMethod(), equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP));
       assertThat(vniSettings.getBumTransportIps(), empty());
     }
     {
-      Layer2Vni vniSettings = config.getVrfs().get("VRF_2").getLayer2Vnis().get(10002);
+      Layer2Vni vniSettings = config.getDefaultVrf().getLayer2Vnis().get(10002);
       assertThat(
           vniSettings.getBumTransportMethod(), equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP));
       assertThat(vniSettings.getBumTransportIps(), empty());
@@ -2525,13 +2525,13 @@ public class AristaGrammarTest {
   }
 
   /**
-   * Ensure that when L2 VNIs are present and no bgp VRFs are defined, we still make Bgp procesess
-   * for non-default VRF to prevent crashing the dataplane computation.
+   * Ensure that when L2 VNIs are present and no bgp VRFs are defined, we do not make a BGP process
+   * for non-default VRF.
    */
   @Test
   public void testEvpnConversionL2VnisOnly() {
     Configuration c = parseConfig("arista_evpn_l2_vni_only");
-    assertThat(c, ConfigurationMatchers.hasVrf("vrf1", hasBgpProcess(notNullValue())));
+    assertThat(c, ConfigurationMatchers.hasVrf("vrf1", hasBgpProcess(nullValue())));
     assertThat(c.getDefaultVrf().getLayer2Vnis(), hasKey(10030));
   }
 


### PR DESCRIPTION
- fixes issue where vxlan flood lists are not updated due to missing
  `Layer2Vni`s on default VRF.
- always put Layer2Vnis in default vrf
- fix conversion for EOS
- fix enum hashing in Layer2Vni hashCode