### PR TITLE
Split VxlanTopology into layer2 and layer3 VNI nodes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -350,7 +350,8 @@ public final class TopologyUtil {
       @Nonnull Layer1Topology layer1LogicalTopology,
       VxlanTopology vxlanTopology,
       @Nonnull Map<String, Configuration> configurations) {
-    if (layer1LogicalTopology.isEmpty() && vxlanTopology.getGraph().edges().isEmpty()) {
+    if (layer1LogicalTopology.isEmpty()
+        && !vxlanTopology.getLayer2VniEdges().findAny().isPresent()) {
       return Layer2Topology.EMPTY;
     }
     Layer2Topology.Builder l2TopologyBuilder = Layer2Topology.builder();
@@ -365,7 +366,8 @@ public final class TopologyUtil {
             .map(Layer1Node::getHostname)
             .collect(ImmutableSet.toImmutableSet());
     Set<String> nodesWithVxlan =
-        vxlanTopology.getGraph().edges().stream()
+        vxlanTopology
+            .getLayer2VniEdges()
             .flatMap(edge -> Stream.of(edge.nodeU(), edge.nodeV()))
             .map(VxlanNode::getHostname)
             .collect(ImmutableSet.toImmutableSet());
@@ -413,7 +415,7 @@ public final class TopologyUtil {
    */
   @VisibleForTesting
   static @Nonnull Stream<Layer2Edge> computeVniInterNodeEdges(VxlanTopology vxlanTopology) {
-    return vxlanTopology.getGraph().edges().stream().flatMap(TopologyUtil::toVniVniEdges);
+    return vxlanTopology.getLayer2VniEdges().flatMap(TopologyUtil::toVniVniEdges);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VniLayer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VniLayer.java
@@ -1,0 +1,7 @@
+package org.batfish.datamodel.vxlan;
+
+/** VNI layer, i.e. 2 or 3 */
+public enum VniLayer {
+  LAYER_2,
+  LAYER_3
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanNode.java
@@ -14,18 +14,21 @@ public final class VxlanNode {
 
   private static final String PROP_HOSTNAME = "hostname";
   private static final String PROP_VNI = "vni";
+  private static final String PROP_VNI_LAYER = "vniLayer";
 
   public static final class Builder {
 
     private @Nullable String _hostname;
     private @Nullable Integer _vni;
+    private @Nullable VniLayer _vniLayer;
 
     private Builder() {}
 
     public @Nonnull VxlanNode build() {
       checkArgument(_hostname != null, "Missing %s", "hostname");
       checkArgument(_vni != null, "Missing %s", "vni");
-      return new VxlanNode(_hostname, _vni);
+      checkArgument(_vniLayer != null, "Missing %s", "vni layer");
+      return new VxlanNode(_hostname, _vni, _vniLayer);
     }
 
     public @Nonnull Builder setHostname(String hostname) {
@@ -37,25 +40,36 @@ public final class VxlanNode {
       _vni = vni;
       return this;
     }
+
+    public @Nonnull Builder setVniLayer(VniLayer vniLayer) {
+      _vniLayer = vniLayer;
+      return this;
+    }
   }
 
   @JsonCreator
   private static @Nonnull VxlanNode create(
-      @JsonProperty(PROP_HOSTNAME) @Nullable String hostname, @JsonProperty(PROP_VNI) int vni) {
+      @JsonProperty(PROP_HOSTNAME) @Nullable String hostname,
+      @JsonProperty(PROP_VNI) @Nullable Integer vni,
+      @JsonProperty(PROP_VNI_LAYER) @Nullable VniLayer vniLayer) {
     checkArgument(hostname != null, "Missing %s", PROP_HOSTNAME);
-    return new VxlanNode(hostname, vni);
+    checkArgument(vni != null, "Missing %s", PROP_VNI);
+    checkArgument(vniLayer != null, "Missing %s", PROP_VNI_LAYER);
+    return new VxlanNode(hostname, vni, vniLayer);
   }
 
   public static @Nonnull Builder builder() {
     return new Builder();
   }
 
-  private final String _hostname;
+  private final @Nonnull String _hostname;
   private final int _vni;
+  private final @Nonnull VniLayer _vniLayer;
 
-  public VxlanNode(String hostname, int vni) {
+  public VxlanNode(String hostname, int vni, VniLayer vniLayer) {
     _hostname = hostname;
     _vni = vni;
+    _vniLayer = vniLayer;
   }
 
   @Override
@@ -67,17 +81,21 @@ public final class VxlanNode {
       return false;
     }
     VxlanNode rhs = (VxlanNode) obj;
-    return _hostname.equals(rhs._hostname) && _vni == rhs._vni;
+    return _hostname.equals(rhs._hostname) && _vni == rhs._vni && _vniLayer == rhs._vniLayer;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_hostname, _vni);
+    return Objects.hash(_hostname, _vni, _vniLayer.ordinal());
   }
 
   @Override
   public String toString() {
-    return toStringHelper(getClass()).add("hostname", _hostname).add("vni", _vni).toString();
+    return toStringHelper(getClass())
+        .add("hostname", _hostname)
+        .add("vni", _vni)
+        .add("vniLayer", _vniLayer)
+        .toString();
   }
 
   /** Hostname of the endpoint. */
@@ -90,5 +108,11 @@ public final class VxlanNode {
   @JsonProperty(PROP_VNI)
   public int getVni() {
     return _vni;
+  }
+
+  /** VNI layer for the VNI number on the endpoint. */
+  @JsonProperty(PROP_VNI_LAYER)
+  public @Nonnull VniLayer getVniLayer() {
+    return _vniLayer;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopology.java
@@ -1,15 +1,20 @@
 package org.batfish.datamodel.vxlan;
 
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_3;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.topology.UndirectedEdge;
@@ -47,6 +52,24 @@ public final class VxlanTopology {
     return _graph.edges().stream()
         .map(endpointPair -> new UndirectedEdge<>(endpointPair.nodeU(), endpointPair.nodeV()))
         .collect(ImmutableList.toImmutableList());
+  }
+
+  @JsonIgnore
+  public @Nonnull Stream<EndpointPair<VxlanNode>> getLayer2VniEdges() {
+    return _graph.edges().stream()
+        .filter(
+            endpointPair ->
+                endpointPair.nodeU().getVniLayer() == LAYER_2
+                    && endpointPair.nodeV().getVniLayer() == LAYER_2);
+  }
+
+  @JsonIgnore
+  public @Nonnull Stream<EndpointPair<VxlanNode>> getLayer3VniEdges() {
+    return _graph.edges().stream()
+        .filter(
+            endpointPair ->
+                endpointPair.nodeU().getVniLayer() == LAYER_3
+                    && endpointPair.nodeV().getVniLayer() == LAYER_3);
   }
 
   @JsonIgnore

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -19,6 +19,7 @@ import static org.batfish.datamodel.matchers.EdgeMatchers.hasNode1;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasNode2;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasTail;
 import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -161,7 +162,7 @@ public final class TopologyUtilTest {
     v2.addLayer2Vni(vnb.build());
 
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
-    graph.putEdge(new VxlanNode(s1Name, vni), new VxlanNode(s2Name, vni));
+    graph.putEdge(new VxlanNode(s1Name, vni, LAYER_2), new VxlanNode(s2Name, vni, LAYER_2));
     VxlanTopology vxlanTopology = new VxlanTopology(graph);
     Layer1Topology layer1Topology = Layer1Topology.EMPTY;
 
@@ -195,7 +196,7 @@ public final class TopologyUtilTest {
     String vniName = computeVniName(vni);
 
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
-    graph.putEdge(new VxlanNode(s1Name, vni), new VxlanNode(s2Name, vni));
+    graph.putEdge(new VxlanNode(s1Name, vni, LAYER_2), new VxlanNode(s2Name, vni, LAYER_2));
     VxlanTopology vxlanTopology = new VxlanTopology(graph);
     Layer2Node n1 = new Layer2Node(s1Name, vniName, null);
     Layer2Node n2 = new Layer2Node(s2Name, vniName, null);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanNodeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanNodeTest.java
@@ -1,5 +1,8 @@
 package org.batfish.datamodel.vxlan;
 
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_3;
+
 import com.google.common.testing.EqualsTester;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,18 +15,24 @@ public final class VxlanNodeTest {
   @Test
   public void testBuilderMissingHostname() {
     _thrown.expect(IllegalArgumentException.class);
-    VxlanNode.builder().setVni(1).build();
+    VxlanNode.builder().setVni(1).setVniLayer(LAYER_2).build();
   }
 
   @Test
   public void testBuilderMissingVni() {
     _thrown.expect(IllegalArgumentException.class);
-    VxlanNode.builder().setHostname("h").build();
+    VxlanNode.builder().setHostname("h").setVniLayer(LAYER_2).build();
+  }
+
+  @Test
+  public void testBuilderMissingVniLayer() {
+    _thrown.expect(IllegalArgumentException.class);
+    VxlanNode.builder().setHostname("h").setVni(1).build();
   }
 
   @Test
   public void testEquals() {
-    VxlanNode.Builder builder = VxlanNode.builder().setHostname("h").setVni(1);
+    VxlanNode.Builder builder = VxlanNode.builder().setHostname("h").setVni(1).setVniLayer(LAYER_2);
     VxlanNode n = builder.build();
 
     new EqualsTester()
@@ -33,6 +42,7 @@ public final class VxlanNodeTest {
         .addEqualityGroup(builder.setHostname("h2").build())
         .addEqualityGroup(builder.build().toString())
         .addEqualityGroup(builder.setVni(5).build())
+        .addEqualityGroup(builder.setVniLayer(LAYER_3).build())
         .addEqualityGroup(builder.build().toString())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyTest.java
@@ -1,8 +1,14 @@
 package org.batfish.datamodel.vxlan;
 
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_3;
 import static org.batfish.datamodel.vxlan.VxlanTopology.EMPTY;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.graph.EndpointPair;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
 import com.google.common.testing.EqualsTester;
@@ -15,8 +21,27 @@ public final class VxlanTopologyTest {
 
   private static @Nonnull VxlanTopology nonTrivialTopology() {
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
-    graph.putEdge(new VxlanNode("a", 1), new VxlanNode("b", 2));
+    graph.putEdge(new VxlanNode("a", 1, LAYER_2), new VxlanNode("b", 2, LAYER_2));
+    graph.putEdge(new VxlanNode("a", 3, LAYER_3), new VxlanNode("b", 4, LAYER_3));
     return new VxlanTopology(graph);
+  }
+
+  @Test
+  public void testGetLayer2VniEdges() {
+    assertThat(
+        nonTrivialTopology().getLayer2VniEdges().collect(ImmutableSet.toImmutableSet()),
+        contains(
+            EndpointPair.unordered(
+                new VxlanNode("a", 1, LAYER_2), new VxlanNode("b", 2, LAYER_2))));
+  }
+
+  @Test
+  public void testGetLayer3VniEdges() {
+    assertThat(
+        nonTrivialTopology().getLayer3VniEdges().collect(ImmutableSet.toImmutableSet()),
+        contains(
+            EndpointPair.unordered(
+                new VxlanNode("a", 3, LAYER_3), new VxlanNode("b", 4, LAYER_3))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
@@ -4,6 +4,8 @@ import static com.google.common.collect.ImmutableSortedSet.of;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Names.generatedTenantVniInterfaceName;
 import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_3;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addTenantVniInterfaces;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addVniEdge;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addVniEdges;
@@ -227,8 +229,12 @@ public final class VxlanTopologyUtilsTest {
         equalTo(
             ImmutableSet.of(
                 EndpointPair.unordered(
-                    VxlanNode.builder().setHostname(NODE2).setVni(VNI).build(),
-                    VxlanNode.builder().setHostname(NODE1).setVni(VNI).build()))));
+                    VxlanNode.builder().setHostname(NODE2).setVni(VNI).setVniLayer(LAYER_2).build(),
+                    VxlanNode.builder()
+                        .setHostname(NODE1)
+                        .setVni(VNI)
+                        .setVniLayer(LAYER_2)
+                        .build()))));
   }
 
   @Test
@@ -277,8 +283,10 @@ public final class VxlanTopologyUtilsTest {
             new VrfId(_c1.getHostname(), _v1.getName()), vniSettingsTail,
             new VrfId(_c2.getHostname(), _v2.getName()), vniSettingsHead));
 
-    VxlanNode nodeTail = VxlanNode.builder().setHostname(NODE1).setVni(VNI).build();
-    VxlanNode nodeHead = VxlanNode.builder().setHostname(NODE2).setVni(VNI).build();
+    VxlanNode nodeTail =
+        VxlanNode.builder().setHostname(NODE1).setVni(VNI).setVniLayer(LAYER_2).build();
+    VxlanNode nodeHead =
+        VxlanNode.builder().setHostname(NODE2).setVni(VNI).setVniLayer(LAYER_2).build();
 
     assertThat(graph.edges(), equalTo(ImmutableSet.of(EndpointPair.unordered(nodeTail, nodeHead))));
   }
@@ -294,7 +302,7 @@ public final class VxlanTopologyUtilsTest {
             .build();
     assertThat(
         buildVxlanNode(new VrfId(_c1.getHostname(), _v1.getName()), vniSettings),
-        equalTo(VxlanNode.builder().setHostname(NODE1).setVni(VNI).build()));
+        equalTo(VxlanNode.builder().setHostname(NODE1).setVni(VNI).setVniLayer(LAYER_2).build()));
   }
 
   @Test
@@ -575,8 +583,10 @@ public final class VxlanTopologyUtilsTest {
     _v2.setLayer2Vnis(
         ImmutableSet.of(vniSettingsBuilder.setSourceAddress(SRC_IP2).setVlan(VLAN2).build()));
 
-    VxlanNode nodeTail = VxlanNode.builder().setHostname(NODE1).setVni(VNI).build();
-    VxlanNode nodeHead = VxlanNode.builder().setHostname(NODE2).setVni(VNI).build();
+    VxlanNode nodeTail =
+        VxlanNode.builder().setHostname(NODE1).setVni(VNI).setVniLayer(LAYER_2).build();
+    VxlanNode nodeHead =
+        VxlanNode.builder().setHostname(NODE2).setVni(VNI).setVniLayer(LAYER_2).build();
 
     assertThat(
         VxlanTopologyUtils.computeVxlanTopology(configurations).getGraph().edges(),
@@ -599,8 +609,10 @@ public final class VxlanTopologyUtilsTest {
     table.put(_c1.getHostname(), _v1.getName(), ImmutableSet.of(vniSettingsTail));
     table.put(_c2.getHostname(), _v2.getName(), ImmutableSet.of(vniSettingsHead));
 
-    VxlanNode nodeTail = VxlanNode.builder().setHostname(NODE1).setVni(VNI).build();
-    VxlanNode nodeHead = VxlanNode.builder().setHostname(NODE2).setVni(VNI).build();
+    VxlanNode nodeTail =
+        VxlanNode.builder().setHostname(NODE1).setVni(VNI).setVniLayer(LAYER_2).build();
+    VxlanNode nodeHead =
+        VxlanNode.builder().setHostname(NODE2).setVni(VNI).setVniLayer(LAYER_2).build();
 
     assertThat(
         computeVxlanTopology(table).getGraph().edges(),
@@ -610,7 +622,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testPrunedVxlanTopologyDiscard() {
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
-    graph.putEdge(new VxlanNode(NODE1, VNI), new VxlanNode(NODE2, VNI));
+    graph.putEdge(new VxlanNode(NODE1, VNI, LAYER_2), new VxlanNode(NODE2, VNI, LAYER_2));
     VxlanTopology initial = new VxlanTopology(graph);
 
     // no reachability
@@ -632,7 +644,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testPrunedVxlanTopologyKeep() {
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
-    graph.putEdge(new VxlanNode(NODE1, VNI), new VxlanNode(NODE2, VNI));
+    graph.putEdge(new VxlanNode(NODE1, VNI, LAYER_2), new VxlanNode(NODE2, VNI, LAYER_2));
     VxlanTopology initial = new VxlanTopology(graph);
 
     assertEquals(
@@ -652,7 +664,8 @@ public final class VxlanTopologyUtilsTest {
   public void testReachableEdgeBothDirections() {
     assertTrue(
         VxlanTopologyUtils.reachableEdge(
-            EndpointPair.unordered(new VxlanNode(NODE1, VNI), new VxlanNode(NODE2, VNI)),
+            EndpointPair.unordered(
+                new VxlanNode(NODE1, VNI, LAYER_2), new VxlanNode(NODE2, VNI, LAYER_2)),
             NetworkConfigurations.of(compatibleVxlanConfigs()),
             new TestTracerouteEngine(
                 ImmutableMap.of(
@@ -666,7 +679,8 @@ public final class VxlanTopologyUtilsTest {
   public void testReachableEdgeFirstDirectionOnly() {
     assertFalse(
         VxlanTopologyUtils.reachableEdge(
-            EndpointPair.unordered(new VxlanNode(NODE1, VNI), new VxlanNode(NODE2, VNI)),
+            EndpointPair.unordered(
+                new VxlanNode(NODE1, VNI, LAYER_2), new VxlanNode(NODE2, VNI, LAYER_2)),
             NetworkConfigurations.of(compatibleVxlanConfigs()),
             new TestTracerouteEngine(
                 ImmutableMap.of(
@@ -697,7 +711,8 @@ public final class VxlanTopologyUtilsTest {
 
     assertFalse(
         VxlanTopologyUtils.reachableEdge(
-            EndpointPair.unordered(new VxlanNode(NODE1, VNI), new VxlanNode(NODE2, VNI)),
+            EndpointPair.unordered(
+                new VxlanNode(NODE1, VNI, LAYER_2), new VxlanNode(NODE2, VNI, LAYER_2)),
             NetworkConfigurations.of(configs),
             new TestTracerouteEngine(
                 ImmutableMap.of(
@@ -711,7 +726,8 @@ public final class VxlanTopologyUtilsTest {
   public void testReachableEdgeSecondDirectionOnly() {
     assertFalse(
         VxlanTopologyUtils.reachableEdge(
-            EndpointPair.unordered(new VxlanNode(NODE1, VNI), new VxlanNode(NODE2, VNI)),
+            EndpointPair.unordered(
+                new VxlanNode(NODE1, VNI, LAYER_2), new VxlanNode(NODE2, VNI, LAYER_2)),
             NetworkConfigurations.of(compatibleVxlanConfigs()),
             new TestTracerouteEngine(
                 ImmutableMap.of(
@@ -854,10 +870,10 @@ public final class VxlanTopologyUtilsTest {
     addTenantVniInterfaces(c2);
 
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
-    VxlanNode l2Node1 = new VxlanNode(c1.getHostname(), l2Vni);
-    VxlanNode l2Node2 = new VxlanNode(c2.getHostname(), l2Vni);
-    VxlanNode l3Node1 = new VxlanNode(c1.getHostname(), l3Vni);
-    VxlanNode l3Node2 = new VxlanNode(c2.getHostname(), l3Vni);
+    VxlanNode l2Node1 = new VxlanNode(c1.getHostname(), l2Vni, LAYER_2);
+    VxlanNode l2Node2 = new VxlanNode(c2.getHostname(), l2Vni, LAYER_2);
+    VxlanNode l3Node1 = new VxlanNode(c1.getHostname(), l3Vni, LAYER_3);
+    VxlanNode l3Node2 = new VxlanNode(c2.getHostname(), l3Vni, LAYER_3);
     // Add VXLAN edges for layer-2 VNIs
     graph.addNode(l2Node1);
     graph.addNode(l2Node2);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -168,7 +168,11 @@ final class IncrementalBdpEngine {
 
     // Update L3 adjacencies if necessary.
     L3Adjacencies newAdjacencies;
-    if (!currentTopologyContext.getVxlanTopology().equals(newVxlanTopology)) {
+    if (!currentTopologyContext
+        .getVxlanTopology()
+        .getLayer2VniEdges()
+        .collect(ImmutableSet.toImmutableSet())
+        .equals(newVxlanTopology.getLayer2VniEdges().collect(ImmutableSet.toImmutableSet()))) {
       LOGGER.info("Updating Layer 3 adjacencies");
       if (L3Adjacencies.USE_NEW_METHOD) {
         newAdjacencies =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
@@ -5,6 +5,7 @@ import static org.batfish.common.topology.TopologyUtil.computeLayer2Topology;
 import static org.batfish.common.topology.TopologyUtil.computeLayer3Topology;
 import static org.batfish.common.topology.TopologyUtil.computeRawLayer3Topology;
 import static org.batfish.datamodel.IpsecSession.IPSEC_UDP_PORT;
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -209,7 +210,9 @@ public final class FixedPointTopologyTest {
     // There should be an active VXLAN tunnel
     assertThat(
         topologies.getVxlanTopology().getGraph().edges(),
-        contains(EndpointPair.unordered(new VxlanNode(S1_NAME, VNI), new VxlanNode(S2_NAME, VNI))));
+        contains(
+            EndpointPair.unordered(
+                new VxlanNode(S1_NAME, VNI, LAYER_2), new VxlanNode(S2_NAME, VNI, LAYER_2))));
 
     // The two host interfaces should be in the same broadcast domain due to VXLAN tunnel
     assertTrue(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TopologyContextTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TopologyContextTest.java
@@ -1,5 +1,6 @@
 package org.batfish.dataplane.ibdp;
 
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -70,7 +71,7 @@ public final class TopologyContextTest {
             "a", "b", "c", "d", ConcreteInterfaceAddress.parse("192.0.2.0/31")));
     MutableGraph<VxlanNode> vxlanTopology =
         GraphBuilder.undirected().allowsSelfLoops(false).build();
-    vxlanTopology.addNode(new VxlanNode("a", 5));
+    vxlanTopology.addNode(new VxlanNode("a", 5, LAYER_2));
 
     new EqualsTester()
         .addEqualityGroup(new Object())
@@ -134,7 +135,7 @@ public final class TopologyContextTest {
             "a", "b", "c", "d", ConcreteInterfaceAddress.parse("192.0.2.0/31")));
     MutableGraph<VxlanNode> vxlanTopology =
         GraphBuilder.undirected().allowsSelfLoops(false).build();
-    vxlanTopology.addNode(new VxlanNode("a", 5));
+    vxlanTopology.addNode(new VxlanNode("a", 5, LAYER_2));
     builder
         .setBgpTopology(new BgpTopology(bgpTopology))
         .setEigrpTopology(new EigrpTopology(eigrpTopology))

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -2,6 +2,7 @@ package org.batfish.question.edges;
 
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
+import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
 import static org.batfish.question.edges.EdgesAnswerer.COL_AS_NUMBER;
 import static org.batfish.question.edges.EdgesAnswerer.COL_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_IP;
@@ -485,8 +486,16 @@ public class EdgesAnswererTest {
                     includeNodes,
                     includeRemoteNodes,
                     EndpointPair.unordered(
-                        VxlanNode.builder().setHostname(VXLAN_NODE1).setVni(VXLAN_VNI).build(),
-                        VxlanNode.builder().setHostname(VXLAN_NODE2).setVni(VXLAN_VNI).build()))
+                        VxlanNode.builder()
+                            .setHostname(VXLAN_NODE1)
+                            .setVni(VXLAN_VNI)
+                            .setVniLayer(LAYER_2)
+                            .build(),
+                        VxlanNode.builder()
+                            .setHostname(VXLAN_NODE2)
+                            .setVni(VXLAN_VNI)
+                            .setVniLayer(LAYER_2)
+                            .build()))
                 .collect(ImmutableMultiset.toImmutableMultiset())));
   }
 
@@ -496,8 +505,10 @@ public class EdgesAnswererTest {
     Map<String, Configuration> configurations = nc.getMap();
     Set<String> includeNodes = configurations.keySet();
     Set<String> includeRemoteNodes = configurations.keySet();
-    VxlanNode node1 = VxlanNode.builder().setHostname(VXLAN_NODE1).setVni(VXLAN_VNI).build();
-    VxlanNode node2 = VxlanNode.builder().setHostname(VXLAN_NODE2).setVni(VXLAN_VNI).build();
+    VxlanNode node1 =
+        VxlanNode.builder().setHostname(VXLAN_NODE1).setVni(VXLAN_VNI).setVniLayer(LAYER_2).build();
+    VxlanNode node2 =
+        VxlanNode.builder().setHostname(VXLAN_NODE2).setVni(VXLAN_VNI).setVniLayer(LAYER_2).build();
 
     // no filter
     assertThat(
@@ -531,8 +542,16 @@ public class EdgesAnswererTest {
     assertThat(
         vxlanEdgeToRow(
             nc,
-            VxlanNode.builder().setHostname(VXLAN_NODE1).setVni(VXLAN_VNI).build(),
-            VxlanNode.builder().setHostname(VXLAN_NODE2).setVni(VXLAN_VNI).build()),
+            VxlanNode.builder()
+                .setHostname(VXLAN_NODE1)
+                .setVni(VXLAN_VNI)
+                .setVniLayer(LAYER_2)
+                .build(),
+            VxlanNode.builder()
+                .setHostname(VXLAN_NODE2)
+                .setVni(VXLAN_VNI)
+                .setVniLayer(LAYER_2)
+                .build()),
         equalTo(
             Row.builder()
                 .put(EdgesAnswerer.COL_VNI, VXLAN_VNI)


### PR DESCRIPTION
- add VniLayer enum to VxlanNode
- only check edges between l2 VNI VxlanNodes when deciding whether to recompute l3 adjacencies
- only use l2 VNI VxlanNodes within computation of l3 adjacencies
- only use l3 VNI edges for computation of l3 edges between generated nve interfaces

Follow-on work:
- creation of l3 VxlanNodes during data plane computation
  - create flood lists for L3 VNIs
- fix flood list calculation for L2 VNIs (remove inapplicable VTEPs)
- surfacing VNI layer in VXLAN topology answer