### PR TITLE
Cisco IOS implement route-map set as-path replace

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
@@ -93,6 +93,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultTag;
@@ -677,6 +678,11 @@ public final class CommunityStructuresVerifier {
       if1.getFalseStatements().stream().forEach(s -> s.accept(this, arg));
       if1.getTrueStatements().stream().forEach(s -> s.accept(this, arg));
       if1.getGuard().accept(BOOLEAN_EXPR_VERIFIER, arg);
+      return null;
+    }
+
+    @Override
+    public Void visitReplaceAsesInAsSequence(ReplaceAsesInAsSequence replaceAsesInAsPathSequence) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
@@ -48,6 +48,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultTag;
@@ -414,6 +415,11 @@ public final class AsPathStructuresVerifier {
     @Override
     public Void visitPrependAsPath(
         PrependAsPath prependAsPath, AsPathStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitReplaceAsesInAsSequence(ReplaceAsesInAsSequence replaceAsesInAsPathSequence) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/ReplaceAsesInAsSequence.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/ReplaceAsesInAsSequence.java
@@ -1,0 +1,285 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.AsSet;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.HasWritableAsPath;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+
+/** Replace every AS in a sequence of ASes with some AS */
+@ParametersAreNonnullByDefault
+public final class ReplaceAsesInAsSequence extends Statement {
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+  public interface AsReplacementExpr extends Serializable {
+    <T> T accept(AsReplacementExprVisitor<T> visitor);
+  }
+
+  public interface AsReplacementExprVisitor<T> {
+    default T visit(AsReplacementExpr asReplacementExpr) {
+      return asReplacementExpr.accept(this);
+    }
+
+    T visitLocalAsOrConfedIfNeighborNotInConfed(
+        LocalAsOrConfedIfNeighborNotInConfed localAsOrConfederationIfNeighborInConfederation);
+  }
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+  public interface AsSequenceExpr extends Serializable {
+    <T> T accept(AsSequenceExprVisitor<T> visitor);
+  }
+
+  public interface AsSequenceExprVisitor<T> {
+    default T visit(AsSequenceExpr asSequenceExpr) {
+      return asSequenceExpr.accept(this);
+    }
+
+    T visitAnyAs(AnyAs anyAs);
+
+    T visitAsPathSequence(AsSequence asSequence);
+  }
+
+  private static final class AnyAs implements AsSequenceExpr {
+
+    @Override
+    public <T> T accept(AsSequenceExprVisitor<T> visitor) {
+      return visitor.visitAnyAs(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return this == obj || obj instanceof AnyAs;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0x40BD5B64; // randomly generated
+    }
+
+    @JsonCreator
+    @JsonValue
+    private static @Nonnull AnyAs instance() {
+      return INSTANCE;
+    }
+
+    private static final AnyAs INSTANCE = new AnyAs();
+  }
+
+  public static @Nonnull AsSequenceExpr anyAs() {
+    return AnyAs.instance();
+  }
+
+  private static final class AsSequence implements AsSequenceExpr {
+
+    public AsSequence(List<Long> sequence) {
+      _sequence = sequence;
+    }
+
+    @JsonCreator
+    private static @Nonnull AsSequence create(
+        @JsonProperty(PROP_SEQUENCE) @Nullable List<Long> sequence) {
+      return new AsSequence(ImmutableList.copyOf(firstNonNull(sequence, ImmutableList.of())));
+    }
+
+    @Override
+    public <T> T accept(AsSequenceExprVisitor<T> visitor) {
+      return visitor.visitAsPathSequence(this);
+    }
+
+    @JsonProperty(PROP_SEQUENCE)
+    public @Nonnull List<Long> getSequence() {
+      return _sequence;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof AsSequence)) {
+        return false;
+      }
+      AsSequence that = (AsSequence) o;
+      return _sequence.equals(that._sequence);
+    }
+
+    @Override
+    public int hashCode() {
+      return _sequence.hashCode();
+    }
+
+    private static final String PROP_SEQUENCE = "sequence";
+
+    private final @Nonnull List<Long> _sequence;
+  }
+
+  public static @Nonnull AsSequenceExpr sequenceOf(List<Long> sequence) {
+    checkArgument(!sequence.isEmpty(), "Sequence must be non-empty");
+    return new AsSequence(sequence);
+  }
+
+  public static @Nonnull AsReplacementExpr localAsOrConfedIfNeighborNotInConfed() {
+    return LOCAL_AS_OR_CONFED_IF_NEIGHBOR_NOT_IN_CONFED;
+  }
+
+  private static final @Nonnull AsReplacementExpr LOCAL_AS_OR_CONFED_IF_NEIGHBOR_NOT_IN_CONFED =
+      new LocalAsOrConfedIfNeighborNotInConfed();
+
+  private static final class LocalAsOrConfedIfNeighborNotInConfed implements AsReplacementExpr {
+
+    @Override
+    public <T> T accept(AsReplacementExprVisitor<T> visitor) {
+      return visitor.visitLocalAsOrConfedIfNeighborNotInConfed(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return this == obj || obj instanceof LocalAsOrConfedIfNeighborNotInConfed;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0x340FFF58; // randomly generated
+    }
+
+    @JsonCreator
+    @JsonValue
+    private static @Nonnull LocalAsOrConfedIfNeighborNotInConfed instance() {
+      return INSTANCE;
+    }
+
+    private static final @Nonnull LocalAsOrConfedIfNeighborNotInConfed INSTANCE =
+        new LocalAsOrConfedIfNeighborNotInConfed();
+  }
+
+  public ReplaceAsesInAsSequence(
+      AsSequenceExpr asSequenceExpr, AsReplacementExpr asReplacementExpr) {
+    _asReplacementExpr = asReplacementExpr;
+    _asSequenceExpr = asSequenceExpr;
+  }
+
+  @JsonCreator
+  private static @Nonnull ReplaceAsesInAsSequence create(
+      @JsonProperty(PROP_AS_SEQUENCE_EXPR) @Nullable AsSequenceExpr asSequenceExpr,
+      @JsonProperty(PROP_AS_REPLACEMENT_EXPR) @Nullable AsReplacementExpr asReplacementExpr) {
+    checkArgument(asSequenceExpr != null, "Missing %s", PROP_AS_SEQUENCE_EXPR);
+    checkArgument(asReplacementExpr != null, "Missing %s", PROP_AS_REPLACEMENT_EXPR);
+    return new ReplaceAsesInAsSequence(asSequenceExpr, asReplacementExpr);
+  }
+
+  @JsonProperty(PROP_AS_SEQUENCE_EXPR)
+  public @Nonnull AsSequenceExpr getAsSequenceExpr() {
+    return _asSequenceExpr;
+  }
+
+  @JsonProperty(PROP_AS_REPLACEMENT_EXPR)
+  public @Nonnull AsReplacementExpr getAsReplacementExpr() {
+    return _asReplacementExpr;
+  }
+
+  private static final String PROP_AS_SEQUENCE_EXPR = "asSequenceExpr";
+  private static final String PROP_AS_REPLACEMENT_EXPR = "asReplacementExpr";
+
+  @Override
+  public <T, U> T accept(StatementVisitor<T, U> visitor, U arg) {
+    return visitor.visitReplaceAsesInAsSequence(this);
+  }
+
+  @Override
+  public Result execute(Environment environment) {
+    Optional<Long> maybeReplacementAs = replacement(environment);
+    if (!maybeReplacementAs.isPresent()) {
+      return new Result();
+    }
+    long replacementAs = maybeReplacementAs.get();
+    if ((environment.getOutputRoute() instanceof HasWritableAsPath<?, ?>)) {
+      HasWritableAsPath<?, ?> outputRoute = (HasWritableAsPath<?, ?>) environment.getOutputRoute();
+      outputRoute.setAsPath(replace(outputRoute.getAsPath(), replacementAs));
+
+      if (environment.getWriteToIntermediateBgpAttributes()) {
+        BgpRoute.Builder<?, ?> ir = environment.getIntermediateBgpAttributes();
+        ir.setAsPath(replace(ir.getAsPath(), replacementAs));
+      }
+    }
+    return new Result();
+  }
+
+  private @Nonnull Optional<Long> replacement(Environment environment) {
+    return new AsReplacementExprVisitor<Optional<Long>>() {
+      @Override
+      public Optional<Long> visitLocalAsOrConfedIfNeighborNotInConfed(
+          LocalAsOrConfedIfNeighborNotInConfed localAsOrConfedForNonConfedNeighbor) {
+        // TODO: return confederation if neighbor not in confederation
+        return environment.getLocalAs();
+      }
+    }.visit(_asReplacementExpr);
+  }
+
+  private @Nonnull AsPath replace(AsPath asPath, long replacementAs) {
+    return new AsSequenceExprVisitor<AsPath>() {
+      @Override
+      public AsPath visitAnyAs(AnyAs anyAs) {
+        ImmutableList.Builder<AsSet> newAsSets = ImmutableList.builder();
+        asPath.getAsSets().forEach(unusedAsSet -> newAsSets.add(AsSet.of(replacementAs)));
+        return AsPath.of(newAsSets.build());
+      }
+
+      @Override
+      public AsPath visitAsPathSequence(AsSequence asSequence) {
+        ImmutableList.Builder<AsSet> newAsSets = ImmutableList.builder();
+        List<AsSet> sequenceAsAsSets =
+            asSequence.getSequence().stream()
+                .map(AsSet::of)
+                .collect(ImmutableList.toImmutableList());
+        for (int i = 0; i < asPath.length(); i++) {
+          int end = i + sequenceAsAsSets.size();
+          if (end < asPath.length()
+              && sequenceAsAsSets.equals(asPath.getAsSets().subList(i, end))) {
+            i += (sequenceAsAsSets.size() - 1);
+            for (int j = 0; j < sequenceAsAsSets.size(); j++) {
+              newAsSets.add(AsSet.of(replacementAs));
+            }
+          } else {
+            newAsSets.add(asPath.getAsSets().get(i));
+          }
+        }
+        return AsPath.of(newAsSets.build());
+      }
+    }.visit(_asSequenceExpr);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof ReplaceAsesInAsSequence)) {
+      return false;
+    }
+    ReplaceAsesInAsSequence that = (ReplaceAsesInAsSequence) obj;
+    return _asReplacementExpr.equals(that._asReplacementExpr)
+        && _asSequenceExpr.equals(that._asSequenceExpr);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_asSequenceExpr, _asReplacementExpr);
+  }
+
+  private final @Nonnull AsSequenceExpr _asSequenceExpr;
+  private final @Nonnull AsReplacementExpr _asReplacementExpr;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/StatementVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/StatementVisitor.java
@@ -51,4 +51,6 @@ public interface StatementVisitor<T, U> {
   T visitStaticStatement(StaticStatement staticStatement, U arg);
 
   T visitTraceableStatement(TraceableStatement traceableStatement, U arg);
+
+  T visitReplaceAsesInAsSequence(ReplaceAsesInAsSequence replaceAsesInAsPathSequence);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
@@ -28,7 +28,6 @@ public enum Statements {
   SetReadIntermediateBgpAttributes,
   SetWriteIntermediateBgpAttributes,
   Suppress,
-  UnsetReadIntermediateBgpAttributes,
   UnsetWriteIntermediateBgpAttributes,
   Unsuppress;
 
@@ -152,10 +151,6 @@ public enum Statements {
 
         case Suppress:
           environment.setSuppressed(true);
-          break;
-
-        case UnsetReadIntermediateBgpAttributes:
-          environment.setReadFromIntermediateBgpAttributes(false);
           break;
 
         case UnsetWriteIntermediateBgpAttributes:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
@@ -28,6 +28,7 @@ public enum Statements {
   SetReadIntermediateBgpAttributes,
   SetWriteIntermediateBgpAttributes,
   Suppress,
+  UnsetReadIntermediateBgpAttributes,
   UnsetWriteIntermediateBgpAttributes,
   Unsuppress;
 
@@ -151,6 +152,10 @@ public enum Statements {
 
         case Suppress:
           environment.setSuppressed(true);
+          break;
+
+        case UnsetReadIntermediateBgpAttributes:
+          environment.setReadFromIntermediateBgpAttributes(false);
           break;
 
         case UnsetWriteIntermediateBgpAttributes:

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/ReplaceAsesInAsSequenceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/ReplaceAsesInAsSequenceTest.java
@@ -1,0 +1,65 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence.anyAs;
+import static org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence.localAsOrConfedIfNeighborNotInConfed;
+import static org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence.sequenceOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link ReplaceAsesInAsSequence}. */
+@ParametersAreNonnullByDefault
+public final class ReplaceAsesInAsSequenceTest {
+
+  @Test
+  public void testJavaSerialization() {
+    {
+      ReplaceAsesInAsSequence obj =
+          new ReplaceAsesInAsSequence(
+              sequenceOf(ImmutableList.of(1L)), localAsOrConfedIfNeighborNotInConfed());
+      assertThat(SerializationUtils.clone(obj), equalTo(obj));
+    }
+    {
+      ReplaceAsesInAsSequence obj =
+          new ReplaceAsesInAsSequence(anyAs(), localAsOrConfedIfNeighborNotInConfed());
+      assertThat(SerializationUtils.clone(obj), equalTo(obj));
+    }
+  }
+
+  @Test
+  public void testJacksonSerialization() {
+    {
+      ReplaceAsesInAsSequence obj =
+          new ReplaceAsesInAsSequence(
+              sequenceOf(ImmutableList.of(1L)), localAsOrConfedIfNeighborNotInConfed());
+      assertThat(BatfishObjectMapper.clone(obj, Statement.class), equalTo(obj));
+    }
+    {
+      ReplaceAsesInAsSequence obj =
+          new ReplaceAsesInAsSequence(anyAs(), localAsOrConfedIfNeighborNotInConfed());
+      assertThat(BatfishObjectMapper.clone(obj, Statement.class), equalTo(obj));
+    }
+  }
+
+  @Test
+  public void testEquals() {
+    ReplaceAsesInAsSequence obj =
+        new ReplaceAsesInAsSequence(anyAs(), localAsOrConfedIfNeighborNotInConfed());
+    new EqualsTester()
+        .addEqualityGroup(
+            obj, new ReplaceAsesInAsSequence(anyAs(), localAsOrConfedIfNeighborNotInConfed()))
+        .addEqualityGroup(
+            new ReplaceAsesInAsSequence(
+                sequenceOf(ImmutableList.of(1L)), localAsOrConfedIfNeighborNotInConfed()))
+        .addEqualityGroup(
+            new ReplaceAsesInAsSequence(
+                sequenceOf(ImmutableList.of(1L, 2L)), localAsOrConfedIfNeighborNotInConfed()))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -36,6 +36,7 @@ tokens {
    PENDING,
    PIPE,
    PROMPT_TIMEOUT,
+   REPLACE,
    QUOTED_TEXT,
    RAW_TEXT,
    SELF_SIGNED,
@@ -7283,6 +7284,8 @@ M_AsPath_PREPEND
 :
    'prepend' -> type ( PREPEND ) , popMode
 ;
+
+M_AsPath_REPLACE: 'replace' -> type(REPLACE), popMode;
 
 M_AsPath_REGEX_MODE
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_routemap.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_routemap.g4
@@ -221,6 +221,15 @@ set_as_path_prepend_rm_stanza
    )+ NEWLINE
 ;
 
+set_as_path_replace_rm_stanza
+:
+  SET AS_PATH REPLACE
+  (
+    ANY
+    | seq += uint16+ // only supports 2-byte ASes
+  ) NEWLINE
+;
+
 set_as_path_tag_rm_stanza
 :
    SET AS_PATH TAG NEWLINE
@@ -396,6 +405,7 @@ set_weight_rm_stanza
 set_rm_stanza
 :
    set_as_path_prepend_rm_stanza
+   | set_as_path_replace_rm_stanza
    | set_as_path_tag_rm_stanza
    | set_comm_list_delete_rm_stanza
    | set_community_rm_stanza

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2226,9 +2226,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
       ifExpr.setComment(clausePolicyName);
       ifExpr.setGuard(conj);
       List<Statement> matchStatements = new LinkedList<>();
-      for (RouteMapSetLine rmSet : rmClause.getSetList()) {
-        rmSet.applyTo(matchStatements, this, c, _w);
-      }
+      // Put as-path prepend at the end
+      Streams.concat(
+              rmClause.getSetList().stream()
+                  .filter(l -> !(l instanceof RouteMapSetAsPathPrependLine)),
+              rmClause.getSetList().stream().filter(RouteMapSetAsPathPrependLine.class::isInstance))
+          .forEach(rmSet -> rmSet.applyTo(matchStatements, this, c, _w));
       switch (rmClause.getAction()) {
         case PERMIT:
           matchStatements.add(Statements.ReturnTrue.toStaticStatement());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAsPathReplaceAnyLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAsPathReplaceAnyLine.java
@@ -27,7 +27,6 @@ public final class RouteMapSetAsPathReplaceAnyLine extends RouteMapSetLine {
   @Override
   public void applyTo(
       List<Statement> statements, CiscoConfiguration cc, Configuration c, Warnings w) {
-    // TODO: confirm prepend occurs after replace
     statements.add(
         new If(
             new MatchBgpSessionType(Type.EBGP),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAsPathReplaceAnyLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAsPathReplaceAnyLine.java
@@ -1,0 +1,42 @@
+package org.batfish.representation.cisco;
+
+import static org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence.anyAs;
+import static org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence.localAsOrConfedIfNeighborNotInConfed;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType.Type;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * If eBGP session, replace every AS in the AS-path with local AS, or the confederation ID if in a
+ * confederation and neighbor is not in the confederation.
+ */
+public final class RouteMapSetAsPathReplaceAnyLine extends RouteMapSetLine {
+
+  public static @Nonnull RouteMapSetAsPathReplaceAnyLine instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void applyTo(
+      List<Statement> statements, CiscoConfiguration cc, Configuration c, Warnings w) {
+    // TODO: confirm prepend occurs after replace
+    statements.add(
+        new If(
+            new MatchBgpSessionType(Type.EBGP),
+            ImmutableList.of(
+                new ReplaceAsesInAsSequence(anyAs(), localAsOrConfedIfNeighborNotInConfed()))));
+  }
+
+  private static final @Nonnull RouteMapSetAsPathReplaceAnyLine INSTANCE =
+      new RouteMapSetAsPathReplaceAnyLine();
+
+  private RouteMapSetAsPathReplaceAnyLine() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAsPathReplaceSequenceLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAsPathReplaceSequenceLine.java
@@ -1,0 +1,40 @@
+package org.batfish.representation.cisco;
+
+import static org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence.localAsOrConfedIfNeighborNotInConfed;
+import static org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence.sequenceOf;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
+import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType.Type;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * If eBGP session, replace every AS in any matched subsequence of the AS-path with local AS, or the
+ * confederation ID if in a confederation and neighbor is not in the confederation.
+ */
+public final class RouteMapSetAsPathReplaceSequenceLine extends RouteMapSetLine {
+
+  public RouteMapSetAsPathReplaceSequenceLine(List<Long> sequence) {
+    _sequence = sequence;
+  }
+
+  @Override
+  public void applyTo(
+      List<Statement> statements, CiscoConfiguration cc, Configuration c, Warnings w) {
+    // TODO: confirm prepend occurs after replace
+    statements.add(
+        new If(
+            new MatchBgpSessionType(Type.EBGP),
+            ImmutableList.of(
+                new ReplaceAsesInAsSequence(
+                    sequenceOf(_sequence), localAsOrConfedIfNeighborNotInConfed()))));
+  }
+
+  private final @Nonnull List<Long> _sequence;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAsPathReplaceSequenceLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RouteMapSetAsPathReplaceSequenceLine.java
@@ -27,7 +27,6 @@ public final class RouteMapSetAsPathReplaceSequenceLine extends RouteMapSetLine 
   @Override
   public void applyTo(
       List<Statement> statements, CiscoConfiguration cc, Configuration c, Warnings w) {
-    // TODO: confirm prepend occurs after replace
     statements.add(
         new If(
             new MatchBgpSessionType(Type.EBGP),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -6838,6 +6838,14 @@ public final class CiscoGrammarTest {
       assertThat(outputRoute.getAsPath(), equalTo(AsPath.ofSingletonAsSets(1L, 100L, 100L, 4L)));
     }
     {
+      RoutingPolicy rp = c.getRoutingPolicies().get("prepend-and-replace-seq");
+      Bgpv4Route.Builder outputRoute =
+          inputRoute.toBuilder().setAsPath(AsPath.ofSingletonAsSets(5L, 1L));
+      rp.processBgpRoute(inputRoute, outputRoute, ebgpSession, Direction.IN, null);
+      // the prepended as should not be replaced
+      assertThat(outputRoute.getAsPath(), equalTo(AsPath.ofSingletonAsSets(1L, 5L, 100L)));
+    }
+    {
       BgpSessionProperties ibgpSession =
           BgpSessionProperties.builder()
               .setSessionType(SessionType.IBGP)

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -6801,4 +6801,41 @@ public final class CiscoGrammarTest {
         // null because track does not exist
         Iterables.getOnlyElement(c.getDefaultVrf().getStaticRoutes()).getTrack(), nullValue());
   }
+
+  @Test
+  public void testRouteMapSetAsPathReplace() throws IOException {
+    Configuration c = parseConfig("route-map-set-as-path-replace");
+    long localAs = 100;
+    BgpSessionProperties session =
+        BgpSessionProperties.builder()
+            .setSessionType(SessionType.EBGP_SINGLEHOP)
+            .setLocalAs(localAs)
+            .setRemoteAs(12345L)
+            .setLocalIp(Ip.ZERO)
+            .setRemoteIp(Ip.ZERO)
+            .build();
+    Bgpv4Route inputRoute =
+        Bgpv4Route.builder()
+            .setAsPath(AsPath.ofSingletonAsSets(1L, 2L, 3L, 4L))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(LEARNED)
+            .setOriginType(OriginType.IGP)
+            .setNetwork(Prefix.ZERO)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHop(NextHopDiscard.instance())
+            .build();
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("replace-any");
+      Bgpv4Route.Builder outputRoute = inputRoute.toBuilder();
+      rp.processBgpRoute(inputRoute, outputRoute, session, Direction.IN, null);
+      assertThat(
+          outputRoute.getAsPath(), equalTo(AsPath.ofSingletonAsSets(100L, 100L, 100L, 100L)));
+    }
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("replace-seq");
+      Bgpv4Route.Builder outputRoute = inputRoute.toBuilder();
+      rp.processBgpRoute(inputRoute, outputRoute, session, Direction.IN, null);
+      assertThat(outputRoute.getAsPath(), equalTo(AsPath.ofSingletonAsSets(1L, 100L, 100L, 4L)));
+    }
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/route-map-set-as-path-replace
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/route-map-set-as-path-replace
@@ -10,3 +10,9 @@ route-map replace-any permit 100
 route-map replace-seq permit 100
   set as-path replace 2 3
 !
+
+route-map prepend-and-replace-seq permit 100
+  ! prepend should be applied after replace
+  set as-path prepend 1
+  set as-path replace 1
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/route-map-set-as-path-replace
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/route-map-set-as-path-replace
@@ -1,0 +1,12 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname route-map-set-as-path-replace
+!
+
+route-map replace-any permit 100
+  set as-path replace any
+!
+
+route-map replace-seq permit 100
+  set as-path replace 2 3
+!

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultTag;
@@ -69,6 +70,14 @@ public class RoutePolicyStatementAsPathCollector
   public Set<SymbolicAsPathRegex> visitPrependAsPath(
       PrependAsPath prependAsPath, Configuration arg) {
     // if/when we update TransferBDD to support AS-path prepending, we will need to update this as
+    // well
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<SymbolicAsPathRegex> visitReplaceAsesInAsSequence(
+      ReplaceAsesInAsSequence replaceAsesInAsPathSequence) {
+    // if/when we update TransferBDD to support AS-path replacing, we will need to update this as
     // well
     return ImmutableSet.of();
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollector.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultTag;
@@ -66,6 +67,12 @@ public class RoutePolicyStatementVarCollector
 
   @Override
   public Set<CommunityVar> visitPrependAsPath(PrependAsPath prependAsPath, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<CommunityVar> visitReplaceAsesInAsSequence(
+      ReplaceAsesInAsSequence replaceAsesInAsPathSequence) {
     return ImmutableSet.of();
   }
 

--- a/projects/question/src/main/java/org/batfish/question/TracingHintsStripper.java
+++ b/projects/question/src/main/java/org/batfish/question/TracingHintsStripper.java
@@ -9,6 +9,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultTag;
@@ -68,6 +69,12 @@ public final class TracingHintsStripper implements StatementVisitor<Statement, V
   @Override
   public Statement visitPrependAsPath(PrependAsPath prependAsPath, Void arg) {
     return prependAsPath;
+  }
+
+  @Override
+  public Statement visitReplaceAsesInAsSequence(
+      ReplaceAsesInAsSequence replaceAsesInAsPathSequence) {
+    return replaceAsesInAsPathSequence;
   }
 
   @Override


### PR DESCRIPTION
Fixes batfish/batfish#8059

- parse and convert route-map statement `set as-path replace`
- add new VI Statement for replacing elements of an as-path
- for now, just support replacing with local-as

Follow-on work:
- On IOS, should use confed insetad of local-as if in confed and neighbor is not in the confed