### PR TITLE
Fix SetOspfMetric crash on inapplicable routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HasWritableOspfMetricType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HasWritableOspfMetricType.java
@@ -1,0 +1,14 @@
+package org.batfish.datamodel;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.ospf.OspfMetricType;
+
+/** A route or route builder with writeable OSPF metric-type. */
+@ParametersAreNonnullByDefault
+public interface HasWritableOspfMetricType<
+    B extends AbstractRouteBuilder<B, R>, R extends AbstractRoute> {
+
+  @Nonnull
+  B setOspfMetricType(@Nonnull OspfMetricType ospfMetricType);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
@@ -18,7 +18,8 @@ import org.batfish.datamodel.route.nh.NextHop;
 public abstract class OspfExternalRoute extends OspfRoute {
   private static final Interner<OspfExternalRoute> _cache = Interners.newWeakInterner();
 
-  public static final class Builder extends AbstractRouteBuilder<Builder, OspfExternalRoute> {
+  public static final class Builder extends AbstractRouteBuilder<Builder, OspfExternalRoute>
+      implements HasWritableOspfMetricType<Builder, OspfExternalRoute> {
 
     @Nullable private String _advertiser;
     @Nullable private Long _area;
@@ -107,6 +108,7 @@ public abstract class OspfExternalRoute extends OspfRoute {
     }
 
     @Nonnull
+    @Override
     public Builder setOspfMetricType(@Nonnull OspfMetricType ospfMetricType) {
       _ospfMetricType = ospfMetricType;
       return getThis();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetOspfMetricType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetOspfMetricType.java
@@ -3,7 +3,7 @@ package org.batfish.datamodel.routing_policy.statement;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.BatfishException;
-import org.batfish.datamodel.OspfExternalRoute;
+import org.batfish.datamodel.HasWritableOspfMetricType;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
@@ -49,9 +49,11 @@ public class SetOspfMetricType extends Statement {
   @Override
   public Result execute(Environment environment) {
     Result result = new Result();
-    OspfExternalRoute.Builder ospfExternalRoute =
-        (OspfExternalRoute.Builder) environment.getOutputRoute();
-    ospfExternalRoute.setOspfMetricType(_metricType);
+    if ((environment.getOutputRoute() instanceof HasWritableOspfMetricType<?, ?>)) {
+      HasWritableOspfMetricType<?, ?> outputRoute =
+          (HasWritableOspfMetricType<?, ?>) environment.getOutputRoute();
+      outputRoute.setOspfMetricType(_metricType);
+    }
     return result;
   }
 


### PR DESCRIPTION
- nop if output route has no OSPF metric-type