### PR TITLE
BDD: add an internal implementation of free

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
@@ -1903,8 +1903,16 @@ public abstract class BDD {
     }
   }
 
-  /** Frees this BDD. Further use of this BDD will result in an exception being thrown. */
+  /**
+   * Frees this BDD. Further use of this BDD will result in an exception being thrown.
+   *
+   * <p>Meant for use exclusively as a public API. See {@link #freeInternal()} for internal
+   * operations that also need to free a BDD.
+   */
   public abstract void free();
+
+  /** Like {@link #free()}, but for calls from inside a {@link BDDFactory itself}. */
+  protected abstract void freeInternal();
 
   /** Protected constructor. */
   protected BDD() {}

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -267,7 +267,7 @@ public final class JFactory extends BDDFactory {
       int a = bdd_restrict(x, y);
       bdd_delref(x);
       if (this != that) {
-        that.free();
+        that.freeInternal();
       }
       bdd_addref(a);
       _index = a;
@@ -319,7 +319,7 @@ public final class JFactory extends BDDFactory {
       int a = bdd_apply(x, y, z);
       bdd_delref(x);
       if (this != that) {
-        that.free();
+        that.freeInternal();
       }
       bdd_addref(a);
       _index = a;
@@ -437,6 +437,11 @@ public final class JFactory extends BDDFactory {
 
     @Override
     public void free() {
+      freeInternal();
+    }
+
+    @Override
+    protected void freeInternal() {
       bdd_delref(_index);
       _index = INVALID_BDD;
       ++freedBDDs;
@@ -893,7 +898,7 @@ public final class JFactory extends BDDFactory {
             .toArray();
     int ret = bdd_andAll(operands);
     if (free) {
-      bddOperands.forEach(BDD::free);
+      bddOperands.forEach(BDD::freeInternal);
     }
     return makeBDD(ret);
   }
@@ -930,7 +935,7 @@ public final class JFactory extends BDDFactory {
             .toArray();
     int ret = bdd_orAll(operands);
     if (free) {
-      bddOperands.forEach(BDD::free);
+      bddOperands.forEach(BDD::freeInternal);
     }
     return makeBDD(ret);
   }
@@ -4475,7 +4480,7 @@ public final class JFactory extends BDDFactory {
           sb.append('=');
           BDDImpl b = new BDDImpl(result[i]);
           sb.append(b);
-          b.free();
+          b.freeInternal();
         }
       }
       sb.append('}');


### PR DESCRIPTION
BDD library instrumentations need to be able to accurately distinguish public
and internal API calls. `BDD#free`, since it changes the BDD object rather than
library internal state, seems to be the unique public API called internally
during the evaluation of other operations (specifically `opWith` or
`opAndFree`).