### PR TITLE
PAN: parse `source-hip` and `destination-hip`

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -179,6 +179,8 @@ DESCRIPTION
 
 DESTINATION: 'destination';
 
+DESTINATION_HIP: 'destination-hip';
+
 DESTINATION_TRANSLATION: 'destination-translation';
 
 DETERMINISTIC_MED_COMPARISON: 'deterministic-med-comparison';
@@ -648,6 +650,8 @@ SHARED: 'shared';
 SHARED_GATEWAY: 'shared-gateway';
 
 SOURCE: 'source';
+
+SOURCE_HIP: 'source-hip';
 
 SOURCE_PORT: 'source-port';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
@@ -50,6 +50,7 @@ srs_definition
         | srs_category
         | srs_description
         | srs_destination
+        | srs_destination_hip
         | srs_disabled
         | srs_from
         | srs_hip_profiles
@@ -61,6 +62,7 @@ srs_definition
         | srs_rule_type
         | srs_service
         | srs_source
+        | srs_source_hip
         | srs_source_user
         | srs_target
         | srs_to
@@ -99,6 +101,11 @@ srs_description
 srs_destination
 :
     DESTINATION src_or_dst_list
+;
+
+srs_destination_hip
+:
+    DESTINATION_HIP ANY // only support any
 ;
 
 srs_disabled
@@ -160,6 +167,11 @@ srs_service
 srs_source
 :
     SOURCE src_or_dst_list
+;
+
+srs_source_hip
+:
+    SOURCE_HIP ANY // only support any
 ;
 
 srs_source_user

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -86,6 +86,8 @@ set mgt-config users admin public-key c3NoLX...
 set rulebase security rules RULE1 target negate no
 set rulebase security rules RULE1 category streaming
 set rulebase security rules RULE1 hip-profiles any
+set rulebase security rules RULE1 source-hip any
+set rulebase security rules RULE1 destination-hip any
 set rulebase security rules RULE1 source-user any
 set rulebase security rules RULE1 log-end no
 set rulebase security rules RULE1 log-start yes


### PR DESCRIPTION
Parse and ignore `source-hip any` and `destination-hip any`, like we do already for `hip-profiles`.

[HIP profiles](https://docs.paloaltonetworks.com/pan-os/8-1/pan-os-web-interface-help/policies/policies-security/building-blocks-in-a-security-policy-rule.html) aren't used in Batfish's model.
