### PR TITLE
Cisco NX-OS parse and convert track ip route

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -35,7 +35,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
 
   private final long _metric;
   private final boolean _recursive;
-  private final @Nullable Integer _track;
+  private final @Nullable String _track;
 
   private transient int _hashCode;
 
@@ -48,7 +48,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int administrativeCost,
       @JsonProperty(PROP_METRIC) long metric,
       @JsonProperty(PROP_TAG) long tag,
-      @JsonProperty(PROP_TRACK) @Nullable Integer track) {
+      @JsonProperty(PROP_TRACK) @Nullable String track) {
     return new StaticRoute(
         requireNonNull(network),
         nextVrf != null
@@ -72,7 +72,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       boolean nonForwarding,
       boolean nonRouting,
       boolean recursive,
-      @Nullable Integer track) {
+      @Nullable String track) {
     super(network, administrativeCost, tag, nonRouting, nonForwarding);
     _metric = metric;
     _nextHop = nextHop;
@@ -105,7 +105,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
   }
 
   @JsonProperty(PROP_TRACK)
-  public @Nullable Integer getTrack() {
+  public @Nullable String getTrack() {
     return _track;
   }
 
@@ -129,7 +129,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
   public static final class Builder extends AbstractRouteBuilder<Builder, StaticRoute> {
 
     private boolean _recursive;
-    private @Nullable Integer _track;
+    private @Nullable String _track;
 
     private Builder() {
       // Tmp hack until parent builder is fixed and doesn't default to primitives
@@ -177,7 +177,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       return this;
     }
 
-    public @Nonnull Builder setTrack(@Nullable Integer track) {
+    public @Nonnull Builder setTrack(@Nullable String track) {
       _track = track;
       return this;
     }
@@ -197,7 +197,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
           .thenComparing(StaticRoute::getNonRouting)
           .thenComparing(StaticRoute::getNonForwarding)
           .thenComparing(StaticRoute::getRecursive)
-          .thenComparing(StaticRoute::getTrack, nullsFirst(Integer::compareTo));
+          .thenComparing(StaticRoute::getTrack, nullsFirst(String::compareTo));
 
   @Override
   public Builder toBuilder() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -197,7 +197,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
           .thenComparing(StaticRoute::getNonRouting)
           .thenComparing(StaticRoute::getNonForwarding)
           .thenComparing(StaticRoute::getRecursive)
-          .thenComparing(StaticRoute::getTrack);
+          .thenComparing(StaticRoute::getTrack, nullsFirst(Integer::compareTo));
 
   @Override
   public Builder toBuilder() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -31,9 +31,11 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
 
   static final long DEFAULT_STATIC_ROUTE_METRIC = 0L;
   private static final String PROP_NEXT_VRF = "nextVrf";
+  private static final String PROP_TRACK = "track";
 
   private final long _metric;
   private final boolean _recursive;
+  private final @Nullable Integer _track;
 
   private transient int _hashCode;
 
@@ -45,7 +47,8 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       @Nullable @JsonProperty(PROP_NEXT_VRF) String nextVrf,
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int administrativeCost,
       @JsonProperty(PROP_METRIC) long metric,
-      @JsonProperty(PROP_TAG) long tag) {
+      @JsonProperty(PROP_TAG) long tag,
+      @JsonProperty(PROP_TRACK) @Nullable Integer track) {
     return new StaticRoute(
         requireNonNull(network),
         nextVrf != null
@@ -56,7 +59,8 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
         tag,
         false,
         false,
-        true);
+        true,
+        track);
   }
 
   private StaticRoute(
@@ -67,11 +71,13 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       long tag,
       boolean nonForwarding,
       boolean nonRouting,
-      boolean recursive) {
+      boolean recursive,
+      @Nullable Integer track) {
     super(network, administrativeCost, tag, nonRouting, nonForwarding);
     _metric = metric;
     _nextHop = nextHop;
     _recursive = recursive;
+    _track = track;
   }
 
   @Override
@@ -98,6 +104,11 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
     return _recursive;
   }
 
+  @JsonProperty(PROP_TRACK)
+  public @Nullable Integer getTrack() {
+    return _track;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -118,6 +129,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
   public static final class Builder extends AbstractRouteBuilder<Builder, StaticRoute> {
 
     private boolean _recursive;
+    private @Nullable Integer _track;
 
     private Builder() {
       // Tmp hack until parent builder is fixed and doesn't default to primitives
@@ -142,7 +154,8 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
           getTag(),
           getNonForwarding(),
           getNonRouting(),
-          _recursive);
+          _recursive,
+          _track);
     }
 
     @Nonnull
@@ -163,6 +176,11 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       _recursive = recursive;
       return this;
     }
+
+    public @Nonnull Builder setTrack(@Nullable Integer track) {
+      _track = track;
+      return this;
+    }
   }
 
   /////// Keep COMPARATOR, #toBuilder, #equals, and #hashCode in sync ////////
@@ -178,7 +196,8 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
           .thenComparing(StaticRoute::getTag)
           .thenComparing(StaticRoute::getNonRouting)
           .thenComparing(StaticRoute::getNonForwarding)
-          .thenComparing(StaticRoute::getRecursive);
+          .thenComparing(StaticRoute::getRecursive)
+          .thenComparing(StaticRoute::getTrack);
 
   @Override
   public Builder toBuilder() {
@@ -190,7 +209,8 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
         .setAdmin(getAdministrativeCost())
         .setNonRouting(getNonRouting())
         .setNonForwarding(getNonForwarding())
-        .setRecursive(getRecursive());
+        .setRecursive(getRecursive())
+        .setTrack(_track);
   }
 
   @Override
@@ -209,7 +229,8 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
         && _metric == rhs._metric
         && _nextHop.equals(rhs._nextHop)
         && _tag == rhs._tag
-        && _recursive == rhs._recursive;
+        && _recursive == rhs._recursive
+        && Objects.equals(_track, rhs._track);
   }
 
   @Override
@@ -225,7 +246,8 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
               _metric,
               _nextHop,
               _tag,
-              _recursive);
+              _recursive,
+              _track);
       _hashCode = h;
     }
     return h;
@@ -234,12 +256,14 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
+        .omitNullValues()
         .add(PROP_NETWORK, _network)
         .add("nextHop", _nextHop)
         .add(PROP_ADMINISTRATIVE_COST, _admin)
         .add(PROP_METRIC, _metric)
         .add("recursive", _recursive)
         .add(PROP_TAG, _tag)
+        .add(PROP_TRACK, _track)
         .toString();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackMethodVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackMethodVisitor.java
@@ -3,4 +3,6 @@ package org.batfish.datamodel.tracking;
 /** Visitor for {@link TrackMethod} */
 public interface GenericTrackMethodVisitor<R> {
   R visitTrackInterface(TrackInterface trackInterface);
+
+  R visitTrackRoute(TrackRoute trackRoute);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/PredicateTrackMethodEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/PredicateTrackMethodEvaluator.java
@@ -6,9 +6,12 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 
 /**
- * Evaluates a {@link TrackMethod} as a predicate. Visiting the method returns {@code true} if the
- * {@link TrackMethod} would be triggered and execute associated {@link TrackAction}s and {@code
- * false} otherwise.
+ * Evaluator for {@link TrackMethod}s whose value may be determined solely from the contents of a
+ * {@link Configuration}. Visiting the method returns {@code true} if the {@link TrackMethod} would
+ * be triggered and execute associated {@link TrackAction}s and {@code false} otherwise.
+ *
+ * <p>For {@link TrackMethod}s requiring data plane information for evaluation, throws {@link
+ * UnsupportedOperationException}.
  */
 @ParametersAreNonnullByDefault
 public class PredicateTrackMethodEvaluator implements GenericTrackMethodVisitor<Boolean> {
@@ -25,6 +28,11 @@ public class PredicateTrackMethodEvaluator implements GenericTrackMethodVisitor<
       return false;
     }
     return !trackedInterface.getActive() || trackedInterface.getBlacklisted();
+  }
+
+  @Override
+  public Boolean visitTrackRoute(TrackRoute trackRoute) {
+    throw new UnsupportedOperationException("Unsupported method for HSRP priority evaluation");
   }
 
   @Nonnull private final Configuration _configuration;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackRoute.java
@@ -6,6 +6,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Objects;
@@ -72,6 +73,7 @@ public final class TrackRoute implements TrackMethod {
   }
 
   public static @Nonnull TrackRoute of(Prefix prefix, Set<RoutingProtocol> protocols, String vrf) {
+    checkArgument(!Strings.isNullOrEmpty(vrf), "vrf name must be non-empty");
     return new TrackRoute(prefix, protocols, vrf);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackRoute.java
@@ -1,0 +1,102 @@
+package org.batfish.datamodel.tracking;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
+
+/**
+ * Tracks whether a route with a particular prefix and optionally matching one of a set of protocols
+ * is in the main RIB of a particular VRF.
+ */
+public final class TrackRoute implements TrackMethod {
+
+  @Override
+  public <R> R accept(GenericTrackMethodVisitor<R> visitor) {
+    return visitor.visitTrackRoute(this);
+  }
+
+  /** The prefix a tracked route must have. */
+  @JsonProperty(PROP_PREFIX)
+  public @Nonnull Prefix getPrefix() {
+    return _prefix;
+  }
+
+  /**
+   * If empty, do not match protocols. Else the protocol of the route to be matched must be present
+   * in the returned set.
+   */
+  @JsonIgnore
+  public @Nonnull Set<RoutingProtocol> getProtocols() {
+    return _protocols;
+  }
+
+  @JsonProperty(PROP_PROTOCOLS)
+  private @Nonnull SortedSet<RoutingProtocol> getProtocolsSorted() {
+    return ImmutableSortedSet.copyOf(_protocols);
+  }
+
+  /** The vrf whose main RIB should be checked for a tracked route. */
+  @JsonProperty(PROP_VRF)
+  public @Nonnull String getVrf() {
+    return _vrf;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof TrackRoute)) {
+      return false;
+    }
+    TrackRoute that = (TrackRoute) o;
+    return _prefix.equals(that._prefix)
+        && _protocols.equals(that._protocols)
+        && _vrf.equals(that._vrf);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_prefix, _protocols, _vrf);
+  }
+
+  public static @Nonnull TrackRoute of(Prefix prefix, Set<RoutingProtocol> protocols, String vrf) {
+    return new TrackRoute(prefix, protocols, vrf);
+  }
+
+  @JsonCreator
+  private static @Nonnull TrackRoute create(
+      @JsonProperty(PROP_PREFIX) @Nullable Prefix prefix,
+      @JsonProperty(PROP_PROTOCOLS) @Nullable Set<RoutingProtocol> protocols,
+      @JsonProperty(PROP_VRF) @Nullable String vrf) {
+    checkArgument(prefix != null, "Missing %s", PROP_PREFIX);
+    checkArgument(vrf != null, "Missing %s", PROP_VRF);
+    return new TrackRoute(
+        prefix, ImmutableSet.copyOf(firstNonNull(protocols, ImmutableSet.of())), vrf);
+  }
+
+  private static final String PROP_PREFIX = "prefix";
+  private static final String PROP_PROTOCOLS = "protocols";
+  private static final String PROP_VRF = "vrf";
+
+  private final @Nonnull Prefix _prefix;
+  private final @Nonnull Set<RoutingProtocol> _protocols;
+  private final @Nonnull String _vrf;
+
+  private TrackRoute(Prefix prefix, Set<RoutingProtocol> protocols, String vrf) {
+    _prefix = prefix;
+    _protocols = protocols;
+    _vrf = vrf;
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/TrackRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/TrackRouteTest.java
@@ -1,0 +1,39 @@
+package org.batfish.datamodel.tracking;
+
+import static org.batfish.datamodel.Prefix.ZERO;
+import static org.batfish.datamodel.RoutingProtocol.HMM;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Prefix;
+import org.junit.Test;
+
+/** Test of {@link TrackRoute}. */
+public final class TrackRouteTest {
+
+  @Test
+  public void testJavaSerialization() {
+    TrackRoute obj = TrackRoute.of(ZERO, ImmutableSet.of(HMM), "foo");
+    assertEquals(obj, SerializationUtils.clone(obj));
+  }
+
+  @Test
+  public void testJacksonSerialization() {
+    TrackRoute obj = TrackRoute.of(ZERO, ImmutableSet.of(HMM), "foo");
+    assertEquals(obj, BatfishObjectMapper.clone(obj, TrackMethod.class));
+  }
+
+  @Test
+  public void testEquals() {
+    TrackRoute obj = TrackRoute.of(ZERO, ImmutableSet.of(), "foo");
+    new EqualsTester()
+        .addEqualityGroup(obj, TrackRoute.of(ZERO, ImmutableSet.of(), "foo"))
+        .addEqualityGroup(TrackRoute.of(Prefix.strict("192.0.2.0/24"), ImmutableSet.of(), "foo"))
+        .addEqualityGroup(TrackRoute.of(ZERO, ImmutableSet.of(HMM), "foo"))
+        .addEqualityGroup(TrackRoute.of(ZERO, ImmutableSet.of(), "bar"))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -598,7 +598,7 @@ DOT1Q
 ;
 
 DOT1Q_TUNNEL: 'dot1q-tunnel';
-
+DOWN: 'down';
 DR_DELAY: 'dr-delay';
 
 DR_PRIORITY: 'dr-priority';
@@ -2436,7 +2436,7 @@ UNREACHABLE: 'unreachable';
 UNREACHABLES: 'unreachables';
 
 UNSUPPRESS_MAP: 'unsuppress-map' -> pushMode(M_Word);
-
+UP: 'up';
 UPDATE: 'update';
 
 UPDATE_SOURCE: 'update-source';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosParser.g4
@@ -602,9 +602,17 @@ track_ip
   )
 ;
 
-track_ip_route: ROUTE prefix = ip_prefix REACHABILITY HMM? NEWLINE track_ip_route_inner*;
+track_ip_route
+:
+  ROUTE prefix = ip_prefix REACHABILITY HMM? NEWLINE
+  track_ip_route_inner*
+;
 
-track_ip_route_inner: tir_vrf | tir_null;
+track_ip_route_inner
+:
+  tir_vrf
+  | tir_null
+;
 
 tir_vrf: VRF MEMBER name = vrf_name NEWLINE;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosParser.g4
@@ -602,15 +602,13 @@ track_ip
   )
 ;
 
-track_ip_route
-:
-  ROUTE null_rest_of_line tir_vrf*
-;
+track_ip_route: ROUTE prefix = ip_prefix REACHABILITY HMM? NEWLINE track_ip_route_inner*;
 
-tir_vrf
-:
-  VRF MEMBER name = vrf_name NEWLINE
-;
+track_ip_route_inner: tir_vrf | tir_null;
+
+tir_vrf: VRF MEMBER name = vrf_name NEWLINE;
+
+tir_null: DELAY null_rest_of_line;
 
 track_ip_sla
 :

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1935,12 +1935,11 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               trackInterface.getMode()));
     } else if (track instanceof TrackIpRoute) {
       TrackIpRoute trackIpRoute = (TrackIpRoute) track;
-      String vrf = trackIpRoute.getVrf();
       return Optional.of(
           TrackRoute.of(
               trackIpRoute.getPrefix(),
               trackIpRoute.getHmm() ? ImmutableSet.of(RoutingProtocol.HMM) : ImmutableSet.of(),
-              vrf != null ? trackIpRoute.getVrf() : DEFAULT_VRF_NAME));
+              firstNonNull(trackIpRoute.getVrf(), DEFAULT_VRF_NAME)));
     }
     // Warnings for unsupported track methods should be handled by parse warnings
     return Optional.empty();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -223,6 +223,7 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
 import org.batfish.datamodel.tracking.DecrementPriority;
+import org.batfish.datamodel.tracking.TrackRoute;
 import org.batfish.datamodel.vendor_family.cisco_nxos.CiscoNxosFamily;
 import org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform;
 import org.batfish.datamodel.vendor_family.cisco_nxos.NxosMajorVersion;
@@ -1932,6 +1933,13 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
           String.format(
               "Interface track mode %s is not yet supported and will be ignored.",
               trackInterface.getMode()));
+    } else if (track instanceof TrackIpRoute) {
+      TrackIpRoute trackIpRoute = (TrackIpRoute) track;
+      return Optional.of(
+          TrackRoute.of(
+              trackIpRoute.getPrefix(),
+              trackIpRoute.getHmm() ? ImmutableSet.of(RoutingProtocol.HMM) : ImmutableSet.of(),
+              trackIpRoute.getVrf()));
     }
     // Warnings for unsupported track methods should be handled by parse warnings
     return Optional.empty();
@@ -3827,7 +3835,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     if (staticRoute.getNextHopVrf() != null) {
       return null;
     }
-    // TODO: support track object number
     String nextHopInterface = staticRoute.getNextHopInterface();
     NextHop nh;
     if (staticRoute.getDiscard()) {
@@ -3856,6 +3863,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         .setNetwork(staticRoute.getPrefix())
         .setNextHop(nh)
         .setTag(staticRoute.getTag())
+        // guaranteed to exist by extractor if non-null
+        .setTrack(staticRoute.getTrack())
         .build();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -3857,6 +3857,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               "Could not determine a next hop for static route: %s", staticRoute.getPrefix()));
       return null;
     }
+    Integer track = staticRoute.getTrack();
     return org.batfish.datamodel.StaticRoute.builder()
         .setAdministrativeCost(staticRoute.getPreference())
         .setMetric(0L)
@@ -3864,7 +3865,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         .setNextHop(nh)
         .setTag(staticRoute.getTag())
         // guaranteed to exist by extractor if non-null
-        .setTrack(staticRoute.getTrack())
+        .setTrack(track != null ? track.toString() : null)
         .build();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1935,11 +1935,12 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               trackInterface.getMode()));
     } else if (track instanceof TrackIpRoute) {
       TrackIpRoute trackIpRoute = (TrackIpRoute) track;
+      String vrf = trackIpRoute.getVrf();
       return Optional.of(
           TrackRoute.of(
               trackIpRoute.getPrefix(),
               trackIpRoute.getHmm() ? ImmutableSet.of(RoutingProtocol.HMM) : ImmutableSet.of(),
-              trackIpRoute.getVrf()));
+              vrf != null ? trackIpRoute.getVrf() : DEFAULT_VRF_NAME));
     }
     // Warnings for unsupported track methods should be handled by parse warnings
     return Optional.empty();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
@@ -160,7 +160,8 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   SYSQOS_QOS("system qos service-policy type qos"),
   SYSQOS_QUEUING("system qos service-policy type queuing"),
   TACACS_SOURCE_INTERFACE("ip tacacs source-interface"),
-  TRACK_INTERFACE("track interface");
+  TRACK_INTERFACE("track interface"),
+  TRACK_IP_ROUTE_VRF("track ip route vrf");
 
   private final @Nonnull String _description;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/TrackIpRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/TrackIpRoute.java
@@ -1,0 +1,33 @@
+package org.batfish.representation.cisco_nxos;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Prefix;
+
+public final class TrackIpRoute implements Track {
+
+  public TrackIpRoute(Prefix prefix, boolean hmm) {
+    _prefix = prefix;
+    _hmm = hmm;
+  }
+
+  public boolean getHmm() {
+    return _hmm;
+  }
+
+  public @Nonnull Prefix getPrefix() {
+    return _prefix;
+  }
+
+  public @Nullable String getVrf() {
+    return _vrf;
+  }
+
+  public void setVrf(@Nullable String vrf) {
+    _vrf = vrf;
+  }
+
+  private final boolean _hmm;
+  private final @Nonnull Prefix _prefix;
+  private @Nullable String _vrf;
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -9764,7 +9764,7 @@ public final class CiscoNxosGrammarTest {
             org.batfish.datamodel.StaticRoute.builder()
                 .setNetwork(Prefix.strict("10.0.1.0/24"))
                 .setNextHop(NextHopIp.of(Ip.parse("10.1.0.2")))
-                .setTrack(10)
+                .setTrack("10")
                 .setAdmin(1)
                 .setTag(0)
                 .build()));
@@ -9774,7 +9774,7 @@ public final class CiscoNxosGrammarTest {
             org.batfish.datamodel.StaticRoute.builder()
                 .setNetwork(Prefix.strict("10.0.3.0/24"))
                 .setNextHop(NextHopIp.of(Ip.parse("10.3.0.2")))
-                .setTrack(20)
+                .setTrack("20")
                 .setAdmin(1)
                 .setTag(0)
                 .build()));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -20,6 +20,7 @@ import static org.batfish.datamodel.Names.generatedEvpnToBgpv4VrfLeakPolicyName;
 import static org.batfish.datamodel.OriginMechanism.REDISTRIBUTE;
 import static org.batfish.datamodel.Route.UNSET_NEXT_HOP_INTERFACE;
 import static org.batfish.datamodel.Route.UNSET_ROUTE_NEXT_HOP_IP;
+import static org.batfish.datamodel.RoutingProtocol.HMM;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDscp;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstPort;
@@ -126,6 +127,7 @@ import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_TIMERS_L
 import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_TIMERS_THROTTLE_LSA_HOLD_INTERVAL_MS;
 import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_TIMERS_THROTTLE_LSA_MAX_INTERVAL_MS;
 import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_TIMERS_THROTTLE_LSA_START_INTERVAL_MS;
+import static org.batfish.representation.cisco_nxos.TrackInterface.Mode.LINE_PROTOCOL;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -296,7 +298,7 @@ import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.tracking.DecrementPriority;
-import org.batfish.datamodel.tracking.TrackMethod;
+import org.batfish.datamodel.tracking.TrackRoute;
 import org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform;
 import org.batfish.dataplane.protocols.BgpProtocolHelper;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
@@ -412,12 +414,14 @@ import org.batfish.representation.cisco_nxos.RouteMapSetWeight;
 import org.batfish.representation.cisco_nxos.RoutingProtocolInstance;
 import org.batfish.representation.cisco_nxos.SnmpCommunity;
 import org.batfish.representation.cisco_nxos.StaticRoute;
+import org.batfish.representation.cisco_nxos.StaticRoute.StaticRouteKey;
 import org.batfish.representation.cisco_nxos.StaticRouteV6;
 import org.batfish.representation.cisco_nxos.SwitchportMode;
 import org.batfish.representation.cisco_nxos.TcpOptions;
 import org.batfish.representation.cisco_nxos.Track;
 import org.batfish.representation.cisco_nxos.TrackInterface;
 import org.batfish.representation.cisco_nxos.TrackInterface.Mode;
+import org.batfish.representation.cisco_nxos.TrackIpRoute;
 import org.batfish.representation.cisco_nxos.TrackUnsupported;
 import org.batfish.representation.cisco_nxos.UdpOptions;
 import org.batfish.representation.cisco_nxos.Vlan;
@@ -1772,7 +1776,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(track, instanceOf(TrackInterface.class));
       TrackInterface trackInterface = (TrackInterface) track;
       assertThat(trackInterface.getInterface(), equalTo("port-channel1"));
-      assertThat(trackInterface.getMode(), equalTo(Mode.LINE_PROTOCOL));
+      assertThat(trackInterface.getMode(), equalTo(LINE_PROTOCOL));
     }
 
     {
@@ -1790,9 +1794,15 @@ public final class CiscoNxosGrammarTest {
       assertThat(trackInterface.getInterface(), equalTo("loopback1"));
       assertThat(trackInterface.getMode(), equalTo(Mode.IPV6_ROUTING));
     }
-
+    {
+      Track track = vc.getTracks().get(100);
+      assertThat(track, instanceOf(TrackIpRoute.class));
+      TrackIpRoute trackIpRoute = (TrackIpRoute) track;
+      assertThat(trackIpRoute.getPrefix(), equalTo(Prefix.strict("192.0.2.1/32")));
+      assertTrue(trackIpRoute.getHmm());
+      assertThat(trackIpRoute.getVrf(), equalTo("v1"));
+    }
     // Should have placeholders for unsupported track types in the VS model
-    assertThat(vc.getTracks().get(100), instanceOf(TrackUnsupported.class));
     assertThat(vc.getTracks().get(101), instanceOf(TrackUnsupported.class));
   }
 
@@ -1810,9 +1820,6 @@ public final class CiscoNxosGrammarTest {
                 "Unsupported interface type: Vlan, expected [ETHERNET, PORT_CHANNEL, LOOPBACK]"),
             allOf(
                 hasComment("This track method is not yet supported and will be ignored."),
-                ParseWarningMatchers.hasText(containsString("ip route 192.0.2.1/32 reachability"))),
-            allOf(
-                hasComment("This track method is not yet supported and will be ignored."),
                 ParseWarningMatchers.hasText(containsString("ip sla 1 reachability"))),
             hasComment("Expected track object-id in range 1-500, but got '0'"),
             hasComment("Expected track object-id in range 1-500, but got '501'"),
@@ -1828,23 +1835,13 @@ public final class CiscoNxosGrammarTest {
     String hostname = "nxos_track_conversion";
     Configuration c = parseConfig(hostname);
 
-    assertThat(c.getTrackingGroups(), hasKeys("1", "500"));
-
-    {
-      TrackMethod trackMethod = c.getTrackingGroups().get("1");
-      assertThat(trackMethod, instanceOf(org.batfish.datamodel.tracking.TrackInterface.class));
-      org.batfish.datamodel.tracking.TrackInterface trackInterface =
-          (org.batfish.datamodel.tracking.TrackInterface) trackMethod;
-      assertThat(trackInterface.getTrackedInterface(), equalTo("port-channel1"));
-    }
-
-    {
-      TrackMethod trackMethod = c.getTrackingGroups().get("500");
-      assertThat(trackMethod, instanceOf(org.batfish.datamodel.tracking.TrackInterface.class));
-      org.batfish.datamodel.tracking.TrackInterface trackInterface =
-          (org.batfish.datamodel.tracking.TrackInterface) trackMethod;
-      assertThat(trackInterface.getTrackedInterface(), equalTo("Ethernet1/1"));
-    }
+    assertThat(
+        c.getTrackingGroups(),
+        equalTo(
+            ImmutableMap.of(
+                "1", new org.batfish.datamodel.tracking.TrackInterface("port-channel1"),
+                "100", TrackRoute.of(Prefix.strict("192.0.2.1/32"), ImmutableSet.of(HMM), "v1"),
+                "500", new org.batfish.datamodel.tracking.TrackInterface("Ethernet1/1"))));
   }
 
   @Test
@@ -8524,10 +8521,7 @@ public final class CiscoNxosGrammarTest {
                     containsString("10.0.1.0/24 Ethernet1/1 10.0.1.1 vrf management"))),
             allOf(
                 hasComment("Cannot delete non-existent route"),
-                ParseWarningMatchers.hasText("10.0.1.0/24 Ethernet1/1")),
-            // caused by route definitions with `track`
-            hasComment("This feature is not currently supported"),
-            hasComment("This feature is not currently supported")));
+                ParseWarningMatchers.hasText("10.0.1.0/24 Ethernet1/1"))));
   }
 
   @Test
@@ -9692,5 +9686,97 @@ public final class CiscoNxosGrammarTest {
             hasText(
                 "Could not enable HMM on interface 'Vlan2' because fabric forwarding"
                     + " anycast-gateway-mac is unset")));
+  }
+
+  @Test
+  public void testStaticRouteTrackExtraction() {
+    String hostname = "nxos_static_route_track";
+    CiscoNxosConfiguration vc = parseVendorConfig(hostname);
+
+    // tracks
+    assertThat(vc.getTracks(), hasKeys(10, 20));
+    {
+      Track track = vc.getTracks().get(10);
+      assertThat(track, instanceOf(TrackInterface.class));
+      TrackInterface ti = (TrackInterface) track;
+      assertThat(ti.getInterface(), equalTo("Ethernet1/2"));
+      assertThat(ti.getMode(), equalTo(LINE_PROTOCOL));
+    }
+    {
+      Track track = vc.getTracks().get(20);
+      assertThat(track, instanceOf(TrackIpRoute.class));
+      TrackIpRoute tr = (TrackIpRoute) track;
+      assertTrue(tr.getHmm());
+      assertThat(tr.getPrefix(), equalTo(Prefix.strict("10.3.0.2/32")));
+      assertThat(tr.getVrf(), equalTo("foo"));
+    }
+
+    // static routes
+    assertThat(
+        vc.getDefaultVrf().getStaticRoutes(),
+        hasKeys(
+            new StaticRouteKey(
+                Prefix.strict("10.0.1.0/24"), false, null, Ip.parse("10.1.0.2"), null)));
+    {
+      StaticRoute sr =
+          vc.getDefaultVrf()
+              .getStaticRoutes()
+              .get(
+                  new StaticRouteKey(
+                      Prefix.strict("10.0.1.0/24"), false, null, Ip.parse("10.1.0.2"), null));
+      assertThat(sr.getPrefix(), equalTo(Prefix.strict("10.0.1.0/24")));
+      assertThat(sr.getTrack(), equalTo(10));
+    }
+    assertThat(
+        vc.getVrfs().get("foo").getStaticRoutes(),
+        hasKeys(
+            new StaticRouteKey(
+                Prefix.strict("10.0.3.0/24"), false, null, Ip.parse("10.3.0.2"), null)));
+    {
+      StaticRoute sr =
+          vc.getVrfs()
+              .get("foo")
+              .getStaticRoutes()
+              .get(
+                  new StaticRouteKey(
+                      Prefix.strict("10.0.3.0/24"), false, null, Ip.parse("10.3.0.2"), null));
+      assertThat(sr.getPrefix(), equalTo(Prefix.strict("10.0.3.0/24")));
+      assertThat(sr.getTrack(), equalTo(20));
+    }
+  }
+
+  @Test
+  public void testStaticRouteTrackConversion() throws IOException {
+    String hostname = "nxos_static_route_track";
+    Configuration c = parseConfig(hostname);
+
+    assertThat(
+        c.getTrackingGroups(),
+        equalTo(
+            ImmutableMap.of(
+                "10",
+                new org.batfish.datamodel.tracking.TrackInterface("Ethernet1/2"),
+                "20",
+                TrackRoute.of(Prefix.strict("10.3.0.2/32"), ImmutableSet.of(HMM), "foo"))));
+    assertThat(
+        c.getDefaultVrf().getStaticRoutes(),
+        contains(
+            org.batfish.datamodel.StaticRoute.builder()
+                .setNetwork(Prefix.strict("10.0.1.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.1.0.2")))
+                .setTrack(10)
+                .setAdmin(1)
+                .setTag(0)
+                .build()));
+    assertThat(
+        c.getVrfs().get("foo").getStaticRoutes(),
+        contains(
+            org.batfish.datamodel.StaticRoute.builder()
+                .setNetwork(Prefix.strict("10.0.3.0/24"))
+                .setNextHop(NextHopIp.of(Ip.parse("10.3.0.2")))
+                .setTrack(20)
+                .setAdmin(1)
+                .setTag(0)
+                .build()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -1839,9 +1839,14 @@ public final class CiscoNxosGrammarTest {
         c.getTrackingGroups(),
         equalTo(
             ImmutableMap.of(
-                "1", new org.batfish.datamodel.tracking.TrackInterface("port-channel1"),
-                "100", TrackRoute.of(Prefix.strict("192.0.2.1/32"), ImmutableSet.of(HMM), "v1"),
-                "500", new org.batfish.datamodel.tracking.TrackInterface("Ethernet1/1"))));
+                "1",
+                new org.batfish.datamodel.tracking.TrackInterface("port-channel1"),
+                "100",
+                TrackRoute.of(Prefix.strict("192.0.2.1/32"), ImmutableSet.of(HMM), "v1"),
+                "200",
+                TrackRoute.of(Prefix.strict("192.0.2.2/32"), ImmutableSet.of(), DEFAULT_VRF_NAME),
+                "500",
+                new org.batfish.datamodel.tracking.TrackInterface("Ethernet1/1"))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_static_route_track
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_static_route_track
@@ -1,0 +1,35 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_static_route_track
+!
+
+! vrf default
+interface Ethernet1/1
+  no switchport
+  no shutdown
+  ip address 10.1.0.1/24
+!
+interface Ethernet1/2
+  no switchport
+  no shutdown
+  ip address 10.2.0.1/24
+!
+track 10 interface Ethernet1/2 line-protocol
+!
+ip route 10.0.1.0/24 10.1.0.2 track 10
+!
+
+! vrf foo
+interface Ethernet1/3
+  no switchport
+  no shutdown
+  vrf member foo
+  ip address 10.3.0.1/24
+!
+track 20 ip route 10.3.0.2/32 reachability hmm
+  vrf member foo
+  delay up 0 down 0
+!
+vrf context foo
+  ip route 10.0.3.0/24 10.3.0.2 track 20
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track
@@ -8,9 +8,8 @@ vrf context v1
 track 1 interface port-channel1 line-protocol
 track 2 interface Ethernet1/1 ip routing
 track 500 interface loopback1 ipv6 routing
-
-! Not yet supported in VS model, but parsed
 track 100 ip route 192.0.2.1/32 reachability hmm
   vrf member v1
+! Not yet supported in VS model, but parsed
 track 101 ip sla 1 reachability
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
@@ -6,6 +6,7 @@ track 1 interface port-channel1 line-protocol
 track 500 interface Ethernet1/1 line-protocol
 track 100 ip route 192.0.2.1/32 reachability hmm
   vrf member v1
+track 200 ip route 192.0.2.2/32 reachability
 
 ! We don't yet convert these track types, but shouldn't crash
 track 101 ip sla 1 reachability

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
@@ -4,9 +4,9 @@ hostname nxos_track_conversion
 !
 track 1 interface port-channel1 line-protocol
 track 500 interface Ethernet1/1 line-protocol
-
-! We don't yet convert these track types, but shouldn't crash
 track 100 ip route 192.0.2.1/32 reachability hmm
   vrf member v1
+
+! We don't yet convert these track types, but shouldn't crash
 track 101 ip sla 1 reachability
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_warn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_warn
@@ -8,8 +8,6 @@ track 0 interface port-channel1 line-protocol
 track 501 interface port-channel2 line-protocol
 !
 ! Not yet supported
-track 100 ip route 192.0.2.1/32 reachability hmm
-  vrf member v1
 track 101 ip sla 1 reachability
 !
 


### PR DESCRIPTION
- add `TrackRoute` `TrackMethod` to datamodel
  - supports matching a route in a main RIB based on:
    - prefix
    - vrf
    - optionally, matching one of a set of protocols