### PR TITLE
Support VRRP over sync interface, and implement for Checkpoint

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -438,7 +438,7 @@ public final class IpOwners {
                                         .computeIfAbsent(ip, k -> new HashMap<>())
                                         .computeIfAbsent(
                                             vrrpMaster.getHostname(), k -> new HashSet<>())
-                                        .add(vrrpMaster.getInterface())));
+                                        .add(receivingInterface)));
               });
         });
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrrpGroup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrrpGroup.java
@@ -108,6 +108,12 @@ public final class VrrpGroup implements Serializable {
       return this;
     }
 
+    public @Nonnull Builder setVirtualAddresses(Map<String, Set<Ip>> virtualAddresses) {
+      _virtualAddresses = new HashMap<>();
+      virtualAddresses.forEach(this::addVirtualAddresses);
+      return this;
+    }
+
     private Builder() {
       _virtualAddresses = new HashMap<>();
     }
@@ -149,6 +155,16 @@ public final class VrrpGroup implements Serializable {
         firstNonNull(priority, 0),
         sourceAddress,
         ImmutableMap.copyOf(firstNonNull(virtualAddresses, ImmutableMap.of())));
+  }
+
+  public @Nonnull Builder toBuilder() {
+    Builder builder =
+        VrrpGroup.builder()
+            .setPreempt(_preempt)
+            .setPriority(_priority)
+            .setSourceAddress(_sourceAddress)
+            .setVirtualAddresses(_virtualAddresses);
+    return builder;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrrpGroup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrrpGroup.java
@@ -21,7 +21,24 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-/** Configuration for a VRID on a router. */
+/**
+ * Configuration for a VRID on a router.
+ *
+ * <p>Hybrid model supporting RFC VRRP, VRRP-A (A10), and CheckPoint cluster IPs.
+ *
+ * <ul>
+ *   <li>For RFC VRRP, all IPs should be assigned to a single interface, and that interface should
+ *       be the same as the sync inteface on which the {@link VrrpGroup} sits.
+ *   <li>TODO: document virtual addresses for VRRP-A (A10)
+ *   <li>For CheckPoint cluster IPs, each entry should be a physical or logical interface interface
+ *       on the device other than the Sync interface, and this VrrpGroup should sit on the Sync
+ *       interface.
+ * </ul>
+ *
+ * TODO: Current limitation: for CheckPoint, if an interface on which to assign IPs is down and this
+ * virtual router is master, the IPs to be assigned to that interface will not be assigned to any
+ * other cluster member.
+ */
 @ParametersAreNonnullByDefault
 public final class VrrpGroup implements Serializable {
 
@@ -163,22 +180,33 @@ public final class VrrpGroup implements Serializable {
         .toString();
   }
 
+  /**
+   * Whether this virtual router should overtake a lower-priority existing master. This property is
+   * informational only, since Batfish does not model VRRP activation order.
+   */
   @JsonProperty(PROP_PREEMPT)
   public boolean getPreempt() {
     return _preempt;
   }
 
+  /** Priority during an election for this VRID. Higher priority is more preferred. */
   @JsonProperty(PROP_PRIORITY)
   public int getPriority() {
     return _priority;
   }
 
+  /** The address from which VRRP control traffic is sent. */
   @JsonProperty(PROP_SOURCE_ADDRESS)
   public @Nullable ConcreteInterfaceAddress getSourceAddress() {
     return _sourceAddress;
   }
 
-  /** interface receiving IPs -> IPs */
+  /**
+   * Virtual addresses assigned to interfaces if this virtual router is the winner of the election
+   * for this VRID.
+   *
+   * <p>Map: interface on which to assign one or more IPs -> IPs to assign to that interface.
+   */
   @JsonIgnore
   public @Nonnull Map<String, Set<Ip>> getVirtualAddresses() {
     return _virtualAddresses;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -590,10 +590,13 @@ public class IpOwnersTest {
     ConcreteInterfaceAddress i2SourceAddress = ConcreteInterfaceAddress.parse("1.2.3.5/24");
     Interface i2 =
         Interface.builder().setOwner(c2).setName("i2").setAddress(i2SourceAddress).build();
+    Interface i3 =
+        Interface.builder().setOwner(c2).setName("i3").setAddress(i2SourceAddress).build();
 
     Ip ip1 = Ip.parse("1.1.1.1");
     Ip ip12 = Ip.parse("1.1.1.2");
     Ip ip22 = Ip.parse("2.2.2.2");
+    Ip ip3 = Ip.parse("3.3.3.3");
 
     Set<Ip> i1VirtualAddresses = ImmutableSet.of(ip1, ip12);
     i1.setVrrpGroups(
@@ -612,6 +615,7 @@ public class IpOwnersTest {
                 .setPriority(200)
                 .setSourceAddress(i2SourceAddress)
                 .setVirtualAddresses(i2.getName(), i2VirtualAddresses)
+                .addVirtualAddress(i3.getName(), ip3)
                 .build()));
     extractVrrp(groups, i1);
     extractVrrp(groups, i2);
@@ -622,11 +626,12 @@ public class IpOwnersTest {
         groups,
         GlobalBroadcastNoPointToPoint.instance(),
         NetworkConfigurations.of(ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2)));
-    assertThat(ipOwners, hasKeys(ip1, ip22));
+    assertThat(ipOwners, hasKeys(ip1, ip22, ip3));
     assertThat(ipOwners.get(ip1), hasKeys(c2.getHostname()));
     assertThat(ipOwners.get(ip22), hasKeys(c2.getHostname()));
     assertThat(ipOwners.get(ip1).get(c2.getHostname()), equalTo(ImmutableSet.of(i2.getName())));
     assertThat(ipOwners.get(ip22).get(c2.getHostname()), equalTo(ImmutableSet.of(i2.getName())));
+    assertThat(ipOwners.get(ip3).get(c2.getHostname()), equalTo(ImmutableSet.of(i3.getName())));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -60,6 +60,7 @@ import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LinkLocalAddress;
+import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportMode;
@@ -1462,7 +1463,7 @@ public final class TopologyUtilTest {
 
   /**
    * Tests that inactive and blacklisted interfaces are properly included or excluded from the
-   * output of {@link IpOwners#computeIpInterfaceOwners(Map, boolean, L3Adjacencies)}
+   * output of {@link IpOwners#computeIpInterfaceOwners}
    */
   @Test
   public void testIpInterfaceOwnersActiveInclusion() {
@@ -1474,15 +1475,18 @@ public final class TopologyUtilTest {
                 iface("shut", "1.1.1.1/32", false, false),
                 iface("active-black", "1.1.1.1/32", true, true),
                 iface("shut-black", "1.1.1.1/32", false, true)));
+    NetworkConfigurations nc =
+        NetworkConfigurations.of(
+            ImmutableMap.of("node", Configuration.builder().setHostname("node").build()));
 
     assertThat(
-        computeIpInterfaceOwners(nodeInterfaces, true, null),
+        computeIpInterfaceOwners(nodeInterfaces, true, null, nc),
         equalTo(
             ImmutableMap.of(
                 Ip.parse("1.1.1.1"), ImmutableMap.of("node", ImmutableSet.of("active")))));
 
     assertThat(
-        computeIpInterfaceOwners(nodeInterfaces, false, null),
+        computeIpInterfaceOwners(nodeInterfaces, false, null, nc),
         equalTo(
             ImmutableMap.of(
                 Ip.parse("1.1.1.1"),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/VrrpComputationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/VrrpComputationTest.java
@@ -45,17 +45,20 @@ public class VrrpComputationTest {
     ConcreteInterfaceAddress i1SourceAddress = ConcreteInterfaceAddress.parse("1.1.1.22/32");
     ConcreteInterfaceAddress i2SourceAddress = ConcreteInterfaceAddress.parse("1.1.1.33/32");
 
+    String i1Name = "i1";
+    String i2Name = "i2";
+
     int vrrpGroupId = 1;
     int priority = 100;
     VrrpGroup.Builder vg1 =
         VrrpGroup.builder()
             .setPriority(priority)
             .setSourceAddress(i1SourceAddress)
-            .setVirtualAddresses(_virtInterfaceAddr);
+            .setVirtualAddresses(i1Name, _virtInterfaceAddr);
     VrrpGroup.Builder vg2 =
         VrrpGroup.builder()
             .setSourceAddress(i2SourceAddress)
-            .setVirtualAddresses(_virtInterfaceAddr);
+            .setVirtualAddresses(i2Name, _virtInterfaceAddr);
     if (equalPriority) {
       vg2.setPriority(priority);
     } else {
@@ -71,12 +74,14 @@ public class VrrpComputationTest {
         ib.setOwner(c1)
             .setAddress(i1SourceAddress)
             .setVrrpGroups(ImmutableSortedMap.of(vrrpGroupId, vg1.build()))
+            .setName(i1Name)
             .build();
 
     _i2 =
         ib.setOwner(c2)
             .setAddress(i2SourceAddress)
             .setVrrpGroups(ImmutableSortedMap.of(vrrpGroupId, vg2.build()))
+            .setName(i2Name)
             .build();
 
     return ImmutableSortedMap.of("n1", c1, "n2", c2);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -299,8 +299,11 @@ public class ForwardingAnalysisImplTest {
     Vrf vrf2 = _vb.build();
     ConcreteInterfaceAddress i1SourceAddress =
         ConcreteInterfaceAddress.create(P1.getFirstHostIp(), P1.getPrefixLength());
+    String i1Name = "i1";
+    String i2Name = "i2";
     Interface i1 =
         _ib.setVrf(vrf1)
+            .setName(i1Name)
             .setAddress(i1SourceAddress)
             .setVrrpGroups(
                 ImmutableSortedMap.of(
@@ -308,7 +311,7 @@ public class ForwardingAnalysisImplTest {
                     VrrpGroup.builder()
                         .setPriority(100)
                         .setSourceAddress(i1SourceAddress)
-                        .setVirtualAddresses(Ip.parse("1.1.1.1"))
+                        .setVirtualAddresses(i1Name, Ip.parse("1.1.1.1"))
                         .build()))
             .build();
 
@@ -316,6 +319,7 @@ public class ForwardingAnalysisImplTest {
         ConcreteInterfaceAddress.create(P1.getLastHostIp(), P1.getPrefixLength());
     Interface i2 =
         _ib.setVrf(vrf2)
+            .setName(i2Name)
             .setAddress(i2SourceAddress)
             .setVrrpGroups(
                 ImmutableSortedMap.of(
@@ -323,7 +327,7 @@ public class ForwardingAnalysisImplTest {
                     VrrpGroup.builder()
                         .setPriority(110)
                         .setSourceAddress(i2SourceAddress)
-                        .setVirtualAddresses(Ip.parse("1.1.1.1"))
+                        .setVirtualAddresses(i2Name, Ip.parse("1.1.1.1"))
                         .build()))
             .build();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrrpGroupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrrpGroupTest.java
@@ -16,7 +16,7 @@ public class VrrpGroupTest {
         VrrpGroup.builder()
             .setPreempt(true)
             .setPriority(1)
-            .setVirtualAddresses(Ip.parse("2.2.2.2"))
+            .setVirtualAddresses("i1", Ip.parse("2.2.2.2"))
             .setSourceAddress(ConcreteInterfaceAddress.create(Ip.parse("1.1.1.1"), 24))
             .build();
     assertThat(SerializationUtils.clone(obj), equalTo(obj));
@@ -34,7 +34,7 @@ public class VrrpGroupTest {
             builder
                 .setSourceAddress(ConcreteInterfaceAddress.create(Ip.parse("1.1.1.1"), 24))
                 .build())
-        .addEqualityGroup(builder.setVirtualAddresses(Ip.parse("2.2.2.2")).build())
+        .addEqualityGroup(builder.setVirtualAddresses("i1", Ip.parse("2.2.2.2")).build())
         .testEquals();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -496,7 +496,7 @@ public final class AristaConfiguration extends VendorConfiguration {
                         newGroup.setSourceAddress(ifaceAddress);
                         Ip virtualAddress = vrrpGroup.getVirtualAddress();
                         if (virtualAddress != null) {
-                          newGroup.setVirtualAddresses(virtualAddress);
+                          newGroup.setVirtualAddresses(ifaceName, virtualAddress);
                         } else {
                           _w.redFlag(
                               "No virtual address set for VRRP on interface: '" + ifaceName + "'");

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -563,7 +563,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                         newGroup.setSourceAddress(ifaceAddress);
                         Ip virtualAddress = vrrpGroup.getVirtualAddress();
                         if (virtualAddress != null) {
-                          newGroup.setVirtualAddresses(virtualAddress);
+                          newGroup.setVirtualAddresses(ifaceName, virtualAddress);
                         } else {
                           _w.redFlag(
                               "No virtual address set for VRRP on interface: '" + ifaceName + "'");

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -624,7 +624,7 @@ public final class AsaConfiguration extends VendorConfiguration {
                         newGroup.setSourceAddress(ifaceAddress);
                         Ip virtualAddress = vrrpGroup.getVirtualAddress();
                         if (virtualAddress != null) {
-                          newGroup.setVirtualAddresses(virtualAddress);
+                          newGroup.setVirtualAddresses(ifaceName, virtualAddress);
                         } else {
                           _w.redFlag(
                               "No virtual address set for VRRP on interface: '" + ifaceName + "'");

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -485,7 +485,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
                         newGroup.setSourceAddress(ifaceAddress);
                         Ip virtualAddress = vrrpGroup.getVirtualAddress();
                         if (virtualAddress != null) {
-                          newGroup.setVirtualAddresses(virtualAddress);
+                          newGroup.setVirtualAddresses(ifaceName, virtualAddress);
                         } else {
                           _w.redFlag(
                               "No virtual address set for VRRP on interface: '" + ifaceName + "'");

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1931,7 +1931,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                   .setPreempt(vrrpGroup.getPreempt())
                   .setPriority(vrrpGroup.getPriority())
                   .setSourceAddress(vrrpGroup.getSourceAddress())
-                  .setVirtualAddresses(virtualAddresses)
+                  .setVirtualAddresses(ifaceName, virtualAddresses)
                   .build());
         });
     return groupsBuilder.build();

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -794,7 +794,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
 
   InterfaceType getInterfaceType(Interface iface) {
     String name = iface.getName();
-    if (name.startsWith("eth") || name.equals(SYNC_INTERFACE_NAME)) {
+    if (name.startsWith("eth")) {
       if (name.contains(".")) {
         return InterfaceType.LOGICAL;
       }
@@ -806,6 +806,8 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
         return InterfaceType.AGGREGATE_CHILD;
       }
       return InterfaceType.AGGREGATED;
+    } else if (name.equals(SYNC_INTERFACE_NAME)) {
+      return InterfaceType.PHYSICAL;
     }
     return InterfaceType.UNKNOWN;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/representation/CheckPointGatewayConfiguration.java
@@ -12,6 +12,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.transformation.Transformation.always;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.aclName;
+import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.createClusterVrrpGroup;
 import static org.batfish.vendor.check_point_gateway.representation.CheckPointGatewayConversions.toIpAccessLists;
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.HIDE_BEHIND_GATEWAY_IP;
 import static org.batfish.vendor.check_point_gateway.representation.CheckpointNatConversions.automaticHideRuleTransformationStep;
@@ -30,7 +31,6 @@ import static org.batfish.vendor.check_point_management.AddressSpaceToIpSpaceMet
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -55,7 +55,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
-import org.batfish.datamodel.Interface.Builder;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceType;
@@ -66,7 +65,6 @@ import org.batfish.datamodel.IpSpaceMetadata;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
-import org.batfish.datamodel.VrrpGroup;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.packet_policy.ApplyFilter;
@@ -111,6 +109,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
 
   public static final String VRF_NAME = "default";
   public static final String INTERFACE_ACL_NAME = "~INTERFACE_ACL~";
+  public static final String SYNC_INTERFACE_NAME = "Sync";
 
   public CheckPointGatewayConfiguration() {
     _bondingGroups = new HashMap<>();
@@ -795,7 +794,7 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
 
   InterfaceType getInterfaceType(Interface iface) {
     String name = iface.getName();
-    if (name.startsWith("eth")) {
+    if (name.startsWith("eth") || name.equals(SYNC_INTERFACE_NAME)) {
       if (name.contains(".")) {
         return InterfaceType.LOGICAL;
       }
@@ -885,40 +884,11 @@ public class CheckPointGatewayConfiguration extends VendorConfiguration {
         new FirewallSessionInterfaceInfo(
             POST_NAT_FIB_LOOKUP, ImmutableList.of(ifaceName), null, null));
 
-    org.batfish.vendor.check_point_management.Interface clusterInterface =
-        Optional.ofNullable(_clusterInterfaces).orElse(ImmutableMap.of()).get(ifaceName);
-    if (clusterInterface != null) {
-      createClusterVrrpGroup(iface, clusterInterface, newIface);
+    if (ifaceName.equals(SYNC_INTERFACE_NAME)) {
+      createClusterVrrpGroup(iface, newIface, _clusterInterfaces, _clusterMemberIndex, _w);
     }
 
     newIface.build();
-  }
-
-  /** Create a VRRP group for the virtual IP the cluster associates with this interface. */
-  private void createClusterVrrpGroup(
-      Interface iface,
-      org.batfish.vendor.check_point_management.Interface clusterInterface,
-      Builder newIface) {
-    ConcreteInterfaceAddress sourceAddress = iface.getAddress();
-    if (sourceAddress == null) {
-      _w.redFlag(
-          String.format(
-              "Cannot assign virtual IP on interface '%s' since it has no source IP for control"
-                  + " traffic",
-              iface.getName()));
-    }
-    Ip virtualIp = clusterInterface.getIpv4Address();
-    assert virtualIp != null;
-    newIface.setVrrpGroups(
-        ImmutableSortedMap.of(
-            0,
-            VrrpGroup.builder()
-                .setSourceAddress(sourceAddress)
-                .setVirtualAddresses(virtualIp)
-                // prefer member with lowest cluster member index
-                .setPriority(VrrpGroup.MAX_PRIORITY - _clusterMemberIndex)
-                .setPreempt(true)
-                .build()));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -2470,7 +2470,8 @@ public class AristaGrammarTest {
     Interface i = c.getAllInterfaces().get("Vlan20");
     assertThat(i.getVrrpGroups(), hasKey(1));
     VrrpGroup group = i.getVrrpGroups().get(1);
-    assertThat(group.getVirtualAddresses(), contains(Ip.parse("1.2.3.4")));
+    assertThat(group.getVirtualAddresses(), hasKeys(i.getName()));
+    assertThat(group.getVirtualAddresses().get(i.getName()), contains(Ip.parse("1.2.3.4")));
     assertThat(group.getSourceAddress(), equalTo(ConcreteInterfaceAddress.parse("2.2.2.2/24")));
     assertThat(group.getPriority(), equalTo(200));
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -6330,13 +6330,16 @@ public final class FlatJuniperGrammarTest {
     {
       org.batfish.datamodel.VrrpGroup v = i.getVrrpGroups().get(1);
       assertThat(v.getSourceAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.0.1/24")));
-      assertThat(v.getVirtualAddresses(), contains(Ip.parse("10.0.0.2")));
+      assertThat(v.getVirtualAddresses(), hasKeys(i.getName()));
+      assertThat(v.getVirtualAddresses().get(i.getName()), contains(Ip.parse("10.0.0.2")));
     }
     {
       org.batfish.datamodel.VrrpGroup v = i.getVrrpGroups().get(2);
       assertThat(v.getSourceAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.1.1/24")));
+      assertThat(v.getVirtualAddresses(), hasKeys(i.getName()));
       assertThat(
-          v.getVirtualAddresses(), containsInAnyOrder(Ip.parse("10.0.1.2"), Ip.parse("10.0.1.3")));
+          v.getVirtualAddresses().get(i.getName()),
+          containsInAnyOrder(Ip.parse("10.0.1.2"), Ip.parse("10.0.1.3")));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/job/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/job/BUILD
@@ -19,6 +19,8 @@ junit_tests(
     deps = [
         "//projects/batfish",
         "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
         "//projects/batfish/src/main/java/org/batfish/representation/cisco",
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -1447,6 +1447,7 @@ public class A10GrammarTest {
                       .setPreempt(true)
                       .setPriority(DEFAULT_VRRP_A_PRIORITY)
                       .setVirtualAddresses(
+                          i.getName(),
                           ImmutableSet.of(
                               Ip.parse("1.0.0.1"),
                               Ip.parse("1.0.0.2"),
@@ -2128,6 +2129,7 @@ public class A10GrammarTest {
                       .setPreempt(false)
                       .setPriority(200)
                       .setVirtualAddresses(
+                          i.getName(),
                           ImmutableSet.of(
                               Ip.parse("10.0.2.1"),
                               Ip.parse("10.0.3.1"),

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConversionTest.java
@@ -34,6 +34,7 @@ import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_T
 import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_NAT_POOL;
 import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_VIRTUAL_SERVER_FLAGGED;
 import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_VIRTUAL_SERVER_UNFLAGGED;
+import static org.batfish.vendor.a10.representation.A10Conversion.RECEIVING_INTERFACE_PLACEHOOLDER;
 import static org.batfish.vendor.a10.representation.A10Conversion.computeAclName;
 import static org.batfish.vendor.a10.representation.A10Conversion.computeUpdateSource;
 import static org.batfish.vendor.a10.representation.A10Conversion.convertAccessList;
@@ -431,7 +432,7 @@ public class A10ConversionTest {
             VrrpGroup.builder()
                 .setPreempt(DEFAULT_VRRP_A_PREEMPT)
                 .setPriority(DEFAULT_VRRP_A_PRIORITY)
-                .setVirtualAddresses(ImmutableSet.of(ip))
+                .setVirtualAddresses(RECEIVING_INTERFACE_PLACEHOOLDER, ImmutableSet.of(ip))
                 .build()));
 
     // non-null vrid config
@@ -445,7 +446,7 @@ public class A10ConversionTest {
             VrrpGroup.builder()
                 .setPreempt(false)
                 .setPriority(5)
-                .setVirtualAddresses(ImmutableSet.of(ip))
+                .setVirtualAddresses(RECEIVING_INTERFACE_PLACEHOOLDER, ImmutableSet.of(ip))
                 .build()));
   }
 
@@ -457,7 +458,7 @@ public class A10ConversionTest {
             VrrpGroup.builder()
                 .setPriority(5)
                 .setPreempt(true)
-                .setVirtualAddresses(Ip.parse("1.1.1.1")));
+                .setVirtualAddresses(RECEIVING_INTERFACE_PLACEHOOLDER, Ip.parse("1.1.1.1")));
     ConcreteInterfaceAddress sourceAddress =
         ConcreteInterfaceAddress.create(Ip.parse("2.2.2.2"), 24);
     org.batfish.datamodel.Interface iface =
@@ -471,7 +472,7 @@ public class A10ConversionTest {
                 VrrpGroup.builder()
                     .setPriority(5)
                     .setPreempt(true)
-                    .setVirtualAddresses(Ip.parse("1.1.1.1"))
+                    .setVirtualAddresses(iface.getName(), Ip.parse("1.1.1.1"))
                     .setSourceAddress(sourceAddress)
                     .build())));
   }

--- a/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/cluster_member
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/check_point_gateway/grammar/testconfigs/cluster_member
@@ -10,4 +10,6 @@ set interface eth0 state on
 set interface eth0 ipv4-address 10.0.0.2 mask-length 24
 set interface eth1 state on
 set interface eth1 ipv4-address 1.0.0.1 mask-length 24
+set interface Sync state on
+set interface Sync ipv4-address 192.0.2.1 mask-length 24
 #

--- a/projects/question/src/test/java/org/batfish/question/vrrpproperties/VrrpPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/vrrpproperties/VrrpPropertiesAnswererTest.java
@@ -56,20 +56,21 @@ public final class VrrpPropertiesAnswererTest {
   public void testGetProperties() {
     Configuration conf1 = new Configuration("node1", ConfigurationFormat.CISCO_IOS);
 
-    VrrpGroup group =
+    VrrpGroup.Builder group =
         VrrpGroup.builder()
-            .setVirtualAddresses(Ip.parse("1.1.1.1"))
             .setSourceAddress(ConcreteInterfaceAddress.create(Ip.parse("1.1.1.2"), 29))
             .setPriority(23)
-            .setPreempt(true)
-            .build();
+            .setPreempt(true);
+
+    VrrpGroup group1 = group.setVirtualAddresses("iface1", Ip.parse("1.1.1.1")).build();
+    VrrpGroup group2 = group.setVirtualAddresses("iface2", Ip.parse("1.1.1.1")).build();
 
     // active interface with VRRP group
     Interface iface1 =
         Interface.builder()
             .setName("iface1")
             .setOwner(conf1)
-            .setVrrpGroups(ImmutableSortedMap.of(0, group))
+            .setVrrpGroups(ImmutableSortedMap.of(0, group1))
             .setActive(true)
             .build();
 
@@ -78,7 +79,7 @@ public final class VrrpPropertiesAnswererTest {
         Interface.builder()
             .setName("iface2")
             .setOwner(conf1)
-            .setVrrpGroups(ImmutableSortedMap.of(0, group))
+            .setVrrpGroups(ImmutableSortedMap.of(0, group2))
             .setActive(false)
             .build();
 
@@ -92,8 +93,8 @@ public final class VrrpPropertiesAnswererTest {
     MockSpecifierContext ctxt =
         MockSpecifierContext.builder().setConfigs(ImmutableMap.of("node1", conf1)).build();
 
-    Row expectedRow1 = populateRow(createRowBuilder("node1", iface1), 0, group).build();
-    Row expectedRow2 = populateRow(createRowBuilder("node1", iface2), 0, group).build();
+    Row expectedRow1 = populateRow(createRowBuilder("node1", iface1), 0, group1).build();
+    Row expectedRow2 = populateRow(createRowBuilder("node1", iface2), 0, group2).build();
 
     assertThat(
         getProperties(
@@ -121,7 +122,8 @@ public final class VrrpPropertiesAnswererTest {
 
     VrrpGroup group =
         VrrpGroup.builder()
-            .setVirtualAddresses(ImmutableList.of(Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2")))
+            .setVirtualAddresses(
+                "iface", ImmutableList.of(Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2")))
             .setSourceAddress(ConcreteInterfaceAddress.create(Ip.parse("1.1.1.2"), 29))
             .setPriority(23)
             .setPreempt(true)
@@ -185,7 +187,7 @@ public final class VrrpPropertiesAnswererTest {
         ConcreteInterfaceAddress.create(Ip.parse("2.2.2.1"), 29);
     VrrpGroup group =
         VrrpGroup.builder()
-            .setVirtualAddresses(address)
+            .setVirtualAddresses("foo", address)
             .setSourceAddress(sourceAddress)
             .setPriority(23)
             .setPreempt(true)


### PR DESCRIPTION
- add support for separate VRRP over sync interface
  - Sync interface participates in election
  - When the sync interface is elected, IPs are assigned to one or more
    interfaces
  - Implement VRRP over sync interface for CheckPoint
  - On all vendors that use real VRRP, each interface that receives IPs
    is its own sync interface
- refactor VRRP computation in `IpOwners` to remove `IdenityHash{MapSet}` usage.

Follow-on work: Convert A10 to use sync interface for VRRP(-A)