### PR TITLE
Junos: Check VRF when using lo0-based BGP local IP

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -317,6 +317,10 @@ public class Interface implements Serializable {
     return _routingInstance;
   }
 
+  public @Nonnull InterfaceType getType() {
+    return _type;
+  }
+
   public Map<String, Interface> getUnits() {
     return _units;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -344,7 +344,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   /** Maximum IS-IS route cost if wide-metrics-only is not set */
   @VisibleForTesting static final int MAX_ISIS_COST_WITHOUT_WIDE_METRICS = 63;
 
-  @VisibleForTesting static final String FIRST_LOOPBACK_INTERFACE_NAME = "lo0";
+  private static final String FIRST_LOOPBACK_INTERFACE_NAME = "lo0";
 
   private static String communityRegexToJavaRegex(String regex) {
     String out = regex;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -431,7 +431,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
     initDefaultBgpExportPolicy();
     initDefaultBgpImportPolicy();
-    String vrfName = routingInstance.getName();
     int ebgpAdmin = firstNonNull(mg.getPreference(), DEFAULT_BGP_ADMIN_DISTANCE);
     int ibgpAdmin = firstNonNull(mg.getPreference(), DEFAULT_BGP_ADMIN_DISTANCE);
     BgpProcess proc =

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -733,7 +733,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // default-address-selection is set.
       if (localIp == null
           && _masterLogicalSystem.getDefaultAddressSelection()
-          && (ibgp || ig.getEbgpMultihop())) {
+          && (ibgp || firstNonNull(ig.getEbgpMultihop(), false))) {
         localIp = getDefaultSourceAddress(routingInstance, _c).orElse(null);
       }
       neighbor.setLocalIp(localIp);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1101,13 +1101,10 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         parseWarnings,
         hasItem(allOf(hasComment("This feature is not currently supported"), hasText("private"))));
-    Warnings convertWarnings =
-        batfish
-            .loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot())
-            .getWarnings()
-            .get(hostname);
+    SortedMap<String, Warnings> convertWarnings =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot()).getWarnings();
     assertThat(
-        convertWarnings.getRedFlagWarnings(),
+        convertWarnings.getOrDefault(hostname, new Warnings()).getRedFlagWarnings(),
         not(
             hasItem(
                 WarningMatchers.hasText(

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -887,8 +887,6 @@ public class JuniperConfigurationTest {
 
     {
       // when both lo0 and primary are present
-      JuniperConfiguration vsC = createConfig();
-
       Interface lo0 = new Interface("lo0.0");
       Interface em0 = new Interface("em0.0");
       em0.setPrimary(true);

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -11190,7 +11190,7 @@
     {
       "class" : "org.batfish.datamodel.answers.ConvertConfigurationAnswerElement",
       "convertStatus" : {
-        "as1border1" : "WARNINGS",
+        "as1border1" : "PASSED",
         "as1border2" : "PASSED",
         "as1core1" : "PASSED",
         "as2border1" : "PASSED",
@@ -14073,18 +14073,6 @@
       },
       "version" : "0.36.0",
       "warnings" : {
-        "as1border1" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine local ip for bgp peering with neighbor ip: 3.2.2.2"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine local ip for bgp peering with neighbor ip: 5.6.7.8"
-            }
-          ]
-        },
         "internet" : { }
       }
     },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71006,7 +71006,7 @@
         "aws_configs" : "WARNINGS",
         "bgp-allow" : "PASSED",
         "bgp-disable" : "PASSED",
-        "bgp-enforce-first-as" : "WARNINGS",
+        "bgp-enforce-first-as" : "PASSED",
         "bgp_address_family" : "WARNINGS",
         "bgp_default_originate_policy" : "PASSED",
         "bgp_nsr" : "PASSED",
@@ -85606,14 +85606,6 @@
             }
           ]
         },
-        "bgp-enforce-first-as" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine local ip for bgp peering with neighbor ip: 1.1.1.1"
-            }
-          ]
-        },
         "bgp_address_family" : {
           "Red flags" : [
             {
@@ -85907,10 +85899,6 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine local ip for bgp peering with neighbor ip: 3.4.5.7"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Currently do not support per-neighbor BGP preference"
             },
             {
@@ -85928,14 +85916,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Both authentication-key and authentication-key-chain specified for neighbor 172.16.2.1/32"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine local ip for bgp peering with neighbor ip: 172.16.2.1"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine local ip for bgp peering with neighbor ip: 172.16.2.2"
             }
           ]
         },


### PR DESCRIPTION
This PR makes two small changes to inferring local Ip for BGP neighbors:
1. Make sure that the neighbor is in the same VRF as lo0 (default)
2. Do not pick 127.0.01 

