### PR TITLE
IBDP: also free handle to Fib

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -367,6 +367,7 @@ final class IncrementalBdpEngine {
           }
 
           updateLayer3Vnis(vrs);
+          currentDataplane = null; // free the old one
           currentDataplane = nextDataplane(currentTopologyContext, nodes, vrs, currentIpOwners);
           TopologyContext nextTopologyContext =
               nextTopologyContext(


### PR DESCRIPTION
So that clearing it in VirtualRouter can do the right thing.