### PR TITLE
Preparation for reachability tracking

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/StaticTrackMethodEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/StaticTrackMethodEvaluator.java
@@ -9,8 +9,8 @@ import org.batfish.datamodel.Interface;
  * {@link Configuration}. Visiting the method returns {@code true} if the {@link TrackMethod} would
  * be triggered and execute associated {@link TrackAction}s and {@code false} otherwise.
  *
- * <p>For {@link TrackMethod}s requiring data plane information for evaluation, throws {@link
- * UnsupportedOperationException}.
+ * <p>For {@link TrackMethod}s requiring data plane information for evaluation, returns {@code
+ * false}.
  */
 public class StaticTrackMethodEvaluator implements GenericTrackMethodVisitor<Boolean> {
   public StaticTrackMethodEvaluator(Configuration configuration) {
@@ -45,7 +45,7 @@ public class StaticTrackMethodEvaluator implements GenericTrackMethodVisitor<Boo
 
   @Override
   public Boolean visitTrackRoute(TrackRoute trackRoute) {
-    throw new UnsupportedOperationException("Unsupported method for HSRP priority evaluation");
+    return false;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethodEvaluatorProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethodEvaluatorProvider.java
@@ -1,0 +1,11 @@
+package org.batfish.datamodel.tracking;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+
+/** Provides {@link TrackMethod} evaluator for an input configuration. */
+@ParametersAreNonnullByDefault
+@FunctionalInterface
+public interface TrackMethodEvaluatorProvider {
+  GenericTrackMethodVisitor<Boolean> getProvider(Configuration configuration);
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -71,6 +71,7 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.isp_configuration.BorderInterfaceInfo;
 import org.batfish.datamodel.isp_configuration.IspConfiguration;
 import org.batfish.datamodel.isp_configuration.IspFilter;
+import org.batfish.datamodel.tracking.StaticTrackMethodEvaluator;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.VxlanNode;
 import org.batfish.datamodel.vxlan.VxlanTopology;
@@ -1479,13 +1480,13 @@ public final class TopologyUtilTest {
             ImmutableMap.of("node", Configuration.builder().setHostname("node").build()));
 
     assertThat(
-        computeIpInterfaceOwners(nodeInterfaces, true, null, nc),
+        computeIpInterfaceOwners(nodeInterfaces, true, null, nc, StaticTrackMethodEvaluator::new),
         equalTo(
             ImmutableMap.of(
                 Ip.parse("1.1.1.1"), ImmutableMap.of("node", ImmutableSet.of("active")))));
 
     assertThat(
-        computeIpInterfaceOwners(nodeInterfaces, false, null, nc),
+        computeIpInterfaceOwners(nodeInterfaces, false, null, nc, StaticTrackMethodEvaluator::new),
         equalTo(
             ImmutableMap.of(
                 Ip.parse("1.1.1.1"),

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
@@ -20,7 +20,6 @@ import java.util.SortedMap;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.batfish.common.topology.IpOwners;
-import org.batfish.common.topology.L3Adjacencies;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
@@ -58,8 +57,7 @@ public final class DataplaneUtil {
       Map<String, Map<String, Fib>> fibs,
       Map<String, Configuration> configs,
       Topology layer3Topology,
-      L3Adjacencies l3Adjacencies) {
-    IpOwners ipOwners = new IpOwners(configs, l3Adjacencies);
+      IpOwners ipOwners) {
     return new ForwardingAnalysisImpl(
         configs, fibs, layer3Topology, computeLocationInfo(ipOwners, configs), ipOwners);
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
@@ -13,6 +13,7 @@ import java.util.SortedMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.L3Adjacencies;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
@@ -100,9 +101,15 @@ public final class PartialDataplane implements DataPlane {
 
   public static class Builder {
 
+    @Nullable private IpOwners _ipOwners;
     @Nullable private Map<String, Node> _nodes;
     @Nullable private Topology _layer3Topology;
     @Nullable private L3Adjacencies _l3Adjacencies;
+
+    public @Nonnull Builder setIpOwners(@Nonnull IpOwners ipOwners) {
+      _ipOwners = ipOwners;
+      return this;
+    }
 
     public Builder setNodes(@Nonnull Map<String, Node> nodes) {
       _nodes = ImmutableMap.copyOf(nodes);
@@ -148,7 +155,7 @@ public final class PartialDataplane implements DataPlane {
     Map<String, Configuration> configs = computeConfigurations(nodes);
     _fibs = computeFibs(nodes);
     _forwardingAnalysis =
-        computeForwardingAnalysis(_fibs, configs, builder._layer3Topology, builder._l3Adjacencies);
+        computeForwardingAnalysis(_fibs, configs, builder._layer3Topology, builder._ipOwners);
     _layer2VniSettings = DataplaneUtil.computeLayer2VniSettings(nodes);
     _layer3VniSettings = DataplaneUtil.computeLayer3VniSettings(nodes);
     _l3Adjacencies = builder._l3Adjacencies;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -15,6 +15,7 @@ import static org.batfish.dataplane.rib.AbstractRib.importRib;
 import static org.batfish.dataplane.rib.RibDelta.importRibDelta;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -27,6 +28,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -185,6 +187,8 @@ public final class VirtualRouter {
   /** Routes in main RIB to redistribute into IS-IS */
   RibDelta.Builder<AnnotatedRoute<AbstractRoute>> _routesForIsisRedistribution;
 
+  private @Nonnull List<HmmRoute> _hmmRoutes;
+
   IsisLevelRib _isisL1Rib;
   IsisLevelRib _isisL2Rib;
   private IsisLevelRib _isisL1StagingRib;
@@ -286,6 +290,7 @@ public final class VirtualRouter {
     }
     _ribExprEvaluator = new RibExprEvaluator(_mainRib);
     _trackEvaluator = new DataplaneTrackEvaluator(_c, _mainRib);
+    _hmmRoutes = ImmutableList.of();
   }
 
   @VisibleForTesting
@@ -327,11 +332,8 @@ public final class VirtualRouter {
    */
   @VisibleForTesting
   void initForIgpComputation(
-      TopologyContext topologyContext,
-      Map<Ip, Map<String, Set<String>>> ipVrfOwners,
-      Map<String, Map<String, Set<Ip>>> interfaceOwners) {
+      TopologyContext topologyContext, Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
     initConnectedRib();
-    initHmmRoutes(topologyContext, interfaceOwners);
     initKernelRib(ipVrfOwners);
     initLocalRib();
     initStaticRibs();
@@ -367,17 +369,20 @@ public final class VirtualRouter {
     initBaseRipRoutes();
   }
 
-  /** Initialize HMM routes, and import them into independent RIB. */
-  private void initHmmRoutes(
-      TopologyContext topologyContext, Map<String, Map<String, Set<Ip>>> interfaceOwners) {
-    Topology l3 = topologyContext.getLayer3Topology();
+  /** Cmopute HMM routes, and import them into independent RIB. */
+  void computeHmmRoutes(
+      Topology initialLayer3Topology, Map<String, Map<String, Set<Ip>>> interfaceOwners) {
+    RibDelta.Builder<HmmRoute> delta = RibDelta.builder();
+    _hmmRoutes.forEach(oldHmmRoute -> delta.remove(oldHmmRoute, Reason.WITHDRAW));
+    ImmutableList.Builder<HmmRoute> newHmmRoutes = ImmutableList.builder();
     _c.getAllInterfaces(_vrf.getName())
         .forEach(
             (ifaceName, iface) -> {
               if (!iface.getHmm()) {
                 return;
               }
-              Set<NodeInterfacePair> neighbors = l3.getNeighbors(NodeInterfacePair.of(iface));
+              Set<NodeInterfacePair> neighbors =
+                  initialLayer3Topology.getNeighbors(NodeInterfacePair.of(iface));
               for (NodeInterfacePair neighbor : neighbors) {
                 Set<Ip> neighborIps =
                     interfaceOwners
@@ -392,10 +397,22 @@ public final class VirtualRouter {
                                 // TODO: set custom administrative distance
                                 .setNextHop(NextHopInterface.of(iface.getName()))
                                 .build())
-                    .map(this::<AbstractRoute>annotateRoute)
-                    .forEach(_independentRib::mergeRoute);
+                    .forEach(delta::add);
               }
             });
+    delta
+        .build()
+        .getActions()
+        .forEach(
+            action -> {
+              if (action.isWithdrawn()) {
+                _independentRib.removeRoute(annotateRoute(action.getRoute()));
+              } else {
+                newHmmRoutes.add(action.getRoute());
+                _independentRib.mergeRoute(annotateRoute(action.getRoute()));
+              }
+            });
+    _hmmRoutes = newHmmRoutes.build();
   }
 
   /** Apply a rib group to a given source rib (which belongs to this VRF) */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -975,7 +975,7 @@ public class VirtualRouterTest {
     Map<Ip, Map<String, Set<String>>> ipVrfOwners =
         new IpOwners(ImmutableMap.of(c.getHostname(), c), emptyTopology.getL3Adjacencies())
             .getIpVrfOwners();
-    vr.initForIgpComputation(emptyTopology, ipVrfOwners, ImmutableMap.of());
+    vr.initForIgpComputation(emptyTopology, ipVrfOwners);
 
     assertNotEquals(vrInitialHashcode, vr.computeIterationHashCode());
   }


### PR DESCRIPTION
- add TrackMethodEvaluatorProvider interface, used by IpOwners to get TrackMethod evaluator to
  compute HSRP/VRRP priority
- add skeleton code for passing in data-plane-based track method evaluator to IpOwners computation
  each data plane iteration
- fix bug where HSRP priority tracks were never applied
- recompute HMM routes each iteration to account for changes in HSRP/VRRP winners

Follow-on work:
- implement VRRP priority tracking
- implement reachability tracking