### PR TITLE
Arista EOS do not treat vxlan multicast-groups as VTEPs

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VniMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VniMatchers.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Collection;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Ip;
@@ -27,7 +28,7 @@ public class VniMatchers {
    * subMatcher}.
    */
   public static @Nonnull Matcher<Layer2Vni> hasBumTransportIps(
-      @Nonnull Matcher<? super Iterable<Ip>> subMatcher) {
+      @Nonnull Matcher<? super Set<Ip>> subMatcher) {
     return new HasBumTransportIps(subMatcher);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VniMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VniMatchersImpl.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.matchers;
 
 import java.util.Collection;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Ip;
@@ -14,13 +15,13 @@ public class VniMatchersImpl {
 
   private VniMatchersImpl() {}
 
-  static final class HasBumTransportIps extends FeatureMatcher<Layer2Vni, Iterable<Ip>> {
-    HasBumTransportIps(@Nonnull Matcher<? super Iterable<Ip>> subMatcher) {
+  static final class HasBumTransportIps extends FeatureMatcher<Layer2Vni, Set<Ip>> {
+    HasBumTransportIps(@Nonnull Matcher<? super Set<Ip>> subMatcher) {
       super(subMatcher, "Layer2Vni with BUM transport IPs:", "bumTransportIps");
     }
 
     @Override
-    protected Iterable<Ip> featureValueOf(Layer2Vni actual) {
+    protected Set<Ip> featureValueOf(Layer2Vni actual) {
       return actual.getBumTransportIps();
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -2741,15 +2741,9 @@ public final class AristaConfiguration extends VendorConfiguration {
     SortedSet<Ip> bumTransportIps =
         firstNonNull(vxlan.getVlanFloodAddresses().get(vlan), vxlan.getFloodAddresses());
 
-    // default to unicast flooding unless specified otherwise
+    // Up to at least 4.23, MULTICAST_GROUP is not supported for BUM traffic (only BM traffic),
+    // and it should never displace unicast VTEPs.
     BumTransportMethod bumTransportMethod = BumTransportMethod.UNICAST_FLOOD_GROUP;
-
-    // Check if multicast is enabled
-    Ip multicastAddress = vxlan.getMulticastGroup();
-    if (bumTransportIps.isEmpty() && multicastAddress != null) {
-      bumTransportMethod = BumTransportMethod.MULTICAST_GROUP;
-      bumTransportIps = ImmutableSortedSet.of(multicastAddress);
-    }
 
     return Layer2Vni.builder()
         .setBumTransportIps(bumTransportIps)

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -270,6 +270,7 @@ import org.batfish.representation.arista.eos.AristaBgpVrfIpv6UnicastAddressFamil
 import org.batfish.representation.arista.eos.AristaEosVxlan;
 import org.batfish.representation.arista.eos.AristaRedistributeType;
 import org.batfish.vendor.VendorStructureId;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -1798,9 +1799,10 @@ public class AristaGrammarTest {
     // Confirm VLAN<->VNI mapping is applied
     assertThat(vnisBase, hasVlan(equalTo(2)));
 
-    // Confirm multicast address is present
-    assertThat(vnisNoAddr, hasBumTransportMethod(equalTo(BumTransportMethod.MULTICAST_GROUP)));
-    assertThat(vnisNoAddr, hasBumTransportIps(contains(Ip.parse("227.10.1.1"))));
+    // https://github.com/batfish/batfish/issues/8061
+    // Confirm multicast address does not change BumTransport method nor VTEPs
+    assertThat(vnisNoAddr, hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)));
+    assertThat(vnisNoAddr, hasBumTransportIps(Matchers.empty()));
     // Confirm no source address is present (no address specified for loopback interface)
     assertThat(vnisNoAddr, hasSourceAddress(nullValue()));
     // Confirm default UDP port is used even though none is supplied


### PR DESCRIPTION
- Fixes batfish/batfish#8061
- Multicast-groups are not supported for BUM traffic on EOS up to at least 4.23
  - They are only for BM traffic, and should not displace unicast VTEPs
- Even on 4.25 which apparently allows multicast VTEPs, they are not configured
  via the `multicast-group` command.