### PR TITLE
PAN: fix `static-route` conversion crash

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2758,11 +2758,12 @@ public class PaloAltoConfiguration extends VendorConfiguration {
           continue;
         }
       }
-      if (sr.getNextHopIp() == null && sr.getNextHopInterface() == null) {
+      if (!sr.getNextHopDiscard()
+          && nextVrf == null
+          && sr.getNextHopIp() == null
+          && sr.getNextHopInterface() == null) {
         _w.redFlag(
-            String.format(
-                "Cannot convert static route %s, as it has no nexthop interface or IP.",
-                e.getKey()));
+            String.format("Cannot convert static route %s, as it has no nexthop.", e.getKey()));
         continue;
       }
       vrf.getStaticRoutes()

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2758,6 +2758,13 @@ public class PaloAltoConfiguration extends VendorConfiguration {
           continue;
         }
       }
+      if (sr.getNextHopIp() == null && sr.getNextHopInterface() == null) {
+        _w.redFlag(
+            String.format(
+                "Cannot convert static route %s, as it has no nexthop interface or IP.",
+                e.getKey()));
+        continue;
+      }
       vrf.getStaticRoutes()
           .add(
               org.batfish.datamodel.StaticRoute.builder()

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2689,6 +2689,42 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testStaticRouteConvertWarnings() throws IOException {
+    String hostname = "static-route-convert-warnings";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    Warnings warn = ccae.getWarnings().get(hostname);
+
+    assertThat(
+        warn,
+        hasRedFlag(
+            hasText(
+                containsString(
+                    "Cannot convert static route NO_NH, as it has no nexthop interface or IP."))));
+    assertThat(
+        warn,
+        hasRedFlag(
+            hasText(
+                containsString(
+                    "Cannot convert static route NO_DEST, as it does not have a destination."))));
+    assertThat(
+        warn,
+        hasRedFlag(
+            hasText(
+                containsString(
+                    "Cannot convert static route NEXT_VR_SELF, as its next-vr 'somename' is its own"
+                        + " virtual-router."))));
+    assertThat(
+        warn,
+        hasRedFlag(
+            hasText(
+                containsString(
+                    "Cannot convert static route NEXT_VR_UNDEF, as its next-vr 'UNDEFINED' is not a"
+                        + " virtual-router."))));
+  }
+
+  @Test
   public void testStaticRouteExtraction() {
     String hostname = "static-route";
     PaloAltoConfiguration vc = parsePaloAltoConfig(hostname);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2699,9 +2699,7 @@ public final class PaloAltoGrammarTest {
     assertThat(
         warn,
         hasRedFlag(
-            hasText(
-                containsString(
-                    "Cannot convert static route NO_NH, as it has no nexthop interface or IP."))));
+            hasText(containsString("Cannot convert static route NO_NH, as it has no nexthop."))));
     assertThat(
         warn,
         hasRedFlag(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/static-route-convert-warnings
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/static-route-convert-warnings
@@ -1,0 +1,8 @@
+set deviceconfig system hostname static-route-convert-warnings
+set network interface ethernet ethernet1/1 layer3 ip 192.0.2.1/24
+set network virtual-router somename routing-table ip static-route NO_NH destination 10.1.0.0/16
+set network virtual-router somename routing-table ip static-route NO_DEST interface ethernet1/1
+set network virtual-router somename routing-table ip static-route NEXT_VR_SELF nexthop next-vr somename
+set network virtual-router somename routing-table ip static-route NEXT_VR_SELF destination 10.2.0.0/16
+set network virtual-router somename routing-table ip static-route NEXT_VR_UNDEF nexthop next-vr UNDEFINED
+set network virtual-router somename routing-table ip static-route NEXT_VR_UNDEF destination 10.3.0.0/16


### PR DESCRIPTION
Fix an issue where a `static-route` missing a `nexthop` would cause conversion crash.
