### PR TITLE
Unify and standarize enter/exit/l3 interface configuration

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -3,6 +3,7 @@ package org.batfish.common.bdd;
 import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
+import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.activeAclSources;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -137,13 +138,7 @@ public final class BDDSourceManager {
       BDDPacket pkt, Map<String, Configuration> configs, boolean initializeSessions) {
     Map<String, Set<String>> activeSources =
         toImmutableMap(
-            configs.entrySet(),
-            Entry::getKey,
-            entry ->
-                ImmutableSet.<String>builder()
-                    .add(SOURCE_ORIGINATING_FROM_DEVICE)
-                    .addAll(entry.getValue().activeInterfaceNames())
-                    .build());
+            configs.entrySet(), Entry::getKey, entry -> activeAclSources(entry.getValue()));
 
     Map<String, Set<String>> activeAndReferenced =
         toImmutableMap(
@@ -153,8 +148,9 @@ public final class BDDSourceManager {
               Configuration config = entry.getValue();
 
               if (initializeSessions
-                  && config.getAllInterfaces().values().stream()
-                      .filter(Interface::getActive)
+                  && config
+                      .activeInterfaces()
+                      .filter(Interface::canSendOrReceiveIpTraffic)
                       .anyMatch(iface -> iface.getFirewallSessionInterfaceInfo() != null)) {
                 // This node may initialize sessions -- have to track all active sources
                 return activeSources.get(config.getHostname());

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -150,7 +150,7 @@ public final class BDDSourceManager {
               if (initializeSessions
                   && config
                       .activeInterfaces()
-                      .filter(Interface::canSendOrReceiveIpTraffic)
+                      .filter(Interface::canReceiveIpTraffic)
                       .anyMatch(iface -> iface.getFirewallSessionInterfaceInfo() != null)) {
                 // This node may initialize sessions -- have to track all active sources
                 return activeSources.get(config.getHostname());

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -387,7 +387,7 @@ public final class CompletionMetadataUtils {
     @Nullable Interface iface = ifaceName != null ? config.getAllInterfaces().get(ifaceName) : null;
 
     return iface != null
-        && ((location instanceof InterfaceLinkLocation && iface.canSendOrReceiveIpTraffic())
+        && ((location instanceof InterfaceLinkLocation && iface.canReceiveIpTraffic())
             || (location instanceof InterfaceLocation && iface.canOriginateIpTraffic()));
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -387,18 +387,8 @@ public final class CompletionMetadataUtils {
     @Nullable Interface iface = ifaceName != null ? config.getAllInterfaces().get(ifaceName) : null;
 
     return iface != null
-        && iface.getActive()
-        && !iface.getSwitchport() // ignore L2 interfaces
-        && ((location instanceof InterfaceLinkLocation
-                // packets can enter (InterfaceLinkLocation) interfaces that are not loopback and
-                // have either LLA or a concrete address with prefix size < 32
-                && !iface.isLoopback()
-                && (!iface.getAllLinkLocalAddresses().isEmpty()
-                    || iface.getAllConcreteAddresses().stream()
-                        .anyMatch(address -> address.getNetworkBits() < Prefix.MAX_PREFIX_LENGTH)))
-            || (location instanceof InterfaceLocation
-                // packets can start (InterfaceLocation) at any interfaces with an IP address
-                && !iface.getAllAddresses().isEmpty()));
+        && ((location instanceof InterfaceLinkLocation && iface.canReceiveIpTraffic())
+            || (location instanceof InterfaceLocation && iface.canOriginateIpTraffic()));
   }
 
   public static Set<String> getStructureNames(Map<String, Configuration> configurations) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -387,7 +387,7 @@ public final class CompletionMetadataUtils {
     @Nullable Interface iface = ifaceName != null ? config.getAllInterfaces().get(ifaceName) : null;
 
     return iface != null
-        && ((location instanceof InterfaceLinkLocation && iface.canReceiveIpTraffic())
+        && ((location instanceof InterfaceLinkLocation && iface.canSendOrReceiveIpTraffic())
             || (location instanceof InterfaceLocation && iface.canOriginateIpTraffic()));
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
@@ -423,10 +422,6 @@ public final class Configuration implements Serializable {
   @JsonProperty(PROP_AUTHENTICATION_KEY_CHAINS)
   public Map<String, AuthenticationKeyChain> getAuthenticationKeyChains() {
     return _authenticationKeyChains;
-  }
-
-  public Set<String> activeInterfaceNames() {
-    return activeInterfaces().map(Interface::getName).collect(ImmutableSet.toImmutableSet());
   }
 
   public @Nonnull Stream<Interface> activeInterfaces() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -433,6 +433,10 @@ public final class Configuration implements Serializable {
     return _interfaces.values().stream().filter(Interface::getActive);
   }
 
+  public @Nonnull Stream<Interface> activeL3Interfaces() {
+    return _interfaces.values().stream().filter(Interface::isActiveL3);
+  }
+
   @JsonIgnore
   public @Nonnull Map<String, AsPathExpr> getAsPathExprs() {
     return _asPathExprs;
@@ -643,16 +647,14 @@ public final class Configuration implements Serializable {
    */
   @JsonIgnore
   public Map<String, Interface> getActiveInterfaces(@Nonnull String vrf) {
-    return _interfaces.entrySet().stream()
-        .filter(e -> e.getValue().getVrfName().equals(vrf) && e.getValue().getActive())
-        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+    return activeInterfaces()
+        .filter(i -> i.getVrfName().equals(vrf))
+        .collect(ImmutableMap.toImmutableMap(Interface::getName, i -> i));
   }
 
   @JsonIgnore
   public Map<String, Interface> getActiveInterfaces() {
-    return _interfaces.entrySet().stream()
-        .filter(e -> e.getValue().getActive())
-        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+    return activeInterfaces().collect(ImmutableMap.toImmutableMap(Interface::getName, i -> i));
   }
 
   /** Whether administratively disconnected interfaces are always automatically line down. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
@@ -422,6 +423,11 @@ public final class Configuration implements Serializable {
   @JsonProperty(PROP_AUTHENTICATION_KEY_CHAINS)
   public Map<String, AuthenticationKeyChain> getAuthenticationKeyChains() {
     return _authenticationKeyChains;
+  }
+
+  @Deprecated
+  public Set<String> activeInterfaceNames() {
+    return activeInterfaces().map(Interface::getName).collect(ImmutableSet.toImmutableSet());
   }
 
   public @Nonnull Stream<Interface> activeInterfaces() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -657,6 +657,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   /** Returns {@code true} if this {@link Interface} is active and has L3 configuration. */
+  @JsonIgnore
   public boolean isActiveL3() {
     return getActive() && !getSwitchport() && !getAllAddresses().isEmpty();
   }
@@ -667,6 +668,7 @@ public final class Interface extends ComparableStructure<String> {
    * <p>Note that this means originating traffic in the VRF, not that traffic can be forwarded out a
    * Layer 3 link attached to this interface.
    */
+  @JsonIgnore
   public boolean canOriginateIpTraffic() {
     return isActiveL3();
   }
@@ -675,6 +677,7 @@ public final class Interface extends ComparableStructure<String> {
    * Returns {@code true} if this {@link Interface} can send or receive an IPv4 packet on an L3 link
    * (which may not be in the snapshot).
    */
+  @JsonIgnore
   public boolean canSendOrReceiveIpTraffic() {
     if (!isActiveL3()) {
       return false;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -656,6 +656,11 @@ public final class Interface extends ComparableStructure<String> {
     return new Builder(nameGenerator);
   }
 
+  /** Returns {@code true} if this {@link Interface} is active and has L3 configuration. */
+  public boolean isActiveL3() {
+    return getActive() && !getSwitchport() && !getAllAddresses().isEmpty();
+  }
+
   /**
    * Returns {@code true} if this {@link Interface} can be the source of an IPv4 packet.
    *
@@ -663,12 +668,15 @@ public final class Interface extends ComparableStructure<String> {
    * Layer 3 link attached to this interface.
    */
   public boolean canOriginateIpTraffic() {
-    return getActive() && !getSwitchport() && !getAllAddresses().isEmpty();
+    return isActiveL3();
   }
 
-  /** Returns {@code true} if this {@link Interface} can receive an IPv4 packet on an L3 link. */
-  public boolean canReceiveIpTraffic() {
-    if (!canOriginateIpTraffic()) {
+  /**
+   * Returns {@code true} if this {@link Interface} can send or receive an IPv4 packet on an L3 link
+   * (which may not be in the snapshot).
+   */
+  public boolean canSendOrReceiveIpTraffic() {
+    if (!isActiveL3()) {
       return false;
     } else if (isLoopback()) {
       // Loopbacks cannot have Layer 3 edges.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -678,7 +678,7 @@ public final class Interface extends ComparableStructure<String> {
    * (which may not be in the snapshot).
    */
   @JsonIgnore
-  public boolean canSendOrReceiveIpTraffic() {
+  public boolean canReceiveIpTraffic() {
     if (!isActiveL3()) {
       return false;
     } else if (isLoopback()) {
@@ -695,6 +695,19 @@ public final class Interface extends ComparableStructure<String> {
       }
     }
     return false;
+  }
+
+  /**
+   * Returns {@code true} if this {@link Interface} can send an IPv4 packet on an L3 link (which may
+   * not be in the snapshot).
+   */
+  @JsonIgnore
+  public boolean canSendIpTraffic() {
+    // TODO: intuitively, it feels like sending and receiving should be symmetric. However,
+    // NHint routes will send arps that can be answered by any same-broadcast-domain device,
+    // regardless of L3 compatibility. We are not yet able to fix this for the `enter[iface]`
+    // case, but we can for the `exit[iface]` case.
+    return isActiveL3() && !isLoopback();
   }
 
   private static InterfaceType computeAosInteraceType(String name) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
@@ -34,7 +34,7 @@ public final class SourcesReferencedByIpAccessLists {
     ImmutableSet.Builder<String> ret = ImmutableSet.builder();
     ret.add(SOURCE_ORIGINATING_FROM_DEVICE);
     for (Interface i : c.getAllInterfaces().values()) {
-      if (i.canSendIpTraffic() || i.canReceiveIpTraffic()) {
+      if (i.canReceiveIpTraffic()) {
         ret.add(i.getName());
       }
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
@@ -34,7 +34,7 @@ public final class SourcesReferencedByIpAccessLists {
     ImmutableSet.Builder<String> ret = ImmutableSet.builder();
     ret.add(SOURCE_ORIGINATING_FROM_DEVICE);
     for (Interface i : c.getAllInterfaces().values()) {
-      if (i.canSendOrReceiveIpTraffic()) {
+      if (i.canSendIpTraffic() || i.canReceiveIpTraffic()) {
         ret.add(i.getName());
       }
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
@@ -8,10 +8,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
 import org.batfish.common.util.NonRecursiveSupplier;
 import org.batfish.datamodel.AclAclLine;
+import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 
 /**
@@ -20,6 +23,23 @@ import org.batfish.datamodel.IpAccessList;
  */
 public final class SourcesReferencedByIpAccessLists {
   public static final String SOURCE_ORIGINATING_FROM_DEVICE = "DEVICE IS THE SOURCE";
+
+  /**
+   * Returns the active sources that can be referred to by an {@link IpAccessList} or collection of
+   * them, where source is either originating on the device ({@link
+   * #SOURCE_ORIGINATING_FROM_DEVICE}) or entering an interface (aka, {@link
+   * org.batfish.specifier.InterfaceLinkLocation}.
+   */
+  public static @Nonnull Set<String> activeAclSources(Configuration c) {
+    ImmutableSet.Builder<String> ret = ImmutableSet.builder();
+    ret.add(SOURCE_ORIGINATING_FROM_DEVICE);
+    for (Interface i : c.getAllInterfaces().values()) {
+      if (i.canSendOrReceiveIpTraffic()) {
+        ret.add(i.getName());
+      }
+    }
+    return ret.build();
+  }
 
   private static final class ReferenceSourcesVisitor
       implements GenericAclLineMatchExprVisitor<Void>, GenericAclLineVisitor<Void> {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedOnDevice.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedOnDevice.java
@@ -1,6 +1,6 @@
 package org.batfish.datamodel.acl;
 
-import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
+import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.activeAclSources;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
@@ -43,9 +43,7 @@ public final class SourcesReferencedOnDevice {
    * interfaces.
    */
   public static Set<String> activeReferencedSources(Configuration c) {
-    return Sets.intersection(
-        allReferencedSources(c),
-        Sets.union(ImmutableSet.of(SOURCE_ORIGINATING_FROM_DEVICE), c.activeInterfaceNames()));
+    return Sets.intersection(allReferencedSources(c), activeAclSources(c));
   }
 
   /**
@@ -177,6 +175,10 @@ public final class SourcesReferencedOnDevice {
   private static void collectAllTransformationReferences(
       Configuration c, Set<Object> visited, Set<String> referenced) {
     for (Interface i : c.getActiveInterfaces().values()) {
+      if (!i.canSendOrReceiveIpTraffic()) {
+        // Transformations can only be reached for sent/received traffic.
+        continue;
+      }
       if (i.getIncomingTransformation() != null) {
         collectTransformationReferences(
             i.getIncomingTransformation(), c.getIpAccessLists(), visited, referenced);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedOnDevice.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedOnDevice.java
@@ -175,7 +175,7 @@ public final class SourcesReferencedOnDevice {
   private static void collectAllTransformationReferences(
       Configuration c, Set<Object> visited, Set<String> referenced) {
     for (Interface i : c.getActiveInterfaces().values()) {
-      if (!i.canSendOrReceiveIpTraffic()) {
+      if (!i.canSendIpTraffic() && !i.canReceiveIpTraffic()) {
         // Transformations can only be reached for sent/received traffic.
         continue;
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierUtils.java
@@ -15,25 +15,20 @@ public final class SpecifierUtils {
   @VisibleForTesting
   static boolean isActive(Location l, Map<String, Configuration> configs) {
     NodeInterfacePair iface;
+    Configuration c = configs.get(l.getNodeName());
     if (l instanceof InterfaceLocation) {
-      iface =
-          NodeInterfacePair.of(
-              ((InterfaceLocation) l).getNodeName(), ((InterfaceLocation) l).getInterfaceName());
+      return c.getAllInterfaces()
+          .get(((InterfaceLocation) l).getInterfaceName())
+          .canOriginateIpTraffic();
     } else {
       assert l instanceof InterfaceLinkLocation;
-      iface =
-          NodeInterfacePair.of(
-              ((InterfaceLinkLocation) l).getNodeName(),
-              ((InterfaceLinkLocation) l).getInterfaceName());
+      return c.getAllInterfaces()
+          .get(((InterfaceLinkLocation) l).getInterfaceName())
+          .canSendOrReceiveIpTraffic();
     }
-    return configs
-        .get(iface.getHostname())
-        .getAllInterfaces()
-        .get(iface.getInterface())
-        .getActive();
   }
 
-  public static Set<Location> resolveActiveLocations(
+  public static Set<Location> resolveActiveStartLocations(
       LocationSpecifier locationSpecifier, SpecifierContext context) {
     return locationSpecifier.resolve(context).stream()
         .filter(l -> isActive(l, context.getConfigs()))

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierUtils.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /** Utility methods for specifiers. */
 public final class SpecifierUtils {
@@ -14,7 +13,6 @@ public final class SpecifierUtils {
   /** Returns {@code true} iff the given {@link Location} is active (aka, interface is up). */
   @VisibleForTesting
   static boolean isActive(Location l, Map<String, Configuration> configs) {
-    NodeInterfacePair iface;
     Configuration c = configs.get(l.getNodeName());
     if (l instanceof InterfaceLocation) {
       return c.getAllInterfaces()
@@ -24,7 +22,7 @@ public final class SpecifierUtils {
       assert l instanceof InterfaceLinkLocation;
       return c.getAllInterfaces()
           .get(((InterfaceLinkLocation) l).getInterfaceName())
-          .canSendOrReceiveIpTraffic();
+          .canReceiveIpTraffic();
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -170,7 +170,8 @@ public class BDDSourceManagerTest {
     nf.interfaceBuilder()
         .setOwner(config)
         .setName(IFACE2)
-        .setAddress(ConcreteInterfaceAddress.parse("2.2.2.2/32"))
+        .setAddress(
+            ConcreteInterfaceAddress.parse("2.2.2.2/32")) // only a /32, so cannot receive packets
         .build();
     nf.interfaceBuilder().setOwner(config).setName(IFACE3).build();
 
@@ -180,15 +181,13 @@ public class BDDSourceManagerTest {
     assertFalse(mgr.isTrivial());
     assertTrue(mgr.allSourcesTracked());
     assertThat(
-        mgr.getSourceBDDs().keySet(),
-        containsInAnyOrder(IFACE1, IFACE2, SOURCE_ORIGINATING_FROM_DEVICE));
-    assertThat(mgr.getSourceBDDs().values().stream().distinct().count(), equalTo(3L));
+        mgr.getSourceBDDs().keySet(), containsInAnyOrder(IFACE1, SOURCE_ORIGINATING_FROM_DEVICE));
+    assertThat(mgr.getSourceBDDs().values().stream().distinct().count(), equalTo(2L));
   }
 
   /**
    * A test that with no ACLs referencing interfaces and no session info, the source manager is
-   * trivial. The trivial source manager still only tracks active sources that can send/receive
-   * packets.
+   * trivial. The trivial source manager still only tracks active sources that can receive packets.
    */
   @Test
   public void testInitializeSessions_noSessionInfo() {
@@ -204,7 +203,7 @@ public class BDDSourceManagerTest {
         .setOwner(config)
         .setName(IFACE2)
         .setAddress(ConcreteInterfaceAddress.parse("2.2.2.2/32"))
-        .build(); // /32 will be tracked, as it can send packets
+        .build(); // /32 will not be tracked, as it cannot receive packets
     nf.interfaceBuilder()
         .setOwner(config)
         .setName("lo")
@@ -222,8 +221,7 @@ public class BDDSourceManagerTest {
     assertTrue(mgr.isTrivial());
     assertFalse(mgr.allSourcesTracked());
     assertThat(
-        mgr.getSourceBDDs().keySet(),
-        containsInAnyOrder(IFACE1, SOURCE_ORIGINATING_FROM_DEVICE, IFACE2));
+        mgr.getSourceBDDs().keySet(), containsInAnyOrder(IFACE1, SOURCE_ORIGINATING_FROM_DEVICE));
     assertEquals(mgr.getSourceBDDs().values().stream().distinct().count(), 1);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/SourcesReferencedOnDeviceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/SourcesReferencedOnDeviceTest.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Set;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.Interface;
@@ -45,12 +46,24 @@ public class SourcesReferencedOnDeviceTest {
     Interface.builder()
         .setOwner(c)
         .setVrf(c.getDefaultVrf())
+        .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
         .setName("in-incoming-trans") // so one is active
         .setType(InterfaceType.LOGICAL)
         .setIncomingTransformation(
             when(and(matchSrcInterface("in-incoming-trans"), OriginatingFromDevice.INSTANCE))
                 .build())
         .setOutgoingTransformation(when(matchSrcInterface("in-outgoing-trans")).build())
+        .build();
+    Interface.builder()
+        .setOwner(c)
+        .setAdminUp(false)
+        .setVrf(c.getDefaultVrf())
+        .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
+        .setName("in-inactive-iface")
+        .setType(InterfaceType.LOGICAL)
+        .setIncomingTransformation(
+            when(and(matchSrcInterface("in-inactive-iface"), OriginatingFromDevice.INSTANCE))
+                .build())
         .build();
     PacketPolicy p =
         new PacketPolicy(
@@ -64,6 +77,7 @@ public class SourcesReferencedOnDeviceTest {
     assertThat(
         allReferencedSources(c),
         containsInAnyOrder(
+            // Also testing does not contain in-inactive-iface
             "in-acl",
             "in-incoming-trans",
             "in-outgoing-trans",

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/SpecifierUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/SpecifierUtilsTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.SortedMap;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.NetworkFactory;
@@ -21,16 +22,34 @@ public final class SpecifierUtilsTest {
     NetworkFactory nf = new NetworkFactory();
     Configuration node = nf.configurationBuilder().setConfigurationFormat(CISCO_IOS).build();
     Vrf vrf = nf.vrfBuilder().setOwner(node).build();
-    Interface activeInterface = nf.interfaceBuilder().setOwner(node).setVrf(vrf).build();
+    Interface activeInterface =
+        nf.interfaceBuilder()
+            .setOwner(node)
+            .setVrf(vrf)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+            .build();
+    Interface activeL2 =
+        nf.interfaceBuilder().setOwner(node).setVrf(vrf).setSwitchport(true).build();
+    Interface active32 =
+        nf.interfaceBuilder()
+            .setOwner(node)
+            .setVrf(vrf)
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/32"))
+            .build();
     Interface inactiveInterface =
         nf.interfaceBuilder().setAdminUp(false).setOwner(node).setVrf(vrf).build();
     SortedMap<String, Configuration> configs = ImmutableSortedMap.of(node.getHostname(), node);
 
     String hostname = node.getHostname();
+    // Originating traffic: activeInterface and active32.
+    assertTrue(isActive(new InterfaceLocation(hostname, activeInterface.getName()), configs));
+    assertFalse(isActive(new InterfaceLocation(hostname, activeL2.getName()), configs));
+    assertTrue(isActive(new InterfaceLocation(hostname, active32.getName()), configs));
+    assertFalse(isActive(new InterfaceLocation(hostname, inactiveInterface.getName()), configs));
+    // Receiving traffic: just activeInterface
     assertTrue(isActive(new InterfaceLinkLocation(hostname, activeInterface.getName()), configs));
-    assertFalse(
-        isActive(new InterfaceLinkLocation(hostname, inactiveInterface.getName()), configs));
-    assertTrue(isActive(new InterfaceLinkLocation(hostname, activeInterface.getName()), configs));
+    assertFalse(isActive(new InterfaceLinkLocation(hostname, activeL2.getName()), configs));
+    assertFalse(isActive(new InterfaceLinkLocation(hostname, active32.getName()), configs));
     assertFalse(
         isActive(new InterfaceLinkLocation(hostname, inactiveInterface.getName()), configs));
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -1233,7 +1233,7 @@ public final class BDDReachabilityAnalysisFactory {
   @VisibleForTesting
   Stream<Edge> generateRules_PreOutInterfaceDisposition_SetupSessionDisposition() {
     return getAllL3Interfaces()
-        .filter(Interface::canSendIpTraffic) // no incoming edge means no outgoing edge
+        .filter(Interface::canSendIpTraffic)
         .flatMap(
             iface -> {
               String node = iface.getOwner().getHostname();

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -455,7 +455,7 @@ public final class BDDReachabilityAnalysisFactory {
             TransformationToTransition toTransition =
                 new TransformationToTransition(_bddPacket, ipAccessListToBddForNode(node));
             return node.activeL3Interfaces()
-                .filter(Interface::canSendOrReceiveIpTraffic)
+                .filter(Interface::canReceiveIpTraffic)
                 .collect(
                     ImmutableMap.toImmutableMap(
                         Interface::getName,
@@ -481,7 +481,7 @@ public final class BDDReachabilityAnalysisFactory {
             TransformationToTransition toTransition =
                 new TransformationToTransition(_bddPacket, ipAccessListToBddForNode(node));
             return node.activeL3Interfaces()
-                .filter(Interface::canSendOrReceiveIpTraffic)
+                .filter(Interface::canSendIpTraffic)
                 .collect(
                     ImmutableMap.toImmutableMap(
                         Interface::getName,
@@ -783,7 +783,7 @@ public final class BDDReachabilityAnalysisFactory {
         .map(_configs::get)
         .filter(Objects::nonNull) // remove finalNodes that don't exist on this network
         .flatMap(Configuration::activeL3Interfaces)
-        .filter(Interface::canSendOrReceiveIpTraffic)
+        .filter(Interface::canSendIpTraffic)
         .map(
             iface -> {
               String node = iface.getOwner().getHostname();
@@ -819,7 +819,7 @@ public final class BDDReachabilityAnalysisFactory {
 
   private Stream<Edge> generateRules_PostInInterface_NodeDropAclIn() {
     return getAllL3Interfaces()
-        .filter(Interface::canSendOrReceiveIpTraffic)
+        .filter(Interface::canReceiveIpTraffic)
         .filter(iface -> iface.getPostTransformationIncomingFilter() != null)
         .map(
             i -> {
@@ -843,7 +843,7 @@ public final class BDDReachabilityAnalysisFactory {
 
   private Stream<Edge> generateRules_PostInInterface_PostInVrf() {
     return getAllL3Interfaces()
-        .filter(Interface::canSendOrReceiveIpTraffic)
+        .filter(Interface::canReceiveIpTraffic)
         .map(
             iface -> {
               IpAccessList acl = iface.getPostTransformationIncomingFilter();
@@ -862,7 +862,7 @@ public final class BDDReachabilityAnalysisFactory {
   @VisibleForTesting
   Stream<Edge> generateRules_PreInInterface_NodeDropAclIn() {
     return getAllL3Interfaces()
-        .filter(Interface::canSendOrReceiveIpTraffic)
+        .filter(Interface::canReceiveIpTraffic)
         .filter(iface -> iface.getPacketPolicyName() == null && iface.getIncomingFilter() != null)
         .map(
             i -> {
@@ -896,7 +896,7 @@ public final class BDDReachabilityAnalysisFactory {
               Multimap<String, String> convertedPolicies = HashMultimap.create();
               return config
                   .activeL3Interfaces()
-                  .filter(Interface::canSendOrReceiveIpTraffic)
+                  .filter(Interface::canReceiveIpTraffic)
                   .filter(iface -> iface.getPacketPolicyName() != null)
                   .flatMap(
                       iface -> {
@@ -962,7 +962,7 @@ public final class BDDReachabilityAnalysisFactory {
   @VisibleForTesting
   Stream<Edge> generateRules_PreInInterface_PostInInterface() {
     return getAllL3Interfaces()
-        .filter(Interface::canSendOrReceiveIpTraffic)
+        .filter(Interface::canReceiveIpTraffic)
         // Policy-based routing edges handled elsewhere
         .filter(iface -> iface.getPacketPolicyName() == null)
         .map(
@@ -1008,7 +1008,7 @@ public final class BDDReachabilityAnalysisFactory {
               String iface2 = edge.getInt2();
 
               Interface i1 = _configs.get(node1).getAllInterfaces().get(iface1);
-              assert i1.canSendOrReceiveIpTraffic();
+              assert i1.canSendIpTraffic();
               IpAccessList preNatAcl = i1.getPreTransformationOutgoingFilter();
               BDD denyPreNat = ignorableAclDenyBDD(node1, preNatAcl);
 
@@ -1039,7 +1039,7 @@ public final class BDDReachabilityAnalysisFactory {
               String iface2 = edge.getInt2();
 
               Interface i1 = _configs.get(node1).getAllInterfaces().get(iface1);
-              assert i1.canSendOrReceiveIpTraffic();
+              assert i1.canSendIpTraffic();
               IpAccessList preNatAcl = i1.getPreTransformationOutgoingFilter();
 
               BDD aclPermit = ignorableAclPermitBDD(node1, preNatAcl);
@@ -1073,7 +1073,7 @@ public final class BDDReachabilityAnalysisFactory {
               String iface2 = edge.getInt2();
 
               Interface i1 = _configs.get(node1).getAllInterfaces().get(iface1);
-              assert i1.canSendOrReceiveIpTraffic();
+              assert i1.canSendIpTraffic();
               IpAccessList acl = i1.getOutgoingFilter();
               BDD aclDenyBDD = ignorableAclDenyBDD(node1, acl);
 
@@ -1109,7 +1109,7 @@ public final class BDDReachabilityAnalysisFactory {
               String iface2 = edge.getInt2();
 
               Interface i1 = _configs.get(node1).getAllInterfaces().get(iface1);
-              assert i1.canSendOrReceiveIpTraffic();
+              assert i1.canSendIpTraffic();
               BDD aclPermitBDD = ignorableAclPermitBDD(node1, i1.getOutgoingFilter());
 
               BDDOutgoingOriginalFlowFilterManager originalFlowFilterMgr =
@@ -1151,7 +1151,7 @@ public final class BDDReachabilityAnalysisFactory {
                         return nodeEntry
                             .getValue()
                             .activeL3Interfaces()
-                            .filter(Interface::canSendOrReceiveIpTraffic)
+                            .filter(Interface::canSendIpTraffic)
                             .filter(
                                 iface ->
                                     iface.getOutgoingOriginalFlowFilter() != null
@@ -1233,7 +1233,7 @@ public final class BDDReachabilityAnalysisFactory {
   @VisibleForTesting
   Stream<Edge> generateRules_PreOutInterfaceDisposition_SetupSessionDisposition() {
     return getAllL3Interfaces()
-        .filter(Interface::canSendOrReceiveIpTraffic) // no incoming edge means no outgoing edge
+        .filter(Interface::canSendIpTraffic) // no incoming edge means no outgoing edge
         .flatMap(
             iface -> {
               String node = iface.getOwner().getHostname();
@@ -1320,7 +1320,7 @@ public final class BDDReachabilityAnalysisFactory {
                * see generateRules_PreOutInterfaceDisposition_SetupSessionDisposition
                */
               return c.activeInterfaces()
-                  .filter(Interface::canSendOrReceiveIpTraffic)
+                  .filter(Interface::canSendIpTraffic)
                   .flatMap(
                       iface -> {
                         String ifaceName = iface.getName();
@@ -1800,7 +1800,7 @@ public final class BDDReachabilityAnalysisFactory {
     // Transformations can live in interfaces.
     c.activeL3Interfaces()
         // Transformations in interfaces can only be reached on transiting traffic
-        .filter(Interface::canSendOrReceiveIpTraffic)
+        .filter(i -> i.canSendIpTraffic() || i.canReceiveIpTraffic())
         .forEach(
             iface -> {
               visitTransformationSteps(iface.getIncomingTransformation(), rangeComputer);
@@ -1810,7 +1810,7 @@ public final class BDDReachabilityAnalysisFactory {
     // interfaces, so only visit each once.
     c.activeL3Interfaces()
         // Packet policies in interfaces can only be reached on transiting traffic
-        .filter(Interface::canSendOrReceiveIpTraffic)
+        .filter(i -> i.canSendIpTraffic() || i.canReceiveIpTraffic())
         .map(i -> Optional.ofNullable(i.getPacketPolicyName()).map(c.getPacketPolicies()::get))
         .filter(Optional::isPresent)
         .map(Optional::get)

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -454,11 +454,12 @@ public final class BDDReachabilityAnalysisFactory {
             Configuration node = nodeEntry.getValue();
             TransformationToTransition toTransition =
                 new TransformationToTransition(_bddPacket, ipAccessListToBddForNode(node));
-            return toImmutableMap(
-                node.getActiveInterfaces(),
-                Entry::getKey, /* iface */
-                ifaceEntry ->
-                    toTransition.toTransition(ifaceEntry.getValue().getIncomingTransformation()));
+            return node.activeL3Interfaces()
+                .filter(Interface::canSendOrReceiveIpTraffic)
+                .collect(
+                    ImmutableMap.toImmutableMap(
+                        Interface::getName,
+                        iface -> toTransition.toTransition(iface.getIncomingTransformation())));
           });
     } finally {
       span.finish();
@@ -479,11 +480,12 @@ public final class BDDReachabilityAnalysisFactory {
             Configuration node = nodeEntry.getValue();
             TransformationToTransition toTransition =
                 new TransformationToTransition(_bddPacket, ipAccessListToBddForNode(node));
-            return toImmutableMap(
-                nodeEntry.getValue().getActiveInterfaces(),
-                Entry::getKey, /* iface */
-                ifaceEntry ->
-                    toTransition.toTransition(ifaceEntry.getValue().getOutgoingTransformation()));
+            return node.activeL3Interfaces()
+                .filter(Interface::canSendOrReceiveIpTraffic)
+                .collect(
+                    ImmutableMap.toImmutableMap(
+                        Interface::getName,
+                        iface -> toTransition.toTransition(iface.getOutgoingTransformation())));
           });
     } finally {
       span.finish();
@@ -780,7 +782,8 @@ public final class BDDReachabilityAnalysisFactory {
     return finalNodes.stream()
         .map(_configs::get)
         .filter(Objects::nonNull) // remove finalNodes that don't exist on this network
-        .flatMap(Configuration::activeInterfaces)
+        .flatMap(Configuration::activeL3Interfaces)
+        .filter(Interface::canSendOrReceiveIpTraffic)
         .map(
             iface -> {
               String node = iface.getOwner().getHostname();
@@ -815,7 +818,8 @@ public final class BDDReachabilityAnalysisFactory {
   }
 
   private Stream<Edge> generateRules_PostInInterface_NodeDropAclIn() {
-    return getInterfaces()
+    return getAllL3Interfaces()
+        .filter(Interface::canSendOrReceiveIpTraffic)
         .filter(iface -> iface.getPostTransformationIncomingFilter() != null)
         .map(
             i -> {
@@ -838,7 +842,8 @@ public final class BDDReachabilityAnalysisFactory {
   }
 
   private Stream<Edge> generateRules_PostInInterface_PostInVrf() {
-    return getInterfaces()
+    return getAllL3Interfaces()
+        .filter(Interface::canSendOrReceiveIpTraffic)
         .map(
             iface -> {
               IpAccessList acl = iface.getPostTransformationIncomingFilter();
@@ -856,7 +861,8 @@ public final class BDDReachabilityAnalysisFactory {
 
   @VisibleForTesting
   Stream<Edge> generateRules_PreInInterface_NodeDropAclIn() {
-    return getInterfaces()
+    return getAllL3Interfaces()
+        .filter(Interface::canSendOrReceiveIpTraffic)
         .filter(iface -> iface.getPacketPolicyName() == null && iface.getIncomingFilter() != null)
         .map(
             i -> {
@@ -889,7 +895,8 @@ public final class BDDReachabilityAnalysisFactory {
                       _bddOutgoingOriginalFlowFilterManagers.get(nodeName));
               Multimap<String, String> convertedPolicies = HashMultimap.create();
               return config
-                  .activeInterfaces()
+                  .activeL3Interfaces()
+                  .filter(Interface::canSendOrReceiveIpTraffic)
                   .filter(iface -> iface.getPacketPolicyName() != null)
                   .flatMap(
                       iface -> {
@@ -954,7 +961,8 @@ public final class BDDReachabilityAnalysisFactory {
 
   @VisibleForTesting
   Stream<Edge> generateRules_PreInInterface_PostInInterface() {
-    return getInterfaces()
+    return getAllL3Interfaces()
+        .filter(Interface::canSendOrReceiveIpTraffic)
         // Policy-based routing edges handled elsewhere
         .filter(iface -> iface.getPacketPolicyName() == null)
         .map(
@@ -1000,7 +1008,7 @@ public final class BDDReachabilityAnalysisFactory {
               String iface2 = edge.getInt2();
 
               Interface i1 = _configs.get(node1).getAllInterfaces().get(iface1);
-              assert i1.getActive();
+              assert i1.canSendOrReceiveIpTraffic();
               IpAccessList preNatAcl = i1.getPreTransformationOutgoingFilter();
               BDD denyPreNat = ignorableAclDenyBDD(node1, preNatAcl);
 
@@ -1031,7 +1039,7 @@ public final class BDDReachabilityAnalysisFactory {
               String iface2 = edge.getInt2();
 
               Interface i1 = _configs.get(node1).getAllInterfaces().get(iface1);
-              assert i1.getActive();
+              assert i1.canSendOrReceiveIpTraffic();
               IpAccessList preNatAcl = i1.getPreTransformationOutgoingFilter();
 
               BDD aclPermit = ignorableAclPermitBDD(node1, preNatAcl);
@@ -1065,7 +1073,7 @@ public final class BDDReachabilityAnalysisFactory {
               String iface2 = edge.getInt2();
 
               Interface i1 = _configs.get(node1).getAllInterfaces().get(iface1);
-              assert i1.getActive();
+              assert i1.canSendOrReceiveIpTraffic();
               IpAccessList acl = i1.getOutgoingFilter();
               BDD aclDenyBDD = ignorableAclDenyBDD(node1, acl);
 
@@ -1101,7 +1109,7 @@ public final class BDDReachabilityAnalysisFactory {
               String iface2 = edge.getInt2();
 
               Interface i1 = _configs.get(node1).getAllInterfaces().get(iface1);
-              assert i1.getActive();
+              assert i1.canSendOrReceiveIpTraffic();
               BDD aclPermitBDD = ignorableAclPermitBDD(node1, i1.getOutgoingFilter());
 
               BDDOutgoingOriginalFlowFilterManager originalFlowFilterMgr =
@@ -1142,9 +1150,8 @@ public final class BDDReachabilityAnalysisFactory {
                         StateExpr postState = new NodeDropAclOut(node);
                         return nodeEntry
                             .getValue()
-                            .getActiveInterfaces(vrfEntry.getKey())
-                            .values()
-                            .stream()
+                            .activeL3Interfaces()
+                            .filter(Interface::canSendOrReceiveIpTraffic)
                             .filter(
                                 iface ->
                                     iface.getOutgoingOriginalFlowFilter() != null
@@ -1225,7 +1232,8 @@ public final class BDDReachabilityAnalysisFactory {
 
   @VisibleForTesting
   Stream<Edge> generateRules_PreOutInterfaceDisposition_SetupSessionDisposition() {
-    return getInterfaces()
+    return getAllL3Interfaces()
+        .filter(Interface::canSendOrReceiveIpTraffic) // no incoming edge means no outgoing edge
         .flatMap(
             iface -> {
               String node = iface.getOwner().getHostname();
@@ -1312,6 +1320,7 @@ public final class BDDReachabilityAnalysisFactory {
                * see generateRules_PreOutInterfaceDisposition_SetupSessionDisposition
                */
               return c.activeInterfaces()
+                  .filter(Interface::canSendOrReceiveIpTraffic)
                   .flatMap(
                       iface -> {
                         String ifaceName = iface.getName();
@@ -1789,7 +1798,9 @@ public final class BDDReachabilityAnalysisFactory {
   /** Compute the ranges for a single {@link Configuration}. */
   private void computeTransformationRanges(Configuration c, RangeComputer rangeComputer) {
     // Transformations can live in interfaces.
-    c.activeInterfaces()
+    c.activeL3Interfaces()
+        // Transformations in interfaces can only be reached on transiting traffic
+        .filter(Interface::canSendOrReceiveIpTraffic)
         .forEach(
             iface -> {
               visitTransformationSteps(iface.getIncomingTransformation(), rangeComputer);
@@ -1797,7 +1808,9 @@ public final class BDDReachabilityAnalysisFactory {
             });
     // Transformations can live in packet policies. Packet policies can be large and reused across
     // interfaces, so only visit each once.
-    c.activeInterfaces()
+    c.activeL3Interfaces()
+        // Packet policies in interfaces can only be reached on transiting traffic
+        .filter(Interface::canSendOrReceiveIpTraffic)
         .map(i -> Optional.ofNullable(i.getPacketPolicyName()).map(c.getPacketPolicies()::get))
         .filter(Optional::isPresent)
         .map(Optional::get)
@@ -1856,10 +1869,10 @@ public final class BDDReachabilityAnalysisFactory {
         configs,
         Entry::getKey,
         nodeEntry ->
-            toImmutableMap(
-                nodeEntry.getValue().getActiveInterfaces().values(),
-                Interface::getName,
-                Interface::getVrfName));
+            nodeEntry
+                .getValue()
+                .activeL3Interfaces()
+                .collect(ImmutableMap.toImmutableMap(Interface::getName, Interface::getVrfName)));
   }
 
   private Map<String, Map<String, Map<String, BDD>>> computeNextVrfBDDs(
@@ -2000,8 +2013,15 @@ public final class BDDReachabilityAnalysisFactory {
     return _lastHopMgr;
   }
 
-  private @Nonnull Stream<Interface> getInterfaces() {
-    return _configs.values().stream().flatMap(Configuration::activeInterfaces);
+  /**
+   * Returns a stream of all active L3 interfaces in the network.
+   *
+   * <p>Note that this may need further filtering depending on application.
+   */
+  private @Nonnull Stream<Interface> getAllL3Interfaces() {
+    return _configs.values().stream()
+        .flatMap(Configuration::activeInterfaces)
+        .filter(Interface::isActiveL3);
   }
 
   private class PacketPolicyActionToEdges implements ActionVisitor<Stream<Edge>> {

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
@@ -13,6 +13,7 @@ import static org.batfish.bddreachability.transition.Transitions.compose;
 import static org.batfish.bddreachability.transition.Transitions.constraint;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
+import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.activeAclSources;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -183,7 +184,7 @@ final class BDDReachabilityAnalysisSessionFactory {
 
     Map<String, Map<NodeInterfacePair, BDD>> lastHopOutgoingInterfaceBdds =
         toImmutableMap(
-            config.activeInterfaceNames(),
+            activeAclSources(config),
             Function.identity(),
             iface ->
                 Optional.ofNullable(

--- a/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/ReachabilityParametersResolver.java
@@ -3,7 +3,7 @@ package org.batfish.main;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
-import static org.batfish.specifier.SpecifierUtils.resolveActiveLocations;
+import static org.batfish.specifier.SpecifierUtils.resolveActiveStartLocations;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -117,7 +117,7 @@ public final class ReachabilityParametersResolver {
   @VisibleForTesting
   IpSpaceAssignment resolveSourceIpSpaceAssignment() throws InvalidReachabilityParametersException {
     Set<Location> sourceLocations =
-        resolveActiveLocations(_params.getSourceLocationSpecifier(), _context);
+        resolveActiveStartLocations(_params.getSourceLocationSpecifier(), _context);
     if (sourceLocations.isEmpty()) {
       throw new InvalidReachabilityParametersException("No matching source locations");
     }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -34,6 +34,7 @@ import org.batfish.bddreachability.transition.Transition;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.HeaderSpaceToBDD;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
@@ -184,9 +185,10 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
       Vrf vrf = nf.vrfBuilder().setName(FW_VRF).setOwner(fw).build();
       vrf.setFirewallSessionVrfInfo(new FirewallSessionVrfInfo(true));
       ib.setOwner(fw).setVrf(vrf);
-      fwi1 = ib.setName(FWI1).build();
-      fwi2 = ib.setName(FWI2).build();
-      Interface fwi3 = ib.setName(FWI3).build();
+      fwi1 = ib.setName(FWI1).setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
+      fwi2 = ib.setName(FWI2).setAddress(ConcreteInterfaceAddress.parse("2.2.2.2/24")).build();
+      Interface fwi3 =
+          ib.setName(FWI3).setAddress(ConcreteInterfaceAddress.parse("3.3.3.3/24")).build();
 
       // Create sessions for flows exiting FW:I3
       fwi3.setFirewallSessionInterfaceInfo(

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
@@ -16,6 +16,7 @@ import org.batfish.bddreachability.BDDReverseTransformationRangesImpl.Key;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.HeaderSpaceToBDD;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Edge;
@@ -84,7 +85,7 @@ public class BDDReverseTransformationRangesImplTest {
 
   @Test
   public void testIncomingTransformationRange() {
-    Interface iface = _ib.build();
+    Interface iface = _ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
     String iName = iface.getName();
 
     Map<String, BDDSourceManager> srcManagers =
@@ -193,7 +194,7 @@ public class BDDReverseTransformationRangesImplTest {
   /** Test that source and last hop constraints are erased. */
   @Test
   public void testEraseNonPacketVars() {
-    Interface iface = _ib.build();
+    Interface iface = _ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
     String iName = iface.getName();
 
     Map<String, BDDSourceManager> srcManagers =

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -579,7 +579,7 @@ public class BatfishTest {
 
     // all of the interfaces should still be active
     assertThat(
-        config1.activeInterfaces().collect(Collectors.toSet()),
+        config1.activeInterfaces().map(Interface::getName).collect(Collectors.toSet()),
         containsInAnyOrder(notIgnored, notIgnored2, notIgnored3, notIgnored4, notIgnored5));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -51,6 +52,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
@@ -577,8 +579,8 @@ public class BatfishTest {
 
     // all of the interfaces should still be active
     assertThat(
-        config1.activeInterfaceNames(),
-        equalTo(ImmutableSet.of(notIgnored, notIgnored2, notIgnored3, notIgnored4, notIgnored5)));
+        config1.activeInterfaces().collect(Collectors.toSet()),
+        containsInAnyOrder(notIgnored, notIgnored2, notIgnored3, notIgnored4, notIgnored5));
   }
 
   // all of these interfaces should be ignored by processManagementInterfaces()
@@ -610,7 +612,7 @@ public class BatfishTest {
     Batfish.processManagementInterfaces(configs);
 
     // none of the interfaces should be active
-    assertThat(config1.activeInterfaceNames(), equalTo(ImmutableSet.of()));
+    assertThat(config1.activeInterfaces().collect(Collectors.toSet()), empty());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/ReachabilityParametersResolverTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.SortedMap;
 import java.util.regex.Pattern;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Ip;
@@ -48,7 +49,11 @@ public class ReachabilityParametersResolverTest {
     NetworkFactory nf = new NetworkFactory();
     _node = nf.configurationBuilder().setConfigurationFormat(CISCO_IOS).build();
     Vrf vrf = nf.vrfBuilder().setOwner(_node).build();
-    nf.interfaceBuilder().setOwner(_node).setVrf(vrf).build();
+    nf.interfaceBuilder()
+        .setOwner(_node)
+        .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
+        .setVrf(vrf)
+        .build();
     SortedMap<String, Configuration> configs = ImmutableSortedMap.of(_node.getHostname(), _node);
     _batfish = BatfishTestUtils.getBatfish(configs, _tempFolder);
     _snapshot = _batfish.getSnapshot();
@@ -133,7 +138,7 @@ public class ReachabilityParametersResolverTest {
         ReachabilityParameters.builder()
             .setActions(ImmutableSortedSet.of(ACCEPTED))
             .setFinalNodesSpecifier(AllNodesNodeSpecifier.INSTANCE)
-            .setDestinationIpSpaceSpecifier(
+            .setSourceIpSpaceSpecifier(
                 new ConstantIpSpaceAssignmentSpecifier(EmptyIpSpace.INSTANCE))
             .setSourceLocationSpecifier(
                 new NodeNameRegexInterfaceLinkLocationSpecifier(Pattern.compile(".*")))

--- a/projects/question/src/main/java/org/batfish/question/differentialreachability/DifferentialReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/differentialreachability/DifferentialReachabilityAnswerer.java
@@ -4,7 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.question.specifiers.PathConstraintsUtil.createPathConstraints;
 import static org.batfish.question.traceroute.TracerouteAnswerer.diffFlowTracesToRows;
 import static org.batfish.question.traceroute.TracerouteAnswerer.metadata;
-import static org.batfish.specifier.SpecifierUtils.resolveActiveLocations;
+import static org.batfish.specifier.SpecifierUtils.resolveActiveStartLocations;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -75,8 +75,8 @@ public class DifferentialReachabilityAnswerer extends Answerer {
     // only consider startLocations that are present+active in both snapshots
     Set<Location> startLocations =
         Sets.intersection(
-            resolveActiveLocations(pathConstraints.getStartLocation(), snapshotCtxt),
-            resolveActiveLocations(pathConstraints.getStartLocation(), referenceCtxt));
+            resolveActiveStartLocations(pathConstraints.getStartLocation(), snapshotCtxt),
+            resolveActiveStartLocations(pathConstraints.getStartLocation(), referenceCtxt));
     if (startLocations.isEmpty()) {
       throw new BatfishException(
           "no matching startLocation is present and active in both snapshots");

--- a/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
@@ -1,5 +1,6 @@
 package org.batfish.question.searchfilters;
 
+import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.activeAclSources;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.referencedSources;
 import static org.batfish.question.FilterQuestionUtils.differentialBDDSourceManager;
 import static org.batfish.question.FilterQuestionUtils.resolveSources;
@@ -263,11 +264,10 @@ public final class SearchFiltersAnswerer extends Answerer {
 
   private static Set<String> getActiveSources(
       Configuration c, SpecifierContext specifierContext, SearchFiltersParameters parameters) {
-    Set<String> inactiveIfaces =
-        Sets.difference(c.getAllInterfaces().keySet(), c.activeInterfaceNames());
-    return Sets.difference(
+    Set<String> activeSources = activeAclSources(c);
+    return Sets.intersection(
         resolveSources(specifierContext, parameters.getStartLocationSpecifier(), c.getHostname()),
-        inactiveIfaces);
+        activeSources);
   }
 
   /** Performs a difference reachFilters analysis (both increased and decreased reachability). */

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
@@ -67,7 +68,10 @@ public class SearchFiltersAnswererDifferentialTest {
   public void testMatchSrcInterface() {
     Configuration config = _cb.build();
     Configuration refConfig = _cb.build();
-    _ib.setName(IFACE1).setOwner(config).build();
+    _ib.setName(IFACE1)
+        .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
+        .setOwner(config)
+        .build();
     _ib.setOwner(refConfig).build();
     String aclName = "aclName";
     IpAccessList refAcl = _ab.setName(aclName).setOwner(config).build();
@@ -167,9 +171,15 @@ public class SearchFiltersAnswererDifferentialTest {
   public void testSourceInterfaceParameter() {
     Configuration refConfig = _cb.build();
     Configuration config = _cb.build();
-    _ib.setName(IFACE1).setOwner(refConfig).build();
+    _ib.setName(IFACE1)
+        .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
+        .setOwner(refConfig)
+        .build();
     _ib.setOwner(config).build();
-    _ib.setName(IFACE2).setOwner(refConfig).build();
+    _ib.setName(IFACE2)
+        .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
+        .setOwner(refConfig)
+        .build();
     _ib.setOwner(config).build();
     String aclName = "acl";
     IpAccessList refAcl = _ab.setName(aclName).setOwner(refConfig).build();

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersDifferentialTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
@@ -66,8 +67,8 @@ public class SearchFiltersDifferentialTest {
     Ip ip = Ip.parse("1.2.3.4");
     Configuration baseConfig = _cb.build();
     Configuration deltaConfig = _cb.build();
-    _ib.setOwner(baseConfig).build();
-    _ib.setOwner(deltaConfig).build();
+    _ib.setOwner(baseConfig).setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
+    _ib.setOwner(deltaConfig).setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
     _ab.setOwner(baseConfig).build();
     _ab.setOwner(deltaConfig)
         .setLines(
@@ -102,8 +103,8 @@ public class SearchFiltersDifferentialTest {
     Ip ip = Ip.parse("1.2.3.4");
     Configuration baseConfig = _cb.build();
     Configuration deltaConfig = _cb.build();
-    _ib.setOwner(baseConfig).build();
-    _ib.setOwner(deltaConfig).build();
+    _ib.setOwner(baseConfig).setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
+    _ib.setOwner(deltaConfig).setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
     _ab.setName("aclName");
     _ab.setOwner(baseConfig).build();
     _ab.setOwner(deltaConfig)

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ExprAclLine;
@@ -160,8 +161,8 @@ public final class SearchFiltersTest {
                 REJECT_ALL_ACL));
 
     Builder ib = nf.interfaceBuilder().setAdminUp(true).setOwner(_config);
-    ib.setName(IFACE1).build();
-    ib.setName(IFACE2).build();
+    ib.setName(IFACE1).setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
+    ib.setName(IFACE2).setAddress(ConcreteInterfaceAddress.parse("2.2.2.2/24")).build();
     ib.setName("inactiveIface").setAdminUp(false).build();
 
     _batfish = new MockBatfish(_config);
@@ -428,8 +429,8 @@ public final class SearchFiltersTest {
     c.getIpAccessLists().put(denyAllButIface2.getName(), denyAllButIface2);
 
     Builder ib = nf.interfaceBuilder().setAdminUp(true).setOwner(c);
-    ib.setName(IFACE1).build();
-    ib.setName(IFACE2).build();
+    ib.setName(IFACE1).setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
+    ib.setName(IFACE2).setAddress(ConcreteInterfaceAddress.parse("2.2.2.2/24")).build();
     ib.setName("inactiveIface").setAdminUp(false).build();
 
     IBatfish bf = new MockBatfish(c);


### PR DESCRIPTION
It is common in Batfish to want to distinguish whether an interface

* is active and L3
* can originate IP (v4) traffic
* can receive IP (v4) traffic
* can send IP (v4) traffic

However, the various logic around this is scattered and inconsistent. For example, traceroute would not let flows
enter L2 interfaces, but reachability and searchFilters would if they were active.

1. Create `Interface` helpers `isActiveL3`, `canOriginateIpTraffic`, `canReceiveIpTraffic`, `canSendIpTraffic`, with
    our current rules.
2. Reify Enter/SourceInterfaces with only interfaces that can receive traffic
3. Reify ExitInterfaces with only interfaces that can send traffic
4. Ensure that only interfaces that `canOriginateIpTraffic` are used as origination points.

and fix up some tests.