### PR TITLE
SourcesReferencedOnDevice: a variant of SourcesReferencedByIpAccessLists for the device

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
@@ -28,7 +28,7 @@ public final class SourcesReferencedByIpAccessLists {
     private final Map<String, Supplier<Void>> _namedAclThunks;
 
     ReferenceSourcesVisitor(Map<String, IpAccessList> namedAcls) {
-      /**
+      /*
        * Thunks used to include sources (on demand) referenced by ACLs referenced by PermittedByAcl
        * match exprs. NonRecursiveSupplier detects cyclic references and throws an exception rather
        * than going into an infinite loop.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedOnDevice.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedOnDevice.java
@@ -1,0 +1,201 @@
+package org.batfish.datamodel.acl;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.packet_policy.ApplyFilter;
+import org.batfish.datamodel.packet_policy.ApplyTransformation;
+import org.batfish.datamodel.packet_policy.BoolExpr;
+import org.batfish.datamodel.packet_policy.BoolExprVisitor;
+import org.batfish.datamodel.packet_policy.Conjunction;
+import org.batfish.datamodel.packet_policy.FalseExpr;
+import org.batfish.datamodel.packet_policy.FibLookupOutgoingInterfaceIsOneOf;
+import org.batfish.datamodel.packet_policy.If;
+import org.batfish.datamodel.packet_policy.PacketMatchExpr;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
+import org.batfish.datamodel.packet_policy.Statement;
+import org.batfish.datamodel.packet_policy.StatementVisitor;
+import org.batfish.datamodel.packet_policy.TrueExpr;
+import org.batfish.datamodel.transformation.Transformation;
+
+/** Find all the sources referenced by configuration on a device. */
+public final class SourcesReferencedOnDevice {
+
+  /**
+   * Like {@link #allReferencedSources(Configuration)}, but limited to only active source
+   * interfaces.
+   */
+  public static Set<String> activeReferencedSources(Configuration c) {
+    return Sets.intersection(allReferencedSources(c), c.activeInterfaceNames());
+  }
+
+  /**
+   * Looks everywhere in a {@link Configuration} that {@link MatchSrcInterface} can occur, and
+   * collects all such references.
+   *
+   * <p>Considered objects include:
+   *
+   * <ul>
+   *   <li>ACLs (including arbitrary nesting)
+   *   <li>Guards in {@link Transformation}
+   *   <li>Guards in {@link PacketPolicy} {@link BoolExpr}
+   * </ul>
+   */
+  public static Set<String> allReferencedSources(Configuration c) {
+    Map<String, IpAccessList> ipAccessLists = c.getIpAccessLists();
+    Map<String, PacketPolicy> packetPolicies = c.getPacketPolicies();
+    Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    Set<String> referenced = new HashSet<>();
+    referenced.addAll(
+        SourcesReferencedByIpAccessLists.referencedSources(ipAccessLists, ipAccessLists.keySet()));
+    collectAllTransformationReferences(c, visited, referenced);
+    collectAllPacketPolicyReferences(packetPolicies, ipAccessLists, visited, referenced);
+    return ImmutableSet.copyOf(referenced);
+  }
+
+  private static void collectAllPacketPolicyReferences(
+      Map<String, PacketPolicy> packetPolicies,
+      Map<String, IpAccessList> ipAccessLists,
+      Set<Object> visited,
+      Set<String> referenced) {
+    for (PacketPolicy p : packetPolicies.values()) {
+      collectPacketPolicyReferences(p, ipAccessLists, visited, referenced);
+    }
+  }
+
+  @VisibleForTesting
+  static void collectPacketPolicyReferences(
+      PacketPolicy p,
+      Map<String, IpAccessList> ipAccessLists,
+      Set<Object> visited,
+      Set<String> referenced) {
+    BoolExprVisitor<Void> boolCollector =
+        new BoolExprVisitor<Void>() {
+          @Override
+          public Void visit(@Nonnull BoolExpr expr) {
+            if (!visited.add(expr)) {
+              // already visited
+              return null;
+            }
+            return BoolExprVisitor.super.visit(expr);
+          }
+
+          @Override
+          public Void visitPacketMatchExpr(PacketMatchExpr expr) {
+            referenced.addAll(
+                SourcesReferencedByIpAccessLists.referencedSources(ipAccessLists, expr.getExpr()));
+            return null;
+          }
+
+          @Override
+          public Void visitTrueExpr(@Nonnull TrueExpr expr) {
+            // Nothing
+            return null;
+          }
+
+          @Override
+          public Void visitFalseExpr(@Nonnull FalseExpr expr) {
+            // Nothing
+            return null;
+          }
+
+          @Override
+          public Void visitFibLookupOutgoingInterfaceIsOneOf(
+              @Nonnull FibLookupOutgoingInterfaceIsOneOf expr) {
+            // Nothing
+            return null;
+          }
+
+          @Override
+          public Void visitConjunction(Conjunction expr) {
+            expr.getConjuncts().forEach(this::visit);
+            return null;
+          }
+        };
+
+    StatementVisitor<Void> collector =
+        new StatementVisitor<Void>() {
+          @Override
+          public Void visit(@Nonnull Statement statement) {
+            if (!visited.add(statement)) {
+              // already visited
+              return null;
+            }
+            return StatementVisitor.super.visit(statement);
+          }
+
+          @Override
+          public Void visitApplyFilter(@Nonnull ApplyFilter applyFilter) {
+            // nothing to do here, we have already converted all ACLs.
+            return null;
+          }
+
+          @Override
+          public Void visitApplyTransformation(ApplyTransformation transformation) {
+            collectTransformationReferences(
+                transformation.getTransformation(), ipAccessLists, visited, referenced);
+            return null;
+          }
+
+          @Override
+          public Void visitIf(If ifStmt) {
+            boolCollector.visit(ifStmt.getMatchCondition());
+            ifStmt.getTrueStatements().forEach(this::visit);
+            return null;
+          }
+
+          @Override
+          public Void visitReturn(@Nonnull Return returnStmt) {
+            // Nothing referenced.
+            return null;
+          }
+        };
+
+    // Collect all references in all statements.
+    p.getStatements().forEach(collector::visit);
+  }
+
+  private static void collectAllTransformationReferences(
+      Configuration c, Set<Object> visited, Set<String> referenced) {
+    for (Interface i : c.getActiveInterfaces().values()) {
+      if (i.getIncomingTransformation() != null) {
+        collectTransformationReferences(
+            i.getIncomingTransformation(), c.getIpAccessLists(), visited, referenced);
+      }
+      if (i.getOutgoingTransformation() != null) {
+        collectTransformationReferences(
+            i.getOutgoingTransformation(), c.getIpAccessLists(), visited, referenced);
+      }
+    }
+  }
+
+  private static void collectTransformationReferences(
+      Transformation t,
+      Map<String, IpAccessList> namedAcls,
+      Set<Object> visitedAlready,
+      Set<String> referenced) {
+    if (!visitedAlready.add(t)) {
+      // already been here.
+      return;
+    }
+    referenced.addAll(SourcesReferencedByIpAccessLists.referencedSources(namedAcls, t.getGuard()));
+    if (t.getAndThen() != null) {
+      collectTransformationReferences(t.getAndThen(), namedAcls, visitedAlready, referenced);
+    }
+    if (t.getOrElse() != null) {
+      collectTransformationReferences(t.getOrElse(), namedAcls, visitedAlready, referenced);
+    }
+  }
+
+  private SourcesReferencedOnDevice() {} // prevent construction of utility class
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -5,9 +5,7 @@ import static org.batfish.datamodel.ExprAclLine.accepting;
 import static org.batfish.datamodel.ExprAclLine.rejecting;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -93,29 +91,6 @@ public class BDDSourceManagerTest {
                 ACCEPT_ALL))
         .build();
     return config;
-  }
-
-  @Test
-  public void testForIpAccessList() {
-    NetworkFactory nf = new NetworkFactory();
-    Configuration config = configWithOneAcl(nf);
-    IpAccessList acl = config.getIpAccessLists().values().iterator().next();
-
-    BDDSourceManager mgr = BDDSourceManager.forIpAccessList(_pkt, config, acl);
-    assertFalse(mgr.isTrivial());
-    assertFalse(mgr.allSourcesTracked());
-
-    BDD iface1BDD = mgr.getSourceInterfaceBDD(IFACE1);
-    BDD iface2BDD = mgr.getSourceInterfaceBDD(IFACE2);
-    BDD iface3BDD = mgr.getSourceInterfaceBDD(IFACE3);
-    BDD origBDD = mgr.getOriginatingFromDeviceBDD();
-
-    assertThat(
-        "BDDs for IFACE1 and IFACE2 should be different", iface1BDD, not(equalTo(iface2BDD)));
-    assertThat(
-        "BDDs for all sources other than IFACE1 should be the same",
-        iface2BDD,
-        allOf(equalTo(iface3BDD), equalTo(origBDD)));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/SourcesReferencedOnDeviceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/SourcesReferencedOnDeviceTest.java
@@ -1,0 +1,100 @@
+package org.batfish.datamodel.acl;
+
+import static org.batfish.datamodel.ConfigurationFormat.CISCO_IOS;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
+import static org.batfish.datamodel.acl.SourcesReferencedOnDevice.activeReferencedSources;
+import static org.batfish.datamodel.acl.SourcesReferencedOnDevice.allReferencedSources;
+import static org.batfish.datamodel.acl.SourcesReferencedOnDevice.collectPacketPolicyReferences;
+import static org.batfish.datamodel.transformation.Transformation.when;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.packet_policy.ApplyTransformation;
+import org.batfish.datamodel.packet_policy.Conjunction;
+import org.batfish.datamodel.packet_policy.Drop;
+import org.batfish.datamodel.packet_policy.If;
+import org.batfish.datamodel.packet_policy.PacketMatchExpr;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
+import org.batfish.datamodel.packet_policy.Statement;
+import org.junit.Test;
+
+public class SourcesReferencedOnDeviceTest {
+  @Test
+  public void testActiveReferences() {
+    Configuration c =
+        Configuration.builder().setHostname("test").setConfigurationFormat(CISCO_IOS).build();
+    IpAccessList.builder()
+        .setName("acl-has-ref")
+        .setOwner(c)
+        .setLines(ExprAclLine.accepting(matchSrcInterface("in-acl")))
+        .build();
+    Interface.builder()
+        .setOwner(c)
+        .setVrf(c.getDefaultVrf())
+        .setName("in-incoming-trans") // so one is active
+        .setType(InterfaceType.LOGICAL)
+        .setIncomingTransformation(when(matchSrcInterface("in-incoming-trans")).build())
+        .setOutgoingTransformation(when(matchSrcInterface("in-outgoing-trans")).build())
+        .build();
+    PacketPolicy p =
+        new PacketPolicy(
+            "policy-has-ref",
+            ImmutableList.of(
+                new If(
+                    new PacketMatchExpr(matchSrcInterface("in-packet-policy")),
+                    ImmutableList.of())),
+            new Return(Drop.instance()));
+    c.setPacketPolicies(ImmutableMap.of(p.getName(), p));
+    assertThat(
+        allReferencedSources(c),
+        containsInAnyOrder("in-acl", "in-incoming-trans", "in-outgoing-trans", "in-packet-policy"));
+    assertThat(activeReferencedSources(c), containsInAnyOrder("in-incoming-trans"));
+  }
+
+  @Test
+  public void testCollectPacketPolicyReferences() {
+    Statement nestedIf =
+        new If(new PacketMatchExpr(matchSrcInterface("nested-if")), ImmutableList.of());
+    Statement ifSt =
+        new If(new PacketMatchExpr(matchSrcInterface("top-level-if")), ImmutableList.of(nestedIf));
+    Statement conjunctionIf =
+        new If(
+            Conjunction.of(new PacketMatchExpr(matchSrcInterface("conjunction"))),
+            ImmutableList.of());
+    Statement transformation =
+        new ApplyTransformation(
+            when(matchSrcInterface("transformation"))
+                .setAndThen(when(matchSrcInterface("transformation-andthen")).build())
+                .setOrElse(when(matchSrcInterface("transformation-orelse")).build())
+                .build());
+    PacketPolicy p =
+        new PacketPolicy(
+            "foo",
+            ImmutableList.of(ifSt, conjunctionIf, transformation),
+            new Return(Drop.instance()));
+    Set<String> referenced = new HashSet<>();
+    collectPacketPolicyReferences(
+        p, ImmutableMap.of(), Collections.newSetFromMap(new IdentityHashMap<>()), referenced);
+    assertThat(
+        referenced,
+        containsInAnyOrder(
+            "top-level-if",
+            "conjunction",
+            "nested-if",
+            "transformation",
+            "transformation-andthen",
+            "transformation-orelse"));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -79,7 +79,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.acl.Evaluator;
-import org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists;
+import org.batfish.datamodel.acl.SourcesReferencedOnDevice;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
 import org.batfish.datamodel.flow.ArpErrorStep;
@@ -275,16 +275,15 @@ class FlowTracer {
 
   static Function<String, Set<String>> createBreadcrumbInterfaces(
       TracerouteEngineImplContext tracerouteContext) {
-    LoadingCache<String, Set<String>> interfacesReferencedByAcls =
+    LoadingCache<String, Set<String>> interfacesMatchedAgainst =
         Caffeine.newBuilder()
             .build(
                 hostname -> {
                   Configuration c = tracerouteContext.getConfigurations().get(hostname);
                   assert c != null;
-                  return SourcesReferencedByIpAccessLists.referencedSources(
-                      c.getIpAccessLists(), c.getIpAccessLists().keySet());
+                  return SourcesReferencedOnDevice.activeReferencedSources(c);
                 });
-    return interfacesReferencedByAcls::get;
+    return interfacesMatchedAgainst::get;
   }
 
   /** Creates an initial {@link FlowTracer} for a new traceroute. */


### PR DESCRIPTION
SourcesReferencedByIpAccessLists does not capture packet policy or transformation.
Sometimes, we need everything.