### PR TITLE
PrefixTrieMultiMap: getOverlappingEntries

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Ordering;
-import com.google.common.collect.Range;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Optional;
@@ -244,11 +243,6 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
       Ip broadcastIp = getEndIp();
       return Ip.create(broadcastIp.asLong() - 1);
     }
-  }
-
-  /** Returns the range of IPs contained in this prefix. */
-  public Range<Ip> asRange() {
-    return Range.closed(getStartIp(), getEndIp());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Ordering;
+import com.google.common.collect.Range;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Optional;
@@ -243,6 +244,11 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
       Ip broadcastIp = getEndIp();
       return Ip.create(broadcastIp.asLong() - 1);
     }
+  }
+
+  /** Returns the range of IPs contained in this prefix. */
+  public Range<Ip> asRange() {
+    return Range.closed(getStartIp(), getEndIp());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.graph.Traverser;
 import java.io.Serializable;
@@ -280,7 +281,8 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     }
 
     Stream<Map.Entry<Prefix, Set<T>>> getOverlappingEntries(RangeSet<Ip> ips) {
-      RangeSet<Ip> matchingIps = ips.subRangeSet(_prefix.asRange());
+      RangeSet<Ip> matchingIps =
+          ips.subRangeSet(Range.closed(_prefix.getStartIp(), _prefix.getEndIp()));
       if (matchingIps.isEmpty()) {
         return Stream.of();
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -8,9 +8,12 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.Maps;
+import com.google.common.collect.RangeSet;
 import com.google.common.graph.Traverser;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -275,6 +278,22 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
           && ((_left != null && _left.intersectsPrefixRange(prefixRange))
               || (_right != null && _right.intersectsPrefixRange(prefixRange)));
     }
+
+    Stream<Map.Entry<Prefix, Set<T>>> getOverlappingEntries(RangeSet<Ip> ips) {
+      RangeSet<Ip> matchingIps = ips.subRangeSet(_prefix.asRange());
+      if (matchingIps.isEmpty()) {
+        return Stream.of();
+      }
+      Stream<Map.Entry<Prefix, Set<T>>> elementsHere =
+          _elements.isEmpty() ? Stream.of() : Stream.of(Maps.immutableEntry(_prefix, _elements));
+      return Stream.concat(
+          // recurse lazily
+          Stream.of(_left, _right)
+              .filter(Objects::nonNull)
+              .flatMap(child -> child.getOverlappingEntries(matchingIps)),
+          // post-order
+          elementsHere);
+    }
   }
 
   private @Nullable Node<T> _root;
@@ -416,6 +435,19 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     Node<T> node = longestMatchNonEmptyNode(Prefix.create(address, maxPrefixLength));
     assert node == null || !node._elements.isEmpty();
     return node == null ? ImmutableSet.of() : ImmutableSet.copyOf(node._elements);
+  }
+
+  /**
+   * Return all values whose keys intersect with the input {@link RangeSet}. Values are returned as
+   * a {@link Stream} in post-order, so if prefix p1 contains p2, values for p2 will be returned
+   * before values for p1.
+   */
+  @Nonnull
+  public Stream<Map.Entry<Prefix, Set<T>>> getOverlappingEntries(RangeSet<Ip> ips) {
+    if (_root == null) {
+      return Stream.of();
+    }
+    return _root.getOverlappingEntries(ips);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.testing.EqualsTester;
 import java.util.ArrayList;
@@ -519,6 +520,6 @@ public class PrefixTrieMultiMapTest {
   }
 
   private static RangeSet<Ip> toRangeSet(Prefix prefix) {
-    return ImmutableRangeSet.of(prefix.asRange());
+    return ImmutableRangeSet.of(Range.closed(prefix.getStartIp(), prefix.getEndIp()));
   }
 }


### PR DESCRIPTION
New method that returns a stream of entries matching an input RangeSet of IPs.