### PR TITLE
JunOS: only allow wildcards inside of groups

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -4,6 +4,8 @@ options {
    superClass = 'org.batfish.grammar.flatjuniper.parsing.FlatJuniperBaseLexer';
 }
 
+// Wildcard is from the first pass lexing. Aka, it appears in the configs.
+// Wildcard artifact is generated when we generate text and run a parser on it (say, apply-path strings).
 @members {
   private void setWildcard() {
     setType(_markWildcards ? WILDCARD_ARTIFACT : WILDCARD);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyGroupsApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyGroupsApplicator.java
@@ -154,11 +154,7 @@ public class ApplyGroupsApplicator extends FlatJuniperParserBaseListener {
     if (_enablePathRecording) {
       String text = node.getText();
       int line = node.getSymbol().getLine();
-      if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
-        _currentPath.addWildcardNode(text, line);
-      } else {
-        _currentPath.addNode(text, line);
-      }
+      _currentPath.addNode(text, line);
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
@@ -102,7 +102,7 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
     if (_enablePathRecording) {
       String text = node.getText();
       int line = node.getSymbol().getLine();
-      if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
+      if (false && node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
         _currentPath.addWildcardNode(text, line);
       } else {
         _currentPath.addNode(text, line);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
@@ -68,7 +68,7 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
     if (newLines != null) {
       _newConfigurationLines.addAll(insertionIndex + 1, newLines);
     }
-    //    _newConfigurationLines.remove(insertionIndex);
+    // TODO: removing this removes definition lines. _newConfigurationLines.remove(insertionIndex);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
@@ -68,6 +68,7 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
     if (newLines != null) {
       _newConfigurationLines.addAll(insertionIndex + 1, newLines);
     }
+    //    _newConfigurationLines.remove(insertionIndex);
   }
 
   @Override
@@ -102,11 +103,7 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
     if (_enablePathRecording) {
       String text = node.getText();
       int line = node.getSymbol().getLine();
-      if (false && node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
-        _currentPath.addWildcardNode(text, line);
-      } else {
-        _currentPath.addNode(text, line);
-      }
+      _currentPath.addNode(text, line);
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/GroupTreeBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/GroupTreeBuilder.java
@@ -25,6 +25,9 @@ public class GroupTreeBuilder extends FlatJuniperParserBaseListener {
 
   private boolean _enablePathRecording;
 
+  /** Whether wildcards are valid in the rest of the current line, or normal text otherwise. */
+  private boolean _enableWildcards;
+
   private final Hierarchy _hierarchy;
 
   private List<ParseTree> _newConfigurationLines;
@@ -62,10 +65,12 @@ public class GroupTreeBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterS_groups_named(S_groups_namedContext ctx) {
     _currentPath = new HierarchyPath();
+    _enableWildcards = true;
   }
 
   @Override
   public void exitS_groups_named(S_groups_namedContext ctx) {
+    _enableWildcards = false;
     HierarchyPath path = _currentPath;
     assert path != null;
     _currentPath = null;
@@ -97,7 +102,7 @@ public class GroupTreeBuilder extends FlatJuniperParserBaseListener {
     if (_enablePathRecording) {
       String text = node.getText();
       int line = node.getSymbol().getLine();
-      if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
+      if (_enableWildcards && node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
         _currentPath.addWildcardNode(text, line);
       } else {
         _currentPath.addNode(text, line);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/InitialTreeBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/InitialTreeBuilder.java
@@ -4,19 +4,24 @@ import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Apply_groupsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Apply_groups_exceptContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.S_groupsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Set_line_tailContext;
 import org.batfish.grammar.flatjuniper.Hierarchy.HierarchyTree.HierarchyPath;
 
-public class InitialTreeBuilder extends FlatJuniperParserBaseListener {
+public final class InitialTreeBuilder extends FlatJuniperParserBaseListener {
 
   private boolean _addLine;
 
   private HierarchyPath _currentPath;
 
+  /** Whether the subtrees of this node go into the {@link #_currentPath}. */
   private boolean _enablePathRecording;
 
-  private Hierarchy _hierarchy;
+  /** Whether wildcards are valid in the rest of the current line, or normal text otherwise. */
+  private boolean _enableWildcards;
+
+  private final Hierarchy _hierarchy;
 
   private HierarchyPath _lastPath;
 
@@ -35,13 +40,12 @@ public class InitialTreeBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterSet_line(Set_lineContext ctx) {
     _addLine = true;
-    _enablePathRecording = true;
-    _currentPath = new HierarchyPath();
   }
 
   @Override
   public void enterSet_line_tail(Set_line_tailContext ctx) {
     _enablePathRecording = true;
+    _enableWildcards = false;
     _currentPath = new HierarchyPath();
   }
 
@@ -69,6 +73,16 @@ public class InitialTreeBuilder extends FlatJuniperParserBaseListener {
   }
 
   @Override
+  public void enterS_groups(S_groupsContext ctx) {
+    _enableWildcards = true;
+  }
+
+  @Override
+  public void exitS_groups(S_groupsContext ctx) {
+    _enableWildcards = false;
+  }
+
+  @Override
   public void exitSet_line_tail(Set_line_tailContext ctx) {
     _enablePathRecording = false;
   }
@@ -82,7 +96,7 @@ public class InitialTreeBuilder extends FlatJuniperParserBaseListener {
     if (_enablePathRecording) {
       String text = node.getText();
       int line = node.getSymbol().getLine();
-      if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
+      if (_enableWildcards && node.getSymbol().getType() == FlatJuniperLexer.WILDCARD) {
         _currentPath.addWildcardNode(text, line);
       } else {
         _currentPath.addNode(text, line);

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/InsertDeleteApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/InsertDeleteApplicator.java
@@ -49,11 +49,17 @@ public class InsertDeleteApplicator extends FlatJuniperParserBaseListener
    * - find the StatementTree node corresponding to the recorded words
    * - add the parse-tree to the set of parse-trees stored at the node corresponding to the last word
    *
+   * Each time an 'insert' parse-tree is encounted:
+   * - reorder subtree at common parent by moving the named child before/after target child
+   *
    * Each time a 'delete' parse-tree is encountered:
    * - record the words following 'delete'
    * - find the node corresponding to the last word
    * - remove the node (and therefore its subtrees) from the tree
    *   - note that this removes both 'set' and 'deactivate' lines
+   *
+   * Each of these statements takes affect when it is reached, rather than after a pass. That way you don't
+   * (e.g.) delete set lines that occur later in the text.
    *
    * After visiting all child parse-trees of the configuration, replace its list of children with a
    * new list corresponding to a pre-order traversal of the statement tree.

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/PreprocessJuniperExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/PreprocessJuniperExtractor.java
@@ -38,7 +38,7 @@ public final class PreprocessJuniperExtractor implements PreprocessExtractor {
    *   <li>Pruning 'groups' lines; and 'apply-groups' and 'apply-groups-except' lines
    *   <li>Pruning wildcard lines
    *   <li>Generating lines corresponding to 'apply-path' lines
-   *   <li>Pruning 'apply-path' lines
+   *   <li>TODO: Pruning 'apply-path' lines
    * </ol>
    *
    * @param tree The flat-Juniper parse tree to be pre-processed in-place.
@@ -91,6 +91,7 @@ public final class PreprocessJuniperExtractor implements PreprocessExtractor {
 
     ApplyPathApplicator ap = new ApplyPathApplicator(hierarchy, w);
     walker.walk(ap, tree);
+    // TODO: pruning apply-path lines removes definition lines
   }
 
   private final FlatJuniperCombinedParser _parser;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/PreprocessJuniperExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/PreprocessJuniperExtractor.java
@@ -30,7 +30,7 @@ public final class PreprocessJuniperExtractor implements PreprocessExtractor {
    * <p>Pre-processing consists of:
    *
    * <ol>
-   *   <li>Applying insertions (moves) and deleteions
+   *   <li>Applying insertions (moves) and deletions
    *   <li>Pruning lines deactivated by 'deactivate' lines
    *   <li>Pruning 'deactivate' lines
    *   <li>Generating lines corresponding to 'apply-groups' lines, while respecting
@@ -53,29 +53,42 @@ public final class PreprocessJuniperExtractor implements PreprocessExtractor {
       FlatJuniperCombinedParser parser,
       Warnings w) {
     ParseTreeWalker walker = new BatfishParseTreeWalker(parser);
+
+    // Implements insert and delete respecting order of configuration lines.
+    // Properly handles set and deactivate lines.
     InsertDeleteApplicator d = new InsertDeleteApplicator(parser, w);
     walker.walk(d, tree);
+
+    // Delete all deactivated lines:
+    // 1. Mark parts of the hierarchy as deleted
     DeactivateTreeBuilder dtb = new DeactivateTreeBuilder(hierarchy);
     walker.walk(dtb, tree);
+    // 2. Remove 'deactivate <tree>' lines
     DeactivateLinePruner dp = new DeactivateLinePruner();
     walker.walk(dp, tree);
+    // 3. Remove 'set' lines that are deactivated
     DeactivatedLinePruner dlp = new DeactivatedLinePruner(hierarchy);
     walker.walk(dlp, tree);
+
     InitialTreeBuilder tb = new InitialTreeBuilder(hierarchy);
     walker.walk(tb, tree);
     GroupTreeBuilder gb = new GroupTreeBuilder(hierarchy);
     walker.walk(gb, tree);
+
     ApplyGroupsApplicator hb;
     do {
+      // Run until convergence: [set groups A apply-groups B] is valid
       hb = new ApplyGroupsApplicator(hierarchy, w);
       walker.walk(hb, tree);
     } while (hb.getChanged());
     GroupPruner.prune(tree);
+
     WildcardApplicator wa = new WildcardApplicator(hierarchy);
     walker.walk(wa, tree);
     WildcardPruner wp = new WildcardPruner();
     walker.walk(wp, tree);
     walker.walk(dlp, tree);
+
     ApplyPathApplicator ap = new ApplyPathApplicator(hierarchy, w);
     walker.walk(ap, tree);
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/WildcardApplicator.java
@@ -65,6 +65,7 @@ public class WildcardApplicator extends FlatJuniperParserBaseListener {
     if (_enablePathRecording) {
       String text = node.getText();
       int line = node.getSymbol().getLine();
+      // WildcardApplicator expands wildcards introduced by apply-groups; they are always valid.
       if (node.getSymbol().getType() == FlatJuniperLexer.WILDCARD_ARTIFACT) {
         _currentPath.addWildcardNode(text, line);
       } else {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3741,6 +3741,15 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testJuniperApplyGroupsChain() {
+    Configuration c = parseConfig("apply-groups-chain");
+    assertThat(
+        c,
+        hasInterface(
+            "em0.0", hasAllAddresses(contains(ConcreteInterfaceAddress.parse("1.1.1.1/31")))));
+  }
+
+  @Test
   public void testJuniperApplyGroupsNode() throws IOException {
     String filename = "juniper-apply-groups-node";
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4407,6 +4407,16 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         c, hasRouteFilterList(prefixList3, RouteFilterListMatchers.rejects(Prefix.parse(prefix2))));
 
+    /* prefix-list p4 should get all addresses from both communities */
+    assertThat(
+        c,
+        hasRouteFilterList(
+            "p4",
+            allOf(
+                permits(Prefix.parse("4.4.4.4/32")),
+                permits(Prefix.parse("5.5.5.5/32")),
+                RouteFilterListMatchers.rejects(Prefix.parse("1.1.1.1/32")))));
+
     /* The wildcard-looking BGP group name should not be pruned since its parse-tree node was not created via preprocessor. */
     assertThat(c, hasDefaultVrf(hasBgpProcess(hasNeighbors(hasKey(neighborIp)))));
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-groups-chain
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-groups-chain
@@ -1,0 +1,6 @@
+set system host-name apply-groups-chain
+set groups G1 apply-groups G2
+set groups G2 interfaces <*> unit 0 apply-groups G3
+set groups G3 interfaces <*> unit <*> family inet address 1.1.1.1/31
+set interfaces em0 description "for test"
+set apply-groups G1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
@@ -15,4 +15,8 @@ set routing-options autonomous-system 1
 set protocols bgp group <SCRUBBED> neighbor 2.2.2.2 peer-as 2
 set protocols ospf apply-groups g3
 set protocols ospf area 0.0.0.1 interface et-0/0/0.0 passive
+## p4 should have all addresses from both communities
+set policy-options prefix-list p4 apply-path "snmp community <*> clients <*>"
+set snmp community "foo" clients 4.4.4.4/32
+set snmp community "<removed>" clients 5.5.5.5/32
 #


### PR DESCRIPTION
Downstream processing distinguishes between wildcards and text, and
e.g., only allows apply-path to expand text. Since wildcards are only valid
inside `set groups` (or nested inside `policy-options prefix-list PL apply-path`,
but that is handled elsewhere) we can treat them as text everywhere else.