### PR TITLE
BDDFactory: cap resizing at maximum allocatable

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -111,20 +111,6 @@ public class BDDPacket {
   public BDDPacket() {
     _factory = JFactory.init(JFACTORY_INITIAL_NODE_TABLE_SIZE, JFACTORY_INITIAL_NODE_CACHE_SIZE);
     _factory.setCacheRatio(JFACTORY_CACHE_RATIO);
-    // Do not impose a maximum node table increase
-    _factory.setMaxIncrease(0);
-    // Disables printing
-    /*
-    try {
-      CallbackHandler handler = new CallbackHandler();
-      Method m = handler.getClass().getDeclaredMethod("handle", (Class<?>[]) null);
-      factory.registerGCCallback(handler, m);
-      factory.registerResizeCallback(handler, m);
-      factory.registerReorderCallback(handler, m);
-    } catch (NoSuchMethodException e) {
-      e.printStackTrace();
-    }
-    */
     // Make sure we have the right number of variables
     int numNeeded =
         IP_LENGTH * 2

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
@@ -286,16 +286,6 @@ public abstract class BDDFactory {
   /** ** CACHE/TABLE PARAMETERS *** */
 
   /**
-   * Set the maximum available number of BDD nodes.
-   *
-   * <p>Compare to bdd_setmaxnodenum.
-   *
-   * @param size maximum number of nodes
-   * @return old value
-   */
-  public abstract int setMaxNodeNum(int size);
-
-  /**
    * Set minimum percentage of nodes to be reclaimed after a garbage collection. If this percentage
    * is not reclaimed, the node table will be grown. The range of x is 0..1. The default is .20.
    *
@@ -307,18 +297,7 @@ public abstract class BDDFactory {
   public abstract double setMinFreeNodes(double x);
 
   /**
-   * Set maximum number of nodes by which to increase node table after a garbage collection.
-   *
-   * <p>Compare to bdd_setmaxincrease.
-   *
-   * @param x maximum number of nodes by which to increase node table
-   * @return old value
-   */
-  public abstract int setMaxIncrease(int x);
-
-  /**
-   * Set factor by which to increase node table after a garbage collection. The amount of growth is
-   * still limited by <tt>setMaxIncrease()</tt>.
+   * Set factor by which to increase node table after a garbage collection.
    *
    * @param x factor by which to increase node table after GC
    * @return old value


### PR DESCRIPTION
Also fix a variety of small things:

* remove ability to control max number of nodes or maximum node increase
* don't resize if requesting same number of nodes as before
* delete some old debugging code
* remove unused and undefined return codes for resize-related functions