### PR TITLE
A10: support unicode dashes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Lexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Lexer.g4
@@ -481,7 +481,7 @@ F_Word: F_WordChar+;
 fragment
 F_WordChar
 :
-  [0-9A-Za-z!@#$%^&*()_=+.;:{}/<>]
+  [0-9A-Za-z!@#$%^&*()_=+.;:{}/<>\u2013]
   | '-'
 ;
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -1594,7 +1594,7 @@ public class A10GrammarTest {
     ServerPort.ServerPortAndType udp81 = new ServerPort.ServerPortAndType(81, ServerPort.Type.UDP);
 
     // Using unicode dash \u2013
-    String server3Name = "SERVER\u20133";
+    String server3Name = "SERVER–3";
     assertThat(c.getServers().keySet(), containsInAnyOrder("SERVER1", "SERVER2", server3Name));
 
     {

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -1593,7 +1593,9 @@ public class A10GrammarTest {
     ServerPort.ServerPortAndType tcp80 = new ServerPort.ServerPortAndType(80, ServerPort.Type.TCP);
     ServerPort.ServerPortAndType udp81 = new ServerPort.ServerPortAndType(81, ServerPort.Type.UDP);
 
-    assertThat(c.getServers().keySet(), containsInAnyOrder("SERVER1", "SERVER2", "SERVER3"));
+    // Using unicode dash \u2013
+    String server3Name = "SERVER\u20133";
+    assertThat(c.getServers().keySet(), containsInAnyOrder("SERVER1", "SERVER2", server3Name));
 
     {
       Server server1 = c.getServers().get("SERVER1");
@@ -1635,9 +1637,9 @@ public class A10GrammarTest {
     }
 
     {
-      Server server3 = c.getServers().get("SERVER3");
+      Server server3 = c.getServers().get(server3Name);
       assertFalse(server3.getEnable());
-      assertThat(server3.getName(), equalTo("SERVER3"));
+      assertThat(server3.getName(), equalTo(server3Name));
       assertFalse(server3.getStatsDataEnable());
       Map<ServerPort.ServerPortAndType, ServerPort> server3Ports = server3.getPorts();
       assertThat(server3Ports.keySet(), contains(udp81));

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/server
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/server
@@ -24,7 +24,8 @@ slb server SERVER2 10.0.0.102
   port 80 tcp
     weight 999
 !
-slb server SERVER3 10.0.0.3
+! Server name has a unicode dash \u2013
+slb server SERVER–3 10.0.0.3
   disable
   health-check-disable
   stats-data-disable


### PR DESCRIPTION
Support – (`\u2013`) in names.
