### PR TITLE
SpecifierGrammar: Remove some deprecated syntax

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteAnswererHelperTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteAnswererHelperTest.java
@@ -140,7 +140,7 @@ public class TracerouteAnswererHelperTest {
   public void testGetFlows_dst() {
     TracerouteAnswererHelper helper =
         new TracerouteAnswererHelper(
-            PacketHeaderConstraints.builder().setDstIp("ofLocation(node2)").build(),
+            PacketHeaderConstraints.builder().setDstIp("node2").build(),
             String.format("%s[%s]", NODE1, LOOPBACK),
             _batfish.specifierContext(_batfish.getSnapshot()));
     Set<Flow> flows = helper.getFlows();

--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteAnswererHelperTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TracerouteAnswererHelperTest.java
@@ -98,7 +98,7 @@ public class TracerouteAnswererHelperTest {
     TracerouteAnswererHelper helper =
         new TracerouteAnswererHelper(
             PacketHeaderConstraints.builder().setDstIp("2.2.2.2").build(),
-            "enter(node1)",
+            "@enter(node1)",
             _batfish.specifierContext(_batfish.getSnapshot()));
     thrown.expect(IllegalArgumentException.class);
     helper.getFlows();
@@ -109,7 +109,7 @@ public class TracerouteAnswererHelperTest {
     TracerouteAnswererHelper helper =
         new TracerouteAnswererHelper(
             PacketHeaderConstraints.builder().setSrcIp("1.1.1.0").setDstIp("2.2.2.2").build(),
-            "enter(node1)",
+            "@enter(node1)",
             _batfish.specifierContext(_batfish.getSnapshot()));
 
     Set<Flow> flows = helper.getFlows();

--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
@@ -52,7 +52,7 @@ import org.junit.rules.TemporaryFolder;
 public class TraceroutePolicyBasedRoutingTest {
 
   private static final String PACKET_POLICY_NAME = "packetPolicy";
-  private static final String SOURCE_LOCATION_STR = "enter(c1[ingressInterface])";
+  private static final String SOURCE_LOCATION_STR = "@enter(c1[ingressInterface])";
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   private static final Ip INGRESS_IFACE_IP = Ip.parse("1.1.1.1");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/DirectionFilterAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/DirectionFilterAstNode.java
@@ -7,9 +7,9 @@ abstract class DirectionFilterAstNode implements FilterAstNode {
   private final InterfaceAstNode _interfaceAst;
 
   static DirectionFilterAstNode create(String direction, AstNode interfaceAst) {
-    if (direction.equalsIgnoreCase("@in") || direction.equalsIgnoreCase("inFilterOf")) {
+    if (direction.equalsIgnoreCase("@in")) {
       return new InFilterAstNode((InterfaceAstNode) interfaceAst);
-    } else if (direction.equalsIgnoreCase("@out") || direction.equalsIgnoreCase("outFilterOf")) {
+    } else if (direction.equalsIgnoreCase("@out")) {
       return new OutFilterAstNode((InterfaceAstNode) interfaceAst);
     } else {
       throw new IllegalStateException("Unknown direction specifier for filters " + direction);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -396,8 +396,8 @@ public class Parser extends CommonParser {
    *
    *   filterWithoutNode := filterWithoutNodeTerm [{@literal &} | , | \ filterWithoutNodeTerm]*
    *
-   *   filterWithoutNodeTerm := @in(interfaceSpec)  // inFilterOf is also supported for back compat
-   *               | @out(interfaceSpec) // outFilterOf is also supported
+   *   filterWithoutNodeTerm := @in(interfaceSpec)
+   *               | @out(interfaceSpec)
    *               | filterName
    *               | filterNameRegex
    *               | ( filterWithoutNode )
@@ -547,7 +547,7 @@ public class Parser extends CommonParser {
    *   interfaceWithoutNode := interfaceWithoutNodeTerm [{@literal &} | , | \ interfaceWithoutNodeTerm]*
    *
    *   interfaceWithoutNodeTerm
-   *                        := @connectedTo(ipSpaceSpec)  // non-@ versions also supported for back compat
+   *                        := @connectedTo(ipSpaceSpec)
    *                        | @interfacegroup(a, b)
    *                        | @interfaceType(interfaceType)
    *                        | @vrf(vrfName)
@@ -822,9 +822,8 @@ public class Parser extends CommonParser {
    * <pre>
    * ipSpaceSpec := ipSpecTerm [{@literal &} | , | \ ipSpecTerm]*
    *
-   * ipSpecTerm := @addgressgroup(groupname, bookname)  //ref.addressgroup for back compat
+   * ipSpecTerm := @addgressgroup(groupname, bookname)
    *               | locationSpec
-   *               | ofLocation(locationSpec)           // back compat
    *               | ipPrefix (e.g., 1.1.1.0/24)
    *               | ipWildcard (e.g., 1.1.1.1:255.255.255.0)
    *               | ipRange (e.g., 1.1.1.1-1.1.1.2)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -474,7 +474,6 @@ public class Parser extends CommonParser {
     return FirstOf(
         FilterInterfaceIn(),
         FilterInterfaceOut(),
-        FilterDirectionDeprecated(),
         FilterNameRegexDeprecated(),
         FilterNameRegex(),
         FilterName(),
@@ -503,20 +502,6 @@ public class Parser extends CommonParser {
         WhiteSpace(),
         CloseParens(),
         push(new OutFilterAstNode((pop()))));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule FilterDirectionDeprecated() {
-    Var<String> direction = new Var<>();
-    return Sequence(
-        FirstOf(IgnoreCase("inFilterOf"), IgnoreCase("outFilterOf")),
-        direction.set(match()),
-        WhiteSpace(),
-        "( ",
-        InterfaceSpec(),
-        WhiteSpace(),
-        CloseParens(),
-        push(DirectionFilterAstNode.create(direction.get(), pop())));
   }
 
   @Anchor(FILTER_NAME)
@@ -657,15 +642,10 @@ public class Parser extends CommonParser {
   public Rule InterfaceFunc() {
     return FirstOf(
         InterfaceConnectedTo(),
-        InterfaceConnectedToDeprecated(),
         InterfaceInterfaceGroup(),
-        InterfaceInterfaceGroupDeprecated(),
         InterfaceType(),
-        InterfaceTypeDeprecated(),
         InterfaceVrf(),
-        InterfaceVrfDeprecated(),
-        InterfaceZone(),
-        InterfaceZoneDeprecated());
+        InterfaceZone());
   }
 
   @Anchor(INTERFACE_CONNECTED_TO)
@@ -680,30 +660,9 @@ public class Parser extends CommonParser {
         push(new ConnectedToInterfaceAstNode(pop())));
   }
 
-  @Anchor(DEPRECATED)
-  public Rule InterfaceConnectedToDeprecated() {
-    return Sequence(
-        IgnoreCase("connectedTo"),
-        WhiteSpace(),
-        "( ",
-        IpSpaceSpec(),
-        WhiteSpace(),
-        CloseParens(),
-        push(new ConnectedToInterfaceAstNode(pop())));
-  }
-
   public Rule InterfaceInterfaceGroup() {
     return Sequence(
         IgnoreCase("@interfaceGroup"),
-        WhiteSpace(),
-        InterfaceGroupAndReferenceBook(),
-        push(new InterfaceGroupInterfaceAstNode(pop(1), pop())));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule InterfaceInterfaceGroupDeprecated() {
-    return Sequence(
-        IgnoreCase("ref.interfaceGroup"),
         WhiteSpace(),
         InterfaceGroupAndReferenceBook(),
         push(new InterfaceGroupInterfaceAstNode(pop(1), pop())));
@@ -738,18 +697,6 @@ public class Parser extends CommonParser {
         push(new TypeInterfaceAstNode(pop())));
   }
 
-  @Anchor(DEPRECATED)
-  public Rule InterfaceTypeDeprecated() {
-    return Sequence(
-        IgnoreCase("type"),
-        WhiteSpace(),
-        "( ",
-        InterfaceTypeSpec(),
-        WhiteSpace(),
-        CloseParens(),
-        push(new TypeInterfaceAstNode(pop())));
-  }
-
   public Rule InterfaceTypeSpec() {
     return Sequence(FirstOf(_interfaceTypeRules), push(new StringAstNode(match())));
   }
@@ -758,18 +705,6 @@ public class Parser extends CommonParser {
   public Rule InterfaceVrf() {
     return Sequence(
         IgnoreCase("@vrf"),
-        WhiteSpace(),
-        "( ",
-        VrfName(),
-        WhiteSpace(),
-        CloseParens(),
-        push(new VrfInterfaceAstNode(pop())));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule InterfaceVrfDeprecated() {
-    return Sequence(
-        IgnoreCase("vrf"),
         WhiteSpace(),
         "( ",
         VrfName(),
@@ -787,18 +722,6 @@ public class Parser extends CommonParser {
   public Rule InterfaceZone() {
     return Sequence(
         IgnoreCase("@zone"),
-        WhiteSpace(),
-        "( ",
-        ZoneName(),
-        WhiteSpace(),
-        CloseParens(),
-        push(new ZoneInterfaceAstNode(pop())));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule InterfaceZoneDeprecated() {
-    return Sequence(
-        IgnoreCase("zone"),
         WhiteSpace(),
         "( ",
         ZoneName(),
@@ -944,8 +867,6 @@ public class Parser extends CommonParser {
         IpRange(),
         IpAddress(),
         IpSpaceAddressGroup(),
-        IpSpaceAddressGroupDeprecated(),
-        IpSpaceLocationDeprecated(),
         IpSpaceLocation(),
         IpSpaceParens());
   }
@@ -958,15 +879,6 @@ public class Parser extends CommonParser {
   public Rule IpSpaceAddressGroup() {
     return Sequence(
         IgnoreCase("@addressgroup"),
-        WhiteSpace(),
-        AddressGroupAndReferenceBook(),
-        push(new AddressGroupIpSpaceAstNode(pop(1), pop())));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule IpSpaceAddressGroupDeprecated() {
-    return Sequence(
-        IgnoreCase("ref.addressgroup"),
         WhiteSpace(),
         AddressGroupAndReferenceBook(),
         push(new AddressGroupIpSpaceAstNode(pop(1), pop())));
@@ -991,18 +903,6 @@ public class Parser extends CommonParser {
 
   public Rule IpSpaceLocation() {
     return Sequence(LocationSpec(), push(new LocationIpSpaceAstNode(pop())));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule IpSpaceLocationDeprecated() {
-    return Sequence(
-        IgnoreCase("ofLocation"),
-        WhiteSpace(),
-        "( ",
-        LocationSpec(),
-        WhiteSpace(),
-        CloseParens(),
-        push(new LocationIpSpaceAstNode(pop())));
   }
 
   /**
@@ -1094,13 +994,7 @@ public class Parser extends CommonParser {
   }
 
   public Rule LocationTerm() {
-    return FirstOf(
-        LocationInternet(),
-        LocationEnterDeprecated(),
-        LocationEnter(),
-        LocationInterfaceDeprecated(),
-        LocationInterface(),
-        LocationParens());
+    return FirstOf(LocationInternet(), LocationEnter(), LocationInterface(), LocationParens());
   }
 
   @Anchor(HIDDEN)
@@ -1116,17 +1010,6 @@ public class Parser extends CommonParser {
         WhiteSpace(),
         "( ",
         LocationInterface(),
-        CloseParens(),
-        push(new EnterLocationAstNode(pop())));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule LocationEnterDeprecated() {
-    return Sequence(
-        IgnoreCase("enter"),
-        WhiteSpace(),
-        "( ",
-        FirstOf(LocationInterfaceDeprecated(), LocationInterface()),
         CloseParens(),
         push(new EnterLocationAstNode(pop())));
   }
@@ -1148,17 +1031,6 @@ public class Parser extends CommonParser {
             InterfaceFunc(),
             WhiteSpace(),
             push(InterfaceLocationAstNode.createFromInterface(pop()))));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule LocationInterfaceDeprecated() {
-    return Sequence(
-        // brackets without node expression
-        "[ ",
-        InterfaceSpec(),
-        WhiteSpace(),
-        CloseBrackets(),
-        push(InterfaceLocationAstNode.createFromInterface(pop())));
   }
 
   @Anchor(LOCATION_PARENS)
@@ -1248,7 +1120,6 @@ public class Parser extends CommonParser {
   public Rule NodeTerm() {
     return FirstOf(
         NodeRole(),
-        NodeRoleDeprecated(),
         NodeType(),
         NodeNameRegexDeprecated(),
         NodeNameRegex(),
@@ -1259,15 +1130,6 @@ public class Parser extends CommonParser {
   public Rule NodeRole() {
     return Sequence(
         IgnoreCase("@role"),
-        WhiteSpace(),
-        NodeRoleAndDimension(),
-        push(new RoleNodeAstNode(pop(1), pop())));
-  }
-
-  @Anchor(DEPRECATED)
-  public Rule NodeRoleDeprecated() {
-    return Sequence(
-        IgnoreCase("ref.noderole"),
         WhiteSpace(),
         NodeRoleAndDimension(),
         push(new RoleNodeAstNode(pop(1), pop())));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ReferenceFilterGroupFilterSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ReferenceFilterGroupFilterSpecifierTest.java
@@ -64,7 +64,7 @@ public class ReferenceFilterGroupFilterSpecifierTest {
                     new FilterGroup(
                         ImmutableList.of(
                             _filter1.getName(),
-                            "outFilterOf(" + _interfaceName + ")", // should match _filter3
+                            "@out(" + _interfaceName + ")", // should match _filter3
                             ""), // should match nothing; shouldn't accidentally match everything
                         _filterGroupName)))
             .build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserFilterTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserFilterTest.java
@@ -129,10 +129,6 @@ public class ParserFilterTest {
     assertThat(ParserUtils.getAst(getRunner().run("@in(eth0)")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run(" @in ( eth0 ) ")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run("@IN(eth0)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(ParserUtils.getAst(getRunner().run("inFilterOf(eth0)")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" InFilterOF ( eth0 ) ")), equalTo(expectedAst));
   }
 
   @Test
@@ -142,10 +138,6 @@ public class ParserFilterTest {
     assertThat(ParserUtils.getAst(getRunner().run("@out(eth0)")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run(" @out ( eth0 ) ")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run("@OUT(eth0)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(ParserUtils.getAst(getRunner().run("outFilterOf(eth0)")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" OUTFilterOf ( eth0 ) ")), equalTo(expectedAst));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserInterfaceTest.java
@@ -180,11 +180,6 @@ public class ParserInterfaceTest {
     assertThat(
         ParserUtils.getAst(getRunner().run(" @connectedTo ( 1.1.1.1 ) ")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run("@COnnECTEDTO(1.1.1.1)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(ParserUtils.getAst(getRunner().run("connectedTo(1.1.1.1)")), equalTo(expectedAst));
-    assertThat(
-        ParserUtils.getAst(getRunner().run(" connectedTo ( 1.1.1.1 ) ")), equalTo(expectedAst));
   }
 
   @Test
@@ -195,12 +190,6 @@ public class ParserInterfaceTest {
     assertThat(
         ParserUtils.getAst(getRunner().run(" @interfacegroup ( a , b ) ")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run("@InterfaceGrouP(a , b)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(
-        ParserUtils.getAst(getRunner().run("ref.interfacegroup(a, b)")), equalTo(expectedAst));
-    assertThat(
-        ParserUtils.getAst(getRunner().run(" ref.interfacegroup (a, b ) ")), equalTo(expectedAst));
   }
 
   @Test
@@ -257,10 +246,6 @@ public class ParserInterfaceTest {
         ParserUtils.getAst(getRunner().run(" @interfaceType ( physical ) ")), equalTo(expectedAst));
     assertThat(
         ParserUtils.getAst(getRunner().run("@interFAcetype(PHYsical)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(ParserUtils.getAst(getRunner().run("type(physical)")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" type ( physical ) ")), equalTo(expectedAst));
   }
 
   @Test
@@ -270,10 +255,6 @@ public class ParserInterfaceTest {
     assertThat(ParserUtils.getAst(getRunner().run("@vrf(vrf-name)")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run(" @vrf ( vrf-name ) ")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run("@VrF(vrf-name)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(ParserUtils.getAst(getRunner().run("vrf(vrf-name)")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" vrf ( vrf-name ) ")), equalTo(expectedAst));
   }
 
   @Test
@@ -283,10 +264,6 @@ public class ParserInterfaceTest {
     assertThat(ParserUtils.getAst(getRunner().run("@zone(zone-name)")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run(" @zone ( zone-name ) ")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run("@ZoNe(zone-name)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(ParserUtils.getAst(getRunner().run("zone(zone-name)")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" zone ( zone-name ) ")), equalTo(expectedAst));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
@@ -114,19 +114,6 @@ public class ParserIpSpaceTest {
   }
 
   @Test
-  public void testIpSpaceAddressGroupRef() {
-    IpSpaceAstNode expectedAst = new AddressGroupIpSpaceAstNode("a", "b");
-
-    assertThat(ParserUtils.getAst(getRunner().run("ref.addressgroup(a, b)")), equalTo(expectedAst));
-    assertThat(
-        ParserUtils.getAst(getRunner().run(" ref.addressgroup ( a , b ) ")), equalTo(expectedAst));
-    assertThat(
-        ParserUtils.getAst(getRunner().run("REF.ADDRESSGROUP(a , b)")), equalTo(expectedAst));
-    assertThat(
-        ParserUtils.getAst(getRunner().run("ref.addressGroup(a , b)")), equalTo(expectedAst));
-  }
-
-  @Test
   public void testIpSpaceIpAddress() {
     assertThat(ParserUtils.getAst(getRunner().run("1.1.1.1")), equalTo(new IpAstNode("1.1.1.1")));
   }
@@ -151,17 +138,6 @@ public class ParserIpSpaceTest {
     assertThat(
         ParserUtils.getAst(getRunner().run("1.1.1.1:2.2.2.2")),
         equalTo(new IpWildcardAstNode("1.1.1.1:2.2.2.2")));
-  }
-
-  @Test
-  public void testIpSpaceLocationNode() {
-    IpSpaceAstNode expectedNode =
-        new LocationIpSpaceAstNode(InterfaceLocationAstNode.createFromNode("node"));
-
-    assertThat(ParserUtils.getAst(getRunner().run("node")), equalTo(expectedNode));
-
-    assertThat(ParserUtils.getAst(getRunner().run("ofLocation(node)")), equalTo(expectedNode));
-    assertThat(ParserUtils.getAst(getRunner().run(" OFlocation ( node ) ")), equalTo(expectedNode));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserLocationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserLocationTest.java
@@ -182,31 +182,6 @@ public class ParserLocationTest {
     assertThat(ParserUtils.getAst(getRunner().run("@enter(node1)")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run(" @enter ( node1 ) ")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run("@EnTER(node1)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(ParserUtils.getAst(getRunner().run("enter(node1)")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" EnTer ( node1 ) ")), equalTo(expectedAst));
-  }
-
-  @Test
-  public void testParseLocationEnterDeprecatedNodeInterface() {
-    assertThat(
-        ParserUtils.getAst(getRunner().run("enter(firewall[GigabitEthernet0/0/2])")),
-        equalTo(
-            new EnterLocationAstNode(
-                InterfaceLocationAstNode.createFromInterfaceWithNode(
-                    new InterfaceWithNodeInterfaceAstNode(
-                        new NameNodeAstNode("firewall"),
-                        new NameInterfaceAstNode("GigabitEthernet0/0/2"))))));
-
-    assertThat(
-        ParserUtils.getAst(getRunner().run("enter(firewall.*[GigabitEthernet0/0/2])")),
-        equalTo(
-            new EnterLocationAstNode(
-                InterfaceLocationAstNode.createFromInterfaceWithNode(
-                    new InterfaceWithNodeInterfaceAstNode(
-                        new NameRegexNodeAstNode("firewall.*"),
-                        new NameInterfaceAstNode("GigabitEthernet0/0/2"))))));
   }
 
   @Test
@@ -216,28 +191,6 @@ public class ParserLocationTest {
         InterfaceLocationAstNode.createFromInterfaceWithNode(
             new NameNodeAstNode("node"),
             new TypeInterfaceAstNode(InterfaceType.PHYSICAL.toString()));
-
-    assertThat(ParserUtils.getAst(getRunner().run(input)), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" " + input + " ")), equalTo(expectedAst));
-  }
-
-  @Test
-  public void testParseLocationInterfaceDeprecated() {
-    String input = "[eth0/1]";
-    InterfaceLocationAstNode expectedAst =
-        InterfaceLocationAstNode.createFromInterface(new NameInterfaceAstNode("eth0/1"));
-
-    assertThat(ParserUtils.getAst(getRunner().run(input)), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" " + input + " ")), equalTo(expectedAst));
-  }
-
-  @Test
-  public void testParseLocationInterfaceDeprecatedInsideFunc() {
-    String input = "enter([ref.interfacegroup(sea, host-iface)])";
-    LocationAstNode expectedAst =
-        new EnterLocationAstNode(
-            InterfaceLocationAstNode.createFromInterface(
-                new InterfaceGroupInterfaceAstNode("sea", "host-iface")));
 
     assertThat(ParserUtils.getAst(getRunner().run(input)), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run(" " + input + " ")), equalTo(expectedAst));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserNodeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserNodeTest.java
@@ -115,10 +115,6 @@ public class ParserNodeTest {
     assertThat(ParserUtils.getAst(getRunner().run("@role(a, b)")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run(" @role ( a , b ) ")), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run("@RoLe(a , b)")), equalTo(expectedAst));
-
-    // old style
-    assertThat(ParserUtils.getAst(getRunner().run("ref.noderole(a, b)")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" ref.noderoLE (a, b ) ")), equalTo(expectedAst));
   }
 
   @Test

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java
@@ -35,7 +35,7 @@ import org.junit.rules.TemporaryFolder;
 public class SearchFiltersDifferentialTest {
   @Rule public TemporaryFolder _tmp = new TemporaryFolder();
 
-  private static final String ENTER_ALL = "enter(.*)";
+  private static final String ENTER_ALL = "@enter(/.*/)";
 
   private static final String HOSTNAME = "hostname";
   private static final String ACLNAME = "acl";

--- a/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererHelperTest.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererHelperTest.java
@@ -70,7 +70,7 @@ public class TracerouteAnswererHelperTest {
 
     PacketHeaderConstraints headerConstraints =
         PacketHeaderConstraints.builder().setSrcIp("1.1.1.1").setDstIp("2.2.2.2").build();
-    String sourceLocationStr = "enter(/.*/)";
+    String sourceLocationStr = "@enter(/.*/)";
 
     // specifier resolves to locations of active and inactive interfaces
     Set<Location> specifiedLocations =

--- a/questions/experimental/loopbackMultipathConsistency.json
+++ b/questions/experimental/loopbackMultipathConsistency.json
@@ -2,11 +2,11 @@
     "class": "org.batfish.question.multipath.MultipathConsistencyQuestion",
     "differential": false,
     "headers": {
-      "dstIps": "ofLocation([type(loopback)])"
+      "dstIps": "@interfaceType(loopback)"
     },
     "maxTraces": "${maxTraces}",
     "pathConstraints": {
-      "startLocation": "[type(loopback)]"
+      "startLocation": "@interfaceType(loopback)"
     },
     "instance": {
         "description": "Validates multipath consistency between all pairs of loopbacks.",

--- a/questions/experimental/subnetMultipathConsistency.json
+++ b/questions/experimental/subnetMultipathConsistency.json
@@ -2,11 +2,11 @@
     "class": "org.batfish.question.multipath.MultipathConsistencyQuestion",
     "differential": false,
     "headers": {
-      "dstIps": "ofLocation(enter(.*))"
+      "dstIps": "@enter(/.*/)"
     },
     "maxTraces": "${maxTraces}",
     "pathConstraints": {
-      "startLocation": "enter(.*)"
+      "startLocation": "@enter(/.*/)"
     },
     "instance": {
         "description": "Validates multipath consistency between all pairs of subnets.",

--- a/tests/basic/commands
+++ b/tests/basic/commands
@@ -22,7 +22,7 @@ test tests/basic/compareSameName.ref get compareSameName
 test tests/basic/error.ref -error get error
 test tests/basic/ospfStatus.ref get ospfstatus interfaces="Loopback.*", status=".*passive"
 test tests/basic/testfilters.ref get testFilters headers={"dstIps": "1.1.1.1"}, nodes="host.*", filters="filter.*"
-test tests/basic/traceroute-1-2.ref get traceroute startLocation="enter(as1core1)", headers={"dstIps": "ofLocation(host1)"}
+test tests/basic/traceroute-1-2.ref get traceroute startLocation="@enter(as1core1)", headers={"dstIps": "host1"}
 test tests/basic/traceroute-2-1.ref get traceroute startLocation="host2", headers={"dstIps": "1.0.1.1"}
 test tests/basic/uniqueIpAssignments.ref get uniqueIpAssignments
 test tests/basic/outliers.ref get outliers

--- a/tests/questions/experimental/loopbackMultipathConsistency.ref
+++ b/tests/questions/experimental/loopbackMultipathConsistency.ref
@@ -1,11 +1,11 @@
 {
   "class" : "org.batfish.question.multipath.MultipathConsistencyQuestion",
   "headers" : {
-    "dstIps" : "ofLocation([type(loopback)])"
+    "dstIps" : "@interfaceType(loopback)"
   },
   "maxTraces" : 1,
   "pathConstraints" : {
-    "startLocation" : "[type(loopback)]"
+    "startLocation" : "@interfaceType(loopback)"
   },
   "differential" : false,
   "includeOneTableKeys" : true,

--- a/tests/questions/experimental/subnetMultipathConsistency.ref
+++ b/tests/questions/experimental/subnetMultipathConsistency.ref
@@ -1,11 +1,11 @@
 {
   "class" : "org.batfish.question.multipath.MultipathConsistencyQuestion",
   "headers" : {
-    "dstIps" : "ofLocation(enter(.*))"
+    "dstIps" : "@enter(/.*/)"
   },
   "maxTraces" : 1,
   "pathConstraints" : {
-    "startLocation" : "enter(.*)"
+    "startLocation" : "@enter(/.*/)"
   },
   "differential" : false,
   "includeOneTableKeys" : true,


### PR DESCRIPTION
This is very old, and we don't need to support it anymore. 