### PR TITLE
NXOS: access VLANs must be configured & active

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -2093,7 +2093,10 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     newIfaceBuilder.setSwitchportMode(switchportMode.toSwitchportMode());
     switch (switchportMode) {
       case ACCESS:
-        newIfaceBuilder.setAccessVlan(iface.getAccessVlan());
+        Integer accessVlan = iface.getAccessVlan();
+        if (accessVlan != null && _vlans.containsKey(accessVlan)) {
+          newIfaceBuilder.setAccessVlan(accessVlan);
+        }
         break;
 
       case NONE:

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -2855,6 +2855,7 @@ public final class CiscoNxosGrammarTest {
             "Ethernet1/13",
             "Ethernet1/14",
             "Ethernet1/15",
+            "Ethernet1/16",
             "loopback0",
             "mgmt0",
             "port-channel1",
@@ -2926,26 +2927,32 @@ public final class CiscoNxosGrammarTest {
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/5");
       assertThat(iface, isActive());
-      assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
-      assertThat(iface.getNativeVlan(), equalTo(2));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 5))));
+      assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.ACCESS));
+      assertThat(iface.getAccessVlan(), nullValue());
     }
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/6");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
-      assertThat(iface.getNativeVlan(), equalTo(1));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 3))));
+      assertThat(iface.getNativeVlan(), equalTo(2));
+      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 5))));
     }
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/7");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4))));
+      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 3))));
     }
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/8");
+      assertThat(iface, isActive());
+      assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
+      assertThat(iface.getNativeVlan(), equalTo(1));
+      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4))));
+    }
+    {
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/9");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
@@ -2954,46 +2961,46 @@ public final class CiscoNxosGrammarTest {
           equalTo(IntegerSpace.unionOf(Range.singleton(1), Range.closed(3, 5))));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/9");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/10");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
       assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.EMPTY));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/10");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/11");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
       assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 2))));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/11");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/12");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.ACCESS));
       assertThat(iface.getAccessVlan(), equalTo(1));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/12");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/13");
       assertThat(iface, isActive());
       assertThat(
           iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.DOT1Q_TUNNEL));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/13");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/14");
       assertThat(iface, isActive());
       assertThat(
           iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.FEX_FABRIC));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/14");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/15");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
       assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 5))));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/15");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/16");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(org.batfish.datamodel.SwitchportMode.MONITOR));
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -3031,6 +3031,7 @@ public final class CiscoNxosGrammarTest {
             "Ethernet1/13",
             "Ethernet1/14",
             "Ethernet1/15",
+            "Ethernet1/16",
             "loopback0",
             "mgmt0",
             "port-channel1",
@@ -3101,26 +3102,32 @@ public final class CiscoNxosGrammarTest {
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/5");
       assertThat(iface.getShutdown(), nullValue());
-      assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
-      assertThat(iface.getNativeVlan(), equalTo(2));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4094))));
+      assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
+      assertThat(iface.getAccessVlan(), equalTo(25));
     }
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/6");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
-      assertThat(iface.getNativeVlan(), equalTo(1));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 3))));
+      assertThat(iface.getNativeVlan(), equalTo(2));
+      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4094))));
     }
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/7");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
-      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4))));
+      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 3))));
     }
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/8");
+      assertThat(iface.getShutdown(), nullValue());
+      assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
+      assertThat(iface.getNativeVlan(), equalTo(1));
+      assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4))));
+    }
+    {
+      Interface iface = vc.getInterfaces().get("Ethernet1/9");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
@@ -3129,44 +3136,44 @@ public final class CiscoNxosGrammarTest {
           equalTo(IntegerSpace.unionOf(Range.singleton(1), Range.closed(3, 3967))));
     }
     {
-      Interface iface = vc.getInterfaces().get("Ethernet1/9");
+      Interface iface = vc.getInterfaces().get("Ethernet1/10");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
       assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.EMPTY));
     }
     {
-      Interface iface = vc.getInterfaces().get("Ethernet1/10");
+      Interface iface = vc.getInterfaces().get("Ethernet1/11");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
       assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 2))));
     }
     {
-      Interface iface = vc.getInterfaces().get("Ethernet1/11");
+      Interface iface = vc.getInterfaces().get("Ethernet1/12");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
       assertThat(iface.getAccessVlan(), equalTo(1));
     }
     {
-      Interface iface = vc.getInterfaces().get("Ethernet1/12");
+      Interface iface = vc.getInterfaces().get("Ethernet1/13");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.DOT1Q_TUNNEL));
     }
     {
-      Interface iface = vc.getInterfaces().get("Ethernet1/13");
+      Interface iface = vc.getInterfaces().get("Ethernet1/14");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.FEX_FABRIC));
     }
     {
-      Interface iface = vc.getInterfaces().get("Ethernet1/14");
+      Interface iface = vc.getInterfaces().get("Ethernet1/15");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
       assertThat(iface.getNativeVlan(), equalTo(1));
       assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 4094))));
     }
     {
-      Interface iface = vc.getInterfaces().get("Ethernet1/15");
+      Interface iface = vc.getInterfaces().get("Ethernet1/16");
       assertThat(iface.getShutdown(), nullValue());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.MONITOR));
       assertTrue(iface.getSwitchportMonitor());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_show_all_2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_show_all_2
@@ -3,6 +3,8 @@
 version 7.0(3)I7(6) Bios:version 07.65
 switchname nxos_interface_show_all_2
 !
+vlan 17
+!
 interface Ethernet1/2
   lacp port-priority 32768
   lacp rate normal

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport
@@ -114,6 +114,16 @@ interface Ethernet1/4
   switchport access vlan 2
 !
 
+! Ethernet interface with access vlan that is not configured
+! - shutdown = false
+! - active = true
+! - switchport = true
+! - switchport mode = ACCESS
+! - switchport access vlan = null
+interface Ethernet1/5
+  switchport access vlan 25
+!
+
 ! Ethernet interface with native vlan
 ! - shutdown = false
 ! - active = true
@@ -121,7 +131,7 @@ interface Ethernet1/4
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 2
 ! - switchport allowed vlans = 1-5 (all active VLANs)
-interface Ethernet1/5
+interface Ethernet1/6
   switchport mode trunk
   switchport trunk native vlan 2
 !
@@ -133,7 +143,7 @@ interface Ethernet1/5
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
 ! - switchport allowed vlans = 1-3
-interface Ethernet1/6
+interface Ethernet1/7
   switchport mode trunk
   switchport trunk allowed vlan 1-3
 !
@@ -145,7 +155,7 @@ interface Ethernet1/6
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
 ! - switchport allowed vlans = 1-4
-interface Ethernet1/7
+interface Ethernet1/8
   switchport mode trunk
   switchport trunk allowed vlan 1-3
   switchport trunk allowed vlan add 4
@@ -158,7 +168,7 @@ interface Ethernet1/7
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
 ! - switchport allowed vlans = 1, 3-5
-interface Ethernet1/8
+interface Ethernet1/9
   switchport mode trunk
   switchport trunk allowed vlan except 2
 !
@@ -170,7 +180,7 @@ interface Ethernet1/8
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
 ! - switchport allowed vlans = {}
-interface Ethernet1/9
+interface Ethernet1/10
   switchport mode trunk
   switchport trunk allowed vlan none
 !
@@ -182,7 +192,7 @@ interface Ethernet1/9
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
 ! - switchport allowed vlans = 1-2
-interface Ethernet1/10
+interface Ethernet1/11
   switchport mode trunk
   switchport trunk allowed vlan 1-3
   switchport trunk allowed vlan remove 3
@@ -194,19 +204,19 @@ interface Ethernet1/10
 ! - switchport = true
 ! - switchport mode = access
 ! - switchport access vlan = 1
-interface Ethernet1/11
+interface Ethernet1/12
   switchport mode access
 !
 
 ! Ethernet interface with dot1q-tunnel mode set
 ! TODO: semantics
-interface Ethernet1/12
+interface Ethernet1/13
   switchport mode dot1q-tunnel
 !
 
 ! Ethernet interface with fex-fabric mode set
 ! TODO: semantics
-interface Ethernet1/13
+interface Ethernet1/14
   switchport mode fex-fabric
   fex associate 100
 !
@@ -218,7 +228,7 @@ interface Ethernet1/13
 ! - switchport mode = TRUNK
 ! - switchport native vlan = 1
 ! - switchport allowed vlans = 1-5
-interface Ethernet1/14
+interface Ethernet1/15
   switchport mode trunk
 !
 
@@ -227,7 +237,7 @@ interface Ethernet1/14
 ! - active = true
 ! - switchport = true
 ! - switchport mode = MONITOR
-interface Ethernet1/15
+interface Ethernet1/16
   no switchport
   switchport
   switchport mode monitor buffer-limit 36000 packets


### PR DESCRIPTION
The CLI will allow you to configure access VLANs that are inactive or not configured.