### PR TITLE
PAN: icmp type in new application datamodel

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Default.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/application_definitions/Default.java
@@ -2,6 +2,10 @@ package org.batfish.representation.palo_alto.application_definitions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -23,22 +27,46 @@ public final class Default {
     return _identByIpProtocol;
   }
 
+  /** Get the ICMP type used for identifying the application. */
+  @Nullable
+  public String getIdentByIcmpType() {
+    return _identByIcmpType;
+  }
+
   private static final String PROP_PORT = "port";
   private static final String PROP_IDENT_BY_IP_PROTOCOL = "ident-by-ip-protocol";
+  private static final String PROP_IDENT_BY_ICMP_TYPE = "ident-by-icmp-type";
 
   @JsonCreator
   private static @Nonnull Default create(
       @JsonProperty(PROP_PORT) @Nullable Port port,
-      @JsonProperty(PROP_IDENT_BY_IP_PROTOCOL) @Nullable String identByIpProtocol) {
-    return new Default(port, identByIpProtocol);
+      @JsonProperty(PROP_IDENT_BY_IP_PROTOCOL) @Nullable String identByIpProtocol,
+      @JsonProperty(PROP_IDENT_BY_ICMP_TYPE) @Nullable JsonNode identByIcmpType) {
+    String type =
+        identByIcmpType == null || identByIcmpType instanceof NullNode
+            ? null
+            : icmpTypeToString(identByIcmpType);
+    return new Default(port, identByIpProtocol, type);
+  }
+
+  /** Extract the type string from an ICMP type. */
+  private static @Nonnull String icmpTypeToString(@Nonnull JsonNode type) {
+    assert type instanceof ObjectNode; // Map/Object
+    ObjectNode objectNode = (ObjectNode) type;
+    JsonNode text = objectNode.findValue("type");
+    assert text instanceof TextNode;
+    return text.textValue();
   }
 
   @VisibleForTesting
-  Default(@Nullable Port port, @Nullable String identByIpProtocol) {
+  Default(
+      @Nullable Port port, @Nullable String identByIpProtocol, @Nullable String identByIcmpType) {
     _port = port;
     _identByIpProtocol = identByIpProtocol;
+    _identByIcmpType = identByIcmpType;
   }
 
   @Nullable private final Port _port;
   @Nullable private final String _identByIpProtocol;
+  @Nullable private final String _identByIcmpType;
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions/ApplicationDefinitionTest.java
@@ -109,5 +109,25 @@ public class ApplicationDefinitionTest {
       assertNotNull(appDef.getDefault());
       assertThat(appDef.getDefault().getIdentByIpProtocol(), equalTo("19"));
     }
+
+    // App definition for an icmp-type based app
+    {
+      String appDefJson =
+          "{"
+              + "  \"@name\": \"ping\","
+              + "  \"default\": {"
+              + "    \"ident-by-icmp-type\": {"
+              + "      \"@minver\": \"7.0.0\","
+              + "      \"type\": \"8\""
+              + "    }"
+              + "  }"
+              + "}";
+      ApplicationDefinition appDef =
+          BatfishObjectMapper.ignoreUnknownMapper()
+              .readValue(appDefJson, ApplicationDefinition.class);
+      assertNotNull(appDef);
+      assertNotNull(appDef.getDefault());
+      assertThat(appDef.getDefault().getIdentByIcmpType(), equalTo("8"));
+    }
   }
 }


### PR DESCRIPTION
Add icmp type field under `default` for application definitions in the updated Palo Alto application datamodel.
