### PR TITLE
BDD: simplify toString

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
@@ -1459,25 +1459,6 @@ public abstract class BDD {
   public abstract BDD replaceWith(BDDPairing pair);
 
   /**
-   * Prints the set of truth assignments specified by this BDD.
-   *
-   * <p>Compare to bdd_printset.
-   */
-  public void printSet() {
-    System.out.println(toString());
-  }
-
-  /**
-   * Prints this BDD using a set notation as in printSet() but with the index of the finite domain
-   * blocks included instead of the BDD variables.
-   *
-   * <p>Compare to fdd_printset.
-   */
-  public void printSetWithDomains() {
-    System.out.println(toStringWithDomains());
-  }
-
-  /**
    * Prints this BDD in dot graph notation.
    *
    * <p>Compare to bdd_printdot.
@@ -1640,6 +1621,15 @@ public abstract class BDD {
 
   @Override
   public String toString() {
+    if (isZero()) {
+      return "ZERO";
+    } else if (isOne()) {
+      return "ONE";
+    }
+    return String.format("hash: %d topVar: %d", hashCode(), var());
+  }
+
+  public String toReprString() {
     BDDFactory f = getFactory();
     int[] set = new int[f.varNum()];
     StringBuffer sb = new StringBuffer();

--- a/projects/bdd/src/test/java/net/sf/javabdd/regression/R3.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/regression/R3.java
@@ -60,26 +60,26 @@ public class R3 extends BDDTestCase {
 
       z0 = or.unique(x0);
       t = x1.not();
-      assertEquals(z0.toString(), z0, t);
+      assertEquals(z0.toReprString(), z0, t);
       t.free();
 
       z1 = or.unique(x1);
       t = x0.not();
-      assertEquals(z1.toString(), z1, t);
+      assertEquals(z1.toReprString(), z1, t);
       t.free();
 
       t = one.unique(x0);
-      assertTrue(t.toString(), t.isZero());
+      assertTrue(t.toReprString(), t.isZero());
       t.free();
 
       y0 = x0.applyUni(x1, BDDFactory.or, x0);
       t = x1.not();
-      assertEquals(y0.toString(), y0, t);
+      assertEquals(y0.toReprString(), y0, t);
       t.free();
 
       y1 = x0.applyUni(x1, BDDFactory.or, x1);
       t = x0.not();
-      assertEquals(y1.toString(), y1, t);
+      assertEquals(y1.toReprString(), y1, t);
       t.free();
 
       x0.free();


### PR DESCRIPTION
The default toString implementation is slow and can take arbitrary amounts of RAM.
Rename it to toReprString() and add a simplifed toString.