### PR TITLE
A10 support check gateway for ha and vrrp-a

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Lexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10Lexer.g4
@@ -220,6 +220,7 @@ PREEMPT_MODE: 'preempt-mode';
 PREEMPTION_DELAY: 'preemption-delay';
 PREEMPTION_ENABLE: 'preemption-enable';
 PRIORITY: 'priority';
+PRIORITY_COST: 'priority-cost';
 RADIUS
 :
   'radius'

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_ha.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_ha.g4
@@ -25,7 +25,20 @@ s_ha
 
 ha_arp_retry: ARP_RETRY null_rest_of_line;
 
-ha_check: CHECK null_rest_of_line;
+ha_check
+:
+  CHECK (
+    ha_check_gateway
+    | ha_check_route
+    | ha_check_vlan
+  )
+;
+
+ha_check_gateway: GATEWAY ip = ip_address NEWLINE;
+
+ha_check_route: ROUTE null_rest_of_line;
+
+ha_check_vlan: VLAN null_rest_of_line;
 
 ha_conn_mirror: CONN_MIRROR IP ip = ip_address NEWLINE;
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/grammar/A10ConfigurationBuilder.java
@@ -61,6 +61,9 @@ import org.batfish.vendor.a10.grammar.A10Parser.Ethernet_numberContext;
 import org.batfish.vendor.a10.grammar.A10Parser.Ethernet_or_trunk_referenceContext;
 import org.batfish.vendor.a10.grammar.A10Parser.Fail_over_policy_template_nameContext;
 import org.batfish.vendor.a10.grammar.A10Parser.Fip_optionContext;
+import org.batfish.vendor.a10.grammar.A10Parser.Ha_check_gatewayContext;
+import org.batfish.vendor.a10.grammar.A10Parser.Ha_check_routeContext;
+import org.batfish.vendor.a10.grammar.A10Parser.Ha_check_vlanContext;
 import org.batfish.vendor.a10.grammar.A10Parser.Ha_conn_mirrorContext;
 import org.batfish.vendor.a10.grammar.A10Parser.Ha_groupContext;
 import org.batfish.vendor.a10.grammar.A10Parser.Ha_idContext;
@@ -1714,6 +1717,21 @@ public final class A10ConfigurationBuilder extends A10ParserBaseListener
                 _currentTrunk.getMembers().add(iface);
               });
         });
+  }
+
+  @Override
+  public void exitHa_check_gateway(Ha_check_gatewayContext ctx) {
+    _c.getOrCreateHa().addCheckGateway(toIp(ctx.ip));
+  }
+
+  @Override
+  public void exitHa_check_route(Ha_check_routeContext ctx) {
+    todo(ctx);
+  }
+
+  @Override
+  public void exitHa_check_vlan(Ha_check_vlanContext ctx) {
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -381,7 +381,6 @@ public final class A10Configuration extends VendorConfiguration {
     // Must be done after interface conversion
     convertVirtualServers();
     convertHealthChecks();
-    // template name -> generated track method name -> action
     convertVrrpA();
     convertHa();
     createKernelRoutes();

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -578,8 +578,6 @@ public final class A10Configuration extends VendorConfiguration {
   /**
    * Process vrrp-a vrids in the case vrrp-a is enabled. Causes the device to own all virtual
    * addresses for each vrid for which it is converted VRRP master.
-   *
-   * @param failOverPolicyTemplateActions
    */
   private void convertVrrpAEnabled(
       // template name -> generated track method name -> action

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -451,9 +451,8 @@ public final class A10Configuration extends VendorConfiguration {
                           // unusable gateway health check
                           return;
                         }
-                        String methodName = generatedServerTrackMethodName(ip);
                         TrackAction action = new DecrementPriority(decrement);
-                        actionsBuilder.put(methodName, action);
+                        actionsBuilder.put(trackMethodName, action);
                       });
               builder.put(templateName, actionsBuilder.build());
             });

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -402,25 +402,25 @@ public final class A10Configuration extends VendorConfiguration {
     for (Server server : _servers.values()) {
       if (!(server.getTarget() instanceof ServerTargetAddress)) {
         // Not an IPv4 server
-        return;
+        continue;
       }
       if (!firstNonNull(server.getEnable(), true)) {
         // server is disabled
-        return;
+        continue;
       }
       if (firstNonNull(server.getHealthCheckDisable(), false)) {
         // health check is disabled
-        return;
+        continue;
       }
       String healthMonitorName = server.getHealthCheck();
       if (healthMonitorName == null) {
         // no associated health monitor
-        return;
+        continue;
       }
       HealthMonitor healthMonitor = _healthMonitors.get(healthMonitorName);
       if (healthMonitor == null) {
         // undefined health monitor
-        return;
+        continue;
       }
       Ip ip = ((ServerTargetAddress) server.getTarget()).getAddress();
       // TODO: Use configured health monitor method (e.g. ICMP, TCP/123, etc.)

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Ha.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/Ha.java
@@ -1,8 +1,10 @@
 package org.batfish.vendor.a10.representation;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
@@ -11,7 +13,23 @@ import org.batfish.datamodel.Ip;
 public final class Ha implements Serializable {
 
   public Ha() {
+    _checkGateways = ImmutableSet.of();
     _groups = ImmutableMap.of();
+  }
+
+  public void addCheckGateway(Ip ip) {
+    if (_checkGateways.contains(ip)) {
+      return;
+    }
+    _checkGateways =
+        ImmutableSet.<Ip>builderWithExpectedSize(_checkGateways.size() + 1)
+            .addAll(_checkGateways)
+            .add(ip)
+            .build();
+  }
+
+  public @Nonnull Set<Ip> getCheckGateways() {
+    return _checkGateways;
   }
 
   public @Nullable Ip getConnMirror() {
@@ -64,6 +82,7 @@ public final class Ha implements Serializable {
     _setId = setId;
   }
 
+  private @Nonnull Set<Ip> _checkGateways;
   private @Nullable Ip _connMirror;
   private @Nonnull Map<Integer, HaGroup> _groups;
   private @Nullable Integer _id;

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/ha_acos2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/ha_acos2
@@ -29,6 +29,8 @@ ha id 1 set-id 2
 ha arp-retry 4
 ha group 1 priority 200
 ha check gateway 10.0.0.1
+ha check route 1.1.1.1 /32 priority-cost 1
+ha check vlan 2 timeout 5
 ha conn-mirror ip 10.0.5.2
 ha interface ethernet 3 both vlan 4094
 ha interface ethernet 3 router-interface no-heartbeat
@@ -46,4 +48,11 @@ ip nat pool pool1 10.0.3.1 10.0.3.2 netmask /24  ha-group-id 1
 slb virtual-server vs1 10.0.4.1
    ha-group 1
    port 22 tcp
+!
+
+health monitor hm1
+!
+
+slb server gateway1 10.0.0.1
+  health-check hm1
 !

--- a/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/vrrp-a-enabled
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/a10/grammar/testconfigs/vrrp-a-enabled
@@ -8,8 +8,13 @@ vrrp-a common
   enable
 !
 
+vrrp-a fail-over-policy-template gateway
+  gateway 10.10.10.10 weight 50
+
 vrrp-a vrid 1
   floating-ip 3.0.0.1
+  blade-parameters
+    fail-over-policy-template gateway
 !
 
 vrrp-a peer-group
@@ -36,5 +41,10 @@ slb virtual-server vs1 2.0.0.1
   vrid 1
 !
 
+health monitor hm1
+!
+
+slb server gateway1 10.10.10.10
+  health-check hm1
 !
 


### PR DESCRIPTION
- create `TrackMethods` for server health-check pointing to valid health monitor
- create `TrackActions` in generated `VrrpGroup`s
  - from ha check gateway
    - decrement 255 from priority
  - from vrrp-a fail-over-policy-template check gateway
    - applied to vrrp-a vrid referencing fail-over-policy-template
    - decrement VRRP priority as indicated

Follow-on work:
- Should have a way of disabling VRRP participation entirely rather than
just decrementing priority. This makes a difference when there is only
one candidate to begin with in the election.