### PR TITLE
ParboiledLocationSpecifier: handle internet[iface] locations correctly.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -1005,8 +1005,9 @@ public class Parser extends CommonParser {
             WhiteSpace(),
             InterfaceWithNodeTail(),
             push(
-                new InterfaceWithNodeInterfaceAstNode(
-                    new NameNodeAstNode(IspModelingUtils.INTERNET_HOST_NAME), pop()))),
+                InterfaceLocationAstNode.createFromInterfaceWithNode(
+                    new InterfaceWithNodeInterfaceAstNode(
+                        new NameNodeAstNode(IspModelingUtils.INTERNET_HOST_NAME), pop())))),
         Sequence(
             IgnoreCase(IspModelingUtils.INTERNET_HOST_NAME),
             push(InternetLocationAstNode.INSTANCE)));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledLocationSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledLocationSpecifierTest.java
@@ -196,4 +196,25 @@ public class ParboiledLocationSpecifierTest {
         ParboiledLocationSpecifier.parse("internet").resolve(ctxt),
         contains(interfaceLocation(i1)));
   }
+
+  @Test
+  public void testParseInternet_toIsp() {
+    NetworkFactory nf = new NetworkFactory();
+
+    Configuration inet =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname(IspModelingUtils.INTERNET_HOST_NAME)
+            .build();
+    Interface i1 = nf.interfaceBuilder().setOwner(inet).setName("To-isp_577").build();
+
+    MockSpecifierContext ctxt =
+        MockSpecifierContext.builder()
+            .setConfigs(ImmutableMap.of(inet.getHostname(), inet))
+            .build();
+
+    assertThat(
+        ParboiledLocationSpecifier.parse("internet[To-isp_577]").resolve(ctxt),
+        contains(interfaceLocation(i1)));
+  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserLocationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserLocationTest.java
@@ -193,9 +193,10 @@ public class ParserLocationTest {
     assertThat(
         ParserUtils.getAst(getRunner().run("internet[To-Isp123]")),
         equalTo(
-            new InterfaceWithNodeInterfaceAstNode(
-                new NameNodeAstNode(IspModelingUtils.INTERNET_HOST_NAME),
-                new NameInterfaceAstNode("To-Isp123"))));
+            InterfaceLocationAstNode.createFromInterfaceWithNode(
+                new InterfaceWithNodeInterfaceAstNode(
+                    new NameNodeAstNode(IspModelingUtils.INTERNET_HOST_NAME),
+                    new NameInterfaceAstNode("To-Isp123")))));
     assertThat(
         ParserUtils.getAst(getRunner().run("@enter(internet[To-Isp123])")),
         equalTo(


### PR DESCRIPTION
Previously we were not returning the correct Ast type, causing parse errors for these valid specifiers.