### PR TITLE
FilterLineReachabilityAnswer: parallelize

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -452,10 +452,10 @@ public class FilterLineReachabilityAnswerer extends Answerer {
 
   private static Stream<UnreachableFilterLine> computeUnreachableFilterLines(
       List<AclSpecs> aclSpecs) {
-    BDDPacket bddPacket = new BDDPacket();
-    return aclSpecs.stream()
+    return aclSpecs.parallelStream()
         .flatMap(
             aclSpec ->
-                FilterLineReachabilityUtils.computeUnreachableFilterLines(aclSpec, bddPacket));
+                FilterLineReachabilityUtils.computeUnreachableFilterLines(
+                    aclSpec, new BDDPacket()));
   }
 }


### PR DESCRIPTION
In large networks, the gains from parallelism are likely much larger
than the gains from BDD Reuse.