### PR TITLE
A10: test `nat pool` references

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -49,6 +49,7 @@ import static org.batfish.vendor.a10.representation.A10Conversion.SNAT_PORT_POOL
 import static org.batfish.vendor.a10.representation.A10StructureType.ACCESS_LIST;
 import static org.batfish.vendor.a10.representation.A10StructureType.HEALTH_MONITOR;
 import static org.batfish.vendor.a10.representation.A10StructureType.INTERFACE;
+import static org.batfish.vendor.a10.representation.A10StructureType.NAT_POOL;
 import static org.batfish.vendor.a10.representation.A10StructureType.VRRP_A_FAIL_OVER_POLICY_TEMPLATE;
 import static org.batfish.vendor.a10.representation.A10StructureType.VRRP_A_VRID;
 import static org.batfish.vendor.a10.representation.Interface.DEFAULT_MTU;
@@ -1315,6 +1316,19 @@ public class A10GrammarTest {
     assertTrue(pool2.getPortOverload());
     assertThat(pool2.getScaleoutDeviceId(), equalTo(1));
     assertThat(pool2.getVrid(), equalTo(2));
+  }
+
+  @Test
+  public void testNatPoolReference() throws IOException {
+    String hostname = "nat_pool_ref";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Confirm reference counts
+    assertThat(ccae, hasNumReferrers(filename, NAT_POOL, "POOL1", 1));
+    assertThat(ccae, hasNumReferrers(filename, NAT_POOL, "POOL2", 0));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -17,6 +17,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasDefinedStructure;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNumReferrers;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasReferencedStructure;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAddressMetadata;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
@@ -52,6 +53,7 @@ import static org.batfish.vendor.a10.representation.A10StructureType.INTERFACE;
 import static org.batfish.vendor.a10.representation.A10StructureType.NAT_POOL;
 import static org.batfish.vendor.a10.representation.A10StructureType.VRRP_A_FAIL_OVER_POLICY_TEMPLATE;
 import static org.batfish.vendor.a10.representation.A10StructureType.VRRP_A_VRID;
+import static org.batfish.vendor.a10.representation.A10StructureUsage.VIRTUAL_SERVER_SOURCE_NAT_POOL;
 import static org.batfish.vendor.a10.representation.Interface.DEFAULT_MTU;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.allOf;
@@ -1328,6 +1330,8 @@ public class A10GrammarTest {
 
     // Confirm reference counts
     assertThat(ccae, hasNumReferrers(filename, NAT_POOL, "POOL1", 1));
+    assertThat(
+        ccae, hasReferencedStructure(filename, NAT_POOL, "POOL1", VIRTUAL_SERVER_SOURCE_NAT_POOL));
     assertThat(ccae, hasNumReferrers(filename, NAT_POOL, "POOL2", 0));
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/nat_pool_ref
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/nat_pool_ref
@@ -1,0 +1,11 @@
+!BATFISH_FORMAT: a10_acos
+hostname nat_pool_ref
+!
+ip nat pool POOL1 10.10.10.10 10.10.10.11 netmask /24
+ip nat pool POOL2 10.10.10.20 10.10.10.21 netmask /24
+!
+!
+slb virtual-server VS1 10.0.0.101
+  port 80 tcp range 10
+    source-nat pool POOL1
+!


### PR DESCRIPTION
Reference tracking was already supported; this PR just adds tests for it