### PR TITLE
Granular status for multifile parsing

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
@@ -11,10 +11,7 @@ public enum ParseStatus {
   EMPTY,
   /** Batfish has encountered an unrecoverable error during parsing */
   FAILED,
-  /**
-   * File was ignored either explicitly by the user or it was of a multi-file bundle that was not
-   * properly packaged.
-   */
+  /** File was explicitly ignore by the user */
   IGNORED,
   /** File is part of an unused overlay configuration */
   ORPHANED,
@@ -22,6 +19,8 @@ public enum ParseStatus {
   PARTIALLY_UNRECOGNIZED,
   /** File was fully parsed */
   PASSED,
+  /** File was packaged in an unexpected manner in the snapshot */
+  UNEXPECTED_PACKAGING,
   /** Batfish could not detect the file format */
   UNKNOWN,
   /** Batfish does not support the format/vendor config in the file */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
@@ -11,7 +11,10 @@ public enum ParseStatus {
   EMPTY,
   /** Batfish has encountered an unrecoverable error during parsing */
   FAILED,
-  /** File was explicitly ignored by the user */
+  /**
+   * File was ignored either explicitly by the user or it was of a multi-file bundle that was not
+   * properly packaged.
+   */
   IGNORED,
   /** File is part of an unused overlay configuration */
   ORPHANED,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
@@ -55,6 +55,8 @@ public enum ParseStatus {
         return "File contained at least one unrecognized line";
       case PASSED:
         return "File parsed successfully";
+      case UNEXPECTED_PACKAGING:
+        return "File was not correctly packaged in the snapshot";
       case UNKNOWN:
         return "File format is unknown";
       case UNSUPPORTED:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -43,6 +43,7 @@ public abstract class VendorConfiguration implements Serializable {
   private transient @Nullable ConversionContext _conversionContext;
   private transient ConvertConfigurationAnswerElement _answerElement;
   protected String _filename;
+  protected @Nonnull List<String> _secondaryFilenames;
   @Nonnull protected transient SnapshotRuntimeData _runtimeData;
   private VendorConfiguration _overlayConfiguration;
   /** Type description -> Name -> DefinedStructureInfo */
@@ -66,6 +67,7 @@ public abstract class VendorConfiguration implements Serializable {
     _structureDefinitions = new TreeMap<>();
     _structureReferences = new TreeMap<>();
     _undefinedReferences = new TreeMap<>();
+    _secondaryFilenames = ImmutableList.of();
   }
 
   public String canonicalizeInterfaceName(String name) {
@@ -81,8 +83,17 @@ public abstract class VendorConfiguration implements Serializable {
     return _conversionContext;
   }
 
+  /** Returns the primary file from which this vendor configuration was extracted */
   public String getFilename() {
     return _filename;
+  }
+
+  /**
+   * Returns any additional files, beyond the primary one, from which this vendor configuration was
+   * extracted
+   */
+  public @Nonnull List<String> getSecondaryFilenames() {
+    return _secondaryFilenames;
   }
 
   public abstract String getHostname();
@@ -360,6 +371,10 @@ public abstract class VendorConfiguration implements Serializable {
 
   public void setFilename(String filename) {
     _filename = filename;
+  }
+
+  public void setSecondaryFilenames(List<String> filenames) {
+    _secondaryFilenames = ImmutableList.copyOf(filenames);
   }
 
   public abstract void setHostname(String hostname);

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -4,6 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.vendor.ConversionContext.EMPTY_CONVERSION_CONTEXT;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -14,6 +15,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
@@ -560,7 +562,11 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     try {
       VendorConfiguration vendorConfiguration = (VendorConfiguration) _configObject;
       Warnings warnings = Batfish.buildWarnings(_settings);
-      String filename = vendorConfiguration.getFilename();
+      List<String> filenames =
+          ImmutableList.<String>builder()
+              .add(vendorConfiguration.getFilename())
+              .addAll(vendorConfiguration.getSecondaryFilenames())
+              .build();
       vendorConfiguration.setWarnings(warnings);
       vendorConfiguration.setAnswerElement(answerElement);
       vendorConfiguration.setConversionContext(_conversionContext);
@@ -590,7 +596,7 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
         String hostname = configuration.getHostname();
         configurations.put(hostname, configuration);
         warningsByHost.put(hostname, warnings);
-        fileMap.put(filename, hostname);
+        filenames.forEach(filename -> fileMap.put(filename, hostname));
       }
       _logger.info(" ...OK\n");
     } catch (Exception e) {

--- a/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
@@ -8,7 +8,6 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.ConfigurationFormat;
-import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.job.ParseVendorConfigurationJob.FileResult;
 import org.batfish.vendor.VendorConfiguration;
 
@@ -20,7 +19,6 @@ public class ParseResult implements Serializable {
   @Nullable private final Throwable _failureCause;
   @Nonnull private final Map<String, FileResult> _fileResults;
   @Nonnull private final ConfigurationFormat _format;
-  @Nonnull private final ParseStatus _status;
   @Nonnull private final Warnings _warnings;
 
   public ParseResult(
@@ -28,13 +26,11 @@ public class ParseResult implements Serializable {
       @Nullable Throwable failureCause,
       Map<String, FileResult> fileResults,
       ConfigurationFormat format,
-      ParseStatus status,
       Warnings warnings) {
     _config = config;
     _failureCause = failureCause;
     _fileResults = ImmutableMap.copyOf(fileResults);
     _format = format;
-    _status = status;
     _warnings = warnings;
   }
 
@@ -60,11 +56,6 @@ public class ParseResult implements Serializable {
   @Nonnull
   public ConfigurationFormat getFormat() {
     return _format;
-  }
-
-  @Nonnull
-  public ParseStatus getStatus() {
-    return _status;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
@@ -1,5 +1,7 @@
 package org.batfish.job;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.Map;
@@ -27,6 +29,9 @@ public class ParseResult implements Serializable {
       Map<String, FileResult> fileResults,
       ConfigurationFormat format,
       Warnings warnings) {
+    checkArgument(
+        fileResults.values().stream().noneMatch(fr -> fr.getParseStatus() == null),
+        "ParseStatus is not set for some files");
     _config = config;
     _failureCause = failureCause;
     _fileResults = ImmutableMap.copyOf(fileResults);

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -196,8 +196,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                         new FileResult(
                             new ParseTreeSentences(),
                             new SilentSyntaxCollection(),
-                            new Warnings(logSettings),
-                            ParseStatus.UNKNOWN)));
+                            new Warnings(logSettings))));
     _expectedFormat = expectedFormat;
     _duplicateHostnames = duplicateHostnames;
     _spanContext = spanContext;

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -2,13 +2,13 @@ package org.batfish.job;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import io.opentracing.References;
 import io.opentracing.Scope;
@@ -109,14 +109,28 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
     @Nonnull private ParseTreeSentences _parseTreeSentences;
     @Nonnull private final SilentSyntaxCollection _silentSyntax;
     @Nonnull private final Warnings _warnings;
+    @Nullable private ParseStatus _parseStatus;
 
     public FileResult(
         ParseTreeSentences parseTreeSentences,
         SilentSyntaxCollection silentSyntax,
         Warnings warnings) {
+      this(parseTreeSentences, silentSyntax, warnings, null);
+    }
+
+    public FileResult(
+        ParseTreeSentences parseTreeSentences,
+        SilentSyntaxCollection silentSyntax,
+        Warnings warnings,
+        @Nullable ParseStatus parseStatus) {
       _parseTreeSentences = parseTreeSentences;
       _silentSyntax = silentSyntax;
       _warnings = warnings;
+      _parseStatus = parseStatus;
+    }
+
+    public void setParseStatus(ParseStatus parseStatus) {
+      _parseStatus = parseStatus;
     }
 
     @Nonnull
@@ -132,6 +146,11 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
     @Nonnull
     public Warnings getWarnings() {
       return _warnings;
+    }
+
+    @Nullable
+    public ParseStatus getParseStatus() {
+      return _parseStatus;
     }
   }
 
@@ -177,7 +196,8 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                         new FileResult(
                             new ParseTreeSentences(),
                             new SilentSyntaxCollection(),
-                            new Warnings(logSettings))));
+                            new Warnings(logSettings),
+                            ParseStatus.UNKNOWN)));
     _expectedFormat = expectedFormat;
     _duplicateHostnames = duplicateHostnames;
     _spanContext = spanContext;
@@ -229,7 +249,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
    */
   @SuppressWarnings("fallthrough")
   private VendorConfiguration parseFiles(ConfigurationFormat format) {
-    ControlPlaneExtractor extractor;
+    VendorConfiguration vc;
     FlattenerLineMap lineMap = null;
 
     Span parseSpan = GlobalTracer.get().buildSpan("Creating parser").start();
@@ -237,27 +257,29 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
       assert scope != null; // avoid unused warning
 
       // pull out the common case
-      String filename = getRepresentativeFilename(_fileTexts, format);
+      String filename = _fileTexts.keySet().iterator().next();
       String fileText = _fileTexts.get(filename);
 
       switch (format) {
         case A10_ACOS:
           {
             A10CombinedParser a10Parser = new A10CombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new A10ControlPlaneExtractor(
                     fileText,
                     a10Parser,
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, a10Parser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
         case ARISTA:
           {
             AristaCombinedParser aristaParser = new AristaCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new AristaControlPlaneExtractor(
                     fileText,
                     aristaParser,
@@ -265,6 +287,8 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, aristaParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
@@ -275,7 +299,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
         case FOUNDRY:
           {
             CiscoCombinedParser ciscoParser = new CiscoCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new CiscoControlPlaneExtractor(
                     fileText,
                     ciscoParser,
@@ -283,18 +307,22 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, ciscoParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
         case CISCO_ASA:
           {
             AsaCombinedParser asaParser = new AsaCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new AsaControlPlaneExtractor(
                     fileText,
                     asaParser,
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, asaParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
@@ -302,20 +330,22 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           {
             CiscoNxosCombinedParser ciscoNxosParser =
                 new CiscoNxosCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new NxosControlPlaneExtractor(
                     fileText,
                     ciscoNxosParser,
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, ciscoNxosParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
         case CISCO_IOS_XR:
           {
             CiscoXrCombinedParser ciscoXrParser = new CiscoXrCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new CiscoXrControlPlaneExtractor(
                     fileText,
                     ciscoXrParser,
@@ -323,6 +353,8 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, ciscoXrParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
@@ -330,13 +362,15 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           {
             CheckPointGatewayCombinedParser checkPointParser =
                 new CheckPointGatewayCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new CheckPointGatewayControlPlaneExtractor(
                     fileText,
                     checkPointParser,
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, checkPointParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
@@ -344,7 +378,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           {
             CumulusConcatenatedCombinedParser parser =
                 new CumulusConcatenatedCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new CumulusConcatenatedControlPlaneExtractor(
                     fileText,
                     _fileResults.get(filename)._warnings,
@@ -356,19 +390,23 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                     _settings.getPrintParseTreeLineNums(),
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, parser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
         case CUMULUS_NCLU:
           {
             CumulusNcluCombinedParser parser = new CumulusNcluCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new CumulusNcluControlPlaneExtractor(
                     fileText,
                     parser,
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, parser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
@@ -376,7 +414,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           {
             F5BigipStructuredCombinedParser parser =
                 new F5BigipStructuredCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new F5BigipStructuredControlPlaneExtractor(
                     fileText,
                     parser,
@@ -388,19 +426,23 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                     _settings.getPrintParseTreeLineNums(),
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, parser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
         case FORTIOS:
           {
             FortiosCombinedParser parser = new FortiosCombinedParser(fileText, _settings);
-            extractor =
+            ControlPlaneExtractor extractor =
                 new FortiosControlPlaneExtractor(
                     fileText,
                     parser,
                     _fileResults.get(filename)._warnings,
                     _fileResults.get(filename)._silentSyntax);
             parseFile(filename, parser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
             break;
           }
 
@@ -427,14 +469,22 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                     .get(); // there has to be another file
             String configDbFileText = _fileTexts.get(configDbFilename);
             FrrCombinedParser frrParser = new FrrCombinedParser(frrText, _settings, 1, 0);
-            extractor =
+            SonicControlPlaneExtractor extractor =
                 new SonicControlPlaneExtractor(
                     configDbFileText,
                     frrText,
                     frrParser,
                     _fileResults.get(frrFilename)._warnings,
                     _fileResults.get(frrFilename)._silentSyntax);
+            try {
+              extractor.processConfigDb();
+            } catch (JsonProcessingException exception) {
+              throw new BatfishException("Error deserializing " + configDbFilename, exception);
+            }
             parseFile(frrFilename, frrParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(frrFilename);
+            vc.setSecondaryFilenames(ImmutableList.of(configDbFilename));
             break;
           }
 
@@ -458,15 +508,19 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                   .getFlattenedConfigurationText();
           // fall through
         case FLAT_VYOS:
-          FlatVyosCombinedParser flatVyosParser = new FlatVyosCombinedParser(fileText, _settings);
-          extractor =
-              new FlatVyosControlPlaneExtractor(
-                  fileText,
-                  flatVyosParser,
-                  _fileResults.get(filename)._warnings,
-                  _fileResults.get(filename)._silentSyntax);
-          parseFile(filename, flatVyosParser, extractor);
-          break;
+          {
+            FlatVyosCombinedParser flatVyosParser = new FlatVyosCombinedParser(fileText, _settings);
+            ControlPlaneExtractor extractor =
+                new FlatVyosControlPlaneExtractor(
+                    fileText,
+                    flatVyosParser,
+                    _fileResults.get(filename)._warnings,
+                    _fileResults.get(filename)._silentSyntax);
+            parseFile(filename, flatVyosParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
+            break;
+          }
 
         case JUNIPER:
           try {
@@ -486,39 +540,51 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           }
           // fall through
         case FLAT_JUNIPER:
-          FlatJuniperCombinedParser flatJuniperParser =
-              new FlatJuniperCombinedParser(fileText, _settings, lineMap);
-          extractor =
-              new FlatJuniperControlPlaneExtractor(
-                  fileText,
-                  flatJuniperParser,
-                  _fileResults.get(filename)._warnings,
-                  _fileResults.get(filename)._silentSyntax);
-          parseFile(filename, flatJuniperParser, extractor);
-          break;
+          {
+            FlatJuniperCombinedParser flatJuniperParser =
+                new FlatJuniperCombinedParser(fileText, _settings, lineMap);
+            ControlPlaneExtractor extractor =
+                new FlatJuniperControlPlaneExtractor(
+                    fileText,
+                    flatJuniperParser,
+                    _fileResults.get(filename)._warnings,
+                    _fileResults.get(filename)._silentSyntax);
+            parseFile(filename, flatJuniperParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
+            break;
+          }
 
         case IPTABLES:
-          IptablesCombinedParser iptablesParser = new IptablesCombinedParser(fileText, _settings);
-          extractor =
-              new IptablesControlPlaneExtractor(
-                  fileText,
-                  iptablesParser,
-                  _fileResults.get(filename)._warnings,
-                  filename,
-                  _fileResults.get(filename)._silentSyntax);
-          parseFile(filename, iptablesParser, extractor);
-          break;
+          {
+            IptablesCombinedParser iptablesParser = new IptablesCombinedParser(fileText, _settings);
+            ControlPlaneExtractor extractor =
+                new IptablesControlPlaneExtractor(
+                    fileText,
+                    iptablesParser,
+                    _fileResults.get(filename)._warnings,
+                    filename,
+                    _fileResults.get(filename)._silentSyntax);
+            parseFile(filename, iptablesParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
+            break;
+          }
 
         case MRV:
-          MrvCombinedParser mrvParser = new MrvCombinedParser(fileText, _settings);
-          extractor =
-              new MrvControlPlaneExtractor(
-                  fileText,
-                  mrvParser,
-                  _fileResults.get(filename)._warnings,
-                  _fileResults.get(filename)._silentSyntax);
-          parseFile(filename, mrvParser, extractor);
-          break;
+          {
+            MrvCombinedParser mrvParser = new MrvCombinedParser(fileText, _settings);
+            ControlPlaneExtractor extractor =
+                new MrvControlPlaneExtractor(
+                    fileText,
+                    mrvParser,
+                    _fileResults.get(filename)._warnings,
+                    _fileResults.get(filename)._silentSyntax);
+            parseFile(filename, mrvParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
+            break;
+          }
 
         case PALO_ALTO_NESTED:
           try {
@@ -538,16 +604,20 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           }
           // fall through
         case PALO_ALTO:
-          PaloAltoCombinedParser paParser =
-              new PaloAltoCombinedParser(fileText, _settings, lineMap);
-          extractor =
-              new PaloAltoControlPlaneExtractor(
-                  fileText,
-                  paParser,
-                  _fileResults.get(filename)._warnings,
-                  _fileResults.get(filename)._silentSyntax);
-          parseFile(filename, paParser, extractor);
-          break;
+          {
+            PaloAltoCombinedParser paParser =
+                new PaloAltoCombinedParser(fileText, _settings, lineMap);
+            ControlPlaneExtractor extractor =
+                new PaloAltoControlPlaneExtractor(
+                    fileText,
+                    paParser,
+                    _fileResults.get(filename)._warnings,
+                    _fileResults.get(filename)._silentSyntax);
+            parseFile(filename, paParser, extractor);
+            vc = extractor.getVendorConfiguration();
+            vc.setFilename(filename);
+            break;
+          }
 
         default:
           throw new BatfishException(
@@ -557,29 +627,19 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
       parseSpan.finish();
     }
 
-    String representativeFilename = getRepresentativeFilename(_fileTexts, format);
-    VendorConfiguration vc = extractor.getVendorConfiguration();
     vc.setVendor(format);
-    vc.setFilename(representativeFilename);
     if (Strings.isNullOrEmpty(vc.getHostname())) {
-      _fileResults
-          .get(representativeFilename)
-          ._warnings
-          .redFlag(
-              String.format(
-                  "No hostname set in %s\n",
-                  _fileTexts.keySet().stream()
-                      .map(f -> f.replace("\\", "/"))
-                      .collect(ImmutableList.toImmutableList())));
+      _warnings.redFlag(
+          String.format("No hostname set in %s\n", jobFilenamesToString(_fileTexts.keySet())));
       String guessedHostname =
-          Paths.get(representativeFilename)
+          Paths.get(vc.getFilename()) // use the primary file for guessing filename
               .getFileName()
               .toString()
               .toLowerCase()
               .replaceAll("\\.(cfg|conf)$", "");
       _logger.redflag(
           "\tNo hostname set! Guessing hostname from filename: '"
-              + representativeFilename
+              + vc.getFilename()
               + "' ==> '"
               + guessedHostname
               + "'\n");
@@ -634,14 +694,21 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
       Batfish.logWarnings(_logger, _fileResults.get(filename)._warnings);
       postProcessSpan.finish();
     }
+
+    _fileResults
+        .get(filename)
+        .setParseStatus(
+            extractor.getVendorConfiguration().getUnrecognized()
+                ? ParseStatus.PARTIALLY_UNRECOGNIZED
+                : ParseStatus.PASSED);
   }
 
   /**
    * Parses the given file and returns a {@link ParseResult} for this job.
    *
-   * <p>The returned {@link ParseResult} will always have a valid {@link ParseResult#getStatus()}.
-   * It may also contain a {@link ParseResult#getConfig() parsed vendor-specific configuration} or a
-   * {@link ParseResult#getFailureCause() failure cause}.
+   * <p>The returned {@link ParseResult} will always have a valid ParseStatus for each file. It may
+   * also contain a {@link ParseResult#getConfig() parsed vendor-specific configuration} or a {@link
+   * ParseResult#getFailureCause() failure cause}.
    */
   @Nonnull
   public ParseResult parse() {
@@ -651,54 +718,55 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
     // Handle specially some cases that will not produce a vendor configuration file.
     if (format == ConfigurationFormat.EMPTY) {
       _warnings.redFlag(String.format("Empty file(s): %s\n", jobFiles));
-      return new ParseResult(null, null, _fileResults, format, ParseStatus.EMPTY, _warnings);
+      _fileResults.forEach((filename, fileResult) -> fileResult.setParseStatus(ParseStatus.EMPTY));
+      return new ParseResult(null, null, _fileResults, format, _warnings);
     } else if (format == ConfigurationFormat.IGNORED) {
       _warnings.redFlag(String.format("Ignored file(s): %s\n", jobFiles));
-      return new ParseResult(null, null, _fileResults, format, ParseStatus.IGNORED, _warnings);
+      _fileResults.forEach(
+          (filename, fileResult) -> fileResult.setParseStatus(ParseStatus.IGNORED));
+      return new ParseResult(null, null, _fileResults, format, _warnings);
     } else if (format == ConfigurationFormat.UNKNOWN) {
       _warnings.redFlag(String.format("Unable to detect format for file(s): %s\n", jobFiles));
-      return new ParseResult(null, null, _fileResults, format, ParseStatus.UNKNOWN, _warnings);
+      _fileResults.forEach(
+          (filename, fileResult) -> fileResult.setParseStatus(ParseStatus.UNKNOWN));
+      return new ParseResult(null, null, _fileResults, format, _warnings);
     } else if (UNIMPLEMENTED_FORMATS.contains(format)) {
       String unsupportedError =
           String.format(
               "Unsupported configuration format '%s' for file(s): %s\n", format, jobFiles);
       if (!_settings.ignoreUnsupported()) {
+        _fileResults.forEach(
+            (filename, fileResult) -> fileResult.setParseStatus(ParseStatus.FAILED));
         return new ParseResult(
-            null,
-            new BatfishException(unsupportedError),
-            _fileResults,
-            format,
-            ParseStatus.FAILED,
-            _warnings);
+            null, new BatfishException(unsupportedError), _fileResults, format, _warnings);
       }
       _warnings.redFlag(unsupportedError);
-      return new ParseResult(null, null, _fileResults, format, ParseStatus.UNSUPPORTED, _warnings);
+      _fileResults.forEach(
+          (filename, fileResult) -> fileResult.setParseStatus(ParseStatus.UNSUPPORTED));
+      return new ParseResult(null, null, _fileResults, format, _warnings);
     }
 
     try {
       // Actually parse the files.
       VendorConfiguration vc = parseFiles(format);
-      ParseStatus status =
-          vc.getUnrecognized() ? ParseStatus.PARTIALLY_UNRECOGNIZED : ParseStatus.PASSED;
-      return new ParseResult(vc, null, _fileResults, format, status, _warnings);
+      return new ParseResult(vc, null, _fileResults, format, _warnings);
     } catch (WillNotCommitException e) {
+      _fileResults.forEach((key, value) -> value.setParseStatus(ParseStatus.WILL_NOT_COMMIT));
       if (_settings.getHaltOnParseError()) {
         // Fail the job if we need to
-        return new ParseResult(
-            null, e, _fileResults, format, ParseStatus.WILL_NOT_COMMIT, _warnings);
+        return new ParseResult(null, e, _fileResults, format, _warnings);
       }
       // Otherwise just generate a warning
       _warnings.redFlag(e.getMessage());
-      return new ParseResult(
-          null, null, _fileResults, format, ParseStatus.WILL_NOT_COMMIT, _warnings);
+      return new ParseResult(null, null, _fileResults, format, _warnings);
     } catch (Exception e) {
+      _fileResults.forEach((filename, fileResult) -> fileResult.setParseStatus(ParseStatus.FAILED));
       return new ParseResult(
           null,
           new BatfishException(
               String.format("Error parsing configuration file(s): %s", _fileTexts.keySet()), e),
           _fileResults,
           format,
-          ParseStatus.FAILED,
           _warnings);
     }
   }
@@ -712,7 +780,6 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           result.getFormat(),
           result.getConfig(),
           result.getWarnings(),
-          result.getStatus(),
           _duplicateHostnames);
     } else if (result.getFailureCause() != null) {
       return new ParseVendorConfigurationResult(
@@ -728,8 +795,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           _logger.getHistory(),
           result.getFileResults(),
           result.getFormat(),
-          result.getWarnings(),
-          result.getStatus());
+          result.getWarnings());
     }
   }
 
@@ -768,23 +834,6 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
             .map(Names::escapeNameIfNeeded)
             .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()))
             .toString();
-  }
-
-  /**
-   * For some existing APIs, e.g., {@link
-   * org.batfish.vendor.VendorConfiguration#setFilename(java.lang.String)}, a single filename is
-   * expected. This representative filename, corresponding to the main file, will be used until we
-   * can upgrade those APIs.
-   */
-  private static String getRepresentativeFilename(
-      Map<String, String> fileTexts, ConfigurationFormat format) {
-    if (fileTexts.size() == 1) {
-      return Iterables.getOnlyElement(fileTexts.keySet());
-    }
-    if (format == ConfigurationFormat.SONIC) {
-      return getSonicFrrFilename(fileTexts);
-    }
-    throw new IllegalArgumentException("Cannot get representative filename for " + format);
   }
 
   private static final Pattern LIKELY_JSON = Pattern.compile("^\\s*\\{", Pattern.DOTALL);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2941,7 +2941,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
             new Warning(
                 "Unexpected packaging: SONiC files must be in a subdirectory under sonic_configs.",
                 "sonic"));
-        pvcae.getParseStatus().put(filename, ParseStatus.IGNORED);
+        pvcae.getParseStatus().put(filename, ParseStatus.UNEXPECTED_PACKAGING);
         continue;
       }
       String dir = path.getParent().toString();
@@ -2959,7 +2959,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
                 "Unexpected packaging: File appears by itself; SONiC files must have their"
                     + " counterpart in the same directory.",
                 "sonic"));
-        pvcae.getParseStatus().put(filename, ParseStatus.IGNORED);
+        pvcae.getParseStatus().put(filename, ParseStatus.UNEXPECTED_PACKAGING);
         continue;
       }
       if (files.size() > 2) {
@@ -2972,7 +2972,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
                           + " files must have only their counterpart in the same directory.",
                       files.size() - 1),
                   "sonic"));
-          pvcae.getParseStatus().put(filename, ParseStatus.IGNORED);
+          pvcae.getParseStatus().put(filename, ParseStatus.UNEXPECTED_PACKAGING);
         }
         continue;
       }

--- a/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
+++ b/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
@@ -111,7 +111,8 @@ public final class Annotate {
                 ImmutableMultimap.of(),
                 null)
             .call();
-    if (parseResult.getStatus() == FAILED) {
+    if (parseResult.getFileResults().values().stream()
+        .anyMatch(result -> result.getParseStatus() == FAILED)) {
       LOGGER.error("Failed to parse: {}", inputFile);
       return null;
     }

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
@@ -45,11 +45,13 @@ public class ParseVendorConfigurationResultTest {
         new ParseVendorConfigurationResult(
             0,
             new BatfishLoggerHistory(),
-            ImmutableMap.of(filename, new FileResult(parseTree, silentSyntax, fileWarnings)),
+            ImmutableMap.of(
+                filename,
+                new FileResult(
+                    parseTree, silentSyntax, fileWarnings, ParseStatus.PARTIALLY_UNRECOGNIZED)),
             ConfigurationFormat.CISCO_IOS,
             config,
             new Warnings(),
-            ParseStatus.PASSED,
             HashMultimap.create());
 
     SortedMap<String, VendorConfiguration> configs = new TreeMap<>();
@@ -66,6 +68,10 @@ public class ParseVendorConfigurationResultTest {
 
     // Confirm result warning was properly applied to answerElement
     assertThat(answerWarnings, hasEntry(filename, fileWarnings));
+
+    // Confirm that status was applied
+    assertThat(
+        answerElement.getParseStatus(), hasEntry(filename, ParseStatus.PARTIALLY_UNRECOGNIZED));
   }
 
   @Test
@@ -97,13 +103,20 @@ public class ParseVendorConfigurationResultTest {
             new BatfishLoggerHistory(),
             ImmutableMap.of(
                 filenames.get(0),
-                new FileResult(parseTrees.get(0), silentSyntaxes.get(0), fileWarnings.get(0)),
+                new FileResult(
+                    parseTrees.get(0),
+                    silentSyntaxes.get(0),
+                    fileWarnings.get(0),
+                    ParseStatus.PARTIALLY_UNRECOGNIZED),
                 filenames.get(1),
-                new FileResult(parseTrees.get(1), silentSyntaxes.get(1), fileWarnings.get(1))),
+                new FileResult(
+                    parseTrees.get(1),
+                    silentSyntaxes.get(1),
+                    fileWarnings.get(1),
+                    ParseStatus.PASSED)),
             ConfigurationFormat.CISCO_IOS,
             config,
             globalWarnings,
-            ParseStatus.PASSED,
             HashMultimap.create());
 
     SortedMap<String, VendorConfiguration> configs = new TreeMap<>();
@@ -125,5 +138,11 @@ public class ParseVendorConfigurationResultTest {
 
     // Confirm that global warnings were applied
     assertThat(answerWarnings, hasEntry("[file1, file2]", globalWarnings));
+
+    // Confirm that status was applied
+    assertThat(
+        answerElement.getParseStatus(),
+        hasEntry(filenames.get(0), ParseStatus.PARTIALLY_UNRECOGNIZED));
+    assertThat(answerElement.getParseStatus(), hasEntry(filenames.get(1), ParseStatus.PASSED));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
@@ -47,8 +47,8 @@ public class ParseVendorConfigurationResultTest {
             new BatfishLoggerHistory(),
             ImmutableMap.of(
                 filename,
-                new FileResult(
-                    parseTree, silentSyntax, fileWarnings, ParseStatus.PARTIALLY_UNRECOGNIZED)),
+                new FileResult(parseTree, silentSyntax, fileWarnings)
+                    .setParseStatus(ParseStatus.PARTIALLY_UNRECOGNIZED)),
             ConfigurationFormat.CISCO_IOS,
             config,
             new Warnings(),
@@ -103,17 +103,11 @@ public class ParseVendorConfigurationResultTest {
             new BatfishLoggerHistory(),
             ImmutableMap.of(
                 filenames.get(0),
-                new FileResult(
-                    parseTrees.get(0),
-                    silentSyntaxes.get(0),
-                    fileWarnings.get(0),
-                    ParseStatus.PARTIALLY_UNRECOGNIZED),
+                new FileResult(parseTrees.get(0), silentSyntaxes.get(0), fileWarnings.get(0))
+                    .setParseStatus(ParseStatus.PARTIALLY_UNRECOGNIZED),
                 filenames.get(1),
-                new FileResult(
-                    parseTrees.get(1),
-                    silentSyntaxes.get(1),
-                    fileWarnings.get(1),
-                    ParseStatus.PASSED)),
+                new FileResult(parseTrees.get(1), silentSyntaxes.get(1), fileWarnings.get(1))
+                    .setParseStatus(ParseStatus.PASSED)),
             ConfigurationFormat.CISCO_IOS,
             config,
             globalWarnings,

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -828,7 +828,7 @@ public class BatfishTest {
           equalTo(ImmutableList.of()));
       assertThat(
           pvcae.getParseStatus(),
-          equalTo(ImmutableMap.of("sonic_configs/frr", ParseStatus.IGNORED)));
+          equalTo(ImmutableMap.of("sonic_configs/frr", ParseStatus.UNEXPECTED_PACKAGING)));
       assertThat(
           pvcae.getWarnings().get("sonic_configs/frr").getRedFlagWarnings(),
           contains(
@@ -844,7 +844,7 @@ public class BatfishTest {
           equalTo(ImmutableList.of()));
       assertThat(
           pvcae.getParseStatus(),
-          equalTo(ImmutableMap.of("sonic_configs/dev/frr", ParseStatus.IGNORED)));
+          equalTo(ImmutableMap.of("sonic_configs/dev/frr", ParseStatus.UNEXPECTED_PACKAGING)));
       assertThat(
           pvcae.getWarnings().get("sonic_configs/dev/frr").getRedFlagWarnings(),
           contains(
@@ -899,7 +899,7 @@ public class BatfishTest {
                   ImmutableSet.of("sonic_configs/dev1/frr", "sonic_configs/dev1/configdb"))));
       assertThat(
           pvcae.getParseStatus(),
-          equalTo(ImmutableMap.of("sonic_configs/dev2/frr", ParseStatus.IGNORED)));
+          equalTo(ImmutableMap.of("sonic_configs/dev2/frr", ParseStatus.UNEXPECTED_PACKAGING)));
       assertThat(
           pvcae.getWarnings().get("sonic_configs/dev2/frr").getRedFlagWarnings(),
           contains(

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -866,11 +866,11 @@ public class BatfishTest {
           equalTo(
               ImmutableMap.of(
                   "sonic_configs/dev/frr1",
-                  ParseStatus.IGNORED,
+                  ParseStatus.UNEXPECTED_PACKAGING,
                   "sonic_configs/dev/frr2",
-                  ParseStatus.IGNORED,
+                  ParseStatus.UNEXPECTED_PACKAGING,
                   "sonic_configs/dev/frr3",
-                  ParseStatus.IGNORED)));
+                  ParseStatus.UNEXPECTED_PACKAGING)));
       String message =
           "Unexpected packaging: File appears in a directory with 2 other files; SONiC files must"
               + " have only their counterpart in the same directory.";

--- a/tests/basic/example-iptables-init.ref
+++ b/tests/basic/example-iptables-init.ref
@@ -85,7 +85,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in [configs/r1.cfg]\n"
+              "text" : "No hostname set in configs/r1.cfg\n"
             }
           ]
         },
@@ -93,7 +93,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in [configs/r2.cfg]\n"
+              "text" : "No hostname set in configs/r2.cfg\n"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in [configs/r3.cfg]\n"
+              "text" : "No hostname set in configs/r3.cfg\n"
             }
           ]
         },
@@ -109,7 +109,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in [configs/z1-firewall.cfg]\n"
+              "text" : "No hostname set in configs/z1-firewall.cfg\n"
             }
           ]
         },
@@ -117,7 +117,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in [configs/z2-firewall.cfg]\n"
+              "text" : "No hostname set in configs/z2-firewall.cfg\n"
             }
           ]
         }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -70324,7 +70324,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in [configs/cisco_style_acl1]\n"
+              "text" : "No hostname set in configs/cisco_style_acl1\n"
             }
           ]
         },
@@ -70332,7 +70332,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No hostname set in [configs/cisco_style_acl2]\n"
+              "text" : "No hostname set in configs/cisco_style_acl2\n"
             }
           ]
         },


### PR DESCRIPTION
In #7742, ParseStatus was a job-level, not file-level. That has some undesirable side-effects for multi-file jobs, such as, parseStatus question not returning the nodes produces by the file and not being able to report the status separately for files. 

This PR makes ParseStatus file-level. It also make VendorConfiguration class aware of any other files that went into its production, which makes for accurate file to node mapping. 