### PR TITLE
Frr: Rename router bgp rules

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrParser.g4
@@ -18,7 +18,6 @@ frr_configuration
 statement
 :
   s_agentx
-  | s_router_bgp
   | s_enable
   | s_end
   | s_interface
@@ -31,6 +30,7 @@ statement
   | s_no
   | s_password
   | s_routemap
+  | s_router_bgp
   | s_router_ospf
   | s_service
   | s_username

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrParser.g4
@@ -18,7 +18,7 @@ frr_configuration
 statement
 :
   s_agentx
-  | s_bgp
+  | s_router_bgp
   | s_enable
   | s_end
   | s_interface

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/Frr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/Frr_bgp.g4
@@ -6,7 +6,7 @@ options {
   tokenVocab = FrrLexer;
 }
 
-s_bgp
+s_router_bgp
 :
   ROUTER BGP autonomous_system (VRF vrf_name)? NEWLINE
   bgp_inner*
@@ -14,158 +14,158 @@ s_bgp
 
 bgp_inner
 :
-  sb_address_family
-| sb_always_compare_med
-| sb_bgp
-| sb_neighbor
-| sb_network
-| sb_no
-| sb_redistribute
-| sb_timers
-| sbafi_neighbor
+  rb_address_family
+| rb_always_compare_med
+| rb_bgp
+| rb_neighbor
+| rb_network
+| rb_no
+| rb_redistribute
+| rb_timers
+| rbafi_neighbor
 ;
 
-sb_bgp
+rb_bgp
 :
   BGP
   (
-    sbb_bestpath
-    | sbb_confederation
-    | sbb_log_neighbor_changes
-    | sbb_router_id
-    | sbb_cluster_id
-    | sbb_max_med_administrative
-    | sbb_listen
+    rbb_bestpath
+    | rbb_confederation
+    | rbb_log_neighbor_changes
+    | rbb_router_id
+    | rbb_cluster_id
+    | rbb_max_med_administrative
+    | rbb_listen
   )
 ;
 
-sb_no
+rb_no
 :
   NO
   (
-    sbno_bgp
+    rbno_bgp
   )
 ;
 
 
-sbno_bgp
+rbno_bgp
 :
   BGP
   (
-     sbnob_default
+     rbnob_default
   )
 ;
 
-sbnob_default
+rbnob_default
 :
   DEFAULT
   (
-     sbnobd_ipv4_unicast
+     rbnobd_ipv4_unicast
   )
 ;
 
-sbb_confederation
+rbb_confederation
 :
   CONFEDERATION IDENTIFIER id = uint32 NEWLINE
 ;
 
-sbb_bestpath
+rbb_bestpath
 :
   BESTPATH
   (
-    sbbb_aspath_multipath_relax
+    rbbb_aspath_multipath_relax
   )
 ;
 
-sbb_log_neighbor_changes
+rbb_log_neighbor_changes
 :
   LOG_NEIGHBOR_CHANGES NEWLINE
 ;
 
-sbb_max_med_administrative
+rbb_max_med_administrative
 :
    MAX_MED ADMINISTRATIVE (med = uint32)? NEWLINE
 ;
 
-sbbb_aspath_multipath_relax
+rbbb_aspath_multipath_relax
 :
   AS_PATH MULTIPATH_RELAX NEWLINE
 ;
 
-sb_redistribute
+rb_redistribute
 :
   REDISTRIBUTE bgp_redist_type (ROUTE_MAP route_map_name)? NEWLINE
 ;
 
-sbb_router_id
+rbb_router_id
 :
   ROUTER_ID IP_ADDRESS NEWLINE
 ;
 
-sbb_cluster_id
+rbb_cluster_id
 :
   CLUSTER_ID IP_ADDRESS NEWLINE
 ;
 
-sb_neighbor
+rb_neighbor
 :
-  NEIGHBOR (sbn_ip | sbn_ip6 | sbn_name)
+  NEIGHBOR (rbn_ip | rbn_ip6 | rbn_name)
 ;
 
-sb_address_family
+rb_address_family
 :
-  ADDRESS_FAMILY sbaf
+  ADDRESS_FAMILY rbaf
   (EXIT_ADDRESS_FAMILY NEWLINE)?
 ;
 
-sbaf
+rbaf
 :
-    sbaf_ipv4_unicast
-  | sbaf_ipv6_unicast
-  | sbaf_l2vpn_evpn
+    rbaf_ipv4_unicast
+  | rbaf_ipv6_unicast
+  | rbaf_l2vpn_evpn
 ;
 
-sbaf_ipv4_unicast
+rbaf_ipv4_unicast
 :
   IPV4 UNICAST NEWLINE
-  sbafi_inner*
+  rbafi_inner*
 ;
 
-sbafi_inner
+rbafi_inner
 :
-  sbafi_aggregate_address
-| sbafi_import
-| sbafi_maximum_paths
-| sbafi_network
-| sbafi_neighbor
-| sbafi_no
-| sbafi_redistribute
+  rbafi_aggregate_address
+| rbafi_import
+| rbafi_maximum_paths
+| rbafi_network
+| rbafi_neighbor
+| rbafi_no
+| rbafi_redistribute
 ;
 
-sbaf_ipv6_unicast
+rbaf_ipv6_unicast
 :
   IPV6 UNICAST NEWLINE
-  sbafi6_inner*
+  rbafi6_inner*
 ;
 
-sbafi6_inner
+rbafi6_inner
 :
-  sbafi6_import
-| sbafi6_maximum_paths
-| sbafi6_null_tail
+  rbafi6_import
+| rbafi6_maximum_paths
+| rbafi6_null_tail
 ;
 
-sbafi6_maximum_paths
+rbafi6_maximum_paths
 :
   MAXIMUM_PATHS (IBGP)? num = uint32 NEWLINE
 ;
 
-sbafi6_import
+rbafi6_import
 :
   IMPORT VRF (vrf_name | ROUTE_MAP route_map_name) NEWLINE
 ;
 
-sbafi6_null_tail
+rbafi6_null_tail
 :
   (
      // there are likely others but haven't seen examples yet, so leaving for later
@@ -178,31 +178,31 @@ sbafi6_null_tail
 ;
 
 
-sbaf_l2vpn_evpn
+rbaf_l2vpn_evpn
 :
   L2VPN EVPN NEWLINE
-  sbafl_inner*
+  rbafl_inner*
 ;
 
-sbafl_inner
+rbafl_inner
 :
-  sbafl_advertise
-| sbafl_advertise_all_vni
-| sbafl_advertise_default_gw
-| sbafl_neighbor
+  rbafl_advertise
+| rbafl_advertise_all_vni
+| rbafl_advertise_default_gw
+| rbafl_neighbor
 ;
 
-sbafl_neighbor
+rbafl_neighbor
 :
    NEIGHBOR neighbor = (IP_ADDRESS | WORD)
    (
-      sbafln_activate
-      | sbafln_route_map
-      | sbafln_route_reflector_client
+      rbafln_activate
+      | rbafln_route_map
+      | rbafln_route_reflector_client
    )
 ;
 
-sbafi_aggregate_address
+rbafi_aggregate_address
 :
   AGGREGATE_ADDRESS IP_PREFIX agg_feature* NEWLINE
 ;
@@ -229,271 +229,271 @@ agg_feature_summary_only: SUMMARY_ONLY;
 
 agg_feature_suppress_map: SUPPRESS_MAP mapname = route_map_name;
 
-sbafi_import
+rbafi_import
 :
   IMPORT VRF (vrf_name | ROUTE_MAP route_map_name) NEWLINE
 ;
 
-sbafi_maximum_paths
+rbafi_maximum_paths
 :
   MAXIMUM_PATHS (IBGP)? num = uint32 NEWLINE
 ;
 
-sbafi_network
+rbafi_network
 :
   NETWORK network = prefix (ROUTE_MAP rm = route_map_name)? NEWLINE
 ;
 
-sbafi_redistribute
+rbafi_redistribute
 :
   REDISTRIBUTE bgp_redist_type (ROUTE_MAP route_map_name)? NEWLINE
 ;
 
-sbafl_advertise
+rbafl_advertise
 :
   ADVERTISE
   (
-     sbafla_ipv4_unicast
-     | sbafla_ipv6_unicast
+     rbafla_ipv4_unicast
+     | rbafla_ipv6_unicast
   )
 ;
 
-sbafla_ipv4_unicast
+rbafla_ipv4_unicast
 :
   IPV4 UNICAST (ROUTE_MAP rm = route_map_name)? NEWLINE
 ;
 
-sbafla_ipv6_unicast
+rbafla_ipv6_unicast
 :
   IPV6 UNICAST (ROUTE_MAP rm = route_map_name)? NEWLINE
 ;
 
-sbafl_advertise_all_vni
+rbafl_advertise_all_vni
 :
   ADVERTISE_ALL_VNI NEWLINE
 ;
 
-sbafl_advertise_default_gw
+rbafl_advertise_default_gw
 :
   ADVERTISE_DEFAULT_GW NEWLINE
 ;
 
-sbafln_activate
+rbafln_activate
 :
   ACTIVATE NEWLINE
 ;
 
-sbafln_route_map
+rbafln_route_map
 :
   ROUTE_MAP name=word (IN | OUT) NEWLINE
 ;
 
-sbafln_route_reflector_client
+rbafln_route_reflector_client
 :
    ROUTE_REFLECTOR_CLIENT NEWLINE
 ;
 
-sb_always_compare_med
+rb_always_compare_med
 :
   BGP ALWAYS_COMPARE_MED NEWLINE
 ;
 
-sbn_ip
+rbn_ip
 :
-  ip = IP_ADDRESS sbn_property
+  ip = IP_ADDRESS rbn_property
 ;
 
-sbn_ip6
+rbn_ip6
 :
-   ip6 = IPV6_ADDRESS sbn_property
+   ip6 = IPV6_ADDRESS rbn_property
 ;
 
-sbn_name
+rbn_name
 :
   name = word
     (
-      sbn_interface       // set an interface neighbor property
-    | sbn_peer_group_decl // declare a new peer group
-    | sbn_property        // set a peer-group property
-    // Nothing else should go in here. New properties should go in sbn_property
+      rbn_interface       // set an interface neighbor property
+    | rbn_peer_group_decl // declare a new peer group
+    | rbn_property        // set a peer-group property
+    // Nothing else should go in here. New properties should go in rbn_property
     )
 ;
 
-sbn_interface
+rbn_interface
 :
-  INTERFACE sbn_property
+  INTERFACE rbn_property
 ;
 
-sbn_peer_group_decl
+rbn_peer_group_decl
 :
   PEER_GROUP NEWLINE
 ;
 
-sbn_property
+rbn_property
 :
- sbnp_advertisement_interval
-| sbnp_bfd
-| sbnp_description
-| sbnp_ebgp_multihop
-| sbnp_local_as
-| sbnp_password
-| sbnp_peer_group
-| sbnp_remote_as
-| sbnp_timers
-| sbnp_update_source
+ rbnp_advertisement_interval
+| rbnp_bfd
+| rbnp_description
+| rbnp_ebgp_multihop
+| rbnp_local_as
+| rbnp_password
+| rbnp_peer_group
+| rbnp_remote_as
+| rbnp_timers
+| rbnp_update_source
 ;
 
-sbnp_advertisement_interval
+rbnp_advertisement_interval
 :
    ADVERTISEMENT_INTERVAL uint32 NEWLINE
 ;
 
 
-sbnp_bfd
+rbnp_bfd
 :
   BFD word* NEWLINE
 ;
 
-sbnp_description
+rbnp_description
 :
   DESCRIPTION REMARK_TEXT NEWLINE
 ;
 
-sbnp_ebgp_multihop
+rbnp_ebgp_multihop
 :
   EBGP_MULTIHOP (num = uint32)? NEWLINE
 ;
 
-sbnp_local_as
+rbnp_local_as
 :
   LOCAL_AS asn = autonomous_system (NO_PREPEND REPLACE_AS?)? NEWLINE
 ;
 
-sbnp_password
+rbnp_password
 :
   PASSWORD REMARK_TEXT NEWLINE
 ;
 
-sbnp_peer_group
+rbnp_peer_group
 :
   PEER_GROUP name = word NEWLINE
 ;
 
-sbnp_remote_as
+rbnp_remote_as
 :
   REMOTE_AS (autonomous_system | EXTERNAL | INTERNAL) NEWLINE
 ;
 
-sbnp_timers
+rbnp_timers
 :
   TIMERS CONNECT uint32 NEWLINE
 ;
 
-sbnp_update_source
+rbnp_update_source
 :
   UPDATE_SOURCE (ip = IP_ADDRESS | name = word) NEWLINE
 ;
 
-sb_network
+rb_network
 :
   NETWORK network = prefix (ROUTE_MAP rm = route_map_name)? NEWLINE
 ;
 
-sbafi_neighbor
+rbafi_neighbor
 :
   NEIGHBOR (ip = IP_ADDRESS | ip6=IPV6_ADDRESS | name = word)
   (
-    sbafin_activate
-  | sbafin_allowas_in
-  | sbafin_default_originate
-  | sbafin_next_hop_self
-  | sbafin_remove_private_as
-  | sbafin_route_reflector_client
-  | sbafin_send_community
-  | sbafin_soft_reconfiguration
-  | sbafin_route_map
+    rbafin_activate
+  | rbafin_allowas_in
+  | rbafin_default_originate
+  | rbafin_next_hop_self
+  | rbafin_remove_private_as
+  | rbafin_route_reflector_client
+  | rbafin_send_community
+  | rbafin_soft_reconfiguration
+  | rbafin_route_map
   )
 ;
 
-sbafi_no
+rbafi_no
 :
-  NO sbafino_neighbor
+  NO rbafino_neighbor
 ;
 
-sbafino_neighbor
+rbafino_neighbor
 :
   NEIGHBOR (ipv4=IP_ADDRESS | ipv6=IPV6_ADDRESS | name = word)
   (
-    sbafinon_activate
+    rbafinon_activate
   )
 ;
 
-sbafinon_activate
+rbafinon_activate
 :
   ACTIVATE NEWLINE
 ;
 
-sbafin_activate
+rbafin_activate
 :
   ACTIVATE NEWLINE
 ;
 
-sbafin_allowas_in
+rbafin_allowas_in
 :
   ALLOWAS_IN (count = UINT8)? NEWLINE
 ;
 
-sbafin_default_originate
+rbafin_default_originate
 :
   DEFAULT_ORIGINATE (ROUTE_MAP route_map_name)? NEWLINE
 ;
 
-sbafin_next_hop_self
+rbafin_next_hop_self
 :
   NEXT_HOP_SELF (FORCE | ALL)? NEWLINE
 ;
 
-sbafin_remove_private_as
+rbafin_remove_private_as
 :
   REMOVE_PRIVATE_AS (ALL REPLACE_AS?)? NEWLINE
 ;
 
 
-sbafin_route_reflector_client
+rbafin_route_reflector_client
 :
   ROUTE_REFLECTOR_CLIENT NEWLINE
 ;
 
-sbafin_send_community
+rbafin_send_community
 :
   SEND_COMMUNITY EXTENDED? NEWLINE
 ;
 
-sbafin_soft_reconfiguration
+rbafin_soft_reconfiguration
 :
   SOFT_RECONFIGURATION INBOUND NEWLINE
 ;
 
-sbafin_route_map
+rbafin_route_map
 :
   ROUTE_MAP name=word (IN | OUT) NEWLINE
 ;
 
-sbb_listen
+rbb_listen
 :
   LISTEN
   (
-    sbbl_limit
-    | sbbl_range
+    rbbl_limit
+    | rbbl_range
   )
 ;
 
-sbbl_limit
+rbbl_limit
 :
   LIMIT uint32 NEWLINE
 ;
 
-sbbl_range
+rbbl_range
 :
   RANGE
    (
@@ -504,12 +504,12 @@ sbbl_range
   NEWLINE
 ;
 
-sbnobd_ipv4_unicast
+rbnobd_ipv4_unicast
 :
     IPV4_UNICAST NEWLINE
 ;
 
-sb_timers
+rb_timers
 :
     TIMERS BGP uint32 uint32 NEWLINE
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/frr/FrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/frr/FrrConfigurationBuilder.java
@@ -7,9 +7,9 @@ import static org.batfish.grammar.frr.FrrParser.Int_exprContext;
 import static org.batfish.representation.frr.FrrConversions.DEFAULT_MAX_MED;
 import static org.batfish.representation.frr.FrrConversions.computeRouteMapEntryName;
 import static org.batfish.representation.frr.FrrStructureType.ABSTRACT_INTERFACE;
+import static org.batfish.representation.frr.FrrStructureType.BGP_AS_PATH_ACCESS_LIST;
+import static org.batfish.representation.frr.FrrStructureType.BGP_COMMUNITY_LIST;
 import static org.batfish.representation.frr.FrrStructureType.IPV6_PREFIX_LIST;
-import static org.batfish.representation.frr.FrrStructureType.IP_AS_PATH_ACCESS_LIST;
-import static org.batfish.representation.frr.FrrStructureType.IP_COMMUNITY_LIST;
 import static org.batfish.representation.frr.FrrStructureType.IP_COMMUNITY_LIST_EXPANDED;
 import static org.batfish.representation.frr.FrrStructureType.IP_COMMUNITY_LIST_STANDARD;
 import static org.batfish.representation.frr.FrrStructureType.IP_PREFIX_LIST;
@@ -101,6 +101,53 @@ import org.batfish.grammar.frr.FrrParser.Pl6_line_actionContext;
 import org.batfish.grammar.frr.FrrParser.Pl_line_actionContext;
 import org.batfish.grammar.frr.FrrParser.Prefix6Context;
 import org.batfish.grammar.frr.FrrParser.PrefixContext;
+import org.batfish.grammar.frr.FrrParser.Rb_neighborContext;
+import org.batfish.grammar.frr.FrrParser.Rb_networkContext;
+import org.batfish.grammar.frr.FrrParser.Rb_redistributeContext;
+import org.batfish.grammar.frr.FrrParser.Rbaf_ipv4_unicastContext;
+import org.batfish.grammar.frr.FrrParser.Rbaf_l2vpn_evpnContext;
+import org.batfish.grammar.frr.FrrParser.Rbafi6_importContext;
+import org.batfish.grammar.frr.FrrParser.Rbafi_aggregate_addressContext;
+import org.batfish.grammar.frr.FrrParser.Rbafi_importContext;
+import org.batfish.grammar.frr.FrrParser.Rbafi_neighborContext;
+import org.batfish.grammar.frr.FrrParser.Rbafi_networkContext;
+import org.batfish.grammar.frr.FrrParser.Rbafi_redistributeContext;
+import org.batfish.grammar.frr.FrrParser.Rbafin_activateContext;
+import org.batfish.grammar.frr.FrrParser.Rbafin_allowas_inContext;
+import org.batfish.grammar.frr.FrrParser.Rbafin_default_originateContext;
+import org.batfish.grammar.frr.FrrParser.Rbafin_next_hop_selfContext;
+import org.batfish.grammar.frr.FrrParser.Rbafin_remove_private_asContext;
+import org.batfish.grammar.frr.FrrParser.Rbafin_route_mapContext;
+import org.batfish.grammar.frr.FrrParser.Rbafin_route_reflector_clientContext;
+import org.batfish.grammar.frr.FrrParser.Rbafino_neighborContext;
+import org.batfish.grammar.frr.FrrParser.Rbafinon_activateContext;
+import org.batfish.grammar.frr.FrrParser.Rbafl_advertise_all_vniContext;
+import org.batfish.grammar.frr.FrrParser.Rbafl_advertise_default_gwContext;
+import org.batfish.grammar.frr.FrrParser.Rbafl_neighborContext;
+import org.batfish.grammar.frr.FrrParser.Rbafla_ipv4_unicastContext;
+import org.batfish.grammar.frr.FrrParser.Rbafla_ipv6_unicastContext;
+import org.batfish.grammar.frr.FrrParser.Rbafln_activateContext;
+import org.batfish.grammar.frr.FrrParser.Rbafln_route_mapContext;
+import org.batfish.grammar.frr.FrrParser.Rbafln_route_reflector_clientContext;
+import org.batfish.grammar.frr.FrrParser.Rbb_cluster_idContext;
+import org.batfish.grammar.frr.FrrParser.Rbb_confederationContext;
+import org.batfish.grammar.frr.FrrParser.Rbb_max_med_administrativeContext;
+import org.batfish.grammar.frr.FrrParser.Rbb_router_idContext;
+import org.batfish.grammar.frr.FrrParser.Rbbb_aspath_multipath_relaxContext;
+import org.batfish.grammar.frr.FrrParser.Rbbl_limitContext;
+import org.batfish.grammar.frr.FrrParser.Rbbl_rangeContext;
+import org.batfish.grammar.frr.FrrParser.Rbn_interfaceContext;
+import org.batfish.grammar.frr.FrrParser.Rbn_ip6Context;
+import org.batfish.grammar.frr.FrrParser.Rbn_ipContext;
+import org.batfish.grammar.frr.FrrParser.Rbn_nameContext;
+import org.batfish.grammar.frr.FrrParser.Rbn_peer_group_declContext;
+import org.batfish.grammar.frr.FrrParser.Rbnobd_ipv4_unicastContext;
+import org.batfish.grammar.frr.FrrParser.Rbnp_descriptionContext;
+import org.batfish.grammar.frr.FrrParser.Rbnp_ebgp_multihopContext;
+import org.batfish.grammar.frr.FrrParser.Rbnp_local_asContext;
+import org.batfish.grammar.frr.FrrParser.Rbnp_peer_groupContext;
+import org.batfish.grammar.frr.FrrParser.Rbnp_remote_asContext;
+import org.batfish.grammar.frr.FrrParser.Rbnp_update_sourceContext;
 import org.batfish.grammar.frr.FrrParser.Rm_callContext;
 import org.batfish.grammar.frr.FrrParser.Rm_descriptionContext;
 import org.batfish.grammar.frr.FrrParser.Rmm_as_pathContext;
@@ -135,58 +182,11 @@ import org.batfish.grammar.frr.FrrParser.Ronopi_interface_nameContext;
 import org.batfish.grammar.frr.FrrParser.Ropi_defaultContext;
 import org.batfish.grammar.frr.FrrParser.Ropi_interface_nameContext;
 import org.batfish.grammar.frr.FrrParser.Route_map_nameContext;
-import org.batfish.grammar.frr.FrrParser.S_bgpContext;
 import org.batfish.grammar.frr.FrrParser.S_interfaceContext;
 import org.batfish.grammar.frr.FrrParser.S_routemapContext;
+import org.batfish.grammar.frr.FrrParser.S_router_bgpContext;
 import org.batfish.grammar.frr.FrrParser.S_router_ospfContext;
 import org.batfish.grammar.frr.FrrParser.S_vrfContext;
-import org.batfish.grammar.frr.FrrParser.Sb_neighborContext;
-import org.batfish.grammar.frr.FrrParser.Sb_networkContext;
-import org.batfish.grammar.frr.FrrParser.Sb_redistributeContext;
-import org.batfish.grammar.frr.FrrParser.Sbaf_ipv4_unicastContext;
-import org.batfish.grammar.frr.FrrParser.Sbaf_l2vpn_evpnContext;
-import org.batfish.grammar.frr.FrrParser.Sbafi6_importContext;
-import org.batfish.grammar.frr.FrrParser.Sbafi_aggregate_addressContext;
-import org.batfish.grammar.frr.FrrParser.Sbafi_importContext;
-import org.batfish.grammar.frr.FrrParser.Sbafi_neighborContext;
-import org.batfish.grammar.frr.FrrParser.Sbafi_networkContext;
-import org.batfish.grammar.frr.FrrParser.Sbafi_redistributeContext;
-import org.batfish.grammar.frr.FrrParser.Sbafin_activateContext;
-import org.batfish.grammar.frr.FrrParser.Sbafin_allowas_inContext;
-import org.batfish.grammar.frr.FrrParser.Sbafin_default_originateContext;
-import org.batfish.grammar.frr.FrrParser.Sbafin_next_hop_selfContext;
-import org.batfish.grammar.frr.FrrParser.Sbafin_remove_private_asContext;
-import org.batfish.grammar.frr.FrrParser.Sbafin_route_mapContext;
-import org.batfish.grammar.frr.FrrParser.Sbafin_route_reflector_clientContext;
-import org.batfish.grammar.frr.FrrParser.Sbafino_neighborContext;
-import org.batfish.grammar.frr.FrrParser.Sbafinon_activateContext;
-import org.batfish.grammar.frr.FrrParser.Sbafl_advertise_all_vniContext;
-import org.batfish.grammar.frr.FrrParser.Sbafl_advertise_default_gwContext;
-import org.batfish.grammar.frr.FrrParser.Sbafl_neighborContext;
-import org.batfish.grammar.frr.FrrParser.Sbafla_ipv4_unicastContext;
-import org.batfish.grammar.frr.FrrParser.Sbafla_ipv6_unicastContext;
-import org.batfish.grammar.frr.FrrParser.Sbafln_activateContext;
-import org.batfish.grammar.frr.FrrParser.Sbafln_route_mapContext;
-import org.batfish.grammar.frr.FrrParser.Sbafln_route_reflector_clientContext;
-import org.batfish.grammar.frr.FrrParser.Sbb_cluster_idContext;
-import org.batfish.grammar.frr.FrrParser.Sbb_confederationContext;
-import org.batfish.grammar.frr.FrrParser.Sbb_max_med_administrativeContext;
-import org.batfish.grammar.frr.FrrParser.Sbb_router_idContext;
-import org.batfish.grammar.frr.FrrParser.Sbbb_aspath_multipath_relaxContext;
-import org.batfish.grammar.frr.FrrParser.Sbbl_limitContext;
-import org.batfish.grammar.frr.FrrParser.Sbbl_rangeContext;
-import org.batfish.grammar.frr.FrrParser.Sbn_interfaceContext;
-import org.batfish.grammar.frr.FrrParser.Sbn_ip6Context;
-import org.batfish.grammar.frr.FrrParser.Sbn_ipContext;
-import org.batfish.grammar.frr.FrrParser.Sbn_nameContext;
-import org.batfish.grammar.frr.FrrParser.Sbn_peer_group_declContext;
-import org.batfish.grammar.frr.FrrParser.Sbnobd_ipv4_unicastContext;
-import org.batfish.grammar.frr.FrrParser.Sbnp_descriptionContext;
-import org.batfish.grammar.frr.FrrParser.Sbnp_ebgp_multihopContext;
-import org.batfish.grammar.frr.FrrParser.Sbnp_local_asContext;
-import org.batfish.grammar.frr.FrrParser.Sbnp_peer_groupContext;
-import org.batfish.grammar.frr.FrrParser.Sbnp_remote_asContext;
-import org.batfish.grammar.frr.FrrParser.Sbnp_update_sourceContext;
 import org.batfish.grammar.frr.FrrParser.Si_descriptionContext;
 import org.batfish.grammar.frr.FrrParser.Si_shutdownContext;
 import org.batfish.grammar.frr.FrrParser.Siip_addressContext;
@@ -475,7 +475,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void enterS_bgp(S_bgpContext ctx) {
+  public void enterS_router_bgp(S_router_bgpContext ctx) {
     if (_frr.getBgpProcess() == null) {
       _frr.setBgpProcess(new BgpProcess());
     }
@@ -493,32 +493,32 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitS_bgp(S_bgpContext ctx) {
+  public void exitS_router_bgp(S_router_bgpContext ctx) {
     _currentBgpVrf = null;
   }
 
   @Override
-  public void enterSbaf_ipv4_unicast(Sbaf_ipv4_unicastContext ctx) {
+  public void enterRbaf_ipv4_unicast(Rbaf_ipv4_unicastContext ctx) {
     if (_currentBgpVrf.getIpv4Unicast() == null) {
       _currentBgpVrf.setIpv4Unicast(new BgpIpv4UnicastAddressFamily());
     }
   }
 
   @Override
-  public void enterSbaf_l2vpn_evpn(Sbaf_l2vpn_evpnContext ctx) {
+  public void enterRbaf_l2vpn_evpn(Rbaf_l2vpn_evpnContext ctx) {
     if (_currentBgpVrf.getL2VpnEvpn() == null) {
       _currentBgpVrf.setL2VpnEvpn(new BgpL2vpnEvpnAddressFamily());
     }
   }
 
   @Override
-  public void exitSb_redistribute(Sb_redistributeContext ctx) {
+  public void exitRb_redistribute(Rb_redistributeContext ctx) {
     String routeMap = ctx.route_map_name() == null ? null : ctx.route_map_name().getText();
     handleOspfToBgpRedistribution(ctx, ctx.bgp_redist_type(), routeMap);
   }
 
   @Override
-  public void exitSbafi_redistribute(Sbafi_redistributeContext ctx) {
+  public void exitRbafi_redistribute(Rbafi_redistributeContext ctx) {
     String routeMap = ctx.route_map_name() == null ? null : ctx.route_map_name().getText();
     handleOspfToBgpRedistribution(ctx, ctx.bgp_redist_type(), routeMap);
   }
@@ -569,7 +569,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafi_import(Sbafi_importContext ctx) {
+  public void exitRbafi_import(Rbafi_importContext ctx) {
     todo(ctx);
     if (ctx.vrf_name() != null) {
       _vc.referenceStructure(
@@ -588,7 +588,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafi6_import(Sbafi6_importContext ctx) {
+  public void exitRbafi6_import(Rbafi6_importContext ctx) {
     if (ctx.vrf_name() != null) {
       _vc.referenceStructure(
           VRF,
@@ -606,7 +606,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafi_network(Sbafi_networkContext ctx) {
+  public void exitRbafi_network(Rbafi_networkContext ctx) {
     @Nullable String routeMap = null;
     if (ctx.rm != null) {
       routeMap = getFullText(ctx.rm);
@@ -617,17 +617,17 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafl_advertise_all_vni(Sbafl_advertise_all_vniContext ctx) {
+  public void exitRbafl_advertise_all_vni(Rbafl_advertise_all_vniContext ctx) {
     _currentBgpVrf.getL2VpnEvpn().setAdvertiseAllVni(true);
   }
 
   @Override
-  public void exitSbafl_advertise_default_gw(Sbafl_advertise_default_gwContext ctx) {
+  public void exitRbafl_advertise_default_gw(Rbafl_advertise_default_gwContext ctx) {
     _currentBgpVrf.getL2VpnEvpn().setAdvertiseDefaultGw(true);
   }
 
   @Override
-  public void enterSbafla_ipv4_unicast(Sbafla_ipv4_unicastContext ctx) {
+  public void enterRbafla_ipv4_unicast(Rbafla_ipv4_unicastContext ctx) {
     // setting in enter instead of exit since in future we can attach a routemap
     _currentBgpVrf.getL2VpnEvpn().setAdvertiseIpv4Unicast(new BgpL2VpnEvpnIpv4Unicast());
     if (ctx.rm != null) {
@@ -645,7 +645,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void enterSbafla_ipv6_unicast(Sbafla_ipv6_unicastContext ctx) {
+  public void enterRbafla_ipv6_unicast(Rbafla_ipv6_unicastContext ctx) {
     if (ctx.rm != null) {
       _vc.referenceStructure(
           ROUTE_MAP,
@@ -656,12 +656,12 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void enterSbafi_aggregate_address(Sbafi_aggregate_addressContext ctx) {
+  public void enterRbafi_aggregate_address(Rbafi_aggregate_addressContext ctx) {
     _currentAggregate = new BgpVrfAddressFamilyAggregateNetworkConfiguration();
   }
 
   @Override
-  public void exitSbafi_aggregate_address(Sbafi_aggregate_addressContext ctx) {
+  public void exitRbafi_aggregate_address(Rbafi_aggregate_addressContext ctx) {
     Map<Prefix, BgpVrfAddressFamilyAggregateNetworkConfiguration> aggregateNetworks =
         _currentBgpVrf.getIpv4Unicast().getAggregateNetworks();
     Prefix prefix = Prefix.parse(ctx.IP_PREFIX().getText());
@@ -735,7 +735,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbnp_local_as(Sbnp_local_asContext ctx) {
+  public void exitRbnp_local_as(Rbnp_local_asContext ctx) {
     long asn = Long.parseLong(ctx.autonomous_system().getText());
     if (_currentBgpNeighbor == null) {
       _w.addWarning(ctx, getFullText(ctx), _parser, "cannot find bgp neighbor");
@@ -748,7 +748,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbnp_update_source(Sbnp_update_sourceContext ctx) {
+  public void exitRbnp_update_source(Rbnp_update_sourceContext ctx) {
     if (_currentBgpNeighbor == null) {
       _w.addWarning(ctx, getFullText(ctx), _parser, "cannot find bgp neighbor");
       return;
@@ -765,7 +765,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void enterSbafl_neighbor(Sbafl_neighborContext ctx) {
+  public void enterRbafl_neighbor(Rbafl_neighborContext ctx) {
     String neighborName = ctx.neighbor.getText();
     BgpNeighbor neighbor = _currentBgpVrf.getNeighbors().get(neighborName);
     if (neighbor == null) {
@@ -784,12 +784,12 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafl_neighbor(Sbafl_neighborContext ctx) {
+  public void exitRbafl_neighbor(Rbafl_neighborContext ctx) {
     _currentBgpNeighborL2vpnEvpnAddressFamily = null;
   }
 
   @Override
-  public void enterSbafi_neighbor(Sbafi_neighborContext ctx) {
+  public void enterRbafi_neighbor(Rbafi_neighborContext ctx) {
     String name;
     if (ctx.ip != null) {
       name = ctx.ip.getText();
@@ -815,12 +815,12 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafi_neighbor(Sbafi_neighborContext ctx) {
+  public void exitRbafi_neighbor(Rbafi_neighborContext ctx) {
     _currentBgpNeighborIpv4UnicastAddressFamily = null;
   }
 
   @Override
-  public void enterSbafino_neighbor(Sbafino_neighborContext ctx) {
+  public void enterRbafino_neighbor(Rbafino_neighborContext ctx) {
     String name;
     if (ctx.ipv4 != null) {
       name = ctx.ipv4.getText();
@@ -846,12 +846,12 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafino_neighbor(Sbafino_neighborContext ctx) {
+  public void exitRbafino_neighbor(Rbafino_neighborContext ctx) {
     _currentBgpNeighborIpv4UnicastAddressFamily = null;
   }
 
   @Override
-  public void exitSb_network(Sb_networkContext ctx) {
+  public void exitRb_network(Rb_networkContext ctx) {
     @Nullable String routeMap = null;
     if (ctx.rm != null) {
       routeMap = getFullText(ctx.rm);
@@ -862,7 +862,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbnobd_ipv4_unicast(Sbnobd_ipv4_unicastContext ctx) {
+  public void exitRbnobd_ipv4_unicast(Rbnobd_ipv4_unicastContext ctx) {
     if (_currentBgpVrf == null) {
       _w.addWarning(ctx, getFullText(ctx), _parser, "cannot find bgp vrf");
       return;
@@ -1080,7 +1080,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafin_activate(Sbafin_activateContext ctx) {
+  public void exitRbafin_activate(Rbafin_activateContext ctx) {
     if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
       return;
     }
@@ -1088,7 +1088,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafinon_activate(Sbafinon_activateContext ctx) {
+  public void exitRbafinon_activate(Rbafinon_activateContext ctx) {
     if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
       return;
     }
@@ -1096,7 +1096,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafin_allowas_in(Sbafin_allowas_inContext ctx) {
+  public void exitRbafin_allowas_in(Rbafin_allowas_inContext ctx) {
     if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
       // TODO: remove this silent ignore from here and other places
       return;
@@ -1112,7 +1112,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafin_default_originate(Sbafin_default_originateContext ctx) {
+  public void exitRbafin_default_originate(Rbafin_default_originateContext ctx) {
     // TODO: handle address-family l2vpn-evpn
     if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
       return;
@@ -1130,7 +1130,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafin_next_hop_self(Sbafin_next_hop_selfContext ctx) {
+  public void exitRbafin_next_hop_self(Rbafin_next_hop_selfContext ctx) {
     if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
       return;
     }
@@ -1144,7 +1144,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafin_remove_private_as(Sbafin_remove_private_asContext ctx) {
+  public void exitRbafin_remove_private_as(Rbafin_remove_private_asContext ctx) {
     if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
       return;
     }
@@ -1159,7 +1159,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafin_route_reflector_client(Sbafin_route_reflector_clientContext ctx) {
+  public void exitRbafin_route_reflector_client(Rbafin_route_reflector_clientContext ctx) {
     if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
       return;
     }
@@ -1167,7 +1167,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafln_activate(Sbafln_activateContext ctx) {
+  public void exitRbafln_activate(Rbafln_activateContext ctx) {
     if (_currentBgpNeighborL2vpnEvpnAddressFamily == null) {
       return;
     }
@@ -1175,7 +1175,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafln_route_map(Sbafln_route_mapContext ctx) {
+  public void exitRbafln_route_map(Rbafln_route_mapContext ctx) {
     String name = ctx.name.getText();
     FrrStructureUsage usage;
     if (ctx.IN() != null) {
@@ -1194,7 +1194,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafln_route_reflector_client(Sbafln_route_reflector_clientContext ctx) {
+  public void exitRbafln_route_reflector_client(Rbafln_route_reflector_clientContext ctx) {
     if (_currentBgpNeighborL2vpnEvpnAddressFamily == null) {
       return;
     }
@@ -1212,29 +1212,29 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbbb_aspath_multipath_relax(Sbbb_aspath_multipath_relaxContext ctx) {
+  public void exitRbbb_aspath_multipath_relax(Rbbb_aspath_multipath_relaxContext ctx) {
     _currentBgpVrf.setAsPathMultipathRelax(true);
   }
 
   @Override
-  public void exitSbb_router_id(Sbb_router_idContext ctx) {
+  public void exitRbb_router_id(Rbb_router_idContext ctx) {
     _currentBgpVrf.setRouterId(Ip.parse(ctx.IP_ADDRESS().getText()));
   }
 
   @Override
-  public void exitSbb_cluster_id(Sbb_cluster_idContext ctx) {
+  public void exitRbb_cluster_id(Rbb_cluster_idContext ctx) {
     _currentBgpVrf.setClusterId(
         Ip.parse(ctx.IP_ADDRESS() != null ? ctx.IP_ADDRESS().getText() : null));
   }
 
   @Override
-  public void exitSbb_confederation(Sbb_confederationContext ctx) {
+  public void exitRbb_confederation(Rbb_confederationContext ctx) {
     Long id = toLong(ctx.id);
     _currentBgpVrf.setConfederationId(id);
   }
 
   @Override
-  public void exitSbb_max_med_administrative(Sbb_max_med_administrativeContext ctx) {
+  public void exitRbb_max_med_administrative(Rbb_max_med_administrativeContext ctx) {
     if (ctx.med != null) {
       _currentBgpVrf.setMaxMedAdministrative(Long.parseLong(ctx.med.getText()));
     } else {
@@ -1243,7 +1243,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbbl_range(Sbbl_rangeContext ctx) {
+  public void exitRbbl_range(Rbbl_rangeContext ctx) {
     BgpNeighbor bgpNeighbor;
     if (ctx.prefix() != null) {
       Prefix listenRange = toPrefix(ctx.prefix());
@@ -1264,12 +1264,12 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbbl_limit(Sbbl_limitContext ctx) {
+  public void exitRbbl_limit(Rbbl_limitContext ctx) {
     warn(ctx, "Batfish does not limit the number sessions for dynamic BGP neighbors");
   }
 
   @Override
-  public void enterSbn_ip(Sbn_ipContext ctx) {
+  public void enterRbn_ip(Rbn_ipContext ctx) {
     _currentBgpNeighbor =
         _currentBgpVrf
             .getNeighbors()
@@ -1278,7 +1278,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void enterSbn_ip6(Sbn_ip6Context ctx) {
+  public void enterRbn_ip6(Rbn_ip6Context ctx) {
     _currentBgpNeighbor =
         _currentBgpVrf
             .getNeighbors()
@@ -1287,19 +1287,19 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void enterSbn_name(Sbn_nameContext ctx) {
+  public void enterRbn_name(Rbn_nameContext ctx) {
     // if neighbor does not already exist, get will return null. That's ok -- the listener for
     // child parse node will create it.
     _currentBgpNeighbor = _currentBgpVrf.getNeighbors().get(ctx.name.getText());
   }
 
   @Override
-  public void exitSb_neighbor(Sb_neighborContext ctx) {
+  public void exitRb_neighbor(Rb_neighborContext ctx) {
     _currentBgpNeighbor = null;
   }
 
   @Override
-  public void enterSbn_interface(Sbn_interfaceContext ctx) {
+  public void enterRbn_interface(Rbn_interfaceContext ctx) {
     if (_currentBgpNeighbor != null) {
       // warn if it's not an interface
       if (!(_currentBgpNeighbor instanceof BgpInterfaceNeighbor)) {
@@ -1312,7 +1312,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
                 "neighbor %s not declared to be an interface", _currentBgpNeighbor.getName()));
       }
     } else {
-      Sbn_nameContext parentCtx = (Sbn_nameContext) ctx.getParent();
+      Rbn_nameContext parentCtx = (Rbn_nameContext) ctx.getParent();
       String ifaceName = parentCtx.name.getText();
       _currentBgpNeighbor = new BgpInterfaceNeighbor(ifaceName);
       checkState(
@@ -1322,7 +1322,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbn_peer_group_decl(Sbn_peer_group_declContext ctx) {
+  public void exitRbn_peer_group_decl(Rbn_peer_group_declContext ctx) {
     if (_currentBgpNeighbor != null) {
       String line = getFullText(ctx.getParent()) + getFullText(ctx);
       _w.addWarning(
@@ -1332,7 +1332,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
           String.format("neighbor %s already defined", _currentBgpNeighbor.getName()));
     }
 
-    Sbn_nameContext parentCtx = (Sbn_nameContext) ctx.getParent();
+    Rbn_nameContext parentCtx = (Rbn_nameContext) ctx.getParent();
     String peerGroupName = parentCtx.name.getText();
     checkState(
         _currentBgpVrf.getNeighbors().put(peerGroupName, new BgpPeerGroupNeighbor(peerGroupName))
@@ -1341,17 +1341,17 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbnp_description(Sbnp_descriptionContext ctx) {
+  public void exitRbnp_description(Rbnp_descriptionContext ctx) {
     _currentBgpNeighbor.setDescription(ctx.REMARK_TEXT().getText());
   }
 
   @Override
-  public void exitSbnp_peer_group(Sbnp_peer_groupContext ctx) {
+  public void exitRbnp_peer_group(Rbnp_peer_groupContext ctx) {
     _currentBgpNeighbor.setPeerGroup(ctx.name.getText());
   }
 
   @Override
-  public void exitSbnp_remote_as(Sbnp_remote_asContext ctx) {
+  public void exitRbnp_remote_as(Rbnp_remote_asContext ctx) {
     assert _currentBgpNeighbor != null;
     if (ctx.autonomous_system() != null) {
       _currentBgpNeighbor.setRemoteAs(
@@ -1365,7 +1365,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbnp_ebgp_multihop(Sbnp_ebgp_multihopContext ctx) {
+  public void exitRbnp_ebgp_multihop(Rbnp_ebgp_multihopContext ctx) {
     if (ctx.num != null) {
       warn(
           ctx.getParent(),
@@ -1389,7 +1389,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
   }
 
   @Override
-  public void exitSbafin_route_map(Sbafin_route_mapContext ctx) {
+  public void exitRbafin_route_map(Rbafin_route_mapContext ctx) {
     if (_currentBgpNeighborIpv4UnicastAddressFamily == null) {
       return;
     }
@@ -1537,7 +1537,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     String name = ctx.name.getText();
     _currentRouteMapEntry.setMatchAsPath(new RouteMapMatchAsPath(name));
     _vc.referenceStructure(
-        IP_AS_PATH_ACCESS_LIST,
+        BGP_AS_PATH_ACCESS_LIST,
         name,
         FrrStructureUsage.ROUTE_MAP_MATCH_AS_PATH,
         ctx.getStart().getLine());
@@ -1548,8 +1548,10 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     ctx.names.forEach(
         name ->
             _vc.referenceStructure(
-                IP_COMMUNITY_LIST, name.getText(),
-                ROUTE_MAP_MATCH_COMMUNITY_LIST, name.getStart().getLine()));
+                BGP_COMMUNITY_LIST,
+                name.getText(),
+                ROUTE_MAP_MATCH_COMMUNITY_LIST,
+                name.getStart().getLine()));
 
     _currentRouteMapEntry.setMatchCommunity(
         new RouteMapMatchCommunity(
@@ -1726,7 +1728,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     }
     _currentRouteMapEntry.setSetCommListDelete(new RouteMapSetCommListDelete(name));
     _vc.referenceStructure(
-        IP_COMMUNITY_LIST, name, ROUTE_MAP_SET_COMM_LIST_DELETE, ctx.getStart().getLine());
+        BGP_COMMUNITY_LIST, name, ROUTE_MAP_SET_COMM_LIST_DELETE, ctx.getStart().getLine());
   }
 
   @Override
@@ -1890,7 +1892,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     _frr.getIpAsPathAccessLists()
         .computeIfAbsent(name, IpAsPathAccessList::new)
         .addLine(new IpAsPathAccessListLine(action, regex));
-    _vc.defineStructure(IP_AS_PATH_ACCESS_LIST, name, ctx);
+    _vc.defineStructure(BGP_AS_PATH_ACCESS_LIST, name, ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/frr/FrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/frr/FrrConfigurationBuilder.java
@@ -7,9 +7,9 @@ import static org.batfish.grammar.frr.FrrParser.Int_exprContext;
 import static org.batfish.representation.frr.FrrConversions.DEFAULT_MAX_MED;
 import static org.batfish.representation.frr.FrrConversions.computeRouteMapEntryName;
 import static org.batfish.representation.frr.FrrStructureType.ABSTRACT_INTERFACE;
-import static org.batfish.representation.frr.FrrStructureType.BGP_AS_PATH_ACCESS_LIST;
-import static org.batfish.representation.frr.FrrStructureType.BGP_COMMUNITY_LIST;
 import static org.batfish.representation.frr.FrrStructureType.IPV6_PREFIX_LIST;
+import static org.batfish.representation.frr.FrrStructureType.IP_AS_PATH_ACCESS_LIST;
+import static org.batfish.representation.frr.FrrStructureType.IP_COMMUNITY_LIST;
 import static org.batfish.representation.frr.FrrStructureType.IP_COMMUNITY_LIST_EXPANDED;
 import static org.batfish.representation.frr.FrrStructureType.IP_COMMUNITY_LIST_STANDARD;
 import static org.batfish.representation.frr.FrrStructureType.IP_PREFIX_LIST;
@@ -1537,7 +1537,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     String name = ctx.name.getText();
     _currentRouteMapEntry.setMatchAsPath(new RouteMapMatchAsPath(name));
     _vc.referenceStructure(
-        BGP_AS_PATH_ACCESS_LIST,
+        IP_AS_PATH_ACCESS_LIST,
         name,
         FrrStructureUsage.ROUTE_MAP_MATCH_AS_PATH,
         ctx.getStart().getLine());
@@ -1548,7 +1548,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     ctx.names.forEach(
         name ->
             _vc.referenceStructure(
-                BGP_COMMUNITY_LIST,
+                IP_COMMUNITY_LIST,
                 name.getText(),
                 ROUTE_MAP_MATCH_COMMUNITY_LIST,
                 name.getStart().getLine()));
@@ -1728,7 +1728,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     }
     _currentRouteMapEntry.setSetCommListDelete(new RouteMapSetCommListDelete(name));
     _vc.referenceStructure(
-        BGP_COMMUNITY_LIST, name, ROUTE_MAP_SET_COMM_LIST_DELETE, ctx.getStart().getLine());
+        IP_COMMUNITY_LIST, name, ROUTE_MAP_SET_COMM_LIST_DELETE, ctx.getStart().getLine());
   }
 
   @Override
@@ -1892,7 +1892,7 @@ public class FrrConfigurationBuilder extends FrrParserBaseListener implements Si
     _frr.getIpAsPathAccessLists()
         .computeIfAbsent(name, IpAsPathAccessList::new)
         .addLine(new IpAsPathAccessListLine(action, regex));
-    _vc.defineStructure(BGP_AS_PATH_ACCESS_LIST, name, ctx);
+    _vc.defineStructure(IP_AS_PATH_ACCESS_LIST, name, ctx);
   }
 
   @Override


### PR DESCRIPTION
Because `bgp` can occur at the top-level (not just under router bgp), and brings things in like with frr/ospf from a naming standpoint. 

No functional change.  