### PR TITLE
PAN: detect and warn about potentially unintended URL wildcard behavior

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -2232,10 +2232,9 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
         warn(
             ctx,
             String.format(
-                "Custom-url-category '%s' will match additional trailing domains beyond the"
-                    + " specified domain, which may be unintended. For example '*.github.com' would"
-                    + " match 'www.github.com.malicious.example.com'.",
-                url));
+                "Did you mean '%s/'? Without the trailing slash, the url will match additional"
+                    + " trailing domains, such as '%s.evil'.",
+                url, url));
       }
       _currentCustomUrlCategory.addToList(url);
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -2227,7 +2227,17 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   @Override
   public void exitSpc_list(PaloAltoParser.Spc_listContext ctx) {
     for (Variable_list_itemContext var : variables(ctx.variable_list())) {
-      _currentCustomUrlCategory.addToList(getText(var));
+      String url = getText(var);
+      if (PaloAltoConfiguration.unexpectedUnboundedCustomUrlWildcard(url)) {
+        warn(
+            ctx,
+            String.format(
+                "Custom-url-category '%s' will match additional trailing domains beyond the"
+                    + " specified domain, which may be unintended. For example '*.github.com' would"
+                    + " match 'www.github.com.malicious.example.com'.",
+                url));
+      }
+      _currentCustomUrlCategory.addToList(url);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -84,6 +84,7 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -3423,6 +3424,21 @@ public class PaloAltoConfiguration extends VendorConfiguration {
             }
           });
     }
+  }
+
+  // Any URL with a `*` in the domain, without a URI/directory after the domain
+  private static final Pattern UNBOUNDED_CUSTOM_URL_WILDCARD_PATTERN =
+      Pattern.compile("[^/]*\\*\\.[^/?*]+$");
+
+  /**
+   * Returns a boolean indicating if the specified custom-url-category url contains an
+   * <b>unexpected</b>, unbounded wildcard. This corresponds to potentially unwanted behavior, where
+   * <b>the entry will match any additional domains at the end of the URL</b> (see Palo Alto docs:
+   * https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-admin/url-filtering/block-and-allow-lists.html).
+   */
+  public static boolean unexpectedUnboundedCustomUrlWildcard(String url) {
+    // Assumes url is a valid URL with wildcards
+    return UNBOUNDED_CUSTOM_URL_WILDCARD_PATTERN.matcher(url).matches();
   }
 
   public @Nullable Vsys getPanorama() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2810,9 +2810,9 @@ public final class PaloAltoGrammarTest {
                 "Expected custom-url-category with length in range 1-31, but got"
                     + " 'THIS_NAME_IS_TOO_LONG_FOR_CATEGOR'"),
             hasComment(
-                "Custom-url-category '*.paloaltonetworks.com' will match additional trailing"
-                    + " domains beyond the specified domain, which may be unintended. For example"
-                    + " '*.github.com' would match 'www.github.com.malicious.example.com'.")));
+                "Did you mean '*.paloaltonetworks.com/'? Without the trailing slash, the url will"
+                    + " match additional trailing domains, such as"
+                    + " '*.paloaltonetworks.com.evil'.")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2808,7 +2808,11 @@ public final class PaloAltoGrammarTest {
                 "Currently only 'URL List' custom-url-category type is supported by Batfish."),
             hasComment(
                 "Expected custom-url-category with length in range 1-31, but got"
-                    + " 'THIS_NAME_IS_TOO_LONG_FOR_CATEGOR'")));
+                    + " 'THIS_NAME_IS_TOO_LONG_FOR_CATEGOR'"),
+            hasComment(
+                "Custom-url-category '*.paloaltonetworks.com' will match additional trailing"
+                    + " domains beyond the specified domain, which may be unintended. For example"
+                    + " '*.github.com' would match 'www.github.com.malicious.example.com'.")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
@@ -23,6 +23,7 @@ import static org.batfish.representation.palo_alto.PaloAltoConfiguration.generat
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.generateSharedGatewayOutgoingFilter;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.generateVsysSharedGatewayCalls;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.securityRuleApplies;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.unexpectedUnboundedCustomUrlWildcard;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneMatchTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneRejectTraceElement;
 import static org.hamcrest.Matchers.contains;
@@ -721,5 +722,21 @@ public final class PaloAltoConfigurationTest {
     assertTrue(deviceBindingAndIdCompatible(NatRule.ActiveActiveDeviceBinding.ONE, 1));
 
     // TODO test PRIMARY once that is better supported
+  }
+
+  @Test
+  public void testUnexpectedUnboundedCustomUrlWildcard() {
+    // Unexpected and unbounded
+    assertTrue(unexpectedUnboundedCustomUrlWildcard("*.github.com"));
+    assertTrue(unexpectedUnboundedCustomUrlWildcard("www.*.github.com"));
+
+    // Not unexpected
+    assertFalse(unexpectedUnboundedCustomUrlWildcard("*.github.*"));
+
+    // Not unbounded
+    assertFalse(unexpectedUnboundedCustomUrlWildcard("*.github.com/"));
+    assertFalse(unexpectedUnboundedCustomUrlWildcard("*.github.com?"));
+    assertFalse(unexpectedUnboundedCustomUrlWildcard("www.*.github.com/"));
+    assertFalse(unexpectedUnboundedCustomUrlWildcard("*.github.com/foobar.something"));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles-warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/profiles-warning
@@ -4,8 +4,7 @@ set deviceconfig system hostname profiles-warning
 set profiles custom-url-category UNSUPPORTED_TYPE type "Category Match"
 set profiles custom-url-category THIS_NAME_IS_TOO_LONG_FOR_CATEGOR description "name is too long"
 
-# TODO uncomment this when warning logic is added
 # Potentially problematic wildcard
 # Matches URL under other domains as well, e.g. `www.paloaltonetworks.com.fake.example.com`
 # see https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-admin/url-filtering/block-and-allow-lists.html
-# set profiles custom-url-category CAT1 list *.paloaltonetworks.com
+set profiles custom-url-category CAT1 list *.paloaltonetworks.com


### PR DESCRIPTION
URL category wildcards have an unexpected behavior where a wildcard URL like `*.github.com` will match `www.github.com` as well as something like `www.github.com.malicious.example.com`.

Add parse warning when URL categories like this are encountered.
