### PR TITLE
Reachability: only consider active L3 interfaces

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/SpecifierUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/SpecifierUtilsTest.java
@@ -1,12 +1,13 @@
 package org.batfish.specifier;
 
 import static org.batfish.datamodel.ConfigurationFormat.CISCO_IOS;
-import static org.batfish.specifier.SpecifierUtils.isActive;
+import static org.batfish.specifier.SpecifierUtils.isActiveL3Interface;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.SortedMap;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.NetworkFactory;
@@ -17,21 +18,47 @@ import org.junit.Test;
 public final class SpecifierUtilsTest {
 
   @Test
-  public void testLocationIsActive() {
+  public void testLocationIsActiveL3Interface() {
     NetworkFactory nf = new NetworkFactory();
     Configuration node = nf.configurationBuilder().setConfigurationFormat(CISCO_IOS).build();
     Vrf vrf = nf.vrfBuilder().setOwner(node).build();
-    Interface activeInterface = nf.interfaceBuilder().setOwner(node).setVrf(vrf).build();
+    Interface activeL3Interface =
+        nf.interfaceBuilder()
+            .setOwner(node)
+            .setVrf(vrf)
+            .setSwitchport(false)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+            .build();
+    Interface activeNonL3Interface =
+        nf.interfaceBuilder().setOwner(node).setVrf(vrf).setSwitchport(false).build();
     Interface inactiveInterface =
-        nf.interfaceBuilder().setAdminUp(false).setOwner(node).setVrf(vrf).build();
+        nf.interfaceBuilder()
+            .setAdminUp(false)
+            .setOwner(node)
+            .setVrf(vrf)
+            .setSwitchport(false)
+            .setAddress(ConcreteInterfaceAddress.parse("2.3.4.5/24"))
+            .build();
     SortedMap<String, Configuration> configs = ImmutableSortedMap.of(node.getHostname(), node);
 
     String hostname = node.getHostname();
-    assertTrue(isActive(new InterfaceLinkLocation(hostname, activeInterface.getName()), configs));
+    // Interfaces
+    assertTrue(
+        isActiveL3Interface(new InterfaceLocation(hostname, activeL3Interface.getName()), configs));
     assertFalse(
-        isActive(new InterfaceLinkLocation(hostname, inactiveInterface.getName()), configs));
-    assertTrue(isActive(new InterfaceLinkLocation(hostname, activeInterface.getName()), configs));
+        isActiveL3Interface(
+            new InterfaceLocation(hostname, activeNonL3Interface.getName()), configs));
     assertFalse(
-        isActive(new InterfaceLinkLocation(hostname, inactiveInterface.getName()), configs));
+        isActiveL3Interface(new InterfaceLocation(hostname, inactiveInterface.getName()), configs));
+    // Links
+    assertTrue(
+        isActiveL3Interface(
+            new InterfaceLinkLocation(hostname, activeL3Interface.getName()), configs));
+    assertFalse(
+        isActiveL3Interface(
+            new InterfaceLinkLocation(hostname, activeNonL3Interface.getName()), configs));
+    assertFalse(
+        isActiveL3Interface(
+            new InterfaceLinkLocation(hostname, inactiveInterface.getName()), configs));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
@@ -3,7 +3,7 @@ package org.batfish.main;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
-import static org.batfish.specifier.SpecifierUtils.resolveActiveLocations;
+import static org.batfish.specifier.SpecifierUtils.resolveActiveL3Locations;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -117,9 +117,9 @@ public final class ReachabilityParametersResolver {
   @VisibleForTesting
   IpSpaceAssignment resolveSourceIpSpaceAssignment() throws InvalidReachabilityParametersException {
     Set<Location> sourceLocations =
-        resolveActiveLocations(_params.getSourceLocationSpecifier(), _context);
+        resolveActiveL3Locations(_params.getSourceLocationSpecifier(), _context);
     if (sourceLocations.isEmpty()) {
-      throw new InvalidReachabilityParametersException("No matching source locations");
+      throw new InvalidReachabilityParametersException("No matching active IPv4 source locations");
     }
 
     // resolve the IpSpaceAssignmentSpecifier, and filter out entries with empty IpSpaces

--- a/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.SortedMap;
 import java.util.regex.Pattern;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Ip;
@@ -48,7 +49,12 @@ public class ReachabilityParametersResolverTest {
     NetworkFactory nf = new NetworkFactory();
     _node = nf.configurationBuilder().setConfigurationFormat(CISCO_IOS).build();
     Vrf vrf = nf.vrfBuilder().setOwner(_node).build();
-    nf.interfaceBuilder().setOwner(_node).setVrf(vrf).build();
+    nf.interfaceBuilder()
+        .setOwner(_node)
+        .setVrf(vrf)
+        .setSwitchport(false)
+        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+        .build();
     SortedMap<String, Configuration> configs = ImmutableSortedMap.of(_node.getHostname(), _node);
     _batfish = BatfishTestUtils.getBatfish(configs, _tempFolder);
     _snapshot = _batfish.getSnapshot();
@@ -122,7 +128,7 @@ public class ReachabilityParametersResolverTest {
         new ReachabilityParametersResolver(_batfish, reachabilityParameters, _snapshot);
 
     exception.expect(InvalidReachabilityParametersException.class);
-    exception.expectMessage("No matching source locations");
+    exception.expectMessage("No matching active IPv4 source locations");
     resolver.resolveSourceIpSpaceAssignment();
   }
 
@@ -133,7 +139,7 @@ public class ReachabilityParametersResolverTest {
         ReachabilityParameters.builder()
             .setActions(ImmutableSortedSet.of(ACCEPTED))
             .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
-            .setDestinationIpSpaceSpecifier(
+            .setSourceIpSpaceSpecifier(
                 new ConstantIpSpaceAssignmentSpecifier(EmptyIpSpace.INSTANCE))
             .setSourceLocationSpecifier(
                 new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile(".*")))

--- a/projects/question/src/main/java/org/batfish/question/differentialreachability/DifferentialReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/differentialreachability/DifferentialReachabilityAnswerer.java
@@ -4,7 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.question.specifiers.PathConstraintsUtil.createPathConstraints;
 import static org.batfish.question.traceroute.TracerouteAnswerer.diffFlowTracesToRows;
 import static org.batfish.question.traceroute.TracerouteAnswerer.metadata;
-import static org.batfish.specifier.SpecifierUtils.resolveActiveLocations;
+import static org.batfish.specifier.SpecifierUtils.resolveActiveL3Locations;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -75,8 +75,8 @@ public class DifferentialReachabilityAnswerer extends Answerer {
     // only consider startLocations that are present+active in both snapshots
     Set<Location> startLocations =
         Sets.intersection(
-            resolveActiveLocations(pathConstraints.getStartLocation(), snapshotCtxt),
-            resolveActiveLocations(pathConstraints.getStartLocation(), referenceCtxt));
+            resolveActiveL3Locations(pathConstraints.getStartLocation(), snapshotCtxt),
+            resolveActiveL3Locations(pathConstraints.getStartLocation(), referenceCtxt));
     if (startLocations.isEmpty()) {
       throw new BatfishException(
           "no matching startLocation is present and active in both snapshots");


### PR DESCRIPTION
Rather than just being active, interfaces must also be L3: have IP addresses.