### PR TITLE
Add a node filter to the viModel question

### DIFF
--- a/projects/question/src/test/java/org/batfish/question/VIModelQuestionPluginTest.java
+++ b/projects/question/src/test/java/org/batfish/question/VIModelQuestionPluginTest.java
@@ -1,0 +1,33 @@
+package org.batfish.question;
+
+import static org.batfish.datamodel.ConfigurationFormat.ARISTA;
+import static org.batfish.question.VIModelQuestionPlugin.VIModelAnswerer.getConfigs;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.batfish.datamodel.Configuration;
+import org.batfish.question.VIModelQuestionPlugin.VIModelQuestion;
+import org.batfish.specifier.MockSpecifierContext;
+import org.junit.Test;
+
+public class VIModelQuestionPluginTest {
+
+  @Test
+  public void testGetConfigs() {
+    Configuration c1 =
+        Configuration.builder().setConfigurationFormat(ARISTA).setHostname("c1").build();
+    Configuration c2 =
+        Configuration.builder().setConfigurationFormat(ARISTA).setHostname("c2").build();
+    MockSpecifierContext context =
+        MockSpecifierContext.builder()
+            .setConfigs(ImmutableSortedMap.of(c1.getHostname(), c1, c2.getHostname(), c2))
+            .build();
+    assertThat(
+        getConfigs(new VIModelQuestion(null), context),
+        equalTo(ImmutableSortedMap.of(c1.getHostname(), c1, c2.getHostname(), c2)));
+    assertThat(
+        getConfigs(new VIModelQuestion(c1.getHostname()), context),
+        equalTo(ImmutableSortedMap.of(c1.getHostname(), c1)));
+  }
+}

--- a/questions/experimental/viModel.json
+++ b/questions/experimental/viModel.json
@@ -1,6 +1,7 @@
 {
     "class": "org.batfish.question.VIModelQuestionPlugin$VIModelQuestion",
     "differential": false,
+    "nodes": "${nodes}",
     "instance": {
         "description": "Lists configuration attributes of nodes and edges in the network.",
         "instanceName": "viModel",
@@ -8,6 +9,13 @@
         "tags": [
             "configuration"
         ],
-        "variables": {}
+        "variables": {
+            "nodes": {
+                "description": "Include nodes matching this name or regex",
+                "type": "nodeSpec",
+                "optional": true,
+                "displayName": "Nodes"
+            }
+        }
     }
 }

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -118,7 +118,7 @@ test -raw tests/questions/experimental/testRoutePolicies.ref validate-template t
 test -raw tests/questions/experimental/traceroute.ref validate-template traceroute startLocation="location", ignoreFilters=false, maxTraces=0, headers={"dstIps" : "1.1.1.1/32"}
 
 # test viModel
-test -raw tests/questions/experimental/viModel.ref validate-template viModel
+test -raw tests/questions/experimental/viModel.ref validate-template viModel nodes="n1"
 
 # validate vrrpProperties
 test -raw tests/questions/experimental/vrrpProperties.ref validate-template vrrpProperties excludeShutInterfaces=true, interfaces="i1", nodes="n1"

--- a/tests/questions/experimental/viModel.ref
+++ b/tests/questions/experimental/viModel.ref
@@ -1,5 +1,6 @@
 {
   "class" : "org.batfish.question.VIModelQuestionPlugin$VIModelQuestion",
+  "nodes" : "n1",
   "differential" : false,
   "includeOneTableKeys" : true,
   "instance" : {
@@ -8,6 +9,15 @@
     "longDescription" : "Returns a JSON dictionary with all of the configuration parameters and neighbor relations stored in the vendor independent data-model.",
     "tags" : [
       "configuration"
-    ]
+    ],
+    "variables" : {
+      "nodes" : {
+        "description" : "Include nodes matching this name or regex",
+        "displayName" : "Nodes",
+        "optional" : true,
+        "type" : "nodeSpec",
+        "value" : "n1"
+      }
+    }
   }
 }


### PR DESCRIPTION
Developer convenience: when playing with large networks, it is useful to fetch and examine the model for just one node.

Cc: @saparikh 