### PR TITLE
CompletionMetadata: exclude p2p prefixes for @enter locations

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -189,6 +189,11 @@ public final class CompletionMetadataUtils {
       Interface iface,
       Prefix prefix,
       RangeSet<Ip> ownedIps) {
+    // exclude p2p subnets
+    if (prefix.getPrefixLength() > Prefix.HOST_SUBNET_MAX_PREFIX_LENGTH) {
+      return;
+    }
+
     // short-circuit when there are no unownedSubnetHostIps. But if the entry is in the trie, there
     // must be some (and we don't need to compute them again).
     Set<IpCompletionMetadata> metadataSet = trie.get(prefix);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
@@ -201,13 +201,6 @@ public final class CompletionMetadataUtilsTest {
             new IpCompletionRelevance(
                 interfaceDisplayString(iface1), config.getHostname(), iface1.getName())));
     trie.put(
-        interfaceAddress1.getPrefix(),
-        new IpCompletionMetadata(
-            unownedSubnetHostIps(interfaceAddress1.getPrefix(), ownedIps),
-            ImmutableList.of(
-                new IpCompletionRelevance(
-                    interfaceLinkDisplayString(iface1), config.getHostname(), iface1.getName()))));
-    trie.put(
         ip2.toPrefix(),
         new IpCompletionMetadata(
             ImmutableList.of(


### PR DESCRIPTION
For consistency with source IP specifiers.