### PR TITLE
NX-OS: Set NVE IP for EVPN address families

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -275,6 +275,7 @@ public final class Conversions {
       BgpProcess proc,
       BgpGlobalConfiguration bgpConfig,
       BgpVrfConfiguration bgpVrf,
+      @Nullable Ip nveIp,
       Warnings warnings) {
     return bgpVrf.getNeighbors().entrySet().stream()
         .peek(e -> e.getValue().doInherit(bgpConfig, warnings))
@@ -294,6 +295,7 @@ public final class Conversions {
                             bgpVrf,
                             e.getValue(),
                             false,
+                            nveIp,
                             warnings)));
   }
 
@@ -305,6 +307,7 @@ public final class Conversions {
       BgpProcess proc,
       BgpGlobalConfiguration bgpConfig,
       BgpVrfConfiguration bgpVrf,
+      @Nullable Ip nveIp,
       Warnings warnings) {
     return bgpVrf.getPassiveNeighbors().entrySet().stream()
         .peek(e -> e.getValue().doInherit(bgpConfig, warnings))
@@ -324,6 +327,7 @@ public final class Conversions {
                             bgpVrf,
                             e.getValue(),
                             true,
+                            nveIp,
                             warnings)));
   }
 
@@ -409,6 +413,7 @@ public final class Conversions {
       BgpVrfConfiguration vrfConfig,
       BgpVrfNeighborConfiguration neighbor,
       boolean dynamic,
+      @Nullable Ip nveIp,
       Warnings warnings) {
 
     BgpPeerConfig.Builder<?, ?> newNeighborBuilder;
@@ -509,7 +514,7 @@ public final class Conversions {
       @Nullable
       BgpVrfL2VpnEvpnAddressFamilyConfiguration vrfL2VpnAf = vrfConfig.getL2VpnEvpnAddressFamily();
       EvpnAddressFamily.Builder evpnFamilyBuilder =
-          EvpnAddressFamily.builder().setPropagateUnmatched(false);
+          EvpnAddressFamily.builder().setPropagateUnmatched(false).setNveIp(nveIp);
 
       RoutingPolicy importPolicy =
           createNeighborImportPolicy(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -1624,6 +1624,7 @@ public final class CiscoNxosGrammarTest {
     assertThat(peer.getEvpnAddressFamily(), notNullValue());
     assertThat(peer.getEvpnAddressFamily().getL2VNIs(), equalTo(expectedL2Vnis));
     assertThat(peer.getEvpnAddressFamily().getL3VNIs(), equalTo(expectedL3Vnis));
+    assertThat(peer.getEvpnAddressFamily().getNveIp(), equalTo(Ip.parse("1.1.1.1")));
     assertThat(c.getVrfs().get(tenantVrfName).getBgpProcess(), notNullValue());
   }
 


### PR DESCRIPTION
For now, assuming that devices only have one NVE, as that seems to be the common case and it is unclear which NVE's source interface address should be used for EVPN NHIPs if there are multiple.