### PR TITLE
Junos: Proper linking of implicitly created interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -6563,13 +6563,15 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     }
     if (unit != null) {
       Map<String, Interface> units = iface.getUnits();
-      iface = units.get(unitFullName);
-      if (iface == null) {
+      Interface unitIface = units.get(unitFullName);
+      if (unitIface == null) {
         // TODO: this is not ideal, interface should not be created here as we are not sure if the
         // interface was defined
-        iface = new Interface(unitFullName);
-        iface.setRoutingInstance(_currentLogicalSystem.getDefaultRoutingInstance().getName());
-        units.put(unitFullName, iface);
+        unitIface = new Interface(unitFullName);
+        unitIface.setRoutingInstance(_currentLogicalSystem.getDefaultRoutingInstance().getName());
+        units.put(unitFullName, unitIface);
+        unitIface.setParent(iface);
+        iface = unitIface;
       }
     }
     return iface;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -6571,8 +6571,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
         unitIface.setRoutingInstance(_currentLogicalSystem.getDefaultRoutingInstance().getName());
         units.put(unitFullName, unitIface);
         unitIface.setParent(iface);
-        iface = unitIface;
       }
+      iface = unitIface;
     }
     return iface;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4979,6 +4979,24 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testImplicitInitInterface() {
+    JuniperConfiguration juniperConfiguration = parseJuniperConfig("implicit-init-interface");
+
+    String phyIfaceName = "ge-1/1/0";
+    String unitIfaceName = phyIfaceName + ".1001";
+    Map<String, org.batfish.representation.juniper.Interface> interfaces =
+        juniperConfiguration.getMasterLogicalSystem().getInterfaces();
+
+    assertThat(interfaces.keySet(), equalTo(ImmutableSet.of(phyIfaceName)));
+    org.batfish.representation.juniper.Interface phyIface = interfaces.get(phyIfaceName);
+
+    assertThat(phyIface.getUnits().keySet(), equalTo(ImmutableSet.of(unitIfaceName)));
+    org.batfish.representation.juniper.Interface unitIface = phyIface.getUnits().get(unitIfaceName);
+
+    assertThat(unitIface.getParent(), equalTo(phyIface));
+  }
+
+  @Test
   public void testRouteFilters() {
     Configuration c = parseConfig("route-filter");
     RouteFilterList rfl = c.getRouteFilterLists().get("route-filter-test:t1");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/implicit-init-interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/implicit-init-interface
@@ -1,0 +1,12 @@
+set system host-name implicit-init-interface
+
+set groups group-name protocols ospf area <*> interface <*> ldp-synchronization
+set apply-groups group-name
+
+# this command will lead to interfaces ge-1/1/0 and ge-1/1/0.1001 being created
+set protocols ospf area 0.0.0.0 interface ge-1/1/0.1001 interface-type p2p
+
+# these lines will barf if ge-1/1/0 and ge-1/1/0.1001 were not properly linked during creation
+set interfaces ge-1/1/0 description "Parent interface"
+set interfaces ge-1/1/0 unit 1001 vlan-id 1001
+


### PR DESCRIPTION
Under some conditions (see test file) BF automatically creates interfaces. Prior to this PR, when such an interface was a sub-interface, it was not being properly linked to its parent. In particular, the parent's units map had the sub-interface but the sub-interface did not have the parent configured. The partial linking was later preventing the parent from being set and then causing an NPE. 