### PR TITLE
NXOS: Support removing BGP neighbors

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_bgp.g4
@@ -544,7 +544,11 @@ rb_no_neighbor
     | prefix6 = ipv6_prefix
   )
   (
-    REMOTE_AS asn = bgp_asn
+    REMOTE_AS
+    (
+      asn = bgp_asn?
+      | ROUTE_MAP mapname = route_map_name
+    )
   )? NEWLINE
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_bgp.g4
@@ -69,6 +69,7 @@ rb_proc_vrf_common
   | rb_log_neighbor_changes
   | rb_maxas_limit
   | rb_neighbor
+  | rb_proc_vrf_common_no
   | rb_reconnect_interval
   | rb_router_id
   | rb_suppress_fib_pending
@@ -524,6 +525,28 @@ rb_neighbor
     )
   )? NEWLINE rb_n_inner*
 ;
+
+rb_proc_vrf_common_no
+ :
+   NO
+   (
+     rb_no_neighbor
+   )
+ ;
+
+rb_no_neighbor
+ :
+  NEIGHBOR
+  (
+    ip = ip_address
+    | prefix = ip_prefix
+    | ip6 = ipv6_address
+    | prefix6 = ipv6_prefix
+  )
+  (
+    REMOTE_AS asn = bgp_asn
+  )? NEWLINE
+ ;
 
 // We might get to this level of the hierarchy in four ways:
 //  1. configuring an actual neighbor (router bgp ; (optional vrf) ; neighbor)

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_bgp.g4
@@ -527,16 +527,16 @@ rb_neighbor
 ;
 
 rb_proc_vrf_common_no
- :
-   NO
-   (
-     rb_no_neighbor
-   )
- ;
+:
+  NO
+  (
+    rb_no_neighbor
+  )
+;
 
 rb_no_neighbor
- :
-  NEIGHBOR
+:
+ NEIGHBOR
   (
     ip = ip_address
     | prefix = ip_prefix
@@ -546,7 +546,7 @@ rb_no_neighbor
   (
     REMOTE_AS asn = bgp_asn
   )? NEWLINE
- ;
+;
 
 // We might get to this level of the hierarchy in four ways:
 //  1. configuring an actual neighbor (router bgp ; (optional vrf) ; neighbor)

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -4045,17 +4045,25 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     // specified remote AS does not match the removed neighbor's remote AS.
     if (ctx.ip != null) {
       Ip ip = toIp(ctx.ip);
-      _currentBgpVrfConfiguration.removeNeighbor(ip);
+      if (!_currentBgpVrfConfiguration.removeNeighbor(ip)) {
+        warn(ctx, String.format("Neighbor %s does not exist", ip));
+      }
     } else if (ctx.prefix != null) {
       Prefix prefix = toPrefix(ctx.prefix);
-      _currentBgpVrfConfiguration.removePassiveNeighbor(prefix);
+      if (!_currentBgpVrfConfiguration.removePassiveNeighbor(prefix)) {
+        warn(ctx, String.format("Neighbor %s does not exist", prefix));
+      }
     } else if (ctx.ip6 != null) {
       Ip6 ip = toIp6(ctx.ip6);
-      _currentBgpVrfConfiguration.removeNeighbor(ip);
+      if (!_currentBgpVrfConfiguration.removeNeighbor(ip)) {
+        warn(ctx, String.format("Neighbor %s does not exist", ip));
+      }
     } else {
       assert ctx.prefix6 != null;
       Prefix6 prefix = toPrefix6(ctx.prefix6);
-      _currentBgpVrfConfiguration.removePassiveNeighbor(prefix);
+      if (!_currentBgpVrfConfiguration.removePassiveNeighbor(prefix)) {
+        warn(ctx, String.format("Neighbor %s does not exist", prefix));
+      }
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -347,6 +347,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_ipv6_address_dhcpContext
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_mtuContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_autostateContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_descriptionContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_vrf_memberContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_private_vlanContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_shutdownContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_speed_numberContext;
@@ -572,6 +573,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_shutdownContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_update_sourceContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_neighborContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_no_enforce_first_asContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_no_neighborContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_router_idContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_template_peerContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_template_peer_policyContext;
@@ -4038,6 +4040,26 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
+  public void exitRb_no_neighbor(Rb_no_neighborContext ctx) {
+    // Note that although ctx may specify remote-as, it doesn't affect the outcome, even if the
+    // specified remote AS does not match the removed neighbor's remote AS.
+    if (ctx.ip != null) {
+      Ip ip = toIp(ctx.ip);
+      _currentBgpVrfConfiguration.removeNeighbor(ip);
+    } else if (ctx.prefix != null) {
+      Prefix prefix = toPrefix(ctx.prefix);
+      _currentBgpVrfConfiguration.removePassiveNeighbor(prefix);
+    } else if (ctx.ip6 != null) {
+      Ip6 ip = toIp6(ctx.ip6);
+      _currentBgpVrfConfiguration.removeNeighbor(ip);
+    } else {
+      assert ctx.prefix6 != null;
+      Prefix6 prefix = toPrefix6(ctx.prefix6);
+      _currentBgpVrfConfiguration.removePassiveNeighbor(prefix);
+    }
+  }
+
+  @Override
   public void enterRb_n_address_family(Rb_n_address_familyContext ctx) {
     String familyStr = ctx.first.getText() + '-' + ctx.second.getText();
     _currentBgpVrfNeighborAddressFamily =
@@ -5734,7 +5756,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
-  public void exitI_no_vrf_member(CiscoNxosParser.I_no_vrf_memberContext ctx) {
+  public void exitI_no_vrf_member(I_no_vrf_memberContext ctx) {
     String name = null;
     if (ctx.name != null) {
       Optional<String> nameOrErr = toString(ctx, ctx.name);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfConfiguration.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.cisco_nxos;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
@@ -82,12 +83,38 @@ public final class BgpVrfConfiguration implements Serializable {
     return _passiveNeighbors6.computeIfAbsent(prefix, p -> new BgpVrfNeighborConfiguration());
   }
 
+  public void removeNeighbor(Ip address) {
+    _neighbors.remove(address);
+  }
+
+  public void removeNeighbor(Ip6 address) {
+    _neighbors6.remove(address);
+  }
+
+  public void removePassiveNeighbor(Prefix prefix) {
+    _passiveNeighbors.remove(prefix);
+  }
+
+  public void removePassiveNeighbor(Prefix6 prefix) {
+    _passiveNeighbors6.remove(prefix);
+  }
+
   public Map<Ip, BgpVrfNeighborConfiguration> getNeighbors() {
     return Collections.unmodifiableMap(_neighbors);
   }
 
+  @VisibleForTesting // IPv6 neighbors not supported past extraction
+  public Map<Ip6, BgpVrfNeighborConfiguration> getNeighbors6() {
+    return _neighbors6;
+  }
+
   public Map<Prefix, BgpVrfNeighborConfiguration> getPassiveNeighbors() {
     return Collections.unmodifiableMap(_passiveNeighbors);
+  }
+
+  @VisibleForTesting // IPv6 neighbors not supported past extraction
+  public Map<Prefix6, BgpVrfNeighborConfiguration> getPassiveNeighbors6() {
+    return _passiveNeighbors6;
   }
 
   public boolean getBestpathAlwaysCompareMed() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfConfiguration.java
@@ -83,20 +83,20 @@ public final class BgpVrfConfiguration implements Serializable {
     return _passiveNeighbors6.computeIfAbsent(prefix, p -> new BgpVrfNeighborConfiguration());
   }
 
-  public void removeNeighbor(Ip address) {
-    _neighbors.remove(address);
+  public boolean removeNeighbor(Ip address) {
+    return _neighbors.remove(address) != null;
   }
 
-  public void removeNeighbor(Ip6 address) {
-    _neighbors6.remove(address);
+  public boolean removeNeighbor(Ip6 address) {
+    return _neighbors6.remove(address) != null;
   }
 
-  public void removePassiveNeighbor(Prefix prefix) {
-    _passiveNeighbors.remove(prefix);
+  public boolean removePassiveNeighbor(Prefix prefix) {
+    return _passiveNeighbors.remove(prefix) != null;
   }
 
-  public void removePassiveNeighbor(Prefix6 prefix) {
-    _passiveNeighbors6.remove(prefix);
+  public boolean removePassiveNeighbor(Prefix6 prefix) {
+    return _passiveNeighbors6.remove(prefix) != null;
   }
 
   public Map<Ip, BgpVrfNeighborConfiguration> getNeighbors() {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_no_neighbor
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_no_neighbor
@@ -55,7 +55,7 @@ router bgp 65001
     neighbor 11.0.0.2 remote-as 65002
     neighbor 11.0.0.3 remote-as 65002
     neighbor 11.0.0.4 remote-as 65002
-    no neighbor 5.5.5.5
+    no neighbor 6.6.6.6
     no neighbor 11.0.0.1
     no neighbor 11.0.0.2 remote-as 65002
     no neighbor 11.0.0.3 remote-as 65100
@@ -64,7 +64,7 @@ router bgp 65001
     neighbor 11.1.2.0/24 remote-as 65002
     neighbor 11.1.3.0/24 remote-as 65002
     neighbor 11.1.4.0/24 remote-as 65002
-    no neighbor 5.5.5.0/24
+    no neighbor 6.6.6.0/24
     no neighbor 11.1.1.0/24
     no neighbor 11.1.2.0/24 remote-as 65002
     no neighbor 11.1.3.0/24 remote-as 65100
@@ -73,7 +73,7 @@ router bgp 65001
     neighbor 11:10::10:2 remote-as 65002
     neighbor 11:10::10:3 remote-as 65002
     neighbor 11:10::10:4 remote-as 65002
-    no neighbor 5:5::5:5
+    no neighbor 6:6::6:6
     no neighbor 11:10::10:1
     no neighbor 11:10::10:2 remote-as 65002
     no neighbor 11:10::10:3 remote-as 65100
@@ -82,7 +82,7 @@ router bgp 65001
     neighbor 11:2::/112 remote-as 65002
     neighbor 11:3::/112 remote-as 65002
     neighbor 11:4::/112 remote-as 65002
-    no neighbor 5:5::/112
+    no neighbor 6:6::/112
     no neighbor 11:1::/112
     no neighbor 11:2::/112 remote-as 65002
     no neighbor 11:3::/112 remote-as 65100

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_no_neighbor
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_no_neighbor
@@ -1,0 +1,88 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_bgp_no_neighbor
+feature bgp
+!
+vrf context vrf1
+!
+router bgp 65001
+    neighbor 10.0.0.1 remote-as 65002
+    neighbor 10.0.0.2 remote-as 65002
+    neighbor 10.0.0.3 remote-as 65002
+    neighbor 10.0.0.4 remote-as 65002
+  ! Remove undefined neighbor: no effect, no warning
+    no neighbor 5.5.5.5
+  ! Remove a neighbor without specifying remote AS
+    no neighbor 10.0.0.1
+  ! Remove a neighbor with correct remote AS specified
+    no neighbor 10.0.0.2 remote-as 65002
+  ! Remove a neighbor with a different remote AS specified (still works)
+    no neighbor 10.0.0.3 remote-as 65100
+  !
+  ! Same tests for passive neighbors
+    neighbor 10.1.1.0/24 remote-as 65002
+    neighbor 10.1.2.0/24 remote-as 65002
+    neighbor 10.1.3.0/24 remote-as 65002
+    neighbor 10.1.4.0/24 remote-as 65002
+    no neighbor 5.5.5.0/24
+    no neighbor 10.1.1.0/24
+    no neighbor 10.1.2.0/24 remote-as 65002
+    no neighbor 10.1.3.0/24 remote-as 65100
+  !
+  ! Same tests for IPV6 neighbors
+    neighbor 10:10::10:1 remote-as 65002
+    neighbor 10:10::10:2 remote-as 65002
+    neighbor 10:10::10:3 remote-as 65002
+    neighbor 10:10::10:4 remote-as 65002
+    no neighbor 5:5::5:5
+    no neighbor 10:10::10:1
+    no neighbor 10:10::10:2 remote-as 65002
+    no neighbor 10:10::10:3 remote-as 65100
+  !
+  ! Same tests for IPV6 passive neighbors
+    neighbor 10:1::/112 remote-as 65002
+    neighbor 10:2::/112 remote-as 65002
+    neighbor 10:3::/112 remote-as 65002
+    neighbor 10:4::/112 remote-as 65002
+    no neighbor 5:5::/112
+    no neighbor 10:1::/112
+    no neighbor 10:2::/112 remote-as 65002
+    no neighbor 10:3::/112 remote-as 65100
+  !
+  ! Same tests in VRF context
+  vrf vrf1
+    neighbor 11.0.0.1 remote-as 65002
+    neighbor 11.0.0.2 remote-as 65002
+    neighbor 11.0.0.3 remote-as 65002
+    neighbor 11.0.0.4 remote-as 65002
+    no neighbor 5.5.5.5
+    no neighbor 11.0.0.1
+    no neighbor 11.0.0.2 remote-as 65002
+    no neighbor 11.0.0.3 remote-as 65100
+    !
+    neighbor 11.1.1.0/24 remote-as 65002
+    neighbor 11.1.2.0/24 remote-as 65002
+    neighbor 11.1.3.0/24 remote-as 65002
+    neighbor 11.1.4.0/24 remote-as 65002
+    no neighbor 5.5.5.0/24
+    no neighbor 11.1.1.0/24
+    no neighbor 11.1.2.0/24 remote-as 65002
+    no neighbor 11.1.3.0/24 remote-as 65100
+    !
+    neighbor 11:10::10:1 remote-as 65002
+    neighbor 11:10::10:2 remote-as 65002
+    neighbor 11:10::10:3 remote-as 65002
+    neighbor 11:10::10:4 remote-as 65002
+    no neighbor 5:5::5:5
+    no neighbor 11:10::10:1
+    no neighbor 11:10::10:2 remote-as 65002
+    no neighbor 11:10::10:3 remote-as 65100
+    !
+    neighbor 11:1::/112 remote-as 65002
+    neighbor 11:2::/112 remote-as 65002
+    neighbor 11:3::/112 remote-as 65002
+    neighbor 11:4::/112 remote-as 65002
+    no neighbor 5:5::/112
+    no neighbor 11:1::/112
+    no neighbor 11:2::/112 remote-as 65002
+    no neighbor 11:3::/112 remote-as 65100


### PR DESCRIPTION
Adds support for removal of BGP neighbors via `no neighbor` command, including all permutations of:
- Active or passive
- IPv4 or IPv6
- Inside or outside of VRF context
- With or without remote AS specified