### PR TITLE
Layer1TopologiesFactory: canonicalize unknown nodes to lowercase

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1TopologiesFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1TopologiesFactory.java
@@ -44,7 +44,7 @@ public final class Layer1TopologiesFactory {
    * Attempts to line up the user-provided {@link Layer1Node} with an actual interface.
    *
    * <p>If no match is found (the device does not exist in this snapshot, or no corresponding
-   * interface), then the original node is returned as-is.
+   * interface), then the original node is returned but the values are lowercased.
    */
   private static @Nonnull Layer1Node canonicalizeUserNode(
       Layer1Node node, Map<String, Configuration> configurations, Set<String> missingDevices) {
@@ -54,8 +54,8 @@ public final class Layer1TopologiesFactory {
         LOGGER.info(
             "Layer 1 topology has node {}, but device {} not found", node, node.getHostname());
       }
-      // Host unknown, return node unchanged.
-      return node;
+      // Host unknown, return node with the hostname in lowercase.
+      return new Layer1Node(node.getHostname(), node.getInterfaceName().toLowerCase());
     }
 
     // Find a matching interface on the host, perhaps with a slightly different interface name.

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1TopologiesFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1TopologiesFactoryTest.java
@@ -18,22 +18,22 @@ public final class Layer1TopologiesFactoryTest {
     NetworkFactory nf = new NetworkFactory();
     Configuration c = nf.configurationBuilder().setHostname("c").build();
     nf.interfaceBuilder().setOwner(c).setName("i").setType(PHYSICAL).build();
-    nf.interfaceBuilder().setOwner(c).setName("i2").setType(PHYSICAL).build();
+    nf.interfaceBuilder().setOwner(c).setName("I2").setType(PHYSICAL).build();
     Layer1Topology l1 =
         new Layer1Topology(
             // both c[I] and c[I2] will be canonicalized
-            new Layer1Edge("c", "I", "c", "I2"),
+            new Layer1Edge("c", "I", "c", "i2"),
             // c[I] canonicalized, but d does not exist.
-            new Layer1Edge("c", "I", "d", "i"));
+            new Layer1Edge("c", "I", "d", "iJk"));
     Layer1Topologies topologies =
         Layer1TopologiesFactory.create(l1, Layer1Topology.EMPTY, ImmutableMap.of("c", c));
 
     assertThat(
-        "c[i] and c[i2] are canonicalized, but nonexistent d[i] is left alone",
+        "c[i] and c[I2] are canonicalized, but nonexistent d[iJk] is just lowercased",
         topologies.getUserProvidedL1(),
         equalTo(
             new Layer1Topology(
-                new Layer1Edge("c", "i", "c", "i2"), new Layer1Edge("c", "i", "d", "i"))));
+                new Layer1Edge("c", "i", "c", "I2"), new Layer1Edge("c", "i", "d", "ijk"))));
   }
 
   @Test


### PR DESCRIPTION
This resolves fake ambiguity when the same unknown external interface
is present in L1 with different case.