### PR TITLE
SearchRoutePolicies: handle the Java regex format for Juniper AS-path regexes

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicRegex.java
@@ -10,7 +10,7 @@ public abstract class SymbolicRegex {
   @Nonnull protected final String _regex;
 
   public SymbolicRegex(String regex) {
-    _regex = regex;
+    _regex = toAutomatonRegex(regex);
   }
 
   @Nonnull
@@ -25,4 +25,12 @@ public abstract class SymbolicRegex {
    * @return the automaton
    */
   public abstract Automaton toAutomaton();
+
+  // modify the given regex to conform to the grammar of the Automaton library that we use to
+  // analyze regexes
+  @Nonnull
+  private String toAutomatonRegex(String regex) {
+    // the Automaton library does not support the character class \d
+    return regex.replace("\\d", "[0-9]");
+  }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -207,11 +207,11 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     // As-path regex automata should only accept strings with this property;
     // see SymbolicAsPathRegex::toAutomaton
     checkState(
-        asPathStr.startsWith("^") && asPathStr.endsWith("$"),
+        asPathStr.startsWith("^^") && asPathStr.endsWith("$"),
         "AS-path example %s has an unexpected format",
         asPathStr);
-    // strip off the leading ^ and trailing $
-    asPathStr = asPathStr.substring(1, asPathStr.length() - 1);
+    // strip off the leading ^^ and trailing $
+    asPathStr = asPathStr.substring(2, asPathStr.length() - 1);
     // the string is a space-separated list of numbers; convert them to a list of numbers
     List<Long> asns;
     if (asPathStr.isEmpty()) {

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/RegexAtomicPredicatesTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/RegexAtomicPredicatesTest.java
@@ -76,13 +76,13 @@ public class RegexAtomicPredicatesTest {
 
     assertEquals(asPathAPs.getNumAtomicPredicates(), 5);
 
-    Automaton a1 = new RegExp("^$").toAutomaton();
+    Automaton a1 = new RegExp("^^$").toAutomaton();
     // starts with 5 and ends with 4
-    Automaton a2 = new RegExp("^5 ((0|[1-9][0-9]*) )*4$").toAutomaton();
+    Automaton a2 = new RegExp("^^5 ((0|[1-9][0-9]*) )*4$").toAutomaton();
     // ends with 4 but does not start with 5
-    Automaton a3 = new RegExp("^([0-4]|[6-9]|[1-9][0-9]+) ((0|[1-9][0-9]*) )*4$").toAutomaton();
+    Automaton a3 = new RegExp("^^([0-4]|[6-9]|[1-9][0-9]+) ((0|[1-9][0-9]*) )*4$").toAutomaton();
     // starts with 5 but does not end with 4
-    Automaton a4 = new RegExp("^5( (0|[1-9][0-9]*))* ([0-3]|[5-9]|[1-9][0-9]+)$").toAutomaton();
+    Automaton a4 = new RegExp("^^5( (0|[1-9][0-9]*))* ([0-3]|[5-9]|[1-9][0-9]+)$").toAutomaton();
 
     assertEquals(asPathAPs.getAtomicPredicateAutomata().size(), 5);
     assertThat(asPathAPs.getAtomicPredicateAutomata().values(), hasItem(a1));

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/SymbolicAsPathRegexTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/SymbolicAsPathRegexTest.java
@@ -14,7 +14,7 @@ public class SymbolicAsPathRegexTest {
   private static final String UNDERSCORE = "(,|{|}|^|$| )";
 
   @Test
-  public void testToAutomaton() {
+  public void testToAutomatonRegex() {
 
     SymbolicAsPathRegex r1 = new SymbolicAsPathRegex("^40$");
     SymbolicAsPathRegex r2 = new SymbolicAsPathRegex("^$");
@@ -26,12 +26,28 @@ public class SymbolicAsPathRegexTest {
     SymbolicAsPathRegex r5 =
         new SymbolicAsPathRegex(UNDERSCORE + "40" + UNDERSCORE + "50" + UNDERSCORE);
 
-    assertThat(r1.toAutomaton(), equalTo(new RegExp("^40$").toAutomaton()));
-    assertThat(r2.toAutomaton(), equalTo(new RegExp("^$").toAutomaton()));
-    assertThat(r3.toAutomaton(), equalTo(new RegExp("^((0|[1-9][0-9]*) )*40$").toAutomaton()));
-    assertThat(r4.toAutomaton(), equalTo(new RegExp("^40( (0|[1-9][0-9]*))*$").toAutomaton()));
+    assertThat(r1.toAutomaton(), equalTo(new RegExp("^^40$").toAutomaton()));
+    assertThat(r2.toAutomaton(), equalTo(new RegExp("^^$").toAutomaton()));
+    assertThat(r3.toAutomaton(), equalTo(new RegExp("^^((0|[1-9][0-9]*) )*40$").toAutomaton()));
+    assertThat(r4.toAutomaton(), equalTo(new RegExp("^^40( (0|[1-9][0-9]*))*$").toAutomaton()));
     assertThat(
         r5.toAutomaton(),
-        equalTo(new RegExp("^((0|[1-9][0-9]*) )*40 50( (0|[1-9][0-9]*))*$").toAutomaton()));
+        equalTo(new RegExp("^^((0|[1-9][0-9]*) )*40 50( (0|[1-9][0-9]*))*$").toAutomaton()));
+  }
+
+  @Test
+  public void testToAutomatonJuniper() {
+
+    SymbolicAsPathRegex r1 = new SymbolicAsPathRegex("^(^| )40$");
+    SymbolicAsPathRegex r2 = new SymbolicAsPathRegex("^$");
+    // .*40$
+    SymbolicAsPathRegex r3 = new SymbolicAsPathRegex("^((^| )\\d+)*(^| )40$");
+    // ^40.*
+    SymbolicAsPathRegex r4 = new SymbolicAsPathRegex("^(^| )40((^| )\\d+)*$");
+
+    assertThat(r1.toAutomaton(), equalTo(new RegExp("^^40$").toAutomaton()));
+    assertThat(r2.toAutomaton(), equalTo(new RegExp("^^$").toAutomaton()));
+    assertThat(r3.toAutomaton(), equalTo(new RegExp("^^((0|[1-9][0-9]*) )*40$").toAutomaton()));
+    assertThat(r4.toAutomaton(), equalTo(new RegExp("^^40( (0|[1-9][0-9]*))*$").toAutomaton()));
   }
 }


### PR DESCRIPTION
Addresses two problems in SearchRoutePolicies for handling AS-path regexes from Juniper devices:
* Previously the \d character class for digits was not handled properly.
* A recent update to parsing for Juniper AS-path regexes introduces the possibility of having two start-of-string ^ characters in a row, which requires special handling.