### PR TITLE
Cisco NX-OS fix layer-2 and layer-3 VNI instantiation requirements

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -226,6 +226,7 @@ import org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform;
 import org.batfish.datamodel.vendor_family.cisco_nxos.NxosMajorVersion;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
+import org.batfish.datamodel.vxlan.Vni;
 import org.batfish.representation.cisco_nxos.BgpVrfIpv6AddressFamilyConfiguration.Network;
 import org.batfish.representation.cisco_nxos.DistributeList.DistributeListFilterType;
 import org.batfish.representation.cisco_nxos.Nve.IngressReplicationProtocol;
@@ -1476,11 +1477,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     } else {
       bumTransportIps = ImmutableSortedSet.copyOf(nveVni.getPeerIps());
     }
-    Integer vlan = getVlanForVni(nveVni.getVni());
-    if (vlan == null) {
-      return;
-    }
-
     if (nveVni.isAssociateVrf()) {
       // L3 VNI
 
@@ -1496,12 +1492,16 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                   nve.getSourceInterface() != null
                       ? getInterfaceIp(_c.getAllInterfaces(), nve.getSourceInterface())
                       : null)
-              .setUdpPort(Layer2Vni.DEFAULT_UDP_PORT)
+              .setUdpPort(Vni.DEFAULT_UDP_PORT)
               .setVni(nveVni.getVni())
               .setSrcVrf(DEFAULT_VRF_NAME)
               .build();
       _c.getVrfs().get(vsTenantVrfForL3Vni.getName()).addLayer3Vni(vniSettings);
     } else {
+      Integer vlan = getVlanForVni(nveVni.getVni());
+      if (vlan == null) {
+        return;
+      }
       Layer2Vni vniSettings =
           Layer2Vni.builder()
               .setBumTransportIps(bumTransportIps)
@@ -1510,7 +1510,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                   nve.getSourceInterface() != null
                       ? getInterfaceIp(_c.getAllInterfaces(), nve.getSourceInterface())
                       : null)
-              .setUdpPort(Layer2Vni.DEFAULT_UDP_PORT)
+              .setUdpPort(Vni.DEFAULT_UDP_PORT)
               .setVni(nveVni.getVni())
               .setVlan(vlan)
               .setSrcVrf(DEFAULT_VRF_NAME)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1480,10 +1480,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     if (vlan == null) {
       return;
     }
-    if (_c.getAllInterfaces().values().stream()
-        .noneMatch(iface -> vlan.equals(iface.getVlan()) && iface.getActive())) {
-      return;
-    }
 
     if (nveVni.isAssociateVrf()) {
       // L3 VNI

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -5302,8 +5302,8 @@ public final class CiscoNxosGrammarTest {
             VniSettingsMatchers.hasVlan(equalTo(5)),
             hasVni(40001)));
 
-    // VLAN for VNI 500001 is shutdown
-    assertThat(c, not(hasDefaultVrf(hasL2VniSettings(hasKey(50001)))));
+    // Even though IRB for vlan6<->VNI 50001 is shutdown, should still communicate about VNI
+    assertThat(c, hasDefaultVrf(hasL2VniSettings(hasKey(50001))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
@@ -11,10 +11,6 @@ vlan 2
   name Name-Of-Vlan-2
   vn-segment 2222
 !
-vlan 3
-  name Name-Of-Vlan-3
-  vn-segment 3333
-!
 vrf context tenant1
   !! this VRF does not appear under "router bgp"
   !! but should still have a BGP process
@@ -23,6 +19,12 @@ vrf context tenant1
   address-family ipv4 unicast
     route-target both auto evpn
 !
+interface ethernet1/1
+  no switchport
+  vrf member tenant1
+  ip address 10.50.0.1/24
+  no shutdown
+
 interface nve1
   no shutdown
   host-reachability protocol bgp

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
@@ -7,7 +7,6 @@ vlan 1
   name Name-Of-Vlan-1
   vn-segment 1111
 !
-!! VLAN interface for vlan 2 is not mapped to any VRF so L2 VNI 2222 will go in default VRF
 vlan 2
   name Name-Of-Vlan-2
   vn-segment 2222
@@ -54,17 +53,6 @@ router bgp 1
   neighbor 1.1.1.1
       inherit peer SPINE
       remote-as 12121
-!
-interface Vlan1
-  vrf member tenant1
-  no shutdown
-!
-interface Vlan2
-  no shutdown
-!
-interface Vlan3
-  vrf member tenant1
-  no shutdown
 !
 interface loopback0
   ip address 1.1.1.1/32


### PR DESCRIPTION
- remove requirement for l2/l3 VNIs to be mapped to some IRB (Vlan)
  interface
- remove requirement for layer3-vnis to be associated with a vlan