### PR TITLE
PAN: revamp application definitions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/BUILD
@@ -11,6 +11,10 @@ java_library(
     ),
     deps = [
         "//projects/batfish-common-protocol:common",
+        "//projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions",
+        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_fasterxml_jackson_core_jackson_databind",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:org_apache_commons_commons_lang3",

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinition.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinition.java
@@ -76,13 +76,13 @@ public final class ApplicationDefinition {
       @Nullable String parentApp,
       @Nullable UseApplications useApplications,
       @Nullable UseApplications implicitUseApplications,
-      @Nullable Default default_) {
+      @Nullable Default defaultVal) {
     _name = name;
     _applicationContainer = applicationContainer;
     _parentApp = parentApp;
     _useApplications = useApplications;
     _implicitUseApplications = implicitUseApplications;
-    _default = default_;
+    _default = defaultVal;
   }
 
   @Nonnull private final String _name;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinition.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinition.java
@@ -63,10 +63,15 @@ public final class ApplicationDefinition {
       @JsonProperty(PROP_USE_APPLICATIONS) @Nullable UseApplications useApplications,
       @JsonProperty(PROP_IMPLICIT_USE_APPLICATIONS) @Nullable
           UseApplications implicitUseApplications,
-      @JsonProperty(PROP_DEFAULT) @Nullable Default default_) {
+      @JsonProperty(PROP_DEFAULT) @Nullable Default defaultVal) {
     checkArgument(name != null, "Missing %s", PROP_NAME);
     return new ApplicationDefinition(
-        name, applicationContainer, parentApp, useApplications, implicitUseApplications, default_);
+        name,
+        applicationContainer,
+        parentApp,
+        useApplications,
+        implicitUseApplications,
+        defaultVal);
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinition.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinition.java
@@ -9,7 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** Data model for Palo Alto application definition. */
+/** Data model for a Palo Alto application definition. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class ApplicationDefinition {
   private static final String PROP_NAME = "@name";
@@ -19,6 +19,7 @@ public final class ApplicationDefinition {
   private static final String PROP_IMPLICIT_USE_APPLICATIONS = "implicit-use-applications";
   private static final String PROP_DEFAULT = "default";
 
+  /** Get the name of the application. */
   @Nonnull
   public String getName() {
     return _name;
@@ -48,7 +49,7 @@ public final class ApplicationDefinition {
     return _implicitUseApplications;
   }
 
-  /** Get information about default IP protocol and port. */
+  /** Get information about default application properties, specifically IP protocol and port. */
   @Nullable
   public Default getDefault() {
     return _default;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinition.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinition.java
@@ -1,0 +1,93 @@
+package org.batfish.representation.palo_alto.application_definitions;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Data model for Palo Alto application definition. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ApplicationDefinition {
+  private static final String PROP_NAME = "@name";
+  private static final String PROP_APPLICATION_CONTAINER = "application-container";
+  private static final String PROP_PARENT_APP = "parent-app";
+  private static final String PROP_USE_APPLICATIONS = "use-applications";
+  private static final String PROP_IMPLICIT_USE_APPLICATIONS = "implicit-use-applications";
+  private static final String PROP_DEFAULT = "default";
+
+  @Nonnull
+  public String getName() {
+    return _name;
+  }
+
+  /**
+   * Get the application container for this application. Appears similar in function to an {@link
+   * org.batfish.representation.palo_alto.ApplicationGroup}.
+   */
+  @Nullable
+  public String getApplicationContainer() {
+    return _applicationContainer;
+  }
+
+  @Nullable
+  public String getParentApp() {
+    return _parentApp;
+  }
+
+  @Nullable
+  public UseApplications getUseApplications() {
+    return _useApplications;
+  }
+
+  @Nullable
+  public UseApplications getImplicitUseApplications() {
+    return _implicitUseApplications;
+  }
+
+  /** Get information about default IP protocol and port. */
+  @Nullable
+  public Default getDefault() {
+    return _default;
+  }
+
+  @JsonCreator
+  private static @Nonnull ApplicationDefinition create(
+      @JsonProperty(PROP_NAME) @Nullable String name,
+      @JsonProperty(PROP_APPLICATION_CONTAINER) @Nullable String applicationContainer,
+      @JsonProperty(PROP_PARENT_APP) @Nullable String parentApp,
+      @JsonProperty(PROP_USE_APPLICATIONS) @Nullable UseApplications useApplications,
+      @JsonProperty(PROP_IMPLICIT_USE_APPLICATIONS) @Nullable
+          UseApplications implicitUseApplications,
+      @JsonProperty(PROP_DEFAULT) @Nullable Default default_) {
+    checkArgument(name != null, "Missing %s", PROP_NAME);
+    return new ApplicationDefinition(
+        name, applicationContainer, parentApp, useApplications, implicitUseApplications, default_);
+  }
+
+  @VisibleForTesting
+  ApplicationDefinition(
+      String name,
+      @Nullable String applicationContainer,
+      @Nullable String parentApp,
+      @Nullable UseApplications useApplications,
+      @Nullable UseApplications implicitUseApplications,
+      @Nullable Default default_) {
+    _name = name;
+    _applicationContainer = applicationContainer;
+    _parentApp = parentApp;
+    _useApplications = useApplications;
+    _implicitUseApplications = implicitUseApplications;
+    _default = default_;
+  }
+
+  @Nonnull private final String _name;
+  @Nullable private final String _applicationContainer;
+  @Nullable private final String _parentApp;
+  @Nullable private final UseApplications _useApplications;
+  @Nullable private final UseApplications _implicitUseApplications;
+  @Nullable private final Default _default;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitions.java
@@ -1,0 +1,40 @@
+package org.batfish.representation.palo_alto.application_definitions;
+
+import static org.batfish.common.util.Resources.readResource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.batfish.common.util.BatfishObjectMapper;
+
+public class ApplicationDefinitions {
+  public static ApplicationDefinitions INSTANCE = new ApplicationDefinitions();
+
+  public Map<String, ApplicationDefinition> getApplications() {
+    return _applications;
+  }
+
+  private ApplicationDefinitions() {
+    List<ApplicationDefinition> apps;
+    try {
+      apps =
+          BatfishObjectMapper.ignoreUnknownMapper()
+              .readValue(
+                  readResource(APPLICATION_DEFINITIONS_PATH, StandardCharsets.UTF_8),
+                  new TypeReference<List<ApplicationDefinition>>() {});
+    } catch (JsonProcessingException e) {
+      apps = ImmutableList.of();
+    }
+    _applications =
+        apps.stream().collect(ImmutableMap.toImmutableMap(ApplicationDefinition::getName, a -> a));
+  }
+
+  private final Map<String, ApplicationDefinition> _applications;
+
+  private static final String APPLICATION_DEFINITIONS_PATH =
+      "org/batfish/representation/palo_alto/application_definitions/application_definitions.json";
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitions.java
@@ -11,7 +11,8 @@ import java.util.List;
 import java.util.Map;
 import org.batfish.common.util.BatfishObjectMapper;
 
-public class ApplicationDefinitions {
+/** Helper class that stores all built-in application definitions for a Palo Alto device. */
+public final class ApplicationDefinitions {
   public static ApplicationDefinitions INSTANCE = new ApplicationDefinitions();
 
   public Map<String, ApplicationDefinition> getApplications() {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/BUILD
@@ -1,0 +1,29 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("@batfish//skylark:pmd_test.bzl", "pmd_test")
+
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "application_definitions",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["BUILD"],
+    ),
+    resources = [
+        "//projects/batfish/src/main/resources/org/batfish/representation/palo_alto/application_definitions:application_definitions.json",
+    ],
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_fasterxml_jackson_core_jackson_databind",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_apache_commons_commons_lang3",
+    ],
+)
+
+pmd_test(
+    name = "pmd",
+    lib = ":application_definitions",
+)

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Default.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Default.java
@@ -10,27 +10,35 @@ import javax.annotation.Nullable;
  * Data model class containing information about a Palo Alto application's default properties,
  * specifically port(s) and IP protocol(s).
  */
-public class Default {
+public final class Default {
+  /** Get default IP protocol and port information. */
   @Nullable
   public Port getPort() {
     return _port;
   }
 
+  /** Get the IP protocol number used for identifying the application. */
+  @Nullable
+  public String getIdentByIpProtocol() {
+    return _identByIpProtocol;
+  }
+
   private static final String PROP_PORT = "port";
+  private static final String PROP_IDENT_BY_IP_PROTOCOL = "ident-by-ip-protocol";
 
   @JsonCreator
-  private static @Nonnull Default create(@JsonProperty(PROP_PORT) @Nullable Port port) {
-    // checkArgument(port != null, "Missing %s", PROP_PORT);
-    if (port == null) {
-      return new Default(null);
-    }
-    return new Default(port);
+  private static @Nonnull Default create(
+      @JsonProperty(PROP_PORT) @Nullable Port port,
+      @JsonProperty(PROP_IDENT_BY_IP_PROTOCOL) @Nullable String identByIpProtocol) {
+    return new Default(port, identByIpProtocol);
   }
 
   @VisibleForTesting
-  Default(@Nonnull Port port) {
+  Default(@Nullable Port port, @Nullable String identByIpProtocol) {
     _port = port;
+    _identByIpProtocol = identByIpProtocol;
   }
 
   @Nullable private final Port _port;
+  @Nullable private final String _identByIpProtocol;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Default.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Default.java
@@ -1,0 +1,36 @@
+package org.batfish.representation.palo_alto.application_definitions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Data model class containing information about a Palo Alto application's default properties,
+ * specifically port(s) and IP protocol(s).
+ */
+public class Default {
+  @Nullable
+  public Port getPort() {
+    return _port;
+  }
+
+  private static final String PROP_PORT = "port";
+
+  @JsonCreator
+  private static @Nonnull Default create(@JsonProperty(PROP_PORT) @Nullable Port port) {
+    // checkArgument(port != null, "Missing %s", PROP_PORT);
+    if (port == null) {
+      return new Default(null);
+    }
+    return new Default(port);
+  }
+
+  @VisibleForTesting
+  Default(@Nonnull Port port) {
+    _port = port;
+  }
+
+  @Nullable private final Port _port;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Port.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Port.java
@@ -1,0 +1,47 @@
+package org.batfish.representation.palo_alto.application_definitions;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Data model class containing information about a Palo Alto application's default port(s) and IP
+ * protocol(s).
+ */
+public class Port {
+  @Nonnull
+  public List<String> getMember() {
+    return _member;
+  }
+
+  private static final String PROP_MEMBER = "member";
+
+  @JsonCreator
+  private static @Nonnull Port create(@JsonProperty(PROP_MEMBER) @Nullable JsonNode member) {
+    checkArgument(member != null, "Missing %s", PROP_MEMBER);
+    // List of members
+    if (member instanceof ArrayNode) {
+      ArrayNode arrayNode = (ArrayNode) member;
+      ImmutableList.Builder<String> names = ImmutableList.builder();
+      arrayNode.forEach(item -> names.add(item.textValue()));
+      return new Port(names.build());
+    }
+    // Single member
+    return new Port(ImmutableList.of(member.textValue()));
+  }
+
+  @VisibleForTesting
+  Port(@Nonnull List<String> member) {
+    _member = member;
+  }
+
+  @Nonnull private final List<String> _member;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Port.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Port.java
@@ -16,7 +16,8 @@ import javax.annotation.Nullable;
  * Data model class containing information about a Palo Alto application's default port(s) and IP
  * protocol(s).
  */
-public class Port {
+public final class Port {
+  /** Get the list of protocol/port combinations that make up this "port". */
   @Nonnull
   public List<String> getMember() {
     return _member;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/UseApplications.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/UseApplications.java
@@ -3,7 +3,6 @@ package org.batfish.representation.palo_alto.application_definitions;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -19,7 +18,6 @@ import javax.annotation.Nullable;
  * Data model class containing information about a Palo Alto application's "{@code
  * use-applications}". These correspond to applications used by / related to others (details TBD).
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public final class UseApplications {
   @Nonnull
   public List<String> getMember() {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/UseApplications.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/UseApplications.java
@@ -1,0 +1,69 @@
+package org.batfish.representation.palo_alto.application_definitions;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Data model class containing information about a Palo Alto application's "{@code
+ * use-applications}". These correspond to related applications (details TBD).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UseApplications {
+  @Nonnull
+  public List<String> getMember() {
+    return _member;
+  }
+
+  private static final String PROP_MEMBER = "member";
+
+  @JsonCreator
+  private static @Nonnull UseApplications create(
+      @JsonProperty(PROP_MEMBER) @Nullable JsonNode member) {
+    checkArgument(member != null, "Missing %s", PROP_MEMBER);
+    // List of members
+    if (member instanceof ArrayNode) {
+      ArrayNode arrayNode = (ArrayNode) member;
+      ImmutableList.Builder<String> names = ImmutableList.builder();
+      arrayNode.forEach(item -> names.add(memberToName(item)));
+      return new UseApplications(names.build());
+    }
+    // Single member
+    return new UseApplications(ImmutableList.of(memberToName(member)));
+  }
+
+  /**
+   * Extract the {@code name} from a member.
+   *
+   * <p>Members will either be a string containing its name, or an object with a {@code #text} field
+   * containing the name.
+   */
+  private static @Nonnull String memberToName(@Nullable JsonNode singleMember) {
+    if (singleMember instanceof TextNode) {
+      return singleMember.textValue();
+    }
+    assert singleMember instanceof ObjectNode; // Map/Object
+    ObjectNode objectNode = (ObjectNode) singleMember;
+    JsonNode text = objectNode.findValue("#text");
+    assert text instanceof TextNode;
+    return text.textValue();
+  }
+
+  @VisibleForTesting
+  UseApplications(@Nonnull List<String> member) {
+    _member = ImmutableList.copyOf(member);
+  }
+
+  @Nonnull private final List<String> _member;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/UseApplications.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/UseApplications.java
@@ -17,10 +17,10 @@ import javax.annotation.Nullable;
 
 /**
  * Data model class containing information about a Palo Alto application's "{@code
- * use-applications}". These correspond to related applications (details TBD).
+ * use-applications}". These correspond to applications used by / related to others (details TBD).
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class UseApplications {
+public final class UseApplications {
   @Nonnull
   public List<String> getMember() {
     return _member;

--- a/projects/batfish/src/main/resources/org/batfish/representation/palo_alto/application_definitions/BUILD
+++ b/projects/batfish/src/main/resources/org/batfish/representation/palo_alto/application_definitions/BUILD
@@ -1,0 +1,8 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "application_definitions",
+    srcs = glob(["**"]),
+)

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/BUILD
@@ -16,6 +16,7 @@ junit_tests(
         "//projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
         "//projects/batfish/src/main/java/org/batfish/representation/palo_alto",
+        "//projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
@@ -29,9 +29,12 @@ import static org.batfish.representation.palo_alto.PaloAltoConfiguration.securit
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.unexpectedUnboundedCustomUrlWildcard;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneMatchTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneRejectTraceElement;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -51,6 +54,8 @@ import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.representation.palo_alto.SecurityRule.RuleType;
 import org.batfish.representation.palo_alto.Zone.Type;
+import org.batfish.representation.palo_alto.application_definitions.ApplicationDefinition;
+import org.batfish.representation.palo_alto.application_definitions.ApplicationDefinitions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -812,5 +817,12 @@ public final class PaloAltoConfigurationTest {
     assertTrue(dest.getServices().containsKey("service"));
     assertTrue(dest.getServiceGroups().containsKey("serviceGroup"));
     assertTrue(dest.getTags().containsKey("tag"));
+  }
+
+  @Test
+  public void testingStuff() {
+    Map<String, ApplicationDefinition> a = ApplicationDefinitions.INSTANCE.getApplications();
+    assertThat(a, notNullValue());
+    assertThat(a, not(anEmptyMap()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/PaloAltoConfigurationTest.java
@@ -29,12 +29,9 @@ import static org.batfish.representation.palo_alto.PaloAltoConfiguration.securit
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.unexpectedUnboundedCustomUrlWildcard;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneMatchTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneRejectTraceElement;
-import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -54,8 +51,6 @@ import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.representation.palo_alto.SecurityRule.RuleType;
 import org.batfish.representation.palo_alto.Zone.Type;
-import org.batfish.representation.palo_alto.application_definitions.ApplicationDefinition;
-import org.batfish.representation.palo_alto.application_definitions.ApplicationDefinitions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -817,12 +812,5 @@ public final class PaloAltoConfigurationTest {
     assertTrue(dest.getServices().containsKey("service"));
     assertTrue(dest.getServiceGroups().containsKey("serviceGroup"));
     assertTrue(dest.getTags().containsKey("tag"));
-  }
-
-  @Test
-  public void testingStuff() {
-    Map<String, ApplicationDefinition> a = ApplicationDefinitions.INSTANCE.getApplications();
-    assertThat(a, notNullValue());
-    assertThat(a, not(anEmptyMap()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitionTest.java
@@ -92,5 +92,22 @@ public class ApplicationDefinitionTest {
       assertNotNull(appDef.getUseApplications());
       assertThat(appDef.getUseApplications().getMember(), contains("something-base"));
     }
+
+    // App definition for an ip-protocol based app
+    {
+      String appDefJson =
+          "{"
+              + "  \"@name\": \"dcn-meas\","
+              + "  \"default\": {"
+              + "    \"ident-by-ip-protocol\": \"19\""
+              + "  }"
+              + "}";
+      ApplicationDefinition appDef =
+          BatfishObjectMapper.ignoreUnknownMapper()
+              .readValue(appDefJson, ApplicationDefinition.class);
+      assertNotNull(appDef);
+      assertNotNull(appDef.getDefault());
+      assertThat(appDef.getDefault().getIdentByIpProtocol(), equalTo("19"));
+    }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitionTest.java
@@ -1,0 +1,96 @@
+package org.batfish.representation.palo_alto.application_definitions;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link ApplicationDefinition}. */
+public class ApplicationDefinitionTest {
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    // Application definitions loosely based on dropbox-personal-uploading
+
+    // App definition with lists of values
+    {
+      String appDefJsonWithLists =
+          "{"
+              + "  \"@name\": \"something-personal-uploading\","
+              + "  \"parent-app\": \"something-uploading\","
+              + "  \"default\": {"
+              + "    \"port\": {"
+              + "      \"member\": [\"tcp/443,80\", \"udp/dynamic\"]"
+              + "    }"
+              + "  },"
+              + "  \"use-applications\": {"
+              + "    \"member\": ["
+              + "      \"something-base\","
+              + "      {"
+              + "        \"@minver\": \"3.0.0\","
+              + "        \"#text\": \"something-uploading\""
+              + "      }"
+              + "    ]"
+              + "  },"
+              + "  \"implicit-use-applications\": {"
+              + "    \"member\": [\"web-browsing\", \"ssl\"]"
+              + "  },"
+              + "  \"application-container\": \"something\","
+              + "  \"unknown-key\": \"unknown-value\""
+              + "}";
+      ApplicationDefinition appDef =
+          BatfishObjectMapper.ignoreUnknownMapper()
+              .readValue(appDefJsonWithLists, ApplicationDefinition.class);
+      assertNotNull(appDef);
+      assertThat(appDef.getApplicationContainer(), equalTo("something"));
+      assertNotNull(appDef.getDefault());
+      assertNotNull(appDef.getDefault().getPort());
+      assertThat(appDef.getDefault().getPort().getMember(), contains("tcp/443,80", "udp/dynamic"));
+      assertThat(appDef.getName(), equalTo("something-personal-uploading"));
+      assertNotNull(appDef.getImplicitUseApplications());
+      assertThat(appDef.getImplicitUseApplications().getMember(), contains("web-browsing", "ssl"));
+      assertNotNull(appDef.getUseApplications());
+      assertThat(
+          appDef.getUseApplications().getMember(),
+          contains("something-base", "something-uploading"));
+    }
+
+    // App definition with single-values, no lists
+    {
+      String appDefJson =
+          "{"
+              + "  \"@name\": \"something-personal-uploading\","
+              + "  \"parent-app\": \"something-uploading\","
+              + "  \"default\": {"
+              + "    \"port\": {"
+              + "      \"member\": \"tcp/443,80\""
+              + "    }"
+              + "  },"
+              + "  \"use-applications\": {"
+              + "    \"member\": \"something-base\""
+              + "  },"
+              + "  \"implicit-use-applications\": {"
+              + "    \"member\": \"web-browsing\""
+              + "  },"
+              + "  \"application-container\": \"something\","
+              + "  \"unknown-key\": \"unknown-value\""
+              + "}";
+      ApplicationDefinition appDef =
+          BatfishObjectMapper.ignoreUnknownMapper()
+              .readValue(appDefJson, ApplicationDefinition.class);
+      assertNotNull(appDef);
+      assertThat(appDef.getApplicationContainer(), equalTo("something"));
+      assertNotNull(appDef.getDefault());
+      assertNotNull(appDef.getDefault().getPort());
+      assertThat(appDef.getDefault().getPort().getMember(), contains("tcp/443,80"));
+      assertThat(appDef.getName(), equalTo("something-personal-uploading"));
+      assertNotNull(appDef.getImplicitUseApplications());
+      assertThat(appDef.getImplicitUseApplications().getMember(), contains("web-browsing"));
+      assertNotNull(appDef.getUseApplications());
+      assertThat(appDef.getUseApplications().getMember(), contains("something-base"));
+    }
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions/BUILD
@@ -1,0 +1,23 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers",
+        "//projects/batfish/src/main/java/org/batfish/representation/palo_alto",
+        "//projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)


### PR DESCRIPTION
Add new VS datamodel representation for Palo Alto applications.

----

Will separately:
1. plumb the new representation into conversion & remove the old representation
2. add a script / instructions for updating these.
