### PR TITLE
VendorConfigurationFormatDetector: detect new Arista syntax

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -132,12 +132,16 @@ public final class VendorConfigurationFormatDetector {
       Pattern.compile("(?m)^! device: .*\\(.*EOS-\\d.*");
   private static final Pattern ARISTA_FLASH_PATTERN =
       Pattern.compile("(?m)^.*boot system flash.*\\.swi");
+  private static final Pattern ARISTA_TELLS =
+      Pattern.compile("(?m)^ip (ext)?community-list regexp");
 
   @Nullable
   private ConfigurationFormat checkArista() {
     if (fileTextMatches(ARISTA_FLASH_PATTERN)) {
       return ConfigurationFormat.ARISTA;
     } else if (fileTextMatches(ARISTA_EOS_PATTERN)) {
+      return ConfigurationFormat.ARISTA;
+    } else if (fileTextMatches(ARISTA_TELLS)) {
       return ConfigurationFormat.ARISTA;
     }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -50,8 +50,18 @@ public class VendorConfigurationFormatDetectorTest {
     String aristaBatfish = "!BATFISH_FORMAT: arista\n";
     String aristaRancid = "!RANCID-CONTENT-TYPE: arista\n";
     String aristaEos = "! device: some-host (DCS-7250QX-64, EOS-4.14.9M)\n";
+    String aristaNewSyntaxCL = "foo\nip community-list regexp FOO permit .....:5000\nbar";
+    String aristaNewSyntaxCL2 =
+        "foo\nip extcommunity-list regexp list_1 deny RT:10:[2-3][0-4]_\nbar";
 
-    for (String fileText : ImmutableList.of(eosFlash, aristaBatfish, aristaRancid, aristaEos)) {
+    for (String fileText :
+        ImmutableList.of(
+            eosFlash,
+            aristaBatfish,
+            aristaRancid,
+            aristaEos,
+            aristaNewSyntaxCL,
+            aristaNewSyntaxCL2)) {
       assertThat(identifyConfigurationFormat(fileText), equalTo(ARISTA));
     }
   }


### PR DESCRIPTION
These are unique to EOS after being required to differentiate from Cisco.