### PR TITLE
Recompute kernel routes every dataplane iteration

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/A10KernelRouteTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/A10KernelRouteTest.java
@@ -9,12 +9,12 @@ import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_T
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Ip;
@@ -43,7 +43,7 @@ public final class A10KernelRouteTest {
    * Topology:
    *
    *          vrrp-a
-   *    .2  10.0.2.0/24  .1
+   *    .1  10.0.2.0/24  .2
    *    ethernet2 ethernet2
    *    <=================>
    * r1                     r2
@@ -78,8 +78,8 @@ public final class A10KernelRouteTest {
     DataPlane dp = _batfish.loadDataPlane(_batfish.getSnapshot());
 
     assertThat(
-        dp.getRibs().get("r1").get(DEFAULT_VRF_NAME).getRoutes().stream()
-            .filter(KernelRoute.class::isInstance)
+        dp.getRibs().get("r1").get(DEFAULT_VRF_NAME).getRoutes(KERNEL_PREFIX).stream()
+            .map(AnnotatedRoute::getAbstractRoute)
             .collect(ImmutableSet.toImmutableSet()),
         contains(
             KernelRoute.builder()
@@ -88,10 +88,10 @@ public final class A10KernelRouteTest {
                 .setNetwork(KERNEL_PREFIX)
                 .build()));
     assertThat(
-        dp.getRibs().get("r2").get(DEFAULT_VRF_NAME).getRoutes().stream()
-            .filter(KernelRoute.class::isInstance)
+        dp.getRibs().get("r2").get(DEFAULT_VRF_NAME).getRoutes(KERNEL_PREFIX).stream()
+            .map(AnnotatedRoute::getAbstractRoute)
             .collect(ImmutableSet.toImmutableSet()),
-        empty());
+        contains(isBgpv4RouteThat(allOf(hasAsPath(equalTo(AsPath.ofSingletonAsSets(1L)))))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/A10KernelRouteTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/A10KernelRouteTest.java
@@ -1,0 +1,112 @@
+package org.batfish.dataplane;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.Prefix.MAX_PREFIX_LENGTH;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasAsPath;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
+import static org.batfish.vendor.a10.representation.A10Conversion.KERNEL_ROUTE_TAG_FLOATING_IP;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.KernelRoute;
+import org.batfish.datamodel.Prefix;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Test of A10 kernel routes, vrrp-a, and BGP. */
+public final class A10KernelRouteTest {
+  private static final String SNAPSHOT_FOLDER = "org/batfish/dataplane/testrigs/a10-kernel-routes";
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private static final Ip FLOATING_IP = Ip.parse("10.0.1.10");
+  private static final Prefix KERNEL_PREFIX = Prefix.create(FLOATING_IP, MAX_PREFIX_LENGTH);
+
+  private Batfish _batfish;
+
+  /*
+   * Topology:
+   *
+   *          vrrp-a
+   *    .2  10.0.2.0/24  .1
+   *    ethernet2 ethernet2
+   *    <=================>
+   * r1                     r2
+   *    <=================>
+   *    ethernet1 ethernet1
+   *    .2  10.0.1.0/24  .1
+   *           bgp
+   * - There is a BGP session betwen r1 and r2 on ethernet1
+   * - There is vrrp-a between r1 and r2 on ethernet2
+   * - r1 and r2 both have a floating-ip 10.0.1.10
+   * - r1 and r2 redistribute floating IPs into BGP
+   * - r1 has higher priority, so:
+   *   - 10.0.1.10/32 should appear in r1's BGP RIB as a local route
+   *   - 10.0.1.10/32 should appear in r2's BGP RIB as a receeived route route
+   */
+  @Before
+  public void setup() throws IOException {
+    String r1Filename = "r1";
+    String r2Filename = "r2";
+    _batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(SNAPSHOT_FOLDER, ImmutableSet.of(r1Filename, r2Filename))
+                .setLayer1TopologyPrefix(SNAPSHOT_FOLDER)
+                .build(),
+            _folder);
+    _batfish.computeDataPlane(_batfish.getSnapshot());
+  }
+
+  @Test
+  public void testMainRibRoutes() {
+    DataPlane dp = _batfish.loadDataPlane(_batfish.getSnapshot());
+
+    assertThat(
+        dp.getRibs().get("r1").get(DEFAULT_VRF_NAME).getRoutes().stream()
+            .filter(KernelRoute.class::isInstance)
+            .collect(ImmutableSet.toImmutableSet()),
+        contains(
+            KernelRoute.builder()
+                .setTag(KERNEL_ROUTE_TAG_FLOATING_IP)
+                .setRequiredOwnedIp(FLOATING_IP)
+                .setNetwork(KERNEL_PREFIX)
+                .build()));
+    assertThat(
+        dp.getRibs().get("r2").get(DEFAULT_VRF_NAME).getRoutes().stream()
+            .filter(KernelRoute.class::isInstance)
+            .collect(ImmutableSet.toImmutableSet()),
+        empty());
+  }
+
+  @Test
+  public void testBgpRibRoutes() {
+    DataPlane dp = _batfish.loadDataPlane(_batfish.getSnapshot());
+
+    assertThat(
+        dp.getBgpRoutes().get("r1", DEFAULT_VRF_NAME),
+        containsInAnyOrder(
+            isBgpv4RouteThat(allOf(hasPrefix(KERNEL_PREFIX), hasAsPath(equalTo(AsPath.empty()))))));
+    assertThat(
+        dp.getBgpRoutes().get("r2", DEFAULT_VRF_NAME),
+        containsInAnyOrder(
+            isBgpv4RouteThat(
+                allOf(
+                    hasPrefix(KERNEL_PREFIX), hasAsPath(equalTo(AsPath.ofSingletonAsSets(1L)))))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/A10KernelRouteTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/A10KernelRouteTest.java
@@ -49,7 +49,7 @@ public final class A10KernelRouteTest {
    * r1                     r2
    *    <=================>
    *    ethernet1 ethernet1
-   *    .2  10.0.1.0/24  .1
+   *    .1  10.0.1.0/24  .2
    *           bgp
    * - There is a BGP session betwen r1 and r2 on ethernet1
    * - There is vrrp-a between r1 and r2 on ethernet2

--- a/projects/batfish/src/test/java/org/batfish/dataplane/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/BUILD
@@ -21,6 +21,7 @@ junit_tests(
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
         "//projects/batfish/src/main/java/org/batfish/representation/arista",
         "//projects/batfish/src/main/java/org/batfish/representation/juniper",
+        "//projects/batfish/src/main/java/org/batfish/vendor/a10/representation",
         "//projects/batfish/src/test/java/org/batfish/dataplane/ibdp:testlib",
         "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_google_code_findbugs_jsr305",

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalBdpEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalBdpEngineTest.java
@@ -389,7 +389,7 @@ public final class IncrementalBdpEngineTest {
         .setName("i1")
         .setOwner(r2)
         .setVrf(v2)
-        .setAddress(r1Address)
+        .setAddress(r2Address)
         .setVrrpGroups(ImmutableSortedMap.of(1, g2))
         .build();
     Map<String, Configuration> configurations =

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/a10-kernel-routes/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/a10-kernel-routes/configs/r1
@@ -1,0 +1,39 @@
+!BATFISH_FORMAT: a10_acos
+hostname r1
+!
+
+vrrp-a common
+  device-id 1
+  set-id 1
+  enable
+!
+
+vrrp-a vrid 1
+  floating-ip 10.0.1.10
+  blade-parameters
+    priority 100
+!
+
+vrrp-a peer-group
+  peer 10.0.2.2
+!
+
+interface ethernet 1
+  mtu 1500
+  enable
+  ip address 10.0.1.1 /24
+!
+
+interface ethernet 2
+  mtu 1500
+  enable
+  ip address 10.0.2.1 /24
+!
+
+router bgp 1
+  bgp router-id 10.0.1.1
+  neighbor 10.0.1.2 remote-as 2
+  neighbor 10.0.1.2 activate
+  neighbor 10.0.1.2 update-source 10.0.1.1
+  redistribute floating-ip
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/a10-kernel-routes/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/a10-kernel-routes/configs/r2
@@ -1,0 +1,39 @@
+!BATFISH_FORMAT: a10_acos
+hostname r2
+!
+
+vrrp-a common
+  device-id 2
+  set-id 1
+  enable
+!
+
+vrrp-a vrid 1
+  floating-ip 10.0.1.10
+  blade-parameters
+    priority 50
+!
+
+vrrp-a peer-group
+  peer 10.0.2.1
+!
+
+interface ethernet 1
+  mtu 1500
+  enable
+  ip address 10.0.1.2 /24
+!
+
+interface ethernet 2
+  mtu 1500
+  enable
+  ip address 10.0.2.2 /24
+!
+
+router bgp 2
+  bgp router-id 10.0.1.2
+  neighbor 10.0.1.1 remote-as 1
+  neighbor 10.0.1.1 activate
+  neighbor 10.0.1.1 update-source 10.0.1.2
+  redistribute floating-ip
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/a10-kernel-routes/layer1_topology.json
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/a10-kernel-routes/layer1_topology.json
@@ -1,0 +1,44 @@
+{
+  "edges": [
+    {
+      "node1": {
+        "hostname": "r2",
+        "interfaceName": "Ethernet1"
+      },
+      "node2": {
+        "hostname": "r1",
+        "interfaceName": "Ethernet1"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r1",
+        "interfaceName": "Ethernet1"
+      },
+      "node2": {
+        "hostname": "r2",
+        "interfaceName": "Ethernet1"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r2",
+        "interfaceName": "Ethernet2"
+      },
+      "node2": {
+        "hostname": "r1",
+        "interfaceName": "Ethernet2"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r1",
+        "interfaceName": "Ethernet2"
+      },
+      "node2": {
+        "hostname": "r2",
+        "interfaceName": "Ethernet2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- fix but where kernel routes depending on ip ownership do not take into account IpOwners changing mid dataplane