### PR TITLE
ColumnFilter: allow exact matching

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/ColumnFilter.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/ColumnFilter.java
@@ -14,20 +14,25 @@ import org.batfish.datamodel.table.Row;
 public final class ColumnFilter {
   private static final String PROP_COLUMN = "column";
   private static final String PROP_FILTER_TEXT = "filterText";
+  private static final String PROP_EXACT = "exact";
 
   @JsonCreator
   private static @Nonnull ColumnFilter create(
-      @JsonProperty(PROP_COLUMN) String column, @JsonProperty(PROP_FILTER_TEXT) String filterText) {
-    return new ColumnFilter(requireNonNull(column), firstNonNull(filterText, ""));
+      @JsonProperty(PROP_COLUMN) String column,
+      @JsonProperty(PROP_FILTER_TEXT) String filterText,
+      @JsonProperty(PROP_EXACT) Boolean exact) {
+    return new ColumnFilter(
+        requireNonNull(column), firstNonNull(filterText, ""), firstNonNull(exact, false));
   }
 
-  private final String _column;
+  private final @Nonnull String _column;
+  private final boolean _exact;
+  private final @Nonnull String _filterText;
 
-  private final String _filterText;
-
-  public ColumnFilter(@Nonnull String column, @Nonnull String filterText) {
+  public ColumnFilter(@Nonnull String column, @Nonnull String filterText, boolean exact) {
     _column = column;
     _filterText = filterText;
+    _exact = exact;
   }
 
   @Override
@@ -39,7 +44,14 @@ public final class ColumnFilter {
       return false;
     }
     ColumnFilter rhs = (ColumnFilter) obj;
-    return _column.equals(rhs._column) && _filterText.equals(rhs._filterText);
+    return _column.equals(rhs._column)
+        && _filterText.equals(rhs._filterText)
+        && _exact == rhs._exact;
+  }
+
+  @JsonProperty(PROP_EXACT)
+  public boolean getExact() {
+    return _exact;
   }
 
   @JsonProperty(PROP_COLUMN)
@@ -54,11 +66,18 @@ public final class ColumnFilter {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_column, _filterText);
+    return Objects.hash(_column, _filterText, _exact);
   }
 
   public boolean matches(@Nonnull Row row) {
-    return row.get(_column).toString().toLowerCase().contains(_filterText.toLowerCase());
+    String rowText = row.get(_column).toString();
+    if (_exact) {
+      // rowText is a stringified JSON type, so strings have extra "", but numbers won't. Accept
+      // either.
+      return rowText.equalsIgnoreCase(_filterText)
+          || rowText.equalsIgnoreCase('"' + _filterText + '"');
+    }
+    return rowText.toLowerCase().contains(_filterText.toLowerCase());
   }
 
   @Override
@@ -66,6 +85,7 @@ public final class ColumnFilter {
     return toStringHelper(getClass())
         .add(PROP_COLUMN, _column)
         .add(PROP_FILTER_TEXT, _filterText)
+        .add(PROP_EXACT, _exact)
         .toString();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/AnswerRowsOptionsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/AnswerRowsOptionsTest.java
@@ -9,10 +9,12 @@ public final class AnswerRowsOptionsTest {
 
   @Test
   public void testEquals() {
+    ColumnFilter cf1 = new ColumnFilter("a", "1", false);
+    ColumnFilter cf2 = new ColumnFilter("a", "1", true);
     AnswerRowsOptions group1Elem1 =
         new AnswerRowsOptions(
             ImmutableSet.of("a"),
-            ImmutableList.of(new ColumnFilter("a", "1")),
+            ImmutableList.of(cf1),
             1,
             2,
             ImmutableList.of(new ColumnSortOption("c", false)),
@@ -20,7 +22,7 @@ public final class AnswerRowsOptionsTest {
     AnswerRowsOptions group1Elem2 =
         new AnswerRowsOptions(
             ImmutableSet.of("a"),
-            ImmutableList.of(new ColumnFilter("a", "1")),
+            ImmutableList.of(cf1),
             1,
             2,
             ImmutableList.of(new ColumnSortOption("c", false)),
@@ -28,7 +30,7 @@ public final class AnswerRowsOptionsTest {
     AnswerRowsOptions group2Elem1 =
         new AnswerRowsOptions(
             ImmutableSet.of("b"),
-            ImmutableList.of(new ColumnFilter("a", "1")),
+            ImmutableList.of(cf1),
             1,
             2,
             ImmutableList.of(new ColumnSortOption("c", false)),
@@ -36,7 +38,7 @@ public final class AnswerRowsOptionsTest {
     AnswerRowsOptions group3Elem1 =
         new AnswerRowsOptions(
             ImmutableSet.of("a"),
-            ImmutableList.of(new ColumnFilter("a", "2")),
+            ImmutableList.of(cf2),
             1,
             2,
             ImmutableList.of(new ColumnSortOption("c", false)),
@@ -44,7 +46,7 @@ public final class AnswerRowsOptionsTest {
     AnswerRowsOptions group4Elem1 =
         new AnswerRowsOptions(
             ImmutableSet.of("a"),
-            ImmutableList.of(new ColumnFilter("a", "1")),
+            ImmutableList.of(cf1),
             3,
             2,
             ImmutableList.of(new ColumnSortOption("c", false)),
@@ -52,7 +54,7 @@ public final class AnswerRowsOptionsTest {
     AnswerRowsOptions group5Elem1 =
         new AnswerRowsOptions(
             ImmutableSet.of("a"),
-            ImmutableList.of(new ColumnFilter("a", "1")),
+            ImmutableList.of(cf1),
             1,
             4,
             ImmutableList.of(new ColumnSortOption("c", false)),
@@ -60,7 +62,7 @@ public final class AnswerRowsOptionsTest {
     AnswerRowsOptions group6Elem1 =
         new AnswerRowsOptions(
             ImmutableSet.of("a"),
-            ImmutableList.of(new ColumnFilter("a", "1")),
+            ImmutableList.of(cf1),
             1,
             2,
             ImmutableList.of(new ColumnSortOption("d", false)),
@@ -68,7 +70,7 @@ public final class AnswerRowsOptionsTest {
     AnswerRowsOptions group7Elem1 =
         new AnswerRowsOptions(
             ImmutableSet.of("a"),
-            ImmutableList.of(new ColumnFilter("a", "1")),
+            ImmutableList.of(cf1),
             1,
             2,
             ImmutableList.of(new ColumnSortOption("c", false)),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/ColumnFilterTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/ColumnFilterTest.java
@@ -47,6 +47,11 @@ public final class ColumnFilterTest {
     ColumnFilter filterInt = new ColumnFilter(columnName, "123", true);
     assertTrue(filterInt.matches(Row.builder().put(columnName, 123).build()));
     assertFalse(filterInt.matches(Row.builder().put(columnName, 1234).build()));
+
+    // Verify regex-like text is not filtered
+    ColumnFilter filterRegex = new ColumnFilter(columnName, "1.3", true);
+    assertTrue(filterRegex.matches(Row.builder().put(columnName, "1.3").build()));
+    assertFalse(filterRegex.matches(Row.builder().put(columnName, "123").build()));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/ColumnFilterTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/ColumnFilterTest.java
@@ -1,8 +1,12 @@
 package org.batfish.common;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.table.Row;
 import org.junit.Test;
 
@@ -10,24 +14,44 @@ public final class ColumnFilterTest {
 
   @Test
   public void testEquals() {
-    ColumnFilter group1Elem1 = new ColumnFilter("a", "1");
-    ColumnFilter group1Elem2 = new ColumnFilter("a", "1");
-    ColumnFilter group2Elem1 = new ColumnFilter("a", "2");
-    ColumnFilter group3Elem1 = new ColumnFilter("b", "1");
-
     new EqualsTester()
-        .addEqualityGroup(group1Elem1, group1Elem2)
-        .addEqualityGroup(group2Elem1)
-        .addEqualityGroup(group3Elem1)
+        .addEqualityGroup(new ColumnFilter("a", "1", false), new ColumnFilter("a", "1", false))
+        .addEqualityGroup(new ColumnFilter("b", "1", false))
+        .addEqualityGroup(new ColumnFilter("b", "2", false))
+        .addEqualityGroup(new ColumnFilter("b", "2", true))
         .testEquals();
   }
 
   @Test
-  public void testMatches() {
+  public void testMatchesContainsIgnoreCase() {
     String columnName = "column";
     String filterText = "bLah";
-    ColumnFilter filter = new ColumnFilter(columnName, filterText);
-    Row row = Row.builder().put(columnName, "BlaHah").build();
-    assertTrue(filter.matches(row));
+    ColumnFilter filter = new ColumnFilter(columnName, filterText, false);
+    assertTrue(filter.matches(Row.builder().put(columnName, "xxBlaHxx").build()));
+    assertFalse(filter.matches(Row.builder().put(columnName, "xxBlaxx").build()));
+    assertFalse(filter.matches(Row.builder().put(columnName, "xxBlaxxh").build()));
+  }
+
+  @Test
+  public void testMatchesExactIgnoreCase() {
+    String columnName = "column";
+    ColumnFilter filter = new ColumnFilter(columnName, "bLah", true);
+    assertFalse(filter.matches(Row.builder().put(columnName, "xxBlaHxx").build()));
+    assertTrue(filter.matches(Row.builder().put(columnName, "BlaH").build()));
+
+    // Also true if the user happens to anticipate JSON stringification format.
+    ColumnFilter filterLiteral = new ColumnFilter(columnName, "\"bLah\"", true);
+    assertTrue(filterLiteral.matches(Row.builder().put(columnName, "BlaH").build()));
+
+    // Test integers
+    ColumnFilter filterInt = new ColumnFilter(columnName, "123", true);
+    assertTrue(filterInt.matches(Row.builder().put(columnName, 123).build()));
+    assertFalse(filterInt.matches(Row.builder().put(columnName, 1234).build()));
+  }
+
+  @Test
+  public void testSerialization() {
+    ColumnFilter cf = new ColumnFilter("a", "b", true);
+    assertThat(BatfishObjectMapper.clone(cf, ColumnFilter.class), equalTo(cf));
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -593,7 +593,7 @@ public class WorkMgrServiceTest {
             questionName,
             new AnswerRowsOptions(
                 ImmutableSet.of(columnName),
-                ImmutableList.of(new ColumnFilter(columnName, "")),
+                ImmutableList.of(new ColumnFilter(columnName, "", false)),
                 Integer.MAX_VALUE,
                 0,
                 ImmutableList.of(new ColumnSortOption(columnName, false)),
@@ -794,7 +794,7 @@ public class WorkMgrServiceTest {
     AnswerRowsOptions answersRowsOptions =
         new AnswerRowsOptions(
             ImmutableSet.of(columnName),
-            ImmutableList.of(new ColumnFilter(columnName, "")),
+            ImmutableList.of(new ColumnFilter(columnName, "", false)),
             Integer.MAX_VALUE,
             0,
             ImmutableList.of(new ColumnSortOption(columnName, false)),
@@ -886,7 +886,7 @@ public class WorkMgrServiceTest {
     AnswerRowsOptions answersRowsOptions =
         new AnswerRowsOptions(
             ImmutableSet.of(columnName),
-            ImmutableList.of(new ColumnFilter(columnName, "")),
+            ImmutableList.of(new ColumnFilter(columnName, "", false)),
             Integer.MAX_VALUE,
             0,
             ImmutableList.of(new ColumnSortOption(columnName, false)),
@@ -956,7 +956,7 @@ public class WorkMgrServiceTest {
     AnswerRowsOptions answersRowsOptions =
         new AnswerRowsOptions(
             ImmutableSet.of(columnName),
-            ImmutableList.of(new ColumnFilter(columnName, "")),
+            ImmutableList.of(new ColumnFilter(columnName, "", false)),
             Integer.MAX_VALUE,
             0,
             ImmutableList.of(new ColumnSortOption(columnName, false)),
@@ -1043,7 +1043,7 @@ public class WorkMgrServiceTest {
     AnswerRowsOptions answersRowsOptions =
         new AnswerRowsOptions(
             ImmutableSet.of(columnName),
-            ImmutableList.of(new ColumnFilter(columnName, "")),
+            ImmutableList.of(new ColumnFilter(columnName, "", false)),
             Integer.MAX_VALUE,
             0,
             ImmutableList.of(new ColumnSortOption(columnName, false)),

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -2312,7 +2312,7 @@ public final class WorkMgrTest {
     AnswerRowsOptions optionsFiltered =
         new AnswerRowsOptions(
             ImmutableSet.of(),
-            ImmutableList.of(new ColumnFilter(columnName, whitelistedValue)),
+            ImmutableList.of(new ColumnFilter(columnName, whitelistedValue, false)),
             Integer.MAX_VALUE,
             0,
             ImmutableList.of(),
@@ -2347,7 +2347,7 @@ public final class WorkMgrTest {
     AnswerRowsOptions optionsFiltered =
         new AnswerRowsOptions(
             ImmutableSet.of("value"), // project onto the value column
-            ImmutableList.of(new ColumnFilter("value", "2")),
+            ImmutableList.of(new ColumnFilter("value", "2", false)),
             Integer.MAX_VALUE,
             0,
             ImmutableList.of(),
@@ -2381,7 +2381,7 @@ public final class WorkMgrTest {
     AnswerRowsOptions optionsFiltered =
         new AnswerRowsOptions(
             ImmutableSet.of(),
-            ImmutableList.of(new ColumnFilter(columnName, whitelistedValue)),
+            ImmutableList.of(new ColumnFilter(columnName, whitelistedValue, false)),
             Integer.MAX_VALUE,
             0,
             ImmutableList.of(),


### PR DESCRIPTION
The default behavor of substring matching is preserved.

Some use cases, however, call for exact matching. Enable this, and additionally
be graceful in whether the user is supposed to know exactly how JSON strings are
stringified.