### PR TITLE
Sonic: Set incoming filter, not inbound filter

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConversions.java
@@ -416,7 +416,7 @@ public class SonicConversions {
         continue;
       }
       if (aclStage == Stage.INGRESS) {
-        viIface.setInboundFilter(ipAccessList);
+        viIface.setIncomingFilter(ipAccessList);
       } else { // EGRESS
         viIface.setOutgoingFilter(ipAccessList);
       }

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicGrammarTest.java
@@ -269,7 +269,7 @@ public class SonicGrammarTest {
                     .build())));
 
     Configuration c = getOnlyElement(vc.toVendorIndependentConfigurations());
-    IpAccessList ipAccessList = c.getAllInterfaces().get("Ethernet0").getInboundFilter();
+    IpAccessList ipAccessList = c.getAllInterfaces().get("Ethernet0").getIncomingFilter();
     assertThat(
         ipAccessList.getLines().stream()
             .map(SonicGrammarTest::toMatchBDD)

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/SonicConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/SonicConversionsTest.java
@@ -339,7 +339,7 @@ public class SonicConversionsTest {
     // ACL exists in the VI model and is attached properly
     IpAccessList ipAccessList = c.getIpAccessLists().get(aclName);
     assertNotNull(ipAccessList);
-    assertEquals(aclName, c.getAllInterfaces().get(ifaceName).getInboundFilter().getName());
+    assertEquals(aclName, c.getAllInterfaces().get(ifaceName).getIncomingFilter().getName());
 
     // ACL has all and only the expected rules
     assertEquals(
@@ -407,7 +407,7 @@ public class SonicConversionsTest {
     // ACLs are still converted with whatever is left
     IpAccessList ipAccessList = c.getIpAccessLists().get(aclName);
     assertNotNull(ipAccessList);
-    assertEquals(aclName, c.getAllInterfaces().get(ifaceName).getInboundFilter().getName());
+    assertEquals(aclName, c.getAllInterfaces().get(ifaceName).getIncomingFilter().getName());
     assertEquals(
         ImmutableList.of("GoodRule"),
         ipAccessList.getLines().stream()
@@ -456,7 +456,7 @@ public class SonicConversionsTest {
       attachAcl(c, aclName, ipAccessList, aclTable, warnings);
 
       assertTrue(warnings.getRedFlagWarnings().isEmpty());
-      assertNull(c.getAllInterfaces().get(ifaceName).getInboundFilter());
+      assertNull(c.getAllInterfaces().get(ifaceName).getIncomingFilter());
     }
     {
       // missing stage
@@ -467,7 +467,7 @@ public class SonicConversionsTest {
       attachAcl(c, aclName, ipAccessList, aclTable, warnings);
 
       assertThat(warnings.getRedFlagWarnings(), contains(hasText("Unimplemented ACL stage: null")));
-      assertNull(c.getAllInterfaces().get(ifaceName).getInboundFilter());
+      assertNull(c.getAllInterfaces().get(ifaceName).getIncomingFilter());
     }
     {
       // one of the ports is missing


### PR DESCRIPTION
Incoming filter is applied to traffic that arrives at the interface, while inbound filter is (supposed to be) applied to traffic destined for an address owned by the interface.