### PR TITLE
owasp: suppress CVE-2020-36518

### DIFF
--- a/projects/build-tools/src/main/resources/org/batfish/owasp/suppressions.xml
+++ b/projects/build-tools/src/main/resources/org/batfish/owasp/suppressions.xml
@@ -4,4 +4,8 @@
     <notes>This is a SUSE packaging bug, nothing to do with jar.</notes>
     <cve>CVE-2020-8022</cve>
   </suppress>
+  <suppress>
+    <notes>This is a non-issue.</notes>
+    <cve>CVE-2020-36518</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
This is not an issue to be concerned about. The current supposed fix is worse
than the issue itself. (Fixed limit that can't be overridden!)