### PR TITLE
Juniper record extra lines of structure definitions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
@@ -3,8 +3,10 @@ package org.batfish.grammar;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -216,5 +218,9 @@ public abstract class BatfishCombinedParser<P extends BatfishParser, L extends B
   @Nonnull
   public String getRuleName(ParserRuleContext ctx) {
     return _parser.getRuleNames()[ctx.getRuleIndex()];
+  }
+
+  public @Nullable Map<Integer, Set<Integer>> getExtraLines() {
+    return _lineMap != null ? _lineMap.getExtraLines() : null;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/flattener/FlattenerLineMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/flattener/FlattenerLineMap.java
@@ -1,12 +1,15 @@
 package org.batfish.grammar.flattener;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import javax.annotation.Nonnull;
 
-public class FlattenerLineMap {
+public final class FlattenerLineMap {
   public static final int UNMAPPED_LINE_NUMBER = -1;
   /**
    * Map of new line number to word map, where word map is map of a word's starting-position in
@@ -14,8 +17,11 @@ public class FlattenerLineMap {
    */
   private NavigableMap<Integer, NavigableMap<Integer, Integer>> _lineMap;
 
+  private final Map<Integer, Set<Integer>> _extraLines;
+
   public FlattenerLineMap() {
     _lineMap = new TreeMap<>();
+    _extraLines = new HashMap<>();
   }
 
   /**
@@ -55,5 +61,28 @@ public class FlattenerLineMap {
     SortedMap<Integer, Integer> wordMap =
         _lineMap.computeIfAbsent(newLineNumber, l -> new TreeMap<>());
     wordMap.put(newStartingPosition, originalLineNumber);
+  }
+
+  /**
+   * Extra original lines associated with an original line. This mapping may be both incomplete and
+   * an overapproximation. For every structure definition whose lines cannot be determined from the
+   * flattened parse tree, the keys should include the original line of at least one surviving token
+   * of that structure definition. The corresponding value should include at minimum all original
+   * lines of the corresponding structure definition that cannot be determined from the flattened
+   * parse tree. There may be extra key and value lines, but they will not cause an
+   * overapproximation of the original lines associated with any structure.
+   */
+  public @Nonnull Map<Integer, Set<Integer>> getExtraLines() {
+    return _extraLines;
+  }
+
+  /**
+   * Associate some original line with some extra original lines. If the original line is part of a
+   * structure definition, all extra lines to associate must be part of that definition.
+   *
+   * <p>Should only be called during preprocessing.
+   */
+  public void setExtraLines(int originalLine, Set<Integer> extraLines) {
+    _extraLines.put(originalLine, extraLines);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConvertConfigurationAnswerElementMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConvertConfigurationAnswerElementMatchers.java
@@ -163,13 +163,13 @@ final class ConvertConfigurationAnswerElementMatchers {
                 _filename, _type, _structureName));
         return false;
       }
-      if (!_subMatcher.matches(
-          byStructureName.get(_structureName).getDefinitionLines().enumerate())) {
+      Set<Integer> definitionLines =
+          byStructureName.get(_structureName).getDefinitionLines().enumerate();
+      if (!_subMatcher.matches(definitionLines)) {
         mismatchDescription.appendText(
             String.format(
-                "File '%s' has no defined structure of type '%s' named '%s' matching definition"
-                    + " lines '%s'",
-                _filename, _type, _structureName, _subMatcher));
+                "File '%s' defined structure of type '%s' named '%s' definition lines were %s",
+                _filename, _type, _structureName, definitionLines));
         return false;
       }
       return true;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
@@ -47,7 +47,7 @@ COMMENT_LINE
 
 MULTILINE_COMMENT
 :
-   '/*' .*? '*/' -> skip // so not counted as last token
+   '/*' .*? '*/'
 ;
 
 OPEN_BRACE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperParser.g4
@@ -7,17 +7,17 @@ options {
 
 braced_clause
 :
-  OPEN_BRACE statement* CLOSE_BRACE
+  OPEN_BRACE statement*
 ;
 
 bracketed_clause
 :
-  OPEN_BRACKET word+ CLOSE_BRACKET
+  OPEN_BRACKET word+
 ;
 
 juniper_configuration
 :
-  statement+ EOF
+  statement+ MULTILINE_COMMENT? EOF
 ;
 
 statement
@@ -33,13 +33,14 @@ flat_statement
 
 hierarchical_statement
 :
+  MULTILINE_COMMENT?
   (
     INACTIVE
     | REPLACE
   )? words += word+
   (
-    braced_clause
-    | bracketed_clause terminator
+    braced_clause close = CLOSE_BRACE
+    | bracketed_clause close = CLOSE_BRACKET terminator
     | terminator
   )
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2174,6 +2174,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _parser = parser;
     _text = text;
     _configuration = new JuniperConfiguration();
+    _configuration.setExtraLines(_parser.getExtraLines());
     setLogicalSystem(_configuration.getMasterLogicalSystem());
     _termRouteFilters = new HashMap<>();
     _w = warnings;
@@ -4382,6 +4383,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     } else {
       _currentLogicalSystem.setDefaultInboundAction(LineAction.PERMIT);
     }
+    _configuration.setExtraLines(null);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
@@ -1,10 +1,12 @@
 package org.batfish.grammar.juniper;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.grammar.flattener.Flattener;
@@ -35,6 +37,7 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
   private List<List<WordContext>> _stack;
   private final String _text;
   private boolean _inEmptyBracedClause;
+  private final List<Set<Integer>> _extraLines;
 
   public JuniperFlattener(String header, String text) {
     _header = header;
@@ -45,6 +48,7 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
     _stack = new ArrayList<>();
     _root = new FlatStatementTree();
     _allFlatStatements = new ArrayList<>();
+    _extraLines = new ArrayList<>();
   }
 
   @Override
@@ -73,6 +77,9 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
   @Override
   public void exitBracketed_clause(Bracketed_clauseContext ctx) {
     if (_inactiveStatement == null) {
+      for (WordContext word : ctx.word()) {
+        recordExtraLines(word.getStart().getLine());
+      }
       _inBrackets = false;
     }
   }
@@ -102,6 +109,17 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
       if (ctx.INACTIVE() != null) {
         _inactiveStatement = ctx;
       } else {
+        int firstWordLine = ctx.words.get(0).getStart().getLine();
+        ImmutableSet.Builder<Integer> extraLinesBuilder =
+            ImmutableSet.<Integer>builder().add(firstWordLine);
+        if (ctx.MULTILINE_COMMENT() != null) {
+          IntStream.range(ctx.MULTILINE_COMMENT().getSymbol().getLine(), firstWordLine)
+              .forEach(extraLinesBuilder::add);
+        }
+        if (ctx.close != null) {
+          extraLinesBuilder.add(ctx.close.getLine());
+        }
+        _extraLines.add(extraLinesBuilder.build());
         String statementTextAtCurrentDepth =
             ctx.words.stream().map(ParserRuleContext::getText).collect(Collectors.joining(" "));
         if (ctx.REPLACE() != null) {
@@ -120,7 +138,11 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
 
   @Override
   public void exitHierarchical_statement(Hierarchical_statementContext ctx) {
+
     if (_inactiveStatement == null) {
+      int firstWordLine = ctx.words.get(0).getStart().getLine();
+      recordExtraLines(firstWordLine);
+      _extraLines.remove(_extraLines.size() - 1);
       _stack.remove(_stack.size() - 1);
       // Finished recording set lines for this node key, so pop up
       _currentTree = _currentTree.getParent();
@@ -185,13 +207,11 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
     StringBuilder sb = new StringBuilder();
     sb.append("set");
     for (List<WordContext> line : _stack) {
+      int originalLine = _allFlatStatements.size() + _headerLineCount;
       for (WordContext wordCtx : line) {
         sb.append(" ");
         // Offset new line number by header line count
-        _lineMap.setOriginalLine(
-            _allFlatStatements.size() + _headerLineCount,
-            sb.length(),
-            wordCtx.WORD().getSymbol().getLine());
+        _lineMap.setOriginalLine(originalLine, sb.length(), wordCtx.WORD().getSymbol().getLine());
         sb.append(wordCtx.getText());
       }
     }
@@ -215,5 +235,11 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
     int start = ctx.getStart().getStartIndex();
     int end = ctx.getStop().getStopIndex();
     return _text.substring(start, end + 1);
+  }
+
+  private void recordExtraLines(int originalLine) {
+    _lineMap.setExtraLines(
+        originalLine,
+        _extraLines.stream().flatMap(Set::stream).collect(ImmutableSet.toImmutableSet()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -159,6 +159,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.AUTHENTICA
 import static org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_CODE_POINT_ALIAS;
 import static org.batfish.representation.juniper.JuniperStructureType.COMMUNITY;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER;
+import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureType.POLICY_STATEMENT;
 import static org.batfish.representation.juniper.JuniperStructureType.POLICY_STATEMENT_TERM;
@@ -2535,11 +2536,14 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(
-            filename, FIREWALL_FILTER, "FILTER1", contains(6, 7, 8, 9, 11, 12)));
+            filename,
+            FIREWALL_FILTER,
+            "FILTER1",
+            contains(5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 23)));
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(
-            filename, FIREWALL_FILTER, "FILTER2", contains(16, 17, 18, 19)));
+            filename, FIREWALL_FILTER, "FILTER2", contains(5, 16, 17, 18, 19, 20, 21, 22, 23)));
   }
 
   @Test
@@ -6742,5 +6746,20 @@ public final class FlatJuniperGrammarTest {
   public void testApplyGroupsParsing() {
     String hostname = "apply-groups";
     parseJuniperConfig(hostname);
+  }
+
+  @Test
+  public void testDefineStructureFromNested() throws IOException {
+    String hostname = "define-structure-from-nested";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    assertThat(
+        ccae,
+        hasDefinedStructureWithDefinitionLines(
+            "configs/" + hostname,
+            FIREWALL_FILTER_TERM,
+            "foo default-deny-udp",
+            equalTo(IntegerSpace.unionOf(new SubRange(6, 19), new SubRange(25, 26)).enumerate())));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/define-structure-from-nested
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/define-structure-from-nested
@@ -1,0 +1,26 @@
+# RANCID-CONTENT-TYPE: juniper
+system {
+  host-name "define-structure-from-nested";
+}
+
+firewall {
+    filter foo {
+        /*
+         ** Count UDP denies.
+         */
+        term default-deny-udp {
+            from {
+                protocol udp;
+            }
+            then {
+                count default-deny-udp;
+                discard;
+            }
+        }
+        term other {
+            then {
+                discard;
+            }
+        }
+    }
+}

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -72871,125 +72871,125 @@
         "configs/gh-2658-juniper-vrf-import-export.cfg" : {
           "bgp group" : {
             "overlay" : {
-              "definitionLines" : "136-140,143-146,148-152",
+              "definitionLines" : "115-116,136-141,143-154,159",
               "numReferrers" : 4
             },
             "underlay" : {
-              "definitionLines" : "118,120-123,125-127,129-130,132-133",
+              "definitionLines" : "115-116,118,120-135,154,159",
               "numReferrers" : 3
             }
           },
           "community" : {
             "fabric" : {
-              "definitionLines" : "191",
+              "definitionLines" : "160,191,194",
               "numReferrers" : 1
             },
             "vni-100" : {
-              "definitionLines" : "192",
+              "definitionLines" : "160,192,194",
               "numReferrers" : 1
             },
             "vni-101" : {
-              "definitionLines" : "193",
+              "definitionLines" : "160,193-194",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "fxp0" : {
-              "definitionLines" : "75-78",
+              "definitionLines" : "52,75-81,103",
               "numReferrers" : 1
             },
             "fxp0.0" : {
-              "definitionLines" : "76-78",
+              "definitionLines" : "52,75-81,103",
               "numReferrers" : 1
             },
             "irb" : {
-              "definitionLines" : "82-86,88",
+              "definitionLines" : "52,82-90,103",
               "numReferrers" : 3
             },
             "irb.100" : {
-              "definitionLines" : "83-86,88",
+              "definitionLines" : "52,82-90,103",
               "numReferrers" : 3
             },
             "lo0" : {
-              "definitionLines" : "91-94,97-99",
+              "definitionLines" : "52,91-103",
               "numReferrers" : 2
             },
             "lo0.0" : {
-              "definitionLines" : "92-94",
+              "definitionLines" : "52,91-96,102-103",
               "numReferrers" : 3
             },
             "lo0.1" : {
-              "definitionLines" : "97-99",
+              "definitionLines" : "52,91,97-103",
               "numReferrers" : 2
             },
             "xe-0/0/2" : {
-              "definitionLines" : "53-56",
+              "definitionLines" : "52-59,103",
               "numReferrers" : 1
             },
             "xe-0/0/2.0" : {
-              "definitionLines" : "54-56",
+              "definitionLines" : "52-59,103",
               "numReferrers" : 1
             },
             "xe-0/0/3" : {
-              "definitionLines" : "60-63",
+              "definitionLines" : "52,60-66,103",
               "numReferrers" : 1
             },
             "xe-0/0/3.0" : {
-              "definitionLines" : "61-63",
+              "definitionLines" : "52,60-66,103",
               "numReferrers" : 1
             },
             "xe-0/0/4" : {
-              "definitionLines" : "67-71",
+              "definitionLines" : "52,67-74,103",
               "numReferrers" : 2
             },
             "xe-0/0/4.0" : {
-              "definitionLines" : "69-71",
+              "definitionLines" : "52,67,69-74,103",
               "numReferrers" : 1
             }
           },
           "policy-statement" : {
             "export-loopback" : {
-              "definitionLines" : "161-164",
+              "definitionLines" : "160-166,194",
               "numReferrers" : 1
             },
             "fabric" : {
-              "definitionLines" : "167-171,173,175-177,179-181",
+              "definitionLines" : "160,167-183,194",
               "numReferrers" : 1
             },
             "lbpp" : {
-              "definitionLines" : "184-187",
+              "definitionLines" : "160,184-190,194",
               "numReferrers" : 1
             }
           },
           "policy-statement term" : {
             "export-loopback lo0" : {
-              "definitionLines" : "162-164",
+              "definitionLines" : "160-166,194",
               "numReferrers" : 2
             },
             "fabric fabric" : {
-              "definitionLines" : "168-171,173",
+              "definitionLines" : "160,167-174,183,194",
               "numReferrers" : 3
             },
             "fabric vni-100" : {
-              "definitionLines" : "175-177",
+              "definitionLines" : "160,167,175-178,183,194",
               "numReferrers" : 2
             },
             "fabric vni-101" : {
-              "definitionLines" : "179-181",
+              "definitionLines" : "160,167,179-183,194",
               "numReferrers" : 2
             },
             "lbpp 1" : {
-              "definitionLines" : "185-187",
+              "definitionLines" : "160,184-190,194",
               "numReferrers" : 1
             }
           },
           "routing-instance" : {
             "fabric" : {
-              "definitionLines" : "200-211,213-214,217-218,221-226,229-233",
+              "definitionLines" : "195,200-238",
               "numReferrers" : 17
             },
             "vr" : {
-              "definitionLines" : "196-198",
+              "definitionLines" : "195-199,238",
               "numReferrers" : 2
             }
           }


### PR DESCRIPTION
- Record Juniper structure definition lines not determinable from the flattened parse tree, including:
  - multiline comments
  - close braces
  - close brackets
  - ancestor lines' multiline comments and close braces