### PR TITLE
A10: create interfaces that are static trunk members

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -1658,6 +1658,11 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
         ifaces -> {
           ifaces.forEach(
               iface -> {
+                assert iface.getType() == Type.ETHERNET;
+                // Interfaces may not show up elsewhere if members of a trunk
+                _c.getInterfacesEthernet()
+                    .computeIfAbsent(iface.getNumber(), n -> new Interface(Type.ETHERNET, n));
+                _c.defineStructure(INTERFACE, getInterfaceName(iface), ctx);
                 _c.referenceStructure(
                     INTERFACE, getInterfaceName(iface), A10StructureUsage.TRUNK_INTERFACE, line);
                 _currentTrunk.getMembers().add(iface);

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -1062,9 +1062,7 @@ public class A10GrammarTest {
                 WarningMatchers.hasText(
                     containsString(
                         "VLAN settings for members of Trunk1 are different, ignoring their VLAN"
-                            + " settings")),
-                WarningMatchers.hasText(
-                    "Trunk member Ethernet10 does not exist, cannot add to Trunk1"))));
+                            + " settings")))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/trunk_acos2
@@ -4,6 +4,7 @@ hostname trunk_acos2
 !
 ! Default (static?) trunk definition
 trunk 2
+ ! Interfaces may not show up below if attached to a trunk
  ethernet 5 ethernet 2 to 3
  name trunk2Name
 !
@@ -13,8 +14,6 @@ interface ethernet 1
  lacp timeout short
  enable
 !
-interface ethernet 2
- enable
 !
 interface ethernet 3
  enable


### PR DESCRIPTION
Static trunk member interfaces may not show up later in configs, at least for acosv2 devices.

So, create them at reference time.
