### PR TITLE
Fix computation of Layer3Vni tunnels for one-sided routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer2Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer2Vni.java
@@ -89,7 +89,7 @@ public final class Layer2Vni implements Vni {
   @Nonnull private final Set<Ip> _bumTransportIps;
   @Nonnull private final BumTransportMethod _bumTransportMethod;
   @Nullable private final Ip _sourceAddress;
-  @Nonnull private final Integer _udpPort;
+  private final int _udpPort;
   private final int _vlan;
   private final int _vni;
   @Nonnull private final String _srcVrf;
@@ -107,7 +107,7 @@ public final class Layer2Vni implements Vni {
       Set<Ip> bumTransportIps,
       BumTransportMethod bumTransportMethod,
       @Nullable Ip sourceAddress,
-      Integer udpPort,
+      int udpPort,
       int vlan,
       int vni,
       String srcVrf) {
@@ -132,7 +132,7 @@ public final class Layer2Vni implements Vni {
     return Objects.equals(_bumTransportMethod, rhs._bumTransportMethod)
         && Objects.equals(_bumTransportIps, rhs._bumTransportIps)
         && Objects.equals(_sourceAddress, rhs._sourceAddress)
-        && Objects.equals(_udpPort, rhs._udpPort)
+        && _udpPort == rhs._udpPort
         && Objects.equals(_vlan, rhs._vlan)
         && _vni == rhs._vni
         && _srcVrf.equals(rhs._srcVrf);
@@ -171,7 +171,7 @@ public final class Layer2Vni implements Vni {
   }
 
   @Override
-  public @Nonnull Integer getUdpPort() {
+  public int getUdpPort() {
     return _udpPort;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer3Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer3Vni.java
@@ -16,14 +16,14 @@ import org.batfish.datamodel.Ip;
 public final class Layer3Vni implements Vni {
   @Nonnull private final Set<Ip> _learnedNexthopVtepIps;
   @Nullable private final Ip _sourceAddress;
-  @Nonnull private final Integer _udpPort;
+  private final int _udpPort;
   private final int _vni;
   @Nonnull private final String _srcVrf;
 
   private Layer3Vni(
       Set<Ip> learnedNexthopVtepIps,
       @Nullable Ip sourceAddress,
-      Integer udpPort,
+      int udpPort,
       int vni,
       String srcVrf) {
     _learnedNexthopVtepIps = learnedNexthopVtepIps;
@@ -49,8 +49,7 @@ public final class Layer3Vni implements Vni {
   }
 
   @Override
-  @Nonnull
-  public Integer getUdpPort() {
+  public int getUdpPort() {
     return _udpPort;
   }
 
@@ -77,7 +76,7 @@ public final class Layer3Vni implements Vni {
     return _vni == layer3Vni._vni
         && _learnedNexthopVtepIps.equals(layer3Vni._learnedNexthopVtepIps)
         && Objects.equals(_sourceAddress, layer3Vni._sourceAddress)
-        && _udpPort.equals(layer3Vni._udpPort)
+        && _udpPort == layer3Vni._udpPort
         && _srcVrf.equals(layer3Vni._srcVrf);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Vni.java
@@ -1,21 +1,20 @@
 package org.batfish.datamodel.vxlan;
 
 import java.io.Serializable;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 
 /** A VXLAN Network Identifier configuration */
 public interface Vni extends Serializable {
   /** Default UDP port on which VXLAN tunnels are established */
-  Integer DEFAULT_UDP_PORT = 4789;
+  int DEFAULT_UDP_PORT = 4789;
 
   /** IP address with which the encapsulated packets would be sourced */
   @Nullable
   Ip getSourceAddress();
 
-  @Nonnull
-  Integer getUdpPort();
+  /** UDP port for encapsulated VXLAN traffic on this VNI. */
+  int getUdpPort();
 
   /** VNI number */
   int getVni();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
@@ -64,7 +64,8 @@ public final class VxlanTopologyUtils {
 
   /**
    * Add edges to the {@code graph} between all VRFs that have the same layer-2 VNI configured on
-   * them (excludes self-edges), if they are compatible.
+   * them (excludes self-edges), if they are compatible. Note that all values of {@code vrfs} must
+   * have the same VNI.
    */
   @VisibleForTesting
   static void addLayer2VniEdges(MutableGraph<VxlanNode> graph, Map<VrfId, Layer2Vni> vrfs) {
@@ -101,7 +102,8 @@ public final class VxlanTopologyUtils {
 
   /**
    * Add edges to the {@code graph} between all VRFs that have the same layer-3 VNI configured on
-   * them (excludes self-edges), if they are compatible.
+   * them (excludes self-edges), if they are compatible. Note that all values of {@code vrfs} must
+   * have the same VNI.
    */
   @VisibleForTesting
   static void addLayer3VniEdges(MutableGraph<VxlanNode> graph, Map<VrfId, Layer3Vni> vrfs) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
@@ -63,29 +63,22 @@ public final class VxlanTopologyUtils {
   }
 
   /**
-   * Add edges to the {@code graph} between all VRFs that have layer-2 {@code vni} configured on
-   * them (excludes self-edges).
+   * Add edges to the {@code graph} between all VRFs that have the same layer-2 VNI configured on
+   * them (excludes self-edges), if they are compatible.
    */
   @VisibleForTesting
-  static void addLayer2VniEdges(
-      MutableGraph<VxlanNode> graph,
-      Table<VrfId, Integer, Layer2Vni> allVniSettings,
-      Integer vni,
-      Map<VrfId, Layer2Vni> vrfs) {
-    for (VrfId vrfTail : vrfs.keySet()) {
-      for (VrfId vrfHead : vrfs.keySet()) {
-        // Generate all VRF combinations without repetition
-        if (vrfTail.equals(vrfHead)) {
-          continue;
-        }
-        addLayer2VniEdge(
-            graph,
-            vrfTail,
-            allVniSettings.get(vrfTail, vni),
-            vrfHead,
-            allVniSettings.get(vrfHead, vni));
-      }
-    }
+  static void addLayer2VniEdges(MutableGraph<VxlanNode> graph, Map<VrfId, Layer2Vni> vrfs) {
+    vrfs.forEach(
+        (vrfTail, vrfTailSettings) ->
+            vrfs.forEach(
+                (vrfHead, vrfHeadSettings) -> {
+                  // Generate all VRF combinations without repetition
+                  if (vrfTail.equals(vrfHead)) {
+                    return;
+                  }
+                  assert vrfTailSettings.getVni() == vrfHeadSettings.getVni();
+                  addLayer2VniEdge(graph, vrfTail, vrfTailSettings, vrfHead, vrfHeadSettings);
+                }));
   }
 
   /**
@@ -107,29 +100,22 @@ public final class VxlanTopologyUtils {
   }
 
   /**
-   * Add edges to the {@code graph} between all VRFs that have layer-3 {@code vni} configured on
-   * them (excludes self-edges).
+   * Add edges to the {@code graph} between all VRFs that have the same layer-3 VNI configured on
+   * them (excludes self-edges), if they are compatible.
    */
   @VisibleForTesting
-  static void addLayer3VniEdges(
-      MutableGraph<VxlanNode> graph,
-      Table<VrfId, Integer, Layer3Vni> allVniSettings,
-      Integer vni,
-      Map<VrfId, Layer3Vni> vrfs) {
-    for (VrfId vrfTail : vrfs.keySet()) {
-      for (VrfId vrfHead : vrfs.keySet()) {
-        // Generate all VRF combinations without repetition
-        if (vrfTail.equals(vrfHead)) {
-          continue;
-        }
-        addLayer3VniEdge(
-            graph,
-            vrfTail,
-            allVniSettings.get(vrfTail, vni),
-            vrfHead,
-            allVniSettings.get(vrfHead, vni));
-      }
-    }
+  static void addLayer3VniEdges(MutableGraph<VxlanNode> graph, Map<VrfId, Layer3Vni> vrfs) {
+    vrfs.forEach(
+        (vrfTail, vrfTailSettings) ->
+            vrfs.forEach(
+                (vrfHead, vrfHeadSettings) -> {
+                  // Generate all VRF combinations without repetition
+                  if (vrfTail.equals(vrfHead)) {
+                    return;
+                  }
+                  assert vrfTailSettings.getVni() == vrfHeadSettings.getVni();
+                  addLayer3VniEdge(graph, vrfTail, vrfTailSettings, vrfHead, vrfHeadSettings);
+                }));
   }
 
   /** Build a {@link VxlanNode} for the given {@link Layer2Vni} and {@link VrfId}. */
@@ -156,7 +142,7 @@ public final class VxlanTopologyUtils {
   @VisibleForTesting
   static boolean compatibleLayer2VniSettings(Layer2Vni vniSettingsTail, Layer2Vni vniSettingsHead) {
     return vniSettingsTail.getBumTransportMethod() == vniSettingsHead.getBumTransportMethod()
-        && vniSettingsTail.getUdpPort().equals(vniSettingsHead.getUdpPort())
+        && vniSettingsTail.getUdpPort() == vniSettingsHead.getUdpPort()
         && vniSettingsTail.getSourceAddress() != null
         && vniSettingsHead.getSourceAddress() != null
         && !vniSettingsTail.getSourceAddress().equals(vniSettingsHead.getSourceAddress())
@@ -171,15 +157,25 @@ public final class VxlanTopologyUtils {
                     .contains(vniSettingsTail.getSourceAddress())));
   }
 
-  /** Check if two {@link Layer3Vni} have compatible configurations */
+  /**
+   * Check if two {@link Layer3Vni} have compatible configurations, modulo reachability. We consider
+   * Layer-3 VNI configurations for two VTEPs to be compatible if at least one VTEP has learned a
+   * route from the other for the given VNI with the other's source address as the VTEP IP of the
+   * next hop of the route.
+   *
+   * <p>Note that edges between layer-3 VNIs with compatible VNIs may still be pruned by later
+   * checks.
+   */
   @VisibleForTesting
   static boolean compatibleLayer3VniSettings(Layer3Vni vniSettingsTail, Layer3Vni vniSettingsHead) {
-    return vniSettingsTail.getUdpPort().equals(vniSettingsHead.getUdpPort())
+    return vniSettingsTail.getUdpPort() == vniSettingsHead.getUdpPort()
         && vniSettingsTail.getSourceAddress() != null
         && vniSettingsHead.getSourceAddress() != null
         && !vniSettingsTail.getSourceAddress().equals(vniSettingsHead.getSourceAddress())
-        && vniSettingsTail.getLearnedNexthopVtepIps().contains(vniSettingsHead.getSourceAddress())
-        && vniSettingsHead.getLearnedNexthopVtepIps().contains(vniSettingsTail.getSourceAddress());
+        && (vniSettingsTail.getLearnedNexthopVtepIps().contains(vniSettingsHead.getSourceAddress())
+            || vniSettingsHead
+                .getLearnedNexthopVtepIps()
+                .contains(vniSettingsTail.getSourceAddress()));
   }
 
   @VisibleForTesting
@@ -188,35 +184,41 @@ public final class VxlanTopologyUtils {
   }
 
   /**
-   * Compute the VXLAN topology based on the {@link Layer2Vni} extracted from the given
-   * configurations
+   * Compute the intiial VXLAN topology based on the {@link Layer2Vni}s and {@link Layer3Vni}s
+   * extracted from the given {@code configurations}.
    */
-  public static @Nonnull VxlanTopology computeVxlanTopology(
+  public static @Nonnull VxlanTopology computeInitialVxlanTopology(
       Map<String, Configuration> configurations) {
     return internalComputeVxlanTopology(
-        computeVniSettingsTable(configurations, Vrf::getLayer2Vnis),
-        computeVniSettingsTable(configurations, Vrf::getLayer3Vnis));
+        computeInitialVniSettingsTable(configurations, Vrf::getLayer2Vnis),
+        computeInitialVniSettingsTable(configurations, Vrf::getLayer3Vnis));
   }
 
   /**
-   * Compute the VXLAN topology based on the {@link Layer2Vni} extracted from the given table.
+   * Compute the VXLAN topology based on the {@link Layer2Vni}s and {@link Layer3Vni}s extracted
+   * from the given tables. May contain edges that will be pruned later because there is no
+   * reachability between VTEP IPs given the corresponding settings.
    *
    * @param layer2VniSettings table of the layer-2 VNI settings. Row is hostname, Column is VRF
    *     name.
    * @param layer3VniSettings table of the layer-3 VNI settings. Row is hostname, Column is VRF
    *     name.
    */
-  public static @Nonnull VxlanTopology computeVxlanTopology(
+  public static @Nonnull VxlanTopology computeNextVxlanTopologyModuloReachability(
       Table<String, String, ? extends Collection<Layer2Vni>> layer2VniSettings,
       Table<String, String, ? extends Collection<Layer3Vni>> layer3VniSettings) {
     return internalComputeVxlanTopology(
-        computeVniSettingsTable(layer2VniSettings), computeVniSettingsTable(layer3VniSettings));
+        computeVniIndexedVniSettingsTable(layer2VniSettings),
+        computeVniIndexedVniSettingsTable(layer3VniSettings));
   }
 
-  /** Convert configurations into a table format that's easier to work with */
+  /**
+   * Convert initial VNI settings from {@code configurations} into a table indexed by ({@link
+   * VrfId}, VNI).
+   */
   @VisibleForTesting
   @Nonnull
-  static <V extends Vni> Table<VrfId, Integer, V> computeVniSettingsTable(
+  static <V extends Vni> Table<VrfId, Integer, V> computeInitialVniSettingsTable(
       Map<String, Configuration> configurations, Function<Vrf, Map<Integer, V>> vniGetter) {
     Table<VrfId, Integer, V> table = HashBasedTable.create();
     for (Configuration c : configurations.values()) {
@@ -230,14 +232,15 @@ public final class VxlanTopologyUtils {
   }
 
   /**
-   * Convert VNI setting table obtained from the dataplane into a table format that's easier to work
-   * with
+   * Convert VNI setting table indexed by (node, vrf) obtained from the dataplane into a table
+   * indexed by ({@link VrfId}, VNI).
    */
   @Nonnull
-  private static <V extends Vni> Table<VrfId, Integer, V> computeVniSettingsTable(
-      Table<String, String, ? extends Collection<V>> allVniSettings) {
+  private static <V extends Vni> Table<VrfId, Integer, V> computeVniIndexedVniSettingsTable(
+      Table<String, String, ? extends Collection<V>> nodeVrfIndexedVniSettingsTable) {
     Table<VrfId, Integer, V> table = HashBasedTable.create();
-    for (Cell<String, String, ? extends Collection<V>> cell : allVniSettings.cellSet()) {
+    for (Cell<String, String, ? extends Collection<V>> cell :
+        nodeVrfIndexedVniSettingsTable.cellSet()) {
       assert cell.getValue() != null;
       assert cell.getRowKey() != null;
       assert cell.getColumnKey() != null;
@@ -255,19 +258,21 @@ public final class VxlanTopologyUtils {
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
     layer2VniSettings
         .columnMap() // group by vni
-        .forEach((vni, vrfs) -> addLayer2VniEdges(graph, layer2VniSettings, vni, vrfs));
+        .values() // Map<NodeVrf, Layer2Vni> where all entries have same VNI
+        .forEach(vrfs -> addLayer2VniEdges(graph, vrfs));
     layer3VniSettings
         .columnMap() // group by vni
-        .forEach((vni, vrfs) -> addLayer3VniEdges(graph, layer3VniSettings, vni, vrfs));
+        .values() // Map<NodeVrf, Layer3Vni> where all entries have same VNI
+        .forEach(vrfs -> addLayer3VniEdges(graph, vrfs));
     return new VxlanTopology(graph);
   }
 
   /**
    * Compute {@link VxlanTopology} that results after pruning edges corresponding to endpoints that
-   * cannot reach each other from an {@code initialVxlanTopology}.
+   * cannot reach each other from a {@code vxlanTopologyModuloReachability}.
    */
   public static @Nonnull VxlanTopology prunedVxlanTopology(
-      VxlanTopology initialVxlanTopology,
+      VxlanTopology vxlanTopologyModuloReachability,
       Map<String, Configuration> configurations,
       TracerouteEngine tracerouteEngine) {
     Span span = GlobalTracer.get().buildSpan("VxlanTopologyUtils.prunedVxlanTopology").start();
@@ -275,7 +280,7 @@ public final class VxlanTopologyUtils {
       assert scope != null;
       NetworkConfigurations nc = NetworkConfigurations.of(configurations);
       MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
-      initialVxlanTopology.getGraph().edges().parallelStream()
+      vxlanTopologyModuloReachability.getGraph().edges().parallelStream()
           .filter(edge -> reachableEdge(edge, nc, tracerouteEngine))
           .collect(ImmutableList.toImmutableList())
           .forEach(edge -> graph.putEdge(edge.nodeU(), edge.nodeV()));
@@ -285,6 +290,15 @@ public final class VxlanTopologyUtils {
     }
   }
 
+  /**
+   * Return {@code true} iff the two VTEPs of the given {@code edge} can reach each other.
+   *
+   * <p>Technically, VXLAN layer-3 VNI reachability is unidirectional. However, since we currently
+   * generate only up to one NVE interface per (node,vni), it is impossible to implement
+   * unidirectional connectivity via layer-3 edge(s) between two generated NVE interfaces. A future
+   * implementation could support unidirectional connectivity by generating a single interface per
+   * (vni, learned VTEP IP). Then this function would only check reachability in one direction.
+   */
   @VisibleForTesting
   static boolean reachableEdge(
       EndpointPair<VxlanNode> edge, NetworkConfigurations nc, TracerouteEngine tracerouteEngine) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -153,7 +153,7 @@ public class IBatfishTestAdapter implements IBatfish {
 
     @Override
     public VxlanTopology getInitialVxlanTopology(NetworkSnapshot snapshot) {
-      return VxlanTopologyUtils.computeVxlanTopology(_batfish.loadConfigurations(snapshot));
+      return VxlanTopologyUtils.computeInitialVxlanTopology(_batfish.loadConfigurations(snapshot));
     }
 
     private class TestIpOwners extends IpOwnersBaseImpl {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1741,7 +1741,7 @@ public final class VirtualRouter {
 
   /**
    * Process EVPN type 5 routes in our RIB and update learned VTEPs on corresponding {@link
-   * Layer3Vni}s if neessary.
+   * Layer3Vni}s if necessary.
    */
   public void updateLayer3Vnis() {
     if (_bgpRoutingProcess == null) {
@@ -1753,10 +1753,7 @@ public final class VirtualRouter {
         .map(AbstractRoute::getNextHop)
         .filter(NextHopVtep.class::isInstance)
         .map(NextHopVtep.class::cast)
-        .forEach(
-            nextHopVtep -> {
-              vtepsByVni.put(nextHopVtep.getVni(), nextHopVtep.getVtepIp());
-            });
+        .forEach(nextHopVtep -> vtepsByVni.put(nextHopVtep.getVni(), nextHopVtep.getVtepIp()));
     Map<Integer, Layer3Vni> newLayer3Vnis = new HashMap<>(_layer3Vnis);
     vtepsByVni
         .asMap()
@@ -1765,6 +1762,11 @@ public final class VirtualRouter {
               Layer3Vni l3Vni = _layer3Vnis.get(vni);
               if (l3Vni == null) {
                 // shouldn't happen, but skip just in case
+                LOGGER.warn(
+                    String.format(
+                        "updateLayer3Vnis: Host '%s' vrf '%s' has route(s) whose next hop is"
+                            + " unconfigured VNI %d with VTEP IP(s) %s",
+                        _c.getHostname(), getName(), vni, ips));
                 return;
               }
               newLayer3Vnis.put(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1681,7 +1681,8 @@ public final class VirtualRouter {
       Optional<BgpRoutingProcess> exportingBgpProc =
           exportingVr.map(VirtualRouter::getBgpRoutingProcess);
       if (exportingBgpProc.isPresent()) {
-        Collection<Layer3Vni> exportingVrfL3Vnis = exportingVr.get().getLayer3Vnis().values();
+        // Use immutable _vrf.getLayer3Vnis() since we don't care about learned IPs here.
+        Collection<Layer3Vni> exportingVrfL3Vnis = exportingVr.get()._vrf.getLayer3Vnis().values();
         if (exportingVrfL3Vnis.size() == 1) {
           int vni = exportingVrfL3Vnis.iterator().next().getVni();
           _bgpRoutingProcess.importCrossVrfV4RoutesToEvpn(

--- a/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
@@ -95,7 +95,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
 
   @Override
   public @Nonnull VxlanTopology getInitialVxlanTopology(NetworkSnapshot snapshot) {
-    return INITIAL_VXLAN_TOPOLOGIES.get(snapshot, this::computeVxlanTopology);
+    return INITIAL_VXLAN_TOPOLOGIES.get(snapshot, this::computeInitialVxlanTopology);
   }
 
   @Override
@@ -337,11 +337,12 @@ public final class TopologyProviderImpl implements TopologyProvider {
     }
   }
 
-  private @Nonnull VxlanTopology computeVxlanTopology(NetworkSnapshot snapshot) {
-    Span span = GlobalTracer.get().buildSpan("TopologyProviderImpl::computeVxlanTopology").start();
+  private @Nonnull VxlanTopology computeInitialVxlanTopology(NetworkSnapshot snapshot) {
+    Span span =
+        GlobalTracer.get().buildSpan("TopologyProviderImpl::computeInitialVxlanTopology").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      return VxlanTopologyUtils.computeVxlanTopology(getConfigurations(snapshot));
+      return VxlanTopologyUtils.computeInitialVxlanTopology(getConfigurations(snapshot));
     } finally {
       span.finish();
     }

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/configs/r1
@@ -1,0 +1,62 @@
+version 9.2(3) Bios:version  
+hostname r1
+
+boot nxos bootflash:/nxos.9.2.3.bin 
+nv overlay evpn
+feature bgp
+feature interface-vlan
+feature vn-segment-vlan-based
+feature nv overlay
+
+! r2's VTEP IP
+ip route 10.0.4.2/32 10.0.3.2
+vlan 1,1001
+vlan 1001
+  vn-segment 10001
+
+vrf context tenant
+  vni 10001
+  rd auto
+  address-family ipv4 unicast
+    route-target import auto
+    route-target import auto evpn
+
+interface Vlan1001
+  no shutdown
+  vrf member tenant
+  ip forward
+
+interface nve1
+  no shutdown
+  host-reachability protocol bgp
+  source-interface loopback0
+  member vni 10001 associate-vrf
+
+interface Ethernet1/1
+  description r2:Ethernet1/1
+  no switchport
+  ip address 10.0.3.1/24
+  no shutdown
+
+interface Ethernet1/2
+  description h1:i1
+  no switchport
+  vrf member tenant
+  ip address 10.0.1.1/24
+  no shutdown
+
+interface loopback0
+  description vtep
+  ip address 10.0.4.1/32
+
+router bgp 65000
+  router-id 10.0.3.1
+  neighbor 10.0.3.2
+    remote-as 65000
+    update-source Ethernet1/1
+    address-family l2vpn evpn
+      send-community
+      send-community extended
+  vrf tenant
+    address-family ipv4 unicast
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/configs/r2
@@ -1,0 +1,64 @@
+version 9.2(3) Bios:version  
+hostname r2
+
+boot nxos bootflash:/nxos.9.2.3.bin 
+nv overlay evpn
+feature bgp
+feature interface-vlan
+feature vn-segment-vlan-based
+feature nv overlay
+
+! r1's VTEP IP
+ip route 10.0.4.1/32 10.0.3.1
+vlan 1,1001
+vlan 1001
+  vn-segment 10001
+
+route-map all permit 100
+vrf context tenant
+  vni 10001
+  rd auto
+  address-family ipv4 unicast
+    route-target both auto
+    route-target both auto evpn
+
+interface Vlan1001
+  no shutdown
+  vrf member tenant
+  ip forward
+
+interface nve1
+  no shutdown
+  host-reachability protocol bgp
+  source-interface loopback0
+  member vni 10001 associate-vrf
+
+interface Ethernet1/1
+  description r1:Ethernet1/1
+  no switchport
+  ip address 10.0.3.2/24
+  no shutdown
+
+interface Ethernet1/2
+  description h2:i1
+  no switchport
+  vrf member tenant
+  ip address 10.0.2.1/24
+  no shutdown
+
+interface loopback0
+  description vtep
+  ip address 10.0.4.2/32
+
+router bgp 65000
+  router-id 10.0.3.2
+  neighbor 10.0.3.1
+    remote-as 65000
+    update-source Ethernet1/1
+    address-family l2vpn evpn
+      send-community
+      send-community extended
+  vrf tenant
+    address-family ipv4 unicast
+      redistribute direct route-map all
+

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/hosts/h1.json
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/hosts/h1.json
@@ -1,0 +1,10 @@
+{
+  "hostname": "h1",
+  "hostInterfaces": {
+    "i1": {
+      "name": "i1",
+      "prefix": "10.0.1.2/24",
+      "gateway": "10.0.1.1"
+    }
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/hosts/h2.json
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/hosts/h2.json
@@ -1,0 +1,10 @@
+{
+  "hostname": "h2",
+  "hostInterfaces": {
+    "i1": {
+      "name": "i1",
+      "prefix": "10.0.2.2/24",
+      "gateway": "10.0.2.1"
+    }
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/layer1_topology.json
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-l3-vnis-one-sided/layer1_topology.json
@@ -1,0 +1,64 @@
+{
+  "edges": [
+    {
+      "node1": {
+        "hostname": "h1",
+        "interfaceName": "i1"
+      },
+      "node2": {
+        "hostname": "r1",
+        "interfaceName": "Ethernet1/2"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r1",
+        "interfaceName": "Ethernet1/2"
+      },
+      "node2": {
+        "hostname": "h1",
+        "interfaceName": "i1"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r1",
+        "interfaceName": "Ethernet1/1"
+      },
+      "node2": {
+        "hostname": "r2",
+        "interfaceName": "Ethernet1/1"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r2",
+        "interfaceName": "Ethernet1/1"
+      },
+      "node2": {
+        "hostname": "r1",
+        "interfaceName": "Ethernet1/1"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "h2",
+        "interfaceName": "i1"
+      },
+      "node2": {
+        "hostname": "r2",
+        "interfaceName": "Ethernet1/2"
+      }
+    },
+    {
+      "node1": {
+        "hostname": "r2",
+        "interfaceName": "Ethernet1/2"
+      },
+      "node2": {
+        "hostname": "h2",
+        "interfaceName": "i1"
+      }
+    }
+  ]
+}

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -492,7 +492,7 @@ public class EdgesAnswererTest {
   public void testGetVxlanEdges() {
     NetworkConfigurations nc = buildVxlanNetworkConfigurations();
     Map<String, Configuration> configurations = nc.getMap();
-    VxlanTopology vxlanTopology = VxlanTopologyUtils.computeVxlanTopology(nc.getMap());
+    VxlanTopology vxlanTopology = VxlanTopologyUtils.computeInitialVxlanTopology(nc.getMap());
     Set<String> includeNodes = configurations.keySet();
     Set<String> includeRemoteNodes = configurations.keySet();
 


### PR DESCRIPTION
- consider pair of `Layer3Vni`s compatible if either has learned the source IP of the other
  - no longer require both
  - if we really want to implement unidirectional tunnels, it must involve more than one generated
    interface per (vrf,vni) (or modeling encapsulation. etc.)
- move computation of learned IPs to topology scope right before computation of next partial data
  plane
  - ensures main RIB has settled and all vrf leaking is complete
  - only compute once per topology iteration rather than once per dependent routes iteration
- clean up API and documentation of `VxlanTopologyUtils`