### PR TITLE
JFactory: don't flush cache when GC frees BDDs

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -4077,6 +4077,9 @@ public final class JFactory extends BDDFactory {
   }
 
   private void BddCache_clean_multiop(BddCache cache) {
+    if (cache == null) {
+      return;
+    }
     for (int n = 0; n < cache.tablesize; n++) {
       MultiOpBddCacheData entry = (MultiOpBddCacheData) cache.table[n];
       if (entry.a != -1) {

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -59,7 +59,7 @@ public final class JFactory extends BDDFactory {
    * entries.
    */
   // Warning: we've never tried with this flag false.
-  private static final boolean FLUSH_CACHE_ON_GC = true;
+  private static final boolean FLUSH_CACHE_ON_GC = false;
 
   /**
    * If set, assertions will be made on BDD internal computations. Used in developing the factory.

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -4077,7 +4077,22 @@ public final class JFactory extends BDDFactory {
   }
 
   private void BddCache_clean_multiop(BddCache cache) {
-    throw new UnsupportedOperationException("Clean is unimplemented for multiop cache.");
+    for (int n = 0; n < cache.tablesize; n++) {
+      MultiOpBddCacheData entry = (MultiOpBddCacheData) cache.table[n];
+      if (entry.a != -1) {
+        boolean invalid = false;
+        for (int i = 0; i < entry.operands.length; i++) {
+          if (LOW(entry.operands[i]) == INVALID_BDD) {
+            invalid = true;
+            break;
+          }
+        }
+        if (invalid) {
+          entry.a = -1;
+          entry.operands = null;
+        }
+      }
+    }
   }
 
   private void bdd_setpair(bddPair pair, int oldvar, int newvar) {


### PR DESCRIPTION
Instead, walk over the cache and delete entries for freed BDDs. This is safe since we do it as part of GC, i.e. before any new BDDs are allocate: we know which BDDs are freed vs not.