### PR TITLE
Cumulus NCLU disable invalid interfaces that are bond slaves with L3

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusNcluConfiguration.java
@@ -667,12 +667,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
     for (org.batfish.datamodel.Interface i : c.getActiveInterfaces().values()) {
       if (!i.getAllAddresses().isEmpty()) {
         String name = i.getName();
-        if (i.getSwitchport()) {
-          w.redFlag(
-              String.format(
-                  "Disabling invalid interface '%s' because it has both L2 and L3 settings", name));
-          i.deactivate(InactiveReason.INVALID);
-        } else if (i.getChannelGroup() != null) {
+        if (i.getChannelGroup() != null) {
           w.redFlag(
               String.format(
                   "Disabling invalid interface '%s' because has L3 settings but is a bond slave of"

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -85288,6 +85288,18 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
+              "text" : "Disabling invalid interface 'swp1' because has L3 settings but is a bond slave of 'bond1'"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Disabling invalid interface 'swp2' because has L3 settings but is a bond slave of 'bond1'"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Disabling invalid interface 'swp3' because has L3 settings but is a bond slave of 'bond1'"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
               "text" : "No support for VLAN switching options on non-'bridge bridge' port: 'bond1'"
             },
             {


### PR DESCRIPTION
- a bond slave (aggregate member) cannot have L3 settings