### PR TITLE
Cisco NX-OS IRB associated with vn-segment should be up via autostate

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -3874,7 +3874,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         (vlanId, vlan) -> {
           if (vlan.getVni() != null) {
             // Ensure IRB stays up even if it has no associated switchports
-            //
             _c.setNormalVlanRange(_c.getNormalVlanRange().difference(IntegerSpace.of(vlanId)));
           }
         });

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1489,9 +1489,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                       && iface.getVrfName().equals(vsTenantVrfForL3Vni.getName()))) {
         return;
       }
-      // Ensure IRB stays up even if it has no associated switchports
-      //
-      _c.setNormalVlanRange(_c.getNormalVlanRange().difference(IntegerSpace.of(vlan)));
       Layer3Vni vniSettings =
           Layer3Vni.builder()
               .setSourceAddress(
@@ -3862,6 +3859,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     convertStaticRoutes();
     computeImplicitOspfAreas();
     convertOspfProcesses();
+    convertVlans();
     convertNves();
     convertBgp();
     convertEigrp();
@@ -3869,6 +3867,17 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     markStructures();
     return _c;
+  }
+
+  private void convertVlans() {
+    _vlans.forEach(
+        (vlanId, vlan) -> {
+          if (vlan.getVni() != null) {
+            // Ensure IRB stays up even if it has no associated switchports
+            //
+            _c.setNormalVlanRange(_c.getNormalVlanRange().difference(IntegerSpace.of(vlanId)));
+          }
+        });
   }
 
   private void makeLeakConfigs() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -5407,9 +5407,9 @@ public final class CiscoNxosGrammarTest {
             hasSourceAddress(nullValue()),
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
             hasVni(20001)));
-    // Make sure Vlan3 and Vlan7 - associated with vn-segments - are up after post-processing.
-    // While they has no associated switchports and are in autostate, they should stay up since they
-    // are associated with vn-segments.
+    // Make sure Vlan3 and Vlan7 are up after post-processing. While they have no associated
+    // switchports and are in autostate, they should stay up since they are associated with
+    // vn-segments.
     assertThat(c, hasInterface("Vlan3", isActive()));
     assertThat(c, hasInterface("Vlan7", isActive()));
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -5407,10 +5407,11 @@ public final class CiscoNxosGrammarTest {
             hasSourceAddress(nullValue()),
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
             hasVni(20001)));
-    // Make sure Vlan3 - associated with VNI 20001 - is up after post-processing. While it has no
-    // associated switchports and is in autostate, it should stay up since it is associated with a
-    // Layer3Vni.
+    // Make sure Vlan3 and Vlan7 - associated with vn-segments - are up after post-processing.
+    // While they has no associated switchports and are in autostate, they should stay up since they
+    // are associated with vn-segments.
     assertThat(c, hasInterface("Vlan3", isActive()));
+    assertThat(c, hasInterface("Vlan7", isActive()));
 
     assertThat(c, hasDefaultVrf(hasLayer2Vnis(hasKey(30001))));
     assertThat(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
@@ -27,6 +27,9 @@ vlan 6
   name Name-Of-Vlan-6
   vn-segment 50001
 !
+vlan 7
+  name Name-Of-Vlan-7
+  vn-segment 60001
 interface loopback0
   ip address 1.1.1.1/32
 !
@@ -92,4 +95,7 @@ interface Vlan5
   no shutdown
 !
 interface Vlan6
+!
+interface Vlan7
+  no shutdown
 !


### PR DESCRIPTION
- relax condition for VXLAN autostate whitelist for vlans to any vlan
  associated with a vn-segment
  - previously, vlan had to be associated with layer-3 VNI