### PR TITLE
Produce VXLAN edges from type-5 routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 
 public interface DataPlane extends Serializable {
 
@@ -52,4 +53,12 @@ public interface DataPlane extends Serializable {
    */
   @Nonnull
   Table<String, String, Set<Layer2Vni>> getLayer2Vnis();
+
+  /**
+   * Return {@link Layer3Vni} for each node/VRF. Returned settings are based on the vni settings in
+   * a {@link Vrf}, but may include additional information obtained during dataplane computation,
+   * such as updated VTEPs due to EVPN route exchange.
+   */
+  @Nonnull
+  Table<String, String, Set<Layer3Vni>> getLayer3Vnis();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkConfigurations.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkConfigurations.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -17,7 +18,7 @@ import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.ospf.OspfNeighborConfig;
 import org.batfish.datamodel.ospf.OspfNeighborConfigId;
 import org.batfish.datamodel.ospf.OspfProcess;
-import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Vni;
 
 /**
  * Represents a set of configurations in a network. Has helper methods to "walk the configuration
@@ -168,16 +169,17 @@ public final class NetworkConfigurations {
         .map(oc -> oc.get(ospfConfigId));
   }
 
-  /** Return {@link Layer2Vni} identificated by {@code hostname} and {@code vni} number. */
+  /** Return {@link Vni} identificated by {@code hostname} and {@code vni} number. */
   @Nonnull
-  public Optional<Layer2Vni> getVniSettings(String hostname, int vni) {
+  public <V extends Vni> Optional<V> getVniSettings(
+      String hostname, int vni, Function<Vrf, Map<Integer, V>> vniGetter) {
     // implementation assumes a given VNI can be present in at most one VRF.
     return get(hostname)
         .map(Configuration::getVrfs)
         .map(
             vrfs ->
                 vrfs.values().stream()
-                    .map(Vrf::getLayer2Vnis)
+                    .map(vniGetter)
                     .map(vniSettingsMap -> vniSettingsMap.get(vni))
                     .filter(Objects::nonNull)
                     .findAny()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -10,6 +10,7 @@ import java.util.SortedMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 
 public class MockDataPlane implements DataPlane {
 
@@ -24,14 +25,16 @@ public class MockDataPlane implements DataPlane {
     @Nonnull
     private SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> _ribs;
 
-    @Nonnull private Table<String, String, Set<Layer2Vni>> _vniSettings;
+    @Nonnull private Table<String, String, Set<Layer2Vni>> _layer2VniSettings;
+    @Nonnull private Table<String, String, Set<Layer3Vni>> _layer3VniSettings;
 
     private Builder() {
       _bgpRoutes = HashBasedTable.create();
       _evpnRoutes = HashBasedTable.create();
       _fibs = ImmutableMap.of();
       _ribs = ImmutableSortedMap.of();
-      _vniSettings = HashBasedTable.create();
+      _layer2VniSettings = HashBasedTable.create();
+      _layer3VniSettings = HashBasedTable.create();
     }
 
     public MockDataPlane build() {
@@ -70,8 +73,15 @@ public class MockDataPlane implements DataPlane {
       return this;
     }
 
-    public Builder setVniSettings(@Nonnull Table<String, String, Set<Layer2Vni>> vniSettings) {
-      _vniSettings = vniSettings;
+    public Builder setLayer2VniSettings(
+        @Nonnull Table<String, String, Set<Layer2Vni>> layer2VniSettings) {
+      _layer2VniSettings = layer2VniSettings;
+      return this;
+    }
+
+    public Builder setLayer3VniSettings(
+        @Nonnull Table<String, String, Set<Layer3Vni>> layer3VniSettings) {
+      _layer3VniSettings = layer3VniSettings;
       return this;
     }
 
@@ -97,7 +107,8 @@ public class MockDataPlane implements DataPlane {
   private final SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
       _ribs;
 
-  @Nonnull private Table<String, String, Set<Layer2Vni>> _vniSettings;
+  @Nonnull private Table<String, String, Set<Layer2Vni>> _layer2VniSettings;
+  @Nonnull private Table<String, String, Set<Layer3Vni>> _layer3VniSettings;
 
   private MockDataPlane(Builder builder) {
     _bgpRoutes = builder._bgpRoutes;
@@ -107,7 +118,8 @@ public class MockDataPlane implements DataPlane {
     _fibs = builder._fibs;
     _forwardingAnalysis = builder._forwardingAnalysis;
     _ribs = ImmutableSortedMap.copyOf(builder._ribs);
-    _vniSettings = builder._vniSettings;
+    _layer2VniSettings = builder._layer2VniSettings;
+    _layer3VniSettings = builder._layer3VniSettings;
   }
 
   @Nonnull
@@ -162,6 +174,12 @@ public class MockDataPlane implements DataPlane {
   @Nonnull
   @Override
   public Table<String, String, Set<Layer2Vni>> getLayer2Vnis() {
-    return _vniSettings;
+    return _layer2VniSettings;
+  }
+
+  @Nonnull
+  @Override
+  public Table<String, String, Set<Layer3Vni>> getLayer3Vnis() {
+    return _layer3VniSettings;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
@@ -3,14 +3,17 @@ package org.batfish.datamodel.vxlan;
 import static com.google.common.collect.ImmutableSortedSet.of;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Names.generatedTenantVniInterfaceName;
-import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.datamodel.vxlan.VniLayer.LAYER_2;
 import static org.batfish.datamodel.vxlan.VniLayer.LAYER_3;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addLayer2VniEdge;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addLayer2VniEdges;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addLayer3VniEdge;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addLayer3VniEdges;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addTenantVniInterfaces;
-import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addVniEdge;
-import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addVniEdges;
-import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.buildVxlanNode;
-import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.compatibleVniSettings;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.buildLayer2VxlanNode;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.buildLayer3VxlanNode;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.compatibleLayer2VniSettings;
+import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.compatibleLayer3VniSettings;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.computeVniSettingsTable;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.computeVxlanTopology;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.prunedVxlanTopology;
@@ -179,7 +182,7 @@ public final class VxlanTopologyUtilsTest {
     ib.setAddresses(ConcreteInterfaceAddress.create(SRC_IP1, 31)).setOwner(_c1).setVrf(_v1).build();
     ib.setAddresses(ConcreteInterfaceAddress.create(SRC_IP2, 31)).setOwner(_c2).setVrf(_v2).build();
     Layer2Vni.Builder vsb =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setUdpPort(UDP_PORT)
             .setVlan(VLAN1)
@@ -202,10 +205,10 @@ public final class VxlanTopologyUtilsTest {
   }
 
   @Test
-  public void testAddVniEdge() {
+  public void testAddLayer2VniEdge() {
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
     Layer2Vni.Builder vniSettingsBuilder =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -216,7 +219,7 @@ public final class VxlanTopologyUtilsTest {
     Layer2Vni vniSettingsHead =
         vniSettingsBuilder.setSourceAddress(SRC_IP2).setVlan(VLAN2).setVni(VNI).build();
     _v2.setLayer2Vnis(ImmutableSet.of(vniSettingsHead));
-    addVniEdge(
+    addLayer2VniEdge(
         graph,
         new VrfId(_c1.getHostname(), _v1.getName()),
         vniSettingsTail,
@@ -238,10 +241,10 @@ public final class VxlanTopologyUtilsTest {
   }
 
   @Test
-  public void testAddVniEdgeIncompatible() {
+  public void testAddLayer2VniEdgeIncompatible() {
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
     Layer2Vni.Builder vniSettingsBuilder =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -250,7 +253,7 @@ public final class VxlanTopologyUtilsTest {
     _v1.setLayer2Vnis(ImmutableSet.of(vniSettingsTail));
     Layer2Vni vniSettingsHead = vniSettingsBuilder.setSourceAddress(SRC_IP1).setVlan(VLAN2).build();
     _v2.setLayer2Vnis(ImmutableSet.of(vniSettingsHead));
-    addVniEdge(
+    addLayer2VniEdge(
         graph,
         new VrfId(_c1.getHostname(), _v1.getName()),
         vniSettingsTail,
@@ -262,11 +265,68 @@ public final class VxlanTopologyUtilsTest {
   }
 
   @Test
-  public void testAddVniEdges() {
+  public void testAddLayer3VniEdge() {
+    MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
+    Layer3Vni.Builder vniSettingsBuilder = Layer3Vni.testBuilder().setUdpPort(UDP_PORT).setVni(VNI);
+    Layer3Vni vniSettingsTail =
+        vniSettingsBuilder
+            .setSourceAddress(SRC_IP1)
+            .setVni(VNI)
+            .setLearnedNexthopVtepIps(ImmutableSet.of(SRC_IP2))
+            .build();
+    _v1.setLayer3Vnis(ImmutableSet.of(vniSettingsTail));
+    Layer3Vni vniSettingsHead =
+        vniSettingsBuilder
+            .setSourceAddress(SRC_IP2)
+            .setVni(VNI)
+            .setLearnedNexthopVtepIps(ImmutableSet.of(SRC_IP1))
+            .build();
+    _v2.setLayer3Vnis(ImmutableSet.of(vniSettingsHead));
+    addLayer3VniEdge(
+        graph,
+        new VrfId(_c1.getHostname(), _v1.getName()),
+        vniSettingsTail,
+        new VrfId(_c2.getHostname(), _v2.getName()),
+        vniSettingsHead);
+    Set<EndpointPair<VxlanNode>> edges = graph.edges();
+
+    assertThat(
+        edges,
+        equalTo(
+            ImmutableSet.of(
+                EndpointPair.unordered(
+                    VxlanNode.builder().setHostname(NODE2).setVni(VNI).setVniLayer(LAYER_3).build(),
+                    VxlanNode.builder()
+                        .setHostname(NODE1)
+                        .setVni(VNI)
+                        .setVniLayer(LAYER_3)
+                        .build()))));
+  }
+
+  @Test
+  public void testAddLayer3VniEdgeIncompatible() {
+    MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
+    Layer3Vni.Builder vniSettingsBuilder = Layer3Vni.testBuilder().setUdpPort(UDP_PORT).setVni(VNI);
+    Layer3Vni vniSettingsTail = vniSettingsBuilder.setSourceAddress(SRC_IP1).setVni(VNI).build();
+    _v1.setLayer3Vnis(ImmutableSet.of(vniSettingsTail));
+    Layer3Vni vniSettingsHead = vniSettingsBuilder.setSourceAddress(SRC_IP2).setVni(VNI).build();
+    addLayer3VniEdge(
+        graph,
+        new VrfId(_c1.getHostname(), _v1.getName()),
+        vniSettingsTail,
+        new VrfId(_c2.getHostname(), _v2.getName()),
+        vniSettingsHead);
+    Set<EndpointPair<VxlanNode>> edges = graph.edges();
+
+    assertThat(edges, empty());
+  }
+
+  @Test
+  public void testAddLayer2VniEdges() {
     Map<String, Configuration> configurations = ImmutableMap.of(NODE1, _c1, NODE2, _c2);
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
     Layer2Vni.Builder vniSettingsBuilder =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -275,9 +335,9 @@ public final class VxlanTopologyUtilsTest {
     _v1.setLayer2Vnis(ImmutableSet.of(vniSettingsTail));
     Layer2Vni vniSettingsHead = vniSettingsBuilder.setSourceAddress(SRC_IP2).setVlan(VLAN2).build();
     _v2.setLayer2Vnis(ImmutableSet.of(vniSettingsHead));
-    addVniEdges(
+    addLayer2VniEdges(
         graph,
-        computeVniSettingsTable(configurations),
+        computeVniSettingsTable(configurations, Vrf::getLayer2Vnis),
         VNI,
         ImmutableMap.of(
             new VrfId(_c1.getHostname(), _v1.getName()), vniSettingsTail,
@@ -292,23 +352,64 @@ public final class VxlanTopologyUtilsTest {
   }
 
   @Test
-  public void testBuildVxlanNode() {
+  public void testAddLayer3VniEdges() {
+    Map<String, Configuration> configurations = ImmutableMap.of(NODE1, _c1, NODE2, _c2);
+    MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
+    Layer3Vni.Builder vniSettingsBuilder = Layer3Vni.testBuilder().setUdpPort(UDP_PORT).setVni(VNI);
+    Layer3Vni vniSettingsTail =
+        vniSettingsBuilder
+            .setSourceAddress(SRC_IP1)
+            .setLearnedNexthopVtepIps(ImmutableSet.of(SRC_IP2))
+            .build();
+    _v1.setLayer3Vnis(ImmutableSet.of(vniSettingsTail));
+    Layer3Vni vniSettingsHead =
+        vniSettingsBuilder
+            .setSourceAddress(SRC_IP2)
+            .setLearnedNexthopVtepIps(ImmutableSet.of(SRC_IP1))
+            .build();
+    _v2.setLayer3Vnis(ImmutableSet.of(vniSettingsHead));
+    addLayer3VniEdges(
+        graph,
+        computeVniSettingsTable(configurations, Vrf::getLayer3Vnis),
+        VNI,
+        ImmutableMap.of(
+            new VrfId(_c1.getHostname(), _v1.getName()), vniSettingsTail,
+            new VrfId(_c2.getHostname(), _v2.getName()), vniSettingsHead));
+
+    VxlanNode nodeTail =
+        VxlanNode.builder().setHostname(NODE1).setVni(VNI).setVniLayer(LAYER_3).build();
+    VxlanNode nodeHead =
+        VxlanNode.builder().setHostname(NODE2).setVni(VNI).setVniLayer(LAYER_3).build();
+
+    assertThat(graph.edges(), equalTo(ImmutableSet.of(EndpointPair.unordered(nodeTail, nodeHead))));
+  }
+
+  @Test
+  public void testBuildLayer2VxlanNode() {
     Layer2Vni vniSettings =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setSourceAddress(SRC_IP1)
             .setVlan(VLAN1)
             .setVni(VNI)
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .build();
     assertThat(
-        buildVxlanNode(new VrfId(_c1.getHostname(), _v1.getName()), vniSettings),
+        buildLayer2VxlanNode(new VrfId(_c1.getHostname(), _v1.getName()), vniSettings),
         equalTo(VxlanNode.builder().setHostname(NODE1).setVni(VNI).setVniLayer(LAYER_2).build()));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchBumTransportHeadFloodGroup() {
+  public void testBuildLayer3VxlanNode() {
+    Layer3Vni vniSettings = Layer3Vni.testBuilder().setSourceAddress(SRC_IP1).setVni(VNI).build();
+    assertThat(
+        buildLayer3VxlanNode(new VrfId(_c1.getHostname(), _v1.getName()), vniSettings),
+        equalTo(VxlanNode.builder().setHostname(NODE1).setVni(VNI).setVniLayer(LAYER_3).build()));
+  }
+
+  @Test
+  public void testCompatibleLayer2VniSettingsMismatchBumTransportHeadFloodGroup() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP2))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -317,7 +418,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP2))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -326,13 +427,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchBumTransportMethod() {
+  public void testCompatibleLayer2VniSettingsMismatchBumTransportMethod() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -341,7 +442,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -350,13 +451,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchBumTransportMulticastGroup() {
+  public void testCompatibleLayer2VniSettingsMismatchBumTransportMulticastGroup() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -365,7 +466,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(Ip.parse("224.0.0.5")))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -374,13 +475,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchBumTransportMulticastGroupUnicast() {
+  public void testCompatibleLayer2VniSettingsMismatchBumTransportMulticastGroupUnicast() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP2))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -389,7 +490,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP1))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -398,13 +499,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchBumTransportTailFloodGroup() {
+  public void testCompatibleLayer2VniSettingsMismatchBumTransportTailFloodGroup() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP1))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -413,7 +514,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP1))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -422,13 +523,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchDifferentUdpPort() {
+  public void testCompatibleLayer2VniSettingsMismatchDifferentUdpPort() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -437,7 +538,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -446,13 +547,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchNullHeadSourceAddress() {
+  public void testCompatibleLayer2VniSettingsMismatchNullHeadSourceAddress() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -461,7 +562,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(null)
@@ -470,13 +571,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchNullTailSourceAddress() {
+  public void testCompatibleLayer2VniSettingsMismatchNullTailSourceAddress() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(null)
@@ -485,7 +586,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -494,13 +595,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMismatchSameSourceAddress() {
+  public void testCompatibleLayer2VniSettingsMismatchSameSourceAddress() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -509,7 +610,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -518,13 +619,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
   }
 
   @Test
-  public void testCompatibleVniSettingsMulticast() {
+  public void testCompatibleLayer2VniSettingsMulticast() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -533,7 +634,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -542,13 +643,13 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(true));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(true));
   }
 
   @Test
-  public void testCompatibleVniSettingsUnicast() {
+  public void testCompatibleLayer2VniSettingsUnicast() {
     Layer2Vni vniSettingsTail =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP2))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -557,7 +658,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP1))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -566,14 +667,154 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
 
-    assertThat(compatibleVniSettings(vniSettingsTail, vniSettingsHead), equalTo(true));
+    assertThat(compatibleLayer2VniSettings(vniSettingsTail, vniSettingsHead), equalTo(true));
+  }
+
+  @Test
+  public void testCompatibleLayer3VniSettingsMismatchHeadLearnedIps() {
+    Layer3Vni vniSettingsTail =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP2))
+            .setSourceAddress(SRC_IP1)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+    Layer3Vni vniSettingsHead =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP2))
+            .setSourceAddress(SRC_IP2)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+
+    assertThat(compatibleLayer3VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+  }
+
+  @Test
+  public void testCompatibleLayer3VniSettingsMismatchTailLearnedIps() {
+    Layer3Vni vniSettingsTail =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP1))
+            .setSourceAddress(SRC_IP1)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+    Layer3Vni vniSettingsHead =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP1))
+            .setSourceAddress(SRC_IP2)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+
+    assertThat(compatibleLayer3VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+  }
+
+  @Test
+  public void testCompatibleLayer3VniSettingsMismatchDifferentUdpPort() {
+    Layer3Vni vniSettingsTail =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP2))
+            .setSourceAddress(SRC_IP1)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+    Layer3Vni vniSettingsHead =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP1))
+            .setSourceAddress(SRC_IP2)
+            .setUdpPort(UDP_PORT + 1)
+            .setVni(VNI)
+            .build();
+
+    assertThat(compatibleLayer3VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+  }
+
+  @Test
+  public void testCompatibleLayer3VniSettingsMismatchNullHeadSourceAddress() {
+    Layer3Vni vniSettingsTail =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP2))
+            .setSourceAddress(SRC_IP1)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+    Layer3Vni vniSettingsHead =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP1))
+            .setSourceAddress(null)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+
+    assertThat(compatibleLayer3VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+  }
+
+  @Test
+  public void testCompatibleLayer3VniSettingsMismatchNullTailSourceAddress() {
+    Layer3Vni vniSettingsTail =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP2))
+            .setSourceAddress(null)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+    Layer3Vni vniSettingsHead =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP1))
+            .setSourceAddress(SRC_IP2)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+
+    assertThat(compatibleLayer3VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+  }
+
+  @Test
+  public void testCompatibleLayer3VniSettingsMismatchSameSourceAddress() {
+    Layer3Vni vniSettingsTail =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP2))
+            .setSourceAddress(SRC_IP1)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+    Layer3Vni vniSettingsHead =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP1))
+            .setSourceAddress(SRC_IP1)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+
+    assertThat(compatibleLayer3VniSettings(vniSettingsTail, vniSettingsHead), equalTo(false));
+  }
+
+  @Test
+  public void testCompatibleLayer3VniSettingsUnicast() {
+    Layer3Vni vniSettingsTail =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP2))
+            .setSourceAddress(SRC_IP1)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+    Layer3Vni vniSettingsHead =
+        Layer3Vni.testBuilder()
+            .setLearnedNexthopVtepIps(ImmutableSortedSet.of(SRC_IP1))
+            .setSourceAddress(SRC_IP2)
+            .setUdpPort(UDP_PORT)
+            .setVni(VNI)
+            .build();
+
+    assertThat(compatibleLayer3VniSettings(vniSettingsTail, vniSettingsHead), equalTo(true));
   }
 
   @Test
   public void testInitialVxlanTopology() {
     Map<String, Configuration> configurations = ImmutableMap.of(NODE1, _c1, NODE2, _c2);
     Layer2Vni.Builder vniSettingsBuilder =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -596,7 +837,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testInitialVxlanTopologyFromTable() {
     Layer2Vni.Builder vniSettingsBuilder =
-        testBuilder()
+        Layer2Vni.testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -614,8 +855,9 @@ public final class VxlanTopologyUtilsTest {
     VxlanNode nodeHead =
         VxlanNode.builder().setHostname(NODE2).setVni(VNI).setVniLayer(LAYER_2).build();
 
+    // TODO: nontrivial l3
     assertThat(
-        computeVxlanTopology(table).getGraph().edges(),
+        computeVxlanTopology(table, HashBasedTable.create()).getGraph().edges(),
         equalTo(ImmutableSet.of(EndpointPair.unordered(nodeTail, nodeHead))));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
@@ -29,6 +29,7 @@ import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 
 /** Utility functions to convert dataplane {@link Node} into other structures */
 public final class DataplaneUtil {
@@ -132,12 +133,26 @@ public final class DataplaneUtil {
                             cell.getValue()))));
   }
 
-  static @Nonnull Table<String, String, Set<Layer2Vni>> computeVniSettings(
+  static @Nonnull Table<String, String, Set<Layer2Vni>> computeLayer2VniSettings(
       Map<String, Node> nodes) {
     ImmutableTable.Builder<String, String, Set<Layer2Vni>> result = ImmutableTable.builder();
     for (Node node : nodes.values()) {
       for (VirtualRouter vr : node.getVirtualRouters()) {
         result.put(node.getConfiguration().getHostname(), vr.getName(), vr.getLayer2Vnis());
+      }
+    }
+    return result.build();
+  }
+
+  static @Nonnull Table<String, String, Set<Layer3Vni>> computeLayer3VniSettings(
+      Map<String, Node> nodes) {
+    ImmutableTable.Builder<String, String, Set<Layer3Vni>> result = ImmutableTable.builder();
+    for (Node node : nodes.values()) {
+      for (VirtualRouter vr : node.getVirtualRouters()) {
+        result.put(
+            node.getConfiguration().getHostname(),
+            vr.getName(),
+            ImmutableSet.copyOf(vr.getLayer3Vnis().values()));
       }
     }
     return result.build();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -136,7 +136,8 @@ final class IncrementalBdpEngine {
     LOGGER.info("Updating VXLAN topology");
     VxlanTopology newVxlanTopology =
         prunedVxlanTopology(
-            computeVxlanTopology(currentDataplane.getLayer2Vnis()),
+            computeVxlanTopology(
+                currentDataplane.getLayer2Vnis(), currentDataplane.getLayer3Vnis()),
             configurations,
             trEngCurrentL3Topology);
 
@@ -197,7 +198,15 @@ final class IncrementalBdpEngine {
     Topology newLayer3Topology;
     if (!newIpsecTopology.equals(currentTopologyContext.getIpsecTopology())
         || !newTunnelTopology.equals(currentTopologyContext.getTunnelTopology())
-        || !newAdjacencies.equals(currentTopologyContext.getL3Adjacencies())) {
+        || !newAdjacencies.equals(currentTopologyContext.getL3Adjacencies())
+        || !newVxlanTopology
+            .getLayer3VniEdges()
+            .collect(ImmutableSet.toImmutableSet())
+            .equals(
+                currentTopologyContext
+                    .getVxlanTopology()
+                    .getLayer3VniEdges()
+                    .collect(ImmutableSet.toImmutableSet()))) {
       LOGGER.info("Updating Layer 3 topology");
       newLayer3Topology =
           computeLayer3Topology(
@@ -512,6 +521,21 @@ final class IncrementalBdpEngine {
 
       // Merge BGP routes from BGP process into the main RIB
       vrs.parallelStream().forEach(VirtualRouter::mergeBgpRoutesToMainRib);
+    } finally {
+      propSpan.finish();
+    }
+
+    Span layer3VniSpan =
+        GlobalTracer.get()
+            .buildSpan(iterationLabel + ": Update learned VTEP IPs for Layer3Vnis")
+            .start();
+    LOGGER.info("{}: Update learned VTEP IPs for Layer3Vnis", iterationLabel);
+
+    try (Scope innerScope = GlobalTracer.get().scopeManager().activate(layer3VniSpan)) {
+      assert innerScope != null; // avoid unused warning
+
+      // Merge BGP routes from BGP process into the main RIB
+      vrs.parallelStream().forEach(VirtualRouter::updateLayer3Vnis);
     } finally {
       propSpan.finish();
     }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 
 /** Dataplane computation result of incremental dataplane engine */
 @ParametersAreNonnullByDefault
@@ -46,7 +47,13 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   @Nonnull
   @Override
   public Table<String, String, Set<Layer2Vni>> getLayer2Vnis() {
-    return _vniSettings;
+    return _layer2VniSettings;
+  }
+
+  @Nonnull
+  @Override
+  public Table<String, String, Set<Layer3Vni>> getLayer3Vnis() {
+    return _layer3VniSettings;
   }
 
   @Nonnull
@@ -123,7 +130,8 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   @Nonnull private final ForwardingAnalysis _forwardingAnalysis;
   @Nonnull private final Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
   @Nonnull private final Table<String, String, Set<EvpnRoute<?, ?>>> _evpnBackupRoutes;
-  @Nonnull private final Table<String, String, Set<Layer2Vni>> _vniSettings;
+  @Nonnull private final Table<String, String, Set<Layer2Vni>> _layer2VniSettings;
+  @Nonnull private final Table<String, String, Set<Layer3Vni>> _layer3VniSettings;
 
   @Nonnull
   private final SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
@@ -156,7 +164,8 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     LOGGER.info("Computing main RIBs");
     _ribs = DataplaneUtil.computeRibs(nodes);
     _prefixTracerSummary = computePrefixTracingInfo(nodes);
-    _vniSettings = DataplaneUtil.computeVniSettings(nodes);
+    _layer2VniSettings = DataplaneUtil.computeLayer2VniSettings(nodes);
+    _layer3VniSettings = DataplaneUtil.computeLayer3VniSettings(nodes);
   }
 
   private static SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 
 /**
  * Partial dataplane to be used during dataplane computation. Should not be used outside of the
@@ -48,7 +49,13 @@ public final class PartialDataplane implements DataPlane {
   @Nonnull
   @Override
   public Table<String, String, Set<Layer2Vni>> getLayer2Vnis() {
-    return _vniSettings;
+    return _layer2VniSettings;
+  }
+
+  @Nonnull
+  @Override
+  public Table<String, String, Set<Layer3Vni>> getLayer3Vnis() {
+    return _layer3VniSettings;
   }
 
   @Nonnull
@@ -127,7 +134,8 @@ public final class PartialDataplane implements DataPlane {
 
   @Nonnull private final Map<String, Map<String, Fib>> _fibs;
   @Nonnull private final ForwardingAnalysis _forwardingAnalysis;
-  @Nonnull private final Table<String, String, Set<Layer2Vni>> _vniSettings;
+  @Nonnull private final Table<String, String, Set<Layer2Vni>> _layer2VniSettings;
+  @Nonnull private final Table<String, String, Set<Layer3Vni>> _layer3VniSettings;
   @Nonnull private final Topology _layer3Topology;
   @Nonnull private final L3Adjacencies _l3Adjacencies;
 
@@ -141,7 +149,8 @@ public final class PartialDataplane implements DataPlane {
     _fibs = computeFibs(nodes);
     _forwardingAnalysis =
         computeForwardingAnalysis(_fibs, configs, builder._layer3Topology, builder._l3Adjacencies);
-    _vniSettings = DataplaneUtil.computeVniSettings(nodes);
+    _layer2VniSettings = DataplaneUtil.computeLayer2VniSettings(nodes);
+    _layer3VniSettings = DataplaneUtil.computeLayer3VniSettings(nodes);
     _l3Adjacencies = builder._l3Adjacencies;
     _layer3Topology = builder._layer3Topology;
   }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -183,6 +183,7 @@ import org.batfish.datamodel.ospf.OspfTopologyUtils;
 import org.batfish.datamodel.questions.InvalidReachabilityParametersException;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.dataplane.TracerouteEngineImpl;
 import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.BatfishParseException;
@@ -810,6 +811,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
         @Override
         public Table<String, String, Set<Layer2Vni>> getLayer2Vnis() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Table<String, String, Set<Layer3Vni>> getLayer3Vnis() {
           throw new UnsupportedOperationException();
         }
       };

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnNxosTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnNxosTest.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Edge;
@@ -124,9 +126,28 @@ public class EvpnNxosTest {
             allOf(
                 hasPrefix(Prefix.strict("10.0.1.0/24")),
                 hasNextHop(NextHopVtep.of(L3VNI, Ip.parse("10.0.4.1"))))));
+
+    // test main RIB routes
+    Set<AnnotatedRoute<AbstractRoute>> r1Routes =
+        dp.getRibs().get("r1").get(TENANT_VRF_NAME).getTypedRoutes();
+    Set<AnnotatedRoute<AbstractRoute>> r2Routes =
+        dp.getRibs().get("r2").get(TENANT_VRF_NAME).getTypedRoutes();
+
+    assertThat(
+        r1Routes,
+        hasItem(
+            allOf(
+                hasPrefix(Prefix.strict("10.0.2.0/24")),
+                hasNextHop(NextHopVtep.of(L3VNI, Ip.parse("10.0.4.2"))))));
+    assertThat(
+        r2Routes,
+        hasItem(
+            allOf(
+                hasPrefix(Prefix.strict("10.0.1.0/24")),
+                hasNextHop(NextHopVtep.of(L3VNI, Ip.parse("10.0.4.1"))))));
   }
 
-  @Test(expected = AssertionError.class) // xfail this until l3vni topology edges are fixed
+  @Test
   public void testTopology() {
     Topology topology = _batfish.getTopologyProvider().getLayer3Topology(_batfish.getSnapshot());
     String vniIface = generatedTenantVniInterfaceName(L3VNI);
@@ -138,7 +159,7 @@ public class EvpnNxosTest {
             hasItem(Edge.of("r2", vniIface, "r1", vniIface))));
   }
 
-  @Test(expected = AssertionError.class) // xfail this until l3vni topology edges are fixed
+  @Test
   public void testConnectivity() {
     Ip h1Ip = Ip.parse("10.0.1.1");
     Ip h2Ip = Ip.parse("10.0.2.2");

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.IpsecPeerConfigId;
 import org.batfish.datamodel.IpsecSession;
 import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.bgp.BgpTopology;
@@ -429,9 +430,11 @@ public class EdgesAnswerer extends Answerer {
 
   @VisibleForTesting
   static Row vxlanEdgeToRow(NetworkConfigurations nc, VxlanNode node, VxlanNode remoteNode) {
-    Layer2Vni node1Settings = nc.getVniSettings(node.getHostname(), node.getVni()).get();
+    // TODO: support information about layer-3 VNIs
+    Layer2Vni node1Settings =
+        nc.getVniSettings(node.getHostname(), node.getVni(), Vrf::getLayer2Vnis).get();
     Layer2Vni node2Settings =
-        nc.getVniSettings(remoteNode.getHostname(), remoteNode.getVni()).get();
+        nc.getVniSettings(remoteNode.getHostname(), remoteNode.getVni(), Vrf::getLayer2Vnis).get();
     RowBuilder row = Row.builder();
     row.put(COL_VNI, node.getVni())
         .put(COL_NODE, new Node(node.getHostname()))

--- a/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswererTest.java
@@ -194,7 +194,7 @@ public final class VxlanVniPropertiesAnswererTest {
                   .setUdpPort(1234)
                   .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
                   .build()));
-      return MockDataPlane.builder().setVniSettings(vnis).build();
+      return MockDataPlane.builder().setLayer2VniSettings(vnis).build();
     }
 
     @Override


### PR DESCRIPTION
- each iteration, update `Layer3Vni`s' learned VTEP IPs based on next
hop VTEP routes in the main RIB with the same VNI
- construct VXLAN edges between for each Layer3Vni pair containing each
other's source IP in their learned VTEP IPs