### PR TITLE
BDDPacket: reduce JFACTORY_CACHE_RATIO to 8

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -44,7 +44,7 @@ public class BDDPacket {
    * The ratio of node table size to node cache size to preserve when resizing. The default
    * value is 0, which means never resize the cache.
    */
-  private static final int JFACTORY_CACHE_RATIO = 32;
+  private static final int JFACTORY_CACHE_RATIO = 8;
 
   /*
    * Initial size of the BDD factory node cache. Automatically resized when the node table is,


### PR DESCRIPTION
... from 32. i.e. use 4x more cache than before