### PR TITLE
NX-OS: Trunk interfaces' allowed VLANs must be active

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -5928,14 +5928,13 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     }
     _currentInterfaces.forEach(
         iface -> {
-          if (iface.getSwitchportMode() == null) {
-            // NX-OS has these commands in show run all even for interfaces in other modes.
-            iface.setSwitchportMode(SwitchportMode.TRUNK);
-          }
           if (ctx.ADD() != null) {
             iface.setAllowedVlans(iface.getAllowedVlans().union(vlans));
           } else if (ctx.REMOVE() != null) {
-            iface.setAllowedVlans(iface.getAllowedVlans().difference(vlans));
+            IntegerSpace allowedAfterRemoval = iface.getAllowedVlans().difference(vlans);
+            // If all allowed VLANs were removed, none are now set, so revert to default.
+            iface.setAllowedVlans(
+                allowedAfterRemoval.isEmpty() ? _currentValidVlanRange : allowedAfterRemoval);
           } else {
             iface.setAllowedVlans(vlans);
           }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -2101,7 +2101,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         break;
 
       case TRUNK:
-        newIfaceBuilder.setAllowedVlans(iface.getAllowedVlans());
+        IntegerSpace.Builder activeVlans = IntegerSpace.builder();
+        _vlans.keySet().forEach(activeVlans::including);
+        newIfaceBuilder.setAllowedVlans(iface.getAllowedVlans().intersection(activeVlans.build()));
         newIfaceBuilder.setNativeVlan(iface.getNativeVlan());
         break;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
@@ -141,7 +141,7 @@ public final class Interface implements Serializable {
 
   private @Nullable Integer _accessVlan;
   private @Nullable InterfaceAddressWithAttributes _address;
-  private @Nullable IntegerSpace _allowedVlans;
+  private @Nonnull IntegerSpace _allowedVlans;
   private boolean _autostate;
   private @Nullable Long _bandwidth;
   private @Nullable String _channelGroup;
@@ -213,7 +213,7 @@ public final class Interface implements Serializable {
     return _address;
   }
 
-  public @Nullable IntegerSpace getAllowedVlans() {
+  public @Nonnull IntegerSpace getAllowedVlans() {
     return _allowedVlans;
   }
 
@@ -477,7 +477,7 @@ public final class Interface implements Serializable {
     _address = address;
   }
 
-  public void setAllowedVlans(@Nullable IntegerSpace allowedVlans) {
+  public void setAllowedVlans(@Nonnull IntegerSpace allowedVlans) {
     _allowedVlans = allowedVlans;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -2928,7 +2928,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(2));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4094))));
+      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 5))));
     }
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/6");
@@ -2949,7 +2949,9 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 3966))));
+      assertThat(
+          iface.getAllowedVlans(),
+          equalTo(IntegerSpace.unionOf(Range.singleton(1), Range.closed(3, 5))));
     }
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/9");
@@ -2988,7 +2990,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4094))));
+      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 5))));
     }
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/15");
@@ -3115,7 +3117,9 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 3966))));
+      assertThat(
+          iface.getAllowedVlans(),
+          equalTo(IntegerSpace.unionOf(Range.singleton(1), Range.closed(3, 3967))));
     }
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/9");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport
@@ -8,6 +8,10 @@ boot nxos bootflash:/nxos.9.2.3.bin
 system default switchport
 no system default switchport shutdown
 
+! Declare VLANs.
+! TODO Add a suspended VLAN once supported to test that it isn't included in allowed VLANs.
+vlan 1-5
+
 ! Ethernet interface with no configuration:
 ! - shutdown = false
 ! - active = true
@@ -116,8 +120,9 @@ interface Ethernet1/4
 ! - switchport = true
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 2
-! - switchport allowed vlans = 1-3967
+! - switchport allowed vlans = 1-5 (all active VLANs)
 interface Ethernet1/5
+  switchport mode trunk
   switchport trunk native vlan 2
 !
 
@@ -129,6 +134,7 @@ interface Ethernet1/5
 ! - switchport native vlan = 1
 ! - switchport allowed vlans = 1-3
 interface Ethernet1/6
+  switchport mode trunk
   switchport trunk allowed vlan 1-3
 !
 
@@ -138,8 +144,9 @@ interface Ethernet1/6
 ! - switchport = true
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
-! - switchport allowed vlans = 1-3
+! - switchport allowed vlans = 1-4
 interface Ethernet1/7
+  switchport mode trunk
   switchport trunk allowed vlan 1-3
   switchport trunk allowed vlan add 4
 !
@@ -150,9 +157,10 @@ interface Ethernet1/7
 ! - switchport = true
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
-! - switchport allowed vlans = 1-3966
+! - switchport allowed vlans = 1, 3-5
 interface Ethernet1/8
-  switchport trunk allowed vlan except 3967
+  switchport mode trunk
+  switchport trunk allowed vlan except 2
 !
 
 ! Ethernet interface with allowed vlans none
@@ -163,6 +171,7 @@ interface Ethernet1/8
 ! - switchport native vlan = 1
 ! - switchport allowed vlans = {}
 interface Ethernet1/9
+  switchport mode trunk
   switchport trunk allowed vlan none
 !
 
@@ -172,8 +181,9 @@ interface Ethernet1/9
 ! - switchport = true
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
-! - switchport allowed vlans = 1-3
+! - switchport allowed vlans = 1-2
 interface Ethernet1/10
+  switchport mode trunk
   switchport trunk allowed vlan 1-3
   switchport trunk allowed vlan remove 3
 !
@@ -207,7 +217,7 @@ interface Ethernet1/13
 ! - switchport = true
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
-! - switchport allowed vlans = 1-3967
+! - switchport allowed vlans = 1-5
 interface Ethernet1/14
   switchport mode trunk
 !


### PR DESCRIPTION
Previously, if no allowed VLANs were specified for an interface in trunk mode, we allowed the full valid range (1-4094). Actually it should default to all active declared VLANs.

Similarly, if allowed VLANs are specified, any that are not active declared VLANs should be ignored.