### PR TITLE
NX-OS: Prefer physical interfaces for BGP router ids

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -177,6 +177,22 @@ public final class Conversions {
       return lowestLoopback.get();
     }
 
+    // Next, NX-OS prefers "physical" interfaces.
+    Optional<Ip> lowestPhysical =
+        interfaces.stream()
+            .filter(
+                i ->
+                    // all three are physical interfaces for this computation
+                    i.getInterfaceType() == InterfaceType.AGGREGATED
+                        || i.getInterfaceType() == InterfaceType.AGGREGATE_CHILD
+                        || i.getInterfaceType() == InterfaceType.PHYSICAL)
+            .map(org.batfish.datamodel.Interface::getConcreteAddress)
+            .map(ConcreteInterfaceAddress::getIp)
+            .min(Comparator.naturalOrder());
+    if (lowestPhysical.isPresent()) {
+      return lowestPhysical.get();
+    }
+
     // Finally, NX-OS uses the first non-loopback interface defined in the vrf, assuming no loopback
     // addresses with IP address are present in the vrf. Older versions of NX-OS are
     // non-deterministic, newer ones choose the smallest IP.

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco_nxos/ConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco_nxos/ConversionsTest.java
@@ -1,0 +1,106 @@
+package org.batfish.representation.cisco_nxos;
+
+import static org.batfish.datamodel.InterfaceType.LOOPBACK;
+import static org.batfish.datamodel.InterfaceType.PHYSICAL;
+import static org.batfish.datamodel.InterfaceType.VLAN;
+import static org.batfish.representation.cisco_nxos.Conversions.inferRouterId;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.Ip;
+import org.junit.Test;
+
+public class ConversionsTest {
+
+  private static org.batfish.datamodel.Interface createInterface(
+      String name, InterfaceType interfaceType, Ip address) {
+    return org.batfish.datamodel.Interface.builder()
+        .setName(name)
+        .setType(interfaceType)
+        .setAddress(ConcreteInterfaceAddress.create(address, 24))
+        .build();
+  }
+
+  @Test
+  public void testInferRouterId() {
+
+    org.batfish.datamodel.Interface loopback0 =
+        createInterface("loopback0", LOOPBACK, Ip.parse("10.10.10.10"));
+    org.batfish.datamodel.Interface loopback1 =
+        createInterface("loopback1", LOOPBACK, Ip.parse("9.9.9.9"));
+    org.batfish.datamodel.Interface loopback2 =
+        createInterface("loopback2", LOOPBACK, Ip.parse("8.8.8.8"));
+    org.batfish.datamodel.Interface physical0 =
+        createInterface("Ethernet0", PHYSICAL, Ip.parse("7.7.7.7"));
+    org.batfish.datamodel.Interface physical1 =
+        createInterface("Ethernet1", PHYSICAL, Ip.parse("6.6.6.6"));
+    org.batfish.datamodel.Interface other0 = createInterface("Vlan0", VLAN, Ip.parse("5.5.5.5"));
+    org.batfish.datamodel.Interface other1 = createInterface("Vlan1", VLAN, Ip.parse("4.4.4.4"));
+
+    // loopback0 wins if present
+    assertEquals(
+        Ip.parse("10.10.10.10"),
+        inferRouterId(
+            "test",
+            ImmutableMap.<String, Interface>builder()
+                .put(loopback0.getName(), loopback0)
+                .put(loopback1.getName(), loopback1)
+                .put(loopback2.getName(), loopback2)
+                .put(physical0.getName(), physical0)
+                .put(physical1.getName(), physical1)
+                .put(other0.getName(), other0)
+                .put(other1.getName(), other1)
+                .build(),
+            new Warnings(),
+            "test"));
+
+    // if loopback0 is missing, lowest loopback wins
+    assertEquals(
+        Ip.parse("8.8.8.8"),
+        inferRouterId(
+            "test",
+            ImmutableMap.<String, Interface>builder()
+                .put(loopback1.getName(), loopback1)
+                .put(loopback2.getName(), loopback2)
+                .put(physical0.getName(), physical0)
+                .put(physical1.getName(), physical1)
+                .put(other0.getName(), other0)
+                .put(other1.getName(), other1)
+                .build(),
+            new Warnings(),
+            "test"));
+
+    // if loopbacks are missing, lowest physical wins
+    assertEquals(
+        Ip.parse("6.6.6.6"),
+        inferRouterId(
+            "test",
+            ImmutableMap.<String, Interface>builder()
+                .put(physical0.getName(), physical0)
+                .put(physical1.getName(), physical1)
+                .put(other0.getName(), other0)
+                .put(other1.getName(), other1)
+                .build(),
+            new Warnings(),
+            "test"));
+
+    // if loopbacks and physicals are missing, lowest other wins
+    assertEquals(
+        Ip.parse("4.4.4.4"),
+        inferRouterId(
+            "test",
+            ImmutableMap.<String, Interface>builder()
+                .put(other0.getName(), other0)
+                .put(other1.getName(), other1)
+                .build(),
+            new Warnings(),
+            "test"));
+
+    // zeroes if nothing is viable
+    assertEquals(Ip.ZERO, inferRouterId("test", ImmutableMap.of(), new Warnings(), "test"));
+  }
+}


### PR DESCRIPTION
After loopbacks, physical interfaces are preferred over other interfaces:
https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/6-x/unicast/configuration/guide/l3_cli_nxos/l3_bgp.html#94583

```
By default, Cisco NX-OS sets the router ID to the IPv4 address of a loopback interface on the router. 
If no loopback interface is configured on the router, the software chooses the highest IPv4 address 
configured to a physical interface on the router to represent the BGP router ID.
```

("highest IPv4" in here is wrong. real world shows lowest.)