### PR TITLE
Warnings: remove transient from Settings, fix possible NPE

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -27,7 +27,7 @@ import org.batfish.grammar.BatfishCombinedParser;
 @ParametersAreNonnullByDefault
 public class Warnings implements Serializable {
 
-  public static class Settings {
+  public static class Settings implements Serializable {
     private final boolean _pedanticRecord;
     private final boolean _redFlagRecord;
     private final boolean _unimplementedRecord;
@@ -57,7 +57,7 @@ public class Warnings implements Serializable {
   private static final String PROP_RED_FLAGS = "Red flags";
   private static final String PROP_UNIMPLEMENTED = "Unimplemented features";
 
-  private final transient Settings _settings;
+  private final Settings _settings;
 
   private @Nullable ErrorDetails _errorDetails;
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2685,6 +2685,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
         try {
           byte[] serialized = SerializationUtils.serialize(result);
           _storage.storeNetworkBlob(new ByteArrayInputStream(serialized), getContainerName(), id);
+          result = SerializationUtils.deserialize(serialized);
         } catch (Exception e) {
           _logger.warnf(
               "Error caching parse result for %s: %s",


### PR DESCRIPTION
This was introduced in batfish/batfish#7741 to replace 3 transient booleans.

The problem: transient boolean almost certainly deserializes as false,
while transient class deserializes as null. So before we were not crashing
because values were just false; now they are null and crashing is happening.

Easiest fix seems to be to simply keep the settings around.