### PR TITLE
Juniper only allow access and trunk on unit 0

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -4499,6 +4499,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitIfe_interface_mode(Ife_interface_modeContext ctx) {
+    if (!_currentInterfaceOrRange.getName().endsWith(".0")) {
+      warn(ctx, "Interface mode can only be configured on unit 0");
+      return;
+    }
     if (ctx.ACCESS() != null) {
       _currentInterfaceOrRange.getEthernetSwitching().setSwitchportMode(SwitchportMode.ACCESS);
     } else if (ctx.TRUNK() != null) {
@@ -4522,6 +4526,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitIfe_vlan(Ife_vlanContext ctx) {
+    if (!_currentInterfaceOrRange.getName().endsWith(".0")) {
+      warn(ctx, "Vlan members can only be configured on unit 0");
+      return;
+    }
     if (ctx.range() != null) {
       IntegerSpace range = IntegerSpace.unionOf(toRange(ctx.range()).toArray(new SubRange[] {}));
       _currentInterfaceOrRange.getEthernetSwitching().getVlanMembers().add(new VlanRange(range));

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2969,9 +2969,6 @@ public final class FlatJuniperGrammarTest {
     assertThat(c, hasInterface("ge-0/3/0.0", hasSwitchPortMode(SwitchportMode.TRUNK)));
     assertThat(
         c, hasInterface("ge-0/3/0.0", hasAllowedVlans(IntegerSpace.of(new SubRange("1-5")))));
-    // Expecting an Interface in TRUNK mode with VLANs 6
-    assertThat(c, hasInterface("ge-0/3/0.1", hasSwitchPortMode(SwitchportMode.TRUNK)));
-    assertThat(c, hasInterface("ge-0/3/0.1", hasAllowedVlans(IntegerSpace.of(6))));
 
     // Expecting interface with encapsulation VLAN set to .0:1000 .1:1
     assertThat(c, hasInterface("ge-0/4/0.0", hasEncapsulationVlan(1000)));
@@ -2979,6 +2976,16 @@ public final class FlatJuniperGrammarTest {
 
     // Without vlan-tagging enabled, encapsulation vlan is ignored
     assertThat(c, hasInterface("ge-0/5/0.7", hasEncapsulationVlan(nullValue())));
+
+    // Expecting an Interface in TRUNK mode with VLANs 6
+    assertThat(c, hasInterface("ge-0/6/0.0", hasSwitchPortMode(SwitchportMode.TRUNK)));
+    assertThat(c, hasInterface("ge-0/6/0.0", hasAllowedVlans(IntegerSpace.of(6))));
+    assertThat(c, hasInterface("ge-0/6/0.1", hasEncapsulationVlan(100)));
+
+    // Cannot configure trunk mode on unit 1
+    assertThat(c, hasInterface("ge-0/7/0.1", hasSwitchPortMode(SwitchportMode.NONE)));
+    assertThat(c, hasInterface("ge-0/7/0.1", hasAllowedVlans(IntegerSpace.EMPTY)));
+    assertThat(c, hasInterface("ge-0/7/0.1", hasAccessVlan(nullValue())));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
@@ -6,12 +6,17 @@ set interfaces ge-0/1/0 unit 0 family ethernet-switching vlan members VLAN_TEST_
 set interfaces ge-0/2/0 unit 0 family ethernet-switching
 set interfaces ge-0/3/0 unit 0 family ethernet-switching port-mode trunk
 set interfaces ge-0/3/0 unit 0 family ethernet-switching vlan members 1-5
-set interfaces ge-0/3/0 unit 1 family ethernet-switching interface-mode trunk
-set interfaces ge-0/3/0 unit 1 family ethernet-switching vlan members 6
 set interfaces ge-0/4/0 unit 0 vlan-id 1000
 set interfaces ge-0/4/0 vlan-tagging
 set interfaces ge-0/4/0 unit 1 vlan-id 1
 set interfaces ge-0/5/0 unit 7 vlan-id 7
+set interfaces ge-0/6/0 unit 0 family ethernet-switching interface-mode trunk
+set interfaces ge-0/6/0 unit 0 family ethernet-switching vlan members 6
+set interfaces ge-0/6/0 vlan-tagging
+set interfaces ge-0/6/0 unit 1 vlan-id 100
+set interfaces ge-0/7/0 unit 1 family ethernet-switching interface-mode trunk
+set interfaces ge-0/7/0 unit 1 family ethernet-switching vlan members 99
+set interfaces ge-0/7/0 unit 2 family ethernet-switching interface-mode trunk
 set interfaces vlan unit 103 family inet address 192.168.3.35/24
 
 set vlans VLAN_TEST vlan-id 101


### PR DESCRIPTION
- Juniper only allows access and trunk switchport modes on unit 0
- rewrite tests accordingly