### PR TITLE
SONiC: Setup for more file types

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -928,7 +928,7 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
     }
     Set<String> unknownFiles =
         Sets.difference(fileTexts.keySet(), ImmutableSet.copyOf(fileTypeMap.values()));
-    if (unknownFiles.size() > 0) {
+    if (!unknownFiles.isEmpty()) {
       throw new IllegalArgumentException(
           String.format(
               "Cannot determine the type of SONiC files: '%s'. Make sure that they have legal"

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
@@ -227,8 +227,8 @@ public class ParseVendorConfigurationJobTest {
   @Test
   public void testGetSonicFileMap_unknownType() {
     _thrown.expect(IllegalArgumentException.class);
-    // frr is not a valid tail
-    getSonicFileMap(ImmutableMap.of("frr", "hello", "config_db,json", "{}"));
+    // frr is not a valid tail, and config_db's content is not json
+    getSonicFileMap(ImmutableMap.of("frr", "hello", "config_db,json", "not json"));
   }
 
   @Test


### PR DESCRIPTION
Prep for supporting more SONiC file types (snmp.yml, resolve.conf)
1. Batfish allows more than two files in the SONiC device bundle
2. Parser detects the type of each file based on filename, which should end with the well-known name string (config_db.json, snmp.yml,...). For backward compatibility, the old content-based detection is used as a fallback when there are only two files present. 

No processing of additional files is added in this PR. 