### PR TITLE
Routes: return warnings in table answer

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/TableAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/TableAnswerElement.java
@@ -25,11 +25,13 @@ public final class TableAnswerElement extends AnswerElement {
   private static final String PROP_EXCLUDED_ROWS = "excludedRows";
   private static final String PROP_METADATA = "metadata";
   private static final String PROP_ROWS = "rows";
+  private static final String PROP_WARNINGS = "warnings";
 
   private List<ExcludedRows> _excludedRows;
   private Set<String> _columnNames;
   private Rows _rows;
   private TableMetadata _tableMetadata;
+  private List<String> _warnings;
 
   @JsonCreator
   public TableAnswerElement(@Nonnull @JsonProperty(PROP_METADATA) TableMetadata tableMetadata) {
@@ -40,6 +42,7 @@ public final class TableAnswerElement extends AnswerElement {
             .collect(ImmutableSet.toImmutableSet());
     _rows = new Rows();
     _excludedRows = new LinkedList<>();
+    _warnings = new LinkedList<>();
   }
 
   /**
@@ -78,6 +81,12 @@ public final class TableAnswerElement extends AnswerElement {
     ExcludedRows rows = new ExcludedRows(exclusionName);
     rows.addRow(row);
     _excludedRows.add(rows);
+    return this;
+  }
+
+  /** Adds a warning to the answer. */
+  public @Nonnull TableAnswerElement addWarning(String warning) {
+    _warnings.add(warning);
     return this;
   }
 
@@ -149,6 +158,11 @@ public final class TableAnswerElement extends AnswerElement {
   @JsonProperty(PROP_ROWS)
   public List<Row> getRowsList() {
     return ImmutableList.copyOf(_rows.iterator());
+  }
+
+  @JsonProperty(PROP_WARNINGS)
+  public List<String> getWarnings() {
+    return _warnings;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/TableAnswerElementMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/TableAnswerElementMatchers.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.matchers;
 
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.matchers.TableAnswerElementMatchersImpl.HasRows;
+import org.batfish.datamodel.matchers.TableAnswerElementMatchersImpl.HasWarnings;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.hamcrest.Matcher;
@@ -15,6 +16,15 @@ public final class TableAnswerElementMatchers {
   public static Matcher<TableAnswerElement> hasRows(
       @Nonnull Matcher<? super Iterable<Row>> subMatcher) {
     return new HasRows(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the {@link
+   * TableAnswerElement TableAnswerElement's} {@link TableAnswerElement#getWarnings() warnings}.
+   */
+  public static Matcher<TableAnswerElement> hasWarnings(
+      @Nonnull Matcher<? super Iterable<String>> subMatcher) {
+    return new HasWarnings(subMatcher);
   }
 
   private TableAnswerElementMatchers() {}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/TableAnswerElementMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/TableAnswerElementMatchersImpl.java
@@ -1,43 +1,12 @@
 package org.batfish.datamodel.matchers;
 
-import java.util.Collection;
-import java.util.Iterator;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
-import org.hamcrest.Description;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 final class TableAnswerElementMatchersImpl {
-
-  static final class HasRowMatchers extends TypeSafeDiagnosingMatcher<TableAnswerElement> {
-
-    private final Collection<Matcher<? super Row>> _rowMatchers;
-
-    public HasRowMatchers(@Nonnull Collection<Matcher<? super Row>> rowMatchers) {
-      _rowMatchers = rowMatchers;
-    }
-
-    @Override
-    public void describeTo(Description description) {
-      description.appendList("A TableAnswerElement with rows matching: [", ",", "]", _rowMatchers);
-    }
-
-    @Override
-    protected boolean matchesSafely(TableAnswerElement item, Description mismatchDescription) {
-      Iterator<Row> iterator = item.getRows().iterator();
-      Iterable<Row> rows = () -> iterator;
-      Matcher<Iterable<? extends Row>> matcher = Matchers.containsInAnyOrder(_rowMatchers);
-      if (!matcher.matches(rows)) {
-        matcher.describeMismatch(rows, mismatchDescription);
-        return false;
-      }
-      return true;
-    }
-  }
 
   static final class HasRows extends FeatureMatcher<TableAnswerElement, Iterable<Row>> {
     public HasRows(@Nonnull Matcher<? super Iterable<Row>> subMatcher) {
@@ -47,6 +16,17 @@ final class TableAnswerElementMatchersImpl {
     @Override
     protected Iterable<Row> featureValueOf(TableAnswerElement actual) {
       return () -> actual.getRows().iterator();
+    }
+  }
+
+  static final class HasWarnings extends FeatureMatcher<TableAnswerElement, Iterable<String>> {
+    public HasWarnings(@Nonnull Matcher<? super Iterable<String>> subMatcher) {
+      super(subMatcher, "TableAnswerElement with warnings:", "warnings");
+    }
+
+    @Override
+    protected Iterable<String> featureValueOf(TableAnswerElement tableAnswerElement) {
+      return tableAnswerElement.getWarnings();
     }
   }
 

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -37,7 +37,6 @@ import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
-import org.batfish.datamodel.answers.StringAnswerElement;
 import org.batfish.datamodel.questions.BgpRouteStatus;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.ColumnMetadata;
@@ -87,8 +86,8 @@ public class RoutesAnswerer extends Answerer {
   // Diff Only
   static final String COL_ROUTE_ENTRY_PRESENCE = "Entry_Presence";
 
-  static final String ERROR_NO_MATCHING_NODES = "No matching nodes found.";
-  static final String ERROR_NO_MATCHING_VRFS = "No matching VRFs found on matching nodes.";
+  static final String WARNING_NO_MATCHING_NODES = "No matching nodes found.";
+  static final String WARNING_NO_MATCHING_VRFS = "No matching VRFs found on matching nodes.";
 
   RoutesAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -110,18 +109,17 @@ public class RoutesAnswerer extends Answerer {
     Set<String> matchingNodes =
         question.getNodeSpecifier().resolve(_batfish.specifierContext(snapshot));
 
-    if (matchingNodes.isEmpty()) {
-      return new StringAnswerElement(ERROR_NO_MATCHING_NODES);
-    }
-
     Prefix network = question.getNetwork();
     RoutingProtocolSpecifier protocolSpec = question.getRoutingProtocolSpecifier();
     String vrfRegex = question.getVrfs();
 
     Multimap<String, String> matchingVrfsByNode =
         computeMatchingVrfsByNode(_batfish.loadConfigurations(snapshot), matchingNodes, vrfRegex);
-    if (matchingVrfsByNode.isEmpty()) {
-      return new StringAnswerElement(ERROR_NO_MATCHING_VRFS);
+
+    if (matchingNodes.isEmpty()) {
+      answer.addWarning(WARNING_NO_MATCHING_NODES);
+    } else if (matchingVrfsByNode.isEmpty()) {
+      answer.addWarning(WARNING_NO_MATCHING_VRFS);
     }
 
     List<Row> rows = new ArrayList<>();

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -3,6 +3,8 @@ package org.batfish.question.routes;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
 import static java.util.Comparator.naturalOrder;
+import static org.batfish.datamodel.matchers.TableAnswerElementMatchers.hasRows;
+import static org.batfish.datamodel.matchers.TableAnswerElementMatchers.hasWarnings;
 import static org.batfish.datamodel.table.TableDiff.COL_BASE_PREFIX;
 import static org.batfish.datamodel.table.TableDiff.COL_DELTA_PREFIX;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ADMIN_DISTANCE;
@@ -30,13 +32,14 @@ import static org.batfish.question.routes.RoutesAnswerer.COL_WEIGHT;
 import static org.batfish.question.routes.RoutesAnswerer.getDiffTableMetadata;
 import static org.batfish.question.routes.RoutesAnswerer.getTableMetadata;
 import static org.batfish.question.routes.RoutesAnswererUtil.getMainRibRoutes;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -83,7 +86,6 @@ import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
-import org.batfish.datamodel.answers.StringAnswerElement;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
@@ -205,9 +207,13 @@ public class RoutesAnswererTest {
         new NetworkSnapshot(new NetworkId("network"), new SnapshotId("snapshot"));
     RoutesQuestion routesQuestion =
         new RoutesQuestion(null, "differentNode", null, null, null, null, null);
-    StringAnswerElement answer =
-        (StringAnswerElement) new RoutesAnswerer(routesQuestion, batfish).answer(snapshot);
-    assertEquals(RoutesAnswerer.ERROR_NO_MATCHING_NODES, answer.getAnswer());
+    TableAnswerElement answer =
+        (TableAnswerElement) new RoutesAnswerer(routesQuestion, batfish).answer(snapshot);
+    assertThat(
+        answer,
+        allOf(
+            hasWarnings(contains(RoutesAnswerer.WARNING_NO_MATCHING_NODES)),
+            hasRows(emptyIterable())));
   }
 
   @Test
@@ -226,9 +232,13 @@ public class RoutesAnswererTest {
     NetworkSnapshot snapshot =
         new NetworkSnapshot(new NetworkId("network"), new SnapshotId("snapshot"));
     RoutesQuestion routesQuestion = new RoutesQuestion(null, "n1", "v2", null, null, null, null);
-    StringAnswerElement answer =
-        (StringAnswerElement) new RoutesAnswerer(routesQuestion, batfish).answer(snapshot);
-    assertEquals(RoutesAnswerer.ERROR_NO_MATCHING_VRFS, answer.getAnswer());
+    TableAnswerElement answer =
+        (TableAnswerElement) new RoutesAnswerer(routesQuestion, batfish).answer(snapshot);
+    assertThat(
+        answer,
+        allOf(
+            hasWarnings(contains(RoutesAnswerer.WARNING_NO_MATCHING_VRFS)),
+            hasRows(emptyIterable())));
   }
 
   @Test


### PR DESCRIPTION
When the input node/vrf matches nothing, return an empty table with a warning instead of the warning alone.