### PR TITLE
Cisco NX-OS fix double-deactivate ISE during interface conversion

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_deactivation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_deactivation
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_interface_deactivation
+!
+interface Ethernet1/1
+  no switchport
+  no shutdown
+  vrf member undefinedvrf
+
+interface Ethernet1/2
+  no switchport
+  no shutdown
+  vrf member disabledvrf
+
+vrf context disabledvrf
+  shutdown
+
+
+


### PR DESCRIPTION
- don't try to deactivate an interface for invalid VRF configuration if
  it is aleady admin down