### PR TITLE
Cisco NX-OS never disable IRB associated with L3 VNI

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -264,8 +264,11 @@ public final class Configuration implements Serializable {
   private final String _name;
   private @Nullable String _humanName;
 
-  /** Normal =&gt; Excluding extended and reserved vlans that should not be modified or deleted. */
-  private SubRange _normalVlanRange;
+  /**
+   * Normal =&gt; Excluding extended and reserved vlans that should not be modified or deleted. Also
+   * excludes vlans on relevant devices (e.g. NX-OS) that are associated with an L3 VNI.
+   */
+  private @Nonnull IntegerSpace _normalVlanRange;
 
   private Set<String> _ntpServers;
 
@@ -336,7 +339,8 @@ public final class Configuration implements Serializable {
     _ipsecPhase2Proposals = ImmutableSortedMap.of();
     _loggingServers = new TreeSet<>();
     _mlags = ImmutableSortedMap.of();
-    _normalVlanRange = new SubRange(VLAN_NORMAL_MIN_DEFAULT, VLAN_NORMAL_MAX_DEFAULT);
+    _normalVlanRange =
+        IntegerSpace.of(new SubRange(VLAN_NORMAL_MIN_DEFAULT, VLAN_NORMAL_MAX_DEFAULT));
     _ntpServers = new TreeSet<>();
     _packetPolicies = new TreeMap<>();
     _routeFilterLists = new TreeMap<>();
@@ -687,7 +691,7 @@ public final class Configuration implements Serializable {
   }
 
   @JsonIgnore
-  public SubRange getNormalVlanRange() {
+  public @Nonnull IntegerSpace getNormalVlanRange() {
     return _normalVlanRange;
   }
 
@@ -962,7 +966,7 @@ public final class Configuration implements Serializable {
   }
 
   @JsonIgnore
-  public void setNormalVlanRange(SubRange normalVlanRange) {
+  public void setNormalVlanRange(@Nonnull IntegerSpace normalVlanRange) {
     _normalVlanRange = normalVlanRange;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -153,7 +153,6 @@ import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
@@ -960,11 +959,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
                 vlanId -> vlanMemberCounts.compute(vlanId, (k, v) -> (v == null) ? 1 : (v + 1)));
       }
       // Disable all "normal" vlan interfaces with zero member counts:
-      SubRange normalVlanRange = c.getNormalVlanRange();
+      IntegerSpace normalVlanRange = c.getNormalVlanRange();
       for (Map.Entry<Integer, Integer> entry : vlanMemberCounts.entrySet()) {
         if (entry.getValue() == 0) {
           int vlanNumber = entry.getKey();
-          if (normalVlanRange.includes(vlanNumber)) {
+          if (normalVlanRange.contains(vlanNumber)) {
             Interface iface = vlanInterfaces.get(vlanNumber);
             if ((iface != null) && iface.getAutoState()) {
               _logger.warnf(

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -2156,7 +2156,8 @@ public final class AristaConfiguration extends VendorConfiguration {
     c.setDnsSourceInterface(_dnsSourceInterface);
     c.setDomainName(_domainName);
     c.setExportBgpFromBgpRib(true);
-    c.setNormalVlanRange(new SubRange(VLAN_NORMAL_MIN_CISCO, VLAN_NORMAL_MAX_CISCO));
+    c.setNormalVlanRange(
+        IntegerSpace.of(new SubRange(VLAN_NORMAL_MIN_CISCO, VLAN_NORMAL_MAX_CISCO)));
     c.setTacacsServers(_tacacsServers);
     c.setTacacsSourceInterface(_tacacsSourceInterface);
     c.setNtpSourceInterface(_ntpSourceInterface);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2379,7 +2379,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
     c.setDnsSourceInterface(_dnsSourceInterface);
     c.setDomainName(_domainName);
     c.setExportBgpFromBgpRib(true);
-    c.setNormalVlanRange(new SubRange(VLAN_NORMAL_MIN_CISCO, VLAN_NORMAL_MAX_CISCO));
+    c.setNormalVlanRange(
+        IntegerSpace.of(new SubRange(VLAN_NORMAL_MIN_CISCO, VLAN_NORMAL_MAX_CISCO)));
     c.setTacacsServers(_tacacsServers);
     c.setTacacsSourceInterface(_tacacsSourceInterface);
     c.setNtpSourceInterface(_ntpSourceInterface);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -2681,7 +2681,8 @@ public final class AsaConfiguration extends VendorConfiguration {
     c.setDnsSourceInterface(_dnsSourceInterface);
     c.setDomainName(_domainName);
     c.setExportBgpFromBgpRib(true);
-    c.setNormalVlanRange(new SubRange(VLAN_NORMAL_MIN_CISCO, VLAN_NORMAL_MAX_CISCO));
+    c.setNormalVlanRange(
+        IntegerSpace.of(new SubRange(VLAN_NORMAL_MIN_CISCO, VLAN_NORMAL_MAX_CISCO)));
     c.setTacacsServers(_tacacsServers);
     c.setTacacsSourceInterface(_tacacsSourceInterface);
     c.setNtpSourceInterface(_ntpSourceInterface);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1496,6 +1496,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                       && iface.getVrfName().equals(vsTenantVrfForL3Vni.getName()))) {
         return;
       }
+      // Ensure IRB stays up even if it has no associated switchports
+      //
+      _c.setNormalVlanRange(_c.getNormalVlanRange().difference(IntegerSpace.of(vlan)));
       Layer3Vni vniSettings =
           Layer3Vni.builder()
               .setBumTransportIps(bumTransportIps)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -93,6 +93,7 @@ import org.batfish.datamodel.GeneratedRoute6;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.IkePhase1Policy;
 import org.batfish.datamodel.IkePhase1Proposal;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceAddress;
@@ -1793,7 +1794,8 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
     c.setDnsSourceInterface(_dnsSourceInterface);
     c.setDomainName(_domainName);
     c.setExportBgpFromBgpRib(true);
-    c.setNormalVlanRange(new SubRange(VLAN_NORMAL_MIN_CISCO, VLAN_NORMAL_MAX_CISCO));
+    c.setNormalVlanRange(
+        IntegerSpace.of(new SubRange(VLAN_NORMAL_MIN_CISCO, VLAN_NORMAL_MAX_CISCO)));
     c.setTacacsServers(_tacacsServers);
     c.setTacacsSourceInterface(_tacacsSourceInterface);
     c.setNtpSourceInterface(_ntpSourceInterface);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -5278,6 +5278,10 @@ public final class CiscoNxosGrammarTest {
             hasSourceAddress(nullValue()),
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
             hasVni(20001)));
+    // Make sure Vlan3 - associated with VNI 20001 - is up after post-processing. While it has no
+    // associated switchports and is in autostate, it should stay up since it is associated with a
+    // Layer3Vni.
+    assertThat(c, hasInterface("Vlan3", isActive()));
 
     assertThat(c, hasDefaultVrf(hasL2VniSettings(hasKey(30001))));
     assertThat(


### PR DESCRIPTION
- remove Layer-3-VNI-associated VLANs from "normal" vlan range on NX-OS
- prevent IRBs associated with Layer-3 VNIs from being shut down for
lack of associated switchports