### PR TITLE
Palo Alto format detector add brace ignore heuristic

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -89,6 +89,8 @@ public final class VendorConfigurationFormatDetector {
   private static final Pattern PALO_ALTO_DEVICECONFIG_PATTERN = Pattern.compile("(?m)deviceconfig");
   private static final Pattern PALO_ALTO_PANORAMA_PATTERN =
       Pattern.compile("(?m)(send-to-panorama|panorama-server)");
+  // open brace not likely to be opening a string literal of a JSON object
+  private static final Pattern PALO_ALTO_NESTED_PATTERN = Pattern.compile("(?m)[^\"']\\{");
 
   private String _fileText;
 
@@ -340,7 +342,7 @@ public final class VendorConfigurationFormatDetector {
     } else if (preMatch
         || fileTextMatches(PALO_ALTO_DEVICECONFIG_PATTERN)
         || fileTextMatches(PALO_ALTO_PANORAMA_PATTERN)) {
-      if (_fileText.contains("{")) {
+      if (fileTextMatches(PALO_ALTO_NESTED_PATTERN)) {
         return ConfigurationFormat.PALO_ALTO_NESTED;
       }
       return ConfigurationFormat.PALO_ALTO;

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -255,18 +255,36 @@ public class VendorConfigurationFormatDetectorTest {
     String flatPanorama = "set deviceconfig system panorama-server 1.2.3.4\n}";
     String flatSendPanorama = "set alarm informational send-to-panorama yes\n";
     String flatDeviceConfig = "set deviceconfig system blah\n";
+    String flatBraceNotMeaningNested =
+        "set panorama log-settings http FOO format system payload '{\"text\": \"*BAR Panorama"
+            + " System Log*\\n"
+            + "*Device Name*:panorama01or panorama01\\n"
+            + "*Receive Time*: $receive_time *Severity:* $severity *Type*: $subtype\\n"
+            + "*Log Message:* $opaque\"}'\n";
     String flattened = "####BATFISH FLATTENED PALO ALTO CONFIG####\n";
 
     /* Confirm hierarchical PAN configs are correctly identified */
     for (String fileText :
-        ImmutableList.of(rancid, rancid2, panorama, sendPanorama, deviceConfig)) {
+        ImmutableList.of(
+            rancid,
+            rancid2,
+            panorama,
+            sendPanorama,
+            deviceConfig,
+            panorama + flatBraceNotMeaningNested)) {
       assertThat(identifyConfigurationFormat(fileText), equalTo(PALO_ALTO_NESTED));
     }
 
     /* Confirm flat (set-style) PAN configs are correctly identified */
     for (String fileText :
         ImmutableList.of(
-            flatRancid, flatRancid2, flatPanorama, flatSendPanorama, flatDeviceConfig, flattened)) {
+            flatRancid,
+            flatRancid2,
+            flatPanorama,
+            flatSendPanorama,
+            flatDeviceConfig,
+            flatPanorama + flatBraceNotMeaningNested,
+            flattened)) {
       assertThat(identifyConfigurationFormat(fileText), equalTo(PALO_ALTO));
     }
   }


### PR DESCRIPTION
- do not consider an open brace following a quote to be evidence for nested
  - use case: string literal of flat JSON object