### PR TITLE
SCTP has ports too

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPort.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPort.java
@@ -41,7 +41,7 @@ public final class FwFromDestinationPort implements FwFrom {
   @VisibleForTesting
   HeaderSpace toHeaderspace() {
     return HeaderSpace.builder()
-        .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP)
+        .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP, IpProtocol.SCTP)
         .setDstPorts(_portRange)
         .build();
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePort.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePort.java
@@ -46,7 +46,7 @@ public final class FwFromSourcePort implements FwFrom {
 
   private HeaderSpace toHeaderspace() {
     return HeaderSpace.builder()
-        .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP)
+        .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP, IpProtocol.SCTP)
         .setSrcPorts(_portRange)
         .build();
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPortTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPortTest.java
@@ -16,7 +16,7 @@ public class FwFromDestinationPortTest {
     assertEquals(
         from.toHeaderspace(),
         HeaderSpace.builder()
-            .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP)
+            .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP, IpProtocol.SCTP)
             .setDstPorts(new SubRange(1, 2))
             .build());
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePortTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePortTest.java
@@ -19,7 +19,7 @@ public class FwFromSourcePortTest {
         from.toAclLineMatchExpr(null, null, null),
         new MatchHeaderSpace(
             HeaderSpace.builder()
-                .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP)
+                .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP, IpProtocol.SCTP)
                 .setSrcPorts(new SubRange(1, 2))
                 .build(),
             TraceElement.of("Matched source-port 1-2")));
@@ -32,7 +32,7 @@ public class FwFromSourcePortTest {
         from.toAclLineMatchExpr(null, null, null),
         new MatchHeaderSpace(
             HeaderSpace.builder()
-                .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP)
+                .setIpProtocols(IpProtocol.TCP, IpProtocol.UDP, IpProtocol.SCTP)
                 .setSrcPorts(SubRange.singleton(1))
                 .build(),
             TraceElement.of("Matched source-port 1")));


### PR DESCRIPTION
For Junos firewall conversions, BF was assuming TCP/UDP when source/destination port filters were used. But SCTP has ports too, so expanding the set of possibilities. 