### PR TITLE
Sonic: Reduce warnings

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrLexer.g4
@@ -480,7 +480,7 @@ METRIC_TYPE: 'metric-type';
 
 NEWLINE
 :
-  F_Newline+
+  F_Newline
 ;
 
 NEXT_HOP: 'next-hop';
@@ -553,13 +553,6 @@ WS
 ;
 
 // Complex tokens
-
-BLANK_LINE
-:
-  F_Whitespace* F_Newline+
-  {lastTokenType() == NEWLINE|| lastTokenType() == -1}?
-    -> channel ( HIDDEN )
-;
 
 DASH: '-';
 
@@ -859,11 +852,19 @@ F_WordChar
   | '-'
 ;
 
+// Any number of newlines, allowing whitespace in between
 fragment
 F_Newline
 :
-  [\n\r] // carriage return or line feed
+  F_NewlineChar (F_Whitespace* F_NewlineChar+)*
+;
 
+// A single newline character [sequence - allowing \r, \r\n, or \n]
+fragment
+F_NewlineChar
+:
+  '\r' '\n'?
+  | '\n'
 ;
 
 fragment

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrLexer.g4
@@ -98,7 +98,7 @@ COMMENT_LINE
 
   F_NonNewline*
   (
-    F_Newline+
+    F_Newline
     | EOF
   ) -> channel ( HIDDEN )
 ;
@@ -917,7 +917,7 @@ M_DoubleQuote_DOUBLE_QUOTE
 M_DoubleQuote_NEWLINE
 :
 // Break out if termination does not occur on same line
-  F_Newline+ -> type ( NEWLINE ) , popMode
+  F_Newline -> type ( NEWLINE ) , popMode
 ;
 
 M_DoubleQuote_QUOTED_TEXT
@@ -1007,7 +1007,7 @@ M_Import_VRF
 
 M_Import_NEWLINE
 :
-  F_Newline+ -> type ( NEWLINE ) , popMode
+  F_Newline -> type ( NEWLINE ) , popMode
 ;
 
 M_Import_WS
@@ -1030,7 +1030,7 @@ M_ImportVrf_WORD
 
 M_ImportVrf_NEWLINE
 :
-  F_Newline+ -> type ( NEWLINE ) , popMode
+  F_Newline -> type ( NEWLINE ) , popMode
 ;
 
 M_ImportVrf_WS
@@ -1083,7 +1083,7 @@ mode M_Word;
 
 M_Word_NEWLINE
 :
-  F_Newline+ -> type ( NEWLINE ) , popMode
+  F_Newline -> type ( NEWLINE ) , popMode
 ;
 
 M_Word_WORD
@@ -1100,7 +1100,7 @@ mode M_Words;
 
 M_Words_NEWLINE
 :
-  F_Newline+ -> type ( NEWLINE ) , popMode
+  F_Newline -> type ( NEWLINE ) , popMode
 ;
 
 M_Words_WORD
@@ -1122,7 +1122,7 @@ M_Remark_REMARK_TEXT
 
 M_Remark_NEWLINE
 :
-  F_Newline+ -> type ( NEWLINE ), popMode
+  F_Newline -> type ( NEWLINE ), popMode
 ;
 
 M_Remark_WS
@@ -1149,7 +1149,7 @@ M_Update_Source_WS
 
 M_Update_NEWLINE
 :
-  F_Newline+ -> type ( NEWLINE ), popMode
+  F_Newline -> type ( NEWLINE ), popMode
 ;
 
 mode M_AccessList;
@@ -1176,7 +1176,7 @@ M_AsPathAccessList_WORD
 
 M_AccessList_NEWLINE
 :
-   F_Newline+ -> type (NEWLINE) , popMode
+   F_Newline -> type (NEWLINE) , popMode
 ;
 
 M_AccessList_WS

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrParser.g4
@@ -11,7 +11,7 @@ options {
 // goal rule
 frr_configuration
 :
-  statement+ EOF
+  NEWLINE* statement+ EOF
 ;
 
 // other rules

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/FrrParser.g4
@@ -11,7 +11,7 @@ options {
 // goal rule
 frr_configuration
 :
-  NEWLINE* statement+ EOF
+  NEWLINE? statement+ EOF
 ;
 
 // other rules

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/ConfigDb.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/ConfigDb.java
@@ -117,7 +117,32 @@ public class ConfigDb implements Serializable {
 
   /** Properties that are knowingly ignored and we won't warn the user about ignoring them */
   public static final Set<String> IGNORED_PROPERTIES =
-      ImmutableSet.of("BUFFER_QUEUE", "DSCP_TO_TC_MAP", "ZTP");
+      ImmutableSet.of(
+          "BREAKOUT_CFG",
+          "BREAKOUT_PORTS",
+          "BUFFER_PG",
+          "BUFFER_POOL",
+          "BUFFER_PROFILE",
+          "BUFFER_QUEUE",
+          "CLASSIFIER_TABLE",
+          "COREDUMP",
+          "DSCP_TO_TC_MAP",
+          "ECMP_LOADSHARE_TABLE_IPV4",
+          "ECMP_LOADSHARE_TABLE_IPV6",
+          "FLEX_COUNTER_TABLE",
+          "HARDWARE",
+          "KDUMP",
+          "POLICY_BINDING_TABLE",
+          "POLICY_SECTIONS_TABLE",
+          "POLICY_TABLE",
+          "PORT_QOS_MAP",
+          "QUEUE",
+          "SCHEDULER",
+          "SWITCH",
+          "TC_TO_QUEUE_MAP",
+          "TELEMETRY",
+          "VERSIONS",
+          "ZTP");
 
   private final @Nonnull Map<String, AclTable> _aclTables;
   private final @Nonnull Map<String, AclRule> _aclRules;
@@ -365,97 +390,101 @@ public class ConfigDb implements Serializable {
       while (fieldIterator.hasNext()) {
         String field = fieldIterator.next();
         TreeNode value = tree.get(field);
-        switch (field) {
-          case PROP_ACL_RULE:
-            configDb.setAclRules(
-                mapper.convertValue(value, new TypeReference<Map<String, AclRule>>() {}));
-            break;
-          case PROP_ACL_TABLE:
-            configDb.setAclTables(
-                mapper.convertValue(value, new TypeReference<Map<String, AclTable>>() {}));
-            break;
-          case PROP_DEVICE_METADATA:
-            configDb.setDeviceMetadata(
-                mapper.convertValue(value, new TypeReference<Map<String, DeviceMetadata>>() {}));
-            break;
-          case PROP_INTERFACE:
-            configDb.setInterfaces(
-                createInterfaces(
-                    mapper
-                        .convertValue(value, new TypeReference<Map<String, Object>>() {})
-                        .keySet()));
-            break;
-          case PROP_LOOPBACK_INTERFACE:
-            configDb.setLoopbackInterfaces(
-                createInterfaces(
-                    mapper
-                        .convertValue(value, new TypeReference<Map<String, Object>>() {})
-                        .keySet()));
-            break;
-          case PROP_MGMT_INTERFACE:
-            {
-              Map<String, Map<String, Object>> mgmtInterfaceMap =
-                  mapper.convertValue(
-                      value, new TypeReference<Map<String, Map<String, Object>>>() {});
-              configDb.setMgmtInterfaces(createInterfaces(mgmtInterfaceMap.keySet()));
-              Set<String> innerProperties =
-                  mgmtInterfaceMap.values().stream()
-                      .flatMap(map -> map.keySet().stream())
-                      .collect(ImmutableSet.toImmutableSet());
-              innerProperties.forEach(
-                  key ->
-                      _warnings.unimplemented(
-                          String.format("Unimplemented MGMT_INTERFACE property '%s'", key)));
+        try {
+          switch (field) {
+            case PROP_ACL_RULE:
+              configDb.setAclRules(
+                  mapper.convertValue(value, new TypeReference<Map<String, AclRule>>() {}));
               break;
-            }
-          case PROP_MGMT_PORT:
-            configDb.setMgmtPorts(
-                mapper.convertValue(value, new TypeReference<Map<String, Port>>() {}));
-            break;
-          case PROP_MGMT_VRF_CONFIG:
-            configDb.setMgmtVrfs(
-                mapper.convertValue(value, new TypeReference<Map<String, MgmtVrf>>() {}));
-            break;
-          case PROP_NTP_SERVER:
-            configDb.setNtpServers(
-                mapper.convertValue(value, new TypeReference<Map<String, Object>>() {}).keySet());
-            break;
-          case PROP_PORT:
-            configDb.setPorts(
-                mapper.convertValue(value, new TypeReference<Map<String, Port>>() {}));
-            break;
-          case PROP_SYSLOG_SERVER:
-            configDb.setSyslogServers(
-                mapper.convertValue(value, new TypeReference<Map<String, Object>>() {}).keySet());
-            break;
-          case PROP_TACPLUS:
-            configDb.setTacplusses(
-                mapper.convertValue(value, new TypeReference<Map<String, Tacplus>>() {}));
-            break;
-          case PROP_TACPLUS_SERVER:
-            // ignoring properties of individual servers
-            configDb.setTacplusServers(
-                mapper.convertValue(value, new TypeReference<Map<String, Object>>() {}).keySet());
-            break;
-          case PROP_VLAN:
-            configDb.setVlans(
-                mapper.convertValue(value, new TypeReference<Map<String, Vlan>>() {}));
-            break;
-          case PROP_VLAN_INTERFACE:
-            configDb.setVlanInterfaces(
-                createInterfaces(
-                    mapper
-                        .convertValue(value, new TypeReference<Map<String, Object>>() {})
-                        .keySet()));
-            break;
-          case PROP_VLAN_MEMBER:
-            configDb.setVlanMembers(
-                mapper.convertValue(value, new TypeReference<Map<String, VlanMember>>() {}));
-            break;
-          default:
-            if (!IGNORED_PROPERTIES.contains(field)) {
-              _warnings.unimplemented(String.format("Unimplemented configdb table '%s'", field));
-            }
+            case PROP_ACL_TABLE:
+              configDb.setAclTables(
+                  mapper.convertValue(value, new TypeReference<Map<String, AclTable>>() {}));
+              break;
+            case PROP_DEVICE_METADATA:
+              configDb.setDeviceMetadata(
+                  mapper.convertValue(value, new TypeReference<Map<String, DeviceMetadata>>() {}));
+              break;
+            case PROP_INTERFACE:
+              configDb.setInterfaces(
+                  createInterfaces(
+                      mapper
+                          .convertValue(value, new TypeReference<Map<String, Object>>() {})
+                          .keySet()));
+              break;
+            case PROP_LOOPBACK_INTERFACE:
+              configDb.setLoopbackInterfaces(
+                  createInterfaces(
+                      mapper
+                          .convertValue(value, new TypeReference<Map<String, Object>>() {})
+                          .keySet()));
+              break;
+            case PROP_MGMT_INTERFACE:
+              {
+                Map<String, Map<String, Object>> mgmtInterfaceMap =
+                    mapper.convertValue(
+                        value, new TypeReference<Map<String, Map<String, Object>>>() {});
+                configDb.setMgmtInterfaces(createInterfaces(mgmtInterfaceMap.keySet()));
+                Set<String> innerProperties =
+                    mgmtInterfaceMap.values().stream()
+                        .flatMap(map -> map.keySet().stream())
+                        .collect(ImmutableSet.toImmutableSet());
+                innerProperties.forEach(
+                    key ->
+                        _warnings.unimplemented(
+                            String.format("Unimplemented MGMT_INTERFACE property '%s'", key)));
+                break;
+              }
+            case PROP_MGMT_PORT:
+              configDb.setMgmtPorts(
+                  mapper.convertValue(value, new TypeReference<Map<String, Port>>() {}));
+              break;
+            case PROP_MGMT_VRF_CONFIG:
+              configDb.setMgmtVrfs(
+                  mapper.convertValue(value, new TypeReference<Map<String, MgmtVrf>>() {}));
+              break;
+            case PROP_NTP_SERVER:
+              configDb.setNtpServers(
+                  mapper.convertValue(value, new TypeReference<Map<String, Object>>() {}).keySet());
+              break;
+            case PROP_PORT:
+              configDb.setPorts(
+                  mapper.convertValue(value, new TypeReference<Map<String, Port>>() {}));
+              break;
+            case PROP_SYSLOG_SERVER:
+              configDb.setSyslogServers(
+                  mapper.convertValue(value, new TypeReference<Map<String, Object>>() {}).keySet());
+              break;
+            case PROP_TACPLUS:
+              configDb.setTacplusses(
+                  mapper.convertValue(value, new TypeReference<Map<String, Tacplus>>() {}));
+              break;
+            case PROP_TACPLUS_SERVER:
+              // ignoring properties of individual servers
+              configDb.setTacplusServers(
+                  mapper.convertValue(value, new TypeReference<Map<String, Object>>() {}).keySet());
+              break;
+            case PROP_VLAN:
+              configDb.setVlans(
+                  mapper.convertValue(value, new TypeReference<Map<String, Vlan>>() {}));
+              break;
+            case PROP_VLAN_INTERFACE:
+              configDb.setVlanInterfaces(
+                  createInterfaces(
+                      mapper
+                          .convertValue(value, new TypeReference<Map<String, Object>>() {})
+                          .keySet()));
+              break;
+            case PROP_VLAN_MEMBER:
+              configDb.setVlanMembers(
+                  mapper.convertValue(value, new TypeReference<Map<String, VlanMember>>() {}));
+              break;
+            default:
+              if (!IGNORED_PROPERTIES.contains(field)) {
+                _warnings.unimplemented(String.format("Unimplemented configdb table '%s'", field));
+              }
+          }
+        } catch (IllegalArgumentException e) { // thrown by convertValue
+          _warnings.redFlag(String.format("Failed to deserialize %s: %s", field, e.getMessage()));
         }
       }
       return configDb.build();

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/Tacplus.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/Tacplus.java
@@ -1,6 +1,7 @@
 package org.batfish.vendor.sonic.representation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
@@ -10,8 +11,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Represents the settings of TACPLUS object */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Tacplus implements Serializable {
-  private static final String PROP_AUTH_TYPE = "auth_type";
   private static final String PROP_SRC_INTF = "src_intf";
 
   private @Nullable final String _srcIntf;
@@ -20,11 +21,8 @@ public class Tacplus implements Serializable {
     return Optional.ofNullable(_srcIntf);
   }
 
-  @SuppressWarnings("unused") // "parse" and ignore PROP_AUTH_TYPE
   @JsonCreator
-  private @Nonnull static Tacplus create(
-      @Nullable @JsonProperty(PROP_AUTH_TYPE) String authType,
-      @Nullable @JsonProperty(PROP_SRC_INTF) String srcIntf) {
+  private @Nonnull static Tacplus create(@Nullable @JsonProperty(PROP_SRC_INTF) String srcIntf) {
     return Tacplus.builder().setSrcIntf(srcIntf).build();
   }
 


### PR DESCRIPTION
1. Add more ignored tables
2. Allow for FRR files starting with newlines
3. Ignore unknown properties in TACPLUS
4. Catch deserialization failures of a TABLE; log warning and do the rest. 