### PR TITLE
Cisco NX-OS fix layer 2 VNIs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1490,7 +1490,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               .build();
       _c.getVrfs().get(vsTenantVrfForL3Vni.getName()).addLayer3Vni(vniSettings);
     } else {
-      org.batfish.datamodel.Vrf viTenantVrfForL2Vni = getMemberVrfForVlan(vlan);
       Layer2Vni vniSettings =
           Layer2Vni.builder()
               .setBumTransportIps(bumTransportIps)
@@ -1504,10 +1503,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               .setVlan(vlan)
               .setSrcVrf(DEFAULT_VRF_NAME)
               .build();
-      if (viTenantVrfForL2Vni == null) {
-        return;
-      }
-      viTenantVrfForL2Vni.addLayer2Vni(vniSettings);
+      _c.getDefaultVrf().addLayer2Vni(vniSettings);
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -1597,7 +1597,7 @@ public final class CiscoNxosGrammarTest {
         ImmutableSortedSet.of(
             Layer2VniConfig.builder()
                 .setVni(1111)
-                .setVrf(tenantVrfName)
+                .setVrf(DEFAULT_VRF_NAME)
                 .setRouteDistinguisher(RouteDistinguisher.from(routerId, 32768))
                 .setRouteTarget(ExtendedCommunity.target(1, 1111))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 1111).matchString())


### PR DESCRIPTION
- put `Layer2Vni`s in default VRF following batfish/batfish#7731