### PR TITLE
A10: test `server` and `service-group` references

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -49,6 +49,8 @@ import static org.batfish.vendor.a10.representation.A10Conversion.SNAT_PORT_POOL
 import static org.batfish.vendor.a10.representation.A10StructureType.ACCESS_LIST;
 import static org.batfish.vendor.a10.representation.A10StructureType.HEALTH_MONITOR;
 import static org.batfish.vendor.a10.representation.A10StructureType.INTERFACE;
+import static org.batfish.vendor.a10.representation.A10StructureType.SERVER;
+import static org.batfish.vendor.a10.representation.A10StructureType.SERVICE_GROUP;
 import static org.batfish.vendor.a10.representation.A10StructureType.VRRP_A_FAIL_OVER_POLICY_TEMPLATE;
 import static org.batfish.vendor.a10.representation.A10StructureType.VRRP_A_VRID;
 import static org.batfish.vendor.a10.representation.Interface.DEFAULT_MTU;
@@ -2221,5 +2223,35 @@ public class A10GrammarTest {
 
     assertThat(ccae, hasNumReferrers(filename, ACCESS_LIST, "ACL_UNUSED", 0));
     assertThat(ccae, hasNumReferrers(filename, ACCESS_LIST, "ACL1", 1));
+  }
+
+  @Test
+  public void testServerReferences() throws IOException {
+    String hostname = "server_ref";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    assertThat(ccae, hasDefinedStructure(filename, SERVER, "SERVER1"));
+    assertThat(ccae, hasDefinedStructure(filename, SERVER, "SERVER2"));
+
+    assertThat(ccae, hasNumReferrers(filename, SERVER, "SERVER1", 1));
+    assertThat(ccae, hasNumReferrers(filename, SERVER, "SERVER2", 0));
+  }
+
+  @Test
+  public void testServiceGroupReferences() throws IOException {
+    String hostname = "service_group_ref";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    assertThat(ccae, hasDefinedStructure(filename, SERVICE_GROUP, "SG1"));
+    assertThat(ccae, hasDefinedStructure(filename, SERVICE_GROUP, "SG2"));
+
+    assertThat(ccae, hasNumReferrers(filename, SERVICE_GROUP, "SG1", 1));
+    assertThat(ccae, hasNumReferrers(filename, SERVICE_GROUP, "SG2", 0));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/server_ref
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/server_ref
@@ -1,0 +1,13 @@
+!BATFISH_FORMAT: a10_acos
+hostname server_ref
+!
+!
+slb server SERVER1 10.0.0.1
+!
+slb server SERVER2 10.0.0.2
+!
+!
+slb service-group SG1 tcp
+  ! Note: can define new ports for a server in this context
+  member SERVER1 80
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/service_group_ref
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/service_group_ref
@@ -1,0 +1,19 @@
+!BATFISH_FORMAT: a10_acos
+hostname service_group_ref
+!
+!
+slb server SERVER1 10.0.0.1
+!
+slb service-group SG1 tcp
+  ! Note: can define new ports for a server in this context
+  member SERVER1 80
+!
+slb service-group SG2 tcp
+  ! Note: can define new ports for a server in this context
+  member SERVER1 81
+!
+!
+slb virtual-server VS1 10.0.0.101
+  port 80 tcp range 10
+    service-group SG1
+!


### PR DESCRIPTION
Reference tracking was already supported; this PR just adds tests for it