### PR TITLE
NXOS: Support unsetting VRF in interface

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -990,6 +990,7 @@ i_no
     | i_no_null
     | i_no_shutdown
     | i_no_switchport
+    | i_no_vrf_member
   )
 ;
 
@@ -1169,6 +1170,11 @@ inos_switchport
 :
   // just newline, for `no switchport`
   NEWLINE
+;
+
+i_no_vrf_member
+:
+  VRF MEMBER (name = vrf_name)? NEWLINE
 ;
 
 i_null

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
@@ -564,7 +564,7 @@ public final class Interface implements Serializable {
     _switchportMonitor = switchportMonitor;
   }
 
-  public void setVrfMember(String vrfMember) {
+  public void setVrfMember(@Nullable String vrfMember) {
     _vrfMember = vrfMember;
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vrf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vrf
@@ -44,15 +44,50 @@ interface Ethernet1/4
   ip address 10.0.4.1/24
 !
 
+! Add interface to vrf1, apply l3 configuration, then remove it from vrf1
+! - shutdown = false
+! - active = true
+! - address = null (erased by clearing vrf member)
+interface Ethernet1/5
+  no switchport
+  no shutdown
+  vrf member vrf1
+  ip address 10.0.5.1/24
+  no vrf member vrf1
+!
+
+! Add interface to vrf1, then remove it without specifying vrf (same effect as above)
+! - shutdown = false
+! - active = true
+! - address = null
+interface Ethernet1/6
+  no switchport
+  no shutdown
+  vrf member vrf1
+  ip address 10.0.6.1/24
+  no vrf member
+!
+
+! Use "no vrf member" on an interface already in the default VRF: no effect, no warnings
+! - shutdown = false
+! - active = true
+! - address = 10.0.7.1/24
+interface Ethernet1/7
+  no switchport
+  no shutdown
+  ip address 10.0.7.1/24
+  no vrf member
+!
+
 ! Add interface to shutdown VRF vrf3
 ! - shutdown = false
 ! - active = false (vrf3 is shutdown)
 ! - address = 10.0.5.1/24
-interface Ethernet1/5
+interface Ethernet1/8
   no switchport
   no shutdown
   vrf member vrf3
-  ip address 10.0.5.1/24
+  ip address 10.0.8.1/24
 !
 
 !!! Keep VRF definitions under default VRF configuration to avoid accidental leakage

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vrf_invalid
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vrf_invalid
@@ -14,8 +14,25 @@ interface Ethernet1/1
   vrf member vrf1
 !
 
+! Cannot remove interface from a VRF it's not in (whether it's in a non-default VRF or not)
+! Attempting to do so should generate a warning and should not clear L3 configuration
+interface Ethernet1/2
+  no switchport
+  no shutdown
+  ip address 10.0.2.1/24
+  no vrf member vrf1
+!
+interface Ethernet1/3
+  no switchport
+  no shutdown
+  vrf member vrf1
+  ip address 10.0.3.1/24
+  no vrf member vrf2
+!
+
 !!! Keep VRF definitions under default VRF configuration to avoid accidental leakage
 vrf context vrf1
+vrf context vrf2
 
 ! VRF name is too long (exceeds 32 characters)
 vrf context .........1.........2.........3...


### PR DESCRIPTION
Adds support for both `no vrf member FOO` and `no vrf member` in interface context. The former will generate a warning if the current interface is not in the specified VRF (in which case the command has no effect).