### PR TITLE
SearchRoutePolicies: Don't share a single BDDFactory

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
-import net.sf.javabdd.JFactory;
 import org.batfish.common.BatfishException;
 import org.batfish.common.bdd.BDDFiniteDomain;
 import org.batfish.common.bdd.BDDInteger;
@@ -47,11 +46,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    * symbolic integer, along with integer-specific operations.
    */
 
-  static BDDFactory factory;
-
   private static List<OspfType> allMetricTypes;
-
-  private static BDDPairing pairing;
 
   private int _hcode = 0;
 
@@ -61,24 +56,10 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     allMetricTypes.add(OspfType.OIA);
     allMetricTypes.add(OspfType.E1);
     allMetricTypes.add(OspfType.E2);
-
-    factory = JFactory.init(100000, 10000);
-    // factory.disableReorder();
-    factory.setCacheRatio(64);
-    /*
-    try {
-      // Disables printing
-      CallbackHandler handler = new CallbackHandler();
-      Method m = handler.getClass().getDeclaredMethod("handle", (Class<?>[]) null);
-      factory.registerGCCallback(handler, m);
-      factory.registerResizeCallback(handler, m);
-      factory.registerReorderCallback(handler, m);
-    } catch (NoSuchMethodException e) {
-      e.printStackTrace();
-    }
-    */
-    pairing = factory.makePair();
   }
+
+  private final BDDFactory _factory;
+  private final BDDPairing _pairing;
 
   private BDDInteger _adminDist;
 
@@ -139,8 +120,9 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    * A constructor that obtains the number of atomic predicates for community and AS-path regexes
    * from a given {@link org.batfish.minesweeper.Graph} object.
    */
-  public BDDRoute(Graph g) {
+  public BDDRoute(BDDFactory factory, Graph g) {
     this(
+        factory,
         g.getCommunityAtomicPredicates().getNumAtomicPredicates(),
         g.getAsPathRegexAtomicPredicates().getNumAtomicPredicates());
   }
@@ -151,7 +133,11 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    * BDD variable and a BDD, and similarly for the atomic predicates for AS-path regexes, so the
    * number of such atomic predicates is provided.
    */
-  public BDDRoute(int numCommAtomicPredicates, int numAsPathRegexAtomicPredicates) {
+  public BDDRoute(
+      BDDFactory factory, int numCommAtomicPredicates, int numAsPathRegexAtomicPredicates) {
+    _factory = factory;
+    _pairing = factory.makePair();
+
     int numVars = factory.varNum();
     int numNeeded =
         32 * 6
@@ -223,6 +209,9 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    * there is no need for a deep copy.
    */
   public BDDRoute(BDDRoute other) {
+    _factory = other._factory;
+    _pairing = other._pairing;
+
     _asPathRegexAtomicPredicates = other._asPathRegexAtomicPredicates.clone();
     _communityAtomicPredicates = other._communityAtomicPredicates.clone();
     _prefixLength = new BDDInteger(other._prefixLength);
@@ -270,7 +259,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    * @return the bdd
    */
   public BDD anyCommunity() {
-    return factory.orAll(_communityAtomicPredicates);
+    return _factory.orAll(_communityAtomicPredicates);
   }
 
   /**
@@ -281,7 +270,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    * @return the BDD representing this constraint
    */
   public BDD anyProtocolIn(Set<RoutingProtocol> protocols) {
-    return factory.orAll(
+    return _factory.orAll(
         protocols.stream()
             .map(_protocolHistory::getConstraintForValue)
             .collect(Collectors.toList()));
@@ -313,7 +302,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     // regexes are all pairwise disjoint
     // Note: the same constraint does not apply to community regexes because a route has a set
     // of communities, so more than one regex can be simultaneously true
-    BDD asPathConstraint = factory.one();
+    BDD asPathConstraint = _factory.one();
     for (int i = 0; i < _asPathRegexAtomicPredicates.length; i++) {
       for (int j = i + 1; j < _asPathRegexAtomicPredicates.length; j++) {
         asPathConstraint.andWith(
@@ -403,7 +392,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
   }
 
   public BDDFactory getFactory() {
-    return factory;
+    return _factory;
   }
 
   public BDDInteger getLocalPref() {
@@ -568,14 +557,14 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     BDD[] vals = new BDD[len];
     // NOTE: do not create a new pairing each time
     // JavaBDD will start to memory leak
-    pairing.reset();
+    _pairing.reset();
     for (int i = 0; i < len; i++) {
       int var = _prefix.getBitvec()[i].var(); // prefixIndex + i;
-      BDD subst = Ip.getBitAtPosition(bits, i) ? factory.one() : factory.zero();
+      BDD subst = Ip.getBitAtPosition(bits, i) ? _factory.one() : _factory.zero();
       vars[i] = var;
       vals[i] = subst;
     }
-    pairing.set(vars, vals);
+    _pairing.set(vars, vals);
 
     BDDRoute rec = new BDDRoute(this);
     BDD[] adminDist = rec.getAdminDist().getBitvec();
@@ -587,24 +576,24 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     BDD[] tag = rec.getTag().getBitvec();
     BDD[] ospfMet = rec.getOspfMetric().getInteger().getBitvec();
     for (int i = 0; i < 32; i++) {
-      adminDist[i] = adminDist[i].veccompose(pairing);
-      med[i] = med[i].veccompose(pairing);
-      localPref[i] = localPref[i].veccompose(pairing);
-      nextHop[i] = nextHop[i].veccompose(pairing);
-      tag[i] = tag[i].veccompose(pairing);
+      adminDist[i] = adminDist[i].veccompose(_pairing);
+      med[i] = med[i].veccompose(_pairing);
+      localPref[i] = localPref[i].veccompose(_pairing);
+      nextHop[i] = nextHop[i].veccompose(_pairing);
+      tag[i] = tag[i].veccompose(_pairing);
     }
-    rec.setNextHopDiscarded(nextHopDiscarded.veccompose(pairing));
-    rec.setNextHopSet(nextHopSet.veccompose(pairing));
+    rec.setNextHopDiscarded(nextHopDiscarded.veccompose(_pairing));
+    rec.setNextHopSet(nextHopSet.veccompose(_pairing));
     for (int i = 0; i < ospfMet.length; i++) {
-      ospfMet[i] = ospfMet[i].veccompose(pairing);
+      ospfMet[i] = ospfMet[i].veccompose(_pairing);
     }
     BDD[] commAPs = rec.getCommunityAtomicPredicates();
     for (int i = 0; i < commAPs.length; i++) {
-      commAPs[i] = commAPs[i].veccompose(pairing);
+      commAPs[i] = commAPs[i].veccompose(_pairing);
     }
     BDD[] asPathAPs = rec.getAsPathRegexAtomicPredicates();
     for (int i = 0; i < asPathAPs.length; i++) {
-      asPathAPs[i] = asPathAPs[i].veccompose(pairing);
+      asPathAPs[i] = asPathAPs[i].veccompose(_pairing);
     }
     return rec;
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -309,10 +309,9 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
             _asPathRegexAtomicPredicates[i].nand(_asPathRegexAtomicPredicates[j]));
       }
     }
-    // the next hop should be neither the min or max possible IP
+    // the next hop should be neither the min nor the max possible IP
     // this constraint is enforced by NextHopIp's constructor
-    BDD nextHopConstraint =
-        _nextHop.geq(Ip.ZERO.asLong() + 1).and(_nextHop.leq(Ip.MAX.asLong() - 1));
+    BDD nextHopConstraint = _nextHop.range(Ip.ZERO.asLong() + 1, Ip.MAX.asLong() - 1);
 
     return protocolConstraint
         .andWith(prefLenConstraint)

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDD.java
@@ -80,7 +80,7 @@ public class CommunityMatchExprToBDD implements CommunityMatchExprVisitor<BDD, A
   public BDD visitCommunityAcl(CommunityAcl communityAcl, Arg arg) {
     List<CommunityAclLine> lines = new ArrayList<>(communityAcl.getLines());
     Collections.reverse(lines);
-    BDD acc = BDDRoute.factory.zero();
+    BDD acc = arg.getTransferBDD().getFactory().zero();
     for (CommunityAclLine line : lines) {
       boolean action = (line.getAction() == LineAction.PERMIT);
       BDD lineBDD = line.getCommunityMatchExpr().accept(this, arg);
@@ -107,15 +107,17 @@ public class CommunityMatchExprToBDD implements CommunityMatchExprVisitor<BDD, A
   public BDD visitCommunityMatchAll(CommunityMatchAll communityMatchAll, Arg arg) {
     return communityMatchAll.getExprs().stream()
         .map(expr -> expr.accept(this, arg))
-        .reduce(BDDRoute.factory.one(), BDD::and);
+        .reduce(arg.getTransferBDD().getFactory().one(), BDD::and);
   }
 
   @Override
   public BDD visitCommunityMatchAny(CommunityMatchAny communityMatchAny, Arg arg) {
-    return BDDRoute.factory.orAll(
-        communityMatchAny.getExprs().stream()
-            .map(expr -> expr.accept(this, arg))
-            .collect(ImmutableList.toImmutableList()));
+    return arg.getTransferBDD()
+        .getFactory()
+        .orAll(
+            communityMatchAny.getExprs().stream()
+                .map(expr -> expr.accept(this, arg))
+                .collect(ImmutableList.toImmutableList()));
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetExprToBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetExprToBDD.java
@@ -63,10 +63,12 @@ public class CommunitySetExprToBDD implements CommunitySetExprVisitor<BDD, Arg> 
 
   @Override
   public BDD visitCommunitySetUnion(CommunitySetUnion communitySetUnion, Arg arg) {
-    return BDDRoute.factory.orAll(
-        communitySetUnion.getExprs().stream()
-            .map(expr -> expr.accept(this, arg))
-            .collect(Collectors.toList()));
+    return arg.getTransferBDD()
+        .getFactory()
+        .orAll(
+            communitySetUnion.getExprs().stream()
+                .map(expr -> expr.accept(this, arg))
+                .collect(Collectors.toList()));
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDD.java
@@ -157,6 +157,6 @@ public class CommunitySetMatchExprToBDD
   static BDD exactlyOneAP(BDD[] aps, int i, Arg arg) {
     ArrayList<BDD> negs = new ArrayList<>(Arrays.asList(aps));
     negs.remove(i);
-    return aps[i].and(negs.stream().reduce(arg.getTransferBDD().getFactory().one(), BDD::diff));
+    return aps[i].diff(arg.getTransferBDD().getFactory().orAll(negs));
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDDState.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDDState.java
@@ -12,10 +12,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class TransferBDDState {
 
-  @Nonnull private final TransferParam<BDDRoute> _param;
+  @Nonnull private final TransferParam _param;
   @Nonnull private final TransferResult _result;
 
-  public TransferBDDState(TransferParam<BDDRoute> param, TransferResult result) {
+  public TransferBDDState(TransferParam param, TransferResult result) {
     // There should only be one 'active' BDDRoute at any time during symbolic route analysis.
     // Eventually we may want to refactor things so the BDDRoute does not live in both
     // the TransferParam and the TransferResult, but it would require non-trivial updates
@@ -27,7 +27,7 @@ public class TransferBDDState {
     _result = result;
   }
 
-  public TransferParam<BDDRoute> getTransferParam() {
+  public TransferParam getTransferParam() {
     return _param;
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferParam.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferParam.java
@@ -3,10 +3,9 @@ package org.batfish.minesweeper.bdd;
 import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
-import org.batfish.minesweeper.IDeepCopy;
 import org.batfish.minesweeper.collections.PList;
 
-public class TransferParam<T extends IDeepCopy<T>> {
+public class TransferParam {
 
   public enum CallContext {
     EXPR_CALL,
@@ -20,7 +19,7 @@ public class TransferParam<T extends IDeepCopy<T>> {
     NONE
   }
 
-  private T _data;
+  private BDDRoute _data;
 
   private int _indent;
 
@@ -38,19 +37,19 @@ public class TransferParam<T extends IDeepCopy<T>> {
 
   private boolean _debug;
 
-  public TransferParam(T data, boolean debug) {
+  public TransferParam(BDDRoute data, boolean debug) {
     _data = data;
     _callContext = CallContext.NONE;
     _chainContext = ChainContext.NONE;
     _indent = 0;
     _scopes = PList.empty();
-    _defaultAccept = BDDRoute.factory.zero();
-    _defaultAcceptLocal = BDDRoute.factory.zero();
+    _defaultAccept = data.getFactory().zero();
+    _defaultAcceptLocal = data.getFactory().zero();
     _defaultPolicy = null;
     _debug = debug;
   }
 
-  private TransferParam(TransferParam<T> p) {
+  private TransferParam(TransferParam p) {
     _data = p._data;
     _callContext = p._callContext;
     _chainContext = p._chainContext;
@@ -62,7 +61,7 @@ public class TransferParam<T extends IDeepCopy<T>> {
     _debug = p._debug;
   }
 
-  public T getData() {
+  public BDDRoute getData() {
     return _data;
   }
 
@@ -94,61 +93,61 @@ public class TransferParam<T extends IDeepCopy<T>> {
     return _scopes.get(0);
   }
 
-  public TransferParam<T> deepCopy() {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam deepCopy() {
+    TransferParam ret = new TransferParam(this);
     ret._data = ret._data.deepCopy();
     return ret;
   }
 
-  public TransferParam<T> setData(T other) {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam setData(BDDRoute other) {
+    TransferParam ret = new TransferParam(this);
     ret._data = other;
     return ret;
   }
 
-  public TransferParam<T> setCallContext(CallContext cc) {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam setCallContext(CallContext cc) {
+    TransferParam ret = new TransferParam(this);
     ret._callContext = cc;
     return ret;
   }
 
-  public TransferParam<T> setChainContext(ChainContext cc) {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam setChainContext(ChainContext cc) {
+    TransferParam ret = new TransferParam(this);
     ret._chainContext = cc;
     return ret;
   }
 
-  public TransferParam<T> setDefaultAccept(BDD defaultAccept) {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam setDefaultAccept(BDD defaultAccept) {
+    TransferParam ret = new TransferParam(this);
     ret._defaultAccept = defaultAccept;
     return ret;
   }
 
-  public TransferParam<T> setDefaultPolicy(@Nullable SetDefaultPolicy defaultPolicy) {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam setDefaultPolicy(@Nullable SetDefaultPolicy defaultPolicy) {
+    TransferParam ret = new TransferParam(this);
     ret._defaultPolicy = defaultPolicy;
     return ret;
   }
 
-  public TransferParam<T> setDefaultAcceptLocal(BDD defaultAcceptLocal) {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam setDefaultAcceptLocal(BDD defaultAcceptLocal) {
+    TransferParam ret = new TransferParam(this);
     ret._defaultAcceptLocal = defaultAcceptLocal;
     return ret;
   }
 
-  public TransferParam<T> setDefaultActionsFrom(TransferParam<T> updatedParam) {
+  public TransferParam setDefaultActionsFrom(TransferParam updatedParam) {
     return setDefaultAccept(updatedParam._defaultAccept)
         .setDefaultAcceptLocal(updatedParam._defaultAcceptLocal);
   }
 
-  public TransferParam<T> enterScope(String name) {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam enterScope(String name) {
+    TransferParam ret = new TransferParam(this);
     ret._scopes = ret._scopes.plus(name);
     return ret;
   }
 
-  public TransferParam<T> indent() {
-    TransferParam<T> ret = new TransferParam<>(this);
+  public TransferParam indent() {
+    TransferParam ret = new TransferParam(this);
     ret._indent = _indent + 1;
     return ret;
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -244,7 +244,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             .setOriginMechanism(OriginMechanism.LEARNED)
             .setOriginType(OriginType.IGP);
 
-    BDDRoute r = new BDDRoute(g);
+    BDDRoute r = new BDDRoute(fullModel.getFactory(), g);
 
     Ip ip = Ip.create(r.getPrefix().satAssignmentToLong(fullModel));
     long len = r.getPrefixLength().satAssignmentToLong(fullModel);
@@ -277,7 +277,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
   // the constraints.  The same approach could be used to provide default values for other fields in
   // the future.
   private BDD constraintsToModel(BDD constraints, Graph g) {
-    BDDRoute route = new BDDRoute(g);
+    BDDRoute route = new BDDRoute(constraints.getFactory(), g);
     // set the protocol field to BGP if it is consistent with the constraints
     BDD isBGP = route.getProtocolHistory().getConstraintForValue(RoutingProtocol.BGP);
     BDD augmentedConstraints = constraints.and(isBGP);
@@ -493,7 +493,9 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outputRoute = result.getFirst();
     BDD intersection;
-    BDD inConstraints = routeConstraintsToBDD(_inputConstraints, new BDDRoute(g), false, g);
+    BDD inConstraints =
+        routeConstraintsToBDD(
+            _inputConstraints, new BDDRoute(outputRoute.getFactory(), g), false, g);
     if (_action == PERMIT) {
       // incorporate the constraints on the output route as well
       BDD outConstraints = routeConstraintsToBDD(_outputConstraints, outputRoute, true, g);

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/AsPathMatchExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/AsPathMatchExprToBDDTest.java
@@ -50,8 +50,8 @@ public class AsPathMatchExprToBDDTest {
     Graph g =
         new Graph(
             batfish, batfish.getSnapshot(), null, null, null, ImmutableSet.of(ASPATH1, ASPATH2));
-    BDDRoute bddRoute = new BDDRoute(g);
     TransferBDD transferBDD = new TransferBDD(g, _baseConfig, ImmutableList.of());
+    BDDRoute bddRoute = new BDDRoute(transferBDD.getFactory(), g);
     _arg = new CommunitySetMatchExprToBDD.Arg(transferBDD, bddRoute);
     _matchExprToBDD = new AsPathMatchExprToBDD();
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityAPDispositionsTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityAPDispositionsTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
+import net.sf.javabdd.JFactory;
 import org.batfish.datamodel.IntegerSpace;
 import org.junit.Test;
 
@@ -15,7 +16,7 @@ public class CommunityAPDispositionsTest {
   private final CommunityAPDispositions _cAPD2 =
       new CommunityAPDispositions(
           4, IntegerSpace.of(1), IntegerSpace.builder().including(0, 2, 3).build());
-  private final BDDRoute _bddRoute = new BDDRoute(4, 0);
+  private final BDDRoute _bddRoute = new BDDRoute(JFactory.init(100, 100), 4, 0);
 
   @Test
   public void testUnion() {

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetExprToBDDTest.java
@@ -64,8 +64,8 @@ public class CommunitySetExprToBDDTest {
                 CommunityVar.from(StandardCommunity.parse("20:30")),
                 CommunityVar.from(StandardCommunity.parse("21:30"))),
             null);
-    BDDRoute bddRoute = new BDDRoute(_g);
     TransferBDD transferBDD = new TransferBDD(_g, _baseConfig, ImmutableList.of());
+    BDDRoute bddRoute = new BDDRoute(transferBDD.getFactory(), _g);
     _arg = new CommunitySetMatchExprToBDD.Arg(transferBDD, bddRoute);
 
     _communitySetExprToBDD = new CommunitySetExprToBDD();
@@ -158,7 +158,9 @@ public class CommunitySetExprToBDDTest {
     BDD[] aps = _arg.getBDDRoute().getCommunityAtomicPredicates();
     Map<CommunityVar, Set<Integer>> regexAtomicPredicates =
         _g.getCommunityAtomicPredicates().getRegexAtomicPredicates();
-    return BDDRoute.factory.orAll(
-        regexAtomicPredicates.get(cvar).stream().map(i -> aps[i]).collect(Collectors.toList()));
+    return _arg.getTransferBDD()
+        .getFactory()
+        .orAll(
+            regexAtomicPredicates.get(cvar).stream().map(i -> aps[i]).collect(Collectors.toList()));
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDDTest.java
@@ -65,8 +65,8 @@ public class CommunitySetMatchExprToBDDTest {
                 CommunityVar.from(StandardCommunity.parse("20:30")),
                 CommunityVar.from(StandardCommunity.parse("21:30"))),
             null);
-    BDDRoute bddRoute = new BDDRoute(_g);
     TransferBDD transferBDD = new TransferBDD(_g, _baseConfig, ImmutableList.of());
+    BDDRoute bddRoute = new BDDRoute(transferBDD.getFactory(), _g);
     _arg = new CommunitySetMatchExprToBDD.Arg(transferBDD, bddRoute);
 
     _communitySetMatchExprToBDD = new CommunitySetMatchExprToBDD();
@@ -177,7 +177,9 @@ public class CommunitySetMatchExprToBDDTest {
     BDD[] aps = _arg.getBDDRoute().getCommunityAtomicPredicates();
     Map<CommunityVar, Set<Integer>> regexAtomicPredicates =
         _g.getCommunityAtomicPredicates().getRegexAtomicPredicates();
-    return BDDRoute.factory.orAll(
-        regexAtomicPredicates.get(cvar).stream().map(i -> aps[i]).collect(Collectors.toList()));
+    return _arg.getTransferBDD()
+        .getFactory()
+        .orAll(
+            regexAtomicPredicates.get(cvar).stream().map(i -> aps[i]).collect(Collectors.toList()));
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/SetCommunitiesVisitorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/SetCommunitiesVisitorTest.java
@@ -62,8 +62,8 @@ public class SetCommunitiesVisitorTest {
                 CommunityVar.from(StandardCommunity.parse("21:30"))),
             null);
 
-    BDDRoute bddRoute = new BDDRoute(_g);
     TransferBDD transferBDD = new TransferBDD(_g, _baseConfig, ImmutableList.of());
+    BDDRoute bddRoute = new BDDRoute(transferBDD.getFactory(), _g);
     _arg = new CommunitySetMatchExprToBDD.Arg(transferBDD, bddRoute);
 
     _scVisitor = new SetCommunitiesVisitor();


### PR DESCRIPTION
Previously there was one statically created BDDFactory shared across all uses of SearchRoutePolicies.  If many route policies are analyzed this could eventually cause Batfish to run out of memory.  Now we create a separate BDDFactory instance for the analysis of each routing policy, which is done by instantiating the factory inside the constructor for TransferBDD.