### PR TITLE
IpCompletionMetadata: add connected subnet IPs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -1,8 +1,13 @@
 package org.batfish.common.util;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -13,6 +18,7 @@ import org.batfish.common.autocomplete.LocationCompletionMetadata;
 import org.batfish.common.autocomplete.NodeCompletionMetadata;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -71,8 +77,38 @@ public final class CompletionMetadataUtils {
     return String.format("%s[%s]%s", configuration.getHostname(), iface.getName(), suffix);
   }
 
+  @VisibleForTesting
+  static String interfaceLinkDisplayString(Configuration configuration, Interface iface) {
+    String suffix =
+        configuration.getHumanName() == null
+            ? ""
+            : String.format(" (%s)", configuration.getHumanName());
+    return String.format("@enter(%s[%s])%s", configuration.getHostname(), iface.getName(), suffix);
+  }
+
+  static RangeSet<Ip> computeOwnedIps(IpOwners ipOwners) {
+    ImmutableRangeSet.Builder<Ip> ownedIps = ImmutableRangeSet.builder();
+    ipOwners.getInterfaceOwners(false).values().stream()
+        .flatMap(m -> m.values().stream())
+        .flatMap(s -> s.stream())
+        .forEach(ip -> ownedIps.add(Range.closed(ip, ip)));
+    return ownedIps.build();
+  }
+
+  static RangeSet<Ip> unownedSubnetHostIps(Prefix prefix, RangeSet<Ip> ownedIps) {
+    TreeRangeSet<Ip> result = TreeRangeSet.create();
+    result.add(Range.closed(prefix.getFirstHostIp(), prefix.getLastHostIp()));
+    result.removeAll(ownedIps);
+    return ImmutableRangeSet.copyOf(result);
+  }
+
   public static PrefixTrieMultiMap<IpCompletionMetadata> getIps(
-      Map<String, Configuration> configurations) {
+      Map<String, Configuration> configurations, IpOwners ipOwners) {
+    return getIps(configurations, computeOwnedIps(ipOwners));
+  }
+
+  public static PrefixTrieMultiMap<IpCompletionMetadata> getIps(
+      Map<String, Configuration> configurations, RangeSet<Ip> ownedIps) {
     PrefixTrieMultiMap<IpCompletionMetadata> ips = new PrefixTrieMultiMap<>();
     configurations
         .values()
@@ -82,26 +118,20 @@ public final class CompletionMetadataUtils {
                   .getAllInterfaces()
                   .values()
                   .forEach(
-                      iface ->
-                          iface.getAllConcreteAddresses().stream()
-                              .map(interfaceAddress -> interfaceAddress.getIp())
-                              .forEach(
-                                  ip -> {
-                                    IpCompletionRelevance relevance =
-                                        new IpCompletionRelevance(
-                                            interfaceDisplayString(configuration, iface),
-                                            configuration.getHumanName(),
-                                            configuration.getHostname(),
-                                            iface.getName());
-                                    Set<IpCompletionMetadata> metadata = ips.get(ip.toPrefix());
-                                    assert metadata.size() < 2
-                                        : "cannot have more than 1 IpCompletionMetadata per Ip";
-                                    if (metadata.isEmpty()) {
-                                      ips.put(ip.toPrefix(), new IpCompletionMetadata(relevance));
-                                    } else {
-                                      metadata.iterator().next().addRelevance(relevance);
-                                    }
-                                  }));
+                      iface -> {
+                        iface.getAllConcreteAddresses().stream()
+                            .forEach(
+                                interfaceAddress -> {
+                                  addInterfaceIp(
+                                      ips, configuration, iface, interfaceAddress.getIp());
+                                  addConnectedSubnet(
+                                      ips,
+                                      configuration,
+                                      iface,
+                                      interfaceAddress.getPrefix(),
+                                      ownedIps);
+                                });
+                      });
 
               configuration
                   .getGeneratedReferenceBooks()
@@ -133,6 +163,64 @@ public final class CompletionMetadataUtils {
           }
         });
     return ips;
+  }
+
+  private static void addInterfaceIp(
+      PrefixTrieMultiMap<IpCompletionMetadata> ips,
+      Configuration configuration,
+      Interface iface,
+      Ip ip) {
+    IpCompletionRelevance relevance =
+        new IpCompletionRelevance(
+            interfaceDisplayString(configuration, iface),
+            configuration.getHumanName(),
+            configuration.getHostname(),
+            iface.getName());
+    Set<IpCompletionMetadata> metadata = ips.get(ip.toPrefix());
+    assert metadata.size() < 2 : "cannot have more than 1 IpCompletionMetadata per Ip";
+    if (metadata.isEmpty()) {
+      ips.put(ip.toPrefix(), new IpCompletionMetadata(relevance));
+    } else {
+      metadata.iterator().next().addRelevance(relevance);
+    }
+  }
+
+  private static void addConnectedSubnet(
+      PrefixTrieMultiMap<IpCompletionMetadata> trie,
+      Configuration configuration,
+      Interface iface,
+      Prefix prefix,
+      RangeSet<Ip> ownedIps) {
+    // short-circuit when there are no unownedSubnetHostIps. But if the entry is in the trie, there
+    // must be some (and we don't need to compute them again).
+    Set<IpCompletionMetadata> metadataSet = trie.get(prefix);
+
+    // note: this invariant may change in the future, e.g. if we want different exclusions for the
+    // same prefix
+    assert metadataSet.size() < 2 : "cannot have more than 1 IpCompletionMetadata per Prefix";
+
+    // extract the metadata object for this prefix
+    IpCompletionMetadata metadata;
+    if (metadataSet.isEmpty()) {
+      // add a new metadata object (if needed)
+      RangeSet<Ip> ips = unownedSubnetHostIps(prefix, ownedIps);
+      if (ips.isEmpty()) {
+        return;
+      }
+      metadata = new IpCompletionMetadata(ips, ImmutableList.of());
+      trie.put(prefix, metadata);
+    } else {
+      metadata = metadataSet.iterator().next();
+    }
+
+    // add the relevance for this interface
+    IpCompletionRelevance relevance =
+        new IpCompletionRelevance(
+            interfaceLinkDisplayString(configuration, iface),
+            configuration.getHumanName(),
+            configuration.getHostname(),
+            iface.getName());
+    metadata.addRelevance(relevance);
   }
 
   @VisibleForTesting

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -87,12 +88,13 @@ public final class CompletionMetadataUtils {
   }
 
   static RangeSet<Ip> computeOwnedIps(IpOwners ipOwners) {
-    ImmutableRangeSet.Builder<Ip> ownedIps = ImmutableRangeSet.builder();
+    TreeRangeSet<Ip> ownedIps = TreeRangeSet.create();
     ipOwners.getInterfaceOwners(false).values().stream()
         .flatMap(m -> m.values().stream())
-        .flatMap(s -> s.stream())
-        .forEach(ip -> ownedIps.add(Range.closed(ip, ip)));
-    return ownedIps.build();
+        .flatMap(Collection::stream)
+        .map(Range::singleton)
+        .forEach(ownedIps::add);
+    return ImmutableRangeSet.copyOf(ownedIps);
   }
 
   static RangeSet<Ip> unownedSubnetHostIps(Prefix prefix, RangeSet<Ip> ownedIps) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -70,21 +70,17 @@ public final class CompletionMetadataUtils {
   }
 
   @VisibleForTesting
-  static String interfaceDisplayString(Configuration configuration, Interface iface) {
-    String suffix =
-        configuration.getHumanName() == null
-            ? ""
-            : String.format(" (%s)", configuration.getHumanName());
-    return String.format("%s[%s]%s", configuration.getHostname(), iface.getName(), suffix);
+  static String interfaceDisplayString(Interface iface) {
+    String deviceHumanName = iface.getOwner().getHumanName();
+    String suffix = deviceHumanName == null ? "" : String.format(" (%s)", deviceHumanName);
+    return NodeInterfacePair.of(iface) + suffix;
   }
 
   @VisibleForTesting
-  static String interfaceLinkDisplayString(Configuration configuration, Interface iface) {
-    String suffix =
-        configuration.getHumanName() == null
-            ? ""
-            : String.format(" (%s)", configuration.getHumanName());
-    return String.format("@enter(%s[%s])%s", configuration.getHostname(), iface.getName(), suffix);
+  static String interfaceLinkDisplayString(Interface iface) {
+    String deviceHumanName = iface.getOwner().getHumanName();
+    String suffix = deviceHumanName == null ? "" : String.format(" (%s)", deviceHumanName);
+    return String.format("@enter(%s)%s", NodeInterfacePair.of(iface), suffix);
   }
 
   static RangeSet<Ip> computeOwnedIps(IpOwners ipOwners) {
@@ -174,7 +170,7 @@ public final class CompletionMetadataUtils {
       Ip ip) {
     IpCompletionRelevance relevance =
         new IpCompletionRelevance(
-            interfaceDisplayString(configuration, iface),
+            interfaceDisplayString(iface),
             configuration.getHumanName(),
             configuration.getHostname(),
             iface.getName());
@@ -218,7 +214,7 @@ public final class CompletionMetadataUtils {
     // add the relevance for this interface
     IpCompletionRelevance relevance =
         new IpCompletionRelevance(
-            interfaceLinkDisplayString(configuration, iface),
+            interfaceLinkDisplayString(iface),
             configuration.getHumanName(),
             configuration.getHostname(),
             iface.getName());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/autocomplete/IpCompletionMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/autocomplete/IpCompletionMetadataTest.java
@@ -1,36 +1,27 @@
 package org.batfish.common.autocomplete;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
-import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 public class IpCompletionMetadataTest {
 
   @Test
   public void testEquals() {
+    IpCompletionRelevance rel1 = new IpCompletionRelevance("display", ImmutableList.of("tag"));
+    IpCompletionRelevance rel2 = new IpCompletionRelevance("display", ImmutableList.of("other"));
     new EqualsTester()
         .addEqualityGroup(
-            new IpCompletionMetadata(
-                ImmutableList.of(new IpCompletionRelevance("display", ImmutableList.of("tag")))),
-            new IpCompletionMetadata(
-                ImmutableList.of(new IpCompletionRelevance("display", ImmutableList.of("tag")))))
-        .addEqualityGroup(
-            new IpCompletionMetadata(
-                ImmutableList.of(new IpCompletionRelevance("display", ImmutableList.of("other")))))
+            new IpCompletionMetadata(null, ImmutableList.of(rel1)),
+            new IpCompletionMetadata(null, ImmutableList.of(rel1)))
+        .addEqualityGroup(new IpCompletionMetadata(null, ImmutableList.of(rel2)))
+        .addEqualityGroup(new IpCompletionMetadata(ImmutableRangeSet.of(), ImmutableList.of(rel1)))
         .testEquals();
-  }
-
-  @Test
-  public void testJsonSerialization() {
-    IpCompletionMetadata metadata = new IpCompletionMetadata(new IpCompletionRelevance("a"));
-    IpCompletionMetadata clone = BatfishObjectMapper.clone(metadata, IpCompletionMetadata.class);
-    assertEquals(metadata, clone);
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
@@ -116,10 +116,11 @@ public final class CompletionMetadataUtilsTest {
     Configuration cfg = new Configuration("host", ConfigurationFormat.CISCO_IOS);
     Configuration cfgHuman = new Configuration("host", ConfigurationFormat.CISCO_IOS);
     cfgHuman.setHumanName("human");
-    Interface iface = Interface.builder().setName("iface").build();
+    Interface iface = Interface.builder().setOwner(cfg).setName("iface1").build();
+    Interface ifaceHuman = Interface.builder().setOwner(cfgHuman).setName("iface2").build();
 
-    assertThat(interfaceDisplayString(cfg, iface), equalTo("host[iface]"));
-    assertThat(interfaceDisplayString(cfgHuman, iface), equalTo("host[iface] (human)"));
+    assertThat(interfaceDisplayString(iface), equalTo("host[iface1]"));
+    assertThat(interfaceDisplayString(ifaceHuman), equalTo("host[iface2] (human)"));
   }
 
   @Test
@@ -198,53 +199,43 @@ public final class CompletionMetadataUtilsTest {
         ip1.toPrefix(),
         new IpCompletionMetadata(
             new IpCompletionRelevance(
-                interfaceDisplayString(config, iface1), config.getHostname(), iface1.getName())));
+                interfaceDisplayString(iface1), config.getHostname(), iface1.getName())));
     trie.put(
         interfaceAddress1.getPrefix(),
         new IpCompletionMetadata(
             unownedSubnetHostIps(interfaceAddress1.getPrefix(), ownedIps),
             ImmutableList.of(
                 new IpCompletionRelevance(
-                    interfaceLinkDisplayString(config, iface1),
-                    config.getHostname(),
-                    iface1.getName()))));
+                    interfaceLinkDisplayString(iface1), config.getHostname(), iface1.getName()))));
     trie.put(
         ip2.toPrefix(),
         new IpCompletionMetadata(
             ImmutableList.of(
                 new IpCompletionRelevance(
-                    interfaceDisplayString(config, iface1), config.getHostname(), iface1.getName()),
+                    interfaceDisplayString(iface1), config.getHostname(), iface1.getName()),
                 new IpCompletionRelevance(
-                    interfaceDisplayString(config, iface2),
-                    config.getHostname(),
-                    iface2.getName()))));
+                    interfaceDisplayString(iface2), config.getHostname(), iface2.getName()))));
     trie.put(
         interfaceAddress2.getPrefix(),
         new IpCompletionMetadata(
             unownedSubnetHostIps(interfaceAddress2.getPrefix(), ownedIps),
             ImmutableList.of(
                 new IpCompletionRelevance(
-                    interfaceLinkDisplayString(config, iface1),
-                    config.getHostname(),
-                    iface1.getName()),
+                    interfaceLinkDisplayString(iface1), config.getHostname(), iface1.getName()),
                 new IpCompletionRelevance(
-                    interfaceLinkDisplayString(config, iface2),
-                    config.getHostname(),
-                    iface2.getName()))));
+                    interfaceLinkDisplayString(iface2), config.getHostname(), iface2.getName()))));
     trie.put(
         ip3.toPrefix(),
         new IpCompletionMetadata(
             new IpCompletionRelevance(
-                interfaceDisplayString(config, iface2), config.getHostname(), iface2.getName())));
+                interfaceDisplayString(iface2), config.getHostname(), iface2.getName())));
     trie.put(
         interfaceAddress3.getPrefix(),
         new IpCompletionMetadata(
             unownedSubnetHostIps(interfaceAddress3.getPrefix(), ownedIps),
             ImmutableList.of(
                 new IpCompletionRelevance(
-                    interfaceLinkDisplayString(config, iface2),
-                    config.getHostname(),
-                    iface2.getName()))));
+                    interfaceLinkDisplayString(iface2), config.getHostname(), iface2.getName()))));
     createWellKnownIpCompletion(WELL_KNOWN_IPS)
         .forEach((ip, metadata) -> trie.put(ip.toPrefix(), metadata));
 
@@ -355,14 +346,12 @@ public final class CompletionMetadataUtilsTest {
             unownedSubnetHostIps(prefix, ownedIps),
             ImmutableList.of(
                 new IpCompletionRelevance(
-                    interfaceLinkDisplayString(config, iface1),
-                    config.getHostname(),
-                    iface1.getName()))));
+                    interfaceLinkDisplayString(iface1), config.getHostname(), iface1.getName()))));
     trie.put(
         ip1.toPrefix(), // 8.8.8.8
         new IpCompletionMetadata(
             new IpCompletionRelevance(
-                interfaceDisplayString(config, iface1), config.getHostname(), iface1.getName())));
+                interfaceDisplayString(iface1), config.getHostname(), iface1.getName())));
     createWellKnownIpCompletion(
             WELL_KNOWN_IPS.entrySet().stream()
                 .filter(e -> !e.getKey().equals(ip1))

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2145,7 +2145,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     return new CompletionMetadata(
         getFilterNames(configurations),
         getInterfaces(configurations),
-        getIps(configurations),
+        getIps(configurations, getTopologyProvider().getIpOwners(snapshot)),
         getLocationCompletionMetadata(getLocationInfo(snapshot), configurations),
         getMlagIds(configurations),
         getNodes(configurations),


### PR DESCRIPTION
For subnets, add IpCompletionMetadata for the subnet's prefix to the trie. To handle excluded IPs (i.e. network/broadcast and owned IPs), add a RangeSet of the IPs within the prefix that share the relevances.