### PR TITLE
Junos: Follow convention for composite filter names

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.Names.isCompositeFilterName;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -180,7 +181,7 @@ public class IpAccessList implements Serializable {
 
   @JsonIgnore
   public boolean isComposite() {
-    return getName().startsWith("~");
+    return isCompositeFilterName(getName());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * Provides helper methods to auto-generate structure names and to check the validity of names of
@@ -146,12 +147,17 @@ public final class Names {
         "~OSPF_INBOUND_DISTRIBUTE_LIST:%s:%s:%s:%s~", vrf, procName, areaNum, ifaceName);
   }
 
-  public static String generatedIncomingInterfaceFilterName(String ifaceName) {
-    return String.format("~INCOMING_FILTER:%s~", ifaceName);
+  /** Generates a composite filter name from provided ingredient names. */
+  public static String generateCompositeFilterName(String... ingredientNames) {
+    checkArgument(ingredientNames.length > 0, "At least one ingredient name must be provided.");
+    return String.format("~filter~%s~", Strings.join(Arrays.asList(ingredientNames), '~'));
   }
 
-  public static String generatedOutgoingInterfaceFilterName(String ifaceName) {
-    return String.format("~OUTGOING_FILTER:%s~", ifaceName);
+  /** Returns whether the specified name matches the generated-named convention for filters. */
+  public static boolean isCompositeFilterName(String name) {
+    // this test could be tighter, given generateCompositeFilterName, but most vendors do not call
+    // into this helper.
+    return name.startsWith("~");
   }
 
   public static String generatedReferenceBook(String hostname, String source) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Names.java
@@ -146,6 +146,14 @@ public final class Names {
         "~OSPF_INBOUND_DISTRIBUTE_LIST:%s:%s:%s:%s~", vrf, procName, areaNum, ifaceName);
   }
 
+  public static String generatedIncomingInterfaceFilterName(String ifaceName) {
+    return String.format("~INCOMING_FILTER:%s~", ifaceName);
+  }
+
+  public static String generatedOutgoingInterfaceFilterName(String ifaceName) {
+    return String.format("~OUTGOING_FILTER:%s~", ifaceName);
+  }
+
   public static String generatedReferenceBook(String hostname, String source) {
     return String.format("%s~on~%s", source, hostname);
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NamesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NamesTest.java
@@ -3,11 +3,14 @@ package org.batfish.datamodel;
 import static org.batfish.datamodel.Names.Type.REFERENCE_OBJECT;
 import static org.batfish.datamodel.Names.Type.TABLE_COLUMN;
 import static org.batfish.datamodel.Names.VALID_PATTERNS;
+import static org.batfish.datamodel.Names.generateCompositeFilterName;
+import static org.batfish.datamodel.Names.isCompositeFilterName;
 import static org.batfish.datamodel.Names.nameNeedsEscaping;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -67,5 +70,17 @@ public class NamesTest {
   @Test
   public void testZoneToZoneFilter() {
     assertThat(zoneToZoneFilter("a", "b"), equalTo("zone~a~to~zone~b"));
+  }
+
+  @Test
+  public void testGenerateCompositeFilterName() {
+    assertEquals("~filter~name~", generateCompositeFilterName("name"));
+    assertEquals("~filter~name1~name2~", generateCompositeFilterName("name1", "name2"));
+  }
+
+  @Test
+  public void testIsCompositeFilterName() {
+    assertTrue(isCompositeFilterName(generateCompositeFilterName("name")));
+    assertFalse(isCompositeFilterName("filter"));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3877,12 +3877,18 @@ public final class JuniperConfiguration extends VendorConfiguration {
   private void handleFilterLists(Interface i) {
     if (i.getIncomingFilterList() != null) {
       i.setIncomingFilter(
-          generateCompositeInterfaceFilter(i.getIncomingFilterList(), i.getName() + "-i"));
+          generateCompositeInterfaceFilter(
+              i.getIncomingFilterList(), compositeInterfaceFilterName(i.getName(), "input")));
     }
     if (i.getOutgoingFilterList() != null) {
       i.setOutgoingFilter(
-          generateCompositeInterfaceFilter(i.getOutgoingFilterList(), i.getName() + "-o"));
+          generateCompositeInterfaceFilter(
+              i.getOutgoingFilterList(), compositeInterfaceFilterName(i.getName(), "output")));
     }
+  }
+
+  private String compositeInterfaceFilterName(String ifaceName, String inputOrOutput) {
+    return String.format("~%s~%s~", ifaceName, inputOrOutput);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1666,6 +1666,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
     return String.format("~ISIS_EXPORT_POLICY:%s~", routingInstanceName);
   }
 
+  public static String computeInterfaceFilterName(String ifaceName, boolean input) {
+    return String.format("~%s~%s~", ifaceName, input ? "input" : "output");
+  }
+
   /**
    * Converts {@link IkePolicy} to {@link IkePhase1Policy} and puts the used pre-shared key as a
    * {@link IkePhase1Key} in the passed-in {@code ikePhase1Keys}
@@ -3878,17 +3882,13 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (i.getIncomingFilterList() != null) {
       i.setIncomingFilter(
           generateCompositeInterfaceFilter(
-              i.getIncomingFilterList(), compositeInterfaceFilterName(i.getName(), "input")));
+              i.getIncomingFilterList(), computeInterfaceFilterName(i.getName(), true)));
     }
     if (i.getOutgoingFilterList() != null) {
       i.setOutgoingFilter(
           generateCompositeInterfaceFilter(
-              i.getOutgoingFilterList(), compositeInterfaceFilterName(i.getName(), "output")));
+              i.getOutgoingFilterList(), computeInterfaceFilterName(i.getName(), false)));
     }
-  }
-
-  private String compositeInterfaceFilterName(String ifaceName, String inputOrOutput) {
-    return String.format("~%s~%s~", ifaceName, inputOrOutput);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -4,6 +4,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static org.batfish.datamodel.BgpPeerConfig.ALL_AS_NUMBERS;
 import static org.batfish.datamodel.Names.escapeNameIfNeeded;
+import static org.batfish.datamodel.Names.generatedIncomingInterfaceFilterName;
+import static org.batfish.datamodel.Names.generatedOutgoingInterfaceFilterName;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
@@ -1664,10 +1666,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   public static String computeIsisExportPolicyName(String routingInstanceName) {
     return String.format("~ISIS_EXPORT_POLICY:%s~", routingInstanceName);
-  }
-
-  public static String computeInterfaceFilterName(String ifaceName, boolean input) {
-    return String.format("~%s~%s~", ifaceName, input ? "input" : "output");
   }
 
   /**
@@ -3882,12 +3880,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (i.getIncomingFilterList() != null) {
       i.setIncomingFilter(
           generateCompositeInterfaceFilter(
-              i.getIncomingFilterList(), computeInterfaceFilterName(i.getName(), true)));
+              i.getIncomingFilterList(), generatedIncomingInterfaceFilterName(i.getName())));
     }
     if (i.getOutgoingFilterList() != null) {
       i.setOutgoingFilter(
           generateCompositeInterfaceFilter(
-              i.getOutgoingFilterList(), computeInterfaceFilterName(i.getName(), false)));
+              i.getOutgoingFilterList(), generatedOutgoingInterfaceFilterName(i.getName())));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -4,8 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static org.batfish.datamodel.BgpPeerConfig.ALL_AS_NUMBERS;
 import static org.batfish.datamodel.Names.escapeNameIfNeeded;
-import static org.batfish.datamodel.Names.generatedIncomingInterfaceFilterName;
-import static org.batfish.datamodel.Names.generatedOutgoingInterfaceFilterName;
+import static org.batfish.datamodel.Names.generateCompositeFilterName;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
@@ -3880,12 +3879,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (i.getIncomingFilterList() != null) {
       i.setIncomingFilter(
           generateCompositeInterfaceFilter(
-              i.getIncomingFilterList(), generatedIncomingInterfaceFilterName(i.getName())));
+              i.getIncomingFilterList(), generateCompositeFilterName("in", i.getName())));
     }
     if (i.getOutgoingFilterList() != null) {
       i.setOutgoingFilter(
           generateCompositeInterfaceFilter(
-              i.getOutgoingFilterList(), generatedOutgoingInterfaceFilterName(i.getName())));
+              i.getOutgoingFilterList(), generateCompositeFilterName("out", i.getName())));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -143,6 +143,7 @@ import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_G
 import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_SECURITY_POLICY;
 import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_ISIS_COST;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeConditionRoutingPolicyName;
+import static org.batfish.representation.juniper.JuniperConfiguration.computeInterfaceFilterName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeOspfExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePeerExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePolicyStatementTermName;
@@ -1607,13 +1608,13 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         c,
         hasIpAccessList(
-            "xe-0/0/3.0-i",
+            computeInterfaceFilterName("xe-0/0/3.0", true),
             allOf(
                 rejects(src1235, null, c), accepts(src1236, null, c), rejects(src8888, null, c))));
     assertThat(
         c,
         hasIpAccessList(
-            "xe-0/0/3.0-o",
+            computeInterfaceFilterName("xe-0/0/3.0", false),
             allOf(
                 rejects(src1235, null, c), rejects(src1236, null, c), rejects(src8888, null, c))));
   }
@@ -4991,18 +4992,19 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testGH6149Preprocess() {
     Configuration c = parseConfig("gh-6149-preprocess");
+    String interfaceFilterName = computeInterfaceFilterName("ae1.0", true);
     assertThat(
         c,
         allOf(
             hasInterface("ae1.0"),
-            hasIpAccessList("ae1.0-i"),
+            hasIpAccessList(interfaceFilterName),
             hasIpAccessList("filterA"),
             hasIpAccessList("filterB")));
     Interface ae1_0 = c.getAllInterfaces().get("ae1.0");
     // The interface gets the Juniper-standard name for a composite input filter.
-    assertThat(ae1_0, hasIncomingFilter(hasName("ae1.0-i")));
+    assertThat(ae1_0, hasIncomingFilter(hasName(interfaceFilterName)));
     // The ACL has the correct lines.
-    List<AclLine> lines = c.getIpAccessLists().get("ae1.0-i").getLines();
+    List<AclLine> lines = c.getIpAccessLists().get(interfaceFilterName).getLines();
     assertThat(lines, contains(instanceOf(AclAclLine.class), instanceOf(AclAclLine.class)));
     AclAclLine line0 = (AclAclLine) lines.get(0);
     assertThat(line0.getAclName(), equalTo("filterA"));

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -15,7 +15,7 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Flow.builder;
 import static org.batfish.datamodel.Ip.ZERO;
 import static org.batfish.datamodel.IpProtocol.OSPF;
-import static org.batfish.datamodel.Names.generatedIncomingInterfaceFilterName;
+import static org.batfish.datamodel.Names.generateCompositeFilterName;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.Route.UNSET_ROUTE_NEXT_HOP_IP;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
@@ -1608,13 +1608,13 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         c,
         hasIpAccessList(
-            generatedIncomingInterfaceFilterName("xe-0/0/3.0"),
+            generateCompositeFilterName("in", "xe-0/0/3.0"),
             allOf(
                 rejects(src1235, null, c), accepts(src1236, null, c), rejects(src8888, null, c))));
     assertThat(
         c,
         hasIpAccessList(
-            generatedIncomingInterfaceFilterName("xe-0/0/3.0"),
+            generateCompositeFilterName("out", "xe-0/0/3.0"),
             allOf(
                 rejects(src1235, null, c), rejects(src1236, null, c), rejects(src8888, null, c))));
   }
@@ -4992,7 +4992,7 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testGH6149Preprocess() {
     Configuration c = parseConfig("gh-6149-preprocess");
-    String interfaceFilterName = generatedIncomingInterfaceFilterName("ae1.0");
+    String interfaceFilterName = generateCompositeFilterName("in", "ae1.0");
     assertThat(
         c,
         allOf(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -15,6 +15,7 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Flow.builder;
 import static org.batfish.datamodel.Ip.ZERO;
 import static org.batfish.datamodel.IpProtocol.OSPF;
+import static org.batfish.datamodel.Names.generatedIncomingInterfaceFilterName;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.Route.UNSET_ROUTE_NEXT_HOP_IP;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
@@ -143,7 +144,6 @@ import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_G
 import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_SECURITY_POLICY;
 import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_ISIS_COST;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeConditionRoutingPolicyName;
-import static org.batfish.representation.juniper.JuniperConfiguration.computeInterfaceFilterName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeOspfExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePeerExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePolicyStatementTermName;
@@ -1608,13 +1608,13 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         c,
         hasIpAccessList(
-            computeInterfaceFilterName("xe-0/0/3.0", true),
+            generatedIncomingInterfaceFilterName("xe-0/0/3.0"),
             allOf(
                 rejects(src1235, null, c), accepts(src1236, null, c), rejects(src8888, null, c))));
     assertThat(
         c,
         hasIpAccessList(
-            computeInterfaceFilterName("xe-0/0/3.0", false),
+            generatedIncomingInterfaceFilterName("xe-0/0/3.0"),
             allOf(
                 rejects(src1235, null, c), rejects(src1236, null, c), rejects(src8888, null, c))));
   }
@@ -4992,7 +4992,7 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testGH6149Preprocess() {
     Configuration c = parseConfig("gh-6149-preprocess");
-    String interfaceFilterName = computeInterfaceFilterName("ae1.0", true);
+    String interfaceFilterName = generatedIncomingInterfaceFilterName("ae1.0");
     assertThat(
         c,
         allOf(


### PR DESCRIPTION
Downstream code (e.g., filter line reachability) depends on this convention