### PR TITLE
Routes: cleanup internal state

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -11,13 +10,9 @@ import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.route.nh.LegacyNextHops;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
-import org.batfish.datamodel.route.nh.NextHopInterface;
-import org.batfish.datamodel.route.nh.NextHopIp;
-import org.batfish.datamodel.route.nh.NextHopVisitor;
-import org.batfish.datamodel.route.nh.NextHopVrf;
-import org.batfish.datamodel.route.nh.NextHopVtep;
 
 /**
  * A base class for all types of routes supported in the dataplane computation, making this the most
@@ -92,7 +87,7 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
   @JsonProperty(PROP_NEXT_HOP_INTERFACE)
   @Nonnull
   public final String getNextHopInterface() {
-    return nextHopInterfaceExtractor().visit(_nextHop);
+    return LegacyNextHops.getNextHopInterface(_nextHop).orElse(Route.UNSET_NEXT_HOP_INTERFACE);
   }
 
   /**
@@ -102,7 +97,7 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
   @JsonProperty(PROP_NEXT_HOP_IP)
   @Nonnull
   public final Ip getNextHopIp() {
-    return nextHopIpExtractor().visit(_nextHop);
+    return LegacyNextHops.getNextHopIp(_nextHop).orElse(Route.UNSET_ROUTE_NEXT_HOP_IP);
   }
 
   /**
@@ -153,107 +148,4 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
 
   /** Return a {@link AbstractRouteBuilder} pre-populated with the values for this route. */
   public abstract AbstractRouteBuilder<?, ?> toBuilder();
-
-  // Private implementation
-
-  // Helper package methods
-  @Nonnull
-  static NextHopVisitor<Ip> nextHopIpExtractor() {
-    return NEXT_HOP_IP_EXTRACTOR;
-  }
-
-  @Nonnull
-  static NextHopVisitor<String> nextHopInterfaceExtractor() {
-    return NEXT_HOP_INTERFACE_EXTRACTOR;
-  }
-
-  private static final NextHopVisitor<Ip> NEXT_HOP_IP_EXTRACTOR =
-      new NextHopVisitor<Ip>() {
-
-        @Override
-        public Ip visitNextHopIp(NextHopIp nextHopIp) {
-          return nextHopIp.getIp();
-        }
-
-        @Override
-        public Ip visitNextHopInterface(NextHopInterface nextHopInterface) {
-          return firstNonNull(nextHopInterface.getIp(), Route.UNSET_ROUTE_NEXT_HOP_IP);
-        }
-
-        @Override
-        public Ip visitNextHopDiscard(NextHopDiscard nextHopDiscard) {
-          return Route.UNSET_ROUTE_NEXT_HOP_IP;
-        }
-
-        @Override
-        public Ip visitNextHopVrf(NextHopVrf nextHopVrf) {
-          return Route.UNSET_ROUTE_NEXT_HOP_IP;
-        }
-
-        @Override
-        public Ip visitNextHopVtep(NextHopVtep nextHopVtep) {
-          return Route.UNSET_ROUTE_NEXT_HOP_IP;
-        }
-      };
-
-  private static final NextHopVisitor<String> NEXT_HOP_INTERFACE_EXTRACTOR =
-      new NextHopVisitor<String>() {
-        @Override
-        public String visitNextHopIp(NextHopIp nextHopIp) {
-          return Route.UNSET_NEXT_HOP_INTERFACE;
-        }
-
-        @Override
-        public String visitNextHopInterface(NextHopInterface nextHopInterface) {
-          return nextHopInterface.getInterfaceName();
-        }
-
-        @Override
-        public String visitNextHopDiscard(NextHopDiscard nextHopDiscard) {
-          return Interface.NULL_INTERFACE_NAME;
-        }
-
-        @Override
-        public String visitNextHopVrf(NextHopVrf nextHopVrf) {
-          return Route.UNSET_NEXT_HOP_INTERFACE;
-        }
-
-        @Override
-        public String visitNextHopVtep(NextHopVtep nextHopVtep) {
-          return Route.UNSET_NEXT_HOP_INTERFACE;
-        }
-      };
-
-  /** Returns the name of next VRF for a given route or {@code null} otherwise. */
-  public static final NextHopVisitor<String> NEXT_VRF_EXTRACTOR =
-      new NextHopVisitor<String>() {
-
-        @Override
-        @Nullable
-        public String visitNextHopIp(NextHopIp nextHopIp) {
-          return null;
-        }
-
-        @Override
-        @Nullable
-        public String visitNextHopInterface(NextHopInterface nextHopInterface) {
-          return null;
-        }
-
-        @Override
-        @Nullable
-        public String visitNextHopDiscard(NextHopDiscard nextHopDiscard) {
-          return null;
-        }
-
-        @Override
-        public String visitNextHopVrf(NextHopVrf nextHopVrf) {
-          return nextHopVrf.getVrfName();
-        }
-
-        @Override
-        public String visitNextHopVtep(NextHopVtep nextHopVtep) {
-          return null;
-        }
-      };
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
@@ -4,6 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.route.nh.LegacyNextHops;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopInterface;
@@ -67,7 +68,7 @@ public abstract class AbstractRouteBuilder<
     if (_nextHop == null) {
       return Route.UNSET_ROUTE_NEXT_HOP_IP;
     }
-    return AbstractRoute.nextHopIpExtractor().visit(_nextHop);
+    return LegacyNextHops.getNextHopIp(_nextHop).orElse(Route.UNSET_ROUTE_NEXT_HOP_IP);
   }
 
   @Nonnull
@@ -113,7 +114,7 @@ public abstract class AbstractRouteBuilder<
     if (_nextHop == null) {
       return Route.UNSET_NEXT_HOP_INTERFACE;
     }
-    return AbstractRoute.nextHopInterfaceExtractor().visit(_nextHop);
+    return LegacyNextHops.getNextHopInterface(_nextHop).orElse(Route.UNSET_NEXT_HOP_INTERFACE);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.route.nh.LegacyNextHops;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopVrf;
@@ -84,7 +85,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
   @Nullable
   @JsonProperty(PROP_NEXT_VRF)
   private String getNextVrf() {
-    return NEXT_VRF_EXTRACTOR.visit(_nextHop);
+    return LegacyNextHops.getNextVrf(_nextHop).orElse(null);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/LegacyNextHops.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/LegacyNextHops.java
@@ -1,0 +1,115 @@
+package org.batfish.datamodel.route.nh;
+
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+
+/** Utilities for dealing with legacy {@link NextHop} objects. */
+public final class LegacyNextHops {
+  /**
+   * Returns the next hop interface, if any, for the given {@link NextHop}.
+   *
+   * <p>NB: for legacy compatibility, returns {@link Interface#NULL_INTERFACE_NAME} for {@link
+   * NextHopDiscard}.
+   */
+  public static @Nonnull Optional<String> getNextHopInterface(NextHop nextHop) {
+    return NEXT_HOP_INTERFACE_EXTRACTOR.visit(nextHop);
+  }
+
+  public static @Nonnull Optional<Ip> getNextHopIp(NextHop nextHop) {
+    return NEXT_HOP_IP_EXTRACTOR.visit(nextHop);
+  }
+
+  public static @Nonnull Optional<String> getNextVrf(NextHop nextHop) {
+    return NEXT_VRF_EXTRACTOR.visit(nextHop);
+  }
+
+  private static final NextHopVisitor<Optional<Ip>> NEXT_HOP_IP_EXTRACTOR =
+      new NextHopVisitor<Optional<Ip>>() {
+
+        @Override
+        public Optional<Ip> visitNextHopIp(NextHopIp nextHopIp) {
+          return Optional.of(nextHopIp.getIp());
+        }
+
+        @Override
+        public Optional<Ip> visitNextHopInterface(NextHopInterface nextHopInterface) {
+          return Optional.ofNullable(nextHopInterface.getIp());
+        }
+
+        @Override
+        public Optional<Ip> visitNextHopDiscard(NextHopDiscard nextHopDiscard) {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<Ip> visitNextHopVrf(NextHopVrf nextHopVrf) {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<Ip> visitNextHopVtep(NextHopVtep nextHopVtep) {
+          return Optional.empty();
+        }
+      };
+
+  private static final NextHopVisitor<Optional<String>> NEXT_HOP_INTERFACE_EXTRACTOR =
+      new NextHopVisitor<Optional<String>>() {
+        @Override
+        public Optional<String> visitNextHopIp(NextHopIp nextHopIp) {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> visitNextHopInterface(NextHopInterface nextHopInterface) {
+          return Optional.of(nextHopInterface.getInterfaceName());
+        }
+
+        @Override
+        public Optional<String> visitNextHopDiscard(NextHopDiscard nextHopDiscard) {
+          return Optional.of(Interface.NULL_INTERFACE_NAME);
+        }
+
+        @Override
+        public Optional<String> visitNextHopVrf(NextHopVrf nextHopVrf) {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> visitNextHopVtep(NextHopVtep nextHopVtep) {
+          return Optional.empty();
+        }
+      };
+
+  private static final NextHopVisitor<Optional<String>> NEXT_VRF_EXTRACTOR =
+      new NextHopVisitor<Optional<String>>() {
+
+        @Override
+        public Optional<String> visitNextHopIp(NextHopIp nextHopIp) {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> visitNextHopInterface(NextHopInterface nextHopInterface) {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> visitNextHopDiscard(NextHopDiscard nextHopDiscard) {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> visitNextHopVrf(NextHopVrf nextHopVrf) {
+          return Optional.of(nextHopVrf.getVrfName());
+        }
+
+        @Override
+        public Optional<String> visitNextHopVtep(NextHopVtep nextHopVtep) {
+          return Optional.empty();
+        }
+      };
+
+  private LegacyNextHops() {} // prevent instantiation
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/LegacyNextHops.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/LegacyNextHops.java
@@ -17,10 +17,12 @@ public final class LegacyNextHops {
     return NEXT_HOP_INTERFACE_EXTRACTOR.visit(nextHop);
   }
 
+  /** Returns the next hop IP, if any, for the given {@link NextHop}. */
   public static @Nonnull Optional<Ip> getNextHopIp(NextHop nextHop) {
     return NEXT_HOP_IP_EXTRACTOR.visit(nextHop);
   }
 
+  /** Returns the next VRF, if any, for the given {@link NextHop}. */
   public static @Nonnull Optional<String> getNextVrf(NextHop nextHop) {
     return NEXT_VRF_EXTRACTOR.visit(nextHop);
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -26,7 +26,6 @@ import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.FibEntry;
 import org.batfish.datamodel.FilterResult;
@@ -56,14 +55,14 @@ import org.batfish.datamodel.flow.StepAction;
 import org.batfish.datamodel.flow.TransformationStep;
 import org.batfish.datamodel.flow.TransformationStep.TransformationStepDetail;
 import org.batfish.datamodel.flow.TransformationStep.TransformationType;
+import org.batfish.datamodel.route.nh.LegacyNextHops;
 import org.batfish.datamodel.transformation.Transformation;
 
 @ParametersAreNonnullByDefault
 public final class TracerouteUtils {
 
   /**
-   * Does a basic validation of input to {@link
-   * TracerouteEngineImplContext#buildTracesAndReturnFlows()}
+   * Does a basic validation of input to {@link TracerouteEngineImplContext#buildTraceDags()}
    *
    * @param configurations {@link Map} of {@link Configuration}s
    * @param flow {@link Flow} for which input validation is to be done
@@ -95,7 +94,7 @@ public final class TracerouteUtils {
                     route.getProtocol(),
                     route.getNetwork(),
                     route.getNextHopIp(),
-                    AbstractRoute.NEXT_VRF_EXTRACTOR.visit(route.getNextHop()),
+                    LegacyNextHops.getNextVrf(route.getNextHop()).orElse(null),
                     route.getAdministrativeCost(),
                     route.getMetric()))
         .distinct()

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
@@ -22,12 +22,10 @@ import org.batfish.datamodel.questions.BgpRouteStatus;
 
 /**
  * Contains the non-key attributes of {@link BgpRoute}s and {@link AbstractRoute}s and defines a
- * sorting order for these attributes
+ * sorting order for these attributes.
  */
 @ParametersAreNullableByDefault
 public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
-  @Nullable private final String _nextHop;
-
   @Nullable private final String _nextHopInterface;
 
   @Nullable private final AsPath _asPath;
@@ -55,7 +53,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   @Nullable private final Integer _weight;
 
   private RouteRowAttribute(
-      String nextHop,
       String nextHopInterface,
       Integer adminDistance,
       Long metric,
@@ -69,7 +66,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
       Long tag,
       BgpRouteStatus status,
       Integer weight) {
-    _nextHop = nextHop;
     _nextHopInterface = nextHopInterface;
     _adminDistance = adminDistance;
     _metric = metric;
@@ -108,11 +104,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   @Nonnull
   public List<String> getCommunities() {
     return _communities;
-  }
-
-  @Nullable
-  public String getNextHop() {
-    return _nextHop;
   }
 
   @Nullable
@@ -159,8 +150,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   }
 
   private static final Comparator<RouteRowAttribute> COMPARATOR =
-      comparing(RouteRowAttribute::getNextHop, nullsLast(String::compareTo))
-          .thenComparing(RouteRowAttribute::getNextHopInterface, nullsLast(String::compareTo))
+      comparing(RouteRowAttribute::getNextHopInterface, nullsLast(String::compareTo))
           .thenComparing(RouteRowAttribute::getAdminDistance, nullsLast(Integer::compareTo))
           .thenComparing(RouteRowAttribute::getMetric, nullsLast(Long::compareTo))
           .thenComparing(RouteRowAttribute::getAsPath, nullsLast(AsPath::compareTo))
@@ -191,8 +181,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
       return false;
     }
     RouteRowAttribute that = (RouteRowAttribute) o;
-    return Objects.equals(_nextHop, that._nextHop)
-        && Objects.equals(_nextHopInterface, that._nextHopInterface)
+    return Objects.equals(_nextHopInterface, that._nextHopInterface)
         && Objects.equals(_adminDistance, that._adminDistance)
         && Objects.equals(_metric, that._metric)
         && Objects.equals(_asPath, that._asPath)
@@ -210,8 +199,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   @Override
   public int hashCode() {
     return Objects.hash(
-        _nextHop,
-        _nextHopInterface,
         _adminDistance,
         _metric,
         _asPath,
@@ -227,7 +214,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
 
   /** Builder for {@link RouteRowAttribute} */
   public static final class Builder {
-    @Nullable private String _nextHop;
     @Nullable private String _nextHopInterface;
     @Nullable private Integer _adminDistance;
     @Nullable private Long _metric;
@@ -247,7 +233,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
         _tag = null;
       }
       return new RouteRowAttribute(
-          _nextHop,
           _nextHopInterface,
           _adminDistance,
           _metric,
@@ -285,11 +270,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
 
     public Builder setCommunities(List<String> communities) {
       _communities = communities;
-      return this;
-    }
-
-    public Builder setNextHop(String nextHop) {
-      _nextHop = nextHop;
       return this;
     }
 

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
@@ -273,6 +273,12 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
       return this;
     }
 
+    @Deprecated
+    @SuppressWarnings("unused")
+    public Builder setNextHop(String nextHop) {
+      return this;
+    }
+
     public Builder setNextHopInterface(String nextHopInterface) {
       _nextHopInterface = nextHopInterface;
       return this;

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
@@ -199,6 +199,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   @Override
   public int hashCode() {
     return Objects.hash(
+        _nextHopInterface,
         _adminDistance,
         _metric,
         _asPath,

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKey.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKey.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.route.nh.NextHop;
 
 /**
@@ -16,13 +15,10 @@ public class RouteRowSecondaryKey {
 
   @Nonnull private final NextHop _nextHop;
 
-  @Nonnull private final Ip _nextHopIp;
-
   @Nonnull private final String _protocol;
 
-  public RouteRowSecondaryKey(NextHop nextHop, Ip nextHopIp, String protocol) {
+  public RouteRowSecondaryKey(NextHop nextHop, String protocol) {
     _nextHop = nextHop;
-    _nextHopIp = nextHopIp;
     _protocol = protocol;
   }
 
@@ -35,28 +31,19 @@ public class RouteRowSecondaryKey {
       return false;
     }
     RouteRowSecondaryKey that = (RouteRowSecondaryKey) o;
-    return _nextHop.equals(that._nextHop)
-        && _nextHopIp.equals(that._nextHopIp)
-        && _protocol.equals(that._protocol);
+    return _nextHop.equals(that._nextHop) && _protocol.equals(that._protocol);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_nextHop, _nextHopIp, _protocol);
+    return Objects.hash(_nextHop, _protocol);
   }
 
-  @Nonnull
-  public NextHop getNextHop() {
+  public @Nonnull NextHop getNextHop() {
     return _nextHop;
   }
 
-  @Nonnull
-  public Ip getNextHopIp() {
-    return _nextHopIp;
-  }
-
-  @Nonnull
-  public String getProtocol() {
+  public @Nonnull String getProtocol() {
     return _protocol;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKey.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKey.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.route.nh.NextHop;
 
 /**
@@ -20,6 +21,12 @@ public class RouteRowSecondaryKey {
   public RouteRowSecondaryKey(NextHop nextHop, String protocol) {
     _nextHop = nextHop;
     _protocol = protocol;
+  }
+
+  @Deprecated
+  @SuppressWarnings("unused")
+  public RouteRowSecondaryKey(NextHop nextHop, Ip nhip, String protocol) {
+    this(nextHop, protocol);
   }
 
   @Override

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -34,7 +34,6 @@ import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.NextHopComparator;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
@@ -192,7 +191,6 @@ public class RoutesAnswerer extends Answerer {
         routesGroupedByKeyInBase;
     Map<RouteRowKey, Map<RouteRowSecondaryKey, SortedSet<RouteRowAttribute>>>
         routesGroupedByKeyInDelta;
-    Map<Ip, Set<String>> ipOwners;
     DataPlane dp;
 
     List<DiffRoutesOutput> routesDiffRaw;
@@ -225,12 +223,10 @@ public class RoutesAnswerer extends Answerer {
       case MAIN:
       default:
         dp = _batfish.loadDataPlane(snapshot);
-        ipOwners = _batfish.getTopologyProvider().getIpOwners(snapshot).getNodeOwners(true);
         routesGroupedByKeyInBase =
             groupRoutes(dp.getRibs(), matchingNodes, network, vrfRegex, protocolSpec);
 
         dp = _batfish.loadDataPlane(reference);
-        ipOwners = _batfish.getTopologyProvider().getIpOwners(snapshot).getNodeOwners(true);
         routesGroupedByKeyInDelta =
             groupRoutes(dp.getRibs(), matchingNodes, network, vrfRegex, protocolSpec);
 

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -227,12 +227,12 @@ public class RoutesAnswerer extends Answerer {
         dp = _batfish.loadDataPlane(snapshot);
         ipOwners = _batfish.getTopologyProvider().getIpOwners(snapshot).getNodeOwners(true);
         routesGroupedByKeyInBase =
-            groupRoutes(dp.getRibs(), matchingNodes, network, vrfRegex, protocolSpec, ipOwners);
+            groupRoutes(dp.getRibs(), matchingNodes, network, vrfRegex, protocolSpec);
 
         dp = _batfish.loadDataPlane(reference);
         ipOwners = _batfish.getTopologyProvider().getIpOwners(snapshot).getNodeOwners(true);
         routesGroupedByKeyInDelta =
-            groupRoutes(dp.getRibs(), matchingNodes, network, vrfRegex, protocolSpec, ipOwners);
+            groupRoutes(dp.getRibs(), matchingNodes, network, vrfRegex, protocolSpec);
 
         routesDiffRaw = getRoutesDiff(routesGroupedByKeyInBase, routesGroupedByKeyInDelta);
         rows = getAbstractRouteRowsDiff(routesDiffRaw);

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -708,6 +708,19 @@ public class RoutesAnswererUtil {
             routeRowAttribute != null ? routeRowAttribute.getTag() : null);
   }
 
+  @Deprecated
+  @SuppressWarnings("unused")
+  public static <T extends AbstractRouteDecorator>
+      Map<RouteRowKey, Map<RouteRowSecondaryKey, SortedSet<RouteRowAttribute>>> groupRoutes(
+          SortedMap<String, SortedMap<String, GenericRib<T>>> ribs,
+          Set<String> matchingNodes,
+          @Nullable Prefix network,
+          String vrfRegex,
+          RoutingProtocolSpecifier protocolSpec,
+          Map<Ip, Set<String>> ipo) {
+    return groupRoutes(ribs, matchingNodes, network, vrfRegex, protocolSpec);
+  }
+
   /**
    * Given a {@link Map} of all RIBs groups the routes in them by the fields of {@link RouteRowKey}
    * and further sub-groups them by {@link RouteRowSecondaryKey} and for routes in the same

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -109,12 +109,12 @@ public class RoutesAnswererUtilTest {
 
   @Test
   public void testAlignRtRowAttrs() {
-    RouteRowAttribute rra1 = RouteRowAttribute.builder().setNextHop("node1").build();
-    RouteRowAttribute rra3 = RouteRowAttribute.builder().setNextHop("node3").build();
-    RouteRowAttribute rra5 = RouteRowAttribute.builder().setNextHop("node5").build();
+    RouteRowAttribute rra1 = RouteRowAttribute.builder().setAdminDistance(10).build();
+    RouteRowAttribute rra3 = RouteRowAttribute.builder().setAdminDistance(30).build();
+    RouteRowAttribute rra5 = RouteRowAttribute.builder().setAdminDistance(50).build();
 
-    RouteRowAttribute rra2 = RouteRowAttribute.builder().setNextHop("node2").build();
-    RouteRowAttribute rra4 = RouteRowAttribute.builder().setNextHop("node4").build();
+    RouteRowAttribute rra2 = RouteRowAttribute.builder().setAdminDistance(20).build();
+    RouteRowAttribute rra4 = RouteRowAttribute.builder().setAdminDistance(40).build();
 
     List<List<RouteRowAttribute>> alignedRouteRowattrs =
         alignRouteRowAttributes(
@@ -134,9 +134,9 @@ public class RoutesAnswererUtilTest {
 
   @Test
   public void testAlignRtRowAttrsTrailingNulls1() {
-    RouteRowAttribute rra1 = RouteRowAttribute.builder().setNextHop("node1").build();
-    RouteRowAttribute rra2 = RouteRowAttribute.builder().setNextHop("node2").build();
-    RouteRowAttribute rra3 = RouteRowAttribute.builder().setNextHop("node3").build();
+    RouteRowAttribute rra1 = RouteRowAttribute.builder().setAdminDistance(10).build();
+    RouteRowAttribute rra2 = RouteRowAttribute.builder().setAdminDistance(20).build();
+    RouteRowAttribute rra3 = RouteRowAttribute.builder().setAdminDistance(30).build();
 
     List<List<RouteRowAttribute>> alignedRouteRowattrs =
         alignRouteRowAttributes(ImmutableList.of(rra1, rra2, rra3), ImmutableList.of(rra1));
@@ -153,9 +153,9 @@ public class RoutesAnswererUtilTest {
 
   @Test
   public void testAlignRtRowAttrsTrailingNulls2() {
-    RouteRowAttribute rra1 = RouteRowAttribute.builder().setNextHop("node1").build();
-    RouteRowAttribute rra2 = RouteRowAttribute.builder().setNextHop("node2").build();
-    RouteRowAttribute rra3 = RouteRowAttribute.builder().setNextHop("node3").build();
+    RouteRowAttribute rra1 = RouteRowAttribute.builder().setAdminDistance(10).build();
+    RouteRowAttribute rra2 = RouteRowAttribute.builder().setAdminDistance(20).build();
+    RouteRowAttribute rra3 = RouteRowAttribute.builder().setAdminDistance(30).build();
 
     List<List<RouteRowAttribute>> alignedRouteRowattrs =
         alignRouteRowAttributes(ImmutableList.of(rra1), ImmutableList.of(rra1, rra2, rra3));
@@ -172,9 +172,9 @@ public class RoutesAnswererUtilTest {
 
   @Test
   public void testAlignRtRowAttrsLeadingNulls() {
-    RouteRowAttribute rra1 = RouteRowAttribute.builder().setNextHop("node1").build();
-    RouteRowAttribute rra2 = RouteRowAttribute.builder().setNextHop("node2").build();
-    RouteRowAttribute rra3 = RouteRowAttribute.builder().setNextHop("node3").build();
+    RouteRowAttribute rra1 = RouteRowAttribute.builder().setAdminDistance(10).build();
+    RouteRowAttribute rra2 = RouteRowAttribute.builder().setAdminDistance(20).build();
+    RouteRowAttribute rra3 = RouteRowAttribute.builder().setAdminDistance(30).build();
 
     List<List<RouteRowAttribute>> alignedRouteRowattrs =
         alignRouteRowAttributes(ImmutableList.of(rra3), ImmutableList.of(rra1, rra2, rra3));
@@ -462,37 +462,37 @@ public class RoutesAnswererUtilTest {
         ImmutableList.of(
             new DiffRoutesOutput(
                 new RouteRowKey("node", "vrf", Prefix.parse("1.1.1.1/24")),
-                new RouteRowSecondaryKey(nextHop, nextHopIp, "bgp"),
+                new RouteRowSecondaryKey(nextHop, "bgp"),
                 KeyPresenceStatus.IN_BOTH,
                 diffMatrix,
                 KeyPresenceStatus.IN_BOTH),
             new DiffRoutesOutput(
                 new RouteRowKey("node", "vrf", Prefix.parse("1.1.1.1/24")),
-                new RouteRowSecondaryKey(nextHop, nextHopIp, "bgp"),
+                new RouteRowSecondaryKey(nextHop, "bgp"),
                 KeyPresenceStatus.IN_BOTH,
                 diffMatrixChanged,
                 KeyPresenceStatus.IN_BOTH),
             new DiffRoutesOutput(
                 new RouteRowKey("node", "vrf", Prefix.parse("1.1.1.1/24")),
-                new RouteRowSecondaryKey(nextHop, nextHopIp, "bgp"),
+                new RouteRowSecondaryKey(nextHop, "bgp"),
                 KeyPresenceStatus.ONLY_IN_SNAPSHOT,
                 diffMatrixMissingRefs,
                 KeyPresenceStatus.IN_BOTH),
             new DiffRoutesOutput(
                 new RouteRowKey("node", "vrf", Prefix.parse("1.1.1.1/24")),
-                new RouteRowSecondaryKey(nextHop, nextHopIp, "bgp"),
+                new RouteRowSecondaryKey(nextHop, "bgp"),
                 KeyPresenceStatus.ONLY_IN_REFERENCE,
                 diffMatrixMissingBase,
                 KeyPresenceStatus.IN_BOTH),
             new DiffRoutesOutput(
                 new RouteRowKey("node", "vrf", Prefix.parse("1.1.1.1/24")),
-                new RouteRowSecondaryKey(nextHop, nextHopIp, "bgp"),
+                new RouteRowSecondaryKey(nextHop, "bgp"),
                 KeyPresenceStatus.IN_BOTH,
                 diffMatrixMissingRefs,
                 KeyPresenceStatus.IN_BOTH),
             new DiffRoutesOutput(
                 new RouteRowKey("node", "vrf", Prefix.parse("1.1.1.1/24")),
-                new RouteRowSecondaryKey(nextHop, nextHopIp, "bgp"),
+                new RouteRowSecondaryKey(nextHop, "bgp"),
                 KeyPresenceStatus.IN_BOTH,
                 diffMatrixMissingBase,
                 KeyPresenceStatus.IN_BOTH));
@@ -566,8 +566,7 @@ public class RoutesAnswererUtilTest {
             ImmutableSet.of("n1"),
             null,
             ".*",
-            RoutingProtocolSpecifier.ALL_PROTOCOLS_SPECIFIER,
-            null);
+            RoutingProtocolSpecifier.ALL_PROTOCOLS_SPECIFIER);
 
     assertThat(grouped.keySet(), hasSize(1));
     RouteRowKey expectedKey =
@@ -579,16 +578,14 @@ public class RoutesAnswererUtilTest {
     // checking equality of inner group
     Map<RouteRowSecondaryKey, SortedSet<RouteRowAttribute>> expectedInnerMap =
         ImmutableMap.of(
-            new RouteRowSecondaryKey(
-                NextHopInterface.of("e0", Ip.parse("1.1.1.2")), Ip.parse("1.1.1.2"), "ospfE2"),
+            new RouteRowSecondaryKey(NextHopInterface.of("e0", Ip.parse("1.1.1.2")), "ospfE2"),
             ImmutableSortedSet.of(
                 RouteRowAttribute.builder()
                     .setAdminDistance(10)
                     .setMetric(30L)
                     .setNextHopInterface("e0")
                     .build()),
-            new RouteRowSecondaryKey(
-                NextHopInterface.of("e0", Ip.parse("1.1.1.3")), Ip.parse("1.1.1.3"), "ospfE2"),
+            new RouteRowSecondaryKey(NextHopInterface.of("e0", Ip.parse("1.1.1.3")), "ospfE2"),
             ImmutableSortedSet.of(
                 RouteRowAttribute.builder()
                     .setAdminDistance(10)
@@ -655,8 +652,7 @@ public class RoutesAnswererUtilTest {
     // only the ibgp route is included because of the RoutingProtocolSpecifier above
     Map<RouteRowSecondaryKey, SortedSet<RouteRowAttribute>> expectedInnerMap =
         ImmutableMap.of(
-            new RouteRowSecondaryKey(
-                NextHopIp.of(Ip.parse("1.1.1.3")), Ip.parse("1.1.1.3"), "ibgp"),
+            new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.3")), "ibgp"),
             ImmutableSortedSet.of(
                 RouteRowAttribute.builder()
                     .setAdminDistance(10)
@@ -723,7 +719,7 @@ public class RoutesAnswererUtilTest {
     // checking equality of inner group
     Map<RouteRowSecondaryKey, SortedSet<RouteRowAttribute>> expectedInnerMap =
         ImmutableMap.of(
-            new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.2")), Ip.parse("1.1.1.2"), "bgp"),
+            new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.2")), "bgp"),
             ImmutableSortedSet.of(
                 RouteRowAttribute.builder()
                     .setAdminDistance(10)
@@ -733,7 +729,7 @@ public class RoutesAnswererUtilTest {
                     .setOriginType(OriginType.IGP)
                     .setStatus(BEST)
                     .build()),
-            new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.3")), Ip.parse("1.1.1.3"), "bgp"),
+            new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.3")), "bgp"),
             ImmutableSortedSet.of(
                 RouteRowAttribute.builder()
                     .setAdminDistance(10)
@@ -786,7 +782,7 @@ public class RoutesAnswererUtilTest {
     // checking equality of inner group
     Map<RouteRowSecondaryKey, SortedSet<RouteRowAttribute>> expectedInnerMap =
         ImmutableMap.of(
-            new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.2")), Ip.parse("1.1.1.2"), "bgp"),
+            new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.2")), "bgp"),
             ImmutableSortedSet.of(
                 RouteRowAttribute.builder()
                     .setAdminDistance(10)
@@ -803,20 +799,16 @@ public class RoutesAnswererUtilTest {
   @Test
   public void testGetRoutesDiffCommonKey() {
     RouteRowKey routeRowKey = new RouteRowKey("node", "vrf", Prefix.parse("2.2.2.2/24"));
-    RouteRowSecondaryKey rrsk1 =
-        new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.1")), Ip.parse("1.1.1.1"), "bgp");
-    RouteRowSecondaryKey rrsk2 =
-        new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.2")), Ip.parse("1.1.1.2"), "bgp");
-    RouteRowSecondaryKey rrsk3 =
-        new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.3")), Ip.parse("1.1.1.3"), "bgp");
-    RouteRowSecondaryKey rrsk4 =
-        new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.4")), Ip.parse("1.1.1.4"), "bgp");
+    RouteRowSecondaryKey rrsk1 = new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.1")), "bgp");
+    RouteRowSecondaryKey rrsk2 = new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.2")), "bgp");
+    RouteRowSecondaryKey rrsk3 = new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.3")), "bgp");
+    RouteRowSecondaryKey rrsk4 = new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.4")), "bgp");
 
-    RouteRowAttribute rra1 = RouteRowAttribute.builder().setNextHop("node1").build();
-    RouteRowAttribute rra2 = RouteRowAttribute.builder().setNextHop("node2").build();
-    RouteRowAttribute rra3 = RouteRowAttribute.builder().setNextHop("node3").build();
-    RouteRowAttribute rra4 = RouteRowAttribute.builder().setNextHop("node4").build();
-    RouteRowAttribute rra5 = RouteRowAttribute.builder().setNextHop("node5").build();
+    RouteRowAttribute rra1 = RouteRowAttribute.builder().setAdminDistance(10).build();
+    RouteRowAttribute rra2 = RouteRowAttribute.builder().setAdminDistance(20).build();
+    RouteRowAttribute rra3 = RouteRowAttribute.builder().setAdminDistance(30).build();
+    RouteRowAttribute rra4 = RouteRowAttribute.builder().setAdminDistance(40).build();
+    RouteRowAttribute rra5 = RouteRowAttribute.builder().setAdminDistance(50).build();
 
     ImmutableMap.Builder<RouteRowSecondaryKey, SortedSet<RouteRowAttribute>>
         immutablelMapBuilderBase = ImmutableMap.builder();
@@ -880,13 +872,11 @@ public class RoutesAnswererUtilTest {
     RouteRowKey routeRowKey1 = new RouteRowKey("node1", "vrf", Prefix.parse("1.1.1.1/24"));
     RouteRowKey routeRowKey2 = new RouteRowKey("node2", "vrf", Prefix.parse("1.1.1.2/24"));
 
-    RouteRowSecondaryKey rrsk1 =
-        new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.1")), Ip.parse("1.1.1.1"), "bgp");
-    RouteRowSecondaryKey rrsk2 =
-        new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.2")), Ip.parse("1.1.1.2"), "bgp");
+    RouteRowSecondaryKey rrsk1 = new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.1")), "bgp");
+    RouteRowSecondaryKey rrsk2 = new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.2")), "bgp");
 
-    RouteRowAttribute rra1 = RouteRowAttribute.builder().setNextHop("node11").build();
-    RouteRowAttribute rra2 = RouteRowAttribute.builder().setNextHop("node22").build();
+    RouteRowAttribute rra1 = RouteRowAttribute.builder().setAdminDistance(11).build();
+    RouteRowAttribute rra2 = RouteRowAttribute.builder().setAdminDistance(22).build();
 
     ImmutableMap.Builder<RouteRowSecondaryKey, SortedSet<RouteRowAttribute>>
         immutablelMapBuilderBase = ImmutableMap.builder();
@@ -925,7 +915,7 @@ public class RoutesAnswererUtilTest {
   @Test
   public void testAbstractRoutesRowDiff() {
     RouteRowAttribute.Builder routeRowAttrBuilder =
-        RouteRowAttribute.builder().setAdminDistance(200).setMetric(2L).setNextHop("node1");
+        RouteRowAttribute.builder().setAdminDistance(200).setMetric(2L);
 
     List<List<RouteRowAttribute>> diffMatrix = new ArrayList<>();
     diffMatrix.add(Lists.newArrayList(routeRowAttrBuilder.build(), routeRowAttrBuilder.build()));
@@ -934,8 +924,7 @@ public class RoutesAnswererUtilTest {
         ImmutableList.of(
             new DiffRoutesOutput(
                 new RouteRowKey("node", "vrf", Prefix.parse("1.1.1.1/24")),
-                new RouteRowSecondaryKey(
-                    NextHopIp.of(Ip.parse("1.1.1.1")), Ip.parse("1.1.1.2"), "bgp"),
+                new RouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.1")), "bgp"),
                 KeyPresenceStatus.IN_BOTH,
                 diffMatrix,
                 KeyPresenceStatus.IN_BOTH));
@@ -952,11 +941,10 @@ public class RoutesAnswererUtilTest {
   }
 
   @Test
-  public void testpopulateRouteRowAttributes() {
+  public void testPopulateRouteRowAttributes() {
     RouteRowAttribute routeRowAttribute =
         RouteRowAttribute.builder()
             .setNextHopInterface("nhIface1")
-            .setNextHop("nh1")
             .setMetric(1L)
             .setAdminDistance(1)
             .setTag(1L)


### PR DESCRIPTION
1. Move the ability to get legacy next hops from NextHop out into a common
   utility.
2. Remove redundant information in RouteRowSecondaryKey.
3. Fixups.

Note no refs changed.