### PR TITLE
BDDReachabilityUtils: correctly free duplicated intermediate BDDs during traversal

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
@@ -346,7 +346,7 @@ public abstract class BDDFactory {
    *
    * @param bddOperands the BDDs to 'or' together
    */
-  public abstract BDD orAll(Collection<BDD> bddOperands);
+  public abstract BDD orAll(Iterable<BDD> bddOperands);
 
   /**
    * Sets the node table size.

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
@@ -854,9 +855,9 @@ public final class JFactory extends BDDFactory {
   }
 
   @Override
-  public BDD orAll(Collection<BDD> bddOperands) {
+  public BDD orAll(Iterable<BDD> bddOperands) {
     int[] operands =
-        bddOperands.stream()
+        StreamSupport.stream(bddOperands.spliterator(), false)
             .mapToInt(bdd -> ((BDDImpl) bdd)._index)
             .peek(this::CHECK)
             .filter(i -> i != 0)


### PR DESCRIPTION
Sets dedupe equal BDDs, so do not free if alternate paths produce the same BDD
twice. ECMP, for example.