### PR TITLE
PAN: fix Panorama categories

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2844,7 +2844,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
    * Copy object configuration from specified source vsys to specified target vsys. Any previously
    * made changes will be overwritten in this process.
    */
-  private void applyVsysObjects(@Nullable Vsys source, Vsys target) {
+  @VisibleForTesting
+  static void applyVsysObjects(@Nullable Vsys source, Vsys target) {
     if (source == null) {
       return;
     }
@@ -2853,6 +2854,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     target.getApplicationGroups().putAll(source.getApplicationGroups());
     target.getAddressObjects().putAll(source.getAddressObjects());
     target.getAddressGroups().putAll(source.getAddressGroups());
+    target.getCustomUrlCategories().putAll(source.getCustomUrlCategories());
     target.getServices().putAll(source.getServices());
     target.getServiceGroups().putAll(source.getServiceGroups());
     target.getTags().putAll(source.getTags());

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
@@ -800,8 +800,8 @@ public final class PaloAltoConfigurationTest {
     source.getServices().put("service", new Service("service"));
     source.getServiceGroups().put("serviceGroup", new ServiceGroup("serviceGroup"));
     source.getTags().put("tag", new Tag("tag"));
-    Vsys dest = new Vsys("dest");
 
+    Vsys dest = new Vsys("dest");
     applyVsysObjects(source, dest);
 
     assertTrue(dest.getApplications().containsKey("app"));

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
@@ -12,6 +12,7 @@ import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejectsByDefault;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.DEFAULT_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.REFERENCE_IN_VSYS;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.applyVsysObjects;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.checkIntrazoneValidityAndWarn;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.deviceBindingAndIdCompatible;
@@ -786,5 +787,30 @@ public final class PaloAltoConfigurationTest {
     assertFalse(unexpectedUnboundedCustomUrlWildcard("*.github.com?"));
     assertFalse(unexpectedUnboundedCustomUrlWildcard("www.*.github.com/"));
     assertFalse(unexpectedUnboundedCustomUrlWildcard("*.github.com/foobar.something"));
+  }
+
+  @Test
+  public void testApplyVsysObjects() {
+    Vsys source = new Vsys("source");
+    source.getApplications().put("app", Application.builder("app").build());
+    source.getApplicationGroups().put("appGroup", new ApplicationGroup("appGroup"));
+    source.getAddressObjects().put("addr", new AddressObject("addr"));
+    source.getAddressGroups().put("addrGroup", new AddressGroup("addrGroup"));
+    source.getCustomUrlCategories().put("category", new CustomUrlCategory("category"));
+    source.getServices().put("service", new Service("service"));
+    source.getServiceGroups().put("serviceGroup", new ServiceGroup("serviceGroup"));
+    source.getTags().put("tag", new Tag("tag"));
+    Vsys dest = new Vsys("dest");
+
+    applyVsysObjects(source, dest);
+
+    assertTrue(dest.getApplications().containsKey("app"));
+    assertTrue(dest.getApplicationGroups().containsKey("appGroup"));
+    assertTrue(dest.getAddressObjects().containsKey("addr"));
+    assertTrue(dest.getAddressGroups().containsKey("addrGroup"));
+    assertTrue(dest.getCustomUrlCategories().containsKey("category"));
+    assertTrue(dest.getServices().containsKey("service"));
+    assertTrue(dest.getServiceGroups().containsKey("serviceGroup"));
+    assertTrue(dest.getTags().containsKey("tag"));
   }
 }


### PR DESCRIPTION
Fix a bug where categories weren't copied during vsys inheritance (e.g. for Panorama managed firewalls).
