### PR TITLE
PAN: ignore more profiles

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -148,9 +148,15 @@ CUSTOM_URL_CATEGORY: 'custom-url-category';
 
 DAMPENING_PROFILE: 'dampening-profile';
 
+DATA_FILTERING: 'data-filtering';
+
+DATA_OBJECTS: 'data-objects';
+
 DAYS: 'days';
 
 DEAD_COUNTS: 'dead-counts';
+
+DECRYPTION: 'decryption';
 
 DEFAULT: 'default';
 
@@ -201,6 +207,8 @@ DNS_SETTING: 'dns-setting';
 
 DOMAIN: 'domain';
 
+DOS_PROTECTION: 'dos-protection';
+
 DOWN: 'down';
 
 DROP: 'drop';
@@ -249,6 +257,8 @@ FACILITY: 'facility';
 
 FAILURE_CONDITION: 'failure-condition';
 
+FILE_BLOCKING: 'file-blocking';
+
 FILTER: 'filter';
 
 FORMAT: 'format';
@@ -287,6 +297,8 @@ GROUP20: 'group20';
 
 GROUP_ID: 'group-id';
 
+GTP: 'gtp';
+
 HALF: 'half';
 
 HA: 'ha';
@@ -300,6 +312,8 @@ HELLO_INTERVAL: 'hello-interval';
 HELPER_ENABLE: 'helper-enable';
 
 HIGH_AVAILABILITY: 'high-availability';
+
+HIP_OBJECTS: 'hip-objects';
 
 HIP_PROFILES: 'hip-profiles';
 
@@ -728,6 +742,8 @@ UPDATE_SERVER: 'update-server';
 
 URL: 'url';
 
+URL_FILTERING: 'url-filtering';
+
 USE_PEER: 'use-peer';
 
 USE_SELF: 'use-self';
@@ -744,6 +760,8 @@ VIRTUAL_ROUTER: 'virtual-router';
 
 VIRTUAL_WIRE: 'virtual-wire';
 
+VIRUS: 'virus';
+
 VISIBLE_VSYS: 'visible-vsys';
 
 VLAN: 'vlan';
@@ -753,6 +771,8 @@ VSYS: 'vsys';
 VULNERABILITY: 'vulnerability';
 
 WEIGHT: 'weight';
+
+WILDFIRE_ANALYSIS: 'wildfire-analysis';
 
 YES: 'yes';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_profiles.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_profiles.g4
@@ -11,13 +11,49 @@ s_profiles: PROFILES sp;
 sp
 :
     sp_custom_url_category
+    | sp_data_filtering
+    | sp_data_objects
+    | sp_decryption
+    | sp_dos_protection
+    | sp_file_blocking
+    | sp_gtp
+    | sp_hip_objects
+    | sp_hip_profiles
+    | sp_sctp
     | sp_spyware
+    | sp_url_filtering
+    | sp_virus
     | sp_vulnerability
+    | sp_wildfire_analysis
 ;
+
+sp_data_filtering: DATA_FILTERING null_rest_of_line;
+
+sp_data_objects: DATA_OBJECTS null_rest_of_line;
+
+sp_decryption: DECRYPTION null_rest_of_line;
+
+sp_dos_protection: DOS_PROTECTION null_rest_of_line;
+
+sp_file_blocking: FILE_BLOCKING null_rest_of_line;
+
+sp_gtp: GTP null_rest_of_line;
+
+sp_hip_objects: HIP_OBJECTS null_rest_of_line;
+
+sp_hip_profiles: HIP_PROFILES null_rest_of_line;
+
+sp_sctp: SCTP null_rest_of_line;
 
 sp_spyware: SPYWARE null_rest_of_line;
 
+sp_url_filtering: URL_FILTERING null_rest_of_line;
+
+sp_virus: VIRUS null_rest_of_line;
+
 sp_vulnerability: VULNERABILITY null_rest_of_line;
+
+sp_wildfire_analysis: WILDFIRE_ANALYSIS null_rest_of_line;
 
 sp_custom_url_category: CUSTOM_URL_CATEGORY custom_url_category_name spc_definition;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_profiles.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_profiles.g4
@@ -21,7 +21,6 @@ sp
     | sp_hip_profiles
     | sp_sctp
     | sp_spyware
-    | sp_url_filtering
     | sp_virus
     | sp_vulnerability
     | sp_wildfire_analysis
@@ -46,8 +45,6 @@ sp_hip_profiles: HIP_PROFILES null_rest_of_line;
 sp_sctp: SCTP null_rest_of_line;
 
 sp_spyware: SPYWARE null_rest_of_line;
-
-sp_url_filtering: URL_FILTERING null_rest_of_line;
 
 sp_virus: VIRUS null_rest_of_line;
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -123,7 +123,6 @@ set device-group DGNAME profiles hip-objects NAME firewall criteria is-enabled y
 set device-group DGNAME profiles hip-profiles NAME match NAME2
 set device-group DGNAME profiles sctp NAME sctp-filtering sctp-ss7 VALUE action block
 set device-group DGNAME profiles spyware NAME rules NAME2 packet-capture disable
-set device-group DGNAME profiles url-filtering NAME credential-enforcement mode disabled
 set device-group DGNAME profiles virus NAME decoder http action reset-both
 set device-group DGNAME profiles vulnerability NAME rules NAME2 action alert
 set device-group DGNAME profiles wildfire-analysis NAME rules NAME2 direction both

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -113,8 +113,21 @@ set template T1 config shared
 set template T1 config devices localhost.localdomain network vlan
 set template T1 config devices localhost.localdomain network virtual-wire
 
+set device-group DGNAME profiles data-filtering NAME rules NAME2 application any
+set device-group DGNAME profiles data-objects NAME pattern-type regex pattern NAME2
+set device-group DGNAME profiles decryption NAME ssl-no-proxy block-expired-certificate yes
+set device-group DGNAME profiles dos-protection NAME flood icmp enable yes
+set device-group DGNAME profiles file-blocking NAME rules NAME2 action alert
+set device-group DGNAME profiles gtp NAME filtering apn VALUE action block
+set device-group DGNAME profiles hip-objects NAME firewall criteria is-enabled yes
+set device-group DGNAME profiles hip-profiles NAME match NAME2
+set device-group DGNAME profiles sctp NAME sctp-filtering sctp-ss7 VALUE action block
 set device-group DGNAME profiles spyware NAME rules NAME2 packet-capture disable
+set device-group DGNAME profiles url-filtering NAME credential-enforcement mode disabled
+set device-group DGNAME profiles virus NAME decoder http action reset-both
 set device-group DGNAME profiles vulnerability NAME rules NAME2 action alert
+set device-group DGNAME profiles wildfire-analysis NAME rules NAME2 direction both
+
 set device-group DGNAME profile-group GROUPNAME spyware NAME2
 set device-group DGNAME profile-group GROUPNAME vulnerability NAME2
 


### PR DESCRIPTION
Ignore more unused `profiles`; cuts down on the number of parse warnings.