### PR TITLE
Cisco NX-OS fix recovery issue with ACL parsing

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpAccessListMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpAccessListMatchers.java
@@ -47,7 +47,8 @@ public final class IpAccessListMatchers {
    * Provides a matcher that matches if the provided {@code subMatcher} matches the IpAccessList's
    * lines.
    */
-  public static HasLines hasLines(@Nonnull Matcher<? super List<AclLine>> subMatcher) {
+  public static @Nonnull Matcher<IpAccessList> hasLines(
+      @Nonnull Matcher<? super List<AclLine>> subMatcher) {
     return new HasLines(subMatcher);
   }
 
@@ -57,7 +58,8 @@ public final class IpAccessListMatchers {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static HasLines hasLines(@Nonnull Matcher<? super AclLine>... subMatchers) {
+  public static @Nonnull Matcher<IpAccessList> hasLines(
+      @Nonnull Matcher<? super AclLine>... subMatchers) {
     return new HasLines(contains(subMatchers));
   }
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_ip_access_list.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_ip_access_list.g4
@@ -9,11 +9,14 @@ options {
 ip_access_list
 :
   ACCESS_LIST name = ip_access_list_name NEWLINE
-  (
-    acl_fragments
-    | acl_line
-    | acl_null
-  )*
+  ip_access_list_inner*
+;
+
+ip_access_list_inner
+:
+  acl_fragments
+  | acl_line
+  | acl_null
 ;
 
 acl_fragments
@@ -46,10 +49,11 @@ acll_action
 :
   action = line_action
   (
-  // DO NOT REORDER
-  // If not using l4 options for l4 protocol, should be considered l3 line.
-    aclla_l3
-    | aclla_l4
+    aclla_icmp
+    | aclla_igmp
+    | aclla_tcp
+    | aclla_udp
+    | aclla_l3
   )
 ;
 
@@ -65,24 +69,20 @@ aclla_l3
 acllal3_protocol_spec
 :
   IP
-  | prot = ip_protocol
+  | prot = acl_l3_protocol
 ;
 
-ip_protocol
+acl_l3_protocol
 :
   num = uint8
   | AHP
   | EIGRP
   | ESP
   | GRE
-  | ICMP
-  | IGMP
   | NOS
   | OSPF
   | PCP
   | PIM
-  | TCP
-  | UDP
 ;
 
 acllal3_src_address
@@ -210,15 +210,7 @@ packet_length
   | UINT16
 ;
 
-aclla_l4
-:
-  acllal4_icmp
-  | acllal4_igmp
-  | acllal4_tcp
-  | acllal4_udp
-;
-
-acllal4_icmp
+aclla_icmp
 :
   ICMP acllal3_src_address acllal3_dst_address
   // NX-OS allows multiple l3 options but only one l4 option, interleaved in any order.
@@ -277,7 +269,7 @@ acllal4icmp_option
   | UNREACHABLE
 ;
 
-acllal4_igmp
+aclla_igmp
 :
   IGMP acllal3_src_address acllal3_dst_address
   (
@@ -301,7 +293,7 @@ igmp_message_type_number
   UINT8
 ;
 
-acllal4_tcp
+aclla_tcp
 :
   TCP acllal3_src_address acllal4tcp_source_port? acllal3_dst_address
   acllal4tcp_destination_port?
@@ -448,7 +440,7 @@ tcp_option_length
   UINT8
 ;
 
-acllal4_udp
+aclla_udp
 :
   UDP acllal3_src_address acllal4udp_source_port? acllal3_dst_address
   acllal4udp_destination_port?

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -253,9 +253,13 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Aaagr_use_vrfContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Aaagt_source_interfaceContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Aaagt_use_vrfContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acl_fragmentsContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acl_l3_protocolContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acl_lineContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acll_actionContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acll_remarkContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Aclla_icmpContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Aclla_tcpContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Aclla_udpContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal3_address_specContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal3_dst_addressContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal3_fragmentsContext;
@@ -267,12 +271,10 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal3o_packet_lengthCont
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal3o_packet_length_specContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal3o_precedenceContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal3o_ttlContext;
-import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4_icmpContext;
-import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4_tcpContext;
-import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4_udpContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4icmp_optionContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4igmp_optionContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4tcp_destination_portContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4tcp_optionContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4tcp_port_specContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4tcp_port_spec_literalContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4tcp_port_spec_port_groupContext;
@@ -281,6 +283,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4tcpo_establishedCon
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4tcpo_flagsContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4tcpo_tcp_flags_maskContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_destination_portContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_optionContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_port_specContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_port_spec_literalContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_port_spec_port_groupContext;
@@ -437,7 +440,6 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ip_prefix_list_description
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ip_prefix_list_line_numberContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ip_prefix_list_line_prefix_lengthContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ip_prefix_list_nameContext;
-import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ip_protocolContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ip_route_networkContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ipp_rp_addressContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ipp_rp_candidateContext;
@@ -1114,7 +1116,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     return Ip6.parse(ctx.getText());
   }
 
-  private static @Nonnull IpProtocol toIpProtocol(Ip_protocolContext ctx) {
+  private static @Nonnull IpProtocol toIpProtocol(Acl_l3_protocolContext ctx) {
     if (ctx.num != null) {
       return IpProtocol.fromNumber(toInteger(ctx.num));
     } else if (ctx.AHP() != null) {
@@ -1125,10 +1127,6 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       return IpProtocol.ESP;
     } else if (ctx.GRE() != null) {
       return IpProtocol.GRE;
-    } else if (ctx.ICMP() != null) {
-      return IpProtocol.ICMP;
-    } else if (ctx.IGMP() != null) {
-      return IpProtocol.IGMP;
     } else if (ctx.NOS() != null) {
       return IpProtocol.IPIP;
     } else if (ctx.OSPF() != null) {
@@ -1137,10 +1135,6 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       return IpProtocol.IPCOMP;
     } else if (ctx.PIM() != null) {
       return IpProtocol.PIM;
-    } else if (ctx.TCP() != null) {
-      return IpProtocol.TCP;
-    } else if (ctx.UDP() != null) {
-      return IpProtocol.UDP;
     } else {
       // All variants should be covered, so just throw if we get here
       throw new IllegalArgumentException(String.format("Unsupported protocol: %s", ctx.getText()));
@@ -1495,15 +1489,13 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
-  public void enterAcllal4_tcp(Acllal4_tcpContext ctx) {
+  public void enterAclla_tcp(Aclla_tcpContext ctx) {
     _currentActionIpAccessListLineBuilder.setProtocol(IpProtocol.TCP);
-    _currentTcpOptionsBuilder = TcpOptions.builder();
   }
 
   @Override
-  public void enterAcllal4_udp(Acllal4_udpContext ctx) {
+  public void enterAclla_udp(Aclla_udpContext ctx) {
     _currentActionIpAccessListLineBuilder.setProtocol(IpProtocol.UDP);
-    _currentUdpOptionsBuilder = UdpOptions.builder();
   }
 
   @Override
@@ -5199,23 +5191,27 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
-  public void exitAcllal4_icmp(Acllal4_icmpContext ctx) {
+  public void exitAclla_icmp(Aclla_icmpContext ctx) {
     _currentActionIpAccessListLineBuilder.setProtocol(IpProtocol.ICMP);
   }
 
   @Override
-  public void exitAcllal4_tcp(Acllal4_tcpContext ctx) {
-    if (_currentTcpFlagsBuilder != null) {
-      _currentTcpOptionsBuilder.setTcpFlags(_currentTcpFlagsBuilder.build());
-      _currentTcpFlagsBuilder = null;
+  public void exitAclla_tcp(Aclla_tcpContext ctx) {
+    if (_currentTcpOptionsBuilder != null) {
+      if (_currentTcpFlagsBuilder != null) {
+        _currentTcpOptionsBuilder.setTcpFlags(_currentTcpFlagsBuilder.build());
+        _currentTcpFlagsBuilder = null;
+      }
+      _currentActionIpAccessListLineBuilder.setL4Options(_currentTcpOptionsBuilder.build());
     }
-    _currentActionIpAccessListLineBuilder.setL4Options(_currentTcpOptionsBuilder.build());
     _currentTcpOptionsBuilder = null;
   }
 
   @Override
-  public void exitAcllal4_udp(Acllal4_udpContext ctx) {
-    _currentActionIpAccessListLineBuilder.setL4Options(_currentUdpOptionsBuilder.build());
+  public void exitAclla_udp(Aclla_udpContext ctx) {
+    if (_currentUdpOptionsBuilder != null) {
+      _currentActionIpAccessListLineBuilder.setL4Options(_currentUdpOptionsBuilder.build());
+    }
     _currentUdpOptionsBuilder = null;
   }
 
@@ -5372,6 +5368,9 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       _currentActionIpAccessListLineUnusable = true;
       return;
     }
+    if (_currentTcpOptionsBuilder == null) {
+      _currentTcpOptionsBuilder = TcpOptions.builder();
+    }
     PortSpec spec = portSpec.get();
     _currentTcpOptionsBuilder.setDstPortSpec(spec);
     if (spec instanceof PortGroupPortSpec) {
@@ -5384,6 +5383,13 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
+  public void enterAcllal4tcp_option(Acllal4tcp_optionContext ctx) {
+    if (_currentTcpOptionsBuilder == null) {
+      _currentTcpOptionsBuilder = TcpOptions.builder();
+    }
+  }
+
+  @Override
   public void exitAcllal4tcp_source_port(Acllal4tcp_source_portContext ctx) {
     Optional<PortSpec> portSpec = toPortSpec(ctx, ctx.port);
     if (!portSpec.isPresent()) {
@@ -5391,6 +5397,9 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       return;
     }
     PortSpec spec = portSpec.get();
+    if (_currentTcpOptionsBuilder == null) {
+      _currentTcpOptionsBuilder = TcpOptions.builder();
+    }
     _currentTcpOptionsBuilder.setSrcPortSpec(spec);
     if (spec instanceof PortGroupPortSpec) {
       _c.referenceStructure(
@@ -5447,6 +5456,9 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       _currentActionIpAccessListLineUnusable = true;
       return;
     }
+    if (_currentUdpOptionsBuilder == null) {
+      _currentUdpOptionsBuilder = UdpOptions.builder();
+    }
     PortSpec spec = portSpec.get();
     _currentUdpOptionsBuilder.setDstPortSpec(spec);
     if (spec instanceof PortGroupPortSpec) {
@@ -5459,11 +5471,21 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
+  public void enterAcllal4udp_option(Acllal4udp_optionContext ctx) {
+    if (_currentUdpOptionsBuilder == null) {
+      _currentUdpOptionsBuilder = UdpOptions.builder();
+    }
+  }
+
+  @Override
   public void exitAcllal4udp_source_port(Acllal4udp_source_portContext ctx) {
     Optional<PortSpec> portSpec = toPortSpec(ctx, ctx.port);
     if (!portSpec.isPresent()) {
       _currentActionIpAccessListLineUnusable = true;
       return;
+    }
+    if (_currentUdpOptionsBuilder == null) {
+      _currentUdpOptionsBuilder = UdpOptions.builder();
     }
     PortSpec spec = portSpec.get();
     _currentUdpOptionsBuilder.setSrcPortSpec(spec);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -53,6 +53,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterfaces;
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessList;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNumReferrers;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRedFlagWarning;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRoute6FilterLists;
@@ -83,6 +84,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVrfName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isAdminUp;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isAutoState;
+import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
 import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.datamodel.matchers.NssaSettingsMatchers.hasSuppressType7;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasNssa;
@@ -9890,5 +9892,17 @@ public final class CiscoNxosGrammarTest {
             isActive(false),
             hasInactiveReason(ADMIN_DOWN),
             hasVrfName("disabledvrf")));
+  }
+
+  @Test
+  public void testIpAccessListNoCrashOnInvalidInput() throws IOException {
+    String hostname = "nxos_ip_access_list_invalid";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Settings settings = batfish.getSettings();
+    settings.setDisableUnrecognized(false);
+    settings.setThrowOnLexerError(false);
+    settings.setThrowOnParserError(false);
+    Configuration c = batfish.loadConfigurations(batfish.getSnapshot()).get(hostname);
+    assertThat(c, hasIpAccessList("foo", hasLines(empty())));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ip_access_list_invalid
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ip_access_list_invalid
@@ -1,0 +1,6 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_ip_access_list_invalid
+!
+ip access-list foo
+  10 deny tcp


### PR DESCRIPTION
- make `acl_action` choice LL(1)
- fixes recovery failure when adaptive prediction fails deeper than `acl_action`