### PR TITLE
A10 fix VRRP conversion between sync and IP owner interfaces

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -80,6 +80,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
@@ -1471,7 +1472,7 @@ public class A10GrammarTest {
                       .setPreempt(true)
                       .setPriority(DEFAULT_VRRP_A_PRIORITY)
                       .setVirtualAddresses(
-                          i.getName(),
+                          i2Name,
                           ImmutableSet.of(
                               Ip.parse("1.0.0.1"),
                               Ip.parse("1.0.0.2"),
@@ -1488,9 +1489,14 @@ public class A10GrammarTest {
       org.batfish.datamodel.Interface i = c.getAllInterfaces().get(i2Name);
       assertThat(i.getVrrpGroups(), anEmptyMap());
       // Should not contain virtual addresses
-      assertThat(i.getAllAddresses(), empty());
+      assertThat(i.getAllAddresses(), contains(ConcreteInterfaceAddress.parse("10.0.2.1/24")));
       // Should not contain address metadata
-      assertThat(i.getAddressMetadata(), anEmptyMap());
+      assertThat(
+          i.getAddressMetadata(),
+          equalTo(
+              ImmutableMap.of(
+                  ConcreteInterfaceAddress.parse("10.0.2.1/24"),
+                  ConnectedRouteMetadata.builder().setGenerateLocalRoute(false).build())));
     }
   }
 
@@ -2180,7 +2186,7 @@ public class A10GrammarTest {
                       .setPreempt(false)
                       .setPriority(200)
                       .setVirtualAddresses(
-                          i.getName(),
+                          i2Name,
                           ImmutableSet.of(
                               Ip.parse("10.0.2.1"),
                               Ip.parse("10.0.3.1"),
@@ -2197,9 +2203,14 @@ public class A10GrammarTest {
       org.batfish.datamodel.Interface i = c.getAllInterfaces().get(i2Name);
       assertThat(i.getVrrpGroups(), anEmptyMap());
       // Should not contain virtual addresses
-      assertThat(i.getAllAddresses(), empty());
-      // Should not contain address metadata
-      assertThat(i.getAddressMetadata(), anEmptyMap());
+      assertThat(i.getAllAddresses(), contains(ConcreteInterfaceAddress.parse("10.10.0.1/24")));
+      // Should only contain metadata for its assigned address
+      assertThat(
+          i.getAddressMetadata(),
+          equalTo(
+              ImmutableMap.of(
+                  ConcreteInterfaceAddress.parse("10.10.0.1/24"),
+                  ConnectedRouteMetadata.builder().setGenerateLocalRoute(false).build())));
     }
     // TODO: something with ethernet 3 / vlan 4094?
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/vrrp_e2e/A10HaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/vrrp_e2e/A10HaTest.java
@@ -1,0 +1,89 @@
+package org.batfish.vendor.a10.vrrp_e2e;
+
+import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceName;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.datamodel.Ip;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.batfish.vendor.a10.representation.Interface.Type;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** End-to-end tests of HA on A10v2 with paired devices. */
+public final class A10HaTest {
+
+  private static final String SNAPSHOT_FOLDER = "org/batfish/vendor/a10/vrrp_e2e/snapshots/ha";
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private Batfish _batfish;
+
+  private static final String R1 = "r1";
+  private static final String R2 = "r2";
+
+  /*
+   * Topology:
+   * r1 <==================> r2
+   *    Ethernet1  Ethernet1
+   *    .1  192.0.2.0/30  .2 (on respective IRB interfaces)
+   * - Ethernet1 on each device is the HA heartbeat interface
+   * - Ethernet1 is a trunk switchport with tagged vlan 4094
+   * - The router-interface (IRB) for VLAN 4094 is VirtualEthernet4094
+   * - Each device has an L3 interface Ethernet2 with a concrete IP
+   *   - ri[Ethernet2] has 10.0.1.1/24
+   *   - r2[Ethernet2] has 10.0.2.1/24
+   * - Each device has a VIP with IP 10.1.0.1
+   * - Each device has an SNAT pool with subnet 10.2.0.1/32
+   * - Each device has a floating IP 10.3.0.1
+   * - A VrrpGroup should be installed on Ethernet1 on each device
+   *   - r1 has higher priority
+   *   - On the winner (r1), the addresses for the VIP, SNAT pool, and floating IPs should be
+   *     installed on Ethernet2
+   */
+  @Before
+  public void setup() throws IOException {
+    _batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(SNAPSHOT_FOLDER, ImmutableSet.of(R1, R2))
+                .setLayer1TopologyPrefix(String.format("%s/batfish", SNAPSHOT_FOLDER))
+                .build(),
+            _folder);
+    _batfish.computeDataPlane(_batfish.getSnapshot());
+  }
+
+  @Test
+  public void testIpOwners() {
+    Map<String, Map<String, Set<Ip>>> ipOwners =
+        _batfish.getTopologyProvider().getIpOwners(_batfish.getSnapshot()).getInterfaceOwners(true);
+    Map<String, Set<Ip>> r1IpsByInterface = ipOwners.get(R1);
+    Map<String, Set<Ip>> r2IpsByInterface = ipOwners.get(R2);
+    String ve4094Name = getInterfaceName(Type.VE, 4094);
+    String e2Name = getInterfaceName(Type.ETHERNET, 2);
+
+    assertThat(r1IpsByInterface.get(ve4094Name), containsInAnyOrder(Ip.parse("192.0.2.1")));
+    assertThat(
+        r1IpsByInterface.get(e2Name),
+        containsInAnyOrder(
+            Ip.parse("10.0.1.1"), // interface addresss
+            Ip.parse("10.1.0.1"), // VIP
+            Ip.parse("10.2.0.1"), // SNAT pool
+            Ip.parse("10.3.0.1") // floating IP
+            ));
+    assertThat(r2IpsByInterface.get(ve4094Name), containsInAnyOrder(Ip.parse("192.0.2.2")));
+    assertThat(
+        r2IpsByInterface.get(e2Name),
+        containsInAnyOrder(
+            Ip.parse("10.0.2.1") // interface addresss
+            ));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/vrrp_e2e/A10VrrpATest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/vrrp_e2e/A10VrrpATest.java
@@ -1,0 +1,89 @@
+package org.batfish.vendor.a10.vrrp_e2e;
+
+import static org.batfish.vendor.a10.representation.A10Configuration.getInterfaceName;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.datamodel.Ip;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.batfish.vendor.a10.representation.Interface.Type;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** End-to-end tests of vrrp-a on A10v5 with paired devices. */
+public final class A10VrrpATest {
+
+  private static final String SNAPSHOT_FOLDER = "org/batfish/vendor/a10/vrrp_e2e/snapshots/vrrp_a";
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private Batfish _batfish;
+
+  private static final String R1 = "r1";
+  private static final String R2 = "r2";
+
+  /*
+   * Topology:
+   * r1 <==================> r2
+   *    Ethernet1  Ethernet1
+   *    .1  192.0.2.0/30  .2 (on respective IRB interfaces)
+   * - Ethernet1 on each device is the HA heartbeat interface
+   * - Ethernet1 is a trunk switchport with tagged vlan 4094
+   * - The router-interface (IRB) for VLAN 4094 is VirtualEthernet4094
+   * - Each device has an L3 interface Ethernet2 with a concrete IP
+   *   - ri[Ethernet2] has 10.0.1.1/24
+   *   - r2[Ethernet2] has 10.0.2.1/24
+   * - Each device has a VIP with IP 10.1.0.1
+   * - Each device has an SNAT pool with subnet 10.2.0.1/32
+   * - Each device has a floating IP 10.3.0.1
+   * - A VrrpGroup should be installed on Ethernet1 on each device
+   *   - r1 has higher priority
+   *   - On the winner (r1), the addresses for the VIP, SNAT pool, and floating IPs should be
+   *     installed on Ethernet2
+   */
+  @Before
+  public void setup() throws IOException {
+    _batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(SNAPSHOT_FOLDER, ImmutableSet.of(R1, R2))
+                .setLayer1TopologyPrefix(String.format("%s/batfish", SNAPSHOT_FOLDER))
+                .build(),
+            _folder);
+    _batfish.computeDataPlane(_batfish.getSnapshot());
+  }
+
+  @Test
+  public void testIpOwners() {
+    Map<String, Map<String, Set<Ip>>> ipOwners =
+        _batfish.getTopologyProvider().getIpOwners(_batfish.getSnapshot()).getInterfaceOwners(true);
+    Map<String, Set<Ip>> r1IpsByInterface = ipOwners.get(R1);
+    Map<String, Set<Ip>> r2IpsByInterface = ipOwners.get(R2);
+    String ve4094Name = getInterfaceName(Type.VE, 4094);
+    String e2Name = getInterfaceName(Type.ETHERNET, 2);
+
+    assertThat(r1IpsByInterface.get(ve4094Name), containsInAnyOrder(Ip.parse("192.0.2.1")));
+    assertThat(
+        r1IpsByInterface.get(e2Name),
+        containsInAnyOrder(
+            Ip.parse("10.0.1.1"), // interface addresss
+            Ip.parse("10.1.0.1"), // VIP
+            Ip.parse("10.2.0.1"), // SNAT pool
+            Ip.parse("10.3.0.1") // floating IP
+            ));
+    assertThat(r2IpsByInterface.get(ve4094Name), containsInAnyOrder(Ip.parse("192.0.2.2")));
+    assertThat(
+        r2IpsByInterface.get(e2Name),
+        containsInAnyOrder(
+            Ip.parse("10.0.2.1") // interface addresss
+            ));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/vrrp_e2e/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/vrrp_e2e/BUILD
@@ -1,0 +1,38 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+        "package-info.java",
+    ]),
+    resources = [
+        "//projects/batfish/src/test/resources:log4j_config",
+        "//projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e",
+    ],
+    tags = ["cpu:4"],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/batfish/src/main/java/org/batfish/vendor/a10/grammar",
+        "//projects/batfish/src/main/java/org/batfish/vendor/a10/representation",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:junit_junit",
+        "@maven//:org_antlr_antlr4_runtime",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/vrrp_e2e/package-info.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/vrrp_e2e/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.vendor.a10.vrrp_e2e;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/ha_acos2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/ha_acos2
@@ -15,6 +15,7 @@ interface ethernet 1
 !
 
 interface ethernet 2
+  ip address 10.10.0.1 255.255.255.0
 !
 
 interface ethernet 3

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/vrrp-a-enabled
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/vrrp-a-enabled
@@ -25,6 +25,7 @@ interface ethernet 1
 interface ethernet 2
   mtu 1500
   enable
+  ip address 10.0.2.1 /24
 !
 
 ip nat pool pool1 1.0.0.1 1.0.0.2 netmask /24 vrid 1

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/BUILD
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/BUILD
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "vrrp_e2e",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD"],
+    ),
+)

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/ha/batfish/layer1_topology.json
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/ha/batfish/layer1_topology.json
@@ -1,0 +1,24 @@
+{
+  "edges": [
+    {
+      "node1": {
+        "hostname": "r1",
+        "interfaceName": "ethernet1"
+      },
+      "node2": {
+        "hostname": "r2",
+        "interfaceName": "ethernet1"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r2",
+        "interfaceName": "ethernet1"
+      },
+      "node2": {
+        "hostname": "r1",
+        "interfaceName": "ethernet1"
+      }
+    }
+  ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/ha/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/ha/configs/r1
@@ -1,0 +1,38 @@
+!BATFISH_FORMAT: a10_acos
+!version 2.7.2, build 123 (Aug-5-2021,01:23)
+hostname r1
+!
+
+!!! Interface configuration
+vlan 4094
+ tagged ethernet 1
+ router-interface ve 4094
+!
+
+interface ve 4094
+  ip address 192.0.2.1 /30
+!
+
+interface ethernet 1
+!
+
+interface ethernet 2
+  ip address 10.0.1.1 /24
+!
+
+!!! ha configuration
+ha id 1 set-id 1
+ha group 1 priority 200
+ha conn-mirror ip 192.0.2.2
+ha interface ethernet 1 both vlan 4094
+ha interface ethernet 1 router-interface no-heartbeat
+
+!!! Other configuration referencing ha
+slb virtual-server vs1 10.1.0.1
+   ha-group 1
+   port 22 tcp
+!
+
+ip nat pool pool1 10.2.0.1 10.2.0.1 netmask /32  ha-group-id 1
+
+floating-ip 10.3.0.1 ha-group 1

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/ha/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/ha/configs/r2
@@ -1,0 +1,38 @@
+!BATFISH_FORMAT: a10_acos
+!version 2.7.2, build 123 (Aug-5-2021,01:23)
+hostname r2
+!
+
+!!! Interface configuration
+vlan 4094
+ tagged ethernet 1
+ router-interface ve 4094
+!
+
+interface ve 4094
+  ip address 192.0.2.2 /30
+!
+
+interface ethernet 1
+!
+
+interface ethernet 2
+  ip address 10.0.2.1 /24
+!
+
+!!! ha configuration
+ha id 1 set-id 2
+ha group 1 priority 100
+ha conn-mirror ip 192.0.2.1
+ha interface ethernet 1 both vlan 4094
+ha interface ethernet 1 router-interface no-heartbeat
+
+!!! Other configuration referencing ha
+slb virtual-server vs1 10.1.0.1
+   ha-group 1
+   port 22 tcp
+!
+
+ip nat pool pool1 10.2.0.1 10.2.0.1 netmask /32  ha-group-id 1
+
+floating-ip 10.3.0.1 ha-group 1

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/vrrp_a/batfish/layer1_topology.json
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/vrrp_a/batfish/layer1_topology.json
@@ -1,0 +1,24 @@
+{
+  "edges": [
+    {
+      "node1": {
+        "hostname": "r1",
+        "interfaceName": "ethernet1"
+      },
+      "node2": {
+        "hostname": "r2",
+        "interfaceName": "ethernet1"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r2",
+        "interfaceName": "ethernet1"
+      },
+      "node2": {
+        "hostname": "r1",
+        "interfaceName": "ethernet1"
+      }
+    }
+  ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/vrrp_a/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/vrrp_a/configs/r1
@@ -1,0 +1,49 @@
+!BATFISH_FORMAT: a10_acos
+hostname r1
+!
+
+vrrp-a common
+  device-id 1
+  set-id 1
+  enable
+!
+
+vrrp-a peer-group
+  peer 192.0.2.2
+!
+
+vrrp-a vrid 1
+  floating-ip 10.3.0.1
+  blade-parameters
+    priority 200
+!
+
+vlan 4094
+ tagged ethernet 1
+ router-interface ve 4094
+!
+
+interface ve 4094
+  ip address 192.0.2.1 /30
+!
+
+interface ethernet 1
+  mtu 1500
+  enable
+!
+
+interface ethernet 2
+  mtu 1500
+  enable
+  ip address 10.0.1.1 /24
+!
+
+ip nat pool pool1 10.2.0.1 10.2.0.1 netmask /32 vrid 1
+
+slb virtual-server vs1 10.1.0.1
+  enable
+  vrid 1
+  port 443 tcp
+    enable
+  !
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/vrrp_a/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/vrrp_e2e/snapshots/vrrp_a/configs/r2
@@ -1,0 +1,49 @@
+!BATFISH_FORMAT: a10_acos
+hostname r2
+!
+
+vrrp-a common
+  device-id 1
+  set-id 2
+  enable
+!
+
+vrrp-a peer-group
+  peer 192.0.2.1
+!
+
+vrrp-a vrid 1
+  floating-ip 10.3.0.1
+  blade-parameters
+    priority 100
+!
+
+vlan 4094
+ tagged ethernet 1
+ router-interface ve 4094
+!
+
+interface ve 4094
+  ip address 192.0.2.2 /30
+!
+
+interface ethernet 1
+  mtu 1500
+  enable
+!
+
+interface ethernet 2
+  mtu 1500
+  enable
+  ip address 10.0.2.1 /24
+!
+
+ip nat pool pool1 10.2.0.1 10.2.0.1 netmask /32 vrid 1
+
+slb virtual-server vs1 10.1.0.1
+  enable
+  vrid 1
+  port 443 tcp
+    enable
+  !
+!


### PR DESCRIPTION
- Install `VrrpGroup`s only on sync interfaces
- Winner should install IPs on all other L3 interfaces