### PR TITLE
Location-independent IpSpace resolution

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ConstantIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ConstantIpSpaceSpecifier.java
@@ -39,6 +39,11 @@ public final class ConstantIpSpaceSpecifier implements IpSpaceSpecifier {
   }
 
   @Override
+  public IpSpace resolve(SpecifierContext ctxt) {
+    return _ipSpace;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(ConstantIpSpaceSpecifier.class)
         .add("ipSpace", _ipSpace)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InferFromLocationIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InferFromLocationIpSpaceSpecifier.java
@@ -19,4 +19,10 @@ public final class InferFromLocationIpSpaceSpecifier implements IpSpaceSpecifier
         location -> builder.assign(location, ctxt.getLocationInfo(location).getSourceIps()));
     return builder.build();
   }
+
+  @Override
+  public IpSpace resolve(SpecifierContext ctxt) {
+    throw new UnsupportedOperationException(
+        "Location-independent resolution is not valid for " + getClass().getSimpleName());
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/IpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/IpSpaceSpecifier.java
@@ -6,9 +6,9 @@ import org.batfish.datamodel.IpSpace;
 /** An abstract specifier of {@link IpSpace}s by some means. */
 public interface IpSpaceSpecifier {
   /**
-   * Resolve the specifier into concrete {@link IpSpace}s.
+   * Resolve the specifier into a concrete {@link IpSpace} for each specified location.
    *
-   * @param locations The @{link Location}s for which concrete {@link IpSpace}s are needed. Which
+   * @param locations The {@link Location}s for which concrete {@link IpSpace}s are needed. Which
    *     concrete {@link IpSpace} is specified may (or may not) vary with {@link Location}.
    * @param ctxt Information about the network that may be used to resolve concrete {@link
    *     IpSpace}s.
@@ -17,4 +17,7 @@ public interface IpSpaceSpecifier {
    *     Location}s, and that no {@link Location} is assigned more than one {@link IpSpace}.
    */
   IpSpaceAssignment resolve(Set<Location> locations, SpecifierContext ctxt);
+
+  /** Resolve the specifier into concrete {@link IpSpace}s. */
+  IpSpace resolve(SpecifierContext ctxt);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationIpSpaceSpecifier.java
@@ -53,6 +53,11 @@ public final class LocationIpSpaceSpecifier implements IpSpaceSpecifier {
     return IpSpaceAssignment.builder().assign(key, computeIpSpace(locations, ctxt)).build();
   }
 
+  @Override
+  public IpSpace resolve(SpecifierContext ctxt) {
+    return computeIpSpace(_locationSpecifier.resolve(ctxt), ctxt);
+  }
+
   @Nonnull
   public static IpSpace computeIpSpace(Set<Location> locations, SpecifierContext ctxt) {
     return firstNonNull(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ReferenceAddressGroupIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ReferenceAddressGroupIpSpaceSpecifier.java
@@ -51,6 +51,11 @@ public final class ReferenceAddressGroupIpSpaceSpecifier implements IpSpaceSpeci
     return IpSpaceAssignment.builder().assign(locations, ipSpace).build();
   }
 
+  @Override
+  public IpSpace resolve(SpecifierContext ctxt) {
+    return computeIpSpace(_addressGroupName, _bookName, ctxt);
+  }
+
   /**
    * Computes the IpSpace in the address group. Returns {@link EmptyIpSpace} if the addressgroup is
    * empty.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledIpSpaceSpecifier.java
@@ -184,6 +184,11 @@ public final class ParboiledIpSpaceSpecifier implements IpSpaceSpecifier {
     return IpSpaceAssignment.builder().assign(locations, ipSpace).build();
   }
 
+  @Override
+  public IpSpace resolve(SpecifierContext ctxt) {
+    return computeIpSpace(_ast, ctxt);
+  }
+
   @VisibleForTesting
   @Nonnull
   static IpSpace computeIpSpace(IpSpaceAstNode ast, SpecifierContext ctxt) {

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersAnswerer.java
@@ -118,14 +118,11 @@ public final class SpecifiersAnswerer extends Answerer {
     TableAnswerElement table = new TableAnswerElement(new TableMetadata(columns));
     Map<String, ColumnMetadata> columnMap = table.getMetadata().toColumnMap();
 
-    // this will yield all default locations for the factory
-    Set<Location> locations = question.getLocationSpecifier().resolve(context);
-    IpSpaceAssignment ipSpaceAssignment =
-        question.getIpSpaceSpecifier().resolve(locations, context);
-
-    for (IpSpaceAssignment.Entry entry : ipSpaceAssignment.getEntries()) {
-      table.addRow(Row.of(columnMap, COL_IP_SPACE, Objects.toString(entry.getIpSpace())));
-    }
+    table.addRow(
+        Row.of(
+            columnMap,
+            COL_IP_SPACE,
+            Objects.toString(question.getIpSpaceSpecifier().resolve(context))));
     return table;
   }
 
@@ -142,7 +139,7 @@ public final class SpecifiersAnswerer extends Answerer {
 
     Set<Location> locations = question.getLocationSpecifier().resolve(context);
     IpSpaceAssignment ipSpaceAssignment =
-        question.getIpSpaceSpecifier().resolve(locations, context);
+        question.getIpSpaceOfLocationSpecifier().resolve(locations, context);
 
     for (IpSpaceAssignment.Entry entry : ipSpaceAssignment.getEntries()) {
       table.addRow(

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersQuestion.java
@@ -9,11 +9,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.specifier.AllFiltersFilterSpecifier;
 import org.batfish.specifier.AllInterfacesInterfaceSpecifier;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
 import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.FilterSpecifier;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
 import org.batfish.specifier.InterfaceSpecifier;
@@ -90,6 +92,14 @@ public final class SpecifiersQuestion extends Question {
 
   @JsonIgnore
   IpSpaceSpecifier getIpSpaceSpecifier() {
+    return SpecifierFactories.getIpSpaceSpecifierOrDefault(
+        _ipSpaceSpecifierInput,
+        new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE),
+        _specifierFactoryVersion);
+  }
+
+  @JsonIgnore
+  IpSpaceSpecifier getIpSpaceOfLocationSpecifier() {
     return SpecifierFactories.getIpSpaceSpecifierOrDefault(
         _ipSpaceSpecifierInput,
         InferFromLocationIpSpaceSpecifier.INSTANCE,

--- a/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersQuestionTest.java
@@ -9,6 +9,7 @@ import org.batfish.specifier.AllFiltersFilterSpecifier;
 import org.batfish.specifier.AllInterfacesInterfaceSpecifier;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
 import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
 import org.batfish.specifier.SpecifierFactories;
 import org.batfish.specifier.SpecifierFactories.Version;
@@ -28,7 +29,10 @@ public final class SpecifiersQuestionTest {
     SpecifiersQuestion question = new SpecifiersQuestion(QueryType.FILTER);
     assertThat(question.getFilterSpecifier(), equalTo(AllFiltersFilterSpecifier.INSTANCE));
     assertThat(question.getInterfaceSpecifier(), equalTo(AllInterfacesInterfaceSpecifier.INSTANCE));
-    assertThat(question.getIpSpaceSpecifier(), instanceOf(InferFromLocationIpSpaceSpecifier.class));
+    assertThat(question.getIpSpaceSpecifier(), instanceOf(ConstantIpSpaceSpecifier.class));
+    assertThat(
+        question.getIpSpaceOfLocationSpecifier(),
+        instanceOf(InferFromLocationIpSpaceSpecifier.class));
     assertThat(question.getLocationSpecifier(), instanceOf(AllInterfacesLocationSpecifier.class));
     assertThat(question.getNodeSpecifier(), instanceOf(AllNodesNodeSpecifier.class));
   }
@@ -53,6 +57,9 @@ public final class SpecifiersQuestionTest {
         instanceOf(SpecifierFactories.getInterfaceSpecifierOrDefault("input", null).getClass()));
     assertThat(
         question.getIpSpaceSpecifier(),
+        instanceOf(SpecifierFactories.getIpSpaceSpecifierOrDefault("input", null).getClass()));
+    assertThat(
+        question.getIpSpaceOfLocationSpecifier(),
         instanceOf(SpecifierFactories.getIpSpaceSpecifierOrDefault("input", null).getClass()));
     assertThat(
         question.getLocationSpecifier(),
@@ -94,6 +101,11 @@ public final class SpecifiersQuestionTest {
                 .getClass()));
     assertThat(
         question.getIpSpaceSpecifier(),
+        instanceOf(
+            SpecifierFactories.getIpSpaceSpecifierOrDefault("1.1.1.1", null, otherVersion)
+                .getClass()));
+    assertThat(
+        question.getIpSpaceOfLocationSpecifier(),
         instanceOf(
             SpecifierFactories.getIpSpaceSpecifierOrDefault("1.1.1.1", null, otherVersion)
                 .getClass()));


### PR DESCRIPTION
IpSpace is a concept that is independent of Location, yet the only resolution BF had for it was tied to Location (the input was a set of Locations and the output was IpSpaceAssignment for those locations). When a location-independent resolution is needed, the clients were being forced to specify all possible locations (or a dummy location). 

This PR adds location-independent resolution for IpSpaceSpecifier, which returns the IpSpace. 