### PR TITLE
CheckPoint: make cluster interfaces optional

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiGatewayCluster.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiGatewayCluster.java
@@ -23,7 +23,6 @@ public final class CpmiGatewayCluster extends Cluster {
       @JsonProperty(PROP_NAME) @Nullable String name,
       @JsonProperty(PROP_POLICY) @Nullable GatewayOrServerPolicy policy,
       @JsonProperty(PROP_UID) @Nullable Uid uid) {
-    checkArgument(interfaces != null, "Missing %s", PROP_INTERFACES);
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(policy != null, "Missing %s", PROP_POLICY);
     checkArgument(uid != null, "Missing %s", PROP_UID);
@@ -31,7 +30,7 @@ public final class CpmiGatewayCluster extends Cluster {
         ImmutableList.copyOf(firstNonNull(clusterMemberNames, ImmutableList.of())),
         ipv4Address,
         name,
-        interfaces,
+        firstNonNull(interfaces, ImmutableList.of()),
         policy,
         uid);
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobj.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobj.java
@@ -23,7 +23,6 @@ public final class CpmiVsxClusterNetobj extends Cluster {
       @JsonProperty(PROP_NAME) @Nullable String name,
       @JsonProperty(PROP_POLICY) @Nullable GatewayOrServerPolicy policy,
       @JsonProperty(PROP_UID) @Nullable Uid uid) {
-    checkArgument(interfaces != null, "Missing %s", PROP_INTERFACES);
     checkArgument(name != null, "Missing %s", PROP_NAME);
     checkArgument(policy != null, "Missing %s", PROP_POLICY);
     checkArgument(uid != null, "Missing %s", PROP_UID);
@@ -31,7 +30,7 @@ public final class CpmiVsxClusterNetobj extends Cluster {
         ImmutableList.copyOf(firstNonNull(clusterMemberNames, ImmutableList.of())),
         ipv4Address,
         name,
-        interfaces,
+        firstNonNull(interfaces, ImmutableList.of()),
         policy,
         uid);
   }

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiGatewayClusterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiGatewayClusterTest.java
@@ -47,14 +47,13 @@ public final class CpmiGatewayClusterTest {
 
   @Test
   public void testJacksonDeserialization_noOptionalFields() throws JsonProcessingException {
-    // missing members and ipv4-address
+    // missing members, ipv4-address, interfaces
     String input =
         "{"
             + "\"GARBAGE\":0,"
             + "\"type\":\"CpmiGatewayCluster\","
             + "\"uid\":\"0\","
             + "\"name\":\"foo\","
-            + "\"interfaces\": [],"
             + "\"policy\":{"
             + "\"access-policy-installed\": true,"
             + "\"access-policy-name\": \"p1\","

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_management/CpmiVsxClusterNetobjTest.java
@@ -47,14 +47,13 @@ public final class CpmiVsxClusterNetobjTest {
 
   @Test
   public void testJacksonDeserialization_noOptionalFields() throws JsonProcessingException {
-    // missing members and ipv4-address
+    // missing members, ipv4-address, interfaces
     String input =
         "{"
             + "\"GARBAGE\":0,"
             + "\"type\":\"CpmiVsxClusterNetobj\","
             + "\"uid\":\"0\","
             + "\"name\":\"foo\","
-            + "\"interfaces\": [],"
             + "\"policy\":{"
             + "\"access-policy-installed\": true,"
             + "\"access-policy-name\": \"p1\","


### PR DESCRIPTION
Make `interfaces` optional for other cluster classes
