### PR TITLE
Sonic ConfigDb: don't blanket ignore all keys

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/ConfigDb.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/ConfigDb.java
@@ -247,7 +247,9 @@ public class ConfigDb implements Serializable {
       ConfigDb.Builder configDb = ConfigDb.builder();
       TreeNode tree = p.readValueAsTree();
       Iterator<String> fieldIterator = tree.fieldNames();
-      ObjectMapper mapper = BatfishObjectMapper.ignoreUnknownMapper();
+      // this mapper is used to convert the child trees. by default, it will not ignore unknown keys
+      // inside children. the child classes may choose to ignore keys via Jackson annotation.
+      ObjectMapper mapper = BatfishObjectMapper.mapper();
       while (fieldIterator.hasNext()) {
         String field = fieldIterator.next();
         TreeNode value = tree.get(field);

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/DeviceMetadata.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/DeviceMetadata.java
@@ -1,6 +1,7 @@
 package org.batfish.vendor.sonic.representation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
@@ -10,6 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Represents device metadata: https://github.com/Azure/SONiC/wiki/Configuration#device-metadata */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DeviceMetadata implements Serializable {
 
   private static final String PROP_HOSTNAME = "hostname";

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/MgmtVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/MgmtVrf.java
@@ -15,6 +15,7 @@ import javax.annotation.Nullable;
  */
 public class MgmtVrf implements Serializable {
   private static final String PROP_MGMT_VRF_ENABLED = "mgmtVrfEnabled";
+  private static final String PROP_IN_BAND_MGMT_ENABLED = "in_band_mgmt_enabled";
 
   private @Nullable final Boolean _mgmtVrfEnabled;
 
@@ -24,7 +25,9 @@ public class MgmtVrf implements Serializable {
 
   @JsonCreator
   private @Nonnull static MgmtVrf create(
+      @Nullable @JsonProperty(PROP_IN_BAND_MGMT_ENABLED) String inBandMgmtEnabled,
       @Nullable @JsonProperty(PROP_MGMT_VRF_ENABLED) String mgmtVrfEnabled) {
+    // ignore PROP_IN_BAND_MGMT_ENABLED
     return MgmtVrf.builder()
         .setMgmtVrfEnabled(Optional.ofNullable(mgmtVrfEnabled).map("true"::equals).orElse(null))
         .build();

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/MgmtVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/MgmtVrf.java
@@ -23,11 +23,11 @@ public class MgmtVrf implements Serializable {
     return Optional.ofNullable(_mgmtVrfEnabled);
   }
 
+  @SuppressWarnings("unused") // "parse" and ignore PROP_IN_BAND_MGMT_ENABLED
   @JsonCreator
   private @Nonnull static MgmtVrf create(
       @Nullable @JsonProperty(PROP_IN_BAND_MGMT_ENABLED) String inBandMgmtEnabled,
       @Nullable @JsonProperty(PROP_MGMT_VRF_ENABLED) String mgmtVrfEnabled) {
-    // ignore PROP_IN_BAND_MGMT_ENABLED
     return MgmtVrf.builder()
         .setMgmtVrfEnabled(Optional.ofNullable(mgmtVrfEnabled).map("true"::equals).orElse(null))
         .build();

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/Port.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/Port.java
@@ -1,6 +1,7 @@
 package org.batfish.vendor.sonic.representation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
@@ -10,19 +11,26 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Represents PORT object: https://github.com/Azure/SONiC/wiki/Configuration#port */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Port implements Serializable {
   private static final String PROP_ADMIN_STATUS = "admin_status";
+  private static final String PROP_ALIAS = "alias";
   private static final String PROP_DESCRIPTION = "description";
   private static final String PROP_MTU = "mtu";
   private static final String PROP_SPEED = "speed";
 
   private @Nullable final Boolean _adminStatusUp;
+  private @Nullable final String _alias;
   private @Nullable final String _description;
   private @Nullable final Integer _mtu;
   private @Nullable final Integer _speed;
 
   public @Nonnull Optional<Boolean> getAdminStatusUp() {
     return Optional.ofNullable(_adminStatusUp);
+  }
+
+  public @Nonnull Optional<String> getAlias() {
+    return Optional.ofNullable(_alias);
   }
 
   public @Nonnull Optional<String> getDescription() {
@@ -40,11 +48,13 @@ public class Port implements Serializable {
   @JsonCreator
   private @Nonnull static Port create(
       @Nullable @JsonProperty(PROP_ADMIN_STATUS) String adminStatus,
+      @Nullable @JsonProperty(PROP_ALIAS) String alias,
       @Nullable @JsonProperty(PROP_DESCRIPTION) String description,
       @Nullable @JsonProperty(PROP_MTU) String mtu,
       @Nullable @JsonProperty(PROP_SPEED) String speed) {
     return Port.builder()
         .setAdminStatusUp(Optional.ofNullable(adminStatus).map("up"::equals).orElse(null))
+        .setAlias(alias)
         .setDescription(description)
         .setMtu(Optional.ofNullable(mtu).map(Integer::parseInt).orElse(null))
         .setSpeed(Optional.ofNullable(speed).map(Integer::parseInt).orElse(null))
@@ -53,10 +63,12 @@ public class Port implements Serializable {
 
   private @Nonnull Port(
       @Nullable Boolean adminStatus,
+      @Nullable String alias,
       @Nullable String description,
       @Nullable Integer mtu,
       @Nullable Integer speed) {
     _adminStatusUp = adminStatus;
+    _alias = alias;
     _description = description;
     _mtu = mtu;
     _speed = speed;
@@ -72,6 +84,7 @@ public class Port implements Serializable {
     }
     Port that = (Port) o;
     return Objects.equals(_adminStatusUp, that._adminStatusUp)
+        && Objects.equals(_alias, that._alias)
         && Objects.equals(_description, that._description)
         && Objects.equals(_mtu, that._mtu)
         && Objects.equals(_speed, that._speed);
@@ -79,7 +92,7 @@ public class Port implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_adminStatusUp, _description, _mtu, _speed);
+    return Objects.hash(_adminStatusUp, _alias, _description, _mtu, _speed);
   }
 
   @Override
@@ -87,6 +100,7 @@ public class Port implements Serializable {
     return MoreObjects.toStringHelper(this)
         .omitNullValues()
         .add("adminStatusUp", _adminStatusUp)
+        .add("alias", _alias)
         .add("description", _description)
         .add("mtu", _mtu)
         .add("speed", _speed)
@@ -99,12 +113,18 @@ public class Port implements Serializable {
 
   public static final class Builder {
     private Boolean _adminStatusUp;
+    private String _alias;
     private String _description;
     private Integer _mtu;
     private Integer _speed;
 
     public @Nonnull Builder setAdminStatusUp(@Nullable Boolean adminStatusUp) {
       this._adminStatusUp = adminStatusUp;
+      return this;
+    }
+
+    public @Nonnull Builder setAlias(@Nullable String alias) {
+      this._alias = alias;
       return this;
     }
 
@@ -124,7 +144,7 @@ public class Port implements Serializable {
     }
 
     public @Nonnull Port build() {
-      return new Port(_adminStatusUp, _description, _mtu, _speed);
+      return new Port(_adminStatusUp, _alias, _description, _mtu, _speed);
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConversions.java
@@ -21,6 +21,7 @@ public class SonicConversions {
       Interface.Builder ib =
           Interface.builder()
               .setName(portName)
+              .setHumanName(port.getAlias().orElse(null))
               .setOwner(c)
               .setVrf(vrf)
               .setType(InterfaceType.PHYSICAL)

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicGrammarTest.java
@@ -98,7 +98,7 @@ public class SonicGrammarTest {
         ImmutableMap.of("eth0", new L3Interface(ConcreteInterfaceAddress.parse("1.1.1.1/24"))),
         vc.getConfigDb().getMgmtInterfaces());
     assertEquals(
-        ImmutableMap.of("eth0", Port.builder().setAdminStatusUp(true).build()),
+        ImmutableMap.of("eth0", Port.builder().setAdminStatusUp(true).setAlias("eth0").build()),
         vc.getConfigDb().getMgmtPorts());
     assertEquals(
         ImmutableMap.of(

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicGrammarTest.java
@@ -98,7 +98,7 @@ public class SonicGrammarTest {
         ImmutableMap.of("eth0", new L3Interface(ConcreteInterfaceAddress.parse("1.1.1.1/24"))),
         vc.getConfigDb().getMgmtInterfaces());
     assertEquals(
-        ImmutableMap.of("eth0", Port.builder().setAdminStatusUp(true).setAlias("eth0").build()),
+        ImmutableMap.of("eth0", Port.builder().setAdminStatusUp(true).build()),
         vc.getConfigDb().getMgmtPorts());
     assertEquals(
         ImmutableMap.of(

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/DeviceMetadataTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/DeviceMetadataTest.java
@@ -14,9 +14,19 @@ public class DeviceMetadataTest {
 
   @Test
   public void testJacksonDeserialization() throws JsonProcessingException {
-    String input = "{ \"hostname\": \"name\", \"GARBAGE\": 1 }";
+    String input =
+        "{"
+            + "    \"bgp_asn\": \"65044\","
+            + "    \"default_config_profile\": \"l3\","
+            + "    \"docker_routing_config_mode\": \"split\","
+            + "    \"hostname\": \"name\","
+            + "    \"hwsku\": \"XXXYYY\","
+            + "    \"mac\": \"c8:f7:50:ec:07:41\","
+            + "    \"platform\": \"x86_64-XXX\","
+            + "    \"type\": \"LeafRouter\""
+            + "}";
     assertThat(
-        BatfishObjectMapper.ignoreUnknownMapper().readValue(input, DeviceMetadata.class),
+        BatfishObjectMapper.mapper().readValue(input, DeviceMetadata.class),
         equalTo(new DeviceMetadata("name")));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/MgmtVrfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/MgmtVrfTest.java
@@ -2,8 +2,10 @@ package org.batfish.vendor.sonic.representation;
 
 import static org.junit.Assert.assertEquals;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 public class MgmtVrfTest {
@@ -22,5 +24,13 @@ public class MgmtVrfTest {
         .addEqualityGroup(builder.build(), builder.build())
         .addEqualityGroup(builder.setMgmtVrfEnabled(true).build())
         .testEquals();
+  }
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input = "{\"in_band_mgmt_enabled\": \"false\", \"mgmtVrfEnabled\": \"true\"}";
+    assertEquals(
+        MgmtVrf.builder().setMgmtVrfEnabled(true).build(),
+        BatfishObjectMapper.mapper().readValue(input, MgmtVrf.class));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/PortTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/PortTest.java
@@ -2,8 +2,10 @@ package org.batfish.vendor.sonic.representation;
 
 import static org.junit.Assert.assertEquals;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 public class PortTest {
@@ -13,6 +15,7 @@ public class PortTest {
     Port obj =
         Port.builder()
             .setAdminStatusUp(true)
+            .setAlias("alias")
             .setDescription("desc")
             .setMtu(32)
             .setSpeed(42)
@@ -27,9 +30,36 @@ public class PortTest {
     new EqualsTester()
         .addEqualityGroup(builder.build(), builder.build())
         .addEqualityGroup(builder.setAdminStatusUp(true).build())
+        .addEqualityGroup(builder.setAlias("alias").build())
         .addEqualityGroup(builder.setDescription("desc").build())
         .addEqualityGroup(builder.setMtu(23).build())
         .addEqualityGroup(builder.setSpeed(42).build())
         .testEquals();
+  }
+
+  @Test
+  public void testDeserialization() throws JsonProcessingException {
+    String input =
+        "{"
+            + "    \"admin_status\": \"up\","
+            + "    \"alias\": \"Eth1/1/1\","
+            + "    \"description\": \"test\","
+            + "    \"fec\": \"none\","
+            + "    \"index\": \"1\","
+            + "    \"lanes\": \"33\","
+            + "    \"mtu\": \"9100\","
+            + "    \"override_unreliable_los\": \"off\","
+            + "    \"speed\": \"25000\""
+            + "}";
+    Port port = BatfishObjectMapper.mapper().readValue(input, Port.class);
+    assertEquals(
+        Port.builder()
+            .setAdminStatusUp(true)
+            .setAlias("Eth1/1/1")
+            .setDescription("test")
+            .setMtu(9100)
+            .setSpeed(25000)
+            .build(),
+        port);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/SonicConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/SonicConversionsTest.java
@@ -3,6 +3,7 @@ package org.batfish.vendor.sonic.representation;
 import static org.batfish.datamodel.ConfigurationFormat.SONIC;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAddress;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasHumanName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSpeed;
@@ -26,6 +27,7 @@ public class SonicConversionsTest {
     Port port =
         Port.builder()
             .setAdminStatusUp(false)
+            .setAlias("alias")
             .setMtu(56)
             .setDescription("desc")
             .setSpeed(23)
@@ -44,6 +46,7 @@ public class SonicConversionsTest {
           Iterables.getOnlyElement(c.getAllInterfaces().values()),
           allOf(
               hasName("iface"),
+              hasHumanName("alias"),
               hasAddress(ifaceAddress),
               hasMtu(56),
               hasDescription("desc"),

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sonic/grammar/snapshots/mgmt/sonic_configs/device/config_db.json
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sonic/grammar/snapshots/mgmt/sonic_configs/device/config_db.json
@@ -19,7 +19,6 @@
   },
   "MGMT_PORT": {
     "eth0": {
-      "alias": "eth0",
       "admin_status": "up"
     }
   },


### PR DESCRIPTION
Let child classes decide how they want to handle unknown keys.