### PR TITLE
Fix Layer3Vni datamodel

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer2Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer2Vni.java
@@ -150,19 +150,16 @@ public final class Layer2Vni implements Vni {
         _srcVrf);
   }
 
-  @Override
   public @Nullable Ip getMulticastGroup() {
     return _bumTransportMethod == BumTransportMethod.MULTICAST_GROUP
         ? Iterables.getOnlyElement(_bumTransportIps)
         : null;
   }
 
-  @Override
   public @Nonnull Set<Ip> getBumTransportIps() {
     return _bumTransportIps;
   }
 
-  @Override
   public @Nonnull BumTransportMethod getBumTransportMethod() {
     return _bumTransportMethod;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer3Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer3Vni.java
@@ -5,57 +5,41 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Ip;
 
 /** Configuration for an L3 VXLAN VNI */
 public final class Layer3Vni implements Vni {
-  @Nonnull private final Set<Ip> _bumTransportIps;
-  @Nonnull private final BumTransportMethod _bumTransportMethod;
+  @Nonnull private final Set<Ip> _learnedNexthopVtepIps;
   @Nullable private final Ip _sourceAddress;
   @Nonnull private final Integer _udpPort;
   private final int _vni;
   @Nonnull private final String _srcVrf;
 
   private Layer3Vni(
-      Set<Ip> bumTransportIps,
-      BumTransportMethod bumTransportMethod,
+      Set<Ip> learnedNexthopVtepIps,
       @Nullable Ip sourceAddress,
       Integer udpPort,
       int vni,
       String srcVrf) {
-    _bumTransportIps = ImmutableSet.copyOf(bumTransportIps);
-    _bumTransportMethod = bumTransportMethod;
+    _learnedNexthopVtepIps = learnedNexthopVtepIps;
     _sourceAddress = sourceAddress;
     _udpPort = udpPort;
     _vni = vni;
     _srcVrf = srcVrf;
   }
 
-  @Override
+  /**
+   * The set of all VTEP IPs of all {@link org.batfish.datamodel.route.nh.NextHopVtep} routes for
+   * this VNI in the VRF corresponding to this Layer3 VNI.
+   */
   @Nonnull
-  public Set<Ip> getBumTransportIps() {
-    return _bumTransportIps;
-  }
-
-  @Override
-  @Nonnull
-  public BumTransportMethod getBumTransportMethod() {
-    return _bumTransportMethod;
-  }
-
-  @Nullable
-  @Override
-  public Ip getMulticastGroup() {
-    return _bumTransportMethod == BumTransportMethod.MULTICAST_GROUP
-        ? Iterables.getOnlyElement(_bumTransportIps)
-        : null;
+  public Set<Ip> getLearnedNexthopVtepIps() {
+    return _learnedNexthopVtepIps;
   }
 
   @Override
@@ -91,8 +75,7 @@ public final class Layer3Vni implements Vni {
     }
     Layer3Vni layer3Vni = (Layer3Vni) o;
     return _vni == layer3Vni._vni
-        && _bumTransportIps.equals(layer3Vni._bumTransportIps)
-        && _bumTransportMethod == layer3Vni._bumTransportMethod
+        && _learnedNexthopVtepIps.equals(layer3Vni._learnedNexthopVtepIps)
         && Objects.equals(_sourceAddress, layer3Vni._sourceAddress)
         && _udpPort.equals(layer3Vni._udpPort)
         && _srcVrf.equals(layer3Vni._srcVrf);
@@ -100,15 +83,13 @@ public final class Layer3Vni implements Vni {
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        _bumTransportIps, _bumTransportMethod, _sourceAddress, _udpPort, _vni, _srcVrf);
+    return Objects.hash(_learnedNexthopVtepIps, _sourceAddress, _udpPort, _vni, _srcVrf);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("bumTransportIps", _bumTransportIps)
-        .add("bumTransportMethod", _bumTransportMethod)
+        .add("learnedNexthopVtepIps", _learnedNexthopVtepIps)
         .add("sourceAddress", _sourceAddress)
         .add("udpPort", _udpPort)
         .add("vni", _vni)
@@ -123,11 +104,11 @@ public final class Layer3Vni implements Vni {
   @Nonnull
   public Builder toBuilder() {
     return builder()
-        .setBumTransportMethod(_bumTransportMethod)
+        .setLearnedNexthopVtepIps(_learnedNexthopVtepIps)
         .setSourceAddress(_sourceAddress)
         .setVni(_vni)
-        .setUdpPort(_udpPort)
-        .setBumTransportIps(_bumTransportIps);
+        .setSrcVrf(_srcVrf)
+        .setUdpPort(_udpPort);
   }
 
   public static Builder testBuilder() {
@@ -136,8 +117,7 @@ public final class Layer3Vni implements Vni {
 
   /** Builder for {@link Layer3Vni} */
   public static final class Builder {
-    @Nonnull private Set<Ip> _bumTransportIps = ImmutableSet.of();
-    @Nullable private BumTransportMethod _bumTransportMethod;
+    @Nonnull private Set<Ip> _learnedNexthopVtepIps = ImmutableSet.of();
     @Nullable private Ip _sourceAddress;
     @Nullable private Integer _udpPort = Vni.DEFAULT_UDP_PORT;
     @Nullable private Integer _vni;
@@ -146,14 +126,8 @@ public final class Layer3Vni implements Vni {
     private Builder() {}
 
     @Nonnull
-    public Builder setBumTransportIps(Set<Ip> bumTransportIps) {
-      _bumTransportIps = bumTransportIps;
-      return this;
-    }
-
-    @Nonnull
-    public Builder setBumTransportMethod(BumTransportMethod bumTransportMethod) {
-      _bumTransportMethod = bumTransportMethod;
+    public Builder setLearnedNexthopVtepIps(Set<Ip> learnedNexthopVtepIps) {
+      _learnedNexthopVtepIps = learnedNexthopVtepIps;
       return this;
     }
 
@@ -184,14 +158,9 @@ public final class Layer3Vni implements Vni {
     @Nonnull
     public Layer3Vni build() {
       checkArgument(_vni != null, "VNI must not be null.");
-      checkArgument(_bumTransportMethod != null, "BumTransportMethod must not be null.");
-      checkArgument(
-          _bumTransportMethod != BumTransportMethod.MULTICAST_GROUP || _bumTransportIps.size() <= 1,
-          "Cannot specify more than one multicast group.");
       checkArgument(_srcVrf != null, "Source VRF for VNI cannot be null");
       return new Layer3Vni(
-          _bumTransportIps,
-          _bumTransportMethod,
+          ImmutableSet.copyOf(_learnedNexthopVtepIps),
           _sourceAddress,
           firstNonNull(_udpPort, DEFAULT_UDP_PORT),
           _vni,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Vni.java
@@ -1,25 +1,14 @@
 package org.batfish.datamodel.vxlan;
 
 import java.io.Serializable;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Ip;
 
 /** A VXLAN Network Identifier configuration */
 public interface Vni extends Serializable {
   /** Default UDP port on which VXLAN tunnels are established */
   Integer DEFAULT_UDP_PORT = 4789;
-
-  @Nullable
-  Ip getMulticastGroup();
-
-  @Nonnull
-  Set<Ip> getBumTransportIps();
-
-  @Nonnull
-  BumTransportMethod getBumTransportMethod();
 
   /** IP address with which the encapsulated packets would be sourced */
   @Nullable

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VniMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VniMatchers.java
@@ -2,37 +2,49 @@ package org.batfish.datamodel.matchers;
 
 import static org.hamcrest.Matchers.equalTo;
 
+import java.util.Collection;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.matchers.VniSettingsMatchersImpl.HasBumTransportIps;
-import org.batfish.datamodel.matchers.VniSettingsMatchersImpl.HasBumTransportMethod;
-import org.batfish.datamodel.matchers.VniSettingsMatchersImpl.HasSourceAddress;
-import org.batfish.datamodel.matchers.VniSettingsMatchersImpl.HasUdpPort;
-import org.batfish.datamodel.matchers.VniSettingsMatchersImpl.HasVlan;
-import org.batfish.datamodel.matchers.VniSettingsMatchersImpl.HasVni;
+import org.batfish.datamodel.matchers.VniMatchersImpl.HasBumTransportIps;
+import org.batfish.datamodel.matchers.VniMatchersImpl.HasBumTransportMethod;
+import org.batfish.datamodel.matchers.VniMatchersImpl.HasLearnedNexthopVtepIps;
+import org.batfish.datamodel.matchers.VniMatchersImpl.HasSourceAddress;
+import org.batfish.datamodel.matchers.VniMatchersImpl.HasUdpPort;
+import org.batfish.datamodel.matchers.VniMatchersImpl.HasVlan;
+import org.batfish.datamodel.matchers.VniMatchersImpl.HasVni;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.datamodel.vxlan.Vni;
 import org.hamcrest.Matcher;
 
-public class VniSettingsMatchers {
+public class VniMatchers {
 
-  private VniSettingsMatchers() {}
+  private VniMatchers() {}
 
   /**
-   * Provides a matcher that matches if the {@link Vni}'s BUM transport IPs matches the {@code
+   * Provides a matcher that matches if the {@link Layer2Vni}'s BUM transport IPs matches the {@code
    * subMatcher}.
    */
-  public static @Nonnull Matcher<Vni> hasBumTransportIps(
+  public static @Nonnull Matcher<Layer2Vni> hasBumTransportIps(
       @Nonnull Matcher<? super Iterable<Ip>> subMatcher) {
     return new HasBumTransportIps(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the {@link Layer3Vni}'s learned next-hop VTEP IPs matches
+   * the {@code subMatcher}.
+   */
+  public static @Nonnull Matcher<Layer3Vni> hasLearnedNexthopVtepIps(
+      @Nonnull Matcher<? super Collection<Ip>> subMatcher) {
+    return new HasLearnedNexthopVtepIps(subMatcher);
   }
 
   /**
    * Provides a matcher that matches if the {@link Vni}'s BUM transport method matches the {@code
    * subMatcher}.
    */
-  public static @Nonnull Matcher<Vni> hasBumTransportMethod(
+  public static @Nonnull Matcher<Layer2Vni> hasBumTransportMethod(
       @Nonnull Matcher<? super BumTransportMethod> subMatcher) {
     return new HasBumTransportMethod(subMatcher);
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VniMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VniMatchersImpl.java
@@ -1,42 +1,55 @@
 package org.batfish.datamodel.matchers;
 
+import java.util.Collection;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.datamodel.vxlan.Vni;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
-public class VniSettingsMatchersImpl {
+public class VniMatchersImpl {
 
-  private VniSettingsMatchersImpl() {}
+  private VniMatchersImpl() {}
 
-  static final class HasBumTransportIps extends FeatureMatcher<Vni, Iterable<Ip>> {
+  static final class HasBumTransportIps extends FeatureMatcher<Layer2Vni, Iterable<Ip>> {
     HasBumTransportIps(@Nonnull Matcher<? super Iterable<Ip>> subMatcher) {
       super(subMatcher, "Layer2Vni with BUM transport IPs:", "bumTransportIps");
     }
 
     @Override
-    protected Iterable<Ip> featureValueOf(Vni actual) {
+    protected Iterable<Ip> featureValueOf(Layer2Vni actual) {
       return actual.getBumTransportIps();
     }
   }
 
-  static final class HasBumTransportMethod extends FeatureMatcher<Vni, BumTransportMethod> {
+  static final class HasLearnedNexthopVtepIps extends FeatureMatcher<Layer3Vni, Collection<Ip>> {
+    HasLearnedNexthopVtepIps(@Nonnull Matcher<? super Collection<Ip>> subMatcher) {
+      super(subMatcher, "Layer3Vni with learned next-hop VTEP IPs:", "learnedNexthopVtepIps");
+    }
+
+    @Override
+    protected Collection<Ip> featureValueOf(Layer3Vni actual) {
+      return actual.getLearnedNexthopVtepIps();
+    }
+  }
+
+  static final class HasBumTransportMethod extends FeatureMatcher<Layer2Vni, BumTransportMethod> {
     HasBumTransportMethod(@Nonnull Matcher<? super BumTransportMethod> subMatcher) {
       super(subMatcher, "Layer2Vni with BUM transport method:", "bumTransportMethod");
     }
 
     @Override
-    protected BumTransportMethod featureValueOf(Vni actual) {
+    protected BumTransportMethod featureValueOf(Layer2Vni actual) {
       return actual.getBumTransportMethod();
     }
   }
 
   static final class HasSourceAddress extends FeatureMatcher<Vni, Ip> {
     HasSourceAddress(@Nonnull Matcher<? super Ip> subMatcher) {
-      super(subMatcher, "Layer2Vni with source IP address:", "sourceAddress");
+      super(subMatcher, "Vni with source IP address:", "sourceAddress");
     }
 
     @Override
@@ -47,7 +60,7 @@ public class VniSettingsMatchersImpl {
 
   static final class HasUdpPort extends FeatureMatcher<Vni, Integer> {
     HasUdpPort(@Nonnull Matcher<? super Integer> subMatcher) {
-      super(subMatcher, "Layer2Vni with UDP port:", "udpPort");
+      super(subMatcher, "Vni with UDP port:", "udpPort");
     }
 
     @Override
@@ -69,7 +82,7 @@ public class VniSettingsMatchersImpl {
 
   static final class HasVni extends FeatureMatcher<Vni, Integer> {
     HasVni(@Nonnull Matcher<? super Integer> subMatcher) {
-      super(subMatcher, "Layer2Vni with VLAN number:", "vlan");
+      super(subMatcher, "Vni with VLAN number:", "vlan");
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchers.java
@@ -17,11 +17,11 @@ import org.batfish.datamodel.matchers.VrfMatchersImpl.HasBgpProcess;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasEigrpProcesses;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasGeneratedRoutes;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasKernelRoutes;
+import org.batfish.datamodel.matchers.VrfMatchersImpl.HasLayer2Vnis;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasName;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasOspfProcesses;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasSnmpServer;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasStaticRoutes;
-import org.batfish.datamodel.matchers.VrfMatchersImpl.HasVniSettings;
 import org.batfish.datamodel.ospf.OspfProcess;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.hamcrest.Matcher;
@@ -94,8 +94,8 @@ public class VrfMatchers {
    * Provides a matcher that matches if the provided {@code subMatcher} matches the VRF's VXLAN VNI
    * settings.
    */
-  public static HasVniSettings hasL2VniSettings(
+  public static @Nonnull Matcher<Vrf> hasLayer2Vnis(
       Matcher<? super Map<Integer, Layer2Vni>> subMatcher) {
-    return new HasVniSettings(subMatcher);
+    return new HasLayer2Vnis(subMatcher);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchersImpl.java
@@ -117,9 +117,9 @@ final class VrfMatchersImpl {
     }
   }
 
-  static final class HasVniSettings extends FeatureMatcher<Vrf, Map<Integer, Layer2Vni>> {
-    HasVniSettings(@Nonnull Matcher<? super Map<Integer, Layer2Vni>> subMatcher) {
-      super(subMatcher, "A VRF with VNI settings:", "vniSettings");
+  static final class HasLayer2Vnis extends FeatureMatcher<Vrf, Map<Integer, Layer2Vni>> {
+    HasLayer2Vnis(@Nonnull Matcher<? super Map<Integer, Layer2Vni>> subMatcher) {
+      super(subMatcher, "A VRF with layer2Vnis:", "layer2Vnis");
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/Layer3VniTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/Layer3VniTest.java
@@ -4,7 +4,6 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.vxlan.Layer3Vni.Builder;
 import org.junit.Test;
@@ -15,21 +14,20 @@ public class Layer3VniTest {
   public void testEquals() {
     Builder builder =
         Layer3Vni.builder()
-            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(Ip.parse("1.1.1.1"))
             .setSrcVrf(DEFAULT_VRF_NAME)
             .setUdpPort(4096)
             .setVni(100001)
-            .setBumTransportIps(ImmutableSet.of());
+            .setLearnedNexthopVtepIps(ImmutableSet.of());
     Layer3Vni vni = builder.build();
     new EqualsTester()
         .addEqualityGroup(vni, vni, builder.build())
-        .addEqualityGroup(builder.setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP).build())
         .addEqualityGroup(builder.setSourceAddress(Ip.parse("2.2.2.2")).build())
         .addEqualityGroup(builder.setSrcVrf("vrf1").build())
         .addEqualityGroup(builder.setUdpPort(4444).build())
         .addEqualityGroup(builder.setVni(200000).build())
-        .addEqualityGroup(builder.setBumTransportIps(ImmutableSet.of(Ip.parse("3.3.3.3"))).build())
+        .addEqualityGroup(
+            builder.setLearnedNexthopVtepIps(ImmutableSet.of(Ip.parse("3.3.3.3"))).build())
         .testEquals();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
@@ -787,12 +787,7 @@ public final class VxlanTopologyUtilsTest {
     Vrf v1 = vb.setName("v1").build();
     Vrf v2 = vb.setName("v2").build();
     Ip sourceAddress = Ip.parse("10.0.0.1");
-    Layer3Vni.Builder l3b =
-        Layer3Vni.builder()
-            .setBumTransportIps(ImmutableSet.of())
-            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
-            .setSrcVrf(DEFAULT_VRF_NAME)
-            .setUdpPort(5);
+    Layer3Vni.Builder l3b = Layer3Vni.builder().setSrcVrf(DEFAULT_VRF_NAME).setUdpPort(5);
     v1.addLayer3Vni(l3b.setVni(1).setSourceAddress(sourceAddress).build());
     v2.addLayer3Vni(l3b.setVni(2).setSourceAddress(null).build());
     String vni1IfaceName = generatedTenantVniInterfaceName(1);
@@ -841,12 +836,7 @@ public final class VxlanTopologyUtilsTest {
     // Add layer-3 VNIs, which should result in layer-3 edges
     int l3Vni = 1000;
     Layer3Vni.Builder l3b =
-        Layer3Vni.builder()
-            .setBumTransportIps(ImmutableSet.of())
-            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
-            .setSrcVrf(DEFAULT_VRF_NAME)
-            .setUdpPort(5)
-            .setVni(l3Vni);
+        Layer3Vni.builder().setSrcVrf(DEFAULT_VRF_NAME).setUdpPort(5).setVni(l3Vni);
     v1.addLayer3Vni(l3b.setSourceAddress(sourceAddress1).build());
     v2.addLayer3Vni(l3b.setSourceAddress(sourceAddress2).build());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -2765,21 +2765,7 @@ public final class AristaConfiguration extends VendorConfiguration {
 
   private static Layer3Vni toL3Vni(
       @Nonnull AristaEosVxlan vxlan, @Nonnull Integer vni, @Nullable Ip sourceAddress) {
-    SortedSet<Ip> bumTransportIps = vxlan.getFloodAddresses();
-
-    // default to unicast flooding unless specified otherwise
-    BumTransportMethod bumTransportMethod = BumTransportMethod.UNICAST_FLOOD_GROUP;
-
-    // Check if multicast is enabled
-    Ip multicastAddress = vxlan.getMulticastGroup();
-    if (bumTransportIps.isEmpty() && multicastAddress != null) {
-      bumTransportMethod = BumTransportMethod.MULTICAST_GROUP;
-      bumTransportIps = ImmutableSortedSet.of(multicastAddress);
-    }
-
     return Layer3Vni.builder()
-        .setBumTransportIps(bumTransportIps)
-        .setBumTransportMethod(bumTransportMethod)
         .setSourceAddress(sourceAddress)
         .setUdpPort(firstNonNull(vxlan.getUdpPort(), AristaEosVxlan.DEFAULT_UDP_PORT))
         .setVni(vni)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1470,14 +1470,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     if (nve.isShutdown()) {
       return;
     }
-    BumTransportMethod bumTransportMethod = getBumTransportMethod(nveVni, nve);
-    SortedSet<Ip> bumTransportIps;
-    if (nveVni.getIngressReplicationProtocol() != IngressReplicationProtocol.STATIC
-        && bumTransportMethod == MULTICAST_GROUP) {
-      bumTransportIps = ImmutableSortedSet.of(getMultiCastGroupIp(nveVni, nve));
-    } else {
-      bumTransportIps = ImmutableSortedSet.copyOf(nveVni.getPeerIps());
-    }
     Integer vlan = getVlanForVni(nveVni.getVni());
     if (vlan == null) {
       // NX-OS requires all VNIs be associated with a VLAN
@@ -1502,8 +1494,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       _c.setNormalVlanRange(_c.getNormalVlanRange().difference(IntegerSpace.of(vlan)));
       Layer3Vni vniSettings =
           Layer3Vni.builder()
-              .setBumTransportIps(bumTransportIps)
-              .setBumTransportMethod(bumTransportMethod)
               .setSourceAddress(
                   nve.getSourceInterface() != null
                       ? getInterfaceIp(_c.getAllInterfaces(), nve.getSourceInterface())
@@ -1514,6 +1504,14 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               .build();
       _c.getVrfs().get(vsTenantVrfForL3Vni.getName()).addLayer3Vni(vniSettings);
     } else {
+      BumTransportMethod bumTransportMethod = getBumTransportMethod(nveVni, nve);
+      SortedSet<Ip> bumTransportIps;
+      if (nveVni.getIngressReplicationProtocol() != IngressReplicationProtocol.STATIC
+          && bumTransportMethod == MULTICAST_GROUP) {
+        bumTransportIps = ImmutableSortedSet.of(getMultiCastGroupIp(nveVni, nve));
+      } else {
+        bumTransportIps = ImmutableSortedSet.copyOf(nveVni.getPeerIps());
+      }
       Layer2Vni vniSettings =
           Layer2Vni.builder()
               .setBumTransportIps(bumTransportIps)

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_concatenated/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_concatenated/CumulusConcatenatedConfiguration.java
@@ -713,7 +713,6 @@ public class CumulusConcatenatedConfiguration extends FrrVendorConfiguration {
                                     .setVni(vxlan.getId())
                                     .setSourceAddress(localIp)
                                     .setUdpPort(NamedPort.VXLAN.number())
-                                    .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
                                     .setSrcVrf(DEFAULT_VRF_NAME)
                                     .build()));
               } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
@@ -1616,7 +1616,6 @@ public final class CumulusConversions {
                                     .setVni(vxlan.getId())
                                     .setSourceAddress(localIp)
                                     .setUdpPort(NamedPort.VXLAN.number())
-                                    .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
                                     .setSrcVrf(DEFAULT_VRF_NAME)
                                     .build()));
               } else {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
@@ -5,7 +5,7 @@ import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasN
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.isEvpnType3RouteThat;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasBumTransportIps;
+import static org.batfish.datamodel.matchers.VniMatchers.hasBumTransportIps;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -61,13 +61,13 @@ import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.datamodel.matchers.MlagMatchers.hasId;
 import static org.batfish.datamodel.matchers.MlagMatchers.hasPeerAddress;
 import static org.batfish.datamodel.matchers.MlagMatchers.hasPeerInterface;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasBumTransportIps;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasBumTransportMethod;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasSourceAddress;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasUdpPort;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasVlan;
+import static org.batfish.datamodel.matchers.VniMatchers.hasBumTransportIps;
+import static org.batfish.datamodel.matchers.VniMatchers.hasBumTransportMethod;
+import static org.batfish.datamodel.matchers.VniMatchers.hasSourceAddress;
+import static org.batfish.datamodel.matchers.VniMatchers.hasUdpPort;
+import static org.batfish.datamodel.matchers.VniMatchers.hasVlan;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
-import static org.batfish.datamodel.matchers.VrfMatchers.hasL2VniSettings;
+import static org.batfish.datamodel.matchers.VrfMatchers.hasLayer2Vnis;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasName;
 import static org.batfish.datamodel.routing_policy.Common.SUMMARY_ONLY_SUPPRESSION_POLICY_NAME;
 import static org.batfish.datamodel.transformation.Transformation.when;
@@ -1693,19 +1693,19 @@ public class AristaGrammarTest {
             hostnameBase, hostnameNoSourceIface, hostnameNoLoopbackAddr);
     // Config with proper loopback iface, VLAN-specific unicast, explicit UDP port
     Configuration configBase = batfish.loadConfigurations(batfish.getSnapshot()).get(hostnameBase);
-    assertThat(configBase, hasDefaultVrf(hasL2VniSettings(hasKey(10002))));
+    assertThat(configBase, hasDefaultVrf(hasLayer2Vnis(hasKey(10002))));
     Layer2Vni vnisBase = configBase.getDefaultVrf().getLayer2Vnis().get(10002);
 
     // Config with no loopback address, using multicast, and default UDP port
     Configuration configNoLoopbackAddr =
         batfish.loadConfigurations(batfish.getSnapshot()).get(hostnameNoLoopbackAddr);
-    assertThat(configNoLoopbackAddr, hasDefaultVrf(hasL2VniSettings(hasKey(10002))));
+    assertThat(configNoLoopbackAddr, hasDefaultVrf(hasLayer2Vnis(hasKey(10002))));
     Layer2Vni vnisNoAddr = configNoLoopbackAddr.getDefaultVrf().getLayer2Vnis().get(10002);
 
     // Config with no source interface and general VXLAN unicast address
     Configuration configNoSourceIface =
         batfish.loadConfigurations(batfish.getSnapshot()).get(hostnameNoSourceIface);
-    assertThat(configNoSourceIface, hasDefaultVrf(hasL2VniSettings(hasKey(10002))));
+    assertThat(configNoSourceIface, hasDefaultVrf(hasLayer2Vnis(hasKey(10002))));
     Layer2Vni vnisNoIface = configNoSourceIface.getDefaultVrf().getLayer2Vnis().get(10002);
 
     // Confirm VLAN-specific unicast address takes priority over the other addresses
@@ -1743,7 +1743,7 @@ public class AristaGrammarTest {
     Configuration config = batfish.loadConfigurations(batfish.getSnapshot()).get(hostname);
 
     // Make sure that misconfigured VXLAN is still converted into VI model properly
-    assertThat(config, hasDefaultVrf(hasL2VniSettings(hasKey(10002))));
+    assertThat(config, hasDefaultVrf(hasLayer2Vnis(hasKey(10002))));
     Layer2Vni vnisMisconfig = config.getDefaultVrf().getLayer2Vnis().get(10002);
 
     // No BUM IPs specified
@@ -2211,9 +2211,8 @@ public class AristaGrammarTest {
     Configuration config = parseConfig("arista_vxlan");
     {
       Layer3Vni vniSettings = config.getVrfs().get("TENANT").getLayer3Vnis().get(10000);
-      assertThat(
-          vniSettings.getBumTransportMethod(), equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP));
-      assertThat(vniSettings.getBumTransportIps(), empty());
+      assertThat(vniSettings.getSrcVrf(), equalTo(DEFAULT_VRF_NAME));
+      assertThat(vniSettings.getLearnedNexthopVtepIps(), empty());
     }
     {
       Layer2Vni vniSettings = config.getDefaultVrf().getLayer2Vnis().get(10001);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -44,10 +44,10 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVrfName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isSwitchport;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasBumTransportMethod;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasSourceAddress;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasUdpPort;
-import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasVni;
+import static org.batfish.datamodel.matchers.VniMatchers.hasBumTransportMethod;
+import static org.batfish.datamodel.matchers.VniMatchers.hasSourceAddress;
+import static org.batfish.datamodel.matchers.VniMatchers.hasUdpPort;
+import static org.batfish.datamodel.matchers.VniMatchers.hasVni;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
@@ -123,7 +123,7 @@ import org.batfish.datamodel.bgp.VniConfig;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.matchers.BgpNeighborMatchers;
-import org.batfish.datamodel.matchers.VniSettingsMatchers;
+import org.batfish.datamodel.matchers.VniMatchers;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
@@ -1570,7 +1570,7 @@ public final class CumulusNcluGrammarTest {
             allOf(
                 hasVni(102000),
                 hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)),
-                VniSettingsMatchers.hasVlan(equalTo(2000)),
+                VniMatchers.hasVlan(equalTo(2000)),
                 hasSourceAddress(equalTo(Ip.parse("1.1.1.1"))),
                 hasUdpPort(equalTo(NamedPort.VXLAN.number())))));
 
@@ -1581,7 +1581,6 @@ public final class CumulusNcluGrammarTest {
             equalTo(
                 Layer3Vni.builder()
                     .setVni(101000)
-                    .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
                     .setSourceAddress(Ip.parse("1.1.1.1"))
                     .setUdpPort(NamedPort.VXLAN.number())
                     .setSrcVrf(DEFAULT_VRF_NAME)


### PR DESCRIPTION
- remove BUM fields, which are only applicable to `Layer2Vni`s
- add `learnedNexthopVtepIps`, which during dp computation should
  contain all next hop vtep ips for the same VNI in the tenant VRF