### PR TITLE
Add support for recording HSRP/VRRP election data

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -3,6 +3,8 @@ package org.batfish.common.topology;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.IpOwnersBaseImpl.ElectionDetails;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.Prefix;
@@ -66,4 +68,12 @@ public interface IpOwners {
    */
   @Nonnull
   Map<String, Map<String, Map<String, IpSpace>>> getVrfIfaceOwnedIpSpaces();
+
+  /** Returns election data for HSRP, if recorded. */
+  @Nullable
+  ElectionDetails getHsrpElectionDetails();
+
+  /** Returns election data for VRRP, if recorded. */
+  @Nullable
+  ElectionDetails getVrrpElectionDetails();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwnersBaseImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwnersBaseImpl.java
@@ -110,6 +110,14 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
         _winnerByCandidate;
   }
 
+  // TODO: remove once downstream projects are migrated
+  protected IpOwnersBaseImpl(
+      Map<String, Configuration> configurations,
+      L3Adjacencies l3Adjacencies,
+      TrackMethodEvaluatorProvider trackMethodEvaluatorProvider) {
+    this(configurations, l3Adjacencies, trackMethodEvaluatorProvider, false);
+  }
+
   /**
    * Compute IP owners based on information in configurations, layer-3 adjencies, and a provider for
    * methods to evaluate track methods affecting HSRP/VRRP priorities.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwnersBaseImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwnersBaseImpl.java
@@ -1,6 +1,7 @@
 package org.batfish.common.topology;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.Maps.immutableEntry;
 import static org.batfish.common.topology.TopologyUtil.computeNodeInterfaces;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
@@ -50,6 +51,65 @@ import org.batfish.datamodel.tracking.TrackMethodEvaluatorProvider;
 @ParametersAreNonnullByDefault
 public abstract class IpOwnersBaseImpl implements IpOwners {
 
+  /** Details of HSRP or VRRP elections. */
+  public static class ElectionDetails {
+
+    /** Map: interface -> VRRP/HSRP group -> actual priority after tracks are applied */
+    public @Nonnull Map<NodeInterfacePair, Map<Integer, Integer>> getActualPriorities() {
+      return _actualPriorities;
+    }
+
+    /**
+     * Map: interface -> VRRP/HSRP group -> successful track method name -> (track method, track
+     * action)
+     */
+    public @Nonnull Map<
+            NodeInterfacePair, Map<Integer, Map<String, Entry<TrackMethod, TrackAction>>>>
+        getSuccessfulTracks() {
+      return _successfulTracks;
+    }
+
+    /** Map: interface -> VRRP/HSRP group -> election winner */
+    public @Nonnull Map<NodeInterfacePair, Map<Integer, NodeInterfacePair>> getWinnerByCandidate() {
+      return _winnerByCandidate;
+    }
+
+    /** Map: interface -> VRRP/HSRP group -> election candidates */
+    public @Nonnull Map<NodeInterfacePair, Map<Integer, Set<NodeInterfacePair>>>
+        getCandidatesByCandidate() {
+      return _candidatesByCandidate;
+    }
+
+    /**
+     * Map: interface -> VRRP/HSRP group -> failed track method name -> (track method, track action)
+     */
+    public @Nonnull Map<
+            NodeInterfacePair, Map<Integer, Map<String, Entry<TrackMethod, TrackAction>>>>
+        getFailedTracks() {
+      return _failedTracks;
+    }
+
+    private ElectionDetails() {
+      _actualPriorities = new HashMap<>();
+      _successfulTracks = new HashMap<>();
+      _failedTracks = new HashMap<>();
+      _candidatesByCandidate = new HashMap<>();
+      _winnerByCandidate = new HashMap<>();
+    }
+
+    private final @Nonnull Map<NodeInterfacePair, Map<Integer, Integer>> _actualPriorities;
+    private final @Nonnull Map<
+            NodeInterfacePair, Map<Integer, Map<String, Entry<TrackMethod, TrackAction>>>>
+        _successfulTracks;
+    private final @Nonnull Map<
+            NodeInterfacePair, Map<Integer, Map<String, Entry<TrackMethod, TrackAction>>>>
+        _failedTracks;
+    private final @Nonnull Map<NodeInterfacePair, Map<Integer, Set<NodeInterfacePair>>>
+        _candidatesByCandidate;
+    private final @Nonnull Map<NodeInterfacePair, Map<Integer, NodeInterfacePair>>
+        _winnerByCandidate;
+  }
+
   /**
    * Compute IP owners based on information in configurations, layer-3 adjencies, and a provider for
    * methods to evaluate track methods affecting HSRP/VRRP priorities.
@@ -66,7 +126,16 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
   protected IpOwnersBaseImpl(
       Map<String, Configuration> configurations,
       L3Adjacencies l3Adjacencies,
-      TrackMethodEvaluatorProvider trackMethodEvaluatorProvider) {
+      TrackMethodEvaluatorProvider trackMethodEvaluatorProvider,
+      boolean recordElections) {
+    if (recordElections) {
+      _hsrpElectionDetails = new ElectionDetails();
+      _vrrpElectionDetails = new ElectionDetails();
+    } else {
+      _hsrpElectionDetails = null;
+      _vrrpElectionDetails = null;
+    }
+
     /* Mapping from a hostname to a set of all (including inactive) interfaces that node owns */
     Map<String, Set<Interface>> allInterfaces =
         ImmutableMap.copyOf(computeNodeInterfaces(configurations));
@@ -79,7 +148,9 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
                   false,
                   l3Adjacencies,
                   NetworkConfigurations.of(configurations),
-                  trackMethodEvaluatorProvider));
+                  trackMethodEvaluatorProvider,
+                  null,
+                  null));
       _activeDeviceOwnedIps =
           ImmutableMap.copyOf(
               computeIpInterfaceOwners(
@@ -87,7 +158,9 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
                   true,
                   l3Adjacencies,
                   NetworkConfigurations.of(configurations),
-                  trackMethodEvaluatorProvider));
+                  trackMethodEvaluatorProvider,
+                  _hsrpElectionDetails,
+                  _vrrpElectionDetails));
     }
 
     {
@@ -101,6 +174,16 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
       _hostToInterfaceToIpSpace = computeInterfaceOwnedIpSpaces(_hostToVrfToInterfaceToIpSpace);
       _allInterfaceHostIps = computeInterfaceHostSubnetIps(configurations, false);
     }
+  }
+
+  @Override
+  public @Nullable ElectionDetails getHsrpElectionDetails() {
+    return _hsrpElectionDetails;
+  }
+
+  @Override
+  public @Nullable ElectionDetails getVrrpElectionDetails() {
+    return _vrrpElectionDetails;
   }
 
   @Override
@@ -258,7 +341,9 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
       boolean excludeInactive,
       L3Adjacencies l3Adjacencies,
       NetworkConfigurations nc,
-      TrackMethodEvaluatorProvider provider) {
+      TrackMethodEvaluatorProvider provider,
+      @Nullable ElectionDetails hsrpElectionDetails,
+      @Nullable ElectionDetails vrrpElectionDetails) {
     Map<Ip, Map<String, Set<String>>> ipOwners = new HashMap<>();
     // vrid -> sync interface -> interface to own IPs if sync interface wins election -> IPs
     Map<Integer, Map<NodeInterfacePair, Map<String, Set<Ip>>>> vrrpGroups = new HashMap<>();
@@ -283,8 +368,8 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
                                   .computeIfAbsent(hostname, k -> new HashSet<>())
                                   .add(i.getName()));
                 }));
-    processVrrpGroups(ipOwners, vrrpGroups, l3Adjacencies, nc, provider);
-    processHsrpGroups(ipOwners, hsrpGroups, l3Adjacencies, nc, provider);
+    processVrrpGroups(ipOwners, vrrpGroups, l3Adjacencies, nc, provider, vrrpElectionDetails);
+    processHsrpGroups(ipOwners, hsrpGroups, l3Adjacencies, nc, provider, hsrpElectionDetails);
 
     // freeze
     return toImmutableMap(
@@ -342,12 +427,9 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
               }
               ips.forEach(
                   ip -> {
-                    Map<NodeInterfacePair, Set<Ip>> candidates = hsrpGroups.get(groupNum);
-                    if (candidates == null) {
-                      candidates = new HashMap<>();
-                      hsrpGroups.put(groupNum, candidates);
-                    }
-                    candidates.put(NodeInterfacePair.of(i), hsrpGroup.getVirtualAddresses());
+                    hsrpGroups
+                        .computeIfAbsent(groupNum, k -> new HashMap<>())
+                        .put(NodeInterfacePair.of(i), hsrpGroup.getVirtualAddresses());
                   });
             });
   }
@@ -362,7 +444,8 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
       Map<Integer, Map<NodeInterfacePair, Set<Ip>>> hsrpGroups,
       L3Adjacencies l3Adjacencies,
       NetworkConfigurations nc,
-      TrackMethodEvaluatorProvider provider) {
+      TrackMethodEvaluatorProvider provider,
+      @Nullable ElectionDetails electionDetails) {
     hsrpGroups.forEach(
         (groupNum, ipSpaceByCandidate) -> {
           assert groupNum != null;
@@ -393,9 +476,26 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
                             Comparator.comparingInt(
                                     (Interface o) ->
                                         computeHsrpPriority(
-                                            o, o.getHsrpGroups().get(groupNum), provider))
+                                            o,
+                                            o.getHsrpGroups().get(groupNum),
+                                            groupNum,
+                                            provider,
+                                            electionDetails))
                                 .thenComparing(o -> o.getConcreteAddress().getIp())
                                 .thenComparing(o -> NodeInterfacePair.of(o))));
+                if (electionDetails != null) {
+                  cp.forEach(
+                      ni -> {
+                        electionDetails
+                            ._winnerByCandidate
+                            .computeIfAbsent(ni, n -> new HashMap<>())
+                            .put(groupNum, hsrpMaster);
+                        electionDetails
+                            ._candidatesByCandidate
+                            .computeIfAbsent(ni, n -> new HashMap<>())
+                            .put(groupNum, ImmutableSet.copyOf(cp));
+                      });
+                }
                 LOGGER.debug(
                     "{} elected HSRP master for groupNum {} among candidates {}",
                     hsrpMaster,
@@ -416,15 +516,25 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
   /** Compute priority for a given HSRP group and the interface it is associated with. */
   @VisibleForTesting
   static int computeHsrpPriority(
-      @Nonnull Interface iface, @Nonnull HsrpGroup group, TrackMethodEvaluatorProvider provider) {
-    return computePriority(iface, group.getPriority(), group.getTrackActions(), provider);
+      Interface iface,
+      HsrpGroup group,
+      int groupNum,
+      TrackMethodEvaluatorProvider provider,
+      @Nullable ElectionDetails electionDetails) {
+    return computePriority(
+        iface, group.getPriority(), groupNum, group.getTrackActions(), provider, electionDetails);
   }
 
   /** Compute priority for a given VRRP group and the interface it is associated with. */
   @VisibleForTesting
   static int computeVrrpPriority(
-      @Nonnull Interface iface, @Nonnull VrrpGroup group, TrackMethodEvaluatorProvider provider) {
-    return computePriority(iface, group.getPriority(), group.getTrackActions(), provider);
+      Interface iface,
+      VrrpGroup group,
+      int vrid,
+      TrackMethodEvaluatorProvider provider,
+      @Nullable ElectionDetails electionDetails) {
+    return computePriority(
+        iface, group.getPriority(), vrid, group.getTrackActions(), provider, electionDetails);
   }
 
   /**
@@ -460,12 +570,9 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
                 return;
               }
               // sync interface -> interface to receive IPs -> IPs
-              Map<NodeInterfacePair, Map<String, Set<Ip>>> candidates = vrrpGroups.get(vrid);
-              if (candidates == null) {
-                candidates = new HashMap<>();
-                vrrpGroups.put(vrid, candidates);
-              }
-              candidates.put(NodeInterfacePair.of(i), vrrpGroup.getVirtualAddresses());
+              vrrpGroups
+                  .computeIfAbsent(vrid, k -> new HashMap<>())
+                  .put(NodeInterfacePair.of(i), vrrpGroup.getVirtualAddresses());
             });
   }
 
@@ -479,7 +586,8 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
       Map<Integer, Map<NodeInterfacePair, Map<String, Set<Ip>>>> vrrpGroups,
       L3Adjacencies l3Adjacencies,
       NetworkConfigurations nc,
-      TrackMethodEvaluatorProvider provider) {
+      TrackMethodEvaluatorProvider provider,
+      @Nullable ElectionDetails electionDetails) {
     vrrpGroups.forEach(
         (vrid, ipSpaceByCandidate) -> {
           assert vrid != null;
@@ -510,9 +618,26 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
                             Comparator.comparingInt(
                                     (Interface o) ->
                                         computeVrrpPriority(
-                                            o, o.getVrrpGroups().get(vrid), provider))
+                                            o,
+                                            o.getVrrpGroups().get(vrid),
+                                            vrid,
+                                            provider,
+                                            electionDetails))
                                 .thenComparing(o -> o.getConcreteAddress().getIp())
                                 .thenComparing(o -> NodeInterfacePair.of(o))));
+                if (electionDetails != null) {
+                  cp.forEach(
+                      ni -> {
+                        electionDetails
+                            ._winnerByCandidate
+                            .computeIfAbsent(ni, n -> new HashMap<>())
+                            .put(vrid, vrrpMaster);
+                        electionDetails
+                            ._candidatesByCandidate
+                            .computeIfAbsent(ni, n -> new HashMap<>())
+                            .put(vrid, ImmutableSet.copyOf(cp));
+                      });
+                }
                 LOGGER.debug(
                     "{} elected VRRP master for vrid {} among candidates {}",
                     vrrpMaster,
@@ -656,23 +781,61 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
   /** Mapping from an IP to hostname to set of VRFs that own that IP. */
   private final @Nonnull Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
 
+  private final @Nullable ElectionDetails _hsrpElectionDetails;
+  private final @Nullable ElectionDetails _vrrpElectionDetails;
+
   private static int computePriority(
       @Nonnull Interface iface,
       int initialPriority,
+      int groupOrVrid,
       @Nonnull Map<String, TrackAction> trackActions,
-      TrackMethodEvaluatorProvider provider) {
+      TrackMethodEvaluatorProvider provider,
+      @Nullable ElectionDetails electionDetails) {
     Configuration c = iface.getOwner();
     Map<String, TrackMethod> trackMethods = c.getTrackingGroups();
     GenericTrackMethodVisitor<Boolean> trackMethodEvaluator = provider.forConfiguration(c);
     PriorityEvaluator evaluator = new PriorityEvaluator(initialPriority);
+    Map<String, Entry<TrackMethod, TrackAction>> successfulTracks;
+    Map<String, Entry<TrackMethod, TrackAction>> failedTracks;
+    NodeInterfacePair ni;
+    if (electionDetails != null) {
+      ni = NodeInterfacePair.of(iface);
+      successfulTracks =
+          electionDetails
+              ._successfulTracks
+              .computeIfAbsent(ni, n -> new HashMap<>())
+              .computeIfAbsent(groupOrVrid, g -> new HashMap<>());
+      failedTracks =
+          electionDetails
+              ._failedTracks
+              .computeIfAbsent(ni, n -> new HashMap<>())
+              .computeIfAbsent(groupOrVrid, g -> new HashMap<>());
+    } else {
+      ni = null;
+      successfulTracks = null;
+      failedTracks = null;
+    }
     trackActions.forEach(
         (trackName, action) -> {
           TrackMethod trackMethod = trackMethods.get(trackName);
-          if (trackMethod != null && (trackMethod.accept(trackMethodEvaluator))) {
+          assert trackMethod != null;
+          if (trackMethod.accept(trackMethodEvaluator)) {
             action.accept(evaluator);
+            if (electionDetails != null) {
+              successfulTracks.put(trackName, immutableEntry(trackMethod, action));
+            }
+          } else if (electionDetails != null) {
+            failedTracks.put(trackName, immutableEntry(trackMethod, action));
           }
         });
-    return evaluator.getPriority();
+    int actualPriority = evaluator.getPriority();
+    if (electionDetails != null) {
+      electionDetails
+          ._actualPriorities
+          .computeIfAbsent(ni, n -> new HashMap<>())
+          .put(groupOrVrid, actualPriority);
+    }
+    return actualPriority;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -161,7 +161,8 @@ public class IBatfishTestAdapter implements IBatfish {
         super(
             _batfish.loadConfigurations(snapshot),
             getInitialL3Adjacencies(snapshot),
-            PreDataPlaneTrackMethodEvaluator::new);
+            PreDataPlaneTrackMethodEvaluator::new,
+            false);
       }
     }
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersBaseImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersBaseImplTest.java
@@ -535,7 +535,6 @@ public class IpOwnersBaseImplTest {
     int basePriority = 100;
     int track1Decrement = 50; // never applied
     int track2Decrement = 25; // always applied
-    int track3Decrement = 10; // not applied, since track method undefined
 
     Configuration c1 =
         Configuration.builder()
@@ -550,10 +549,7 @@ public class IpOwnersBaseImplTest {
                     "1", // never applied
                     new DecrementPriority(track1Decrement),
                     "2", // always applied
-                    new DecrementPriority(track2Decrement),
-                    "3", // undefined
-                    new DecrementPriority(track3Decrement)))
-            .setVirtualAddresses(ImmutableSet.of(Ip.parse("10.10.10.1")))
+                    new DecrementPriority(track2Decrement)))
             .build();
     Interface i1 =
         Interface.builder()
@@ -581,7 +577,6 @@ public class IpOwnersBaseImplTest {
     int basePriority = 100;
     int track1Decrement = 50; // never applied
     int track2Decrement = 25; // always applied
-    int track3Decrement = 10; // not applied, since track method undefined
 
     Configuration c1 =
         Configuration.builder()
@@ -596,9 +591,7 @@ public class IpOwnersBaseImplTest {
                     "1", // never applied
                     new DecrementPriority(track1Decrement),
                     "2", // always applied
-                    new DecrementPriority(track2Decrement),
-                    "3", // undefined
-                    new DecrementPriority(track3Decrement)))
+                    new DecrementPriority(track2Decrement)))
             .addVirtualAddress("i1", Ip.parse("10.10.10.1"))
             .build();
     Interface i1 =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -1481,14 +1481,26 @@ public final class TopologyUtilTest {
 
     assertThat(
         computeIpInterfaceOwners(
-            nodeInterfaces, true, null, nc, PreDataPlaneTrackMethodEvaluator::new),
+            nodeInterfaces,
+            true,
+            GlobalBroadcastNoPointToPoint.instance(),
+            nc,
+            PreDataPlaneTrackMethodEvaluator::new,
+            null,
+            null),
         equalTo(
             ImmutableMap.of(
                 Ip.parse("1.1.1.1"), ImmutableMap.of("node", ImmutableSet.of("active")))));
 
     assertThat(
         computeIpInterfaceOwners(
-            nodeInterfaces, false, null, nc, PreDataPlaneTrackMethodEvaluator::new),
+            nodeInterfaces,
+            false,
+            GlobalBroadcastNoPointToPoint.instance(),
+            nc,
+            PreDataPlaneTrackMethodEvaluator::new,
+            null,
+            null),
         equalTo(
             ImmutableMap.of(
                 Ip.parse("1.1.1.1"),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/VrrpComputationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/VrrpComputationTest.java
@@ -141,7 +141,8 @@ public class VrrpComputationTest {
       super(
           configurations,
           GlobalBroadcastNoPointToPoint.instance(),
-          PreDataPlaneTrackMethodEvaluator::new);
+          PreDataPlaneTrackMethodEvaluator::new,
+          false);
     }
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -1552,7 +1552,8 @@ public class ForwardingAnalysisImplTest {
       super(
           configurations,
           GlobalBroadcastNoPointToPoint.instance(),
-          PreDataPlaneTrackMethodEvaluator::new);
+          PreDataPlaneTrackMethodEvaluator::new,
+          false);
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataPlaneIpOwners.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataPlaneIpOwners.java
@@ -22,6 +22,6 @@ final class DataPlaneIpOwners extends IpOwnersBaseImpl {
       Map<String, Configuration> configurations,
       L3Adjacencies l3Adjacencies,
       DataPlaneTrackMethodEvaluatorProvider trackMethodEvaluatorProvider) {
-    super(configurations, l3Adjacencies, trackMethodEvaluatorProvider);
+    super(configurations, l3Adjacencies, trackMethodEvaluatorProvider, false);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -48,7 +48,6 @@ import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.TunnelTopology;
 import org.batfish.common.topology.broadcast.BroadcastL3Adjacencies;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
@@ -75,6 +74,7 @@ import org.batfish.dataplane.TracerouteEngineImpl;
 import org.batfish.dataplane.ibdp.DataplaneTrackEvaluator.DataPlaneTrackMethodEvaluatorProvider;
 import org.batfish.dataplane.ibdp.schedule.IbdpSchedule;
 import org.batfish.dataplane.ibdp.schedule.IbdpSchedule.Schedule;
+import org.batfish.dataplane.rib.Rib;
 import org.batfish.dataplane.rib.RibDelta;
 import org.batfish.version.BatfishVersion;
 
@@ -620,17 +620,8 @@ final class IncrementalBdpEngine {
 
   @VisibleForTesting
   static boolean evaluateTrackRoute(TrackRoute trackRoute, Node node) {
-    Set<AnnotatedRoute<AbstractRoute>> routesForPrefix =
-        node.getVirtualRouter(trackRoute.getVrf())
-            .get()
-            .getMainRib()
-            .getRoutes(trackRoute.getPrefix());
-    if (trackRoute.getProtocols().isEmpty()) {
-      return !routesForPrefix.isEmpty();
-    } else {
-      return routesForPrefix.stream()
-          .anyMatch(r -> trackRoute.getProtocols().contains(r.getRoute().getProtocol()));
-    }
+    Rib rib = node.getVirtualRouter(trackRoute.getVrf()).get().getMainRib();
+    return TrackRouteUtils.evaluateTrackRoute(trackRoute, rib);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TrackReachabilityUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TrackReachabilityUtils.java
@@ -38,7 +38,7 @@ public final class TrackReachabilityUtils {
    * <p>The originating node's FIBs and the starting VRF in the provided {@link TrackReachability}
    * are used to determine potential source IPs for the test flow(s).
    */
-  static boolean evaluateTrackReachability(
+  public static boolean evaluateTrackReachability(
       TrackReachability trackReachability,
       Configuration c,
       Map<String, Fib> fibsByVrf,

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TrackRouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TrackRouteUtils.java
@@ -1,0 +1,25 @@
+package org.batfish.dataplane.ibdp;
+
+import java.util.Set;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.tracking.TrackRoute;
+
+/** Utilities for evaluating {@link TrackRoute}. */
+public final class TrackRouteUtils {
+
+  /** Evaluates a {@link TrackRoute} given a {@code rib}. */
+  public static boolean evaluateTrackRoute(
+      TrackRoute trackRoute, GenericRib<AnnotatedRoute<AbstractRoute>> rib) {
+    Set<AnnotatedRoute<AbstractRoute>> routesForPrefix = rib.getRoutes(trackRoute.getPrefix());
+    if (trackRoute.getProtocols().isEmpty()) {
+      return !routesForPrefix.isEmpty();
+    } else {
+      return routesForPrefix.stream()
+          .anyMatch(r -> trackRoute.getProtocols().contains(r.getRoute().getProtocol()));
+    }
+  }
+
+  private TrackRouteUtils() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/topology/PreDataPlaneIpOwners.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/PreDataPlaneIpOwners.java
@@ -28,6 +28,6 @@ import org.batfish.datamodel.tracking.PreDataPlaneTrackMethodEvaluator;
 final class PreDataPlaneIpOwners extends IpOwnersBaseImpl {
 
   PreDataPlaneIpOwners(Map<String, Configuration> configurations, L3Adjacencies l3Adjacencies) {
-    super(configurations, l3Adjacencies, PreDataPlaneTrackMethodEvaluator::new);
+    super(configurations, l3Adjacencies, PreDataPlaneTrackMethodEvaluator::new, false);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
@@ -518,7 +518,7 @@ public final class FixedPointTopologyTest {
   private static class TestIpOwners extends IpOwnersBaseImpl {
     protected TestIpOwners(
         Map<String, Configuration> configurations, L3Adjacencies initialL3Adjacencies) {
-      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new);
+      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new, false);
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalBdpEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalBdpEngineTest.java
@@ -468,7 +468,8 @@ public final class IncrementalBdpEngineTest {
       super(
           configurations,
           GlobalBroadcastNoPointToPoint.instance(),
-          PreDataPlaneTrackMethodEvaluator::new);
+          PreDataPlaneTrackMethodEvaluator::new,
+          false);
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -1146,7 +1146,7 @@ public class IncrementalDataPlanePluginTest {
   private static class TestIpOwners extends IpOwnersBaseImpl {
     protected TestIpOwners(
         Map<String, Configuration> configurations, L3Adjacencies initialL3Adjacencies) {
-      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new);
+      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new, false);
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -756,7 +756,7 @@ public class IsisTest {
   private static class TestIpOwners extends IpOwnersBaseImpl {
     protected TestIpOwners(
         Map<String, Configuration> configurations, L3Adjacencies initialL3Adjacencies) {
-      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new);
+      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new, false);
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -1364,7 +1364,7 @@ public class OspfTest {
   private static class TestIpOwners extends IpOwnersBaseImpl {
     protected TestIpOwners(
         Map<String, Configuration> configurations, L3Adjacencies initialL3Adjacencies) {
-      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new);
+      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new, false);
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -484,7 +484,7 @@ public class RouteReflectionTest {
   private static class TestIpOwners extends IpOwnersBaseImpl {
     protected TestIpOwners(
         Map<String, Configuration> configurations, L3Adjacencies initialL3Adjacencies) {
-      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new);
+      super(configurations, initialL3Adjacencies, PreDataPlaneTrackMethodEvaluator::new, false);
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -976,7 +976,8 @@ public class VirtualRouterTest {
       super(
           configurations,
           GlobalBroadcastNoPointToPoint.instance(),
-          PreDataPlaneTrackMethodEvaluator::new);
+          PreDataPlaneTrackMethodEvaluator::new,
+          false);
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
@@ -229,7 +229,8 @@ public class NodeColoredScheduleTest {
       super(
           configurations,
           GlobalBroadcastNoPointToPoint.instance(),
-          PreDataPlaneTrackMethodEvaluator::new);
+          PreDataPlaneTrackMethodEvaluator::new,
+          false);
     }
   }
 }


### PR DESCRIPTION
- add APIs and implementation for recording of detailed HSRP/VRRP election data
- factor out route and reachability tracking code so it may be used by post-dataplane clients
- remove VRRP references to undefined track methods in post-processing