### PR TITLE
EVPN: Use NVE IP as NHIP for originated routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/EvpnAddressFamily.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/EvpnAddressFamily.java
@@ -13,6 +13,7 @@ import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
 
 /** Configuration settings for EVPN address family */
 @ParametersAreNonnullByDefault
@@ -21,10 +22,12 @@ public final class EvpnAddressFamily extends AddressFamily {
   private static final String PROP_L2_VNIS = "l2Vnis";
   private static final String PROP_L3_VNIS = "l3Vnis";
   private static final String PROP_PROPAGATE_UNMATCHED = "propagateUnmatched";
+  private static final String PROP_NVE_IP = "nveIp";
 
   @Nonnull private final SortedSet<Layer2VniConfig> _l2VNIs;
   @Nonnull private final SortedSet<Layer3VniConfig> _l3VNIs;
   private final boolean _propagateUnmatched;
+  @Nullable private final Ip _nveIp;
 
   protected EvpnAddressFamily(
       // super fields
@@ -37,6 +40,7 @@ public final class EvpnAddressFamily extends AddressFamily {
       // local fields
       Set<Layer2VniConfig> l2Vnis,
       Set<Layer3VniConfig> l3Vnis,
+      @Nullable Ip nveIp,
       boolean propagateUnmatched) {
     super(
         addressFamilyCapabilities,
@@ -47,6 +51,7 @@ public final class EvpnAddressFamily extends AddressFamily {
         routeReflectorClient);
     _l2VNIs = ImmutableSortedSet.copyOf(l2Vnis);
     _l3VNIs = ImmutableSortedSet.copyOf(l3Vnis);
+    _nveIp = nveIp;
     _propagateUnmatched = propagateUnmatched;
   }
 
@@ -63,6 +68,7 @@ public final class EvpnAddressFamily extends AddressFamily {
       // local fields
       @Nullable @JsonProperty(PROP_L2_VNIS) Set<Layer2VniConfig> l2Vnis,
       @Nullable @JsonProperty(PROP_L3_VNIS) Set<Layer3VniConfig> l3Vnis,
+      @Nullable @JsonProperty(PROP_NVE_IP) Ip nveIp,
       @Nullable @JsonProperty(PROP_PROPAGATE_UNMATCHED) Boolean propagateUnmatched) {
     checkArgument(propagateUnmatched != null, "Missing %s", PROP_PROPAGATE_UNMATCHED);
     return new Builder()
@@ -74,6 +80,7 @@ public final class EvpnAddressFamily extends AddressFamily {
         .setRouteReflectorClient(firstNonNull(routeReflectorClient, Boolean.FALSE))
         .setL2Vnis(firstNonNull(l2Vnis, ImmutableSortedSet.of()))
         .setL3Vnis(firstNonNull(l3Vnis, ImmutableSortedSet.of()))
+        .setNveIp(nveIp)
         .setPropagateUnmatched(propagateUnmatched)
         .build();
   }
@@ -90,6 +97,18 @@ public final class EvpnAddressFamily extends AddressFamily {
   @JsonProperty(PROP_L3_VNIS)
   public SortedSet<Layer3VniConfig> getL3VNIs() {
     return _l3VNIs;
+  }
+
+  /**
+   * IP of the network virtualization edge. Should be used as NHIP for originated EVPN routes when
+   * sending to neighbors.
+   *
+   * <p>See: https://datatracker.ietf.org/doc/html/rfc8365#section-5.1.3
+   */
+  @Nullable
+  @JsonProperty(PROP_NVE_IP)
+  public Ip getNveIp() {
+    return _nveIp;
   }
 
   /**
@@ -151,6 +170,7 @@ public final class EvpnAddressFamily extends AddressFamily {
     @Nonnull private SortedSet<Layer2VniConfig> _l2Vnis;
     @Nonnull private SortedSet<Layer3VniConfig> _l3Vnis;
     @Nullable private Boolean _propagateUnmatched;
+    @Nullable private Ip _nveIp;
 
     private Builder() {
       _l2Vnis = ImmutableSortedSet.of();
@@ -177,6 +197,12 @@ public final class EvpnAddressFamily extends AddressFamily {
     }
 
     @Nonnull
+    public Builder setNveIp(@Nullable Ip nveIp) {
+      _nveIp = nveIp;
+      return getThis();
+    }
+
+    @Nonnull
     @Override
     public Builder getThis() {
       return this;
@@ -197,6 +223,7 @@ public final class EvpnAddressFamily extends AddressFamily {
           _routeReflectorClient,
           _l2Vnis,
           _l3Vnis,
+          _nveIp,
           _propagateUnmatched);
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -35,6 +35,7 @@ import org.batfish.datamodel.bgp.AddressFamily.Type;
 import org.batfish.datamodel.bgp.AllowRemoteAsOutMode;
 import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.BgpTopologyUtils.ConfedSessionType;
+import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
@@ -391,6 +392,17 @@ public final class BgpProtocolHelper {
           BgpSessionProperties ourSessionProperties,
           AddressFamily af,
           Ip originalRouteNhip) {
+    // For EVPN routes that we originated, set NHIP to NVE IP; otherwise to original NHIP
+    if (af.getType().equals(Type.EVPN)) {
+      if (originalRouteNhip.equals(UNSET_ROUTE_NEXT_HOP_IP)) {
+        EvpnAddressFamily evpnFamily = (EvpnAddressFamily) af;
+        if (evpnFamily.getNveIp() != null) {
+          routeBuilder.setNextHop(NextHopIp.of(evpnFamily.getNveIp()));
+        }
+      } else {
+        routeBuilder.setNextHop(NextHopIp.of(originalRouteNhip));
+      }
+    }
     transformBgpRoutePostExport(
         routeBuilder,
         ourSessionProperties.isEbgp(),

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -16,6 +16,7 @@ import static org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker.NO_PREFER
 import static org.batfish.datamodel.bgp.NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP;
 import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
+import static org.batfish.representation.arista.AristaConversions.getSourceInterfaceIp;
 import static org.batfish.representation.arista.AristaConversions.getVrfForVlan;
 import static org.batfish.representation.arista.AristaConversions.toBgpAggregate;
 import static org.batfish.representation.arista.AristaConversions.toCommunityMatchExpr;
@@ -1070,15 +1071,26 @@ public final class AristaConfiguration extends VendorConfiguration {
     //      c.getRoute6FilterLists().put(localFilter6.getName(), localFilter6);
     //    }
 
+    Ip vxlanSourceInterfaceIp = getSourceInterfaceIp(_eosVxlan, _interfaces).orElse(null);
+
     // Process active neighbors first.
     Map<Ip, BgpActivePeerConfig> activeNeighbors =
-        AristaConversions.getNeighbors(c, v, newBgpProcess, bgpGlobal, bgpVrf, _eosVxlan, _w);
+        AristaConversions.getNeighbors(
+            c, v, newBgpProcess, bgpGlobal, bgpVrf, _eosVxlan, vxlanSourceInterfaceIp, _w);
     newBgpProcess.setNeighbors(ImmutableSortedMap.copyOf(activeNeighbors));
 
     // Process passive neighbors next
     Map<Prefix, BgpPassivePeerConfig> passiveNeighbors =
         AristaConversions.getPassiveNeighbors(
-            c, v, newBgpProcess, bgpGlobal, bgpVrf, _eosVxlan, _peerFilters, _w);
+            c,
+            v,
+            newBgpProcess,
+            bgpGlobal,
+            bgpVrf,
+            _eosVxlan,
+            vxlanSourceInterfaceIp,
+            _peerFilters,
+            _w);
     newBgpProcess.setPassiveNeighbors(ImmutableSortedMap.copyOf(passiveNeighbors));
 
     return newBgpProcess;
@@ -2538,22 +2550,21 @@ public final class AristaConfiguration extends VendorConfiguration {
 
     // convert Arista EOS VXLAN
     if (_eosVxlan != null) {
-      String sourceIfaceName = _eosVxlan.getSourceInterface();
-      Interface sourceIface = sourceIfaceName == null ? null : _interfaces.get(sourceIfaceName);
+      Ip sourceAddress = getSourceInterfaceIp(_eosVxlan, _interfaces).orElse(null);
 
       _eosVxlan
           .getVlanVnis()
           .forEach(
               (vlan, vni) -> {
                 org.batfish.datamodel.Vrf vrf = getVrfForVlan(c, vlan).orElse(c.getDefaultVrf());
-                vrf.addLayer2Vni(toL2Vni(_eosVxlan, vni, vlan, sourceIface));
+                vrf.addLayer2Vni(toL2Vni(_eosVxlan, vni, vlan, sourceAddress));
               });
       _eosVxlan
           .getVrfToVni()
           .forEach(
               (vrfName, vni) ->
                   Optional.ofNullable(c.getVrfs().get(vrfName))
-                      .ifPresent(vrf -> vrf.addLayer3Vni(toL3Vni(_eosVxlan, vni, sourceIface))));
+                      .ifPresent(vrf -> vrf.addLayer3Vni(toL3Vni(_eosVxlan, vni, sourceAddress))));
     }
 
     // For EOS, if a VRF has VNIs but no BGP process, create a dummy BGP processes in VI.
@@ -2728,12 +2739,7 @@ public final class AristaConfiguration extends VendorConfiguration {
   }
 
   private static Layer2Vni toL2Vni(
-      @Nonnull AristaEosVxlan vxlan, int vni, int vlan, @Nullable Interface sourceInterface) {
-    Ip sourceAddress =
-        sourceInterface == null
-            ? null
-            : sourceInterface.getAddress() == null ? null : sourceInterface.getAddress().getIp();
-
+      @Nonnull AristaEosVxlan vxlan, int vni, int vlan, @Nullable Ip sourceAddress) {
     // Prefer VLAN-specific or general flood address (in that order) over multicast address
     SortedSet<Ip> bumTransportIps =
         firstNonNull(vxlan.getVlanFloodAddresses().get(vlan), vxlan.getFloodAddresses());
@@ -2760,12 +2766,7 @@ public final class AristaConfiguration extends VendorConfiguration {
   }
 
   private static Layer3Vni toL3Vni(
-      @Nonnull AristaEosVxlan vxlan, @Nonnull Integer vni, @Nullable Interface sourceInterface) {
-    Ip sourceAddress =
-        sourceInterface == null
-            ? null
-            : sourceInterface.getAddress() == null ? null : sourceInterface.getAddress().getIp();
-
+      @Nonnull AristaEosVxlan vxlan, @Nonnull Integer vni, @Nullable Ip sourceAddress) {
     SortedSet<Ip> bumTransportIps = vxlan.getFloodAddresses();
 
     // default to unicast flooding unless specified otherwise

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -784,7 +784,7 @@ final class AristaConversions {
     return newNeighborBuilder.build();
   }
 
-  static Optional<Ip> getSourceInterfaceIp(
+  static @Nonnull Optional<Ip> getSourceInterfaceIp(
       @Nullable AristaEosVxlan vxlan,
       Map<String, org.batfish.representation.arista.Interface> interfaces) {
     return Optional.ofNullable(vxlan)

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -191,6 +191,7 @@ import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.BgpConfederation;
 import org.batfish.datamodel.bgp.BgpTopologyUtils;
+import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
@@ -2478,12 +2479,12 @@ public class AristaGrammarTest {
     Ip[] neighborIPs = {Ip.parse("192.168.255.1"), Ip.parse("192.168.255.2")};
     for (Ip ip : neighborIPs) {
       BgpActivePeerConfig neighbor = c.getDefaultVrf().getBgpProcess().getActiveNeighbors().get(ip);
-      assertThat(neighbor.getEvpnAddressFamily(), notNullValue());
+      EvpnAddressFamily af = neighbor.getEvpnAddressFamily();
+      assertThat(af, notNullValue());
+      assertThat(af.getAddressFamilyCapabilities().getAllowRemoteAsOut(), equalTo(ALWAYS));
+      assertThat(af.getNveIp(), equalTo(Ip.parse("192.168.254.3")));
       assertThat(
-          neighbor.getEvpnAddressFamily().getAddressFamilyCapabilities().getAllowRemoteAsOut(),
-          equalTo(ALWAYS));
-      assertThat(
-          neighbor.getEvpnAddressFamily().getL2VNIs(),
+          af.getL2VNIs(),
           equalTo(
               ImmutableSet.of(
                   Layer2VniConfig.builder()
@@ -2502,7 +2503,7 @@ public class AristaGrammarTest {
                       .build())));
 
       assertThat(
-          neighbor.getEvpnAddressFamily().getL3VNIs(),
+          af.getL3VNIs(),
           equalTo(
               ImmutableSet.of(
                   Layer3VniConfig.builder()


### PR DESCRIPTION
Local EVPN routes don't appear to have any NHIP attached, but when they're sent out, the sender sets their NHIP to the IP of the NVE (Network Virtualization Edge): https://datatracker.ietf.org/doc/html/rfc8365#section-5.1.3

In this PR we add the NVE IP as an attribute of `EvpnAddressFamily`, so every peer sending EVPN routes has an IP to use as NHIP for its local EVPN routes.