### PR TITLE
Fix arpFailureTrace IPs, plus FibImpl and ForwardingAnalysis fallout

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibForward.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibForward.java
@@ -2,28 +2,37 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
+import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.visitors.FibActionVisitor;
 
 /**
- * A {@link FibAction} directing the device to ARP for a given IP on a given interface, then forward
- * a packet given a successful reply.
+ * A {@link FibAction} directing the device to ARP for an IP on a given interface, then forward a
+ * packet given a successful reply.
  */
 @ParametersAreNonnullByDefault
 public final class FibForward implements FibAction {
 
-  private final @Nonnull Ip _arpIp;
+  private final @Nullable Ip _arpIp;
   private final @Nonnull String _interfaceName;
 
-  public FibForward(Ip arpIp, String interfaceName) {
+  public FibForward(@Nullable Ip arpIp, String interfaceName) {
+    // TODO: remove once Route.UNSET_NEXT_HOP_IP and Ip.AUTO are killed
+    assert !Route.UNSET_ROUTE_NEXT_HOP_IP.equals(arpIp);
     _arpIp = arpIp;
     _interfaceName = interfaceName;
   }
 
-  /** IP that a router would ARP for to send the packet */
-  public @Nonnull Ip getArpIp() {
-    return _arpIp;
+  /**
+   * IP that a router would ARP for to send the packet. If {@link Optional#empty()}, then router
+   * should use ARP IP of an earlier entry in the resolution chain, or the destination IP if this is
+   * the only entry in the chain.
+   */
+  public @Nonnull Optional<Ip> getArpIp() {
+    return Optional.ofNullable(_arpIp);
   }
 
   /** Name of the interface to be used to send the packet out */
@@ -32,25 +41,25 @@ public final class FibForward implements FibAction {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
-    }
-    if (!(o instanceof FibForward)) {
+    } else if (!(o instanceof FibForward)) {
       return false;
     }
     FibForward rhs = (FibForward) o;
-    return _arpIp.equals(rhs._arpIp) && _interfaceName.equals(rhs._interfaceName);
+    return Objects.equals(_arpIp, rhs._arpIp) && _interfaceName.equals(rhs._interfaceName);
   }
 
   @Override
   public int hashCode() {
-    return _arpIp.hashCode() * 31 + _interfaceName.hashCode();
+    return (_arpIp != null ? _arpIp.hashCode() : 0) * 31 + _interfaceName.hashCode();
   }
 
   @Override
   public @Nonnull String toString() {
     return toStringHelper(FibForward.class)
+        .omitNullValues()
         .add("arpIp", _arpIp)
         .add("interfaceName", _interfaceName)
         .toString();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -80,7 +80,7 @@ public final class FibImpl implements Fib {
       _children.add(child);
     }
 
-    public void setUnresolvable(boolean unresolvable) {
+    public void markUnresolvable() {
       _unresolvable = true;
     }
 
@@ -223,8 +223,6 @@ public final class FibImpl implements Fib {
       @Override
       public Void visitNextHopIp(NextHopIp nextHopIp) {
         Set<AbstractRoute> lpmRoutes;
-        // For repeat cases, we don't want to keep around the unresolvable children
-        treeNode.getChildren().clear();
         lpmRoutes =
             rib
                 .longestPrefixMatch(
@@ -257,11 +255,7 @@ public final class FibImpl implements Fib {
           // will only survive in the final FIB if they do not cause an oscillation during data
           // plane computation. On other vendors, the main RIB does not activate such routes, so we
           // will not encounter them here.
-          treeNode.setUnresolvable(true);
-          if (depth == 0) {
-            // Add a child node to satisfy invariant that leaf nodes have a parent.
-            ResolutionTreeNode.withParent(route, treeNode, null).setUnresolvable(true);
-          }
+          treeNode.markUnresolvable();
           return null;
         }
         // We have at least one longest-prefix match, and have not looped yet.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.datamodel.Names.generatedTenantVniInterfaceName;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -37,21 +38,22 @@ public final class FibImpl implements Fib {
     private final @Nullable Ip _finalNextHopIp;
 
     private final @Nonnull List<ResolutionTreeNode> _children;
+    private boolean _unresolvable;
 
     /** Use static factories for sanity */
     private ResolutionTreeNode(
         AbstractRoute route, @Nullable Ip finalNextHopIp, List<ResolutionTreeNode> children) {
+      // TODO: remove once Route.UNSET_NEXT_HOP_IP and Ip.AUTO are killed
+      assert !Ip.AUTO.equals(finalNextHopIp);
       _route = route;
-      _finalNextHopIp = finalNextHopIp;
       _children = children;
+      _finalNextHopIp = finalNextHopIp;
     }
 
     static ResolutionTreeNode withParent(
-        AbstractRoute route, @Nullable ResolutionTreeNode parent, @Nullable Ip finalNextHopIp) {
+        AbstractRoute route, ResolutionTreeNode parent, @Nullable Ip finalNextHopIp) {
       ResolutionTreeNode child = new ResolutionTreeNode(route, finalNextHopIp, new LinkedList<>());
-      if (parent != null) {
-        parent.addChild(child);
-      }
+      parent.addChild(child);
       return child;
     }
 
@@ -77,6 +79,14 @@ public final class FibImpl implements Fib {
     private void addChild(ResolutionTreeNode child) {
       _children.add(child);
     }
+
+    public void setUnresolvable(boolean unresolvable) {
+      _unresolvable = true;
+    }
+
+    public boolean getUnresolvable() {
+      return _unresolvable;
+    }
   }
 
   private static final int MAX_DEPTH = 10;
@@ -87,14 +97,12 @@ public final class FibImpl implements Fib {
   private transient Supplier<Set<FibEntry>> _entries;
 
   public <R extends AbstractRouteDecorator> FibImpl(
-      @Nonnull GenericRib<R> rib, ResolutionRestriction<R> restriction) {
+      GenericRib<R> rib, ResolutionRestriction<R> restriction) {
     _root = new PrefixTrieMultiMap<>(Prefix.ZERO);
-    rib.getTypedRoutes()
-        .forEach(
-            r -> {
-              Set<FibEntry> s = resolveRoute(rib, r.getAbstractRoute(), restriction);
-              _root.putAll(r.getNetwork(), s);
-            });
+    rib.getTypedRoutes().stream()
+        .map(AbstractRouteDecorator::getAbstractRoute)
+        .filter(r -> !r.getNonForwarding())
+        .forEach(r -> _root.putAll(r.getNetwork(), resolveRoute(rib, r, restriction)));
     initSuppliers();
   }
 
@@ -127,16 +135,7 @@ public final class FibImpl implements Fib {
   <R extends AbstractRouteDecorator> Set<FibEntry> resolveRoute(
       GenericRib<R> rib, AbstractRoute route, ResolutionRestriction<R> restriction) {
     ResolutionTreeNode resolutionRoot = ResolutionTreeNode.root(route);
-    buildResolutionTree(
-        rib,
-        route,
-        Route.UNSET_ROUTE_NEXT_HOP_IP,
-        new HashSet<>(),
-        0,
-        Prefix.MAX_PREFIX_LENGTH,
-        null,
-        resolutionRoot,
-        restriction);
+    buildResolutionTree(rib, route, null, new HashSet<>(), 0, resolutionRoot, restriction);
     Builder<FibEntry> collector = ImmutableSet.builder();
     collectEntries(resolutionRoot, new Stack<>(), collector);
     return collector.build();
@@ -147,14 +146,19 @@ public final class FibImpl implements Fib {
       Stack<AbstractRoute> stack,
       ImmutableCollection.Builder<FibEntry> entriesBuilder) {
     AbstractRoute route = node.getRoute();
-    if (node.getChildren().isEmpty() && node.getFinalNextHopIp() != null) {
+    assert !route.getNonForwarding();
+    if (node.getChildren().isEmpty()) {
       FibAction fibAction =
           new NextHopVisitor<FibAction>() {
 
             @Override
             public FibAction visitNextHopIp(NextHopIp nextHopIp) {
-              throw new IllegalStateException(
-                  String.format("FIB resolution failed to reach an interface route for %s", route));
+              checkState(
+                  node.getUnresolvable(),
+                  "FIB resolution failed to reach a terminal route for NHIP route not marked"
+                      + " unresolvable: %s",
+                  route);
+              return FibNullRoute.INSTANCE;
             }
 
             @Override
@@ -198,18 +202,14 @@ public final class FibImpl implements Fib {
   private <R extends AbstractRouteDecorator> void buildResolutionTree(
       GenericRib<R> rib,
       AbstractRoute route,
-      Ip mostRecentNextHopIp,
+      @Nullable Ip mostRecentNextHopIp,
       Set<Prefix> seenNetworks,
       int depth,
-      int maxPrefixLength,
-      @Nullable AbstractRoute parentRoute,
       ResolutionTreeNode treeNode,
       ResolutionRestriction<R> restriction) {
+    assert !route.getNonForwarding();
     Prefix network = route.getNetwork();
-    if (seenNetworks.contains(network)) {
-      // Don't enter a resolution loop
-      return;
-    }
+    checkState(!seenNetworks.contains(network), "Unexpected resolution loop resolving %s", route);
     Set<Prefix> newSeenNetworks = new HashSet<>(seenNetworks);
     newSeenNetworks.add(network);
     if (depth > MAX_DEPTH) {
@@ -218,35 +218,17 @@ public final class FibImpl implements Fib {
       return;
     }
 
-    // For non-forwarding routes, try to find a less specific route
-    if (route.getNonForwarding()) {
-      if (parentRoute == null) {
-        return;
-      } else {
-        seenNetworks.remove(parentRoute.getNetwork());
-        buildResolutionTree(
-            rib,
-            parentRoute,
-            mostRecentNextHopIp,
-            seenNetworks,
-            depth + 1,
-            maxPrefixLength - 1,
-            null,
-            treeNode,
-            restriction);
-        return;
-      }
-    }
-
     new NextHopVisitor<Void>() {
 
       @Override
       public Void visitNextHopIp(NextHopIp nextHopIp) {
-        Set<AbstractRoute> forwardingRoutes =
+        Set<AbstractRoute> lpmRoutes;
+        // For repeat cases, we don't want to keep around the unresolvable children
+        treeNode.getChildren().clear();
+        lpmRoutes =
             rib
                 .longestPrefixMatch(
                     nextHopIp.getIp(),
-                    maxPrefixLength,
                     r -> {
                       if (route.getProtocol() == RoutingProtocol.STATIC) {
                         // TODO: factor out common code with
@@ -268,60 +250,57 @@ public final class FibImpl implements Fib {
                 .map(AbstractRouteDecorator::getAbstractRoute)
                 .collect(ImmutableSet.toImmutableSet());
 
-        if (forwardingRoutes.isEmpty()) {
-          // Re-resolve *this route* with a less specific prefix match
-          seenNetworks.remove(route.getNetwork());
+        if (lpmRoutes.isEmpty()
+            || newSeenNetworks.contains(lpmRoutes.iterator().next().getNetwork())) {
+          // The next hop IP does not resolve or resolves in a loop, so this route becomes a
+          // discard entry. Note that such entries may only exist on some vendors (e.g. IOS), and
+          // will only survive in the final FIB if they do not cause an oscillation during data
+          // plane computation. On other vendors, the main RIB does not activate such routes, so we
+          // will not encounter them here.
+          treeNode.setUnresolvable(true);
+          if (depth == 0) {
+            // Add a child node to satisfy invariant that leaf nodes have a parent.
+            ResolutionTreeNode.withParent(route, treeNode, null).setUnresolvable(true);
+          }
+          return null;
+        }
+        // We have at least one longest-prefix match, and have not looped yet.
+        for (AbstractRoute nextHopLongestPrefixMatchRoute : lpmRoutes) {
           buildResolutionTree(
               rib,
-              route,
-              mostRecentNextHopIp,
-              seenNetworks,
+              nextHopLongestPrefixMatchRoute,
+              nextHopIp.getIp(),
+              newSeenNetworks,
               depth + 1,
-              maxPrefixLength - 1,
-              parentRoute,
-              treeNode,
+              ResolutionTreeNode.withParent(nextHopLongestPrefixMatchRoute, treeNode, null),
               restriction);
-        } else {
-          // We have at least one valid longest-prefix match
-          for (AbstractRoute nextHopLongestPrefixMatchRoute : forwardingRoutes) {
-            buildResolutionTree(
-                rib,
-                nextHopLongestPrefixMatchRoute,
-                nextHopIp.getIp(),
-                newSeenNetworks,
-                depth + 1,
-                Prefix.MAX_PREFIX_LENGTH,
-                route,
-                ResolutionTreeNode.withParent(nextHopLongestPrefixMatchRoute, treeNode, null),
-                restriction);
-          }
         }
         return null;
       }
 
       @Override
       public Void visitNextHopInterface(NextHopInterface nextHopInterface) {
-        Ip finalNextHopIp =
-            nextHopInterface.getIp() == null ? mostRecentNextHopIp : route.getNextHopIp();
+        Ip nhintIp = nextHopInterface.getIp();
+        Ip finalNextHopIp = nhintIp != null ? nhintIp : mostRecentNextHopIp;
         ResolutionTreeNode.withParent(route, treeNode, finalNextHopIp);
         return null;
       }
 
       @Override
       public Void visitNextHopDiscard(NextHopDiscard nextHopDiscard) {
-        ResolutionTreeNode.withParent(route, treeNode, Route.UNSET_ROUTE_NEXT_HOP_IP);
+        ResolutionTreeNode.withParent(route, treeNode, null);
         return null;
       }
 
       @Override
       public Void visitNextHopVrf(NextHopVrf nextHopVrf) {
-        ResolutionTreeNode.withParent(route, treeNode, Route.UNSET_ROUTE_NEXT_HOP_IP);
+        ResolutionTreeNode.withParent(route, treeNode, null);
         return null;
       }
 
       @Override
       public Void visitNextHopVtep(NextHopVtep nextHopVtep) {
-        ResolutionTreeNode.withParent(route, treeNode, Route.UNSET_ROUTE_NEXT_HOP_IP);
+        ResolutionTreeNode.withParent(route, treeNode, null);
         return null;
       }
     }.visit(route.getNextHop());

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -196,8 +196,9 @@ public final class FibImpl implements Fib {
 
   /**
    * Tail-recursive method to build a route resolution tree. Each top-level route is mapped to a
-   * number of leaf {@link ResolutionTreeNode}. Leaf nodes must contain non-null {@link
-   * ResolutionTreeNode#_finalNextHopIp}
+   * number of leaf {@link ResolutionTreeNode}. Only leaf nodes of {@link NextHopInterface} routes
+   * may contain non-null {@link ResolutionTreeNode#_finalNextHopIp}. Each {@link NextHopIp} route
+   * node must have one or more children, or be an unresolvable leaf node.
    */
   private <R extends AbstractRouteDecorator> void buildResolutionTree(
       GenericRib<R> rib,
@@ -255,7 +256,7 @@ public final class FibImpl implements Fib {
           // will only survive in the final FIB if they do not cause an oscillation during data
           // plane computation. On other vendors, the main RIB does not activate such routes, so we
           // will not encounter them here.
-          treeNode.markUnresolvable();
+          ResolutionTreeNode.withParent(route, treeNode, null).markUnresolvable();
           return null;
         }
         // We have at least one longest-prefix match, and have not looped yet.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -1226,8 +1226,8 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
   }
 
   /**
-   * Mapping: route -&gt; nexthopinterface -&gt; resolved nextHopIps (or Optional.empty() if dest IP
-   * should be used for ARP
+   * Mapping: route -&gt; nexthopinterface -&gt; resolved nextHopIps (or {@link Optional#empty()})
+   * if dest IP should be used for ARP
    */
   private static @Nonnull Map<AbstractRoute, Map<String, Set<Optional<Ip>>>>
       computeNextHopInterfaces(Fib fib) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -425,6 +425,8 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
   /** Find the elements associated with the longest matching prefix of a given IP address. */
   @Nonnull
   public Set<T> longestPrefixMatch(Ip address) {
+    // TODO: remove once Route.UNSET_NEXT_HOP_IP and Ip.AUTO are killed
+    assert !Route.UNSET_ROUTE_NEXT_HOP_IP.equals(address);
     return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -48,6 +48,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.batfish.common.topology.GlobalBroadcastNoPointToPoint;
 import org.batfish.common.topology.IpOwners;
@@ -821,9 +822,7 @@ public class ForwardingAnalysisImplTest {
                             ImmutableSet.of(
                                 new FibEntry(FibNullRoute.INSTANCE, ImmutableList.of(nullRoute)),
                                 new FibEntry(
-                                    new FibForward(
-                                        Route.UNSET_ROUTE_NEXT_HOP_IP,
-                                        otherRoute.getNextHopInterface()),
+                                    new FibForward(null, otherRoute.getNextHopInterface()),
                                     ImmutableList.of(otherRoute)))))
                     .build()));
     IpSpace result =
@@ -928,12 +927,12 @@ public class ForwardingAnalysisImplTest {
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, i1);
     Map<String, Set<AbstractRoute>> routesWithNextHop =
         ImmutableMap.of(i1, ImmutableSet.of(r1, ifaceRoute));
-    Map<AbstractRoute, Map<String, Set<Ip>>> nextHopInterfaces =
+    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
         ImmutableMap.of(
             r1,
-            ImmutableMap.of(i1, ImmutableSet.of(r1.getNextHopIp())),
+            ImmutableMap.of(i1, ImmutableSet.of(Optional.of(r1.getNextHopIp()))),
             ifaceRoute,
-            ImmutableMap.of(i1, ImmutableSet.of(Route.UNSET_ROUTE_NEXT_HOP_IP)));
+            ImmutableMap.of(i1, ImmutableSet.of(Optional.empty())));
     Map<String, Set<AbstractRoute>> result =
         computeRoutesWhereDstIpCanBeArpIp(nextHopInterfaces, routesWithNextHop);
 
@@ -969,9 +968,8 @@ public class ForwardingAnalysisImplTest {
         MockFib.builder()
             .setFibEntries(
                 ImmutableMap.of(
-                    Ip.AUTO,
-                    ImmutableSet.of(
-                        new FibEntry(new FibForward(Ip.AUTO, i1), ImmutableList.of(r1)))))
+                    P1.getFirstHostIp(),
+                    ImmutableSet.of(new FibEntry(new FibForward(null, i1), ImmutableList.of(r1)))))
             .build();
     Map<String, Map<String, Fib>> fibs =
         ImmutableMap.of(
@@ -1009,8 +1007,8 @@ public class ForwardingAnalysisImplTest {
             .setAdministrativeCost(1)
             .build();
     Set<AbstractRoute> routesWithNextHop = ImmutableSet.of(r1);
-    Map<AbstractRoute, Map<String, Set<Ip>>> nextHopInterfaces =
-        ImmutableMap.of(r1, ImmutableMap.of(i1, ImmutableSet.of(r1.getNextHopIp())));
+    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
+        ImmutableMap.of(r1, ImmutableMap.of(i1, ImmutableSet.of(Optional.of(r1.getNextHopIp()))));
     IpSpace someoneReplies = P2.getEndIp().toIpSpace();
     Set<AbstractRoute> result =
         computeArpFalseNhipRoutes(i1, nextHopInterfaces, routesWithNextHop, someoneReplies);
@@ -1036,14 +1034,16 @@ public class ForwardingAnalysisImplTest {
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, outInterface);
     Set<AbstractRoute> candidateRoutes =
         ImmutableSet.of(nextHopIpRoute1, nextHopIpRoute2, ifaceRoute);
-    Map<AbstractRoute, Map<String, Set<Ip>>> nextHopInterfaces =
+    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
         ImmutableMap.of(
             nextHopIpRoute1,
-            ImmutableMap.of(outInterface, ImmutableSet.of(nextHopIpRoute1.getNextHopIp())),
+            ImmutableMap.of(
+                outInterface, ImmutableSet.of(Optional.of(nextHopIpRoute1.getNextHopIp()))),
             nextHopIpRoute2,
-            ImmutableMap.of(outInterface, ImmutableSet.of(nextHopIpRoute2.getNextHopIp())),
+            ImmutableMap.of(
+                outInterface, ImmutableSet.of(Optional.of(nextHopIpRoute2.getNextHopIp()))),
             ifaceRoute,
-            ImmutableMap.of(outInterface, ImmutableSet.of(Route.UNSET_ROUTE_NEXT_HOP_IP)));
+            ImmutableMap.of(outInterface, ImmutableSet.of(Optional.empty())));
     Set<AbstractRoute> result =
         computeRoutesWithNextHopIpArpFalseForInterface(
             nextHopInterfaces, outInterface, candidateRoutes, P2.getStartIp().toIpSpace());
@@ -1073,14 +1073,16 @@ public class ForwardingAnalysisImplTest {
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, outInterface);
     Set<AbstractRoute> candidateRoutes =
         ImmutableSet.of(nextHopIpRoute1, nextHopIpRoute2, ifaceRoute);
-    Map<AbstractRoute, Map<String, Set<Ip>>> nextHopInterfaces =
+    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
         ImmutableMap.of(
             nextHopIpRoute1,
-            ImmutableMap.of(outInterface, ImmutableSet.of(nextHopIpRoute1.getNextHopIp())),
+            ImmutableMap.of(
+                outInterface, ImmutableSet.of(Optional.of(nextHopIpRoute1.getNextHopIp()))),
             nextHopIpRoute2,
-            ImmutableMap.of(outInterface, ImmutableSet.of(nextHopIpRoute2.getNextHopIp())),
+            ImmutableMap.of(
+                outInterface, ImmutableSet.of(Optional.of(nextHopIpRoute2.getNextHopIp()))),
             ifaceRoute,
-            ImmutableMap.of(outInterface, ImmutableSet.of(Route.UNSET_ROUTE_NEXT_HOP_IP)));
+            ImmutableMap.of(outInterface, ImmutableSet.of(Optional.empty())));
     Set<AbstractRoute> result =
         computeRoutesWithNextHopIpArpFalseForInterface(
             nextHopInterfaces, outInterface, candidateRoutes, EmptyIpSpace.INSTANCE);
@@ -1117,12 +1119,12 @@ public class ForwardingAnalysisImplTest {
             .build();
     Map<String, Set<AbstractRoute>> routesWithNextHop =
         ImmutableMap.of(i1, ImmutableSet.of(r1, r2));
-    Map<AbstractRoute, Map<String, Set<Ip>>> nextHopInterfaces =
+    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
         ImmutableMap.of(
             r1,
-            ImmutableMap.of(i1, ImmutableSet.of(r1.getNextHopIp())),
+            ImmutableMap.of(i1, ImmutableSet.of(Optional.of(r1.getNextHopIp()))),
             r2,
-            ImmutableMap.of(i1, ImmutableSet.of(r2.getNextHopIp())));
+            ImmutableMap.of(i1, ImmutableSet.of(Optional.of(r2.getNextHopIp()))));
     Map<Edge, Set<AbstractRoute>> result =
         computeRoutesWithNextHopIpArpTrue(
             c1, nextHopInterfaces, topology, arpReplies, routesWithNextHop);
@@ -1467,10 +1469,10 @@ public class ForwardingAnalysisImplTest {
             .setMatchingIps(ImmutableMap.of(prefix, ipSpace))
             .setFibEntries(
                 ImmutableMap.of(
-                    Ip.AUTO,
+                    prefix.getFirstHostIp(),
                     ImmutableSet.of(
                         new FibEntry(
-                            new FibForward(Ip.AUTO, i1.getName()), ImmutableList.of(route1)))))
+                            new FibForward(null, i1.getName()), ImmutableList.of(route1)))))
             .build();
 
     MockFib fib2 =
@@ -1478,10 +1480,10 @@ public class ForwardingAnalysisImplTest {
             .setMatchingIps(ImmutableMap.of(prefix, ipSpace))
             .setFibEntries(
                 ImmutableMap.of(
-                    Ip.AUTO,
+                    prefix.getFirstHostIp(),
                     ImmutableSet.of(
                         new FibEntry(
-                            new FibForward(Ip.AUTO, i2.getName()), ImmutableList.of(route2)))))
+                            new FibForward(null, i2.getName()), ImmutableList.of(route2)))))
             .build();
 
     Map<String, Map<String, Fib>> fibs =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
@@ -30,6 +30,8 @@ public class MockFib implements Fib {
     }
 
     public Builder setFibEntries(@Nonnull Map<Ip, Set<FibEntry>> fibEntries) {
+      // TODO: remove once Route.UNSET_NEXT_HOP_IP and Ip.AUTO are killed
+      assert !fibEntries.containsKey(Route.UNSET_ROUTE_NEXT_HOP_IP);
       _fibEntries = fibEntries;
       return this;
     }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -214,6 +214,7 @@ public final class FibImplTest {
     Set<AbstractRoute> fibRoutes = getTopLevelRoutesByInterface(fib, "Eth1");
 
     assertThat(fibRoutes, not(hasItem(hasPrefix(Prefix.parse("1.1.1.0/24")))));
+    assertThat(fibRoutes, not(hasItem(hasPrefix(Prefix.parse("3.3.3.0/24")))));
     assertThat(fibRoutes, hasItem(hasPrefix(Prefix.parse("2.2.2.0/24"))));
   }
 

--- a/tests/basic/traceroute-1-2.ref
+++ b/tests/basic/traceroute-1-2.ref
@@ -400,7 +400,6 @@
                     "type" : "Routing",
                     "action" : "FORWARDED",
                     "detail" : {
-                      "arpIp" : "AUTO/NONE(-1l)",
                       "forwardingDetail" : {
                         "type" : "ForwardedOutInterface",
                         "outputInterface" : "GigabitEthernet2/0"
@@ -834,7 +833,6 @@
                     "type" : "Routing",
                     "action" : "FORWARDED",
                     "detail" : {
-                      "arpIp" : "AUTO/NONE(-1l)",
                       "forwardingDetail" : {
                         "type" : "ForwardedOutInterface",
                         "outputInterface" : "GigabitEthernet2/0"
@@ -1268,7 +1266,6 @@
                     "type" : "Routing",
                     "action" : "FORWARDED",
                     "detail" : {
-                      "arpIp" : "AUTO/NONE(-1l)",
                       "forwardingDetail" : {
                         "type" : "ForwardedOutInterface",
                         "outputInterface" : "GigabitEthernet2/0"
@@ -1702,7 +1699,6 @@
                     "type" : "Routing",
                     "action" : "FORWARDED",
                     "detail" : {
-                      "arpIp" : "AUTO/NONE(-1l)",
                       "forwardingDetail" : {
                         "type" : "ForwardedOutInterface",
                         "outputInterface" : "GigabitEthernet2/0"
@@ -2164,7 +2160,6 @@
                     "type" : "Routing",
                     "action" : "FORWARDED",
                     "detail" : {
-                      "arpIp" : "AUTO/NONE(-1l)",
                       "forwardingDetail" : {
                         "type" : "ForwardedOutInterface",
                         "outputInterface" : "GigabitEthernet2/0"
@@ -2598,7 +2593,6 @@
                     "type" : "Routing",
                     "action" : "FORWARDED",
                     "detail" : {
-                      "arpIp" : "AUTO/NONE(-1l)",
                       "forwardingDetail" : {
                         "type" : "ForwardedOutInterface",
                         "outputInterface" : "GigabitEthernet2/0"
@@ -3032,7 +3026,6 @@
                     "type" : "Routing",
                     "action" : "FORWARDED",
                     "detail" : {
-                      "arpIp" : "AUTO/NONE(-1l)",
                       "forwardingDetail" : {
                         "type" : "ForwardedOutInterface",
                         "outputInterface" : "GigabitEthernet2/0"
@@ -3466,7 +3459,6 @@
                     "type" : "Routing",
                     "action" : "FORWARDED",
                     "detail" : {
-                      "arpIp" : "AUTO/NONE(-1l)",
                       "forwardingDetail" : {
                         "type" : "ForwardedOutInterface",
                         "outputInterface" : "GigabitEthernet2/0"


### PR DESCRIPTION
- Fix bug where dest IP showed up as arp IP for neighbor unreachable
when the interface had no neighbors.
- To ensure we always display real arp IP, remove pathways for `Route.UNSET_NEXT_HOP_IP` to make it
  into `FibForward.getArpIp`.
  - make `FibForward.getArpIp` optional, and disallow `Route.UNSET_NEXT_HOP_IP`.
- Fix bugs and cruft encountered while updating `FibImpl` to use new `FibForward` API
  - Ensure every `Rib` entry results in at least one `FibAction`
    - Make sure unresolvable or looping NextHopIp routes result in `FibNullRoute`, instead of
      silent missing `FibEntry`s
  - Remove unnecessary loop duplicating `Rib.longestPrefixMatch` filtering of non-forwarding routes
  - Ensure non-forwarding routes are never part of the resolution chain
  - Remove unused parameters not caught because the function was called with
    the same parameter value recursively
- Update old/incorrect documentation in `ForwardingAnalysisImpl` near usages of `FibForward`