### PR TITLE
BDDOps: cleanup and make efficient

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -181,14 +181,14 @@ public final class BDDFlowConstraintGenerator {
   }
 
   @VisibleForTesting
-  static BDD isPrivateIp(IpSpaceToBDD ip) {
-    return BDDOps.orNull(
+  static BDD isPrivateIp(BDDOps ops, IpSpaceToBDD ip) {
+    return ops.or(
         ip.toBDD(PRIVATE_SUBNET_10), ip.toBDD(PRIVATE_SUBNET_172), ip.toBDD(PRIVATE_SUBNET_192));
   }
 
   @VisibleForTesting
-  static BDD isDocumentationIp(IpSpaceToBDD ip) {
-    return BDDOps.orNull(
+  static BDD isDocumentationIp(BDDOps ops, IpSpaceToBDD ip) {
+    return ops.or(
         ip.toBDD(RESERVED_DOCUMENTATION_192),
         ip.toBDD(RESERVED_DOCUMENTATION_198),
         ip.toBDD(RESERVED_DOCUMENTATION_203));
@@ -206,13 +206,13 @@ public final class BDDFlowConstraintGenerator {
   }
 
   private List<BDD> computeIpConstraints() {
-    BDD srcIpPrivate = isPrivateIp(_bddPacket.getSrcIpSpaceToBDD());
-    BDD dstIpPrivate = isPrivateIp(_bddPacket.getDstIpSpaceToBDD());
+    BDD srcIpPrivate = isPrivateIp(_bddOps, _bddPacket.getSrcIpSpaceToBDD());
+    BDD dstIpPrivate = isPrivateIp(_bddOps, _bddPacket.getDstIpSpaceToBDD());
 
     return ImmutableList.<BDD>builder()
         // 0. Try to not use documentation IPs if that is possible.
-        .add(isDocumentationIp(_bddPacket.getSrcIpSpaceToBDD()).not())
-        .add(isDocumentationIp(_bddPacket.getDstIpSpaceToBDD()).not())
+        .add(isDocumentationIp(_bddOps, _bddPacket.getSrcIpSpaceToBDD()).not())
+        .add(isDocumentationIp(_bddOps, _bddPacket.getDstIpSpaceToBDD()).not())
         // First, try to nudge src and dst IP apart. E.g., if one is private the other should be
         // public.
         .add(_bddOps.and(srcIpPrivate, dstIpPrivate.not()))

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -394,11 +394,7 @@ public class BDDInteger {
         _hasVariablesOnly,
         "getVars can only be called on a BDDInteger with hasVariablesOnly() true");
     if (_vars == null) {
-      _vars =
-          _bitvec.length == 0
-              ? _factory.one() // empty set
-              : BDDOps.andNull(_bitvec);
-      assert _vars != null;
+      _vars = _factory.andAll(_bitvec);
     }
     return _vars;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDOps.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDOps.java
@@ -1,15 +1,13 @@
 package org.batfish.common.bdd;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import javax.annotation.Nonnull;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.datamodel.AclIpSpace;
@@ -22,63 +20,20 @@ public final class BDDOps {
     _factory = factory;
   }
 
-  public BDD and(BDD... conjuncts) {
-    return and(Arrays.asList(conjuncts));
+  public @Nonnull BDD and(BDD... conjuncts) {
+    return _factory.andAll(conjuncts);
   }
 
-  public BDD and(Iterable<BDD> conjuncts) {
-    return firstNonNull(andNull(conjuncts), _factory.one());
+  public @Nonnull BDD and(Iterable<BDD> conjuncts) {
+    return _factory.andAll(conjuncts);
   }
 
-  /** A variant of {@link #and(BDD...)} that returns {@code null} when all conjuncts are null. */
-  public static BDD andNull(BDD... conjuncts) {
-    return andNull(Arrays.asList(conjuncts));
+  public @Nonnull BDD or(BDD... disjuncts) {
+    return _factory.orAll(disjuncts);
   }
 
-  public static BDD andNull(Iterable<BDD> conjuncts) {
-    BDD result = null;
-    for (BDD conjunct : conjuncts) {
-      if (conjunct != null) {
-        result = result == null ? conjunct : result.and(conjunct);
-      }
-    }
-    return result;
-  }
-
-  public BDD orAll(Collection<BDD> bdds) {
-    return _factory.orAll(bdds);
-  }
-
-  public BDD orAll(BDD... bdds) {
-    return _factory.orAll(bdds);
-  }
-
-  /** Returns bdd.not() or {@code null} if given {@link BDD} is null. */
-  public static BDD negateIfNonNull(BDD bdd) {
-    return bdd == null ? bdd : bdd.not();
-  }
-
-  public BDD or(BDD... disjuncts) {
-    return or(Arrays.asList(disjuncts));
-  }
-
-  public BDD or(Iterable<BDD> disjuncts) {
-    return firstNonNull(orNull(disjuncts), _factory.zero());
-  }
-
-  /** A variant of {@link #or(BDD...)} that returns {@code null} when all disjuncts are null. */
-  public static BDD orNull(BDD... disjuncts) {
-    return orNull(Arrays.asList(disjuncts));
-  }
-
-  public static BDD orNull(Iterable<BDD> disjuncts) {
-    BDD result = null;
-    for (BDD disjunct : disjuncts) {
-      if (disjunct != null) {
-        result = result == null ? disjunct : result.or(disjunct);
-      }
-    }
-    return result;
+  public @Nonnull BDD or(Iterable<BDD> disjuncts) {
+    return _factory.orAll(disjuncts);
   }
 
   /**
@@ -104,10 +59,10 @@ public final class BDDOps {
         if (currentAction == LineAction.PERMIT) {
           // matched by any of the permit lines, or permitted by the rest of the acl.
           lineBddsWithCurrentAction.add(result);
-          result = orAll(lineBddsWithCurrentAction);
+          result = or(lineBddsWithCurrentAction);
         } else {
           // permitted by the rest of the acl and not matched by any of the deny lines.
-          result = result.diff(orAll(lineBddsWithCurrentAction));
+          result = result.diff(or(lineBddsWithCurrentAction));
         }
         currentAction = lineAction;
         lineBddsWithCurrentAction.clear();
@@ -121,9 +76,9 @@ public final class BDDOps {
     // Reached the start of the ACL. Combine the last batch of lines into the result.
     if (currentAction == LineAction.PERMIT) {
       lineBddsWithCurrentAction.add(result);
-      result = orAll(lineBddsWithCurrentAction);
+      result = or(lineBddsWithCurrentAction);
     } else {
-      result = result.diff(orAll(lineBddsWithCurrentAction));
+      result = result.diff(or(lineBddsWithCurrentAction));
     }
     return result;
   }
@@ -156,6 +111,6 @@ public final class BDDOps {
       alreadyMatched = alreadyMatched.or(currentLine.getMatchBdd());
     }
 
-    return new PermitAndDenyBdds(orAll(reachAndPermitBdds), orAll(reachAndDenyBdds));
+    return new PermitAndDenyBdds(or(reachAndPermitBdds), or(reachAndDenyBdds));
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
@@ -267,7 +267,7 @@ public abstract class IpAccessListToBdd {
 
     @Override
     public final BDD visitOrMatchExpr(OrMatchExpr orMatchExpr) {
-      return _bddOps.orAll(
+      return _bddOps.or(
           orMatchExpr.getDisjuncts().stream()
               .map(IpAccessListToBdd.this::toBdd)
               .toArray(BDD[]::new));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpSpaceToBDD.java
@@ -170,13 +170,13 @@ public class IpSpaceToBDD implements GenericIpSpaceVisitor<BDD> {
   @Override
   public BDD visitIpWildcardSetIpSpace(IpWildcardSetIpSpace ipWildcardSetIpSpace) {
     BDD whitelist =
-        _bddOps.orAll(
+        _bddOps.or(
             ipWildcardSetIpSpace.getWhitelist().stream()
                 .map((IpWildcard wc) -> visit(wc.toIpSpace()))
                 .collect(Collectors.toList()));
 
     BDD blacklist =
-        _bddOps.orAll(
+        _bddOps.or(
             ipWildcardSetIpSpace.getBlacklist().stream()
                 .map((IpWildcard wc) -> visit(wc.toIpSpace()))
                 .collect(Collectors.toList()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFlowConstraintGeneratorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFlowConstraintGeneratorTest.java
@@ -10,13 +10,13 @@ import net.sf.javabdd.BDD;
 import org.junit.Test;
 
 public class BDDFlowConstraintGeneratorTest {
-  private static BDDPacket PKT = new BDDPacket();
-
   @Test
   public void testIsPrivateIp() {
-    BDD isPrivateIp = isPrivateIp(PKT.getDstIpSpaceToBDD());
+    BDDPacket pkt = new BDDPacket();
+    BDDOps ops = new BDDOps(pkt.getFactory());
+    BDD isPrivateIp = isPrivateIp(ops, pkt.getDstIpSpaceToBDD());
 
-    IpSpaceToBDD dstIp = PKT.getDstIpSpaceToBDD();
+    IpSpaceToBDD dstIp = pkt.getDstIpSpaceToBDD();
     BDD privateSubnet10 = dstIp.toBDD(PRIVATE_SUBNET_10);
     BDD privateSubnet172 = dstIp.toBDD(PRIVATE_SUBNET_172);
     BDD privateSubnet192 = dstIp.toBDD(PRIVATE_SUBNET_192);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDOpsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDOpsTest.java
@@ -1,7 +1,6 @@
 package org.batfish.common.bdd;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import net.sf.javabdd.BDD;
@@ -19,12 +18,6 @@ public class BDDOpsTest {
     _factory = JFactory.init(10000, 1000);
     _factory.setCacheRatio(64);
     _bddOps = new BDDOps(_factory);
-  }
-
-  @Test
-  public void testAnd_null() {
-    assertThat(_bddOps.and(), equalTo(_factory.one()));
-    assertThat(_bddOps.and(null, null), equalTo(_factory.one()));
   }
 
   @Test
@@ -49,37 +42,10 @@ public class BDDOpsTest {
   }
 
   @Test
-  public void testAndNull_null() {
-    assertThat(BDDOps.andNull(), nullValue());
-    assertThat(BDDOps.andNull(null, null), nullValue());
-  }
-
-  @Test
-  public void testAndNull_one() {
-    _factory.setVarNum(1);
-    BDD var = _factory.ithVar(0);
-    assertThat(BDDOps.andNull(var, null), equalTo(var));
-  }
-
-  @Test
-  public void testAndNull_two() {
-    _factory.setVarNum(2);
-    BDD var1 = _factory.ithVar(0);
-    BDD var2 = _factory.ithVar(1);
-    assertThat(BDDOps.andNull(var1, var2, null), equalTo(var1.and(var2)));
-  }
-
-  @Test
   public void testOr_one() {
     _factory.setVarNum(1);
     BDD var = _factory.ithVar(0);
     assertThat(_bddOps.or(var, _factory.one()), equalTo(_factory.one()));
-  }
-
-  @Test
-  public void testOr_null() {
-    assertThat(_bddOps.or(), equalTo(_factory.zero()));
-    assertThat(_bddOps.or(null, null), equalTo(_factory.zero()));
   }
 
   @Test
@@ -94,26 +60,5 @@ public class BDDOpsTest {
     _factory.setVarNum(1);
     BDD var = _factory.ithVar(0);
     assertThat(_bddOps.or(var, _factory.zero()), equalTo(var));
-  }
-
-  @Test
-  public void testOrNull_null() {
-    assertThat(BDDOps.orNull(), nullValue());
-    assertThat(BDDOps.orNull(null, null), nullValue());
-  }
-
-  @Test
-  public void testOrNull_one() {
-    _factory.setVarNum(1);
-    BDD var = _factory.ithVar(0);
-    assertThat(BDDOps.orNull(var, null), equalTo(var));
-  }
-
-  @Test
-  public void testOrNull_two() {
-    _factory.setVarNum(2);
-    BDD var1 = _factory.ithVar(0);
-    BDD var2 = _factory.ithVar(1);
-    assertThat(BDDOps.orNull(null, var1, var2), equalTo(var1.or(var2)));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -1,6 +1,5 @@
 package org.batfish.common.bdd;
 
-import static org.batfish.common.bdd.BDDOps.orNull;
 import static org.batfish.datamodel.ExprAclLine.ACCEPT_ALL;
 import static org.batfish.datamodel.ExprAclLine.accepting;
 import static org.batfish.datamodel.ExprAclLine.rejecting;
@@ -40,7 +39,8 @@ public class BDDSourceManagerTest {
   private static final Set<String> IFACES_1_2 = ImmutableSet.of(IFACE1, IFACE2);
   private static final Set<String> ALL_IFACES = ImmutableSet.of(IFACE1, IFACE2, IFACE3, IFACE4);
 
-  private BDDPacket _pkt = new BDDPacket();
+  private final BDDPacket _pkt = new BDDPacket();
+  private final BDDOps _ops = new BDDOps(_pkt.getFactory());
 
   @Test
   public void test() {
@@ -57,7 +57,7 @@ public class BDDSourceManagerTest {
   public void testSane() {
     BDDSourceManager mgr = BDDSourceManager.forInterfaces(_pkt, IFACES_1_2);
     BDD noSource =
-        orNull(
+        _ops.or(
                 mgr.getOriginatingFromDeviceBDD(),
                 mgr.getSourceInterfaceBDD(IFACE1),
                 mgr.getSourceInterfaceBDD(IFACE2))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDUtilsTest.java
@@ -1,6 +1,5 @@
 package org.batfish.common.bdd;
 
-import static org.batfish.common.bdd.BDDOps.andNull;
 import static org.batfish.common.bdd.BDDUtils.swap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -45,17 +44,19 @@ public class BDDUtilsTest {
     Ip ip2 = Ip.parse("2.2.2.2");
 
     BDD orig =
-        andNull(
-            dstIp.value(ip1.asLong()),
-            dstPort.value(5),
-            srcIp.value(ip2.asLong()),
-            srcPort.value(7));
+        pkt.getFactory()
+            .andAll(
+                dstIp.value(ip1.asLong()),
+                dstPort.value(5),
+                srcIp.value(ip2.asLong()),
+                srcPort.value(7));
     BDD swapped =
-        andNull(
-            srcIp.value(ip1.asLong()),
-            srcPort.value(5),
-            dstIp.value(ip2.asLong()),
-            dstPort.value(7));
+        pkt.getFactory()
+            .andAll(
+                srcIp.value(ip1.asLong()),
+                srcPort.value(5),
+                dstIp.value(ip2.asLong()),
+                dstPort.value(7));
     assertThat(swap(orig, dstIp, srcIp, dstPort, srcPort), equalTo(swapped));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
@@ -498,7 +498,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                 mapping(
                     Entry::getValue,
                     collectingAndThen(
-                        toList(), bdds -> ipProtocolsWithSessionsBdd.and(ops.orAll(bdds))))));
+                        toList(), bdds -> ipProtocolsWithSessionsBdd.and(ops.or(bdds))))));
   }
 
   /**
@@ -545,7 +545,6 @@ final class BDDReachabilityAnalysisSessionFactory {
                                 Entry::getKey, // VRF name
                                 vrfEntry ->
                                     // BDD of flows that can match originating session on VRF
-                                    ipProtocolsWithSessionsBdd.and(
-                                        ops.orAll(vrfEntry.getValue()))))));
+                                    ipProtocolsWithSessionsBdd.and(ops.or(vrfEntry.getValue()))))));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
@@ -319,7 +319,7 @@ class PacketPolicyToBdd {
       BDDPacket bddPacket = _ipAccessListToBdd.getBDDPacket();
       IpSpaceToBDD dst = bddPacket.getDstIpSpaceToBDD();
       BDDOps ops = new BDDOps(bddPacket.getFactory());
-      return ops.orAll(
+      return ops.or(
           expr.getInterfaceNames().stream()
               .map(_ipsRoutedOutInterfaces::getIpsRoutedOutInterface)
               .map(dst::visit)

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -28,9 +28,9 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
 import org.batfish.bddreachability.BDDReverseTransformationRangesImpl.Key;
 import org.batfish.bddreachability.transition.Transition;
-import org.batfish.common.bdd.BDDOps;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.HeaderSpaceToBDD;
@@ -96,7 +96,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
             String iface,
             @Nullable String inIface,
             @Nullable NodeInterfacePair lastHop) {
-          return _pkt.getFactory().one();
+          return _factory.one();
         }
 
         @Nonnull
@@ -106,11 +106,12 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
             String iface,
             @Nullable String inIface,
             @Nullable NodeInterfacePair lastHop) {
-          return _pkt.getFactory().one();
+          return _factory.one();
         }
       };
 
   private final BDDPacket _pkt = new BDDPacket();
+  private final BDDFactory _factory = _pkt.getFactory();
   private final HeaderSpaceToBDD _toBDD = new HeaderSpaceToBDD(_pkt, ImmutableMap.of());
 
   private LastHopOutgoingInterfaceManager _lastHopMgr;
@@ -327,14 +328,14 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
     Prefix destPrefix = Prefix.parse("1.0.0.0/8");
     BDD tcp = _pkt.getIpProtocol().value(IpProtocol.TCP);
     BDD outBdd =
-        BDDOps.andNull(
+        _factory.andAll(
             dstBdd(destPrefix), // dst IP constraint
             srcBdd(sourcePrefix),
             dstPortBdd(1),
             srcPortBdd(2),
             tcp,
             // everything below will be erased
-            _pkt.getFactory().ithVar(0), // unallocated variable
+            _factory.ithVar(0), // unallocated variable
             _lastHopMgr.getLastHopOutgoingInterfaceBdd(R1, R1I1, FW, FWI1),
             _fwSrcMgr.getSourceInterfaceBDD(FWI1),
             _pkt.getTcpCwr(),
@@ -342,7 +343,8 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
             _pkt.getEcn().value(0));
 
     BDD sessionFlows =
-        BDDOps.andNull(srcBdd(destPrefix), dstBdd(sourcePrefix), dstPortBdd(2), srcPortBdd(1), tcp);
+        _factory.andAll(
+            srcBdd(destPrefix), dstBdd(sourcePrefix), dstPortBdd(2), srcPortBdd(1), tcp);
 
     BDDReachabilityAnalysisSessionFactory sessionFactory =
         new BDDReachabilityAnalysisSessionFactory(
@@ -404,7 +406,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
 
     BDDReverseTransformationRanges transformationRanges =
         new MockBDDReverseTransformationRanges(
-            _pkt.getFactory().zero(),
+            _factory.zero(),
             ImmutableMap.of(
                 // incoming transformation ranges
                 new Key(FW, FWI1, INCOMING, FWI1, NEXT_HOP_R1I1),
@@ -651,7 +653,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
 
     BDDReverseTransformationRanges transformationRanges =
         new MockBDDReverseTransformationRanges(
-            _pkt.getFactory().zero(),
+            _factory.zero(),
             ImmutableMap.of(
                 // incoming transformation ranges
                 new Key(FW, FWI1, INCOMING, FWI1, NEXT_HOP_R1I1),

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransitionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransitionsTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
 import org.batfish.common.bdd.BDDFiniteDomain;
-import org.batfish.common.bdd.BDDOps;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.datamodel.Ip;
@@ -31,11 +31,12 @@ import org.junit.Test;
 /** Tests of {@link Transitions}. */
 public class TransitionsTest {
   private final BDDPacket _pkt = new BDDPacket();
-  private final BDD _zero = _pkt.getFactory().zero();
-  private final BDD _one = _pkt.getFactory().one();
+  private final BDDFactory _factory = _pkt.getFactory();
+  private final BDD _zero = _factory.zero();
+  private final BDD _one = _factory.one();
 
   private BDD var(int i) {
-    return _pkt.getFactory().ithVar(i);
+    return _factory.ithVar(i);
   }
 
   private Transition eraseVar(int i) {
@@ -212,7 +213,7 @@ public class TransitionsTest {
     Transition expected =
         compose(
             constraint(bdd.and(finiteDomain.getIsValidConstraint())),
-            eraseAndSet(finiteDomain.getVar(), _pkt.getFactory().one()));
+            eraseAndSet(finiteDomain.getVar(), _factory.one()));
     assertEquals(expected, actual);
   }
 
@@ -343,7 +344,7 @@ public class TransitionsTest {
     BDD v2 = var(2);
     BDD v3 = var(3);
     Transition actual = or(constraint(v0), constraint(v1), constraint(v2), constraint(v3));
-    assertThat(actual, equalTo(constraint(BDDOps.orNull(v0, v1, v2, v3))));
+    assertThat(actual, equalTo(constraint(_factory.orAll(v0, v1, v2, v3))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -54,7 +54,6 @@ import java.util.SortedMap;
 import java.util.Stack;
 import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
-import org.batfish.common.bdd.BDDOps;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.MemoizedIpAccessListToBdd;
@@ -1546,12 +1545,13 @@ public final class FlowTracerTest {
       BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow).toAclLineMatchExpr());
       assertEquals(
           returnFlowBdd,
-          BDDOps.andNull(
-              returnFlowDstIpBdd,
-              returnFlowSrcIpBdd,
-              pkt.getDstPort().value(flow.getSrcPort()),
-              pkt.getSrcPort().value(flow.getDstPort()),
-              pkt.getIpProtocol().value(flow.getIpProtocol())));
+          pkt.getFactory()
+              .andAll(
+                  returnFlowDstIpBdd,
+                  returnFlowSrcIpBdd,
+                  pkt.getDstPort().value(flow.getSrcPort()),
+                  pkt.getSrcPort().value(flow.getDstPort()),
+                  pkt.getIpProtocol().value(flow.getIpProtocol())));
     }
 
     // UDP
@@ -1560,12 +1560,13 @@ public final class FlowTracerTest {
       BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow).toAclLineMatchExpr());
       assertEquals(
           returnFlowBdd,
-          BDDOps.andNull(
-              returnFlowDstIpBdd,
-              returnFlowSrcIpBdd,
-              pkt.getDstPort().value(flow.getSrcPort()),
-              pkt.getSrcPort().value(flow.getDstPort()),
-              pkt.getIpProtocol().value(flow.getIpProtocol())));
+          pkt.getFactory()
+              .andAll(
+                  returnFlowDstIpBdd,
+                  returnFlowSrcIpBdd,
+                  pkt.getDstPort().value(flow.getSrcPort()),
+                  pkt.getSrcPort().value(flow.getDstPort()),
+                  pkt.getIpProtocol().value(flow.getIpProtocol())));
     }
 
     // ICMP
@@ -1574,10 +1575,11 @@ public final class FlowTracerTest {
       BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow).toAclLineMatchExpr());
       assertEquals(
           returnFlowBdd,
-          BDDOps.andNull(
-              returnFlowDstIpBdd,
-              returnFlowSrcIpBdd,
-              pkt.getIpProtocol().value(flow.getIpProtocol())));
+          pkt.getFactory()
+              .andAll(
+                  returnFlowDstIpBdd,
+                  returnFlowSrcIpBdd,
+                  pkt.getIpProtocol().value(flow.getIpProtocol())));
     }
   }
 


### PR DESCRIPTION
* Kill andNull: all users of it were using it for the "I don't need a Factory" reason,
  not the "I want null returned" reason.
* Move null-handling into HeaderSpaceToBDD, the only user
* Move all and- and or- operations on to andAll or orAll respectively