### PR TITLE
Cisco NX-OS fix layer-2 and layer-3 VNI instantiation correction

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
@@ -11,6 +11,9 @@ vlan 2
   name Name-Of-Vlan-2
   vn-segment 2222
 !
+vlan 3
+  vn-segment 3333
+!
 vrf context tenant1
   !! this VRF does not appear under "router bgp"
   !! but should still have a BGP process
@@ -24,7 +27,12 @@ interface ethernet1/1
   vrf member tenant1
   ip address 10.50.0.1/24
   no shutdown
-
+!
+interface Vlan3
+  vrf member tenant1
+  no shutdown
+  ! Needed when interface has no IP. Currently unsupported (assumed true).
+  ip forward
 interface nve1
   no shutdown
   host-reachability protocol bgp

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
@@ -36,6 +36,10 @@ vrf context tenant1
   rd auto
   address-family ipv4 unicast
     route-target both auto evpn
+interface vlan3
+  vrf member tenant1
+  no shutdown
+  ip forward
 interface nve1
   no shutdown
   global mcast-group 233.0.0.0 L2


### PR DESCRIPTION
Correction to batfish/batfish#7797
- Layer-3 VNIs *do* need to ba associated with a VLAN
  - There also must be an IRB (Vlan) interface for that VLAN in the tenant VRF