### PR TITLE
NX-OS: better handling for `[no] ip route`

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/StaticRoute.java
@@ -14,6 +14,59 @@ import org.batfish.datamodel.Prefix;
 /** An IPv4 static route */
 public final class StaticRoute implements Serializable {
 
+  /** Uniquely identifies a static route. */
+  public static final class StaticRouteKey implements Serializable {
+    private final boolean _discard;
+    private final @Nullable String _nextHopInterface;
+    private final @Nullable Ip _nextHopIp;
+    private final @Nullable String _nextHopVrf;
+    private final @Nonnull Prefix _prefix;
+
+    public StaticRouteKey(
+        Prefix prefix,
+        boolean discard,
+        @Nullable String nextHopInterface,
+        @Nullable Ip nextHopIp,
+        @Nullable String nextHopVrf) {
+      _discard = discard;
+      _nextHopInterface = nextHopInterface;
+      _nextHopIp = nextHopIp;
+      _nextHopVrf = nextHopVrf;
+      _prefix = prefix;
+    }
+
+    /** Creates a {@link StaticRoute} with this key's properties. Non-key properties are not set. */
+    public StaticRoute toRoute() {
+      return StaticRoute.builder()
+          .setDiscard(_discard)
+          .setNextHopInterface(_nextHopInterface)
+          .setNextHopIp(_nextHopIp)
+          .setNextHopVrf(_nextHopVrf)
+          .setPrefix(_prefix)
+          .build();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof StaticRouteKey)) {
+        return false;
+      }
+      StaticRouteKey that = (StaticRouteKey) o;
+      return _discard == that._discard
+          && Objects.equals(_nextHopInterface, that._nextHopInterface)
+          && Objects.equals(_nextHopIp, that._nextHopIp)
+          && Objects.equals(_nextHopVrf, that._nextHopVrf)
+          && _prefix.equals(that._prefix);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_discard, _nextHopInterface, _nextHopIp, _nextHopVrf, _prefix);
+    }
+  }
+
   public static final class Builder {
 
     private boolean _discard;
@@ -144,15 +197,14 @@ public final class StaticRoute implements Serializable {
   }
 
   private final boolean _discard;
-  private final @Nullable String _name;
+  private @Nullable String _name;
   private final @Nullable String _nextHopInterface;
   private final @Nullable Ip _nextHopIp;
   private final @Nullable String _nextHopVrf;
-  private final int _preference;
+  private int _preference;
   private final @Nonnull Prefix _prefix;
-  private final long _tag;
-
-  private final @Nullable Integer _track;
+  private long _tag;
+  private @Nullable Integer _track;
 
   private StaticRoute(
       boolean discard,
@@ -183,6 +235,10 @@ public final class StaticRoute implements Serializable {
     return _name;
   }
 
+  public void setName(String name) {
+    _name = name;
+  }
+
   /**
    * The interface used for ARP lookup and forwarding. If not {@code null}, must be a member of
    * {@link #getNextHopVrf}.
@@ -207,6 +263,10 @@ public final class StaticRoute implements Serializable {
     return _preference;
   }
 
+  public void setPreference(int preference) {
+    _preference = preference;
+  }
+
   public @Nonnull Prefix getPrefix() {
     return _prefix;
   }
@@ -215,7 +275,15 @@ public final class StaticRoute implements Serializable {
     return _tag;
   }
 
+  public void setTag(long tag) {
+    _tag = tag;
+  }
+
   public @Nullable Integer getTrack() {
     return _track;
+  }
+
+  public void setTrack(int track) {
+    _track = track;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/StaticRoute.java
@@ -28,6 +28,7 @@ public final class StaticRoute implements Serializable {
         @Nullable String nextHopInterface,
         @Nullable Ip nextHopIp,
         @Nullable String nextHopVrf) {
+      checkNextHopFields(discard, nextHopInterface, nextHopIp, nextHopVrf);
       _discard = discard;
       _nextHopInterface = nextHopInterface;
       _nextHopIp = nextHopIp;
@@ -84,12 +85,7 @@ public final class StaticRoute implements Serializable {
     }
 
     public @Nonnull StaticRoute build() {
-      checkArgument(
-          _discard || _nextHopInterface != null || _nextHopIp != null,
-          "Must specify either discard or next-hop options");
-      checkArgument(
-          !_discard || (_nextHopInterface == null && _nextHopIp == null && _nextHopVrf == null),
-          "Discard static route mutually exclusive with next-hop options");
+      checkNextHopFields(_discard, _nextHopInterface, _nextHopIp, _nextHopVrf);
       checkArgument(
           STATIC_ROUTE_PREFERENCE_RANGE.contains(_preference),
           "Invalid preference %s outside of %s",
@@ -155,6 +151,24 @@ public final class StaticRoute implements Serializable {
       _track = track;
       return this;
     }
+  }
+
+  /**
+   * Checks that the given set of next hop properties are compatible.
+   *
+   * @throws IllegalArgumentException if next hop properties are incompatible
+   */
+  private static void checkNextHopFields(
+      boolean discard,
+      @Nullable String nextHopInterface,
+      @Nullable Ip nextHopIp,
+      @Nullable String nextHopVrf) {
+    checkArgument(
+        discard || nextHopInterface != null || nextHopIp != null,
+        "Must specify either discard or next-hop options");
+    checkArgument(
+        !discard || (nextHopInterface == null && nextHopIp == null && nextHopVrf == null),
+        "Discard static route mutually exclusive with next-hop options");
   }
 
   public static final IntegerSpace STATIC_ROUTE_PREFERENCE_RANGE =

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
 
 /** A virtual routing and forwarding instance. */
@@ -26,7 +25,7 @@ public final class Vrf implements Serializable {
     _id = id;
     _addressFamilies = new HashMap<>();
     _nameServers = new ArrayList<>(1);
-    _staticRoutes = HashMultimap.create();
+    _staticRoutes = new HashMap<>();
     _staticRoutesV6 = HashMultimap.create();
   }
 
@@ -87,10 +86,15 @@ public final class Vrf implements Serializable {
     _shutdown = shutdown;
   }
 
-  public @Nonnull Multimap<Prefix, StaticRoute> getStaticRoutes() {
+  public @Nonnull Map<StaticRoute.StaticRouteKey, StaticRoute> getStaticRoutes() {
     return _staticRoutes;
   }
 
+  /**
+   * Returns V6 static routes.
+   *
+   * <p>TODO V6 static routes should probably be keyed on a set of key properties, not on prefix
+   */
   public @Nonnull Multimap<Prefix6, StaticRouteV6> getStaticRoutesV6() {
     return _staticRoutesV6;
   }
@@ -114,7 +118,7 @@ public final class Vrf implements Serializable {
   @Nonnull private final List<NameServer> _nameServers;
   private @Nullable RouteDistinguisherOrAuto _rd;
   private boolean _shutdown;
-  private final Multimap<Prefix, StaticRoute> _staticRoutes;
+  private final Map<StaticRoute.StaticRouteKey, StaticRoute> _staticRoutes;
   private final Multimap<Prefix6, StaticRouteV6> _staticRoutesV6;
   private @Nullable Integer _vni;
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco_nxos/StaticRouteTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco_nxos/StaticRouteTest.java
@@ -20,4 +20,18 @@ public class StaticRouteTest {
         .addEqualityGroup(builder.setTrack(3).build())
         .testEquals();
   }
+
+  @Test
+  public void testEqualsStaticRouteKey() {
+    Prefix prefix = Prefix.strict("1.1.1.0/24");
+    Ip nhip = Ip.parse("2.2.2.2");
+    new EqualsTester()
+        .addEqualityGroup(
+            new StaticRoute.StaticRouteKey(prefix, true, null, null, null),
+            new StaticRoute.StaticRouteKey(prefix, true, null, null, null))
+        .addEqualityGroup(new StaticRoute.StaticRouteKey(prefix, false, "iface", null, null))
+        .addEqualityGroup(new StaticRoute.StaticRouteKey(prefix, false, "iface", nhip, null))
+        .addEqualityGroup(new StaticRoute.StaticRouteKey(prefix, false, "iface", nhip, "vrf"))
+        .testEquals();
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_no_static_route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_no_static_route
@@ -2,6 +2,9 @@
 !
 hostname nxos_no_static_route
 !
+! Must exist or lines referencing this below will be rejected
+track 500 interface Ethernet1/1 line-protocol
+!
 interface Ethernet1/1
   no switchport
   no shutdown
@@ -17,6 +20,17 @@ no ip route 10.0.1.0/24 Ethernet1/1 10.0.1.2
 !no ip route
 ! Ignored, nhip does not match
 no ip route 10.0.1.0/24 Ethernet1/1
+!
+! Test that `no` command still works if missing non-key attributes
+ip route 10.0.2.0/24 10.0.1.1 track 500 name foo tag 1000 5
+no ip route 10.0.2.0/24 10.0.1.1
+!
+! Test that `no` command still works if it has mismatched non-key attributes
+ip route 10.0.3.0/24 10.0.1.1
+no ip route 10.0.3.0/24 10.0.1.1 track 500 name foo tag 1000 5
+!
+! Test that `no` command does NOT work if it has invalid non-key attributes (256 exceeds max preference)
+no ip route 10.0.1.0/24 Ethernet1/1 10.0.1.1 track 500 name foo tag 1000 256
 !
 ! Test in vrf context
 vrf context vrf1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_static_route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_static_route
@@ -55,13 +55,28 @@ ip route 10.0.9.0/24 10.255.2.254 vrf vrf2 track 500 name foo 5 tag 1000
 ! ..with next-hop interface
 ip route 10.0.10.0/24 Ethernet1/2 10.255.2.254 vrf vrf2 track 500 name foo 5 tag 1000
 
-!!! Keep VRF definitions under default VRF configuration to avoid accidental leakage
+! Routes that differ in next-hop attributes are separate routes
+ip route 10.0.14.0/24 null0
+ip route 10.0.14.0/24 10.255.1.254
+ip route 10.0.14.0/24 Ethernet1/1 10.255.1.254
+ip route 10.0.14.0/24 Ethernet1/1
+! Unrealistic for NHIP not to be owned by vrf2, but would defeat the point of this line to change.
+! Need to see that this is considered a different route from the version with no VRF specified.
+ip route 10.0.14.0/24 Ethernet1/1 10.255.1.254 vrf vrf2
+
+! Route commands that only differ in non-key attributes are edits to the same route
+ip route 10.0.15.0/24 10.255.1.254 name foo
+ip route 10.0.15.0/24 10.255.1.254 name bar
+ip route 10.0.15.0/24 10.255.1.254 track 500 tag 1000 5
+
+!!! Keep VRF definitions under default VRF configuration to avoid accidental leakage.
+!!! Technically vrf1's routes should use a NHIP owned by vrf1, but doesn't matter for current tests.
 vrf context vrf1
   ! route in non-default vrf
-  ip route 10.0.11.0/24 10.255.2.254
+  ip route 10.0.11.0/24 10.255.1.254
 
   ! undefined reference to next hop interface Ethernet1/100
-  ip route 10.0.12.0/24 Ethernet1/100 10.255.2.254
+  ip route 10.0.12.0/24 Ethernet1/100 10.255.1.254
 
 !!! static route bfd detection
 ip route static bfd Ethernet1/1 10.255.1.50


### PR DESCRIPTION
In NX-OS, two static route definition lines will only result in different routes if key properties (prefix or next hop info) differ. For example, these two lines will create different routes:
```
ip route 10.0.1.0/24 10.0.1.1
ip route 10.0.1.0/24 Ethernet1/1 10.0.1.1
```
But these two lines will result in one route with the properties listed in the second line:
```
ip route 10.0.15.0/24 10.0.1.1
ip route 10.0.15.0/24 10.0.1.1 track 500 name foo tag 1000 5
```

Additionally, a `no ip route` command will remove the route with the specified key properties, ignoring any other properties on the route or in the `no` command, so the second line here will work:
```
ip route 10.0.1.0/24 10.0.1.1 track 500 tag 10
no ip route 10.0.1.0/24 10.0.1.1 name foo tag 1000 5
```

Batfish currently creates a new route for every (valid) `ip route` command, and only removes routes via `no ip route` if the `no` line exactly matches the existing route. To update the behavior, this PR:
- Changes the NX-OS VS model to store static routes keyed on a new `StaticRouteKey` object that includes all the key properties, rather than keying on prefix
- Makes the non-key property fields in `StaticRoute` nonfinal, since they may be modified
- Updates behavior in extraction for `ip route` and `no ip route` accordingly