### PR TITLE
NXOS: Support removing static routes in VRF context

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vrf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vrf.g4
@@ -111,7 +111,15 @@ vc_ipv6
 
 vc_no
 :
-  NO vc_no_shutdown
+  NO (
+    vc_no_ip
+    | vc_no_shutdown
+  )
+;
+
+vc_no_ip
+:
+  IP no_ip_route
 ;
 
 vc_no_shutdown

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -6043,7 +6043,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
               Collection<StaticRoute> staticRoutes =
                   _currentVrf.getStaticRoutes().get(sr.getPrefix());
               // TODO smarter "equality" checking
-              // Some attributes don't need to match the original route, like tag or priority
+              // Some attributes don't need to match the original route, like tag, priority, name
               if (!staticRoutes.contains(sr)) {
                 warn(ctx, "Cannot delete non-existent route");
                 return;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -8388,19 +8388,30 @@ public final class CiscoNxosGrammarTest {
     String hostname = "nxos_no_static_route";
     CiscoNxosConfiguration vc = parseVendorConfig(hostname);
 
-    assertThat(vc.getVrfs(), hasKeys(DEFAULT_VRF_NAME, MANAGEMENT_VRF_NAME));
-    assertThat(vc.getDefaultVrf().getStaticRoutes().asMap(), hasKeys(Prefix.strict("10.0.1.0/24")));
-
-    Collection<StaticRoute> routes =
-        vc.getDefaultVrf().getStaticRoutes().get(Prefix.strict("10.0.1.0/24"));
-    assertThat(
-        routes,
-        contains(
-            StaticRoute.builder()
-                .setPrefix(Prefix.parse("10.0.1.0/24"))
-                .setNextHopInterface("Ethernet1/1")
-                .setNextHopIp(Ip.parse("10.0.1.1"))
-                .build()));
+    assertThat(vc.getVrfs(), hasKeys(DEFAULT_VRF_NAME, MANAGEMENT_VRF_NAME, "vrf1"));
+    {
+      // Default VRF
+      Collection<StaticRoute> routes = vc.getDefaultVrf().getStaticRoutes().values();
+      assertThat(
+          routes,
+          contains(
+              StaticRoute.builder()
+                  .setPrefix(Prefix.parse("10.0.1.0/24"))
+                  .setNextHopInterface("Ethernet1/1")
+                  .setNextHopIp(Ip.parse("10.0.1.1"))
+                  .build()));
+    }
+    {
+      // vrf1
+      Collection<StaticRoute> routes = vc.getVrfs().get("vrf1").getStaticRoutes().values();
+      assertThat(
+          routes,
+          contains(
+              StaticRoute.builder()
+                  .setPrefix(Prefix.parse("11.0.1.0/24"))
+                  .setNextHopIp(Ip.parse("11.0.1.1"))
+                  .build()));
+    }
 
     assertThat(
         vc.getWarnings().getParseWarnings(),

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_no_static_route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_no_static_route
@@ -17,3 +17,9 @@ no ip route 10.0.1.0/24 Ethernet1/1 10.0.1.2
 !no ip route
 ! Ignored, nhip does not match
 no ip route 10.0.1.0/24 Ethernet1/1
+!
+! Test in vrf context
+vrf context vrf1
+  ip route 11.0.1.0/24 11.0.1.1
+  ip route 11.0.1.0/24 11.0.1.2
+  no ip route 11.0.1.0/24 11.0.1.2


### PR DESCRIPTION
This was already supported for static routes in the default VRF, and the extraction method used for the `no_ip_route` rule already removes from `_currentVrf` rather than the default VRF, so all that was needed was to add that rule in the `no ip` rule for VRFs.