### PR TITLE
NX-OS OSPF: Support `no redistribute` commands

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_ospf.g4
@@ -27,6 +27,7 @@ ro_common
   | ro_max_metric
   | ro_name_lookup
   | ro_network
+  | ro_no
   | ro_passive_interface
   | ro_redistribute
   | ro_router_id
@@ -196,6 +197,19 @@ ro_network
     ip = ip_address wildcard = ip_address
     | prefix = ip_prefix
   ) AREA id = ospf_area_id NEWLINE
+;
+
+ro_no
+:
+  NO
+  (
+    ro_no_redistribute
+  )
+;
+
+ro_no_redistribute
+:
+  REDISTRIBUTE routing_instance_v4 (ROUTE_MAP mapname = route_map_name)? NEWLINE
 ;
 
 ro_passive_interface

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -2978,6 +2978,27 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
+  public void exitRo_no_redistribute(CiscoNxosParser.Ro_no_redistributeContext ctx) {
+    Optional<RoutingProtocolInstance> rpiOrError =
+        toRoutingProtocolInstance(ctx, ctx.routing_instance_v4());
+    if (!rpiOrError.isPresent()) {
+      return;
+    }
+    RoutingProtocolInstance rpi = rpiOrError.get();
+    String routeMap = null;
+    if (ctx.route_map_name() != null) {
+      Optional<String> mapOrError = toString(ctx, ctx.route_map_name());
+      if (!mapOrError.isPresent()) {
+        return;
+      }
+      routeMap = mapOrError.get();
+    }
+    if (!_currentOspfProcess.deleteRedistributionPolicy(rpi, routeMap)) {
+      warn(ctx, "No matching redistribution policy to remove");
+    }
+  }
+
+  @Override
   public void exitRo_router_id(Ro_router_idContext ctx) {
     _currentOspfProcess.setRouterId(toIp(ctx.id));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfProcess.java
@@ -106,6 +106,16 @@ public abstract class OspfProcess implements Serializable {
     _redistributionPolicies.put(instance, new RedistributionPolicy(instance, routeMap));
   }
 
+  public final boolean deleteRedistributionPolicy(
+      RoutingProtocolInstance instance, @Nullable String routeMap) {
+    if (routeMap == null) {
+      // Doesn't matter what route-map is assigned to the redistribution policy
+      return _redistributionPolicies.remove(instance) != null;
+    }
+    // Only remove the redistribution policy if it uses the specified route-map
+    return _redistributionPolicies.remove(instance, new RedistributionPolicy(instance, routeMap));
+  }
+
   public @Nullable Ip getRouterId() {
     return _routerId;
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ospf
@@ -185,6 +185,19 @@ router ospf r_mp_withdraw_n
 router ospf r_static
   redistribute static route-map rm1
 
+!!! no redistribute
+router ospf r_no_redistribute
+  ! Should warn
+  no redistribute direct
+  ! Should successfully add and remove redistribution policies
+  redistribute bgp 1 route-map rm1
+  no redistribute bgp 1
+  redistribute direct route-map rm1
+  no redistribute direct route-map rm1
+  ! Should fail to remove policy and warn because route-map doesn't match
+  redistribute static route-map rm1
+  no redistribute static route-map rm2
+
 !!! router-id
 router ospf router_id
   router-id 192.0.2.1


### PR DESCRIPTION
Adds support for OSPF `no redistribute`. On NX-OS, `redistribute` commands must specify a route-map. The `no redistribute` version does not have to specify a route-map, but if it does, the route-map has to match the redistribution policy being removed.