### PR TITLE
FRR: Factor out conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
@@ -244,7 +244,7 @@ public final class FrrConversions {
    * For interfaces that didn't get an address via either OutOfBand or FRR, give them a link-local
    * address if they are being used for BGP unnumbered.
    */
-  public static void addBgpUnnumberedLLAs(Configuration c, FrrConfiguration frrConfiguration) {
+  private static void addBgpUnnumberedLLAs(Configuration c, FrrConfiguration frrConfiguration) {
     c.getAllInterfaces()
         .forEach(
             (iname, iface) -> {
@@ -260,7 +260,7 @@ public final class FrrConversions {
    * For interfaces that didn't get an address via either OutOfBand or FRR, give them a link-local
    * address if they are being used for OSPF unnumbered.
    */
-  public static void addOspfUnnumberedLLAs(Configuration c) {
+  private static void addOspfUnnumberedLLAs(Configuration c) {
     c.getAllInterfaces()
         .forEach(
             (iname, iface) -> {
@@ -289,7 +289,7 @@ public final class FrrConversions {
    *
    * <p>The VRFs must have been created in {@code c} before calling this function.
    */
-  public static void convertStaticRoutes(Configuration c, FrrConfiguration frr) {
+  private static void convertStaticRoutes(Configuration c, FrrConfiguration frr) {
     // default vrf static routes
     org.batfish.datamodel.Vrf defVrf = c.getVrfs().get(DEFAULT_VRF_NAME);
     frr.getStaticRoutes().forEach(sr -> defVrf.getStaticRoutes().add(sr.convert()));
@@ -314,8 +314,7 @@ public final class FrrConversions {
    * @return the inferred Ip or empty optional if that is not possible.
    */
   @VisibleForTesting
-  @Nonnull
-  static Optional<Ip> inferPeerIp(Interface viIface) {
+  static @Nonnull Optional<Ip> inferPeerIp(Interface viIface) {
     // one concrete interface address
     if (viIface.getAllAddresses().size() != 1
         || viIface.getAddress() == null
@@ -347,7 +346,7 @@ public final class FrrConversions {
   }
 
   /** Creates BGP aggregates aggregate routes for the input vrf. */
-  static void generateBgpAggregates(
+  private static void generateBgpAggregates(
       Configuration c,
       org.batfish.datamodel.BgpProcess proc,
       Map<Prefix, BgpVrfAddressFamilyAggregateNetworkConfiguration> aggregateNetworks) {
@@ -386,8 +385,8 @@ public final class FrrConversions {
    * <p>If any Batfish-generated structures are generated, does the bookkeeping in the provided
    * {@link Configuration} to ensure they are available and tracked.
    */
-  @Nullable
-  static If suppressSummarizedPrefixes(
+  @VisibleForTesting
+  static @Nullable If suppressSummarizedPrefixes(
       Configuration c, String vrfName, Stream<Prefix> summaryOnlyPrefixes) {
     Iterator<Prefix> prefixesToSuppress = summaryOnlyPrefixes.iterator();
     if (!prefixesToSuppress.hasNext()) {
@@ -411,7 +410,7 @@ public final class FrrConversions {
         ImmutableList.of());
   }
 
-  public static void convertBgpProcess(
+  private static void convertBgpProcess(
       Configuration c, FrrVendorConfiguration vc, FrrConfiguration frr, Warnings w) {
     BgpProcess bgpProcess = frr.getBgpProcess();
     if (bgpProcess == null) {
@@ -458,8 +457,7 @@ public final class FrrConversions {
             });
   }
 
-  @Nonnull
-  private static org.batfish.datamodel.BgpProcess.Builder bgpProcessBuilder() {
+  private static @Nonnull org.batfish.datamodel.BgpProcess.Builder bgpProcessBuilder() {
     return org.batfish.datamodel.BgpProcess.builder()
         .setEbgpAdminCost(DEFAULT_EBGP_ADMIN)
         .setIbgpAdminCost(DEFAULT_IBGP_ADMIN)
@@ -473,8 +471,8 @@ public final class FrrConversions {
    * Returns {@link org.batfish.datamodel.BgpProcess} for named {@code bgpVrf} if valid, or else
    * {@code null}.
    */
-  @Nullable
-  static org.batfish.datamodel.BgpProcess toBgpProcess(
+  @VisibleForTesting
+  static @Nonnull org.batfish.datamodel.BgpProcess toBgpProcess(
       Configuration c, FrrConfiguration frr, String vrfName, BgpVrf bgpVrf) {
     BgpProcess bgpProcess = frr.getBgpProcess();
     Ip routerId = bgpVrf.getRouterId();
@@ -664,8 +662,7 @@ public final class FrrConversions {
   }
 
   @VisibleForTesting
-  @Nullable
-  static Ipv4UnicastAddressFamily convertIpv4UnicastAddressFamily(
+  static @Nullable Ipv4UnicastAddressFamily convertIpv4UnicastAddressFamily(
       @Nullable BgpNeighborIpv4UnicastAddressFamily ipv4UnicastAddressFamily,
       boolean defaultIpv4Unicast,
       RoutingPolicy exportRoutingPolicy,
@@ -744,8 +741,7 @@ public final class FrrConversions {
         c, vc, frr, neighbor, localAs, bgpVrf, newProc, peerConfigBuilder, w);
   }
 
-  @Nonnull
-  private static RoutingPolicy computeBgpNeighborExportRoutingPolicy(
+  private static @Nonnull RoutingPolicy computeBgpNeighborExportRoutingPolicy(
       Configuration c, BgpNeighbor neighbor, BgpVrf bgpVrf, @Nullable Long localAs) {
     String vrfName = bgpVrf.getVrfName();
 
@@ -815,9 +811,8 @@ public final class FrrConversions {
         .build();
   }
 
-  @Nullable
   @VisibleForTesting
-  static RoutingPolicy computeBgpNeighborImportRoutingPolicy(
+  static @Nullable RoutingPolicy computeBgpNeighborImportRoutingPolicy(
       Configuration c, BgpNeighbor neighbor, BgpVrf bgpVrf) {
     BooleanExpr peerImportConditions = getBgpNeighborImportPolicyCallExpr(neighbor);
     if (peerImportConditions == null) {
@@ -918,9 +913,8 @@ public final class FrrConversions {
         : null;
   }
 
-  @Nullable
   @VisibleForTesting
-  static Ip resolveLocalIpFromUpdateSource(
+  static @Nullable Ip resolveLocalIpFromUpdateSource(
       @Nullable BgpNeighborSource source, Configuration c, Warnings warnings) {
     if (source == null) {
       return null;
@@ -966,9 +960,8 @@ public final class FrrConversions {
   }
 
   /** Scan all interfaces, find first that contains given remote IP */
-  @Nullable
   @VisibleForTesting
-  static Ip computeLocalIpForBgpNeighbor(Ip remoteIp, Configuration c, String vrfName) {
+  static @Nullable Ip computeLocalIpForBgpNeighbor(Ip remoteIp, Configuration c, String vrfName) {
     org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
     if (vrf == null) {
       return null;
@@ -1117,8 +1110,7 @@ public final class FrrConversions {
         && Boolean.TRUE.equals(neighbor.getIpv4UnicastAddressFamily().getDefaultOriginate());
   }
 
-  @Nullable
-  private static EvpnAddressFamily toEvpnAddressFamily(
+  private static @Nullable EvpnAddressFamily toEvpnAddressFamily(
       Configuration c,
       FrrVendorConfiguration vc,
       FrrConfiguration frr,
@@ -1249,9 +1241,8 @@ public final class FrrConversions {
    * href="https://docs.cumulusnetworks.com/display/DOCS/Ethernet+Virtual+Private+Network+-+EVPN#EthernetVirtualPrivateNetwork-EVPN-RD-auto-derivationAuto-derivationofRDsandRTs">
    * cumulus documentation</a> for detailed explanation.
    */
-  @Nonnull
   @VisibleForTesting
-  static ExtendedCommunity toRouteTarget(long asn, long vxlanId) {
+  static @Nonnull ExtendedCommunity toRouteTarget(long asn, long vxlanId) {
     return ExtendedCommunity.target(asn & 0xFFFFL, vxlanId);
   }
 
@@ -1375,8 +1366,7 @@ public final class FrrConversions {
   }
 
   @VisibleForTesting
-  @Nonnull
-  static If convertOspfRedistributionPolicy(
+  static @Nonnull If convertOspfRedistributionPolicy(
       RedistributionPolicy policy, Map<String, RouteMap> routeMaps) {
     CumulusRoutingProtocol protocol = policy.getCumulusRoutingProtocol();
 
@@ -1413,7 +1403,7 @@ public final class FrrConversions {
    * device is used. Otherwise, 0.0.0.0 is used.
    */
   @VisibleForTesting
-  static Ip inferRouterId(Configuration c) {
+  static @Nonnull Ip inferRouterId(Configuration c) {
     if (c.getAllInterfaces().containsKey(LOOPBACK_INTERFACE_NAME)) {
       Optional<ConcreteInterfaceAddress> maxLoIp =
           c.getAllInterfaces().get(LOOPBACK_INTERFACE_NAME).getAllConcreteAddresses().stream()
@@ -1444,8 +1434,7 @@ public final class FrrConversions {
    * @param routerId router ID of the {@code bgpVrf} (already inferred if needed)
    */
   @VisibleForTesting
-  @Nullable
-  static Long inferClusterId(
+  static @Nullable Long inferClusterId(
       BgpVrf bgpVrf, Ip routerId, BgpNeighbor neighbor, @Nullable Long localAs) {
     assert neighbor.getRemoteAs() != null; // precondition
     // Do not set cluster Id if peer is eBGP
@@ -1511,7 +1500,7 @@ public final class FrrConversions {
   }
 
   @VisibleForTesting
-  static SortedMap<Long, OspfArea> computeOspfAreas(
+  static @Nonnull SortedMap<Long, OspfArea> computeOspfAreas(
       Configuration c,
       FrrConfiguration vsConfig,
       OspfVrf ospfVrf,
@@ -1585,8 +1574,7 @@ public final class FrrConversions {
     return ret.build();
   }
 
-  @Nullable
-  private static org.batfish.datamodel.ospf.OspfNetworkType toOspfNetworkType(
+  private static @Nullable org.batfish.datamodel.ospf.OspfNetworkType toOspfNetworkType(
       @Nullable OspfNetworkType type, Warnings w) {
     if (type == null) {
       return null;
@@ -1720,7 +1708,7 @@ public final class FrrConversions {
     return output;
   }
 
-  public static void convertIpAsPathAccessLists(
+  private static void convertIpAsPathAccessLists(
       Configuration c, Map<String, IpAsPathAccessList> ipAsPathAccessLists) {
     ipAsPathAccessLists.forEach(
         (name, asPathAccessList) ->
@@ -1739,7 +1727,7 @@ public final class FrrConversions {
     return new AsPathAccessList(name, lines);
   }
 
-  public static void convertIpPrefixLists(
+  private static void convertIpPrefixLists(
       Configuration c, Map<String, IpPrefixList> ipPrefixLists, String vendorConfigFilename) {
     ipPrefixLists.forEach(
         (name, ipPrefixList) ->
@@ -1771,21 +1759,21 @@ public final class FrrConversions {
         ipPrefixListLine.getLengthRange());
   }
 
-  public static void convertRouteMaps(
+  private static void convertRouteMaps(
       Configuration c, FrrConfiguration vc, String filename, Warnings w) {
     vc.getRouteMaps()
         .forEach(
             (name, routeMap) -> new RouteMapConvertor(c, vc, routeMap, filename, w).toRouteMap());
   }
 
-  public static void convertDnsServers(Configuration c, List<Ip> ipv4Nameservers) {
+  private static void convertDnsServers(Configuration c, List<Ip> ipv4Nameservers) {
     c.setDnsServers(
         ipv4Nameservers.stream()
             .map(Object::toString)
             .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
   }
 
-  public static @Nonnull String computeRouteMapEntryName(String routeMapName, int sequence) {
+  static @Nonnull String computeRouteMapEntryName(String routeMapName, int sequence) {
     return String.format("%s %d", routeMapName, sequence);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
@@ -1773,7 +1773,7 @@ public final class FrrConversions {
             .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
   }
 
-  static @Nonnull String computeRouteMapEntryName(String routeMapName, int sequence) {
+  public static @Nonnull String computeRouteMapEntryName(String routeMapName, int sequence) {
     return String.format("%s %d", routeMapName, sequence);
   }
 


### PR DESCRIPTION
Move most FRR-related conversion to its own method (so, it can be shared), and document what should have been done before that method is called. 

Also fix method annotations along the way.