### PR TITLE
Add VNI interfaces to tenant VRFs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
@@ -146,6 +146,10 @@ public final class Names {
     return String.format("%s~on~%s", source, hostname);
   }
 
+  public static String generatedTenantVniInterfaceName(int vni) {
+    return String.format("nve~%d", vni);
+  }
+
   /**
    * Return the Batfish canonical name for a filter between zones.
    *

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
@@ -19,18 +19,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.NetworkConfigurations;
@@ -280,10 +277,7 @@ public final class VxlanTopologyUtils {
                     .setName(generatedTenantVniInterfaceName(vni))
                     .setOwner(c)
                     .setVrf(vrf)
-                    .setAdditionalArpIps(
-                        Optional.ofNullable(l3vni.getSourceAddress())
-                            .<IpSpace>map(Ip::toIpSpace)
-                            .orElse(EmptyIpSpace.INSTANCE))
+                    .setAdditionalArpIps(l3vni.getSourceAddress().toIpSpace())
                     .setAddresses(LinkLocalAddress.of(TENANT_VNI_INTERFACE_LINK_LOCAL_ADDRESS))
                     .setActive(true)
                     .setProxyArp(false)

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -1,8 +1,7 @@
 package org.batfish.job;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static org.batfish.datamodel.InterfaceType.TUNNEL;
-import static org.batfish.datamodel.Names.generatedTenantVniInterfaceName;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addTenantVniInterfaces;
 import static org.batfish.vendor.ConversionContext.EMPTY_CONVERSION_CONTEXT;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -20,7 +19,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -44,7 +42,6 @@ import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6AccessList;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpIpSpace;
@@ -52,7 +49,6 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcardIpSpace;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
-import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.Mlag;
 import org.batfish.datamodel.PrefixIpSpace;
 import org.batfish.datamodel.Route6FilterList;
@@ -468,34 +464,6 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     verifyAsPathStructures(c);
     verifyCommunityStructures(c);
     removeInvalidAcls(c, w);
-  }
-
-  // does this value matter?
-  private static final Ip TENANT_VNI_INTERFACE_LINK_LOCAL_ADDRESS = Ip.parse("169.254.0.1");
-
-  /** Add an interface for each l3vni to its tenant VRF to represent endpoints of a VXLAN tunnel. */
-  @VisibleForTesting
-  static void addTenantVniInterfaces(Configuration c) {
-    for (Vrf vrf : c.getVrfs().values()) {
-      vrf.getLayer3Vnis()
-          .forEach(
-              (vni, l3vni) -> {
-                Interface.builder()
-                    .setName(generatedTenantVniInterfaceName(vni))
-                    .setOwner(c)
-                    .setVrf(vrf)
-                    .setAdditionalArpIps(
-                        Optional.ofNullable(l3vni.getSourceAddress())
-                            .<IpSpace>map(Ip::toIpSpace)
-                            .orElse(EmptyIpSpace.INSTANCE))
-                    .setAddresses(LinkLocalAddress.of(TENANT_VNI_INTERFACE_LINK_LOCAL_ADDRESS))
-                    .setActive(true)
-                    .setProxyArp(false)
-                    .setType(TUNNEL)
-                    .setSwitchportMode(SwitchportMode.NONE)
-                    .build();
-              });
-    }
   }
 
   private static void verifyAsPathStructures(Configuration c) {

--- a/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
@@ -1,30 +1,41 @@
 package org.batfish.job;
 
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.Names.generatedTenantVniInterfaceName;
+import static org.batfish.job.ConvertConfigurationJob.addTenantVniInterfaces;
 import static org.batfish.job.ConvertConfigurationJob.finalizeConfiguration;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.AclAclLine;
+import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprReference;
 import org.batfish.datamodel.transformation.Transformation;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.job.ConvertConfigurationJob.CollectIpSpaceReferences;
 import org.junit.Rule;
 import org.junit.Test;
@@ -131,5 +142,42 @@ public final class ConvertConfigurationJobTest {
     _thrown.expect(VendorConversionException.class);
     _thrown.expectMessage(containsString("Undefined reference"));
     finalizeConfiguration(c, new Warnings());
+  }
+
+  @Test
+  public void testAddTenantVniInterfaces() {
+    Configuration c = new Configuration("c", ConfigurationFormat.CISCO_NX);
+    c.setDefaultCrossZoneAction(LineAction.PERMIT);
+    c.setDefaultInboundAction(LineAction.PERMIT);
+    Vrf.Builder vb = Vrf.builder().setOwner(c);
+    Vrf v1 = vb.setName("v1").build();
+    Vrf v2 = vb.setName("v2").build();
+    Ip sourceAddress = Ip.parse("10.0.0.1");
+    Layer3Vni.Builder l3b =
+        Layer3Vni.builder()
+            .setBumTransportIps(ImmutableSet.of())
+            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+            .setSrcVrf(DEFAULT_VRF_NAME)
+            .setUdpPort(5);
+    v1.addLayer3Vni(l3b.setVni(1).setSourceAddress(sourceAddress).build());
+    v2.addLayer3Vni(l3b.setVni(2).setSourceAddress(null).build());
+    String vni1IfaceName = generatedTenantVniInterfaceName(1);
+    String vni2IfaceName = generatedTenantVniInterfaceName(2);
+    addTenantVniInterfaces(c);
+
+    // v1 vni 1
+    assertThat(c.getAllInterfaces(v1.getName()), hasKey(vni1IfaceName));
+
+    Interface vni1Iface = c.getAllInterfaces().get(vni1IfaceName);
+
+    assertThat(vni1Iface.getAdditionalArpIps(), equalTo(sourceAddress.toIpSpace()));
+
+    // v2 vni 2
+
+    assertThat(c.getAllInterfaces(v2.getName()), hasKey(vni2IfaceName));
+
+    Interface vni2Iface = c.getAllInterfaces().get(vni2IfaceName);
+
+    assertThat(vni2Iface.getAdditionalArpIps(), equalTo(EmptyIpSpace.INSTANCE));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
@@ -1,41 +1,30 @@
 package org.batfish.job;
 
-import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
-import static org.batfish.datamodel.Names.generatedTenantVniInterfaceName;
-import static org.batfish.job.ConvertConfigurationJob.addTenantVniInterfaces;
 import static org.batfish.job.ConvertConfigurationJob.finalizeConfiguration;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.AclAclLine;
-import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprReference;
 import org.batfish.datamodel.transformation.Transformation;
-import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.job.ConvertConfigurationJob.CollectIpSpaceReferences;
 import org.junit.Rule;
 import org.junit.Test;
@@ -142,42 +131,5 @@ public final class ConvertConfigurationJobTest {
     _thrown.expect(VendorConversionException.class);
     _thrown.expectMessage(containsString("Undefined reference"));
     finalizeConfiguration(c, new Warnings());
-  }
-
-  @Test
-  public void testAddTenantVniInterfaces() {
-    Configuration c = new Configuration("c", ConfigurationFormat.CISCO_NX);
-    c.setDefaultCrossZoneAction(LineAction.PERMIT);
-    c.setDefaultInboundAction(LineAction.PERMIT);
-    Vrf.Builder vb = Vrf.builder().setOwner(c);
-    Vrf v1 = vb.setName("v1").build();
-    Vrf v2 = vb.setName("v2").build();
-    Ip sourceAddress = Ip.parse("10.0.0.1");
-    Layer3Vni.Builder l3b =
-        Layer3Vni.builder()
-            .setBumTransportIps(ImmutableSet.of())
-            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
-            .setSrcVrf(DEFAULT_VRF_NAME)
-            .setUdpPort(5);
-    v1.addLayer3Vni(l3b.setVni(1).setSourceAddress(sourceAddress).build());
-    v2.addLayer3Vni(l3b.setVni(2).setSourceAddress(null).build());
-    String vni1IfaceName = generatedTenantVniInterfaceName(1);
-    String vni2IfaceName = generatedTenantVniInterfaceName(2);
-    addTenantVniInterfaces(c);
-
-    // v1 vni 1
-    assertThat(c.getAllInterfaces(v1.getName()), hasKey(vni1IfaceName));
-
-    Interface vni1Iface = c.getAllInterfaces().get(vni1IfaceName);
-
-    assertThat(vni1Iface.getAdditionalArpIps(), equalTo(sourceAddress.toIpSpace()));
-
-    // v2 vni 2
-
-    assertThat(c.getAllInterfaces(v2.getName()), hasKey(vni2IfaceName));
-
-    Interface vni2Iface = c.getAllInterfaces().get(vni2IfaceName);
-
-    assertThat(vni2Iface.getAdditionalArpIps(), equalTo(EmptyIpSpace.INSTANCE));
   }
 }


### PR DESCRIPTION
- each layer-3 VNI results in an interface in the associated VRF
- generated interface:
  - responds to ARPs for VTEP address
  - has link-local address

Follow-on work: add l3 edges between these generated interfaces based on
                VxlanTopology