### PR TITLE
Overhaul new L3 adjacencies computation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/L3Adjacencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/L3Adjacencies.java
@@ -10,6 +10,7 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 @ParametersAreNonnullByDefault
 public interface L3Adjacencies extends Serializable {
   boolean USE_NEW_METHOD = false;
+  boolean USE_NEW_NEW_METHOD = true;
 
   /**
    * Return whether the two interfaces are in the same broadcast domain.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/BridgeDomainL3Adjacencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/BridgeDomainL3Adjacencies.java
@@ -1,0 +1,60 @@
+package org.batfish.common.topology.bridge_domain;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.L3Adjacencies;
+import org.batfish.common.topology.Layer1Topologies;
+import org.batfish.common.topology.PointToPointComputer;
+import org.batfish.common.topology.PointToPointInterfaces;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.vxlan.VxlanTopology;
+
+public final class BridgeDomainL3Adjacencies implements L3Adjacencies {
+
+  public static @Nonnull BridgeDomainL3Adjacencies create(
+      Layer1Topologies l1, VxlanTopology vxlan, Map<String, Configuration> configs) {
+    PointToPointInterfaces p2p = PointToPointComputer.compute(l1.getLogicalL1(), configs);
+    L3AdjacencyComputer adj = new L3AdjacencyComputer(configs, l1, vxlan);
+    return new BridgeDomainL3Adjacencies(adj.findAllBroadcastDomains(), p2p);
+  }
+
+  @Override
+  public boolean inSameBroadcastDomain(NodeInterfacePair i1, NodeInterfacePair i2) {
+    checkArgument(_domains.containsKey(i1), "Missing domain for %s: is it an L3 interface?", i1);
+    checkArgument(_domains.containsKey(i2), "Missing domain for %s: is it an L3 interface?", i2);
+    return _domains.get(i1).equals(_domains.get(i2));
+  }
+
+  @Nonnull
+  @Override
+  public Optional<NodeInterfacePair> pairedPointToPointL3Interface(NodeInterfacePair iface) {
+    checkArgument(
+        _domains.containsKey(iface), "Missing domain for %s: is it an L3 interface?", iface);
+    NodeInterfacePair ret = null;
+    for (NodeInterfacePair otherIf : _pointToPointInterfaces.pointToPointInterfaces(iface)) {
+      if (!_domains.containsKey(otherIf) || !inSameBroadcastDomain(iface, otherIf)) {
+        // otherIf is not L3 or not in same domain.
+        continue;
+      } else if (ret != null) {
+        // Two p2p neighbors, not unique. Should not happen.
+        return Optional.empty();
+      }
+      ret = otherIf;
+    }
+    return Optional.ofNullable(ret);
+  }
+
+  private BridgeDomainL3Adjacencies(
+      Map<NodeInterfacePair, Integer> domains, PointToPointInterfaces pointToPointInterfaces) {
+    _domains = ImmutableMap.copyOf(domains);
+    _pointToPointInterfaces = pointToPointInterfaces;
+  }
+
+  private final @Nonnull Map<NodeInterfacePair, Integer> _domains;
+  private final @Nonnull PointToPointInterfaces _pointToPointInterfaces;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/L3AdjacencyComputer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/L3AdjacencyComputer.java
@@ -1,0 +1,561 @@
+package org.batfish.common.topology.bridge_domain;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.batfish.common.topology.bridge_domain.node.BridgeDomain.newVlanAwareBridge;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
+import com.google.common.graph.EndpointPair;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.batfish.common.topology.Layer1Edge;
+import org.batfish.common.topology.Layer1Topologies;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.common.topology.bridge_domain.edge.Edges;
+import org.batfish.common.topology.bridge_domain.node.BridgeDomain;
+import org.batfish.common.topology.bridge_domain.node.BridgeDomain.BridgeId;
+import org.batfish.common.topology.bridge_domain.node.BridgedL3Interface;
+import org.batfish.common.topology.bridge_domain.node.DisconnectedL3Interface;
+import org.batfish.common.topology.bridge_domain.node.EthernetHub;
+import org.batfish.common.topology.bridge_domain.node.L2Interface;
+import org.batfish.common.topology.bridge_domain.node.L2Vni;
+import org.batfish.common.topology.bridge_domain.node.L2VniHub;
+import org.batfish.common.topology.bridge_domain.node.L3Interface;
+import org.batfish.common.topology.bridge_domain.node.NonBridgedL3Interface;
+import org.batfish.common.topology.bridge_domain.node.PhysicalInterface;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.Interface.DependencyType;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.SwitchportMode;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.VniLayer;
+import org.batfish.datamodel.vxlan.VxlanNode;
+import org.batfish.datamodel.vxlan.VxlanTopology;
+import org.jgrapht.alg.util.UnionFind;
+
+/** Computes the set of L3 interfaces that are in the same broadcast domain as a given interface. */
+final class L3AdjacencyComputer {
+  private static final Logger LOGGER = LogManager.getLogger(L3AdjacencyComputer.class);
+  @VisibleForTesting static final String BATFISH_GLOBAL_HUB = "Batfish Global Ethernet Hub";
+
+  public @Nonnull Map<NodeInterfacePair, Integer> findAllBroadcastDomains() {
+    ImmutableMap.Builder<NodeInterfacePair, Integer> ret = ImmutableMap.builder();
+    SortedSet<NodeInterfacePair> unchecked = new TreeSet<>(_layer3Interfaces.keySet());
+    while (!unchecked.isEmpty()) {
+      Set<NodeInterfacePair> domain = findBroadcastDomain(unchecked.first());
+      int cur = unchecked.size();
+      domain.forEach(i -> ret.put(i, cur));
+      unchecked.removeAll(domain);
+    }
+    return ret.build();
+  }
+
+  L3AdjacencyComputer(
+      Map<String, Configuration> configs,
+      Layer1Topologies layer1Topologies,
+      VxlanTopology vxlanTopology) {
+    _layer1Topologies = layer1Topologies;
+    _physicalInterfaces = computePhysicalInterfaces(configs);
+    _ethernetHubs =
+        computeEthernetHubs(configs, _physicalInterfaces, _layer1Topologies.getLogicalL1());
+    _bridgeDomains = computeBridgeDomains(configs, _physicalInterfaces);
+    _l2Vnis = computeL2Vnis(configs, _bridgeDomains);
+    _l2VniHubs = computeL2VniHubs(_l2Vnis, vxlanTopology);
+    _layer3Interfaces = computeLayer3Interfaces(configs, _bridgeDomains, _physicalInterfaces);
+  }
+
+  private Set<NodeInterfacePair> findBroadcastDomain(NodeInterfacePair first) {
+    L3Interface originator = _layer3Interfaces.get(first);
+    return Search.originate(originator).stream()
+        .map(L3Interface::getInterface)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  private static Map<NodeInterfacePair, PhysicalInterface> computePhysicalInterfaces(
+      Map<String, Configuration> configs) {
+    ImmutableMap.Builder<NodeInterfacePair, PhysicalInterface> ret = ImmutableMap.builder();
+    for (Configuration c : configs.values()) {
+      for (Interface i : c.getAllInterfaces().values()) {
+        if (shouldCreatePhysicalInterface(i)) {
+          NodeInterfacePair nip = NodeInterfacePair.of(i);
+          ret.put(nip, new PhysicalInterface(nip));
+        }
+      }
+    }
+    return ret.build();
+  }
+
+  /**
+   * Returns whether this {@link Interface} should be modeled as a {@link PhysicalInterface}. Only
+   * active, interfaces that should be in the logical {@link Layer1Topology} are included --
+   * physical interfaces and aggregated interfaces.
+   */
+  @VisibleForTesting
+  static boolean shouldCreatePhysicalInterface(Interface i) {
+    if (!PHYSICAL_INTERFACE_TYPES.contains(i.getInterfaceType())) {
+      LOGGER.debug(
+          "Not creating physical interface {}: not a physical interface", NodeInterfacePair.of(i));
+      return false;
+    } else if (isAggregated(i)) {
+      LOGGER.debug(
+          "Not creating physical interface {}: physical interface but aggregated",
+          NodeInterfacePair.of(i));
+      return false;
+    } else if (!i.getActive()) {
+      LOGGER.debug("Not creating physical interface {}: not active", NodeInterfacePair.of(i));
+      return false;
+    }
+    return true;
+  }
+
+  @VisibleForTesting
+  static @Nonnull Map<String, EthernetHub> computeEthernetHubs(
+      Map<String, Configuration> configs,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces,
+      Layer1Topology layer1Topology) {
+    Set<NodeInterfacePair> physicalInterfacesMentionedInL1 =
+        layer1Topology.getGraph().nodes().stream()
+            .map(l1node -> NodeInterfacePair.of(l1node.getHostname(), l1node.getInterfaceName()))
+            .sorted() // sorted for determinism
+            .collect(ImmutableSet.toImmutableSet());
+
+    // Build the global hub if needed.
+    Set<NodeInterfacePair> interfacesAttachedToGlobalHub =
+        Sets.difference(physicalInterfaces.keySet(), physicalInterfacesMentionedInL1);
+    ImmutableMap.Builder<String, EthernetHub> ret = ImmutableMap.builder();
+    if (interfacesAttachedToGlobalHub.isEmpty()) {
+      LOGGER.debug("Not creating a global Ethernet hub: all physical interfaces have L1 edges");
+    } else {
+      LOGGER.debug(
+          "Creating a global Ethernet hub with {} physical interfaces",
+          interfacesAttachedToGlobalHub.size());
+      EthernetHub globalHub = new EthernetHub(BATFISH_GLOBAL_HUB);
+      Edges.connectToHub(
+          globalHub,
+          interfacesAttachedToGlobalHub.stream()
+              .filter(nip -> getInterface(nip, configs).getActive())
+              .map(physicalInterfaces::get)
+              .toArray(PhysicalInterface[]::new));
+      ret.put(globalHub.getId(), globalHub);
+    }
+
+    // Build an EthernetHub for every L1 cluster.
+    if (physicalInterfacesMentionedInL1.isEmpty()) {
+      LOGGER.debug("L1 topology is empty, so only the global hub exists");
+    } else {
+      UnionFind<NodeInterfacePair> clusters = new UnionFind<>(physicalInterfacesMentionedInL1);
+      for (Layer1Edge edge : layer1Topology.getGraph().edges()) {
+        NodeInterfacePair i1 =
+            NodeInterfacePair.of(edge.getNode1().getHostname(), edge.getNode1().getInterfaceName());
+        NodeInterfacePair i2 =
+            NodeInterfacePair.of(edge.getNode2().getHostname(), edge.getNode2().getInterfaceName());
+        if (physicalInterfaces.containsKey(i1) && physicalInterfaces.containsKey(i2)) {
+          // Only apply L1 edges where both interfaces exist.
+          clusters.union(i1, i2);
+        }
+      }
+      // Build up the set of interfaces attached to each hub. Note that since we are only looking
+      // at interfaces that exist in this snapshot, and we only applied edges that exist in this
+      // snapshot, we guarantee both the representative NodeInterfacePair and the elements in the
+      // group are actually in the snapshot.
+      Multimap<NodeInterfacePair, NodeInterfacePair> groups =
+          LinkedListMultimap.create(clusters.numberOfSets());
+      for (NodeInterfacePair nip :
+          Sets.intersection(physicalInterfaces.keySet(), physicalInterfacesMentionedInL1)) {
+        groups.put(clusters.find(nip), nip);
+      }
+      // Create one EthernetHub for each group.
+      groups
+          .asMap()
+          .forEach(
+              (id, nodes) -> {
+                EthernetHub hub = new EthernetHub("Hub for " + id);
+                PhysicalInterface[] interfaces = new PhysicalInterface[nodes.size()];
+                int i = 0;
+                for (NodeInterfacePair node : nodes) {
+                  PhysicalInterface pi = physicalInterfaces.get(node);
+                  assert pi != null;
+                  interfaces[i] = pi;
+                  ++i;
+                }
+                Edges.connectToHub(hub, interfaces);
+                ret.put(hub.getId(), hub);
+              });
+    }
+
+    // Log if at least one L2 interface is mentioned in L1 and at least one L2 interface is attached
+    // to global hub.
+    Set<NodeInterfacePair> l2AttachedToGlobalHub =
+        interfacesAttachedToGlobalHub.stream()
+            .filter(
+                nip ->
+                    Optional.ofNullable(configs.get(nip.getHostname()))
+                        .map(c -> c.getAllInterfaces().get(nip.getInterface()))
+                        .map(Interface::getSwitchport)
+                        .orElse(false))
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural()));
+    Set<NodeInterfacePair> l2MentionedInL1 =
+        physicalInterfacesMentionedInL1.stream()
+            .filter(
+                nip ->
+                    Optional.ofNullable(configs.get(nip.getHostname()))
+                        .map(c -> c.getAllInterfaces().get(nip.getInterface()))
+                        .map(Interface::getSwitchport)
+                        .orElse(false))
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural()));
+    if (!l2AttachedToGlobalHub.isEmpty() && !l2MentionedInL1.isEmpty()) {
+      LOGGER.warn(
+          "Surprised that some L2 interfaces are mentioned in L1 ({}) but not all ({}): {} are not",
+          l2MentionedInL1.size(),
+          l2AttachedToGlobalHub.size(),
+          l2AttachedToGlobalHub);
+    }
+
+    return ret.build();
+  }
+
+  private static @Nonnull Map<BridgeId, BridgeDomain> computeBridgeDomains(
+      Map<String, Configuration> configs,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces) {
+    ImmutableMap.Builder<BridgeId, BridgeDomain> ret = ImmutableMap.builder();
+    for (Configuration c : configs.values()) {
+      // TODO: do something different for devices with bridge interfaces or named bridge domains.
+      BridgeDomain vlanAwareBridge = newVlanAwareBridge(c.getHostname());
+      ret.put(vlanAwareBridge.getId(), vlanAwareBridge);
+      for (Interface i : c.getAllInterfaces().values()) {
+        connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+            i, c.getAllInterfaces(), physicalInterfaces, vlanAwareBridge);
+      }
+    }
+    return ret.build();
+  }
+
+  @VisibleForTesting
+  static @Nonnull Optional<L2Interface> connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+      Interface i,
+      Map<String, Interface> allInterfaces,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces,
+      BridgeDomain bridgeDomain) {
+    NodeInterfacePair nip = NodeInterfacePair.of(i);
+    if (!i.getSwitchport()) {
+      LOGGER.debug("Skipping non-L2 interface {}: switchport is not set", nip);
+      return Optional.empty();
+    }
+
+    // Identify the physical interface corresponding to this L2 interface.
+    Optional<PhysicalInterface> maybeIface =
+        findCorrespondingPhysicalInterface(i, nip, allInterfaces, physicalInterfaces);
+    if (!maybeIface.isPresent()) {
+      // Already warned/logged inside the prior function.
+      return Optional.empty();
+    }
+    PhysicalInterface physicalInterface = maybeIface.get();
+    L2Interface l2Interface = new L2Interface(nip);
+
+    // Connect L2 interface to domain and physical interface based on L2 config.
+    if (i.getSwitchportMode() == SwitchportMode.ACCESS) {
+      Integer vlan = i.getAccessVlan();
+      if (vlan == null) {
+        LOGGER.warn("Skipping L2 connection for {}: access mode vlan is missing", nip);
+        return Optional.empty();
+      }
+      Edges.connectAccessToBridgeDomainAndPhysical(
+          vlan, l2Interface, bridgeDomain, physicalInterface, i.getAccessVlan());
+      return Optional.of(l2Interface);
+    } else if (i.getSwitchportMode() == SwitchportMode.TRUNK) {
+      assert i.getAllowedVlans() != null;
+      Edges.connectTrunkToBridgeDomainAndPhysical(
+          l2Interface, bridgeDomain, physicalInterface, i.getNativeVlan(), i.getAllowedVlans());
+      return Optional.of(l2Interface);
+    } else {
+      // TODO: l2transport
+      LOGGER.warn("Unsupported L2 interface {}: unsure how to connect", nip);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Returns the {@link PhysicalInterface} corresponding to the given {@link Interface}, if one
+   * exists. This function returns a present {@link Optional} if {@code i} is a physical interface
+   * already, or if {@code i} is a correctly configured subinterface.
+   *
+   * <p>In other cases (virtual interface like Vlan, missing parent interface, etc.) the return
+   * value will be {@link Optional#empty()}.
+   */
+  @VisibleForTesting
+  static @Nonnull Optional<PhysicalInterface> findCorrespondingPhysicalInterface(
+      Interface i,
+      NodeInterfacePair nip,
+      Map<String, Interface> deviceInterfaces,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces) {
+    PhysicalInterface iface = physicalInterfaces.get(nip);
+    if (iface != null) {
+      return Optional.of(iface);
+    }
+    Optional<Dependency> parent =
+        i.getDependencies().stream().filter(d -> d.getType() == DependencyType.BIND).findFirst();
+    if (!parent.isPresent()) {
+      LOGGER.debug("No corresponding physical interface found for {}", nip);
+      return Optional.empty();
+    }
+    String parentName = parent.get().getInterfaceName();
+    NodeInterfacePair parentNip = NodeInterfacePair.of(nip.getHostname(), parentName);
+    if (!deviceInterfaces.containsKey(parentName)) {
+      LOGGER.warn("Subinterface {}: missing parent {}, skipping", nip, parentNip);
+      return Optional.empty();
+    }
+    iface = physicalInterfaces.get(parentNip);
+    if (iface == null) {
+      LOGGER.debug("Subinterface {}: parent {} has no physical interface", nip, parentNip);
+      return Optional.empty();
+    } else {
+      return Optional.of(iface);
+    }
+  }
+
+  private static @Nonnull Map<NodeInterfacePair, L3Interface> computeLayer3Interfaces(
+      Map<String, Configuration> configs,
+      Map<BridgeId, BridgeDomain> bridgeDomains,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces) {
+    ImmutableMap.Builder<NodeInterfacePair, L3Interface> ret = ImmutableMap.builder();
+    for (Configuration c : configs.values()) {
+      for (Interface i : c.getAllInterfaces().values()) {
+        if (!shouldCreateL3Interface(i)) {
+          continue;
+        }
+        L3Interface l3Interface =
+            connectL3InterfaceToPhysicalOrDomain(
+                    i, c.getAllInterfaces(), physicalInterfaces, bridgeDomains)
+                .orElse(new DisconnectedL3Interface(NodeInterfacePair.of(i)));
+        ret.put(l3Interface.getInterface(), l3Interface);
+      }
+    }
+    return ret.build();
+  }
+
+  @VisibleForTesting
+  static boolean shouldCreateL3Interface(Interface i) {
+    NodeInterfacePair nip = NodeInterfacePair.of(i);
+    if (i.getAllAddresses().isEmpty()) {
+      LOGGER.debug("Not creating L3 interface {}: no addresses", nip);
+      return false;
+    } else if (!i.getActive()) {
+      LOGGER.debug("Not creating L3 interface {}: not active", nip);
+      return false;
+    } else if (i.getInterfaceType() == InterfaceType.LOOPBACK) {
+      LOGGER.debug("Skipping L3 interface {}: loopback", nip);
+      return false;
+    } else if (i.getSwitchport()) {
+      LOGGER.warn("Skipping L3 interface {}: has switchport set to true", nip);
+      return false;
+    }
+    LOGGER.debug("Created L3 interface for {} with addresses {}", nip, i.getAllAddresses());
+    return true;
+  }
+
+  @VisibleForTesting
+  static @Nonnull Optional<L3Interface> connectL3InterfaceToPhysicalOrDomain(
+      Interface i,
+      Map<String, Interface> deviceInterfaces,
+      Map<NodeInterfacePair, PhysicalInterface> physicalInterfaces,
+      Map<BridgeId, BridgeDomain> bridgeDomains) {
+    NodeInterfacePair nip = NodeInterfacePair.of(i);
+    if (PHYSICAL_INTERFACE_TYPES.contains(i.getInterfaceType())) {
+      PhysicalInterface physicalInterface = physicalInterfaces.get(nip);
+      if (physicalInterface == null) {
+        LOGGER.warn("L3 interface {}: surprised not to find physical interface; skipping", nip);
+        return Optional.empty();
+      }
+      // This is a physical interface with an IP address. Either it has encapsulation or
+      // it sends out untagged.
+      NonBridgedL3Interface l3Interface = new NonBridgedL3Interface(nip);
+      Integer encapsulationVlan = i.getEncapsulationVlan();
+      if (encapsulationVlan == null) {
+        LOGGER.debug("L3 interface {} connected to physical interface {} untagged", nip, nip);
+      } else {
+        LOGGER.debug(
+            "L3 interface {} connected to physical interface {} in vlan {}",
+            nip,
+            nip,
+            i.getEncapsulationVlan());
+      }
+      Edges.connectNonBridgedL3ToPhysical(l3Interface, physicalInterface, encapsulationVlan);
+      return Optional.of(l3Interface);
+    }
+
+    Optional<Dependency> parent =
+        i.getDependencies().stream().filter(d -> d.getType() == DependencyType.BIND).findFirst();
+    if (parent.isPresent()) {
+      String parentName = parent.get().getInterfaceName();
+      NodeInterfacePair parentNip = NodeInterfacePair.of(nip.getHostname(), parentName);
+      if (!deviceInterfaces.containsKey(parentName)) {
+        LOGGER.warn("Not connecting L3 interface {} to parent: {} not found", nip, parentNip);
+        return Optional.empty();
+      }
+      PhysicalInterface parentIface = physicalInterfaces.get(parentNip);
+      if (parentIface == null) {
+        LOGGER.warn(
+            "Not connecting L3 interface {} to parent {}: physical interface not found",
+            nip,
+            parentNip);
+        return Optional.empty();
+      }
+      NonBridgedL3Interface l3Interface = new NonBridgedL3Interface(nip);
+      Integer encapsulationVlan = i.getEncapsulationVlan();
+      if (encapsulationVlan == null) {
+        LOGGER.debug("L3 interface {} connected to physical interface {} untagged", nip, parentNip);
+      } else {
+        LOGGER.debug(
+            "Connecting L3 interface {} to physical interface {} in vlan {}",
+            nip,
+            parentNip,
+            i.getEncapsulationVlan());
+      }
+      Edges.connectNonBridgedL3ToPhysical(l3Interface, parentIface, encapsulationVlan);
+      return Optional.of(l3Interface);
+    }
+
+    if (i.getInterfaceType() == InterfaceType.TUNNEL) {
+      // These interfaces do not use L2 broadcast domains / adjacency to establish edges
+      return Optional.empty();
+    }
+
+    if (i.getInterfaceType() == InterfaceType.VLAN) {
+      Integer vlan = i.getVlan();
+      if (vlan == null) {
+        LOGGER.warn("Not connecting L3 interface {}: surprised vlan is not set", nip);
+        return Optional.empty();
+      }
+      // TODO: store bridge domain in interface
+      BridgeDomain bridgeDomain = bridgeDomains.get(BridgeId.vlanAwareBridgeId(nip.getHostname()));
+      if (bridgeDomain == null) {
+        LOGGER.warn("Not connecting L3 interface {}: surprised not to find vlan-aware bridge", nip);
+        return Optional.empty();
+      }
+      LOGGER.debug(
+          "Connecting L3 interface {} to bridge domain {} in vlan {}",
+          nip,
+          bridgeDomain.getId(),
+          vlan);
+      BridgedL3Interface bridgedL3Interface = new BridgedL3Interface(nip);
+      Edges.connectIrbToBridgeDomain(bridgedL3Interface, bridgeDomain, vlan);
+      return Optional.of(bridgedL3Interface);
+    }
+
+    LOGGER.warn(
+        "Surprised by L3 interface {} of type {}: unsure how to connect",
+        nip,
+        i.getInterfaceType());
+    return Optional.empty();
+  }
+
+  private static @Nonnull Map<VxlanNode, L2Vni> computeL2Vnis(
+      Map<String, Configuration> configs, Map<BridgeId, BridgeDomain> bridgeDomains) {
+    ImmutableMap.Builder<VxlanNode, L2Vni> ret = ImmutableMap.builder();
+    for (Configuration c : configs.values()) {
+      // TODO: support other bridge domains
+      BridgeDomain bridgeDomain = bridgeDomains.get(BridgeId.vlanAwareBridgeId(c.getHostname()));
+      checkState(
+          bridgeDomain != null,
+          "Device bridge domain not yet created for device %s",
+          c.getHostname());
+      for (Vrf vrf : c.getVrfs().values()) {
+        for (Layer2Vni vniSettings : vrf.getLayer2Vnis().values()) {
+          VxlanNode node = new VxlanNode(c.getHostname(), vniSettings.getVni(), VniLayer.LAYER_2);
+          L2Vni vni = new L2Vni(node);
+          ret.put(node, vni);
+          Edges.connectVniToVlanAwareBridgeDomain(vni, bridgeDomain, vniSettings.getVlan());
+        }
+      }
+    }
+    return ret.build();
+  }
+
+  @VisibleForTesting
+  static @Nonnull Map<String, L2VniHub> computeL2VniHubs(
+      Map<VxlanNode, L2Vni> l2vnis, VxlanTopology vxlanTopology) {
+    Set<EndpointPair<VxlanNode>> l2edges =
+        vxlanTopology.getLayer2VniEdges().collect(ImmutableSet.toImmutableSet());
+    if (l2vnis.isEmpty() || l2edges.isEmpty()) {
+      return ImmutableMap.of();
+    }
+
+    // Build a hub for every L2VNI cluster.
+    Set<VxlanNode> nodesWithEdges =
+        l2edges.stream()
+            .flatMap(e -> Stream.of(e.nodeU(), e.nodeV()))
+            .collect(ImmutableSet.toImmutableSet());
+    UnionFind<VxlanNode> clusters = new UnionFind<>(nodesWithEdges);
+    for (EndpointPair<VxlanNode> edge : l2edges) {
+      clusters.union(edge.nodeU(), edge.nodeV());
+    }
+
+    // Build up the set of L2VNIs attached to each hub.
+    Multimap<VxlanNode, VxlanNode> groups = LinkedListMultimap.create(clusters.numberOfSets());
+    for (VxlanNode node : nodesWithEdges) {
+      groups.put(clusters.find(node), node);
+    }
+    // Create one L2VNIHub for each group.
+    ImmutableMap.Builder<String, L2VniHub> ret = ImmutableMap.builder();
+    groups
+        .asMap()
+        .forEach(
+            (id, nodes) -> {
+              L2VniHub hub = new L2VniHub("Hub for " + id);
+              L2Vni[] vnis = new L2Vni[nodes.size()];
+              int i = 0;
+              for (VxlanNode node : nodes) {
+                L2Vni vni = l2vnis.get(node);
+                assert vni != null;
+                vnis[i] = vni;
+                ++i;
+              }
+              Edges.connectToL2VniHub(hub, vnis);
+              ret.put(hub.getName(), hub);
+            });
+    return ret.build();
+  }
+
+  private static Interface getInterface(NodeInterfacePair i, Map<String, Configuration> configs) {
+    return configs.get(i.getHostname()).getAllInterfaces().get(i.getInterface());
+  }
+
+  private static final @Nonnull EnumSet<InterfaceType> PHYSICAL_INTERFACE_TYPES =
+      EnumSet.of(InterfaceType.PHYSICAL, InterfaceType.AGGREGATED);
+
+  private static boolean isAggregated(Interface i) {
+    return i.getChannelGroup() != null;
+  }
+
+  @SuppressWarnings("unused")
+  private final @Nonnull Map<BridgeId, BridgeDomain> _bridgeDomains;
+
+  @SuppressWarnings("unused")
+  private final @Nonnull Map<String, EthernetHub> _ethernetHubs;
+
+  private final @Nonnull Layer1Topologies _layer1Topologies;
+  private final @Nonnull Map<NodeInterfacePair, PhysicalInterface> _physicalInterfaces;
+  private final @Nonnull Map<NodeInterfacePair, L3Interface> _layer3Interfaces;
+  private final @Nonnull Map<VxlanNode, L2Vni> _l2Vnis;
+
+  @SuppressWarnings("unused")
+  private final @Nonnull Map<String, L2VniHub> _l2VniHubs;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/NodeAndState.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/NodeAndState.java
@@ -1,0 +1,51 @@
+package org.batfish.common.topology.bridge_domain;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.node.Node;
+
+final class NodeAndState {
+
+  public static @Nonnull NodeAndState of(Node node, State state) {
+    return new NodeAndState(node, state);
+  }
+
+  public @Nonnull Node getNode() {
+    return _node;
+  }
+
+  public @Nonnull State getState() {
+    return _state;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof NodeAndState)) {
+      return false;
+    }
+    NodeAndState that = (NodeAndState) o;
+    return _node.equals(that._node) && _state.equals(that._state);
+  }
+
+  @Override
+  public int hashCode() {
+    return _node.hashCode() * 31 + _state.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("_node", _node).add("_state", _state).toString();
+  }
+
+  private NodeAndState(Node node, State state) {
+    _node = node;
+    _state = state;
+  }
+
+  private final @Nonnull Node _node;
+  private final @Nonnull State _state;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/Search.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/Search.java
@@ -1,0 +1,190 @@
+package org.batfish.common.topology.bridge_domain;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Stack;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.common.topology.bridge_domain.function.AssignVlanFromOuterTag;
+import org.batfish.common.topology.bridge_domain.function.ClearVlanId;
+import org.batfish.common.topology.bridge_domain.function.ComposeBaseImpl;
+import org.batfish.common.topology.bridge_domain.function.FilterByOuterTagImpl;
+import org.batfish.common.topology.bridge_domain.function.FilterByVlanIdImpl;
+import org.batfish.common.topology.bridge_domain.function.Identity;
+import org.batfish.common.topology.bridge_domain.function.PopTagImpl;
+import org.batfish.common.topology.bridge_domain.function.PushTag;
+import org.batfish.common.topology.bridge_domain.function.PushVlanId;
+import org.batfish.common.topology.bridge_domain.function.SetVlanId;
+import org.batfish.common.topology.bridge_domain.function.StateFunctionVisitor;
+import org.batfish.common.topology.bridge_domain.function.TranslateVlanImpl;
+import org.batfish.common.topology.bridge_domain.node.L3Interface;
+import org.batfish.common.topology.bridge_domain.node.Node;
+
+final class Search {
+
+  /** Returns the broadcast domain reachable from a given {@code originator}. */
+  public static @Nonnull Set<L3Interface> originate(L3Interface originator) {
+    return new Search(originator).getBroadcastDomain();
+  }
+
+  private @Nonnull Set<L3Interface> getBroadcastDomain() {
+    return _broadcastDomain;
+  }
+
+  private void search() {
+    _broadcastDomain.add(_originator);
+    NodeAndState initialNodeAndState = NodeAndState.of(_originator, State.empty());
+    _visited.add(initialNodeAndState);
+    _originator
+        .getOutEdges()
+        .forEach(
+            (nextNode, edgeToNextNode) ->
+                _remainingTraversals.add(
+                    () -> traverseEdge(initialNodeAndState, edgeToNextNode, nextNode)));
+    // TODO: parallelize
+    while (!_remainingTraversals.empty()) {
+      _remainingTraversals.pop().run();
+    }
+  }
+
+  private void traverseEdge(NodeAndState currentNodeAndState, Edge edge, Node toNode) {
+    Node currentNode = currentNodeAndState.getNode();
+    STATE_FUNCTION_EVALUATOR
+        .visit(edge.getStateFunction(), currentNodeAndState.getState())
+        .ifPresent(nextState -> visit(currentNode, NodeAndState.of(toNode, nextState)));
+  }
+
+  private void visit(Node lastNode, NodeAndState nodeAndState) {
+    if (_visited.contains(nodeAndState)) {
+      return;
+    }
+    _visited.add(nodeAndState);
+    if (nodeAndState.getNode() instanceof L3Interface) {
+      _broadcastDomain.add((L3Interface) nodeAndState.getNode());
+    } else {
+      nodeAndState
+          .getNode()
+          .getOutEdges()
+          .forEach(
+              (nextNode, edgeToNextNode) -> {
+                if (nextNode.equals(lastNode)) {
+                  return;
+                }
+                _remainingTraversals.push(
+                    () -> traverseEdge(nodeAndState, edgeToNextNode, nextNode));
+              });
+    }
+  }
+
+  static class StateFunctionEvaluator implements StateFunctionVisitor<Optional<State>, State> {
+
+    @Override
+    public Optional<State> visitAssignVlanFromOuterTag(
+        AssignVlanFromOuterTag assignVlanFromOuterTag, State state) {
+      Integer outerTag = state.getOuterTag();
+      Integer nativeVlan = assignVlanFromOuterTag.getNativeVlan();
+      assert outerTag != null || nativeVlan != null;
+      assert state.getVlan() == null;
+      if (outerTag == null) {
+        return Optional.of(State.of(null, nativeVlan));
+      } else {
+        // TODO: preserve rest of tag stack in this case when tag stacks are supported.
+        return Optional.of(State.of(null, outerTag));
+      }
+    }
+
+    @Override
+    public Optional<State> visitClearVlanId(ClearVlanId clearVlanId, State state) {
+      assert state.getVlan() != null;
+      return Optional.of(State.of(state.getOuterTag(), null));
+    }
+
+    @Override
+    public Optional<State> visitCompose(ComposeBaseImpl<?> compose, State state) {
+      return visit(compose.getFunc1(), state).flatMap(s1 -> visit(compose.getFunc2(), s1));
+    }
+
+    @Override
+    public Optional<State> visitFilterByOuterTag(
+        FilterByOuterTagImpl filterByOuterTag, State state) {
+      Integer outerTag = state.getOuterTag();
+      if (outerTag == null) {
+        return filterByOuterTag.getAllowUntagged() ? Optional.of(state) : Optional.empty();
+      } else {
+        return filterByOuterTag.getAllowedOuterTags().contains(outerTag)
+            ? Optional.of(state)
+            : Optional.empty();
+      }
+    }
+
+    @Override
+    public Optional<State> visitFilterByVlanId(FilterByVlanIdImpl filterByVlanId, State state) {
+      assert state.getVlan() != null;
+      return Optional.of(state)
+          .filter(s -> filterByVlanId.getAllowedVlanIds().contains(s.getVlan()));
+    }
+
+    @Override
+    public Optional<State> visitIdentity(Identity identity, State state) {
+      return Optional.of(state);
+    }
+
+    @Override
+    public Optional<State> visitPopTag(PopTagImpl popTag, State state) {
+      // TODO: remove this assertion when tag stacks are supported
+      assert popTag.getCount() == 1;
+      assert state.getOuterTag() != null;
+      return Optional.of(State.of(null, state.getVlan()));
+    }
+
+    @Override
+    public Optional<State> visitPushTag(PushTag pushTag, State state) {
+      // TODO: remove this assertion when tag stacks are supported
+      assert state.getOuterTag() == null;
+      return Optional.of(State.of(pushTag.getTagToPush(), state.getVlan()));
+    }
+
+    @Override
+    public Optional<State> visitPushVlanId(PushVlanId pushVlanId, State state) {
+      // TODO: remove this assertion when tag stacks are supported
+      assert state.getOuterTag() == null;
+      assert state.getVlan() != null;
+      int vlan = state.getVlan();
+      return Optional.of(
+          State.of(Objects.equals(vlan, pushVlanId.getExceptVlan()) ? null : vlan, vlan));
+    }
+
+    @Override
+    public Optional<State> visitSetVlanId(SetVlanId setVlanId, State state) {
+      assert state.getVlan() == null;
+      return Optional.of(State.of(state.getOuterTag(), setVlanId.getVlanId()));
+    }
+
+    @Override
+    public Optional<State> visitTranslateVlan(TranslateVlanImpl translateVlan, State state) {
+      assert state.getVlan() != null;
+      int oldVlan = state.getVlan();
+      int newVlan = translateVlan.getTranslations().getOrDefault(oldVlan, oldVlan);
+      return Optional.of(State.of(state.getOuterTag(), newVlan));
+    }
+  }
+
+  private Search(L3Interface originator) {
+    _originator = originator;
+    _broadcastDomain = new HashSet<>();
+    _visited = new HashSet<>();
+    _remainingTraversals = new Stack<>();
+    search();
+  }
+
+  @VisibleForTesting
+  static final StateFunctionEvaluator STATE_FUNCTION_EVALUATOR = new StateFunctionEvaluator();
+
+  private final @Nonnull Set<NodeAndState> _visited;
+  private final @Nonnull L3Interface _originator;
+  private final @Nonnull Set<L3Interface> _broadcastDomain;
+  private final @Nonnull Stack<Runnable> _remainingTraversals;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/State.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/State.java
@@ -1,0 +1,63 @@
+package org.batfish.common.topology.bridge_domain;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+final class State {
+
+  public static @Nonnull State of(@Nullable Integer outerTag, @Nullable Integer vlan) {
+    return outerTag == null && vlan == null ? EMPTY : new State(outerTag, vlan);
+  }
+
+  public static @Nonnull State empty() {
+    return EMPTY;
+  }
+
+  public @Nullable Integer getOuterTag() {
+    return _outerTag;
+  }
+
+  public @Nullable Integer getVlan() {
+    return _vlan;
+  }
+
+  // Internal implementation details
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    State state = (State) o;
+    return Objects.equals(_outerTag, state._outerTag) && Objects.equals(_vlan, state._vlan);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * (_outerTag == null ? 0 : _outerTag) + (_vlan == null ? 0 : _vlan);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .omitNullValues()
+        .add("_outerTag", _outerTag)
+        .add("_vlan", _vlan)
+        .toString();
+  }
+
+  private static final State EMPTY = new State(null, null);
+
+  private State(@Nullable Integer outerTag, @Nullable Integer vlan) {
+    _outerTag = outerTag;
+    _vlan = vlan;
+  }
+
+  private final @Nullable Integer _outerTag;
+  private final @Nullable Integer _vlan;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/BridgeDomainToBridgedL3.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/BridgeDomainToBridgedL3.java
@@ -1,0 +1,40 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.filterByOuterTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.filterByVlanId;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+import org.batfish.datamodel.IntegerSpace;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.BridgeDomain} to a {@link
+ * org.batfish.common.topology.bridge_domain.node.BridgedL3Interface}.
+ */
+public final class BridgeDomainToBridgedL3 extends Edge {
+
+  public interface Function extends StateFunction {}
+
+  /**
+   * Helper for creating an edge from an IOS-XR named bridge domain to its BVI (bridged virtual
+   * interface).
+   */
+  public static @Nonnull BridgeDomainToBridgedL3 bridgeDomainToBvi() {
+    return of(filterByOuterTag(IntegerSpace.EMPTY, true));
+  }
+
+  /** Helper for creating an edge from a vlan-aware bridge to an IRB/Vlan interface. */
+  public static @Nonnull BridgeDomainToBridgedL3 bridgeDomainToIrb(int vlanId) {
+    return of(filterByVlanId(IntegerSpace.of(vlanId)));
+  }
+
+  @VisibleForTesting
+  public static @Nonnull BridgeDomainToBridgedL3 of(Function stateFunction) {
+    return new BridgeDomainToBridgedL3(stateFunction);
+  }
+
+  private BridgeDomainToBridgedL3(Function stateFunction) {
+    super(stateFunction);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/BridgeDomainToL2.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/BridgeDomainToL2.java
@@ -1,0 +1,71 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.filterByVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.translateVlan;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.function.ComposeBaseImpl;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+import org.batfish.datamodel.IntegerSpace;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.BridgeDomain} to an {@link
+ * org.batfish.common.topology.bridge_domain.node.L2Interface}.
+ */
+public final class BridgeDomainToL2 extends Edge {
+
+  public interface Function extends StateFunction {}
+
+  /**
+   * Helper for creating an edge from a vlan-aware bridge domain to a traditional access-mode
+   * switchport.
+   */
+  public static @Nonnull BridgeDomainToL2 bridgeDomainToAccess(int accessVlan) {
+    return new BridgeDomainToL2(filterByVlanId(IntegerSpace.of(accessVlan)));
+  }
+
+  /**
+   * Helper for creating an edge from a vlan-aware bridge domain to a traditional trunk-mode
+   * switchport.
+   */
+  public static @Nonnull BridgeDomainToL2 bridgeDomainToTrunk(
+      Map<Integer, Integer> translations, IntegerSpace allowedVlans) {
+    Function filter = filterByVlanId(allowedVlans);
+    return new BridgeDomainToL2(
+        translations.isEmpty() ? filter : compose(filter, translateVlan(translations)));
+  }
+
+  /**
+   * Helper for creating an edge from a vlan-aware bridge domain to an IOS-XR-style l2transport
+   * interface.
+   */
+  public static @Nonnull BridgeDomainToL2 bridgeDomainToL2Transport() {
+    return new BridgeDomainToL2(identity());
+  }
+
+  @VisibleForTesting
+  public static @Nonnull Function compose(Function func1, Function func2) {
+    return func1.equals(identity())
+        ? func2
+        : func2.equals(identity()) ? func1 : new Compose(func1, func2);
+  }
+
+  @VisibleForTesting
+  public static @Nonnull BridgeDomainToL2 of(Function stateFunction) {
+    return new BridgeDomainToL2(stateFunction);
+  }
+
+  private BridgeDomainToL2(Function stateFunction) {
+    super(stateFunction);
+  }
+
+  private static final class Compose extends ComposeBaseImpl<Function> implements Function {
+
+    private Compose(Function func1, Function func2) {
+      super(func1, func2);
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/BridgeDomainToL2Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/BridgeDomainToL2Vni.java
@@ -1,0 +1,54 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.clearVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.filterByVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.function.ComposeBaseImpl;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+import org.batfish.datamodel.IntegerSpace;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.BridgeDomain} to an {@link
+ * org.batfish.common.topology.bridge_domain.node.L2Vni}.
+ */
+public final class BridgeDomainToL2Vni extends Edge {
+  public interface Function extends StateFunction {}
+
+  /** Helper for creating an edge from a vlan-aware bridge domain to an attached layer-2 VNI. */
+  public static @Nonnull BridgeDomainToL2Vni vlanAwareBridgeDomainToL2Vni(int vlan) {
+    return of(compose(filterByVlanId(IntegerSpace.of(vlan)), clearVlanId()));
+  }
+
+  /** Helper for creating an edge from a non-vlan-aware bridge domain to an attached layer-2 VNI. */
+  public static @Nonnull BridgeDomainToL2Vni nonVlanAwareBridgeDomainToL2Vni() {
+    return NON_VLAN_AWARE_BRIDGE_DOMAIN_TO_L2_VNI;
+  }
+
+  @VisibleForTesting
+  public static @Nonnull Function compose(Function func1, Function func2) {
+    return func1.equals(identity())
+        ? func2
+        : func2.equals(identity()) ? func1 : new Compose(func1, func2);
+  }
+
+  @VisibleForTesting
+  public static @Nonnull BridgeDomainToL2Vni of(Function stateFunction) {
+    return new BridgeDomainToL2Vni(stateFunction);
+  }
+
+  private static final BridgeDomainToL2Vni NON_VLAN_AWARE_BRIDGE_DOMAIN_TO_L2_VNI = of(identity());
+
+  private static final class Compose extends ComposeBaseImpl<Function> implements Function {
+
+    private Compose(Function func1, Function func2) {
+      super(func1, func2);
+    }
+  }
+
+  private BridgeDomainToL2Vni(Function stateFunction) {
+    super(stateFunction);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/BridgedL3ToBridgeDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/BridgedL3ToBridgeDomain.java
@@ -1,0 +1,42 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.setVlanId;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.BridgedL3Interface} to a
+ * {@link org.batfish.common.topology.bridge_domain.node.BridgeDomain}.
+ */
+public final class BridgedL3ToBridgeDomain extends Edge {
+
+  public interface Function extends StateFunction {}
+
+  /**
+   * Helper for creating an edge from an IOS-XR BVI (bridged virtual interface) to its bridge
+   * domain.
+   */
+  public static @Nonnull BridgedL3ToBridgeDomain bviToBridgeDomain() {
+    return of(identity());
+  }
+
+  /**
+   * Helper for creating an edge from an IRB/Vlan interface to the a device's vlan-aware bridge
+   * domain.
+   */
+  public static @Nonnull BridgedL3ToBridgeDomain irbToBridgeDomain(int vlanId) {
+    return of(setVlanId(vlanId));
+  }
+
+  @VisibleForTesting
+  public static @Nonnull BridgedL3ToBridgeDomain of(Function stateFunction) {
+    return new BridgedL3ToBridgeDomain(stateFunction);
+  }
+
+  private BridgedL3ToBridgeDomain(Function stateFunction) {
+    super(stateFunction);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/Edge.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/Edge.java
@@ -1,0 +1,22 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+
+/**
+ * A directed edge between two {@link org.batfish.common.topology.bridge_domain.node.Node}s in the
+ * L3 adjacencies computation graph.
+ */
+public abstract class Edge {
+
+  /** A transformation on state to be performed when this edge is traversed. */
+  public final @Nonnull StateFunction getStateFunction() {
+    return _stateFunction;
+  }
+
+  protected Edge(StateFunction stateFunction) {
+    _stateFunction = stateFunction;
+  }
+
+  private final @Nonnull StateFunction _stateFunction;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/Edges.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/Edges.java
@@ -1,0 +1,110 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import com.google.common.collect.ImmutableMap;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.node.BridgeDomain;
+import org.batfish.common.topology.bridge_domain.node.BridgedL3Interface;
+import org.batfish.common.topology.bridge_domain.node.EthernetHub;
+import org.batfish.common.topology.bridge_domain.node.L2Interface;
+import org.batfish.common.topology.bridge_domain.node.L2Vni;
+import org.batfish.common.topology.bridge_domain.node.L2VniHub;
+import org.batfish.common.topology.bridge_domain.node.NonBridgedL3Interface;
+import org.batfish.common.topology.bridge_domain.node.PhysicalInterface;
+import org.batfish.datamodel.IntegerSpace;
+
+/**
+ * Utility class containing helper methods for generating all the directed edges between a set of
+ * inter-related {@link org.batfish.common.topology.bridge_domain.node.Node}s.
+ */
+public final class Edges {
+
+  /**
+   * Generate edges connecting an {@link EthernetHub} to every one of a list of {@link
+   * PhysicalInterface}s.
+   */
+  public static void connectToHub(EthernetHub hub, PhysicalInterface... phys) {
+    for (PhysicalInterface p : phys) {
+      hub.addAttachedInterface(p);
+      p.attachToHub(hub);
+    }
+  }
+
+  /**
+   * Generate edges connecting an access port {@link L2Interface} to its {@link PhysicalInterface}
+   * and the device's vlan-aware {@link BridgeDomain}.
+   */
+  public static void connectAccessToBridgeDomainAndPhysical(
+      int vlan,
+      L2Interface l2Interface,
+      BridgeDomain bridgeDomain,
+      PhysicalInterface physicalInterface,
+      Integer accessVlan) {
+    l2Interface.connectToBridgeDomain(bridgeDomain, L2ToBridgeDomain.accessToBridgeDomain(vlan));
+    bridgeDomain.connectToL2Interface(
+        l2Interface, BridgeDomainToL2.bridgeDomainToAccess(accessVlan));
+    l2Interface.connectToPhysicalInterface(physicalInterface, L2ToPhysical.accessToPhysical());
+    physicalInterface.connectToL2Interface(l2Interface, PhysicalToL2.physicalToAccess());
+  }
+
+  /**
+   * Generate edges connecting a trunk port {@link L2Interface} to its {@link PhysicalInterface} and
+   * the device's vlan-aware {@link BridgeDomain}.
+   */
+  public static void connectTrunkToBridgeDomainAndPhysical(
+      L2Interface l2Interface,
+      BridgeDomain bridgeDomain,
+      PhysicalInterface physicalInterface,
+      @Nullable Integer nativeVlan,
+      IntegerSpace allowedVlans) {
+    // TODO: support translations
+    l2Interface.connectToBridgeDomain(
+        bridgeDomain, L2ToBridgeDomain.trunkToBridgeDomain(ImmutableMap.of()));
+    // TODO: support translations
+    bridgeDomain.connectToL2Interface(
+        l2Interface, BridgeDomainToL2.bridgeDomainToTrunk(ImmutableMap.of(), allowedVlans));
+    l2Interface.connectToPhysicalInterface(
+        physicalInterface, L2ToPhysical.trunkToPhysical(nativeVlan));
+    physicalInterface.connectToL2Interface(
+        l2Interface, PhysicalToL2.physicalToTrunk(allowedVlans, nativeVlan));
+  }
+
+  /** Generate edges connecting a {@link NonBridgedL3Interface} to its {@link PhysicalInterface}. */
+  public static void connectNonBridgedL3ToPhysical(
+      NonBridgedL3Interface nonBridgedL3Interface,
+      PhysicalInterface physicalInterface,
+      @Nullable Integer tag) {
+    nonBridgedL3Interface.connectToPhysicalInterface(
+        physicalInterface, NonBridgedL3ToPhysical.nonBridgedLayer3ToPhysical(tag));
+    physicalInterface.connectToNonBridgedL3Interface(
+        nonBridgedL3Interface, PhysicalToNonBridgedL3.physicalToNonBridgedL3(tag));
+  }
+
+  /**
+   * Generate edges connecting an IRB/Vlan {@link BridgedL3Interface} to the device's vlan-aware
+   * {@link BridgeDomain}.
+   */
+  public static void connectIrbToBridgeDomain(
+      BridgedL3Interface bridgedL3Interface, BridgeDomain bridgeDomain, int vlan) {
+    bridgedL3Interface.connectToBridgeDomain(
+        bridgeDomain, BridgedL3ToBridgeDomain.irbToBridgeDomain(vlan));
+    bridgeDomain.connectToBridgedL3Interface(
+        bridgedL3Interface, BridgeDomainToBridgedL3.bridgeDomainToIrb(vlan));
+  }
+
+  /** Generate edges connecting an {@link L2Vni} to a vlan-aware {@link BridgeDomain}. */
+  public static void connectVniToVlanAwareBridgeDomain(
+      L2Vni vni, BridgeDomain bridgeDomain, int vlan) {
+    vni.connectToBridgeDomain(bridgeDomain, L2VniToBridgeDomain.l2VniToVlanAwareBridgeDomain(vlan));
+    bridgeDomain.connectToL2Vni(vni, BridgeDomainToL2Vni.vlanAwareBridgeDomainToL2Vni(vlan));
+  }
+
+  /** Generate edges connecting an {@link L2VniHub} to every one of a list of {@link L2Vni}s. */
+  public static void connectToL2VniHub(L2VniHub l2VniHub, L2Vni... l2Vnis) {
+    for (L2Vni l2Vni : l2Vnis) {
+      l2VniHub.attachL2Vni(l2Vni);
+      l2Vni.connectToL2VniHub(l2VniHub);
+    }
+  }
+
+  private Edges() {}
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/EthernetHubToPhysical.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/EthernetHubToPhysical.java
@@ -1,0 +1,22 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.EthernetHub} to a {@link
+ * org.batfish.common.topology.bridge_domain.node.PhysicalInterface}.
+ */
+public final class EthernetHubToPhysical extends Edge {
+
+  public static @Nonnull EthernetHubToPhysical instance() {
+    return INSTANCE;
+  }
+
+  private static final EthernetHubToPhysical INSTANCE = new EthernetHubToPhysical();
+
+  private EthernetHubToPhysical() {
+    super(identity());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2ToBridgeDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2ToBridgeDomain.java
@@ -1,0 +1,50 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.popTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.setVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.translateVlan;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+
+/**
+ * An edge from an {@link org.batfish.common.topology.bridge_domain.node.L2Interface} to a {@link
+ * org.batfish.common.topology.bridge_domain.node.BridgeDomain}.
+ */
+public final class L2ToBridgeDomain extends Edge {
+  public interface Function extends StateFunction {}
+
+  /**
+   * Helper for creating and edge from a traditional access-mode switchport to a device's vlan-aware
+   * bridge domain.
+   */
+  public static @Nonnull L2ToBridgeDomain accessToBridgeDomain(int vlanId) {
+    return of(setVlanId(vlanId));
+  }
+
+  /**
+   * Helper for creating and edge from an IOS-XR-style l2transport interface to its bridge domain.
+   */
+  public static @Nonnull L2ToBridgeDomain l2TransportToBridgeDomain(int tagPopCount) {
+    return of(popTag(tagPopCount));
+  }
+
+  /**
+   * Helper for creating an edge from a traditional trunk-mode switchport to a device's vlan-aware
+   * bridge domain.
+   */
+  public static @Nonnull L2ToBridgeDomain trunkToBridgeDomain(Map<Integer, Integer> translations) {
+    return of(translateVlan(translations));
+  }
+
+  @VisibleForTesting
+  public static @Nonnull L2ToBridgeDomain of(Function stateFunction) {
+    return new L2ToBridgeDomain(stateFunction);
+  }
+
+  private L2ToBridgeDomain(Function stateFunction) {
+    super(stateFunction);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2ToPhysical.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2ToPhysical.java
@@ -1,0 +1,67 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.clearVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.pushTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.pushVlanId;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.function.ComposeBaseImpl;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+
+/**
+ * An edge between an {@link org.batfish.common.topology.bridge_domain.node.L2Interface} and a
+ * {@link org.batfish.common.topology.bridge_domain.node.PhysicalInterface}.
+ */
+public final class L2ToPhysical extends Edge {
+  public interface Function extends StateFunction {}
+
+  /**
+   * Helper for creating an edge from a traditional access-mode switchport to its physical
+   * interface.
+   */
+  public static @Nonnull L2ToPhysical accessToPhysical() {
+    return of(clearVlanId());
+  }
+
+  /**
+   * Helper for creating an edge from an IOS-XR-style l2transport interface to a physical interface.
+   *
+   * <p>The API may evolve as new features are added, e.g. pushing more than one tag.
+   */
+  public static @Nonnull L2ToPhysical l2TransportToPhysical(@Nullable Integer tagToPush) {
+    return of(tagToPush == null ? identity() : pushTag(tagToPush));
+  }
+
+  /**
+   * Helper for creating an edge from a traditional trunk-mode switchport to its physical interface.
+   */
+  public static @Nonnull L2ToPhysical trunkToPhysical(@Nullable Integer exceptVlan) {
+    return of(compose(pushVlanId(exceptVlan), clearVlanId()));
+  }
+
+  @VisibleForTesting
+  public static @Nonnull Function compose(Function func1, Function func2) {
+    return func1.equals(identity())
+        ? func2
+        : func2.equals(identity()) ? func1 : new Compose(func1, func2);
+  }
+
+  @VisibleForTesting
+  public static @Nonnull L2ToPhysical of(Function stateFunction) {
+    return new L2ToPhysical(stateFunction);
+  }
+
+  private L2ToPhysical(Function stateFunction) {
+    super(stateFunction);
+  }
+
+  private static final class Compose extends ComposeBaseImpl<Function> implements Function {
+
+    private Compose(Function func1, Function func2) {
+      super(func1, func2);
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2VniHubToL2Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2VniHubToL2Vni.java
@@ -1,0 +1,22 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An edge from an {@link org.batfish.common.topology.bridge_domain.node.L2VniHub} to an {@link
+ * org.batfish.common.topology.bridge_domain.node.L2Vni}.
+ */
+public final class L2VniHubToL2Vni extends Edge {
+
+  public static @Nonnull L2VniHubToL2Vni instance() {
+    return INSTANCE;
+  }
+
+  private static final L2VniHubToL2Vni INSTANCE = new L2VniHubToL2Vni();
+
+  private L2VniHubToL2Vni() {
+    super(identity());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2VniToBridgeDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2VniToBridgeDomain.java
@@ -1,0 +1,38 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.setVlanId;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+
+/**
+ * An edge from an {@link org.batfish.common.topology.bridge_domain.node.L2Vni} to a {@link
+ * org.batfish.common.topology.bridge_domain.node.BridgeDomain}.
+ */
+public final class L2VniToBridgeDomain extends Edge {
+
+  public interface Function extends StateFunction {}
+
+  /** Helper for creating an edge from a layer-2 VNI to a device's vlan-aware bridge domain. */
+  public static @Nonnull L2VniToBridgeDomain l2VniToVlanAwareBridgeDomain(int vlan) {
+    return of(setVlanId(vlan));
+  }
+
+  /** Helper for creating an edge from a layer-2 VNI to some non-vlan-aware bridge domain. */
+  public static @Nonnull L2VniToBridgeDomain l2VniToNonVlanAwareBridgeDomain() {
+    return L2VNI_TO_NON_VLAN_AWARE_BRIDGE_DOMAIN;
+  }
+
+  @VisibleForTesting
+  public static @Nonnull L2VniToBridgeDomain of(Function stateFunction) {
+    return new L2VniToBridgeDomain(stateFunction);
+  }
+
+  private static final L2VniToBridgeDomain L2VNI_TO_NON_VLAN_AWARE_BRIDGE_DOMAIN = of(identity());
+
+  private L2VniToBridgeDomain(Function stateFunction) {
+    super(stateFunction);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2VniToL2VniHub.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/L2VniToL2VniHub.java
@@ -1,0 +1,22 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An edge from an {@link org.batfish.common.topology.bridge_domain.node.L2Vni} to an {@link
+ * org.batfish.common.topology.bridge_domain.node.L2VniHub}.
+ */
+public final class L2VniToL2VniHub extends Edge {
+
+  public static @Nonnull L2VniToL2VniHub instance() {
+    return INSTANCE;
+  }
+
+  private static final L2VniToL2VniHub INSTANCE = new L2VniToL2VniHub();
+
+  private L2VniToL2VniHub() {
+    super(identity());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/NonBridgedL3ToPhysical.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/NonBridgedL3ToPhysical.java
@@ -1,0 +1,32 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.pushTag;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.NonBridgedL3Interface} to a
+ * {@link org.batfish.common.topology.bridge_domain.node.PhysicalInterface}.
+ */
+public final class NonBridgedL3ToPhysical extends Edge {
+  public interface Function extends StateFunction {}
+
+  /** Helper for creating an edge from a non-bridged layer-3 interface to its physical interface. */
+  public static @Nonnull NonBridgedL3ToPhysical nonBridgedLayer3ToPhysical(
+      @Nullable Integer tagToPush) {
+    return of(tagToPush == null ? identity() : pushTag(tagToPush));
+  }
+
+  @VisibleForTesting
+  public static @Nonnull NonBridgedL3ToPhysical of(Function stateFunction) {
+    return new NonBridgedL3ToPhysical(stateFunction);
+  }
+
+  private NonBridgedL3ToPhysical(Function stateFunction) {
+    super(stateFunction);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/PhysicalToEthernetHub.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/PhysicalToEthernetHub.java
@@ -1,0 +1,22 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.PhysicalInterface} to an
+ * {@link org.batfish.common.topology.bridge_domain.node.EthernetHub}.
+ */
+public final class PhysicalToEthernetHub extends Edge {
+
+  public static @Nonnull PhysicalToEthernetHub instance() {
+    return INSTANCE;
+  }
+
+  private static final PhysicalToEthernetHub INSTANCE = new PhysicalToEthernetHub();
+
+  private PhysicalToEthernetHub() {
+    super(identity());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/PhysicalToL2.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/PhysicalToL2.java
@@ -1,0 +1,72 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.assignVlanFromOuterTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.filterByOuterTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.function.ComposeBaseImpl;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+import org.batfish.datamodel.IntegerSpace;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.PhysicalInterface} to an
+ * {@link org.batfish.common.topology.bridge_domain.node.L2Interface}.
+ */
+public final class PhysicalToL2 extends Edge {
+  public interface Function extends StateFunction {}
+
+  public static @Nonnull PhysicalToL2 physicalToAccess() {
+    return of(filterByOuterTag(IntegerSpace.EMPTY, true));
+  }
+
+  /**
+   * Helper for creating an edge from a physical interface to an IOS-XR-style l2transport interface,
+   * i.e. a general purpose L2 interface. Note there is no concept of VLANs for this type of
+   * interface.
+   *
+   * <p>The API may evolve as new features are added.
+   */
+  public static @Nonnull PhysicalToL2 physicalToL2Transport(
+      IntegerSpace allowedOuterTags, boolean allowUntagged) {
+    return of(filterByOuterTag(allowedOuterTags, allowUntagged));
+  }
+
+  /**
+   * Helper for creating an edge from a physical interface to a traditional trunk-mode switchport
+   * interface.
+   */
+  public static @Nonnull PhysicalToL2 physicalToTrunk(
+      IntegerSpace allowedOuterTags, @Nullable Integer nativeVlan) {
+    boolean allowUntagged = nativeVlan != null && allowedOuterTags.contains(nativeVlan);
+    return of(
+        compose(
+            filterByOuterTag(allowedOuterTags, allowUntagged),
+            assignVlanFromOuterTag(allowUntagged ? nativeVlan : null)));
+  }
+
+  @VisibleForTesting
+  public static @Nonnull Function compose(Function func1, Function func2) {
+    return func1.equals(identity())
+        ? func2
+        : func2.equals(identity()) ? func1 : new Compose(func1, func2);
+  }
+
+  @VisibleForTesting
+  public static @Nonnull PhysicalToL2 of(Function stateFunction) {
+    return new PhysicalToL2(stateFunction);
+  }
+
+  private static final class Compose extends ComposeBaseImpl<Function> implements Function {
+
+    private Compose(Function func1, Function func2) {
+      super(func1, func2);
+    }
+  }
+
+  private PhysicalToL2(Function stateFunction) {
+    super(stateFunction);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/PhysicalToNonBridgedL3.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/PhysicalToNonBridgedL3.java
@@ -1,0 +1,35 @@
+package org.batfish.common.topology.bridge_domain.edge;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.filterByOuterTag;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+import org.batfish.datamodel.IntegerSpace;
+
+/**
+ * An edge from a {@link org.batfish.common.topology.bridge_domain.node.PhysicalInterface} to a
+ * {@link org.batfish.common.topology.bridge_domain.node.NonBridgedL3Interface}.
+ */
+public final class PhysicalToNonBridgedL3 extends Edge {
+  public interface Function extends StateFunction {}
+
+  /** Helper for creating an edge from a physical interface to a non-bridged layer-3 interface. */
+  public static @Nonnull PhysicalToNonBridgedL3 physicalToNonBridgedL3(
+      @Nullable Integer allowedTag) {
+    return of(
+        allowedTag != null
+            ? filterByOuterTag(IntegerSpace.of(allowedTag), false)
+            : filterByOuterTag(IntegerSpace.EMPTY, true));
+  }
+
+  @VisibleForTesting
+  public static @Nonnull PhysicalToNonBridgedL3 of(Function stateFunction) {
+    return new PhysicalToNonBridgedL3(stateFunction);
+  }
+
+  private PhysicalToNonBridgedL3(Function stateFunction) {
+    super(stateFunction);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/package-info.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/edge/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.common.topology.bridge_domain.edge;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/AssignVlanFromOuterTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/AssignVlanFromOuterTag.java
@@ -1,0 +1,37 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.PhysicalToL2;
+
+/**
+ * A {@link StateFunction} that assigns a VLAN based on the outer tag (or its absence) of a frame
+ * and pops the outer tag if it was present.
+ */
+public final class AssignVlanFromOuterTag implements PhysicalToL2.Function {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitAssignVlanFromOuterTag(this, arg);
+  }
+
+  /**
+   * If not {@code null}, the VLAN ID to set if the outer tag is absent. If {@code null} and the
+   * outer tag is absent, the frame should be dropped.
+   */
+  public @Nullable Integer getNativeVlan() {
+    return _nativeVlan;
+  }
+
+  static @Nonnull AssignVlanFromOuterTag of(@Nullable Integer nativeVlan) {
+    return nativeVlan == null ? ONLY_TAGGED : new AssignVlanFromOuterTag(nativeVlan);
+  }
+
+  private static final AssignVlanFromOuterTag ONLY_TAGGED = new AssignVlanFromOuterTag(null);
+
+  private AssignVlanFromOuterTag(@Nullable Integer nativeVlan) {
+    _nativeVlan = nativeVlan;
+  }
+
+  private final @Nullable Integer _nativeVlan;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/ClearVlanId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/ClearVlanId.java
@@ -1,0 +1,22 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2Vni;
+import org.batfish.common.topology.bridge_domain.edge.L2ToPhysical;
+
+/** A {@link StateFunction} that clears the VLAN ID of the state. */
+public final class ClearVlanId implements L2ToPhysical.Function, BridgeDomainToL2Vni.Function {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitClearVlanId(this, arg);
+  }
+
+  static @Nonnull ClearVlanId instance() {
+    return INSTANCE;
+  }
+
+  private static final ClearVlanId INSTANCE = new ClearVlanId();
+
+  private ClearVlanId() {}
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/ComposeBaseImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/ComposeBaseImpl.java
@@ -1,0 +1,35 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Base implementation for {@link StateFunction} composition.
+ *
+ * <p>Due to desired type invariants and the Java type system, it is not possible to make a single
+ * {@code Compose} class whose result is of the correct {@link StateFunction} subtype {@code E}.
+ */
+public abstract class ComposeBaseImpl<E extends StateFunction> implements StateFunction {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitCompose(this, arg);
+  }
+
+  /** The first function to apply in order to the state. */
+  public @Nonnull E getFunc1() {
+    return _func1;
+  }
+
+  /** The function to apply to the result of applying {@link #getFunc1()} to the state. */
+  public @Nonnull E getFunc2() {
+    return _func2;
+  }
+
+  protected ComposeBaseImpl(E func1, E func2) {
+    _func1 = func1;
+    _func2 = func2;
+  }
+
+  private final @Nonnull E _func1;
+  private final @Nonnull E _func2;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/FilterByOuterTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/FilterByOuterTag.java
@@ -1,0 +1,11 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToBridgedL3;
+import org.batfish.common.topology.bridge_domain.edge.PhysicalToL2;
+import org.batfish.common.topology.bridge_domain.edge.PhysicalToNonBridgedL3;
+
+/** Helper interface to allow simplification of {@link FilterByOuterTagImpl}. */
+interface FilterByOuterTag
+    extends PhysicalToL2.Function,
+        PhysicalToNonBridgedL3.Function,
+        BridgeDomainToBridgedL3.Function {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/FilterByOuterTagImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/FilterByOuterTagImpl.java
@@ -1,0 +1,50 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.ALL_VLAN_IDS;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.IntegerSpace;
+
+/**
+ * A filter {@link StateFunction} that accepts a state with any of a space of allowed outer tags or
+ * optionally no outer tag.
+ */
+public final class FilterByOuterTagImpl implements FilterByOuterTag {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitFilterByOuterTag(this, arg);
+  }
+
+  /** Outer tags accepted by this filter, assuming outer tag is present. */
+  public @Nonnull IntegerSpace getAllowedOuterTags() {
+    return _allowedOuterTags;
+  }
+
+  /** Whether this filter accepts state with no outer tag. */
+  public boolean getAllowUntagged() {
+    return _allowUntagged;
+  }
+
+  static @Nonnull FilterByOuterTag of(IntegerSpace allowedOuterTags, boolean allowUntagged) {
+    if (allowedOuterTags.contains(ALL_VLAN_IDS) && allowUntagged) {
+      return identity();
+    } else if (allowedOuterTags.isEmpty() && allowUntagged) {
+      return ALLOW_ONLY_UNTAGGED;
+    } else {
+      return new FilterByOuterTagImpl(allowedOuterTags, allowUntagged);
+    }
+  }
+
+  private static final FilterByOuterTagImpl ALLOW_ONLY_UNTAGGED =
+      new FilterByOuterTagImpl(IntegerSpace.EMPTY, true);
+
+  private FilterByOuterTagImpl(IntegerSpace allowedOuterTags, boolean allowUntagged) {
+    _allowedOuterTags = allowedOuterTags;
+    _allowUntagged = allowUntagged;
+  }
+
+  private final @Nonnull IntegerSpace _allowedOuterTags;
+  private final boolean _allowUntagged;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/FilterByVlanId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/FilterByVlanId.java
@@ -1,0 +1,11 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToBridgedL3;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2Vni;
+
+/** Helper interface to allow simplification of {@link FilterByVlanIdImpl}. */
+public interface FilterByVlanId
+    extends BridgeDomainToL2.Function,
+        BridgeDomainToBridgedL3.Function,
+        BridgeDomainToL2Vni.Function {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/FilterByVlanIdImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/FilterByVlanIdImpl.java
@@ -1,0 +1,41 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.ALL_VLAN_IDS;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.IntegerSpace;
+
+/** Filter that accepts state with set VLAN ID in a some space of allowed VLAN IDs. */
+public final class FilterByVlanIdImpl implements FilterByVlanId {
+
+  @Override
+  public final <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitFilterByVlanId(this, arg);
+  }
+
+  /**
+   * The space of allowed VLAN IDs in the state for which this filter accepts.
+   *
+   * <p>Note that this filter never accepts a state without a set VLAN ID.
+   */
+  public final @Nonnull IntegerSpace getAllowedVlanIds() {
+    return _allowedVlanIds;
+  }
+
+  static FilterByVlanId of(IntegerSpace allowedVlanIds) {
+    return allowedVlanIds.isEmpty()
+        ? DENY_ALL
+        : allowedVlanIds.contains(ALL_VLAN_IDS)
+            ? identity()
+            : new FilterByVlanIdImpl(allowedVlanIds);
+  }
+
+  private static final FilterByVlanIdImpl DENY_ALL = new FilterByVlanIdImpl(IntegerSpace.EMPTY);
+
+  private final @Nonnull IntegerSpace _allowedVlanIds;
+
+  private FilterByVlanIdImpl(IntegerSpace allowedVlanIds) {
+    _allowedVlanIds = allowedVlanIds;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/Identity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/Identity.java
@@ -1,0 +1,38 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToBridgedL3;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2Vni;
+import org.batfish.common.topology.bridge_domain.edge.BridgedL3ToBridgeDomain;
+import org.batfish.common.topology.bridge_domain.edge.L2ToPhysical;
+import org.batfish.common.topology.bridge_domain.edge.L2VniToBridgeDomain;
+import org.batfish.common.topology.bridge_domain.edge.NonBridgedL3ToPhysical;
+import org.batfish.common.topology.bridge_domain.edge.PhysicalToL2;
+
+/** The identity {@link StateFunction}. */
+public final class Identity
+    implements BridgeDomainToL2.Function,
+        BridgeDomainToL2Vni.Function,
+        BridgeDomainToBridgedL3.Function,
+        L2ToPhysical.Function,
+        L2VniToBridgeDomain.Function,
+        BridgedL3ToBridgeDomain.Function,
+        PhysicalToL2.Function,
+        NonBridgedL3ToPhysical.Function,
+        FilterByOuterTag,
+        FilterByVlanId,
+        PopTag,
+        TranslateVlan {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitIdentity(this, arg);
+  }
+
+  static @Nonnull Identity instance() {
+    return INSTANCE;
+  }
+
+  private static final Identity INSTANCE = new Identity();
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/PopTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/PopTag.java
@@ -1,0 +1,7 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import org.batfish.common.topology.bridge_domain.edge.L2ToBridgeDomain;
+import org.batfish.common.topology.bridge_domain.edge.PhysicalToL2;
+
+/** Helper interface to allow simplification of {@link PopTagImpl}. */
+public interface PopTag extends PhysicalToL2.Function, L2ToBridgeDomain.Function {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/PopTagImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/PopTagImpl.java
@@ -1,0 +1,35 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import javax.annotation.Nonnull;
+
+/** A {@link StateFunction} that remove a given number of tags from the tag stack. */
+public final class PopTagImpl implements PopTag {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitPopTag(this, arg);
+  }
+
+  /**
+   * The number of outer tags to remove from the state.
+   *
+   * <p>The result is undefined if this number exceeds the number of outer tags in the state.
+   */
+  public int getCount() {
+    return _count;
+  }
+
+  static @Nonnull PopTag of(int count) {
+    return count == 0 ? identity() : count == 1 ? POP_ONE_TAG : new PopTagImpl(count);
+  }
+
+  private static final PopTagImpl POP_ONE_TAG = new PopTagImpl(1);
+
+  private PopTagImpl(int count) {
+    _count = count;
+  }
+
+  private final int _count;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/PushTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/PushTag.java
@@ -1,0 +1,29 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.edge.L2ToPhysical;
+import org.batfish.common.topology.bridge_domain.edge.NonBridgedL3ToPhysical;
+
+/** A {@link StateFunction} that pushes a fixed outer tag. */
+public final class PushTag implements L2ToPhysical.Function, NonBridgedL3ToPhysical.Function {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitPushTag(this, arg);
+  }
+
+  /** The tag to push that will become the outer tag. */
+  public int getTagToPush() {
+    return _tagToPush;
+  }
+
+  static @Nonnull PushTag of(int tagToPush) {
+    return new PushTag(tagToPush);
+  }
+
+  private PushTag(int tagToPush) {
+    _tagToPush = tagToPush;
+  }
+
+  private final int _tagToPush;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/PushVlanId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/PushVlanId.java
@@ -1,0 +1,40 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.L2ToPhysical;
+
+/**
+ * A {@link StateFunction} that pushes the state's VLAN ID onto the tag stack, unless it is an
+ * optional exception VLAN ID.
+ */
+public final class PushVlanId implements L2ToPhysical.Function {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitPushVlanId(this, arg);
+  }
+
+  /**
+   * An optional exception VLAN ID that is not pushed onto the tag stack.
+   *
+   * <p>If {@code null}, the state's VLAN ID is always pushed onto the tag stack.
+   *
+   * <p>The result is undefined if the state has no set VLAN ID.
+   */
+  public @Nullable Integer getExceptVlan() {
+    return _exceptVlan;
+  }
+
+  static @Nonnull PushVlanId of(@Nullable Integer exceptVlan) {
+    return exceptVlan == null ? ALWAYS : new PushVlanId(exceptVlan);
+  }
+
+  private PushVlanId(@Nullable Integer exceptVlan) {
+    _exceptVlan = exceptVlan;
+  }
+
+  private static final PushVlanId ALWAYS = new PushVlanId(null);
+
+  private final @Nullable Integer _exceptVlan;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/SetVlanId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/SetVlanId.java
@@ -1,0 +1,37 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.edge.BridgedL3ToBridgeDomain;
+import org.batfish.common.topology.bridge_domain.edge.L2ToBridgeDomain;
+import org.batfish.common.topology.bridge_domain.edge.L2VniToBridgeDomain;
+
+/** A {@link StateFunction} that sets a specific VLAN ID in the state. */
+public final class SetVlanId
+    implements L2ToBridgeDomain.Function,
+        BridgedL3ToBridgeDomain.Function,
+        L2VniToBridgeDomain.Function {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitSetVlanId(this, arg);
+  }
+
+  /**
+   * The VLAN ID to set.
+   *
+   * <p>The result is undefined if the VLAN ID is already set in the state.
+   */
+  public int getVlanId() {
+    return _vlanId;
+  }
+
+  static @Nonnull SetVlanId of(int vlanId) {
+    return new SetVlanId(vlanId);
+  }
+
+  private SetVlanId(int vlanId) {
+    _vlanId = vlanId;
+  }
+
+  private final int _vlanId;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/StateFunction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/StateFunction.java
@@ -1,0 +1,6 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+/** A function or filter on state. */
+public interface StateFunction {
+  <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/StateFunctionVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/StateFunctionVisitor.java
@@ -1,0 +1,34 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+/**
+ * A visitor of {@link StateFunction} that takes a generic argument of type {@code U} and returns a
+ * generic value of type {@code T}.
+ */
+public interface StateFunctionVisitor<T, U> {
+
+  default T visit(StateFunction stateFunction, U arg) {
+    return stateFunction.accept(this, arg);
+  }
+
+  T visitAssignVlanFromOuterTag(AssignVlanFromOuterTag assignVlanFromOuterTag, U arg);
+
+  T visitClearVlanId(ClearVlanId clearVlanId, U arg);
+
+  T visitCompose(ComposeBaseImpl<?> compose, U arg);
+
+  T visitFilterByOuterTag(FilterByOuterTagImpl filterByOuterTag, U arg);
+
+  T visitFilterByVlanId(FilterByVlanIdImpl filterByVlanId, U arg);
+
+  T visitIdentity(Identity identity, U arg);
+
+  T visitPopTag(PopTagImpl popTag, U arg);
+
+  T visitPushTag(PushTag pushTag, U arg);
+
+  T visitPushVlanId(PushVlanId pushVlanId, U arg);
+
+  T visitSetVlanId(SetVlanId setVlanId, U arg);
+
+  T visitTranslateVlan(TranslateVlanImpl translateVlan, U arg);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/StateFunctions.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/StateFunctions.java
@@ -1,0 +1,61 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.SubRange;
+
+/**
+ * A utility class for generating {@link StateFunction}s.
+ *
+ * <p>See the documentation for the return type of each function for the function's semantics.
+ */
+public final class StateFunctions {
+
+  public static @Nonnull Identity identity() {
+    return Identity.instance();
+  }
+
+  public static @Nonnull AssignVlanFromOuterTag assignVlanFromOuterTag(
+      @Nullable Integer nativeVlan) {
+    return AssignVlanFromOuterTag.of(nativeVlan);
+  }
+
+  public static @Nonnull ClearVlanId clearVlanId() {
+    return ClearVlanId.instance();
+  }
+
+  public static @Nonnull FilterByOuterTag filterByOuterTag(
+      IntegerSpace allowedOuterTags, boolean allowUntagged) {
+    return FilterByOuterTagImpl.of(allowedOuterTags, allowUntagged);
+  }
+
+  public static @Nonnull FilterByVlanId filterByVlanId(IntegerSpace allowedVlanIds) {
+    return FilterByVlanIdImpl.of(allowedVlanIds);
+  }
+
+  public static @Nonnull PopTag popTag(int count) {
+    return PopTagImpl.of(count);
+  }
+
+  public static @Nonnull PushTag pushTag(int tagToPush) {
+    return PushTag.of(tagToPush);
+  }
+
+  public static @Nonnull PushVlanId pushVlanId(@Nullable Integer exceptVlan) {
+    return PushVlanId.of(exceptVlan);
+  }
+
+  public static @Nonnull SetVlanId setVlanId(int vlanId) {
+    return SetVlanId.of(vlanId);
+  }
+
+  public static @Nonnull TranslateVlan translateVlan(Map<Integer, Integer> translations) {
+    return TranslateVlanImpl.of(translations);
+  }
+
+  static final IntegerSpace ALL_VLAN_IDS = IntegerSpace.of(new SubRange(1, 4094));
+
+  private StateFunctions() {}
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/TranslateVlan.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/TranslateVlan.java
@@ -1,0 +1,7 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2;
+import org.batfish.common.topology.bridge_domain.edge.L2ToBridgeDomain;
+
+/** Helper interface to allow simplification of {@link TranslateVlanImpl}. */
+public interface TranslateVlan extends BridgeDomainToL2.Function, L2ToBridgeDomain.Function {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/TranslateVlanImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/TranslateVlanImpl.java
@@ -1,0 +1,35 @@
+package org.batfish.common.topology.bridge_domain.function;
+
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/** A {@link StateFunction} that maps the state's VLAN ID to another VLAN ID. */
+public final class TranslateVlanImpl implements TranslateVlan {
+
+  @Override
+  public <T, U> T accept(StateFunctionVisitor<T, U> visitor, U arg) {
+    return visitor.visitTranslateVlan(this, arg);
+  }
+
+  /**
+   * A map of concrete VLAN ID translations. If the state's set VLAN ID is not in the map, it
+   * remains unmodified.
+   *
+   * <p>The result is undefined if no VLAN ID is set in the state.
+   */
+  public @Nonnull Map<Integer, Integer> getTranslations() {
+    return _translations;
+  }
+
+  static @Nonnull TranslateVlan of(Map<Integer, Integer> translations) {
+    return translations.isEmpty() ? identity() : new TranslateVlanImpl(translations);
+  }
+
+  private TranslateVlanImpl(Map<Integer, Integer> translations) {
+    _translations = translations;
+  }
+
+  private final @Nonnull Map<Integer, Integer> _translations;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/package-info.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/function/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.common.topology.bridge_domain.function;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/BridgeDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/BridgeDomain.java
@@ -1,0 +1,182 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToBridgedL3;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2;
+import org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2Vni;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+
+/**
+ * A vlan-aware or non-vlan-aware bridge domain that propagates each frame to a subset of its
+ * bridged interfaces.
+ *
+ * <ul>
+ *   <li>Frames reaching a vlan-aware bridge domain will propagate to the subset of its bridged
+ *       interfaces that carry traffic for the VLAN ID set in the state. A device typically can have
+ *       up to one vlan-aware bridge.
+ *   <li>Frames reaching a non-vlan-aware bridge domain will propagate to a subset of its bridged
+ *       interfaces determined by an arbitrary filter on the state. A device may generally may have
+ *       any number of named non-vlan-aware bridges.
+ *       <ul>
+ *         <li>On IOS-XR, a frame will be propagated to all bridged interfaces except the
+ *             routed-interface if any tag remains in the tag stack. If the tag stack is empty, then
+ *             a frame is propagated to all bridged interfaces.
+ *       </ul>
+ * </ul>
+ */
+public final class BridgeDomain implements Node {
+
+  public static final class BridgeId {
+    public static @Nonnull BridgeId vlanAwareBridgeId(String hostname) {
+      return new BridgeId(hostname, VLAN_AWARE_BRIDGE_NAME);
+    }
+
+    public static @Nonnull BridgeId nonVlanAwareBridgeId(String hostname, String bridgeName) {
+      return new BridgeId(hostname, bridgeName);
+    }
+
+    public @Nonnull String getHostname() {
+      return _hostname;
+    }
+
+    public @Nonnull String getBridgeName() {
+      return _bridgeName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof BridgeId)) {
+        return false;
+      }
+      BridgeId bridgeId = (BridgeId) o;
+      return _hostname.equals(bridgeId._hostname) && _bridgeName.equals(bridgeId._bridgeName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_hostname, _bridgeName);
+    }
+
+    @Override
+    public String toString() {
+      return toStringHelper(this)
+          .add("_hostname", _hostname)
+          .add("_bridgeName", _bridgeName)
+          .toString();
+    }
+
+    private BridgeId(String hostname, String bridgeName) {
+      _hostname = hostname;
+      _bridgeName = bridgeName;
+    }
+
+    private final @Nonnull String _hostname;
+    private final @Nonnull String _bridgeName;
+  }
+
+  public static @Nonnull BridgeDomain newNonVlanAwareBridge(String hostname, String bridgeName) {
+    return new BridgeDomain(BridgeId.nonVlanAwareBridgeId(hostname, bridgeName));
+  }
+
+  public static @Nonnull BridgeDomain newVlanAwareBridge(String hostname) {
+    return new BridgeDomain(BridgeId.vlanAwareBridgeId(hostname));
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    return ImmutableMap.<Node, Edge>builderWithExpectedSize(_toBridgedL3.size() + _toL2.size())
+        .putAll(_toBridgedL3)
+        .putAll(_toL2)
+        .putAll(_toL2Vni)
+        .build();
+  }
+
+  public void connectToL2Interface(L2Interface l2Interface, BridgeDomainToL2 edge) {
+    checkState(
+        !_toL2.containsKey(l2Interface),
+        "Already connected to L2 interface: %s",
+        l2Interface.getInterface());
+    _toL2.put(l2Interface, edge);
+  }
+
+  public void connectToBridgedL3Interface(
+      BridgedL3Interface bridgedL3Interface, BridgeDomainToBridgedL3 edge) {
+    checkState(
+        !_toBridgedL3.containsKey(bridgedL3Interface),
+        "Already connected to bridged L3 interface: %s",
+        bridgedL3Interface.getInterface());
+    _toBridgedL3.put(bridgedL3Interface, edge);
+  }
+
+  public void connectToL2Vni(L2Vni l2Vni, BridgeDomainToL2Vni edge) {
+    BridgeDomainToL2Vni existing = _toL2Vni.putIfAbsent(l2Vni, edge);
+    checkState(existing == null, "Already connected to L2Vni: %s", l2Vni.getNode());
+  }
+
+  public @Nonnull BridgeId getId() {
+    return _id;
+  }
+
+  // Internal implementation details
+
+  private BridgeDomain(BridgeId id) {
+    _id = id;
+    _toBridgedL3 = new HashMap<>();
+    _toL2 = new HashMap<>();
+    _toL2Vni = new HashMap<>();
+  }
+
+  @VisibleForTesting
+  public @Nonnull Map<L2Interface, BridgeDomainToL2> getToL2ForTest() {
+    return _toL2;
+  }
+
+  @VisibleForTesting
+  public @Nonnull Map<L2Vni, BridgeDomainToL2Vni> getToL2VniForTest() {
+    return _toL2Vni;
+  }
+
+  @VisibleForTesting
+  public @Nonnull Map<BridgedL3Interface, BridgeDomainToBridgedL3> getToBridgedL3ForTest() {
+    return _toBridgedL3;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof BridgeDomain)) {
+      return false;
+    }
+    BridgeDomain that = (BridgeDomain) o;
+    return _id.equals(that._id);
+  }
+
+  @Override
+  public int hashCode() {
+    return BridgeDomain.class.hashCode() * 31 + _id.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("_id", _id).toString();
+  }
+
+  private static final String VLAN_AWARE_BRIDGE_NAME = "Batfish vlan-aware bridge";
+
+  private final @Nonnull BridgeId _id;
+  private final @Nonnull Map<BridgedL3Interface, BridgeDomainToBridgedL3> _toBridgedL3;
+  private final @Nonnull Map<L2Interface, BridgeDomainToL2> _toL2;
+  private final @Nonnull Map<L2Vni, BridgeDomainToL2Vni> _toL2Vni;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/BridgedL3Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/BridgedL3Interface.java
@@ -1,0 +1,90 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.edge.BridgedL3ToBridgeDomain;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+/**
+ * A {@link Node} representing a bridged layer-3 interface:
+ *
+ * <ul>
+ *   <li>An IRB/Vlan interface, which belongs to a device's vlan-aware bridge
+ *   <li>A BVI, Juniper bridged interface, or traditional linux Bridge interface, which belongs to a
+ *       named non-vlan-aware bridge
+ * </ul>
+ *
+ * See for comparison {@link NonBridgedL3Interface}.
+ */
+public final class BridgedL3Interface implements L3Interface {
+  public BridgedL3Interface(NodeInterfacePair iface) {
+    _interface = iface;
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    assert _toBridgeDomain != null;
+    assert _bridgeDomain != null;
+    return ImmutableMap.of(_bridgeDomain, _toBridgeDomain);
+  }
+
+  @Override
+  public @Nonnull NodeInterfacePair getInterface() {
+    return _interface;
+  }
+
+  /**
+   * Set the bridge domain to which this interface belongs, as well as the correpsonding edge to it.
+   *
+   * <p>This function should be called exactly once.
+   */
+  public void connectToBridgeDomain(BridgeDomain bridgeDomain, BridgedL3ToBridgeDomain edge) {
+    checkState(
+        _bridgeDomain == null, "Already connected to bridge domain: %s", bridgeDomain.getId());
+    _bridgeDomain = bridgeDomain;
+    _toBridgeDomain = edge;
+  }
+
+  // Internal implementation details
+
+  @VisibleForTesting
+  public BridgeDomain getBridgeDomainForTest() {
+    return _bridgeDomain;
+  }
+
+  @VisibleForTesting
+  public BridgedL3ToBridgeDomain getToBridgeDomainForTest() {
+    return _toBridgeDomain;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof BridgedL3Interface)) {
+      return false;
+    }
+    BridgedL3Interface that = (BridgedL3Interface) o;
+    return _interface.equals(that._interface);
+  }
+
+  @Override
+  public int hashCode() {
+    return BridgedL3Interface.class.hashCode() * 31 + _interface.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("_interface", _interface).toString();
+  }
+
+  private final @Nonnull NodeInterfacePair _interface;
+  private BridgeDomain _bridgeDomain;
+  private BridgedL3ToBridgeDomain _toBridgeDomain;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/DisconnectedL3Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/DisconnectedL3Interface.java
@@ -1,0 +1,50 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+/**
+ * A layer-3 interface disconnected from the broadcast domain search graph:
+ *
+ * <ul>
+ *   <li>A tunnel interface, for which adjacency is determined by outside code.
+ *   <li>A layer-3 interface that is invalid in some way.
+ * </ul>
+ */
+public final class DisconnectedL3Interface implements L3Interface {
+
+  public DisconnectedL3Interface(NodeInterfacePair iface) {
+    _interface = iface;
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    return ImmutableMap.of();
+  }
+
+  @Override
+  public @Nonnull NodeInterfacePair getInterface() {
+    return _interface;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof DisconnectedL3Interface)) {
+      return false;
+    }
+    DisconnectedL3Interface that = (DisconnectedL3Interface) o;
+    return _interface.equals(that._interface);
+  }
+
+  @Override
+  public int hashCode() {
+    return DisconnectedL3Interface.class.hashCode() * 31 + _interface.hashCode();
+  }
+
+  private final @Nonnull NodeInterfacePair _interface;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/EthernetHub.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/EthernetHub.java
@@ -1,0 +1,68 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.common.topology.bridge_domain.edge.EthernetHubToPhysical;
+
+/**
+ * A central point representing a connected subgraph of {@link PhysicalInterface}s that are
+ * generally from different devices.
+ */
+public final class EthernetHub implements Node {
+
+  public EthernetHub(String id) {
+    _id = id;
+    _toPhysical = new HashMap<>();
+  }
+
+  public @Nonnull String getId() {
+    return _id;
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    return ImmutableMap.copyOf(_toPhysical);
+  }
+
+  public void addAttachedInterface(PhysicalInterface p) {
+    _toPhysical.put(p, EthernetHubToPhysical.instance());
+  }
+
+  // Internal implementation details
+
+  @VisibleForTesting
+  public @Nonnull Map<PhysicalInterface, EthernetHubToPhysical> getToPhysicalForTest() {
+    return _toPhysical;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof EthernetHub)) {
+      return false;
+    }
+    EthernetHub that = (EthernetHub) o;
+    return _id.equals(that._id);
+  }
+
+  @Override
+  public int hashCode() {
+    return EthernetHub.class.hashCode() * 31 + _id.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("_id", _id).toString();
+  }
+
+  private final @Nonnull String _id;
+  private final @Nonnull Map<PhysicalInterface, EthernetHubToPhysical> _toPhysical;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/L2Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/L2Interface.java
@@ -1,0 +1,108 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.common.topology.bridge_domain.edge.L2ToBridgeDomain;
+import org.batfish.common.topology.bridge_domain.edge.L2ToPhysical;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+/**
+ * A layer-2 aspect or a subinterface of a physical or aggregated interface:
+ *
+ * <ul>
+ *   <li>A traditional access-mode switchport
+ *   <li>A traditional trunk-mode switchport
+ *   <li>An IOS-XR-style l2transport interface
+ * </ul>
+ */
+public final class L2Interface implements Node {
+  public L2Interface(NodeInterfacePair iface) {
+    _interface = iface;
+  }
+
+  public @Nonnull NodeInterfacePair getInterface() {
+    return _interface;
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    assert _bridgeDomain != null;
+    assert _physicalInterface != null;
+    return ImmutableMap.<Node, Edge>builderWithExpectedSize(2)
+        .put(_bridgeDomain, _toBridgeDomain)
+        .put(_physicalInterface, _toPhysical)
+        .build();
+  }
+
+  public void connectToBridgeDomain(BridgeDomain bridgeDomain, L2ToBridgeDomain edge) {
+    checkState(
+        _bridgeDomain == null, "Already connected to bridge domain: %s", bridgeDomain.getId());
+    _bridgeDomain = bridgeDomain;
+    _toBridgeDomain = edge;
+  }
+
+  public void connectToPhysicalInterface(PhysicalInterface physicalInterface, L2ToPhysical edge) {
+    checkState(
+        _physicalInterface == null,
+        "Already connected to physical interface: %s",
+        physicalInterface.getInterface());
+    _physicalInterface = physicalInterface;
+    _toPhysical = edge;
+  }
+
+  // Internal implementation details
+
+  @VisibleForTesting
+  public BridgeDomain getBridgeDomainForTest() {
+    return _bridgeDomain;
+  }
+
+  @VisibleForTesting
+  public L2ToBridgeDomain getToBridgeDomainForTest() {
+    return _toBridgeDomain;
+  }
+
+  @VisibleForTesting
+  public PhysicalInterface getPhysicalInterfaceForTest() {
+    return _physicalInterface;
+  }
+
+  @VisibleForTesting
+  public L2ToPhysical getToPhysicalForTest() {
+    return _toPhysical;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof L2Interface)) {
+      return false;
+    }
+    L2Interface that = (L2Interface) o;
+    return _interface.equals(that._interface);
+  }
+
+  @Override
+  public int hashCode() {
+    return L2Interface.class.hashCode() * 31 + _interface.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("_interface", _interface).toString();
+  }
+
+  private final @Nonnull NodeInterfacePair _interface;
+  private L2ToBridgeDomain _toBridgeDomain;
+  private BridgeDomain _bridgeDomain;
+  private PhysicalInterface _physicalInterface;
+  private L2ToPhysical _toPhysical;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/L2Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/L2Vni.java
@@ -1,0 +1,74 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.common.topology.bridge_domain.edge.L2VniToBridgeDomain;
+import org.batfish.common.topology.bridge_domain.edge.L2VniToL2VniHub;
+import org.batfish.datamodel.vxlan.VxlanNode;
+
+/**
+ * A node-specific VNI associated with a bridge domain:
+ *
+ * <p>If the associated bridge domain is vlan-aware, then the VNI should be associated with a VLAN.
+ */
+public final class L2Vni implements Node {
+
+  public L2Vni(VxlanNode node) {
+    _node = node;
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    ImmutableMap.Builder<Node, Edge> builder =
+        ImmutableMap.<Node, Edge>builder().put(_bridgeDomain, _toBridgeDomain);
+    if (_l2VniHub != null) {
+      assert _toL2VniHub != null;
+      builder.put(_l2VniHub, _toL2VniHub);
+    }
+    return builder.build();
+  }
+
+  public @Nonnull VxlanNode getNode() {
+    return _node;
+  }
+
+  public void connectToBridgeDomain(BridgeDomain bridgeDomain, L2VniToBridgeDomain edge) {
+    checkState(
+        _bridgeDomain == null, "Already attached to bridge domain: %s", bridgeDomain.getId());
+    _bridgeDomain = bridgeDomain;
+    _toBridgeDomain = edge;
+  }
+
+  public void connectToL2VniHub(L2VniHub l2VniHub) {
+    checkState(_l2VniHub == null, "Already attached to L2VniHub: %s", l2VniHub.getName());
+    _l2VniHub = l2VniHub;
+    _toL2VniHub = L2VniToL2VniHub.instance();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof L2Vni)) {
+      return false;
+    }
+    L2Vni that = (L2Vni) o;
+    return _node.equals(that._node);
+  }
+
+  @Override
+  public int hashCode() {
+    return L2Vni.class.hashCode() * 31 + _node.hashCode();
+  }
+
+  private final @Nonnull VxlanNode _node;
+  private L2VniHub _l2VniHub;
+  private L2VniToL2VniHub _toL2VniHub;
+  private BridgeDomain _bridgeDomain;
+  private L2VniToBridgeDomain _toBridgeDomain;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/L2VniHub.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/L2VniHub.java
@@ -1,0 +1,59 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.common.topology.bridge_domain.edge.L2VniHubToL2Vni;
+
+/**
+ * A central point representing a connected subgraph of {@link L2Vni}s that are generally from
+ * different devices.
+ */
+public final class L2VniHub implements Node {
+
+  public L2VniHub(String name) {
+    _name = name;
+    _attachedVNIs = new HashSet<>();
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    return _attachedVNIs.stream()
+        .collect(ImmutableMap.toImmutableMap(Function.identity(), l -> L2VniHubToL2Vni.instance()));
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public void attachL2Vni(L2Vni l2Vni) {
+    boolean added = _attachedVNIs.add(l2Vni);
+    checkState(added, "Already attached to l2vni: %s", l2Vni.getNode());
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof L2VniHub)) {
+      return false;
+    }
+    L2VniHub that = (L2VniHub) o;
+    return _name.equals(that._name);
+  }
+
+  @Override
+  public int hashCode() {
+    return L2VniHub.class.hashCode() * 31 + _name.hashCode();
+  }
+
+  private final @Nonnull Set<L2Vni> _attachedVNIs;
+  private final @Nonnull String _name;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/L3Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/L3Interface.java
@@ -1,0 +1,11 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+/** A {@link BridgedL3Interface} or a {@link NonBridgedL3Interface}. */
+public interface L3Interface extends Node {
+
+  @Nonnull
+  NodeInterfacePair getInterface();
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/Node.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/Node.java
@@ -1,0 +1,11 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+
+/** A node in the broadcast domain computation graph. */
+public interface Node {
+  @Nonnull
+  Map<Node, Edge> getOutEdges();
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/NonBridgedL3Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/NonBridgedL3Interface.java
@@ -1,0 +1,89 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.common.topology.bridge_domain.edge.NonBridgedL3ToPhysical;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+/**
+ * A {@link Node} representing a non-bridged layer-3 interface:
+ *
+ * <ul>
+ *   <li>The layer-3 aspect of a physical or aggregated interface
+ *   <li>An optionally tagged layer-3 sub-interface of a physical or aggregated interface
+ * </ul>
+ *
+ * See for comparison {@link BridgedL3Interface}.
+ */
+public final class NonBridgedL3Interface implements L3Interface {
+
+  public NonBridgedL3Interface(NodeInterfacePair iface) {
+    _interface = iface;
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    assert _toPhysical != null;
+    assert _physicalInterface != null;
+    return ImmutableMap.of(_physicalInterface, _toPhysical);
+  }
+
+  public void connectToPhysicalInterface(
+      PhysicalInterface physicalInterface, NonBridgedL3ToPhysical edge) {
+    checkState(
+        _physicalInterface == null,
+        "Already connected to physical interface: %s",
+        physicalInterface.getInterface());
+    _physicalInterface = physicalInterface;
+    _toPhysical = edge;
+  }
+
+  @Override
+  public @Nonnull NodeInterfacePair getInterface() {
+    return _interface;
+  }
+
+  // Internal implementation details
+
+  @VisibleForTesting
+  public PhysicalInterface getPhysicalInterfaceForTest() {
+    return _physicalInterface;
+  }
+
+  @VisibleForTesting
+  public NonBridgedL3ToPhysical getToPhysicalForTest() {
+    return _toPhysical;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof NonBridgedL3Interface)) {
+      return false;
+    }
+    NonBridgedL3Interface that = (NonBridgedL3Interface) o;
+    return _interface.equals(that._interface);
+  }
+
+  @Override
+  public int hashCode() {
+    return NonBridgedL3Interface.class.hashCode() * 31 + _interface.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("_interface", _interface).toString();
+  }
+
+  private final @Nonnull NodeInterfacePair _interface;
+  private PhysicalInterface _physicalInterface;
+  private NonBridgedL3ToPhysical _toPhysical;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/PhysicalInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/PhysicalInterface.java
@@ -1,0 +1,116 @@
+package org.batfish.common.topology.bridge_domain.node;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.topology.bridge_domain.edge.Edge;
+import org.batfish.common.topology.bridge_domain.edge.PhysicalToEthernetHub;
+import org.batfish.common.topology.bridge_domain.edge.PhysicalToL2;
+import org.batfish.common.topology.bridge_domain.edge.PhysicalToNonBridgedL3;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+/**
+ * A physical Ethernet interface sends possibly-tagged frames.
+ *
+ * <p>Can have edges to any number of {@link NonBridgedL3Interface}s when receiving frames tagged
+ * for a dot1q encapsulated subinterface/untagged frames directly, and/or to any number of {@link
+ * L2Interface}s that handle untagged/tagged frames. The sets of tags handled by the {@link
+ * L2Interface}s and {@link NonBridgedL3Interface}s must be mutually disjoint.
+ */
+public final class PhysicalInterface implements Node {
+
+  public PhysicalInterface(NodeInterfacePair iface) {
+    _interface = iface;
+    _toL2 = new HashMap<>();
+    _toNonBridgedL3 = new HashMap<>();
+  }
+
+  @Override
+  public @Nonnull Map<Node, Edge> getOutEdges() {
+    ImmutableMap.Builder<Node, Edge> builder =
+        ImmutableMap.<Node, Edge>builder().putAll(_toL2).putAll(_toNonBridgedL3);
+    if (_attachedHub != null) {
+      builder.put(_attachedHub, _toEthernetHub);
+    }
+    return builder.build();
+  }
+
+  public void attachToHub(EthernetHub hub) {
+    checkState(
+        _attachedHub == null, "Cannot connect a physical interface to multiple Ethernet hubs");
+    _attachedHub = hub;
+    _toEthernetHub = PhysicalToEthernetHub.instance();
+  }
+
+  public void connectToL2Interface(L2Interface l2Interface, PhysicalToL2 edge) {
+    checkState(
+        !_toL2.containsKey(l2Interface),
+        "Already connected to L2 interface: %s",
+        l2Interface.getInterface());
+    _toL2.put(l2Interface, edge);
+  }
+
+  public void connectToNonBridgedL3Interface(
+      NonBridgedL3Interface nonBridgedL3Interface, PhysicalToNonBridgedL3 edge) {
+    checkState(
+        !_toNonBridgedL3.containsKey(nonBridgedL3Interface),
+        "Already connected to non-bridged L3 interface: %s",
+        nonBridgedL3Interface.getInterface());
+    _toNonBridgedL3.put(nonBridgedL3Interface, edge);
+  }
+
+  public @Nonnull NodeInterfacePair getInterface() {
+    return _interface;
+  }
+
+  // Internal implementation details.
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PhysicalInterface)) {
+      return false;
+    }
+    PhysicalInterface that = (PhysicalInterface) o;
+    return _interface.equals(that._interface);
+  }
+
+  @Override
+  public int hashCode() {
+    return PhysicalInterface.class.hashCode() * 31 + _interface.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("_interface", _interface).toString();
+  }
+
+  @VisibleForTesting
+  public EthernetHub getAttachedHubForTest() {
+    return _attachedHub;
+  }
+
+  @VisibleForTesting
+  public Map<L2Interface, PhysicalToL2> getToL2ForTest() {
+    return _toL2;
+  }
+
+  @VisibleForTesting
+  public Map<NonBridgedL3Interface, PhysicalToNonBridgedL3> getToNonBridgedL3ForTest() {
+    return _toNonBridgedL3;
+  }
+
+  private final @Nonnull NodeInterfacePair _interface;
+
+  private final @Nonnull Map<L2Interface, PhysicalToL2> _toL2;
+  private final @Nonnull Map<NonBridgedL3Interface, PhysicalToNonBridgedL3> _toNonBridgedL3;
+  private PhysicalToEthernetHub _toEthernetHub;
+  private EthernetHub _attachedHub;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/package-info.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/node/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.common.topology.bridge_domain.node;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/package-info.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/bridge_domain/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.common.topology.bridge_domain;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/bridge_domain/BridgeDomainL3AdjacenciesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/bridge_domain/BridgeDomainL3AdjacenciesTest.java
@@ -1,0 +1,98 @@
+package org.batfish.common.topology.bridge_domain;
+
+import static org.batfish.datamodel.InterfaceType.PHYSICAL;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import org.batfish.common.topology.Layer1Edge;
+import org.batfish.common.topology.Layer1Topologies;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.vxlan.VxlanTopology;
+import org.junit.Test;
+
+/** Test of {@link BridgeDomainL3Adjacencies}. */
+public final class BridgeDomainL3AdjacenciesTest {
+  /** A simple test that the code works end-to-end. */
+  @Test
+  public void testE2e() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c1 = nf.configurationBuilder().build();
+    Interface i1 =
+        nf.interfaceBuilder()
+            .setOwner(c1)
+            .setType(PHYSICAL)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.1/24"))
+            .build();
+    NodeInterfacePair n1 = NodeInterfacePair.of(i1);
+    Configuration c2 = nf.configurationBuilder().build();
+    Interface i2 =
+        nf.interfaceBuilder()
+            .setOwner(c2)
+            .setType(PHYSICAL)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.2/24"))
+            .build();
+    NodeInterfacePair n2 = NodeInterfacePair.of(i2);
+    Configuration c3 = nf.configurationBuilder().build();
+    Interface i3 =
+        nf.interfaceBuilder()
+            .setOwner(c3)
+            .setType(PHYSICAL)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.3/24"))
+            .build();
+    NodeInterfacePair n3 = NodeInterfacePair.of(i3);
+    {
+      // With no L1 topology, all 3 interfaces in same domain but not p2p domain.
+      BridgeDomainL3Adjacencies adjacencies =
+          BridgeDomainL3Adjacencies.create(
+              Layer1Topologies.empty(),
+              VxlanTopology.EMPTY,
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3));
+      assertTrue(adjacencies.inSameBroadcastDomain(n1, n2));
+      assertTrue(adjacencies.inSameBroadcastDomain(n2, n1));
+      assertTrue(adjacencies.inSameBroadcastDomain(n2, n3));
+      assertTrue(adjacencies.inSameBroadcastDomain(n3, n1));
+      assertFalse(adjacencies.inSamePointToPointDomain(n1, n2));
+      assertFalse(adjacencies.inSamePointToPointDomain(n2, n3));
+      assertFalse(adjacencies.inSamePointToPointDomain(n3, n1));
+    }
+    {
+      // With L1 topology, only connected interfaces in same domain.
+      Layer1Topology physical =
+          new Layer1Topology(
+              new Layer1Edge(
+                  n1.getHostname(), n1.getInterface(), n3.getHostname(), n3.getInterface()));
+      BridgeDomainL3Adjacencies adjacencies =
+          BridgeDomainL3Adjacencies.create(
+              new Layer1Topologies(physical, Layer1Topology.EMPTY, physical, physical),
+              VxlanTopology.EMPTY,
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3));
+      assertTrue(adjacencies.inSameBroadcastDomain(n1, n3));
+      assertFalse(adjacencies.inSameBroadcastDomain(n2, n3));
+      assertFalse(adjacencies.inSameBroadcastDomain(n2, n1));
+      assertTrue(adjacencies.inSamePointToPointDomain(n1, n3));
+      assertTrue(adjacencies.inSamePointToPointDomain(n3, n1));
+      assertFalse(adjacencies.inSamePointToPointDomain(n2, n3));
+      assertFalse(adjacencies.inSamePointToPointDomain(n1, n2));
+    }
+    {
+      // Encapsulation vlan honored, even with no L1.
+      i1.setEncapsulationVlan(4);
+      BridgeDomainL3Adjacencies adjacencies =
+          BridgeDomainL3Adjacencies.create(
+              Layer1Topologies.empty(),
+              VxlanTopology.EMPTY,
+              ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3));
+      assertTrue(adjacencies.inSameBroadcastDomain(n2, n3));
+      assertFalse(adjacencies.inSameBroadcastDomain(n1, n2));
+      assertFalse(adjacencies.inSameBroadcastDomain(n1, n3));
+      assertFalse(adjacencies.inSamePointToPointDomain(n2, n3));
+      assertFalse(adjacencies.inSamePointToPointDomain(n1, n2));
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/bridge_domain/L3AdjacencyComputerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/bridge_domain/L3AdjacencyComputerTest.java
@@ -1,0 +1,1065 @@
+package org.batfish.common.topology.bridge_domain;
+
+import static org.batfish.common.topology.bridge_domain.L3AdjacencyComputer.BATFISH_GLOBAL_HUB;
+import static org.batfish.common.topology.bridge_domain.L3AdjacencyComputer.computeEthernetHubs;
+import static org.batfish.common.topology.bridge_domain.L3AdjacencyComputer.connectL2InterfaceToBridgeDomainAndPhysicalInterface;
+import static org.batfish.common.topology.bridge_domain.L3AdjacencyComputer.connectL3InterfaceToPhysicalOrDomain;
+import static org.batfish.common.topology.bridge_domain.L3AdjacencyComputer.findCorrespondingPhysicalInterface;
+import static org.batfish.common.topology.bridge_domain.L3AdjacencyComputer.shouldCreateL3Interface;
+import static org.batfish.common.topology.bridge_domain.L3AdjacencyComputer.shouldCreatePhysicalInterface;
+import static org.batfish.common.topology.bridge_domain.node.BridgeDomain.newVlanAwareBridge;
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.ConfigurationFormat.CISCO_IOS;
+import static org.batfish.datamodel.InterfaceType.LOGICAL;
+import static org.batfish.datamodel.InterfaceType.LOOPBACK;
+import static org.batfish.datamodel.InterfaceType.PHYSICAL;
+import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.batfish.common.topology.Layer1Edge;
+import org.batfish.common.topology.Layer1Topologies;
+import org.batfish.common.topology.Layer1TopologiesFactory;
+import org.batfish.common.topology.Layer1Topology;
+import org.batfish.common.topology.bridge_domain.node.BridgeDomain;
+import org.batfish.common.topology.bridge_domain.node.BridgedL3Interface;
+import org.batfish.common.topology.bridge_domain.node.EthernetHub;
+import org.batfish.common.topology.bridge_domain.node.L2Interface;
+import org.batfish.common.topology.bridge_domain.node.L3Interface;
+import org.batfish.common.topology.bridge_domain.node.NonBridgedL3Interface;
+import org.batfish.common.topology.bridge_domain.node.PhysicalInterface;
+import org.batfish.datamodel.BumTransportMethod;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.Interface.DependencyType;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LinkLocalAddress;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.SwitchportMode;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.VxlanTopology;
+import org.batfish.datamodel.vxlan.VxlanTopologyUtils;
+import org.junit.Test;
+
+public class L3AdjacencyComputerTest {
+  private static final InterfaceAddress CONCRETE = ConcreteInterfaceAddress.parse("1.2.3.4/24");
+
+  private static Set<Dependency> dependsOn(Interface i) {
+    return ImmutableSet.of(new Dependency(i.getName(), DependencyType.BIND));
+  }
+
+  @Test
+  public void testFindCorrespondingPhysicalInterface_physical() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair nip = NodeInterfacePair.of(physical);
+    PhysicalInterface iface = new PhysicalInterface(nip);
+    // Correct
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            physical, nip, c.getAllInterfaces(), ImmutableMap.of(nip, iface)),
+        equalTo(Optional.of(iface)));
+    // Missing physical interface
+    assertThat(
+        findCorrespondingPhysicalInterface(physical, nip, c.getAllInterfaces(), ImmutableMap.of()),
+        equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testFindCorrespondingPhysicalInterface_subinterface() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair physicalNip = NodeInterfacePair.of(physical);
+    PhysicalInterface physicalIface = new PhysicalInterface(physicalNip);
+
+    // Correct
+    Interface subif =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(LOGICAL)
+            .setDependencies(dependsOn(physical))
+            .build();
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            subif,
+            NodeInterfacePair.of(subif),
+            c.getAllInterfaces(),
+            ImmutableMap.of(physicalNip, physicalIface)),
+        equalTo(Optional.of(physicalIface)));
+
+    // Dep not in configuration
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            subif,
+            NodeInterfacePair.of(subif),
+            ImmutableMap.of(subif.getName(), subif),
+            ImmutableMap.of()),
+        equalTo(Optional.empty()));
+    // Dep not a physical interface
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            subif, NodeInterfacePair.of(subif), c.getAllInterfaces(), ImmutableMap.of()),
+        equalTo(Optional.empty()));
+
+    // No deps
+    Interface subifNoDeps = nf.interfaceBuilder().setOwner(c).setType(LOGICAL).build();
+    assertThat(
+        findCorrespondingPhysicalInterface(
+            subifNoDeps,
+            NodeInterfacePair.of(subifNoDeps),
+            c.getAllInterfaces(),
+            ImmutableMap.of(physicalNip, physicalIface)),
+        equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBridgeDomain_l3() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface l3 =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setAddress(CONCRETE)
+            .setType(PHYSICAL)
+            .setSwitchport(false)
+            .setSwitchportMode(SwitchportMode.NONE)
+            .build();
+    NodeInterfacePair nip = NodeInterfacePair.of(l3);
+    BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+    PhysicalInterface physicalInterface = new PhysicalInterface(nip);
+
+    // Since L3 non-bridged interface, no edges should be established.
+    connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+        l3, c.getAllInterfaces(), ImmutableMap.of(nip, physicalInterface), domain);
+    assertThat(domain.getToL2ForTest(), anEmptyMap());
+    assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+    assertThat(physicalInterface.getAttachedHubForTest(), nullValue());
+    assertThat(physicalInterface.getToL2ForTest(), anEmptyMap());
+    assertThat(physicalInterface.getToNonBridgedL3ForTest(), anEmptyMap());
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBridgeDomain_access() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface access =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(PHYSICAL)
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.ACCESS)
+            .setAccessVlan(3)
+            .build();
+    NodeInterfacePair nip = NodeInterfacePair.of(access);
+
+    {
+      // Access should be attached
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      PhysicalInterface physicalInterface = new PhysicalInterface(nip);
+      Optional<L2Interface> maybeL2 =
+          connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+              access, c.getAllInterfaces(), ImmutableMap.of(nip, physicalInterface), domain);
+      assertTrue(maybeL2.isPresent());
+      L2Interface l2Interface = maybeL2.get();
+      assertThat(l2Interface.getBridgeDomainForTest(), sameInstance(domain));
+      assertThat(l2Interface.getToBridgeDomainForTest(), notNullValue());
+      assertThat(l2Interface.getPhysicalInterfaceForTest(), sameInstance(physicalInterface));
+      assertThat(l2Interface.getToPhysicalForTest(), notNullValue());
+      assertThat(domain.getToL2ForTest(), hasKeys(l2Interface));
+      assertThat(physicalInterface.getAttachedHubForTest(), nullValue());
+      assertThat(physicalInterface.getToL2ForTest(), hasKeys(l2Interface));
+      assertThat(physicalInterface.getToNonBridgedL3ForTest(), anEmptyMap());
+    }
+
+    {
+      // Missing access vlan should be no results
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      PhysicalInterface physicalInterface = new PhysicalInterface(nip);
+      access.setAccessVlan(null);
+      Optional<L2Interface> maybeL2 =
+          connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+              access, c.getAllInterfaces(), ImmutableMap.of(nip, physicalInterface), domain);
+      assertFalse(maybeL2.isPresent());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+      assertThat(physicalInterface.getAttachedHubForTest(), nullValue());
+      assertThat(physicalInterface.getToL2ForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBroadcastDomain_trunk() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface trunk =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(PHYSICAL)
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.TRUNK)
+            .setAllowedVlans(IntegerSpace.of(3))
+            .setNativeVlan(3)
+            .build();
+    NodeInterfacePair nip = NodeInterfacePair.of(trunk);
+
+    // Trunk should be attached
+    BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+    PhysicalInterface physicalInterface = new PhysicalInterface(nip);
+    Optional<L2Interface> maybeL2 =
+        connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+            trunk, c.getAllInterfaces(), ImmutableMap.of(nip, physicalInterface), domain);
+    assertTrue(maybeL2.isPresent());
+    L2Interface l2Interface = maybeL2.get();
+    assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+    assertThat(domain.getToL2ForTest().keySet(), contains(sameInstance(l2Interface)));
+    assertThat(l2Interface.getPhysicalInterfaceForTest(), sameInstance(physicalInterface));
+    assertThat(l2Interface.getToPhysicalForTest(), notNullValue());
+    assertThat(l2Interface.getBridgeDomainForTest(), sameInstance(domain));
+    assertThat(l2Interface.getToBridgeDomainForTest(), notNullValue());
+    assertThat(physicalInterface.getAttachedHubForTest(), nullValue());
+    assertThat(physicalInterface.getToL2ForTest().keySet(), contains(sameInstance(l2Interface)));
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBroadcastDomain_subif_access() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    Interface subif =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(LOGICAL)
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.ACCESS)
+            .setDependencies(dependsOn(physical))
+            .setAccessVlan(3)
+            .build();
+    NodeInterfacePair physicalNip = NodeInterfacePair.of(physical);
+
+    {
+      // Should be attached to physical iface
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      PhysicalInterface physicalInterface = new PhysicalInterface(physicalNip);
+      Optional<L2Interface> maybeL2 =
+          connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+              subif, c.getAllInterfaces(), ImmutableMap.of(physicalNip, physicalInterface), domain);
+      assertTrue(maybeL2.isPresent());
+      L2Interface l2Interface = maybeL2.get();
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest().keySet(), contains(sameInstance(l2Interface)));
+      assertThat(l2Interface.getPhysicalInterfaceForTest(), sameInstance(physicalInterface));
+      assertThat(l2Interface.getToPhysicalForTest(), notNullValue());
+      assertThat(l2Interface.getBridgeDomainForTest(), sameInstance(domain));
+      assertThat(l2Interface.getToBridgeDomainForTest(), notNullValue());
+      assertThat(physicalInterface.getAttachedHubForTest(), nullValue());
+      assertThat(physicalInterface.getToL2ForTest().keySet(), contains(sameInstance(l2Interface)));
+    }
+    {
+      // Clear the dependency, should find nothing
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      PhysicalInterface physicalInterface = new PhysicalInterface(physicalNip);
+      subif.setDependencies(ImmutableSet.of());
+      Optional<L2Interface> maybeL2 =
+          connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+              subif, c.getAllInterfaces(), ImmutableMap.of(physicalNip, physicalInterface), domain);
+      assertFalse(maybeL2.isPresent());
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+      assertThat(physicalInterface.getAttachedHubForTest(), nullValue());
+      assertThat(physicalInterface.getToL2ForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL2InterfaceToBroadcastDomain_unknown_mode() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface unhandledMode =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(PHYSICAL)
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.MONITOR)
+            .build();
+    NodeInterfacePair nip = NodeInterfacePair.of(unhandledMode);
+
+    BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+    PhysicalInterface physicalInterface = new PhysicalInterface(nip);
+    Optional<L2Interface> maybeL2 =
+        connectL2InterfaceToBridgeDomainAndPhysicalInterface(
+            unhandledMode, c.getAllInterfaces(), ImmutableMap.of(nip, physicalInterface), domain);
+    assertFalse(maybeL2.isPresent());
+    assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+    assertThat(domain.getToL2ForTest(), anEmptyMap());
+    assertThat(physicalInterface.getAttachedHubForTest(), nullValue());
+    assertThat(physicalInterface.getToL2ForTest(), anEmptyMap());
+  }
+
+  @Test
+  public void testShouldCreatePhysicalInterface() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    assertTrue(
+        "physical should be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).setAdminUp(true).build()));
+    assertFalse(
+        "physical but shutdown should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).setAdminUp(false).build()));
+    assertFalse(
+        "physical, active but aggregated should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setChannelGroup("Port-Channel1")
+                .setAdminUp(true)
+                .build()));
+    assertFalse(
+        "logical should not be created",
+        shouldCreatePhysicalInterface(nf.interfaceBuilder().setOwner(c).setType(LOGICAL).build()));
+    assertFalse(
+        "vlan should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(InterfaceType.VLAN)
+                .setAdminUp(true)
+                .build()));
+    assertTrue(
+        "aggregate,active should be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(InterfaceType.AGGREGATED)
+                .setAdminUp(true)
+                .build()));
+    assertFalse(
+        "aggregate but shutdown should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(InterfaceType.AGGREGATED)
+                .setAdminUp(false)
+                .build()));
+    assertFalse(
+        "aggregate child should not be created",
+        shouldCreatePhysicalInterface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(InterfaceType.AGGREGATE_CHILD)
+                .setAdminUp(true)
+                .build()));
+  }
+
+  @Test
+  public void testShouldCreateL3Interface() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    assertTrue(
+        "l3 should be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(false)
+                .setAddress(CONCRETE)
+                .setAdminUp(true)
+                .build()));
+    assertTrue(
+        "l3 with LLA should be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(false)
+                .setAddress(LinkLocalAddress.of(Ip.parse("169.254.0.1")))
+                .setAdminUp(true)
+                .build()));
+    assertFalse(
+        "l3 with no addresses should not be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(false)
+                .setAdminUp(true)
+                .build()));
+    assertFalse(
+        "l3 shutdown should not be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(false)
+                .setAddress(CONCRETE)
+                .setAdminUp(false)
+                .build()));
+    assertFalse(
+        "l3 loopback should not be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(LOOPBACK)
+                .setSwitchport(false)
+                .setAddress(CONCRETE)
+                .setAdminUp(true)
+                .build()));
+    assertFalse(
+        "l3 in weird l3/switchport mode should not be created",
+        shouldCreateL3Interface(
+            nf.interfaceBuilder()
+                .setOwner(c)
+                .setType(PHYSICAL)
+                .setSwitchport(true)
+                .setSwitchportMode(SwitchportMode.ACCESS)
+                .setAddress(CONCRETE)
+                .setAdminUp(true)
+                .build()));
+  }
+
+  @Test
+  public void testConnectL3InterfaceToPhysicalOrDomain_physical() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical =
+        nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).setAddress(CONCRETE).build();
+    NodeInterfacePair nip = NodeInterfacePair.of(physical);
+    {
+      // Connect to physical interface and not domain
+      PhysicalInterface physicalInterface = new PhysicalInterface(nip);
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              physical,
+              c.getAllInterfaces(),
+              ImmutableMap.of(nip, physicalInterface),
+              ImmutableMap.of(domain.getId(), domain));
+      assertTrue(maybeL3.isPresent());
+      L3Interface l3Interface = maybeL3.get();
+      assertThat(l3Interface, instanceOf(NonBridgedL3Interface.class));
+      NonBridgedL3Interface nbl3Interface = (NonBridgedL3Interface) l3Interface;
+      assertThat(nbl3Interface.getPhysicalInterfaceForTest(), sameInstance(physicalInterface));
+      assertThat(nbl3Interface.getToPhysicalForTest(), notNullValue());
+      assertThat(
+          physicalInterface.getToNonBridgedL3ForTest().keySet(),
+          contains(sameInstance(nbl3Interface)));
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+    {
+      // Missing physical interface
+      PhysicalInterface physicalInterface = new PhysicalInterface(nip);
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              physical,
+              c.getAllInterfaces(),
+              ImmutableMap.of(),
+              ImmutableMap.of(domain.getId(), domain));
+      assertFalse(maybeL3.isPresent());
+      assertThat(physicalInterface.getToNonBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL3InterfaceToPhysicalOrDomain_subif() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface physical = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    Interface subif =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(LOGICAL)
+            .setAddress(CONCRETE)
+            .setDependencies(dependsOn(physical))
+            .setEncapsulationVlan(3)
+            .build();
+    {
+      // Connect to physical interface and not domain
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              subif,
+              c.getAllInterfaces(),
+              ImmutableMap.of(physicalInterface.getInterface(), physicalInterface),
+              ImmutableMap.of(domain.getId(), domain));
+      assertTrue(maybeL3.isPresent());
+      L3Interface l3Interface = maybeL3.get();
+      assertThat(l3Interface, instanceOf(NonBridgedL3Interface.class));
+      NonBridgedL3Interface nbl3Interface = (NonBridgedL3Interface) l3Interface;
+      assertThat(nbl3Interface.getPhysicalInterfaceForTest(), sameInstance(physicalInterface));
+      assertThat(nbl3Interface.getToPhysicalForTest(), notNullValue());
+      assertThat(
+          physicalInterface.getToNonBridgedL3ForTest().keySet(),
+          contains(sameInstance(nbl3Interface)));
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+    {
+      // Parent is missing on config
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              subif,
+              ImmutableMap.of(),
+              ImmutableMap.of(physicalInterface.getInterface(), physicalInterface),
+              ImmutableMap.of(domain.getId(), domain));
+      assertFalse(maybeL3.isPresent());
+      assertThat(physicalInterface.getToNonBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+    {
+      // Parent is missing PhysicalInterface
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              subif,
+              c.getAllInterfaces(),
+              ImmutableMap.of(),
+              ImmutableMap.of(domain.getId(), domain));
+      assertFalse(maybeL3.isPresent());
+      assertThat(physicalInterface.getToNonBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+    {
+      // Subif handles untagged frames
+      subif.setEncapsulationVlan(null);
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(physical));
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              subif,
+              c.getAllInterfaces(),
+              ImmutableMap.of(physicalInterface.getInterface(), physicalInterface),
+              ImmutableMap.of(domain.getId(), domain));
+      assertTrue(maybeL3.isPresent());
+      L3Interface l3Interface = maybeL3.get();
+      assertThat(l3Interface, instanceOf(NonBridgedL3Interface.class));
+      NonBridgedL3Interface nbl3Interface = (NonBridgedL3Interface) l3Interface;
+      assertThat(nbl3Interface.getPhysicalInterfaceForTest(), sameInstance(physicalInterface));
+      assertThat(nbl3Interface.getToPhysicalForTest(), notNullValue());
+      assertThat(
+          physicalInterface.getToNonBridgedL3ForTest().keySet(),
+          contains(sameInstance(nbl3Interface)));
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL3InterfaceToPhysicalOrDomain_vlan() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface vlan =
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setType(InterfaceType.VLAN)
+            .setAddress(CONCRETE)
+            .setVlan(4)
+            .build();
+    {
+      // Connect to domain and not physical interface
+      // Should not create physical iface for VLAN, but ensure the connection doesn't happen anyway.
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(vlan));
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              vlan,
+              c.getAllInterfaces(),
+              ImmutableMap.of(physicalInterface.getInterface(), physicalInterface),
+              ImmutableMap.of(domain.getId(), domain));
+      assertTrue(maybeL3.isPresent());
+      L3Interface l3Interface = maybeL3.get();
+      assertThat(l3Interface, instanceOf(BridgedL3Interface.class));
+      BridgedL3Interface bridgedL3Interface = (BridgedL3Interface) l3Interface;
+      assertThat(bridgedL3Interface.getBridgeDomainForTest(), sameInstance(domain));
+      assertThat(bridgedL3Interface.getToBridgeDomainForTest(), notNullValue());
+      assertThat(physicalInterface.getToNonBridgedL3ForTest(), anEmptyMap());
+      assertThat(
+          domain.getToBridgedL3ForTest().keySet(), contains(sameInstance(bridgedL3Interface)));
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+    {
+      // Missing domain
+      // Should not create physical iface for VLAN, but ensure the connection doesn't happen anyway.
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(vlan));
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              vlan,
+              c.getAllInterfaces(),
+              ImmutableMap.of(physicalInterface.getInterface(), physicalInterface),
+              ImmutableMap.of());
+      assertFalse(maybeL3.isPresent());
+      assertThat(physicalInterface.getToNonBridgedL3ForTest(), anEmptyMap());
+    }
+    {
+      // Missing VLAN
+      vlan.setVlan(null);
+      // Should not create physical iface for VLAN, but ensure the connection doesn't happen anyway.
+      PhysicalInterface physicalInterface = new PhysicalInterface(NodeInterfacePair.of(vlan));
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              vlan,
+              c.getAllInterfaces(),
+              ImmutableMap.of(physicalInterface.getInterface(), physicalInterface),
+              ImmutableMap.of(domain.getId(), domain));
+      assertFalse(maybeL3.isPresent());
+      assertThat(physicalInterface.getToNonBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+  }
+
+  @Test
+  public void testConnectL3InterfaceToPhysicalOrDomain_unknown() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface loopback =
+        nf.interfaceBuilder().setOwner(c).setType(LOOPBACK).setAddress(CONCRETE).build();
+    {
+      // Loopback should be filtered out ahead of time, but if it makes it here
+      // then there should still be no issues.
+      BridgeDomain domain = newVlanAwareBridge(c.getHostname());
+      Optional<L3Interface> maybeL3 =
+          connectL3InterfaceToPhysicalOrDomain(
+              loopback,
+              c.getAllInterfaces(),
+              ImmutableMap.of(),
+              ImmutableMap.of(domain.getId(), domain));
+      assertFalse(maybeL3.isPresent());
+      assertThat(domain.getToBridgedL3ForTest(), anEmptyMap());
+      assertThat(domain.getToL2ForTest(), anEmptyMap());
+    }
+  }
+
+  private static Map<NodeInterfacePair, PhysicalInterface> makePhysicalMap(
+      Interface... interfaces) {
+    return Arrays.stream(interfaces)
+        .map(NodeInterfacePair::of)
+        .collect(ImmutableMap.toImmutableMap(nip -> nip, PhysicalInterface::new));
+  }
+
+  private static Set<NodeInterfacePair> getPairs(Collection<PhysicalInterface> interfaces) {
+    return interfaces.stream()
+        .map(PhysicalInterface::getInterface)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Test
+  public void testComputeEthernetHubs() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c = nf.configurationBuilder().build();
+    Interface i1 = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair n1 = NodeInterfacePair.of(i1);
+    Interface i2 = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair n2 = NodeInterfacePair.of(i2);
+    Interface i3 = nf.interfaceBuilder().setOwner(c).setType(PHYSICAL).build();
+    NodeInterfacePair n3 = NodeInterfacePair.of(i3);
+    {
+      // No l1 topology.
+      Map<NodeInterfacePair, PhysicalInterface> physical = makePhysicalMap(i1, i2, i3);
+      Map<String, EthernetHub> hubs =
+          computeEthernetHubs(ImmutableMap.of(c.getHostname(), c), physical, Layer1Topology.EMPTY);
+      assertThat(hubs.keySet(), contains(BATFISH_GLOBAL_HUB));
+      assertThat(
+          getPairs(hubs.get(BATFISH_GLOBAL_HUB).getToPhysicalForTest().keySet()),
+          containsInAnyOrder(n1, n2, n3));
+    }
+    {
+      // One edge.
+      Map<String, EthernetHub> hubs =
+          computeEthernetHubs(
+              ImmutableMap.of(c.getHostname(), c),
+              makePhysicalMap(i1, i2, i3),
+              new Layer1Topology(
+                  ImmutableSet.of(
+                      new Layer1Edge(
+                          c.getHostname(), i1.getName(), c.getHostname(), i2.getName()))));
+      assertThat(hubs, aMapWithSize(2));
+      String otherKey =
+          Iterables.getOnlyElement(
+              Sets.difference(hubs.keySet(), ImmutableSet.of(BATFISH_GLOBAL_HUB)));
+      assertThat(
+          getPairs(hubs.get(BATFISH_GLOBAL_HUB).getToPhysicalForTest().keySet()), contains(n3));
+      assertThat(
+          getPairs(hubs.get(otherKey).getToPhysicalForTest().keySet()), containsInAnyOrder(n1, n2));
+    }
+    {
+      // One interface with disconnected edge.
+      Map<String, EthernetHub> hubs =
+          computeEthernetHubs(
+              ImmutableMap.of(c.getHostname(), c),
+              makePhysicalMap(i1, i2, i3),
+              new Layer1Topology(
+                  ImmutableSet.of(
+                      new Layer1Edge(
+                          c.getHostname(), i1.getName(), "no-such-hostname", "no-such-iface"))));
+      assertThat(hubs, aMapWithSize(2));
+      String otherKey =
+          Iterables.getOnlyElement(
+              Sets.difference(hubs.keySet(), ImmutableSet.of(BATFISH_GLOBAL_HUB)));
+      assertThat(
+          getPairs(hubs.get(BATFISH_GLOBAL_HUB).getToPhysicalForTest().keySet()),
+          containsInAnyOrder(n2, n3));
+      assertThat(getPairs(hubs.get(otherKey).getToPhysicalForTest().keySet()), contains(n1));
+    }
+    {
+      // Line.
+      Map<String, EthernetHub> hubs =
+          computeEthernetHubs(
+              ImmutableMap.of(c.getHostname(), c),
+              makePhysicalMap(i1, i2, i3),
+              new Layer1Topology(
+                  ImmutableSet.of(
+                      new Layer1Edge(c.getHostname(), i1.getName(), c.getHostname(), i2.getName()),
+                      new Layer1Edge(
+                          c.getHostname(), i3.getName(), c.getHostname(), i2.getName()))));
+      assertThat(hubs, aMapWithSize(1));
+      assertThat(
+          getPairs(Iterables.getOnlyElement(hubs.values()).getToPhysicalForTest().keySet()),
+          containsInAnyOrder(n1, n2, n3));
+    }
+  }
+
+  private static Map<String, Configuration> simple3InterfaceNetwork() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c1 = nf.configurationBuilder().setHostname("c1").build();
+    nf.interfaceBuilder()
+        .setOwner(c1)
+        .setName("i1")
+        .setType(PHYSICAL)
+        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.1/24"))
+        .build();
+    Configuration c2 = nf.configurationBuilder().setHostname("c2").build();
+    nf.interfaceBuilder()
+        .setOwner(c2)
+        .setName("i2")
+        .setType(PHYSICAL)
+        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.2/24"))
+        .build();
+    Configuration c3 = nf.configurationBuilder().setHostname("c3").build();
+    nf.interfaceBuilder()
+        .setOwner(c3)
+        .setName("i3")
+        .setType(PHYSICAL)
+        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.3/24"))
+        .build();
+    return ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3);
+  }
+
+  @Test
+  public void testE2e_noL1() {
+    Map<String, Configuration> configs = simple3InterfaceNetwork();
+    // With no L1 topology, all 3 interfaces in same domain.
+    L3AdjacencyComputer l3 =
+        new L3AdjacencyComputer(configs, Layer1Topologies.empty(), VxlanTopology.EMPTY);
+    Map<NodeInterfacePair, Integer> domains = l3.findAllBroadcastDomains();
+    assertThat("all interfaces have a domain", domains, aMapWithSize(3));
+    assertThat("all interfaces in same domain", ImmutableSet.copyOf(domains.values()), hasSize(1));
+  }
+
+  @Test
+  public void testE2e_L1() {
+    // With L1 topology, only connected interfaces in same domain.
+    Map<String, Configuration> configs = simple3InterfaceNetwork();
+    NodeInterfacePair n1 = NodeInterfacePair.of("c1", "i1");
+    NodeInterfacePair n2 = NodeInterfacePair.of("c2", "i2");
+    NodeInterfacePair n3 = NodeInterfacePair.of("c3", "i3");
+    Layer1Topology physical =
+        new Layer1Topology(
+            new Layer1Edge(
+                n1.getHostname(), n1.getInterface(), n3.getHostname(), n3.getInterface()));
+    L3AdjacencyComputer l3 =
+        new L3AdjacencyComputer(
+            configs,
+            Layer1TopologiesFactory.create(physical, Layer1Topology.EMPTY, configs),
+            VxlanTopology.EMPTY);
+    Map<NodeInterfacePair, Integer> domains = l3.findAllBroadcastDomains();
+    assertThat("all interfaces have a domain", domains, aMapWithSize(3));
+    assertThat("connected ifaces in same domain", domains.get(n1), equalTo(domains.get(n3)));
+    assertThat(
+        "global hub not connected to other interfaces",
+        domains.get(n2),
+        not(equalTo(domains.get(n1))));
+  }
+
+  @Test
+  public void testE2e_disconnected() {
+    Map<String, Configuration> configs = simple3InterfaceNetwork();
+    NodeInterfacePair n1 = NodeInterfacePair.of("c1", "i1");
+    NodeInterfacePair n2 = NodeInterfacePair.of("c2", "i2");
+    NodeInterfacePair n3 = NodeInterfacePair.of("c3", "i3");
+    // With L1 topology to disconnected interface, only global hub connected.
+    Layer1Topology physical =
+        new Layer1Topology(
+            new Layer1Edge(n1.getHostname(), n1.getInterface(), "no-such-host", "no-such-iface"));
+    L3AdjacencyComputer l3 =
+        new L3AdjacencyComputer(
+            configs,
+            Layer1TopologiesFactory.create(physical, Layer1Topology.EMPTY, configs),
+            VxlanTopology.EMPTY);
+    Map<NodeInterfacePair, Integer> domains = l3.findAllBroadcastDomains();
+    assertThat("all interfaces have a domain", domains, aMapWithSize(3));
+    assertThat("global hub ifaces in same domain", domains.get(n2), equalTo(domains.get(n3)));
+    assertThat(
+        "n1 is disconnected, not connected to other interfaces",
+        domains.get(n1),
+        not(equalTo(domains.get(n2))));
+  }
+
+  @Test
+  public void testE2e_encapsulation() {
+    // Encapsulation vlan honored, even with no L1.
+    Map<String, Configuration> configs = simple3InterfaceNetwork();
+    NodeInterfacePair n1 = NodeInterfacePair.of("c1", "i1");
+    NodeInterfacePair n2 = NodeInterfacePair.of("c2", "i2");
+    NodeInterfacePair n3 = NodeInterfacePair.of("c3", "i3");
+    configs.get(n1.getHostname()).getAllInterfaces().get(n1.getInterface()).setEncapsulationVlan(4);
+    L3AdjacencyComputer l3 =
+        new L3AdjacencyComputer(configs, Layer1Topologies.empty(), VxlanTopology.EMPTY);
+    Map<NodeInterfacePair, Integer> domains = l3.findAllBroadcastDomains();
+    assertThat("all interfaces have a domain", domains, aMapWithSize(3));
+    assertThat(
+        "unencapsulated interface in same domain", domains.get(n2), equalTo(domains.get(n3)));
+    assertThat(
+        "encapsulated interface not connected to unencapsulated interfaces",
+        domains.get(n2),
+        not(equalTo(domains.get(n1))));
+  }
+
+  @Test
+  public void testE2e_vxlan() {
+    // Topology:
+    // h11 <=>           <=> h21
+    //     vlan10     vlan10
+    //         r1 <=> r2
+    //     vlan20     vlan20
+    // h12 <=>           <=> h22
+    //
+    // r1 and r2 only have underlay and vxlan tunnel between them - no vlans
+    // vlans 10 and 20 should be bridged across vxlan so that:
+    // - h11 and h21 are in the same broadcast domain
+    // - h12 and h22 are in the same broadcast domain
+    // vlan 10 corresponds to VNI 10010
+    // vlan 20 corresponds to VNI 10020
+    Configuration h11 =
+        Configuration.builder().setHostname("h11").setConfigurationFormat(CISCO_IOS).build();
+    Vrf h11Vrf = Vrf.builder().setName(DEFAULT_VRF_NAME).setOwner(h11).build();
+    Interface h11i =
+        Interface.builder()
+            .setName("h11i")
+            .setAddress(ConcreteInterfaceAddress.parse("10.0.10.1/24"))
+            .setType(PHYSICAL)
+            .setVrf(h11Vrf)
+            .setOwner(h11)
+            .build();
+
+    Configuration h12 =
+        Configuration.builder().setHostname("h12").setConfigurationFormat(CISCO_IOS).build();
+    Vrf h12Vrf = Vrf.builder().setName(DEFAULT_VRF_NAME).setOwner(h12).build();
+    Interface h12i =
+        Interface.builder()
+            .setName("h12i")
+            .setAddress(ConcreteInterfaceAddress.parse("10.0.20.1/24"))
+            .setType(PHYSICAL)
+            .setVrf(h12Vrf)
+            .setOwner(h12)
+            .build();
+
+    Configuration h21 =
+        Configuration.builder().setHostname("h21").setConfigurationFormat(CISCO_IOS).build();
+    Vrf h21Vrf = Vrf.builder().setName(DEFAULT_VRF_NAME).setOwner(h21).build();
+    Interface h21i =
+        Interface.builder()
+            .setName("h21i")
+            .setAddress(ConcreteInterfaceAddress.parse("10.0.10.2/24"))
+            .setType(PHYSICAL)
+            .setVrf(h21Vrf)
+            .setOwner(h21)
+            .build();
+
+    Configuration h22 =
+        Configuration.builder().setHostname("h22").setConfigurationFormat(CISCO_IOS).build();
+    Vrf h22Vrf = Vrf.builder().setName(DEFAULT_VRF_NAME).setOwner(h22).build();
+    Interface h22i =
+        Interface.builder()
+            .setName("h22i")
+            .setAddress(ConcreteInterfaceAddress.parse("10.0.20.2/24"))
+            .setType(PHYSICAL)
+            .setVrf(h22Vrf)
+            .setOwner(h22)
+            .build();
+
+    Configuration r1 =
+        Configuration.builder().setHostname("r1").setConfigurationFormat(CISCO_IOS).build();
+    Vrf r1Vrf = Vrf.builder().setName(DEFAULT_VRF_NAME).setOwner(r1).build();
+    Interface r1h11 =
+        Interface.builder()
+            .setName("r1h11")
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.ACCESS)
+            .setAccessVlan(10)
+            .setType(PHYSICAL)
+            .setVrf(r1Vrf)
+            .setOwner(r1)
+            .build();
+    Interface r1h12 =
+        Interface.builder()
+            .setName("r1h12")
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.ACCESS)
+            .setAccessVlan(20)
+            .setType(PHYSICAL)
+            .setVrf(r1Vrf)
+            .setOwner(r1)
+            .build();
+    Interface r1r2 =
+        Interface.builder()
+            .setName("r1r2")
+            .setAddress(ConcreteInterfaceAddress.parse("10.0.0.1/24"))
+            .setType(PHYSICAL)
+            .setVrf(r1Vrf)
+            .setOwner(r1)
+            .build();
+    r1Vrf.addLayer2Vni(
+        Layer2Vni.builder()
+            .setVni(10010)
+            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+            .setSrcVrf(DEFAULT_VRF_NAME)
+            .setVlan(10)
+            .setSourceAddress(Ip.parse("10.0.0.1"))
+            .setBumTransportIps(ImmutableSet.of(Ip.parse("10.0.0.2")))
+            .build());
+    r1Vrf.addLayer2Vni(
+        Layer2Vni.builder()
+            .setVni(10020)
+            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+            .setSrcVrf(DEFAULT_VRF_NAME)
+            .setVlan(20)
+            .setSourceAddress(Ip.parse("10.0.0.1"))
+            .setBumTransportIps(ImmutableSet.of(Ip.parse("10.0.0.2")))
+            .build());
+
+    Configuration r2 =
+        Configuration.builder().setHostname("r2").setConfigurationFormat(CISCO_IOS).build();
+    Vrf r2Vrf = Vrf.builder().setName(DEFAULT_VRF_NAME).setOwner(r2).build();
+    Interface r2h21 =
+        Interface.builder()
+            .setName("r2h21")
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.ACCESS)
+            .setAccessVlan(10)
+            .setType(PHYSICAL)
+            .setVrf(r2Vrf)
+            .setOwner(r2)
+            .build();
+    Interface r2h22 =
+        Interface.builder()
+            .setName("r2h22")
+            .setSwitchport(true)
+            .setSwitchportMode(SwitchportMode.ACCESS)
+            .setAccessVlan(20)
+            .setType(PHYSICAL)
+            .setVrf(r2Vrf)
+            .setOwner(r2)
+            .build();
+    Interface r2r1 =
+        Interface.builder()
+            .setName("r2r1")
+            .setAddress(ConcreteInterfaceAddress.parse("10.0.0.2/24"))
+            .setType(PHYSICAL)
+            .setVrf(r2Vrf)
+            .setOwner(r2)
+            .build();
+    r2Vrf.addLayer2Vni(
+        Layer2Vni.builder()
+            .setVni(10010)
+            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+            .setSrcVrf(DEFAULT_VRF_NAME)
+            .setVlan(10)
+            .setSourceAddress(Ip.parse("10.0.0.2"))
+            .setBumTransportIps(ImmutableSet.of(Ip.parse("10.0.0.1")))
+            .build());
+    r2Vrf.addLayer2Vni(
+        Layer2Vni.builder()
+            .setVni(10020)
+            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+            .setSrcVrf(DEFAULT_VRF_NAME)
+            .setVlan(20)
+            .setSourceAddress(Ip.parse("10.0.0.2"))
+            .setBumTransportIps(ImmutableSet.of(Ip.parse("10.0.0.1")))
+            .build());
+
+    Map<String, Configuration> configurations =
+        ImmutableMap.of(
+            h11.getHostname(), h11,
+            h12.getHostname(), h12,
+            h21.getHostname(), h21,
+            h22.getHostname(), h22,
+            r1.getHostname(), r1,
+            r2.getHostname(), r2);
+    Set<Layer1Edge> l1EdgesOneSided =
+        ImmutableSet.of(
+            new Layer1Edge(h11.getHostname(), h11i.getName(), r1.getHostname(), r1h11.getName()),
+            new Layer1Edge(h12.getHostname(), h12i.getName(), r1.getHostname(), r1h12.getName()),
+            new Layer1Edge(r1.getHostname(), r1r2.getName(), r2.getHostname(), r2r1.getName()),
+            new Layer1Edge(h21.getHostname(), h21i.getName(), r2.getHostname(), r2h21.getName()),
+            new Layer1Edge(h22.getHostname(), h22i.getName(), r2.getHostname(), r2h22.getName()));
+    Set<Layer1Edge> l1Edges =
+        l1EdgesOneSided.stream()
+            .flatMap(e -> Stream.of(e, e.reverse()))
+            .collect(ImmutableSet.toImmutableSet());
+    Layer1Topology l1 = new Layer1Topology(l1Edges);
+    Layer1Topologies layer1Topologies =
+        Layer1TopologiesFactory.create(l1, Layer1Topology.EMPTY, configurations);
+    VxlanTopology vxlanTopology = VxlanTopologyUtils.computeInitialVxlanTopology(configurations);
+    L3AdjacencyComputer l3 =
+        new L3AdjacencyComputer(configurations, layer1Topologies, vxlanTopology);
+    Map<NodeInterfacePair, Integer> bds = l3.findAllBroadcastDomains();
+
+    assertThat(bds.get(NodeInterfacePair.of(h11i)), equalTo(bds.get(NodeInterfacePair.of(h21i))));
+    assertThat(bds.get(NodeInterfacePair.of(h12i)), equalTo(bds.get(NodeInterfacePair.of(h22i))));
+    assertThat(
+        bds.get(NodeInterfacePair.of(h11i)), not(equalTo(bds.get(NodeInterfacePair.of(h22i)))));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/bridge_domain/SearchTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/bridge_domain/SearchTest.java
@@ -1,0 +1,177 @@
+package org.batfish.common.topology.bridge_domain;
+
+import static org.batfish.common.topology.bridge_domain.Search.STATE_FUNCTION_EVALUATOR;
+import static org.batfish.common.topology.bridge_domain.edge.BridgeDomainToL2.compose;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.assignVlanFromOuterTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.clearVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.filterByOuterTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.filterByVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.identity;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.popTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.pushTag;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.pushVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.setVlanId;
+import static org.batfish.common.topology.bridge_domain.function.StateFunctions.translateVlan;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.batfish.common.topology.bridge_domain.function.StateFunction;
+import org.batfish.datamodel.IntegerSpace;
+import org.junit.Test;
+
+/** Test of {@link Search}. */
+public final class SearchTest {
+
+  @Test
+  public void testVisitAssignVlanFromOuterTag() {
+    assertThat(
+        visit(assignVlanFromOuterTag(null), State.of(1, null)),
+        equalTo(Optional.of(State.of(null, 1))));
+    assertThat(
+        visit(assignVlanFromOuterTag(1), State.of(null, null)),
+        equalTo(Optional.of(State.of(null, 1))));
+    assertThat(
+        visit(assignVlanFromOuterTag(2), State.of(1, null)),
+        equalTo(Optional.of(State.of(null, 1))));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitAssignVlanFromOuterTag_invalid() {
+    visit(assignVlanFromOuterTag(null), State.empty());
+  }
+
+  @Test
+  public void testVisitClearVlanId() {
+    assertThat(visit(clearVlanId(), State.of(1, 1)), equalTo(Optional.of(State.of(1, null))));
+    assertThat(visit(clearVlanId(), State.of(null, 1)), equalTo(Optional.of(State.of(null, null))));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitClearVlanId_invalid() {
+    visit(clearVlanId(), State.empty());
+  }
+
+  @Test
+  public void testVisitCompose() {
+    assertThat(
+        visit(
+            compose(translateVlan(ImmutableMap.of(1, 2)), filterByVlanId(IntegerSpace.of(2))),
+            State.of(1, 1)),
+        equalTo(Optional.of(State.of(1, 2))));
+    assertThat(
+        visit(
+            compose(filterByVlanId(IntegerSpace.of(2)), translateVlan(ImmutableMap.of(1, 2))),
+            State.of(1, 1)),
+        equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testVisitFilterByOuterTag() {
+    assertThat(
+        visit(filterByOuterTag(IntegerSpace.of(1), true), State.of(null, 100)),
+        equalTo(Optional.of(State.of(null, 100))));
+    assertThat(
+        visit(filterByOuterTag(IntegerSpace.of(1), false), State.of(null, 100)),
+        equalTo(Optional.empty()));
+    assertThat(
+        visit(filterByOuterTag(IntegerSpace.of(1), false), State.of(1, 100)),
+        equalTo(Optional.of(State.of(1, 100))));
+  }
+
+  @Test
+  public void testVisitFilterByVlanId() {
+    assertThat(
+        visit(filterByVlanId(IntegerSpace.of(1)), State.of(2, 1)),
+        equalTo(Optional.of(State.of(2, 1))));
+    assertThat(
+        visit(filterByVlanId(IntegerSpace.of(2)), State.of(2, 1)), equalTo(Optional.empty()));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitFilterByVlanId_invalid() {
+    visit(filterByVlanId(IntegerSpace.of(1)), State.of(2, null));
+  }
+
+  @Test
+  public void testVisitIdentity() {
+    assertThat(visit(identity(), State.empty()), equalTo(Optional.of(State.empty())));
+    assertThat(visit(identity(), State.of(null, 1)), equalTo(Optional.of(State.of(null, 1))));
+    assertThat(visit(identity(), State.of(1, null)), equalTo(Optional.of(State.of(1, null))));
+    assertThat(visit(identity(), State.of(1, 1)), equalTo(Optional.of(State.of(1, 1))));
+  }
+
+  @Test
+  public void testVisitPopTag() {
+    assertThat(visit(popTag(0), State.empty()), equalTo(Optional.of(State.empty())));
+    assertThat(visit(popTag(0), State.of(1, 2)), equalTo(Optional.of(State.of(1, 2))));
+    assertThat(visit(popTag(1), State.of(1, 2)), equalTo(Optional.of(State.of(null, 2))));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitPopTag_invalid() {
+    visit(popTag(1), State.of(null, 2));
+  }
+
+  @Test
+  public void testVisitPushTag() {
+    assertThat(visit(pushTag(1), State.of(null, 2)), equalTo(Optional.of(State.of(1, 2))));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitPushTag_invalid() {
+    // TODO: remove/update when tag stacks are supported
+    visit(pushTag(1), State.of(1, 1));
+  }
+
+  @Test
+  public void testVisitPushVlanId() {
+    assertThat(visit(pushVlanId(null), State.of(null, 2)), equalTo(Optional.of(State.of(2, 2))));
+    assertThat(visit(pushVlanId(2), State.of(null, 2)), equalTo(Optional.of(State.of(null, 2))));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitPushVlanId_invalidNoVlanId() {
+    visit(pushVlanId(null), State.of(null, null));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitPushVlanId_invalidTagPresent() {
+    // TODO: remove/update when tag stacks are supported
+    visit(pushVlanId(null), State.of(1, 2));
+  }
+
+  @Test
+  public void testVisitSetVlanId() {
+    assertThat(visit(setVlanId(3), State.of(1, null)), equalTo(Optional.of(State.of(1, 3))));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitSetVlanId_invalid() {
+    visit(setVlanId(3), State.of(1, 2));
+  }
+
+  @Test
+  public void testVisitTranslateVlan() {
+    assertThat(
+        visit(translateVlan(ImmutableMap.of(1, 2)), State.of(null, 1)),
+        equalTo(Optional.of(State.of(null, 2))));
+    assertThat(
+        visit(translateVlan(ImmutableMap.of(1, 2)), State.of(5, 2)),
+        equalTo(Optional.of(State.of(5, 2))));
+    assertThat(
+        visit(translateVlan(ImmutableMap.of(1, 2)), State.of(5, 3)),
+        equalTo(Optional.of(State.of(5, 3))));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testVisitTranslateVlan_invalid() {
+    visit(translateVlan(ImmutableMap.of(1, 2)), State.of(5, null));
+  }
+
+  private static @Nonnull Optional<State> visit(StateFunction stateFunction, State arg) {
+    return STATE_FUNCTION_EVALUATOR.visit(stateFunction, arg);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -46,6 +46,7 @@ import org.batfish.common.topology.L3Adjacencies;
 import org.batfish.common.topology.Layer1Topologies;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.TunnelTopology;
+import org.batfish.common.topology.bridge_domain.BridgeDomainL3Adjacencies;
 import org.batfish.common.topology.broadcast.BroadcastL3Adjacencies;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpAdvertisement;
@@ -195,8 +196,11 @@ final class IncrementalBdpEngine {
       LOGGER.info("Updating Layer 3 adjacencies");
       if (L3Adjacencies.USE_NEW_METHOD) {
         newAdjacencies =
-            BroadcastL3Adjacencies.create(
-                initialTopologyContext.getLayer1Topologies(), newVxlanTopology, configurations);
+            L3Adjacencies.USE_NEW_NEW_METHOD
+                ? BridgeDomainL3Adjacencies.create(
+                    initialTopologyContext.getLayer1Topologies(), newVxlanTopology, configurations)
+                : BroadcastL3Adjacencies.create(
+                    initialTopologyContext.getLayer1Topologies(), newVxlanTopology, configurations);
       } else {
         Layer1Topologies topologies = initialTopologyContext.getLayer1Topologies();
         if (topologies.getCombinedL1().isEmpty()) {

--- a/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
@@ -26,6 +26,7 @@ import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.TopologyProvider;
 import org.batfish.common.topology.TopologyUtil;
 import org.batfish.common.topology.TunnelTopology;
+import org.batfish.common.topology.bridge_domain.BridgeDomainL3Adjacencies;
 import org.batfish.common.topology.broadcast.BroadcastL3Adjacencies;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.NetworkConfigurations;
@@ -259,8 +260,11 @@ public final class TopologyProviderImpl implements TopologyProvider {
       assert scope != null; // avoid unused warning
       Layer1Topologies l1 = getLayer1Topologies(networkSnapshot);
       if (L3Adjacencies.USE_NEW_METHOD) {
-        return BroadcastL3Adjacencies.create(
-            l1, VxlanTopology.EMPTY, getConfigurations(networkSnapshot));
+        return L3Adjacencies.USE_NEW_NEW_METHOD
+            ? BridgeDomainL3Adjacencies.create(
+                l1, VxlanTopology.EMPTY, getConfigurations(networkSnapshot))
+            : BroadcastL3Adjacencies.create(
+                l1, VxlanTopology.EMPTY, getConfigurations(networkSnapshot));
       }
       if (l1.getCombinedL1().isEmpty()) {
         return GlobalBroadcastNoPointToPoint.instance();


### PR DESCRIPTION
Move to a more granular model with reified state functions associated with edges.

Major differences over old "new l3 adjacencies" algorithm:
- add nodes for L2 interfaces instead of overloading physical interfaces
- split L3 interface into bridged and non-bridged variants
- support multiple tag-handling l2/l3 interfaces on the same physical interface
- allow multiple bridge domains per node
- use typed edges between nodes, where each edge contains a state function
- restrict the type of operations that can be performed on each edge type