### PR TITLE
PAN: parse and extract `custom-url-category`

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -144,6 +144,8 @@ CONTENT_PREVIEW: 'content-preview';
 
 CRYPTO_PROFILES: 'crypto-profiles';
 
+CUSTOM_URL_CATEGORY: 'custom-url-category';
+
 DAMPENING_PROFILE: 'dampening-profile';
 
 DAYS: 'days';
@@ -378,6 +380,8 @@ LINK_SPEED: 'link-speed';
 LINK_STATE: 'link-state';
 
 LINK_TYPE: 'link-type';
+
+LIST: 'list';
 
 LLDP: 'lldp';
 
@@ -637,6 +641,8 @@ SOURCE_TRANSLATION: 'source-translation';
 
 SOURCE_USER: 'source-user';
 
+SPYWARE: 'spyware';
+
 SSL
 :
     [Ss][Ss][Ll]
@@ -743,6 +749,8 @@ VISIBLE_VSYS: 'visible-vsys';
 VLAN: 'vlan';
 
 VSYS: 'vsys';
+
+VULNERABILITY: 'vulnerability';
 
 WEIGHT: 'weight';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -13,6 +13,7 @@ import
     PaloAlto_interface,
     PaloAlto_network,
     PaloAlto_ospf,
+    PaloAlto_profiles,
     PaloAlto_readonly,
     PaloAlto_response,
     PaloAlto_rip,
@@ -109,6 +110,7 @@ statement_config_devices
     | s_deviceconfig
     | s_network
     | s_null
+    | s_profiles
     | s_rulebase
     | s_service
     | s_service_group
@@ -200,6 +202,7 @@ statement_device_group
     | s_address_group
     | s_application
     | s_application_group
+    | s_profiles
     | s_service
     | s_service_group
     | s_tag
@@ -210,7 +213,6 @@ statement_device_group
     | sdg_description
     | sdg_devices
     | sdg_parent_dg
-    | sdg_profiles
     | sdg_profile_group
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
@@ -26,11 +26,6 @@ sdg_profile_group
     PROFILE_GROUP null_rest_of_line
 ;
 
-sdg_profiles
-:
-    PROFILES null_rest_of_line
-;
-
 sdgd_vsys
 :
     VSYS name = variable

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_profiles.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_profiles.g4
@@ -1,0 +1,33 @@
+parser grammar PaloAlto_profiles;
+
+import PaloAlto_common;
+
+options {
+    tokenVocab = PaloAltoLexer;
+}
+
+s_profiles: PROFILES sp;
+
+sp
+:
+    sp_custom_url_category
+    | sp_spyware
+    | sp_vulnerability
+;
+
+sp_spyware: SPYWARE null_rest_of_line;
+
+sp_vulnerability: VULNERABILITY null_rest_of_line;
+
+sp_custom_url_category: CUSTOM_URL_CATEGORY custom_url_category_name spc_definition;
+
+spc_definition: spc_description | spc_list | spc_type;
+
+spc_description: DESCRIPTION description = value;
+
+spc_list: LIST list = variable_list;
+
+spc_type: TYPE type = variable;
+
+// Up to 31 characters
+custom_url_category_name: variable;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
@@ -4,6 +4,7 @@ import
     PaloAlto_application,
     PaloAlto_common,
     PaloAlto_log_settings,
+    PaloAlto_profiles,
     PaloAlto_service,
     PaloAlto_service_group,
     PaloAlto_tag;
@@ -27,6 +28,7 @@ ss_common
     | s_application_group
     | s_external_list
     | s_log_settings
+    | s_profiles
     | s_post_rulebase
     | s_pre_rulebase
     | s_service

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -2233,8 +2233,12 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
 
   @Override
   public void exitSpc_type(PaloAltoParser.Spc_typeContext ctx) {
-    if (!getText(ctx.type).equals("URL List")) {
-      warn(ctx, "Currently only 'URL List' custom-url-category type is supported by Batfish.");
+    if (!getText(ctx.type).equals(CustomUrlCategory.TYPE_URL_LIST)) {
+      warn(
+          ctx,
+          String.format(
+              "Currently only '%s' custom-url-category type is supported by Batfish.",
+              CustomUrlCategory.TYPE_URL_LIST));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -18,6 +18,7 @@ import static org.batfish.representation.palo_alto.PaloAltoStructureType.APPLICA
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.APPLICATION_GROUP_OR_APPLICATION_OR_NONE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.APPLICATION_OR_NONE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.APPLICATION_OVERRIDE_RULE;
+import static org.batfish.representation.palo_alto.PaloAltoStructureType.CUSTOM_URL_CATEGORY;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.EXTERNAL_LIST;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.INTERFACE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.NAT_RULE;
@@ -398,6 +399,7 @@ import org.batfish.representation.palo_alto.BgpVr;
 import org.batfish.representation.palo_alto.BgpVrRoutingOptions.AsFormat;
 import org.batfish.representation.palo_alto.CryptoProfile;
 import org.batfish.representation.palo_alto.CryptoProfile.Type;
+import org.batfish.representation.palo_alto.CustomUrlCategory;
 import org.batfish.representation.palo_alto.DestinationTranslation;
 import org.batfish.representation.palo_alto.DeviceGroup;
 import org.batfish.representation.palo_alto.DynamicIpAndPort;
@@ -490,6 +492,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   private BgpVr _currentBgpVr;
   private PaloAltoConfiguration _currentConfiguration;
   private CryptoProfile _currentCrytoProfile;
+  private CustomUrlCategory _currentCustomUrlCategory;
   private DeviceGroup _currentDeviceGroup;
   private String _currentDeviceGroupVsys;
   private String _currentDeviceName;
@@ -2199,6 +2202,43 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   }
 
   @Override
+  public void enterSp_custom_url_category(PaloAltoParser.Sp_custom_url_categoryContext ctx) {
+    Optional<String> maybeName = toString(ctx, ctx.custom_url_category_name());
+    if (maybeName.isPresent()) {
+      String name = maybeName.get();
+      _currentCustomUrlCategory = _currentVsys.getOrCreateCustomUrlCategory(name);
+      defineFlattenedStructure(
+          CUSTOM_URL_CATEGORY, computeObjectName(_currentVsys.getName(), name), ctx);
+    } else {
+      _currentCustomUrlCategory = new CustomUrlCategory(getText(ctx.custom_url_category_name()));
+    }
+  }
+
+  @Override
+  public void exitSp_custom_url_category(PaloAltoParser.Sp_custom_url_categoryContext ctx) {
+    _currentCustomUrlCategory = null;
+  }
+
+  @Override
+  public void exitSpc_description(PaloAltoParser.Spc_descriptionContext ctx) {
+    _currentCustomUrlCategory.setDescription(getText(ctx.description));
+  }
+
+  @Override
+  public void exitSpc_list(PaloAltoParser.Spc_listContext ctx) {
+    for (Variable_list_itemContext var : variables(ctx.variable_list())) {
+      _currentCustomUrlCategory.addToList(getText(var));
+    }
+  }
+
+  @Override
+  public void exitSpc_type(PaloAltoParser.Spc_typeContext ctx) {
+    if (!getText(ctx.type).equals("URL List")) {
+      warn(ctx, "Currently only 'URL List' custom-url-category type is supported by Batfish.");
+    }
+  }
+
+  @Override
   public void exitSniv_unit(Sniv_unitContext ctx) {
     _currentInterface = _currentParentInterface;
   }
@@ -3377,6 +3417,15 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
 
   private @Nonnull Optional<String> toString(ParserRuleContext ctx, Bgp_peer_nameContext peer) {
     return toStringWithLengthInSpace(ctx, peer, BGP_PEER_NAME_LENGTH_SPACE, "bgp peer");
+  }
+
+  private static final IntegerSpace CUSTOM_URL_CATEGORY_NAME_LENGTH_SPACE =
+      IntegerSpace.of(Range.closed(1, 31));
+
+  private @Nonnull Optional<String> toString(
+      ParserRuleContext ctx, PaloAltoParser.Custom_url_category_nameContext name) {
+    return toStringWithLengthInSpace(
+        ctx, name, CUSTOM_URL_CATEGORY_NAME_LENGTH_SPACE, "custom-url-category");
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/CustomUrlCategory.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/CustomUrlCategory.java
@@ -1,13 +1,15 @@
 package org.batfish.representation.palo_alto;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
-import java.util.List;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Represents configuration of a PaloAlto custom-url-category. */
 public final class CustomUrlCategory implements Serializable {
+  public static final String TYPE_URL_LIST = "URL List";
+
   public @Nullable String getDescription() {
     return _description;
   }
@@ -16,13 +18,13 @@ public final class CustomUrlCategory implements Serializable {
     _description = description;
   }
 
-  public @Nonnull List<String> getList() {
+  public @Nonnull Set<String> getList() {
     return _list;
   }
 
   public void addToList(String item) {
     _list =
-        ImmutableList.<String>builderWithExpectedSize(_list.size() + 1)
+        ImmutableSet.<String>builderWithExpectedSize(_list.size() + 1)
             .addAll(_list)
             .add(item)
             .build();
@@ -33,11 +35,11 @@ public final class CustomUrlCategory implements Serializable {
   }
 
   public CustomUrlCategory(String name) {
-    _list = ImmutableList.of();
+    _list = ImmutableSet.of();
     _name = name;
   }
 
   private @Nullable String _description;
-  private @Nonnull List<String> _list;
+  private @Nonnull Set<String> _list;
   private @Nonnull final String _name;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/CustomUrlCategory.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/CustomUrlCategory.java
@@ -1,0 +1,54 @@
+package org.batfish.representation.palo_alto;
+
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Represents configuration of a PaloAlto custom-url-category. */
+public final class CustomUrlCategory implements Serializable {
+  /**
+   * Returns a boolean indicating if the specified custom-url-category url contains an unbounded
+   * wildcard. This corresponds to potentially unwanted behavior, where <b>the entry will match any
+   * additional subdomains at the beginning or end of the URL</b> (see Palo Alto docs:
+   * https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-admin/url-filtering/block-and-allow-lists.html).
+   */
+  public static boolean unboundedWildcard(String url) {
+
+    return false;
+  }
+
+  public @Nullable String getDescription() {
+    return _description;
+  }
+
+  public void setDescription(String description) {
+    _description = description;
+  }
+
+  public @Nonnull List<String> getList() {
+    return _list;
+  }
+
+  public void addToList(String item) {
+    _list =
+        ImmutableList.<String>builderWithExpectedSize(_list.size() + 1)
+            .addAll(_list)
+            .add(item)
+            .build();
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public CustomUrlCategory(String name) {
+    _list = ImmutableList.of();
+    _name = name;
+  }
+
+  private @Nullable String _description;
+  private @Nonnull List<String> _list;
+  private @Nonnull final String _name;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/CustomUrlCategory.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/CustomUrlCategory.java
@@ -8,17 +8,6 @@ import javax.annotation.Nullable;
 
 /** Represents configuration of a PaloAlto custom-url-category. */
 public final class CustomUrlCategory implements Serializable {
-  /**
-   * Returns a boolean indicating if the specified custom-url-category url contains an unbounded
-   * wildcard. This corresponds to potentially unwanted behavior, where <b>the entry will match any
-   * additional subdomains at the beginning or end of the URL</b> (see Palo Alto docs:
-   * https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-admin/url-filtering/block-and-allow-lists.html).
-   */
-  public static boolean unboundedWildcard(String url) {
-
-    return false;
-  }
-
   public @Nullable String getDescription() {
     return _description;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureType.java
@@ -16,6 +16,7 @@ public enum PaloAltoStructureType implements StructureType {
   APPLICATION_GROUP_OR_APPLICATION_OR_NONE("application-group or application or none"),
   APPLICATION_OR_NONE("application or none"),
   APPLICATION_OVERRIDE_RULE("application-override rule"),
+  CUSTOM_URL_CATEGORY("custom-url-category"),
   EXTERNAL_LIST("external-list"),
   GLOBAL_PROTECT_APP_CRYPTO_PROFILE("global-protect-app-crypto-profile"),
   IKE_CRYPTO_PROFILE("ike-crypto-profile"),

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
@@ -32,7 +32,7 @@ public final class Vsys implements Serializable {
 
   private final SortedMap<String, ApplicationGroup> _applicationGroups;
 
-  @Nonnull private final Map<String, CustomUrlCategory> _customUrlCategory;
+  @Nonnull private final Map<String, CustomUrlCategory> _customUrlCategories;
 
   private String _displayName;
 
@@ -76,7 +76,7 @@ public final class Vsys implements Serializable {
     _addressObjects = new TreeMap<>();
     _applications = new TreeMap<>();
     _applicationGroups = new TreeMap<>();
-    _customUrlCategory = new HashMap<>();
+    _customUrlCategories = new HashMap<>();
     _importedInterfaces = new HashSet<>();
     _importedVsyses = new HashSet<>();
     _rulebase = new Rulebase();
@@ -109,14 +109,14 @@ public final class Vsys implements Serializable {
     return _applicationGroups;
   }
 
-  /** Returns a map of custom-url-category names to {@link CustomUrlCategory}. */
-  public @Nonnull Map<String, CustomUrlCategory> getCustomUrlCategory() {
-    return _customUrlCategory;
+  /** Returns a map of custom-url-category name to {@link CustomUrlCategory}. */
+  public @Nonnull Map<String, CustomUrlCategory> getCustomUrlCategories() {
+    return _customUrlCategories;
   }
 
   /** Returns the specified {@link CustomUrlCategory}, creating it if it doesn't already exist. */
   public @Nonnull CustomUrlCategory getOrCreateCustomUrlCategory(String name) {
-    return _customUrlCategory.computeIfAbsent(name, CustomUrlCategory::new);
+    return _customUrlCategories.computeIfAbsent(name, CustomUrlCategory::new);
   }
 
   /** Returns the display name for this vsys. */

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
@@ -2,6 +2,7 @@ package org.batfish.representation.palo_alto;
 
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +31,8 @@ public final class Vsys implements Serializable {
   private final SortedMap<String, Application> _applications;
 
   private final SortedMap<String, ApplicationGroup> _applicationGroups;
+
+  @Nonnull private final Map<String, CustomUrlCategory> _customUrlCategory;
 
   private String _displayName;
 
@@ -73,6 +76,7 @@ public final class Vsys implements Serializable {
     _addressObjects = new TreeMap<>();
     _applications = new TreeMap<>();
     _applicationGroups = new TreeMap<>();
+    _customUrlCategory = new HashMap<>();
     _importedInterfaces = new HashSet<>();
     _importedVsyses = new HashSet<>();
     _rulebase = new Rulebase();
@@ -103,6 +107,16 @@ public final class Vsys implements Serializable {
   /** Returns a map of application group name to {@link ApplicationGroup}. */
   public SortedMap<String, ApplicationGroup> getApplicationGroups() {
     return _applicationGroups;
+  }
+
+  /** Returns a map of custom-url-category names to {@link CustomUrlCategory}. */
+  public @Nonnull Map<String, CustomUrlCategory> getCustomUrlCategory() {
+    return _customUrlCategory;
+  }
+
+  /** Returns the specified {@link CustomUrlCategory}, creating it if it doesn't already exist. */
+  public @Nonnull CustomUrlCategory getOrCreateCustomUrlCategory(String name) {
+    return _customUrlCategory.computeIfAbsent(name, CustomUrlCategory::new);
   }
 
   /** Returns the display name for this vsys. */

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2745,9 +2745,9 @@ public final class PaloAltoGrammarTest {
   @Test
   public void testPanoramaProfilesExtraction() {
     PaloAltoConfiguration vc = parsePaloAltoConfig("panorama-profiles");
+
     DeviceGroup dg = vc.getDeviceGroup("DG1");
     assertNotNull(dg);
-
     Vsys panorama = dg.getPanorama();
     assertNotNull(panorama);
     assertThat(panorama.getCustomUrlCategory(), hasKey("DG1_CAT1"));
@@ -2793,7 +2793,7 @@ public final class PaloAltoGrammarTest {
     assertThat(ccae, hasDefinedStructure(filename, CUSTOM_URL_CATEGORY, category1Name));
     assertThat(ccae, hasDefinedStructure(filename, CUSTOM_URL_CATEGORY, category2Name));
 
-    // TODO references and undefined references
+    // TODO references and undefined references once refs are added
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2730,7 +2730,7 @@ public final class PaloAltoGrammarTest {
     PaloAltoConfiguration vc = parsePaloAltoConfig("profiles");
     Vsys vsys = vc.getVirtualSystems().get(DEFAULT_VSYS_NAME);
 
-    Map<String, CustomUrlCategory> customUrlCategoryMap = vsys.getCustomUrlCategory();
+    Map<String, CustomUrlCategory> customUrlCategoryMap = vsys.getCustomUrlCategories();
     assertThat(customUrlCategoryMap.keySet(), containsInAnyOrder("CAT1", "CAT2"));
 
     CustomUrlCategory cat1 = customUrlCategoryMap.get("CAT1");
@@ -2750,15 +2750,15 @@ public final class PaloAltoGrammarTest {
     assertNotNull(dg);
     Vsys panorama = dg.getPanorama();
     assertNotNull(panorama);
-    assertThat(panorama.getCustomUrlCategory(), hasKey("DG1_CAT1"));
-    CustomUrlCategory cat1 = panorama.getOrCreateCustomUrlCategory("DG1_CAT1");
+    assertThat(panorama.getCustomUrlCategories(), hasKey("DG1_CAT1"));
+    CustomUrlCategory cat1 = panorama.getCustomUrlCategories().get("DG1_CAT1");
     assertNull(cat1.getDescription());
     assertThat(cat1.getList(), contains("github.com"));
 
     Vsys shared = vc.getShared();
     assertNotNull(shared);
-    assertThat(shared.getCustomUrlCategory(), hasKey("SHARED_CAT1"));
-    CustomUrlCategory sharedCat1 = shared.getOrCreateCustomUrlCategory("SHARED_CAT1");
+    assertThat(shared.getCustomUrlCategories(), hasKey("SHARED_CAT1"));
+    CustomUrlCategory sharedCat1 = shared.getCustomUrlCategories().get("SHARED_CAT1");
     assertThat(sharedCat1.getDescription(), equalTo("descr"));
     assertThat(sharedCat1.getList(), contains("example.com"));
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -72,6 +72,7 @@ import static org.batfish.representation.palo_alto.PaloAltoConfiguration.compute
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.ADDRESS_OBJECT;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.APPLICATION_GROUP;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.APPLICATION_GROUP_OR_APPLICATION;
+import static org.batfish.representation.palo_alto.PaloAltoStructureType.CUSTOM_URL_CATEGORY;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.EXTERNAL_LIST;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.INTERFACE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.SERVICE;
@@ -238,6 +239,7 @@ import org.batfish.representation.palo_alto.BgpVr;
 import org.batfish.representation.palo_alto.BgpVrRoutingOptions.AsFormat;
 import org.batfish.representation.palo_alto.CryptoProfile;
 import org.batfish.representation.palo_alto.CryptoProfile.Type;
+import org.batfish.representation.palo_alto.CustomUrlCategory;
 import org.batfish.representation.palo_alto.DeviceGroup;
 import org.batfish.representation.palo_alto.EbgpPeerGroupType;
 import org.batfish.representation.palo_alto.EbgpPeerGroupType.ExportNexthopMode;
@@ -2721,6 +2723,77 @@ public final class PaloAltoGrammarTest {
     Configuration c = parseConfig("static-route-misc");
     // don't warn, and do install the route
     assertThat(c.getVrfs().get("somename"), hasStaticRoutes(contains(hasPrefix(Prefix.ZERO))));
+  }
+
+  @Test
+  public void testProfilesExtraction() {
+    PaloAltoConfiguration vc = parsePaloAltoConfig("profiles");
+    Vsys vsys = vc.getVirtualSystems().get(DEFAULT_VSYS_NAME);
+
+    Map<String, CustomUrlCategory> customUrlCategoryMap = vsys.getCustomUrlCategory();
+    assertThat(customUrlCategoryMap.keySet(), containsInAnyOrder("CAT1", "CAT2"));
+
+    CustomUrlCategory cat1 = customUrlCategoryMap.get("CAT1");
+    CustomUrlCategory cat2 = customUrlCategoryMap.get("CAT2");
+
+    assertThat(cat1.getDescription(), equalTo("category description"));
+    assertThat(cat1.getList(), contains("*.batfish.org/", "example.com", "github.com"));
+    assertNull(cat2.getDescription());
+    assertThat(cat2.getList(), contains("github.com"));
+  }
+
+  @Test
+  public void testPanoramaProfilesExtraction() {
+    PaloAltoConfiguration vc = parsePaloAltoConfig("panorama-profiles");
+    DeviceGroup dg = vc.getDeviceGroup("DG1");
+    assertNotNull(dg);
+
+    Vsys panorama = dg.getPanorama();
+    assertNotNull(panorama);
+    assertThat(panorama.getCustomUrlCategory(), hasKey("DG1_CAT1"));
+    CustomUrlCategory cat1 = panorama.getOrCreateCustomUrlCategory("DG1_CAT1");
+    assertNull(cat1.getDescription());
+    assertThat(cat1.getList(), contains("github.com"));
+
+    Vsys shared = vc.getShared();
+    assertNotNull(shared);
+    assertThat(shared.getCustomUrlCategory(), hasKey("SHARED_CAT1"));
+    CustomUrlCategory sharedCat1 = shared.getOrCreateCustomUrlCategory("SHARED_CAT1");
+    assertThat(sharedCat1.getDescription(), equalTo("descr"));
+    assertThat(sharedCat1.getList(), contains("example.com"));
+  }
+
+  @Test
+  public void testProfilesWarning() {
+    PaloAltoConfiguration c = parsePaloAltoConfig("profiles-warning");
+    List<ParseWarning> parseWarnings = c.getWarnings().getParseWarnings();
+    assertThat(
+        parseWarnings,
+        containsInAnyOrder(
+            hasComment(
+                "Currently only 'URL List' custom-url-category type is supported by Batfish."),
+            hasComment(
+                "Expected custom-url-category with length in range 1-31, but got"
+                    + " 'THIS_NAME_IS_TOO_LONG_FOR_CATEGOR'")));
+  }
+
+  @Test
+  public void testProfilesReference() throws IOException {
+    String hostname = "profiles-reference";
+    String filename = "configs/" + hostname;
+
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    String category1Name = computeObjectName(DEFAULT_VSYS_NAME, "CAT1");
+    String category2Name = computeObjectName(DEFAULT_VSYS_NAME, "CAT2");
+
+    // Confirm structure definitions are tracked
+    assertThat(ccae, hasDefinedStructure(filename, CUSTOM_URL_CATEGORY, category1Name));
+    assertThat(ccae, hasDefinedStructure(filename, CUSTOM_URL_CATEGORY, category2Name));
+
+    // TODO references and undefined references
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-profiles
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-profiles
@@ -1,0 +1,10 @@
+set deviceconfig system hostname panorama-profiles
+!
+set shared profiles custom-url-category SHARED_CAT1 description descr
+set shared profiles custom-url-category SHARED_CAT1 list example.com
+set shared profiles custom-url-category SHARED_CAT1 type "URL List"
+!
+set device-group DG1 profiles custom-url-category DG1_CAT1 list github.com
+set device-group DG1 profiles custom-url-category DG1_CAT1 type "URL List"
+!
+set device-group DG1 devices 00000001

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles
@@ -1,0 +1,9 @@
+set deviceconfig system hostname profiles
+
+set profiles custom-url-category CAT1 description "category description"
+set profiles custom-url-category CAT1 list [ *.batfish.org/ example.com ]
+# This appends to the existing list
+set profiles custom-url-category CAT1 list github.com
+set profiles custom-url-category CAT1 type "URL List"
+
+set profiles custom-url-category CAT2 list github.com

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles-reference
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles-reference
@@ -1,0 +1,4 @@
+set deviceconfig system hostname profiles-reference
+
+set profiles custom-url-category CAT1 description description1
+set profiles custom-url-category CAT2 description description2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles-warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles-warning
@@ -1,0 +1,10 @@
+set deviceconfig system hostname profiles-warning
+
+# Non-URL List types not supported yet
+set profiles custom-url-category UNSUPPORTED_TYPE type "Category Match"
+set profiles custom-url-category THIS_NAME_IS_TOO_LONG_FOR_CATEGOR description "name is too long"
+
+# Potentially problematic wildcard
+# Matches URL under other domains as well, e.g. `www.paloaltonetworks.com.fake.example.com`
+# see https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-admin/url-filtering/block-and-allow-lists.html
+# set profiles custom-url-category CAT1 list *.paloaltonetworks.com

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles-warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles-warning
@@ -4,6 +4,7 @@ set deviceconfig system hostname profiles-warning
 set profiles custom-url-category UNSUPPORTED_TYPE type "Category Match"
 set profiles custom-url-category THIS_NAME_IS_TOO_LONG_FOR_CATEGOR description "name is too long"
 
+# TODO uncomment this when warning logic is added
 # Potentially problematic wildcard
 # Matches URL under other domains as well, e.g. `www.paloaltonetworks.com.fake.example.com`
 # see https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-admin/url-filtering/block-and-allow-lists.html


### PR DESCRIPTION
`custom-url-category` can be applied to security rules or url-filtering profiles. Neither of those are supported yet, but will add support for attaching to security rules in a subsequent PR.

----

Note: there are some other `profiles` that are no longer parsed and ignored, which may result in more unrecognized-line parse warnings.
