### PR TITLE
Cisco IOS-XR disable subinterfaces whose parent is admin down in conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -95,6 +95,7 @@ import org.batfish.datamodel.GeneratedRoute6;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.IkePhase1Policy;
 import org.batfish.datamodel.IkePhase1Proposal;
+import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
@@ -2049,6 +2050,9 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
               org.batfish.datamodel.Interface viIface = c.getAllInterfaces().get(ifaceName);
               if (viIface != null) {
                 viIface.addDependency(new Dependency(parentInterfaceName, DependencyType.BIND));
+                if (viIface.getActive() && !parentInterface.getActive()) {
+                  viIface.deactivate(InactiveReason.PARENT_DOWN);
+                }
               }
             }
           }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/bundle-ether-subif
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/bundle-ether-subif
@@ -13,7 +13,7 @@ interface TenGigE0/1
  bundle id 500 mode active
 !
 !
-! Since Bundle-Ether600 is shut down, should cascade to Bundle-Ether600.2.
+! Since Bundle-Ether600 is shut down, should cascade to Bundle-Ether600.3.
 interface Bundle-Ether600
  shutdown
  mtu 9216


### PR DESCRIPTION
- prep for forthcoming interface topology invariant:
  - cannot in general compute intra-device interface topology for an admin-down interface