### PR TITLE
Accept 'junos' as rancid content type

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -397,6 +397,7 @@ public final class VendorConfigurationFormatDetector {
         return ConfigurationFormat.IBM_BNT;
       case "juniper":
       case "juniper-srx":
+      case "junos": // not documented but seen in the wild in multiple organizations
         return checkJuniper(true);
       case "mrv":
         return ConfigurationFormat.MRV;

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -209,6 +209,7 @@ public class VendorConfigurationFormatDetectorTest {
             "!RANCID-CONTENT-TYPE: juniper\n!\nsomething {\n blah;\n}\n",
             "#RANCID-CONTENT-TYPE: juniper\n!\nsomething {\n blah;\n}\n",
             "#RANCID-CONTENT-TYPE: juniper-srx\n!\nsomething {\n blah;\n}\n",
+            "#RANCID-CONTENT-TYPE: junos\n!\nsomething {\n blah;\n}\n",
             "snmp {\n}\n")) {
       assertThat(fileText, identifyConfigurationFormat(fileText), equalTo(JUNIPER));
     }
@@ -220,6 +221,7 @@ public class VendorConfigurationFormatDetectorTest {
             "!RANCID-CONTENT-TYPE: juniper\n!\nset blah\n",
             "#RANCID-CONTENT-TYPE: juniper\n!\nset blah\n",
             "#RANCID-CONTENT-TYPE: juniper-srx\n!\nset blah\n",
+            "#RANCID-CONTENT-TYPE: junos\n!\nset blah\n",
             "#\nset apply-groups blah\n",
             "####BATFISH FLATTENED JUNIPER CONFIG####\n")) {
       assertThat(identifyConfigurationFormat(fileText), equalTo(FLAT_JUNIPER));


### PR DESCRIPTION
I cannot find official documentation for it but have come across this twice over the last month, in configurations from two independent users.