### PR TITLE
Remove references to undefined tracks in post-processing

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/hsrp/HsrpGroup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/hsrp/HsrpGroup.java
@@ -175,25 +175,6 @@ public final class HsrpGroup implements Serializable {
     _trackActions = trackActions;
   }
 
-  @Override
-  public boolean equals(@Nullable Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (!(obj instanceof HsrpGroup)) {
-      return false;
-    }
-    HsrpGroup rhs = (HsrpGroup) obj;
-    return Objects.equals(_authentication, rhs._authentication)
-        && _groupNumber == rhs._groupNumber
-        && _helloTime == rhs._helloTime
-        && _holdTime == rhs._holdTime
-        && Objects.equals(_ips, rhs._ips)
-        && _preempt == rhs._preempt
-        && _priority == rhs._priority
-        && _trackActions.equals(rhs._trackActions);
-  }
-
   /** SHA256-hashed authentication string */
   @JsonProperty(PROP_AUTHENTICATION)
   public @Nullable String getAuthentication() {
@@ -248,6 +229,37 @@ public final class HsrpGroup implements Serializable {
   @JsonProperty(PROP_TRACK_ACTIONS)
   public @Nonnull SortedMap<String, TrackAction> getTrackActions() {
     return _trackActions;
+  }
+
+  public @Nonnull Builder toBuilder() {
+    return builder()
+        .setAuthentication(_authentication)
+        .setGroupNumber(_groupNumber)
+        .setHelloTime(_helloTime)
+        .setHoldTime(_holdTime)
+        .setIps(_ips)
+        .setPreempt(_preempt)
+        .setPriority(_priority)
+        .setTrackActions(_trackActions);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof HsrpGroup)) {
+      return false;
+    }
+    HsrpGroup rhs = (HsrpGroup) obj;
+    return Objects.equals(_authentication, rhs._authentication)
+        && _groupNumber == rhs._groupNumber
+        && _helloTime == rhs._helloTime
+        && _holdTime == rhs._holdTime
+        && Objects.equals(_ips, rhs._ips)
+        && _preempt == rhs._preempt
+        && _priority == rhs._priority
+        && _trackActions.equals(rhs._trackActions);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackMethodVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackMethodVisitor.java
@@ -13,4 +13,6 @@ public interface GenericTrackMethodVisitor<R> {
   R visitTrackMethodReference(TrackMethodReference trackMethodReference);
 
   R visitTrackRoute(TrackRoute trackRoute);
+
+  R visitTrackTrue(TrackTrue trackTrue);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/StaticTrackMethodEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/StaticTrackMethodEvaluator.java
@@ -48,5 +48,10 @@ public class StaticTrackMethodEvaluator implements GenericTrackMethodVisitor<Boo
     throw new UnsupportedOperationException("Unsupported method for HSRP priority evaluation");
   }
 
+  @Override
+  public Boolean visitTrackTrue(TrackTrue trackTrue) {
+    return true;
+  }
+
   @Nonnull private final Configuration _configuration;
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackTrue.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackTrue.java
@@ -1,0 +1,34 @@
+package org.batfish.datamodel.tracking;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nonnull;
+
+/** A track that always matches. Placeholder for unsupported vendor track methods. */
+public final class TrackTrue implements TrackMethod {
+
+  @JsonCreator
+  @JsonValue
+  public static @Nonnull TrackTrue instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public <R> R accept(GenericTrackMethodVisitor<R> visitor) {
+    return visitor.visitTrackTrue(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return this == obj || obj instanceof TrackTrue;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0x6D7DC4CB; // randomly generated
+  }
+
+  private static @Nonnull TrackTrue INSTANCE = new TrackTrue();
+
+  private TrackTrue() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/StaticRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/StaticRouteMatchers.java
@@ -38,5 +38,32 @@ public final class StaticRouteMatchers {
     }
   }
 
+  private static final class HasTrack extends FeatureMatcher<StaticRoute, String> {
+    HasTrack(@Nonnull Matcher<? super String> subMatcher) {
+      super(subMatcher, "A StaticRoute with track:", "track");
+    }
+
+    @Override
+    protected String featureValueOf(StaticRoute actual) {
+      return actual.getTrack();
+    }
+  }
+
+  /**
+   * Provides a matcher that matches when the supplied {@code subMatcher} matches {@link
+   * StaticRoute#getTrack()}.
+   */
+  public static @Nonnull Matcher<StaticRoute> hasTrack(Matcher<? super String> subMatcher) {
+    return new HasTrack(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches when the {@link StaticRoute#getTrack()} is equal to {@code
+   * expectedTrack}.
+   */
+  public static @Nonnull Matcher<StaticRoute> hasTrack(String expectedTrack) {
+    return hasTrack(equalTo(expectedTrack));
+  }
+
   private StaticRouteMatchers() {}
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/StaticTrackMethodEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/StaticTrackMethodEvaluatorTest.java
@@ -1,12 +1,12 @@
 package org.batfish.datamodel.tracking;
 
+import static org.batfish.datamodel.ConfigurationFormat.CISCO_IOS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.junit.Test;
 
@@ -14,36 +14,32 @@ import org.junit.Test;
 public class StaticTrackMethodEvaluatorTest {
   @Test
   public void testVisitTrackInterface() {
-    Configuration c1 =
-        Configuration.builder()
-            .setHostname("c1")
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
-            .build();
-    c1.setTrackingGroups(ImmutableMap.of("1", new TrackInterface("i1tracked")));
+    Configuration c =
+        Configuration.builder().setHostname("c").setConfigurationFormat(CISCO_IOS).build();
     // i1: active
     Interface.builder()
-        .setOwner(c1)
+        .setOwner(c)
         .setName("i1")
         .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
         .setActive(true)
         .build();
     // i2: not active
     Interface.builder()
-        .setOwner(c1)
+        .setOwner(c)
         .setName("i2")
         .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
         .setActive(false)
         .build();
     // i3: active, but blacklisted
     Interface.builder()
-        .setOwner(c1)
+        .setOwner(c)
         .setName("i3")
         .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
         .setActive(true)
         .setBlacklisted(true)
         .build();
 
-    StaticTrackMethodEvaluator evaluator = new StaticTrackMethodEvaluator(c1);
+    StaticTrackMethodEvaluator evaluator = new StaticTrackMethodEvaluator(c);
     // Iface is active
     TrackInterface trackInterface1 = new TrackInterface("i1");
     assertTrue(evaluator.visit(trackInterface1));
@@ -63,48 +59,31 @@ public class StaticTrackMethodEvaluatorTest {
 
   @Test
   public void testVisitNegatedTrackMethod() {
-    Configuration c1 =
-        Configuration.builder()
-            .setHostname("c1")
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
-            .build();
-    c1.setTrackingGroups(ImmutableMap.of("1", new TrackInterface("i1")));
-    // i1: active
-    Interface.builder()
-        .setOwner(c1)
-        .setName("i1")
-        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
-        .setActive(true)
-        .build();
-    StaticTrackMethodEvaluator evaluator = new StaticTrackMethodEvaluator(c1);
-    // Iface is active
-    TrackInterface trackInterface1 = new TrackInterface("i1");
+    Configuration c =
+        Configuration.builder().setHostname("c").setConfigurationFormat(CISCO_IOS).build();
+    TrackMethod base = TrackTrue.instance();
+    StaticTrackMethodEvaluator evaluator = new StaticTrackMethodEvaluator(c);
 
-    assertTrue(evaluator.visit(trackInterface1));
-    assertFalse(evaluator.visit(NegatedTrackMethod.of(trackInterface1)));
+    assertFalse(evaluator.visit(NegatedTrackMethod.of(base)));
   }
 
   @Test
   public void testVisitTrackMethodReference() {
-    Configuration c1 =
-        Configuration.builder()
-            .setHostname("c1")
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
-            .build();
-    // Iface is active
-    TrackInterface trackInterface1 = new TrackInterface("i1");
+    Configuration c =
+        Configuration.builder().setHostname("c").setConfigurationFormat(CISCO_IOS).build();
+    TrackMethod base = TrackTrue.instance();
+    c.setTrackingGroups(ImmutableMap.of("1", base));
+    StaticTrackMethodEvaluator evaluator = new StaticTrackMethodEvaluator(c);
 
-    c1.setTrackingGroups(ImmutableMap.of("1", trackInterface1));
-    // i1: active
-    Interface.builder()
-        .setOwner(c1)
-        .setName("i1")
-        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
-        .setActive(true)
-        .build();
-    StaticTrackMethodEvaluator evaluator = new StaticTrackMethodEvaluator(c1);
-
-    assertTrue(evaluator.visit(trackInterface1));
     assertTrue(evaluator.visit(TrackMethodReference.of("1")));
+  }
+
+  @Test
+  public void testVisitTrackTrue() {
+    Configuration c =
+        Configuration.builder().setHostname("c").setConfigurationFormat(CISCO_IOS).build();
+    StaticTrackMethodEvaluator evaluator = new StaticTrackMethodEvaluator(c);
+
+    assertTrue(evaluator.visit(TrackTrue.instance()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/TrackTrueTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/TrackTrueTest.java
@@ -1,0 +1,30 @@
+package org.batfish.datamodel.tracking;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link TrackTrue}. */
+public final class TrackTrueTest {
+
+  @Test
+  public void testJavaSerialization() {
+    TrackTrue obj = TrackTrue.instance();
+    assertEquals(obj, SerializationUtils.clone(obj));
+  }
+
+  @Test
+  public void testJacksonSerialization() {
+    TrackTrue obj = TrackTrue.instance();
+    assertEquals(obj, BatfishObjectMapper.clone(obj, TrackMethod.class));
+  }
+
+  @Test
+  public void testEquals() {
+    TrackTrue obj = TrackTrue.instance();
+    new EqualsTester().addEqualityGroup(obj, TrackTrue.instance()).testEquals();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneTrackEvaluator.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneTrackEvaluator.java
@@ -14,6 +14,7 @@ import org.batfish.datamodel.tracking.TrackInterface;
 import org.batfish.datamodel.tracking.TrackMethod;
 import org.batfish.datamodel.tracking.TrackMethodReference;
 import org.batfish.datamodel.tracking.TrackRoute;
+import org.batfish.datamodel.tracking.TrackTrue;
 
 /**
  * Evaluator for a {@link org.batfish.datamodel.tracking.TrackMethod} given knowledge of the routes
@@ -58,6 +59,11 @@ public class DataplaneTrackEvaluator implements GenericTrackMethodVisitor<Boolea
       return routesForPrefix.stream()
           .anyMatch(r -> trackRoute.getProtocols().contains(r.getRoute().getProtocol()));
     }
+  }
+
+  @Override
+  public Boolean visitTrackTrue(TrackTrue trackTrue) {
+    return _staticEvaluator.visit(trackTrue);
   }
 
   private final @Nonnull Configuration _configuration;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1955,7 +1955,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       w.redFlag(
           String.format(
               "Interface track mode %s is not yet supported and will be treated as always"
-                  + " matching.",
+                  + " succeeding.",
               trackInterface.getMode()));
     } else if (track instanceof TrackIpRoute) {
       TrackIpRoute trackIpRoute = (TrackIpRoute) track;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -226,6 +226,7 @@ import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
 import org.batfish.datamodel.tracking.DecrementPriority;
 import org.batfish.datamodel.tracking.TrackMethodReference;
 import org.batfish.datamodel.tracking.TrackRoute;
+import org.batfish.datamodel.tracking.TrackTrue;
 import org.batfish.datamodel.vendor_family.cisco_nxos.CiscoNxosFamily;
 import org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform;
 import org.batfish.datamodel.vendor_family.cisco_nxos.NxosMajorVersion;
@@ -1313,18 +1314,15 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
             .filter(_tracks::containsKey)
             .collect(ImmutableSet.toImmutableSet());
     _tracks.forEach(
-        (num, track) ->
-            toTrackMethod(track, _w)
-                .ifPresent(
-                    m -> {
-                      _c.getTrackingGroups().put(num.toString(), m);
-                      if (negatedTracks.contains(num)) {
-                        _c.getTrackingGroups()
-                            .put(
-                                generatedNegatedTrackMethodId(num.toString()),
-                                TrackMethodReference.negated(num.toString()));
-                      }
-                    }));
+        (num, track) -> {
+          _c.getTrackingGroups().put(num.toString(), toTrackMethod(track, _w));
+          if (negatedTracks.contains(num)) {
+            _c.getTrackingGroups()
+                .put(
+                    generatedNegatedTrackMethodId(num.toString()),
+                    TrackMethodReference.negated(num.toString()));
+          }
+        });
   }
 
   private void convertIpPrefixLists() {
@@ -1947,28 +1945,27 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   @Override
   public void setVendor(ConfigurationFormat format) {}
 
-  private static @Nonnull Optional<org.batfish.datamodel.tracking.TrackMethod> toTrackMethod(
+  private static @Nonnull org.batfish.datamodel.tracking.TrackMethod toTrackMethod(
       @Nonnull Track track, @Nonnull Warnings w) {
     if (track instanceof TrackInterface) {
       TrackInterface trackInterface = (TrackInterface) track;
       if (trackInterface.getMode() == Mode.LINE_PROTOCOL) {
-        return Optional.of(
-            new org.batfish.datamodel.tracking.TrackInterface(trackInterface.getInterface()));
+        return new org.batfish.datamodel.tracking.TrackInterface(trackInterface.getInterface());
       }
       w.redFlag(
           String.format(
-              "Interface track mode %s is not yet supported and will be ignored.",
+              "Interface track mode %s is not yet supported and will be treated as always"
+                  + " matching.",
               trackInterface.getMode()));
     } else if (track instanceof TrackIpRoute) {
       TrackIpRoute trackIpRoute = (TrackIpRoute) track;
-      return Optional.of(
-          TrackRoute.of(
-              trackIpRoute.getPrefix(),
-              trackIpRoute.getHmm() ? ImmutableSet.of(RoutingProtocol.HMM) : ImmutableSet.of(),
-              firstNonNull(trackIpRoute.getVrf(), DEFAULT_VRF_NAME)));
+      return TrackRoute.of(
+          trackIpRoute.getPrefix(),
+          trackIpRoute.getHmm() ? ImmutableSet.of(RoutingProtocol.HMM) : ImmutableSet.of(),
+          firstNonNull(trackIpRoute.getVrf(), DEFAULT_VRF_NAME));
     }
-    // Warnings for unsupported track methods should be handled by parse warnings
-    return Optional.empty();
+    // unhandled cases
+    return TrackTrue.instance();
   }
 
   private static @Nonnull org.batfish.datamodel.hsrp.HsrpGroup toHsrpGroup(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/DataplaneTrackEvaluatorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/DataplaneTrackEvaluatorTest.java
@@ -17,8 +17,10 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.tracking.NegatedTrackMethod;
 import org.batfish.datamodel.tracking.TrackInterface;
+import org.batfish.datamodel.tracking.TrackMethod;
 import org.batfish.datamodel.tracking.TrackMethodReference;
 import org.batfish.datamodel.tracking.TrackRoute;
+import org.batfish.datamodel.tracking.TrackTrue;
 import org.batfish.dataplane.rib.Rib;
 import org.junit.Test;
 
@@ -69,19 +71,10 @@ public final class DataplaneTrackEvaluatorTest {
   public void testVisitTrackMethodReference() {
     Configuration c =
         Configuration.builder().setHostname("foo").setConfigurationFormat(CISCO_IOS).build();
-    Vrf.builder().setOwner(c).setName(DEFAULT_VRF_NAME).build();
-    Interface.builder().setName("i1").setOwner(c).setVrf(c.getDefaultVrf()).setActive(true).build();
-    Interface.builder()
-        .setName("i2")
-        .setOwner(c)
-        .setVrf(c.getDefaultVrf())
-        .setActive(false)
-        .build();
-    TrackInterface tiUp = new TrackInterface("i1");
-    c.setTrackingGroups(ImmutableMap.of("1", tiUp));
+    TrackMethod base = TrackTrue.instance();
+    c.setTrackingGroups(ImmutableMap.of("1", base));
     DataplaneTrackEvaluator e = new DataplaneTrackEvaluator(c, new Rib());
 
-    assertTrue(e.visit(tiUp));
     assertTrue(e.visit(TrackMethodReference.of("1")));
   }
 
@@ -89,18 +82,17 @@ public final class DataplaneTrackEvaluatorTest {
   public void testVisitNegatedTrackMethod() {
     Configuration c =
         Configuration.builder().setHostname("foo").setConfigurationFormat(CISCO_IOS).build();
-    Vrf.builder().setOwner(c).setName(DEFAULT_VRF_NAME).build();
-    Interface.builder().setName("i1").setOwner(c).setVrf(c.getDefaultVrf()).setActive(true).build();
-    Interface.builder()
-        .setName("i2")
-        .setOwner(c)
-        .setVrf(c.getDefaultVrf())
-        .setActive(false)
-        .build();
-    TrackInterface tiUp = new TrackInterface("i1");
     DataplaneTrackEvaluator e = new DataplaneTrackEvaluator(c, new Rib());
 
-    assertTrue(e.visit(tiUp));
-    assertFalse(e.visit(NegatedTrackMethod.of(tiUp)));
+    assertFalse(e.visit(NegatedTrackMethod.of(TrackTrue.instance())));
+  }
+
+  @Test
+  public void testVisitTrackTrue() {
+    Configuration c =
+        Configuration.builder().setHostname("c").setConfigurationFormat(CISCO_IOS).build();
+    DataplaneTrackEvaluator evaluator = new DataplaneTrackEvaluator(c, new Rib());
+
+    assertTrue(evaluator.visit(TrackTrue.instance()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -300,6 +300,7 @@ import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.tracking.DecrementPriority;
 import org.batfish.datamodel.tracking.TrackRoute;
+import org.batfish.datamodel.tracking.TrackTrue;
 import org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform;
 import org.batfish.dataplane.protocols.BgpProtocolHelper;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
@@ -1844,6 +1845,8 @@ public final class CiscoNxosGrammarTest {
                 new org.batfish.datamodel.tracking.TrackInterface("port-channel1"),
                 "100",
                 TrackRoute.of(Prefix.strict("192.0.2.1/32"), ImmutableSet.of(HMM), "v1"),
+                "101",
+                TrackTrue.instance(),
                 "200",
                 TrackRoute.of(Prefix.strict("192.0.2.2/32"), ImmutableSet.of(), DEFAULT_VRF_NAME),
                 "500",
@@ -1858,14 +1861,15 @@ public final class CiscoNxosGrammarTest {
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
 
-    assertThat(c.getTrackingGroups(), anEmptyMap());
+    assertThat(c.getTrackingGroups(), hasKeys("1", "500"));
     assertThat(
         ccae,
         hasRedFlagWarning(
             hostname,
             containsString(
                 String.format(
-                    "Interface track mode %s is not yet supported and will be ignored.",
+                    "Interface track mode %s is not yet supported and will be treated as always"
+                        + " succeeding.",
                     Mode.IP_ROUTING))));
     assertThat(
         ccae,
@@ -1873,7 +1877,8 @@ public final class CiscoNxosGrammarTest {
             hostname,
             containsString(
                 String.format(
-                    "Interface track mode %s is not yet supported and will be ignored.",
+                    "Interface track mode %s is not yet supported and will be treated as always"
+                        + " succeeding.",
                     Mode.IPV6_ROUTING))));
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
@@ -8,6 +8,6 @@ track 100 ip route 192.0.2.1/32 reachability hmm
   vrf member v1
 track 200 ip route 192.0.2.2/32 reachability
 
-! We don't yet convert these track types, but shouldn't crash
+! We don't yet support these track types, but shouldn't crash
 track 101 ip sla 1 reachability
 !


### PR DESCRIPTION
- remove references to undefined tracks in:
  - HsrpGroup
  - StaticRoute
- fixes NPEs on evaluation of undefined tracks
- add TrackTrue as placeholder implementation for unsupported tracks
  - use in NX-OS to avoid extra warning for removal of undefined track
  - use TrackTrue to simplify existing evaluator tests