### PR TITLE
JunOS: fix typo in FwFromPacketLength

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPacketLength.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromPacketLength.java
@@ -25,7 +25,7 @@ public class FwFromPacketLength implements FwFrom {
 
   @Override
   public Field getField() {
-    return _except ? Field.FRAGMENT_OFFSET_EXCEPT : Field.PACKET_LENGTH;
+    return _except ? Field.PACKET_LENGTH_EXCEPT : Field.PACKET_LENGTH;
   }
 
   @Override


### PR DESCRIPTION
This effectively only matters for changes to packet-length except, so
really affected nothing. But I noticed.