### PR TITLE
BidirectionalTrace: add test coverage

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTrace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/BidirectionalTrace.java
@@ -19,55 +19,6 @@ public final class BidirectionalTrace {
   private final @Nullable Flow _reverseFlow;
   private final @Nullable Trace _reverseTrace;
 
-  public static final class Key {
-    private final @Nonnull Flow _forwardFlow;
-    private final @Nonnull Set<FirewallSessionTraceInfo> _newSessions;
-    private final @Nullable Flow _reverseFlow;
-
-    public Key(
-        @Nonnull Flow forwardFlow,
-        @Nonnull Set<FirewallSessionTraceInfo> newSessions,
-        @Nullable Flow reverseFlow) {
-      _forwardFlow = forwardFlow;
-      _newSessions = ImmutableSet.copyOf(newSessions);
-      _reverseFlow = reverseFlow;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof Key)) {
-        return false;
-      }
-      Key key = (Key) o;
-      return Objects.equals(_forwardFlow, key._forwardFlow)
-          && Objects.equals(_newSessions, key._newSessions)
-          && Objects.equals(_reverseFlow, key._reverseFlow);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(_forwardFlow, _newSessions, _reverseFlow);
-    }
-
-    @Nonnull
-    public Flow getForwardFlow() {
-      return _forwardFlow;
-    }
-
-    @Nonnull
-    public Set<FirewallSessionTraceInfo> getNewSessions() {
-      return _newSessions;
-    }
-
-    @Nullable
-    public Flow getReverseFlow() {
-      return _reverseFlow;
-    }
-  }
-
   public BidirectionalTrace(
       Flow forwardFlow,
       Trace forwardTrace,
@@ -96,9 +47,9 @@ public final class BidirectionalTrace {
       return false;
     }
     BidirectionalTrace that = (BidirectionalTrace) o;
-    return Objects.equals(_forwardFlow, that._forwardFlow)
-        && Objects.equals(_forwardTrace, that._forwardTrace)
-        && Objects.equals(_newSessions, that._newSessions)
+    return _forwardFlow.equals(that._forwardFlow)
+        && _forwardTrace.equals(that._forwardTrace)
+        && _newSessions.equals(that._newSessions)
         && Objects.equals(_reverseFlow, that._reverseFlow)
         && Objects.equals(_reverseTrace, that._reverseTrace);
   }
@@ -116,11 +67,6 @@ public final class BidirectionalTrace {
   @Nonnull
   public Trace getForwardTrace() {
     return _forwardTrace;
-  }
-
-  @Nonnull
-  public Key getKey() {
-    return new Key(_forwardFlow, _newSessions, _reverseFlow);
   }
 
   @Nonnull

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTraceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTraceTest.java
@@ -1,60 +1,66 @@
 package org.batfish.datamodel.flow;
 
-import static org.batfish.datamodel.FlowDisposition.ACCEPTED;
-import static org.batfish.datamodel.FlowDisposition.DENIED_IN;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
 import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
-import org.batfish.datamodel.flow.BidirectionalTrace.Key;
+import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
+import org.batfish.datamodel.flow.OriginateStep.OriginateStepDetail;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.transformation.Transformation;
 import org.junit.Test;
 
 /** Tests for {@link BidirectionalTrace}. */
 public final class BidirectionalTraceTest {
-  @Test
-  public void testKeyEquals() {
-    Flow flow1 = Flow.builder().setIngressNode("ingressNode").setDstIp(Ip.ZERO).build();
-    Flow flow2 = Flow.builder().setIngressNode("ingressNode").setDstIp(Ip.MAX).build();
-    SessionMatchExpr dummySessionMatch =
-        new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
-    FirewallSessionTraceInfo session =
-        new FirewallSessionTraceInfo(
-            "hostname", Accept.INSTANCE, ImmutableSet.of(), dummySessionMatch, null);
-    new EqualsTester()
-        .addEqualityGroup(
-            new Key(flow1, ImmutableSet.of(), flow1), new Key(flow1, ImmutableSet.of(), flow1))
-        .addEqualityGroup(new Key(flow2, ImmutableSet.of(), flow1))
-        .addEqualityGroup(new Key(flow1, ImmutableSet.of(session), flow1))
-        .addEqualityGroup(new Key(flow1, ImmutableSet.of(), null))
-        .testEquals();
+  private static Trace trace(String hostname) {
+    return new Trace(
+        FlowDisposition.ACCEPTED,
+        ImmutableList.of(
+            new Hop(
+                new Node(hostname),
+                ImmutableList.of(
+                    OriginateStep.builder()
+                        .setAction(StepAction.ORIGINATED)
+                        .setDetail(OriginateStepDetail.builder().setOriginatingVrf("vrf").build())
+                        .build(),
+                    InboundStep.builder().setDetail(new InboundStepDetail("iface")).build()))));
   }
 
   @Test
-  public void testKey() {
-    Flow flow1 = Flow.builder().setIngressNode("ingressNode").setDstIp(Ip.ZERO).build();
-    Flow flow2 = Flow.builder().setIngressNode("ingressNode").setDstIp(Ip.MAX).build();
-    SessionMatchExpr dummySessionMatch =
-        new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
-    Trace successTrace = new Trace(ACCEPTED, ImmutableList.of());
-    assertThat(
-        new BidirectionalTrace(flow1, successTrace, ImmutableSet.of(), flow2, successTrace)
-            .getKey(),
-        equalTo(new Key(flow1, ImmutableSet.of(), flow2)));
-    assertThat(
-        new BidirectionalTrace(flow2, successTrace, ImmutableSet.of(), flow1, successTrace)
-            .getKey(),
-        equalTo(new Key(flow2, ImmutableSet.of(), flow1)));
-    FirewallSessionTraceInfo session =
+  public void testEquals() {
+    Flow f1 =
+        Flow.builder()
+            .setIngressNode("n1")
+            .setIngressVrf("v")
+            .setIpProtocol(IpProtocol.ICMP)
+            .setSrcIp(Ip.parse("1.1.1.1"))
+            .setDstIp(Ip.parse("1.1.1.2"))
+            .setPacketLength(64)
+            .setIcmpType(0)
+            .setIcmpCode(0)
+            .build();
+    Flow f2 = f1.toBuilder().setIcmpCode(5).build();
+    FirewallSessionTraceInfo info =
         new FirewallSessionTraceInfo(
-            "hostname", Accept.INSTANCE, ImmutableSet.of(), dummySessionMatch, null);
-    Trace failTrace = new Trace(DENIED_IN, ImmutableList.of());
-    assertThat(
-        new BidirectionalTrace(flow1, failTrace, ImmutableSet.of(session), null, null).getKey(),
-        equalTo(new Key(flow1, ImmutableSet.of(session), null)));
+            "n",
+            Accept.INSTANCE,
+            ImmutableSet.of(),
+            new SessionMatchExpr(IpProtocol.ICMP, f1.getSrcIp(), f1.getDstIp(), null, null),
+            Transformation.always().build());
+    Trace t1 = trace(f1.getIngressNode());
+    Trace t2 = trace("n2");
+    new EqualsTester()
+        .addEqualityGroup(
+            new BidirectionalTrace(f1, t1, ImmutableSet.of(), f1, t2),
+            new BidirectionalTrace(f1, t1, ImmutableSet.of(), f1, t2))
+        .addEqualityGroup(new BidirectionalTrace(f2, t1, ImmutableSet.of(), f1, t2))
+        .addEqualityGroup(new BidirectionalTrace(f2, t2, ImmutableSet.of(), f1, t2))
+        .addEqualityGroup(new BidirectionalTrace(f2, t2, ImmutableSet.of(info), f1, t2))
+        .addEqualityGroup(new BidirectionalTrace(f2, t2, ImmutableSet.of(info), f2, t2))
+        .addEqualityGroup(new BidirectionalTrace(f2, t2, ImmutableSet.of(info), f2, t1))
+        .testEquals();
   }
 }


### PR DESCRIPTION
Sick of fraudulent coverage diffs on unrelated PRs.

Moved the answerer-specific Key into its user rather than leaving it in the
datamodel itself.