### PR TITLE
AclLineMatchExprs: switch new tcp flows to syn-only

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlagsMatchConditions.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TcpFlagsMatchConditions.java
@@ -90,18 +90,34 @@ public final class TcpFlagsMatchConditions
     }
   }
 
-  /** Shorthand for match conditions for a ACK (acknowledgement) packet */
+  /**
+   * Shorthand for match conditions for a ACK (acknowledgement) packet. Other bits are
+   * unconstrained.
+   */
   public static final TcpFlagsMatchConditions ACK_TCP_FLAG =
       builder().setTcpFlags(TcpFlags.builder().setAck(true).build()).setUseAck(true).build();
-  /** Shorthand for match conditions for a RST (reset) packet */
+  /** Shorthand for match conditions for a RST (reset) packet. Other bits are unconstrained. */
   public static final TcpFlagsMatchConditions RST_TCP_FLAG =
       builder().setTcpFlags(TcpFlags.builder().setRst(true).build()).setUseRst(true).build();
-  /** Shorthand for match conditions for a SYN-ACK packet */
+  /** Shorthand for match conditions for a SYN-ACK packet. Other bits are unconstrained. */
   public static final TcpFlagsMatchConditions SYN_ACK_TCP_FLAG =
       builder()
           .setTcpFlags(TcpFlags.builder().setAck(true).setSyn(true).build())
           .setUseAck(true)
           .setUseSyn(true)
+          .build();
+  /** Shorthand for match conditions for a SYN-only packet, with all other bits cleared */
+  public static final TcpFlagsMatchConditions SYN_ONLY_TCP_FLAG =
+      builder()
+          .setTcpFlags(TcpFlags.builder().setSyn(true).build())
+          .setUseAck(true)
+          .setUseCwr(true)
+          .setUseFin(true)
+          .setUseEce(true)
+          .setUsePsh(true)
+          .setUseRst(true)
+          .setUseSyn(true)
+          .setUseUrg(true)
           .build();
 
   private static final Comparator<TcpFlagsMatchConditions> COMPARATOR =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -37,15 +37,8 @@ public final class AclLineMatchExprs {
   static final AclLineMatchExpr UDP_FLOWS = matchIpProtocol(IpProtocol.UDP);
 
   @VisibleForTesting
-  static final AclLineMatchExpr ESTABLISHED_TCP_FLOWS =
-      and(
-          TCP_FLOWS,
-          matchTcpFlags(
-              // ack or rst
-              TcpFlagsMatchConditions.ACK_TCP_FLAG, TcpFlagsMatchConditions.RST_TCP_FLAG));
-
-  @VisibleForTesting
-  static final AclLineMatchExpr NEW_TCP_FLOWS = and(TCP_FLOWS, not(ESTABLISHED_TCP_FLOWS));
+  static final AclLineMatchExpr NEW_TCP_FLOWS =
+      and(TCP_FLOWS, matchTcpFlags(TcpFlagsMatchConditions.SYN_ONLY_TCP_FLAG));
 
   /** A reusable expression to indicate new flows. */
   public static final AclLineMatchExpr NEW_FLOWS = implies(TCP_FLOWS, NEW_TCP_FLOWS);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclLineMatchExprsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclLineMatchExprsTest.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel.acl;
 
-import static org.batfish.datamodel.acl.AclLineMatchExprs.ESTABLISHED_TCP_FLOWS;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.NEW_FLOWS;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.NEW_TCP_FLOWS;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
@@ -16,7 +15,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.function.Supplier;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.IpProtocol;
-import org.batfish.datamodel.TcpFlags;
 import org.junit.Test;
 
 public class AclLineMatchExprsTest {
@@ -24,18 +22,20 @@ public class AclLineMatchExprsTest {
     return new Evaluator(flow, "src", ImmutableMap.of(), ImmutableMap.of()).visit(expr);
   }
 
-  private static final Flow NEW_TCP_FLOW;
   private static final Flow ACK_FLOW;
   private static final Flow RST_FLOW;
+  private static final Flow SYN_FLOW;
+  private static final Flow SYN_ACK_FLOW;
   private static final Flow UDP_FLOW;
 
   static {
     Supplier<Flow.Builder> fb = () -> Flow.builder().setIngressNode("n");
     Supplier<Flow.Builder> tcpFb =
         () -> fb.get().setIpProtocol(IpProtocol.TCP).setSrcPort(1).setDstPort(2);
-    ACK_FLOW = tcpFb.get().setTcpFlags(TcpFlags.builder().setAck(true).build()).build();
-    RST_FLOW = tcpFb.get().setTcpFlags(TcpFlags.builder().setRst(true).build()).build();
-    NEW_TCP_FLOW = tcpFb.get().build();
+    ACK_FLOW = tcpFb.get().setTcpFlagsAck(true).build();
+    RST_FLOW = tcpFb.get().setTcpFlagsRst(true).build();
+    SYN_FLOW = tcpFb.get().setTcpFlagsSyn(true).build();
+    SYN_ACK_FLOW = tcpFb.get().setTcpFlagsSyn(true).setTcpFlagsAck(true).build();
 
     UDP_FLOW = fb.get().setIpProtocol(IpProtocol.UDP).setSrcPort(1).setDstPort(2).build();
   }
@@ -57,25 +57,21 @@ public class AclLineMatchExprsTest {
   }
 
   @Test
-  public void testEstablishedTcpFlows() {
-    assertTrue(matches(ESTABLISHED_TCP_FLOWS, ACK_FLOW));
-    assertTrue(matches(ESTABLISHED_TCP_FLOWS, RST_FLOW));
-    assertFalse(matches(ESTABLISHED_TCP_FLOWS, NEW_TCP_FLOW));
-  }
-
-  @Test
   public void testNewTcpFlows() {
+    assertFalse(matches(NEW_TCP_FLOWS, ACK_FLOW));
     assertFalse(matches(NEW_TCP_FLOWS, ACK_FLOW));
     assertFalse(matches(NEW_TCP_FLOWS, RST_FLOW));
     assertFalse(matches(NEW_TCP_FLOWS, UDP_FLOW));
-    assertTrue(matches(NEW_TCP_FLOWS, NEW_TCP_FLOW));
+    assertTrue(matches(NEW_TCP_FLOWS, SYN_FLOW));
+    assertFalse(matches(NEW_TCP_FLOWS, SYN_ACK_FLOW));
   }
 
   @Test
   public void testNewFlows() {
     assertFalse(matches(NEW_FLOWS, ACK_FLOW));
     assertFalse(matches(NEW_FLOWS, RST_FLOW));
-    assertTrue(matches(NEW_FLOWS, NEW_TCP_FLOW));
+    assertFalse(matches(NEW_FLOWS, SYN_ACK_FLOW));
+    assertTrue(matches(NEW_FLOWS, SYN_FLOW));
     assertTrue(matches(NEW_FLOWS, UDP_FLOW));
   }
 }


### PR DESCRIPTION
1. Instead of not established, make it affirmatively syn
2. Make it use all tcp bits, so that reachability and other headerspace searches
   do not turn other bits on.