### PR TITLE
BDDReachabilityUtils: use orAll and traverse incrementally

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityUtils.java
@@ -5,8 +5,11 @@ import static com.google.common.collect.ImmutableTable.toImmutableTable;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
@@ -14,7 +17,6 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -22,6 +24,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
 import org.batfish.bddreachability.transition.Transition;
 import org.batfish.bddreachability.transition.Transitions;
 import org.batfish.common.BatfishException;
@@ -47,10 +50,7 @@ public final class BDDReachabilityUtils {
   static Table<StateExpr, StateExpr, Transition> computeForwardEdgeTable(Stream<Edge> edges) {
     return edges.collect(
         toImmutableTable(
-            Edge::getPreState,
-            Edge::getPostState,
-            Edge::getTransition,
-            (t1, t2) -> Transitions.or(t1, t2)));
+            Edge::getPreState, Edge::getPostState, Edge::getTransition, Transitions::or));
   }
 
   /** Apply edges to the reachableSets until a fixed point is reached. */
@@ -62,16 +62,41 @@ public final class BDDReachabilityUtils {
     Span span = GlobalTracer.get().buildSpan("BDDReachabilityAnalysis.fixpoint").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
+
+      if (reachableSets.isEmpty()) {
+        // No work to do.
+        return;
+      }
+      // Get a BDDFactory for zero and orAll.
+      BDDFactory factory = reachableSets.entrySet().iterator().next().getValue().getFactory();
+
+      // The set of states to process in the next round.
       Set<StateExpr> dirtyStates = ImmutableSet.copyOf(reachableSets.keySet());
+      // For each state to process in the next round, all the incoming BDDs.
+      SetMultimap<StateExpr, BDD> dirtyInputs = HashMultimap.create();
+      // Seed the dirty inputs with the initial reachable sets, then clear the reachable sets.
+      reachableSets.forEach(dirtyInputs::put);
+      reachableSets.clear();
 
       while (!dirtyStates.isEmpty()) {
-        Set<StateExpr> newDirtyStates = new HashSet<>();
-
         dirtyStates.forEach(
             dirtyState -> {
+              Set<BDD> inputs = dirtyInputs.removeAll(dirtyState);
+              assert !inputs.isEmpty();
+              BDD prior = reachableSets.get(dirtyState);
+              BDD newValue =
+                  prior == null
+                      ? factory.orAll(inputs)
+                      : factory.orAll(Sets.union(inputs, ImmutableSet.of(prior)));
+              if (newValue.equals(prior)) {
+                // No change, so no need to update neighbors.
+                return;
+              }
+              reachableSets.put(dirtyState, newValue);
+
               Map<StateExpr, Transition> dirtyStateEdges = edges.row(dirtyState);
-              if (dirtyStateEdges == null) {
-                // dirtyState has no edges
+              if (dirtyStateEdges.isEmpty()) {
+                // dirtyState has no edges, so no neighbors to update.
                 return;
               }
 
@@ -79,21 +104,13 @@ public final class BDDReachabilityUtils {
               dirtyStateEdges.forEach(
                   (neighbor, edge) -> {
                     BDD result = traverse.apply(edge, dirtyStateBDD);
-                    if (result.isZero()) {
-                      return;
-                    }
-
-                    // update neighbor's reachable set
-                    BDD oldReach = reachableSets.get(neighbor);
-                    BDD newReach = oldReach == null ? result : oldReach.or(result);
-                    if (oldReach == null || !oldReach.equals(newReach)) {
-                      reachableSets.put(neighbor, newReach);
-                      newDirtyStates.add(neighbor);
+                    if (!result.isZero()) {
+                      dirtyInputs.put(neighbor, result);
                     }
                   });
             });
 
-        dirtyStates = newDirtyStates;
+        dirtyStates = ImmutableSet.copyOf(dirtyInputs.keySet());
       }
     } finally {
       span.finish();

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityUtils.java
@@ -9,7 +9,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
@@ -84,10 +83,8 @@ public final class BDDReachabilityUtils {
               Set<BDD> inputs = dirtyInputs.removeAll(dirtyState);
               assert !inputs.isEmpty();
               BDD prior = reachableSets.get(dirtyState);
-              BDD newValue =
-                  prior == null
-                      ? factory.orAll(inputs)
-                      : factory.orAll(Sets.union(inputs, ImmutableSet.of(prior)));
+              BDD learned = factory.orAll(inputs);
+              BDD newValue = prior == null ? learned : learned.or(prior);
               if (newValue.equals(prior)) {
                 // No change, so no need to update neighbors.
                 return;
@@ -100,10 +97,9 @@ public final class BDDReachabilityUtils {
                 return;
               }
 
-              BDD dirtyStateBDD = reachableSets.get(dirtyState);
               dirtyStateEdges.forEach(
                   (neighbor, edge) -> {
-                    BDD result = traverse.apply(edge, dirtyStateBDD);
+                    BDD result = traverse.apply(edge, learned);
                     if (!result.isZero()) {
                       dirtyInputs.put(neighbor, result);
                     }


### PR DESCRIPTION
This is two changes that can be separated out if desired.

1. Rather than "pushing BDDs to neighbor states" one at a time, instead we stage all the BDDs and `orAll` them into a single new BDD to unioned with the existing reachable set for a state. Using `orAll` saves in computation. It can also push BDDs farther in fewer iterations (if A and B are both dirty, and A->B, and A is processed first, then processing B will handle A's output in this same iteration).

2. Since the newly-learned reachability (overapproximation, since some may be contained in `prior`) is "free", switch to an incremental traversal algorithm. Instead of feeding everything reachable in a state forward, feed only the learned reachability. This seems to converge faster, but induces more garbage collection than 1.