### PR TITLE
BDD tracing

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -104,13 +104,31 @@ public class BDDPacket {
   private final Supplier<BDDFlowConstraintGenerator> _flowConstraintGeneratorSupplier =
       Suppliers.memoize(() -> new BDDFlowConstraintGenerator(this));
 
-  /*
-   * Creates a collection of BDD variables representing the
-   * various attributes of a control plane advertisement.
+  public static JFactory defaultJFactory(boolean tracing) {
+    JFactory factory =
+        (JFactory)
+            JFactory.init(JFACTORY_INITIAL_NODE_TABLE_SIZE, JFACTORY_INITIAL_NODE_CACHE_SIZE);
+    factory.setCacheRatio(JFACTORY_CACHE_RATIO);
+    if (tracing) {
+      factory.enableTracing();
+    }
+    return factory;
+  }
+
+  /**
+   * Creates a collection of BDD variables representing the various attributes of a control plane
+   * advertisement.
    */
   public BDDPacket() {
-    _factory = JFactory.init(JFACTORY_INITIAL_NODE_TABLE_SIZE, JFACTORY_INITIAL_NODE_CACHE_SIZE);
-    _factory.setCacheRatio(JFACTORY_CACHE_RATIO);
+    this(defaultJFactory(false));
+  }
+
+  /**
+   * Creates a collection of BDD variables representing the various attributes of a control plane
+   * advertisement using the given existing {@link JFactory}.
+   */
+  public BDDPacket(JFactory factory) {
+    _factory = factory;
     // Make sure we have the right number of variables
     int numNeeded =
         IP_LENGTH * 2
@@ -229,7 +247,9 @@ public class BDDPacket {
     return _srcIpSpaceToBDD;
   }
 
-  /** @return The {@link BDDFactory} used by this packet. */
+  /**
+   * @return The {@link BDDFactory} used by this packet.
+   */
   public BDDFactory getFactory() {
     return _factory;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -247,9 +247,7 @@ public class BDDPacket {
     return _srcIpSpaceToBDD;
   }
 
-  /**
-   * @return The {@link BDDFactory} used by this packet.
-   */
+  /** @return The {@link BDDFactory} used by this packet. */
   public BDDFactory getFactory() {
     return _factory;
   }

--- a/projects/batfish/src/main/java/org/batfish/allinone/bdd/main/ReplayBDDTrace.java
+++ b/projects/batfish/src/main/java/org/batfish/allinone/bdd/main/ReplayBDDTrace.java
@@ -20,7 +20,7 @@ public final class ReplayBDDTrace {
       inputPath = Paths.get(wd).resolve(inputPath);
     }
 
-    JFactory factory = BDDPacket.defaultJFactory();
+    JFactory factory = BDDPacket.defaultJFactory(false);
     factory.replayTrace(inputPath);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/allinone/bdd/main/ReplayBDDTrace.java
+++ b/projects/batfish/src/main/java/org/batfish/allinone/bdd/main/ReplayBDDTrace.java
@@ -1,0 +1,26 @@
+package org.batfish.allinone.bdd.main;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import net.sf.javabdd.JFactory;
+import org.batfish.common.bdd.BDDPacket;
+
+/** Replays a BDD trace. */
+public final class ReplayBDDTrace {
+  public static void main(String[] args) throws IOException, ClassNotFoundException {
+    checkArgument(args.length == 1, "Expected arguments: <trace file>");
+    Path inputPath = Paths.get(args[0]);
+
+    // Bazel: resolve relative to current working directory. No-op if paths are already absolute.
+    String wd = System.getenv("BUILD_WORKING_DIRECTORY");
+    if (wd != null) {
+      inputPath = Paths.get(wd).resolve(inputPath);
+    }
+
+    JFactory factory = BDDPacket.defaultJFactory();
+    factory.replayTrace(inputPath);
+  }
+}

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
@@ -1903,16 +1903,8 @@ public abstract class BDD {
     }
   }
 
-  /**
-   * Frees this BDD. Further use of this BDD will result in an exception being thrown.
-   *
-   * <p>Meant for use exclusively as a public API. See {@link #freeInternal()} for internal
-   * operations that also need to free a BDD.
-   */
+  /** Frees this BDD. Further use of this BDD will result in an exception being thrown. */
   public abstract void free();
-
-  /** Like {@link #free()}, but for calls from inside a {@link BDDFactory itself}. */
-  protected abstract void freeInternal();
 
   /** Protected constructor. */
   protected BDD() {}

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
@@ -141,6 +141,33 @@ public abstract class BDDFactory {
   /** Inverse implication. */
   public static final BDDOp invimp = new BDDOp(9, "invimp");
 
+  public BDDOp getOp(int op) {
+    switch (op) {
+      case 0:
+        return and;
+      case 1:
+        return xor;
+      case 2:
+        return or;
+      case 3:
+        return nand;
+      case 4:
+        return nor;
+      case 5:
+        return imp;
+      case 6:
+        return biimp;
+      case 7:
+        return diff;
+      case 8:
+        return less;
+      case 9:
+        return invimp;
+      default:
+        throw new IllegalArgumentException(Integer.toString(op));
+    }
+  }
+
   /**
    * Enumeration class for binary operations on BDDs. Use the static fields in BDDFactory to access
    * the different binary operations.
@@ -246,17 +273,6 @@ public abstract class BDDFactory {
    * @return true if this BDD factory is initialized
    */
   public abstract boolean isInitialized();
-
-  /**
-   * Sets the error condition. This will cause the BDD package to throw an exception at the next
-   * garbage collection.
-   *
-   * @param code the error code to set
-   */
-  public abstract void setError(int code);
-
-  /** Clears any outstanding error condition. */
-  public abstract void clearError();
 
   /** ** CACHE/TABLE PARAMETERS *** */
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -18,6 +18,7 @@ java_binary(
     runtime_deps = [
         "//projects/allinone",
         "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
 )
 
@@ -27,5 +28,16 @@ java_binary(
     runtime_deps = [
         "//projects/allinone",
         "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ],
+)
+
+java_binary(
+    name = "replay_bdd_trace",
+    main_class = "org.batfish.allinone.bdd.main.ReplayBDDTrace",
+    runtime_deps = [
+        "//projects/allinone",
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
 )


### PR DESCRIPTION
Draft PR with two different tracing implementations.

1/ Inside JFactory and BDDImpl itself
2/ Using a wrapper BDD class. This removes the need for `freeInternal`, and reverts it.

thoughts?