### PR TITLE
Enforce more interface invariants (attempt 2)

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -2181,7 +2181,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
     _currentInterface =
         _currentParentInterface
             .getUnits()
-            .computeIfAbsent(name, n -> new Interface(n, Interface.Type.TUNNEL));
+            .computeIfAbsent(name, n -> new Interface(n, Interface.Type.TUNNEL_UNIT));
     _currentInterface.setParent(_currentParentInterface);
     defineFlattenedStructure(INTERFACE, name, ctx);
   }
@@ -2197,9 +2197,11 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
     _currentInterface =
         _currentParentInterface
             .getUnits()
-            .computeIfAbsent(name, n -> new Interface(n, Interface.Type.VLAN));
+            .computeIfAbsent(name, n -> new Interface(n, Interface.Type.VLAN_UNIT));
     _currentInterface.setParent(_currentParentInterface);
     defineFlattenedStructure(INTERFACE, name, ctx);
+    // TODO: convert vlan ID for created vlan units
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -103,6 +103,7 @@ import org.batfish.datamodel.GeneratedRoute6;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.IkePhase1Policy;
 import org.batfish.datamodel.IkePhase1Proposal;
+import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
@@ -1375,7 +1376,16 @@ public final class CiscoConfiguration extends VendorConfiguration {
     if (!iface.getActive()) {
       newIface.adminDown();
     }
-    newIface.setChannelGroup(iface.getChannelGroup());
+    String channelGroup = iface.getChannelGroup();
+    newIface.setChannelGroup(channelGroup);
+    if (iface.getActive() && channelGroup != null && !_interfaces.containsKey(channelGroup)) {
+      _w.redFlag(
+          String.format(
+              "Deactivating interface %s that refers to undefined channel-group %s",
+              ifaceName, channelGroup));
+      newIface.deactivate(InactiveReason.INVALID);
+    }
+
     newIface.setCryptoMap(iface.getCryptoMap());
     newIface.setHsrpVersion(iface.getHsrpVersion());
     newIface.setVrf(c.getVrfs().get(vrfName));

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusNcluConfiguration.java
@@ -43,10 +43,12 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.VendorConversionException;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceModel;
+import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
@@ -189,7 +191,9 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
   }
 
   private void convertBondInterfaces() {
-    _bonds.forEach((name, bond) -> _c.getAllInterfaces().put(name, toInterface(bond)));
+    _bonds.forEach(
+        (name, bond) ->
+            toInterface(bond).ifPresent(newIface -> _c.getAllInterfaces().put(name, newIface)));
   }
 
   private void convertDefaultVrf() {
@@ -514,15 +518,17 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
     _vxlans = ImmutableMap.copyOf(vxlans);
   }
 
-  private @Nonnull org.batfish.datamodel.Interface toInterface(Bond bond) {
+  private @Nonnull Optional<org.batfish.datamodel.Interface> toInterface(Bond bond) {
     String name = bond.getName();
+    if (!verifyValidSlaves(name, bond.getSlaves())) {
+      return Optional.empty();
+    }
     org.batfish.datamodel.Interface newIface =
         org.batfish.datamodel.Interface.builder()
             .setName(name)
             .setOwner(_c)
             .setType(InterfaceType.AGGREGATED)
             .build();
-
     bond.getSlaves().forEach(slave -> _c.getAllInterfaces().get(slave).setChannelGroup(name));
     newIface.setChannelGroupMembers(bond.getSlaves());
     newIface.setDependencies(
@@ -539,7 +545,31 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
 
     newIface.setMlagId(bond.getClagId());
 
-    return newIface;
+    return Optional.of(newIface);
+  }
+
+  private boolean verifyValidSlaves(String bondName, Set<String> slaves) {
+    for (String slaveName : slaves) {
+      Interface slave = _interfaces.get(slaveName);
+      if (!slave.getIpAddresses().isEmpty()) {
+        _w.redFlag(
+            String.format(
+                "Refusing to create bond-interface %s that refers to a slave with L3 address %s",
+                bondName, slaveName));
+        return false;
+      }
+      for (Interface i : _interfaces.values()) {
+        if (slaveName.equals(i.getSuperInterfaceName())) {
+          _w.redFlag(
+              String.format(
+                  "Refusing to create bond-interface %s that refers to slave %s that has a"
+                      + " subinterface %s",
+                  bondName, slaveName, i.getName()));
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   @VisibleForTesting
@@ -591,13 +621,19 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
   }
 
   private org.batfish.datamodel.Interface toInterface(Vlan vlan) {
+    Integer vlanId = vlan.getVlanId();
     org.batfish.datamodel.Interface newIface =
         org.batfish.datamodel.Interface.builder()
             .setName(vlan.getName())
             .setOwner(_c)
             .setType(InterfaceType.VLAN)
             .build();
-    newIface.setVlan(vlan.getVlanId());
+    newIface.setVlan(vlanId);
+    if (vlanId == null) {
+      // TODO: perhaps there should be a default based on the name?
+      _w.redFlag(String.format("Deactivating vlan %s which has no vlan-id set", vlan.getName()));
+      newIface.deactivate(InactiveReason.INCOMPLETE);
+    }
 
     // Interface addreses
     if (!vlan.getAddresses().isEmpty()) {
@@ -620,10 +656,10 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
     _c.setExportBgpFromBgpRib(true);
 
     convertPhysicalInterfaces();
-    convertBondInterfaces();
     convertSubinterfaces();
     convertVlanInterfaces();
     convertLoopback();
+    convertBondInterfaces();
     convertVrfLoopbackInterfaces();
     convertVrfs();
     convertDefaultVrf();
@@ -656,7 +692,25 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
 
     warnDuplicateClagIds();
 
+    disableInvalidInterfaces(_c, _w);
+
     return _c;
+  }
+
+  private static void disableInvalidInterfaces(Configuration c, Warnings w) {
+    for (org.batfish.datamodel.Interface i : c.getActiveInterfaces().values()) {
+      if (!i.getAllAddresses().isEmpty()) {
+        String name = i.getName();
+        if (i.getChannelGroup() != null) {
+          w.redFlag(
+              String.format(
+                  "Disabling invalid interface '%s' because has L3 settings but is a bond slave of"
+                      + " '%s'",
+                  name, i.getChannelGroup()));
+          i.deactivate(InactiveReason.INVALID);
+        }
+      }
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -56,6 +56,7 @@ import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IcmpType;
+import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
@@ -1507,7 +1508,12 @@ public class F5BigipConfiguration extends VendorConfiguration {
             .setType(InterfaceType.VLAN)
             .build();
     // TODO: Possibly add dependencies on ports allowing this VLAN
-    newIface.setVlan(vlan.getTag());
+    Integer vlanId = vlan.getTag();
+    newIface.setVlan(vlanId);
+    if (vlanId == null) {
+      _w.redFlag(String.format("Deactivating vlan %s because it has no tag set", vlan.getName()));
+      newIface.deactivate(InactiveReason.INCOMPLETE);
+    }
     newIface.setBandwidth(Interface.DEFAULT_BANDWIDTH);
     newIface.setVrf(_c.getDefaultVrf());
     // Assume each interface has its own session info (sessions are not shared by interfaces).

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -81,6 +81,7 @@ import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.IkePhase1Policy;
 import org.batfish.datamodel.IkePhase1Proposal;
+import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
@@ -1828,6 +1829,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
       return null;
     }
     String name = iface.getName();
+    if (iface.getParent().getRedundantParentInterface() != null) {
+      _w.redFlag(
+          String.format(
+              "Refusing to convert illegal unit '%s' on parent that is a member of a redundant"
+                  + " ethernet group '%s'",
+              name, iface.getParent().getRedundantParentInterface()));
+      return null;
+    }
     org.batfish.datamodel.Interface newIface =
         org.batfish.datamodel.Interface.builder().setName(name).setOwner(_c).build();
     newIface.setDeclaredNames(ImmutableSortedSet.of(name));
@@ -4094,6 +4103,15 @@ public final class JuniperConfiguration extends VendorConfiguration {
                         String name = newUnitInterface.getName();
                         // set IRB VLAN ID if assigned
                         newUnitInterface.setVlan(irbVlanIds.get(name));
+                        if (unit.getType() == InterfaceType.IRB_UNIT
+                            && newUnitInterface.getVlan() == null) {
+                          // TODO: May still be active if part of a bridge, though maybe it still
+                          //       needs a vlan.
+                          _w.redFlag(
+                              String.format(
+                                  "Deactivating %s because it has no assigned vlan", name));
+                          newUnitInterface.deactivate(InactiveReason.INCOMPLETE);
+                        }
 
                         // Don't create bind dependency for 'irb.XXX' interfcaes, since there isn't
                         // really an 'irb' interface

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Interface.java
@@ -20,7 +20,9 @@ public final class Interface implements Serializable {
     LOOPBACK,
     PHYSICAL,
     TUNNEL,
+    TUNNEL_UNIT,
     VLAN,
+    VLAN_UNIT,
   }
 
   public static final int DEFAULT_INTERFACE_MTU = 1500;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2040,8 +2040,14 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       case LOOPBACK:
         return InterfaceType.LOOPBACK;
       case TUNNEL:
+        // TODO: temporary hack until bind dependencies are removed
+        return InterfaceType.LOOPBACK;
+      case TUNNEL_UNIT:
         return InterfaceType.TUNNEL;
       case VLAN:
+        // TODO: temporary hack until bind dependencies are removed
+        return InterfaceType.LOOPBACK;
+      case VLAN_UNIT:
         return InterfaceType.VLAN;
       default:
         w.unimplemented("Unknown Palo Alto interface type " + panType);
@@ -3215,12 +3221,12 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     // Batfish cannot handle interfaces without a Vrf
     // So put orphaned interfaces in a constructed Vrf and shut them down
     Vrf nullVrf = new Vrf(NULL_VRF_NAME);
-    int oraphnedInterfaces = 0;
+    int orphanedInterfaces = 0;
     for (Entry<String, org.batfish.datamodel.Interface> i : _c.getAllInterfaces().entrySet()) {
       org.batfish.datamodel.Interface iface = i.getValue();
       if (iface.getVrf() == null) {
         iface.setVrf(nullVrf);
-        oraphnedInterfaces++;
+        orphanedInterfaces++;
         if (iface.getDependencies().stream().anyMatch(d -> d.getType() == DependencyType.BIND)) {
           // This is a child interface. Just shut it down.
           iface.deactivate(INCOMPLETE);
@@ -3264,7 +3270,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       }
     }
     // Don't pollute VI model will null VRF unless we have to.
-    if (oraphnedInterfaces > 0) {
+    if (orphanedInterfaces > 0) {
       _c.getVrfs().put(nullVrf.getName(), nullVrf);
     }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.BgpPeerConfig.ALL_AS_NUMBERS;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.InactiveReason.INCOMPLETE;
 import static org.batfish.datamodel.Names.generatedBgpCommonExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
@@ -35,6 +36,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDependencies;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasEncapsulationVlan;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInactiveReason;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMlagId;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
@@ -1370,8 +1372,10 @@ public final class CumulusNcluGrammarTest {
 
     // vlan-id
     assertThat(c, hasInterface("vlan2", hasVlan(2)));
-    assertThat(c, hasInterface("vlan3", hasVlan(nullValue())));
-    assertThat(c, hasInterface("vlan4", hasVlan(nullValue())));
+    assertThat(
+        c, hasInterface("vlan3", allOf(hasVlan(nullValue()), hasInactiveReason(INCOMPLETE))));
+    assertThat(
+        c, hasInterface("vlan4", allOf(hasVlan(nullValue()), hasInactiveReason(INCOMPLETE))));
     assertThat(c, hasInterface("vlan5", hasVlan(6)));
 
     // ip address

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
@@ -32,6 +32,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAddress;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasBandwidth;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDependencies;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInactiveReason;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSpeed;
@@ -196,6 +197,7 @@ import org.batfish.datamodel.FilterResult;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDiff;
 import org.batfish.datamodel.IcmpType;
+import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.InterfaceType;
@@ -3624,8 +3626,8 @@ public final class F5BigipStructuredGrammarTest {
     String vlanName = "/Common/MYVLAN";
 
     assertThat(
-        c.getAllInterfaces().keySet(),
-        containsInAnyOrder(portName, trunkName, "2.0", "3.0", vlanName));
+        c.getAllInterfaces(),
+        hasKeys(portName, trunkName, "2.0", "3.0", "4.0", vlanName, "/Common/MISSINGTAG"));
 
     // port interface
     assertThat(c, hasInterface(portName, isActive()));
@@ -3648,6 +3650,7 @@ public final class F5BigipStructuredGrammarTest {
     assertThat(c, hasInterface(vlanName, hasVlan(123)));
     assertThat(c, hasInterface(vlanName, hasAddress("10.0.0.1/24")));
     assertThat(c, hasInterface(vlanName, hasInterfaceType(InterfaceType.VLAN)));
+    assertThat(c, hasInterface("/Common/MISSINGTAG", hasInactiveReason(InactiveReason.INCOMPLETE)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3140,9 +3140,7 @@ public final class FlatJuniperGrammarTest {
 
     // all interfaces should show up; no need to test their specific settings here
     Configuration c = parseConfig("interface-range");
-    assertThat(
-        c.getAllInterfaces().keySet(),
-        equalTo(ImmutableSet.of("xe-0/0/0", "xe-0/0/1", "xe-8/1/2")));
+    assertThat(c.getAllInterfaces(), hasKeys("xe-0/0/0", "xe-0/0/1", "xe-8/1/2", "reth0"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -48,6 +48,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isLineUp;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.accepts;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
+import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.datamodel.matchers.NssaSettingsMatchers.hasDefaultOriginateType;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasNssa;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasStub;
@@ -4469,5 +4470,14 @@ public final class PaloAltoGrammarTest {
     assertThat(ccae, hasNumReferrers(filename, SERVICE, service2Name, 1));
     assertThat(ccae, hasNumReferrers(filename, APPLICATION_GROUP, appGroup1Name, 1));
     assertThat(ccae, hasNumReferrers(filename, APPLICATION_GROUP, appGroup2Name, 1));
+  }
+
+  // TODO: remove fake interfaces "vlan" and "tunnel" and associated bind dependencies
+  @Test(expected = AssertionError.class)
+  public void testVlanTunnelUnits() {
+    String hostname = "paloalto_vlan_tunnel_units";
+    Configuration c = parseConfig(hostname);
+    // Do not convert parents "tunnel" and "vlan", which are not real interfaces.
+    assertThat(c.getAllInterfaces(), hasKeys("vlan.1", "tunnel.3"));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
@@ -16,17 +16,22 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.SortedMap;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.AclAclLine;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Interface.Dependency;
+import org.batfish.datamodel.Interface.DependencyType;
+import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
@@ -34,6 +39,7 @@ import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.VrrpGroup;
 import org.batfish.datamodel.acl.AndMatchExpr;
@@ -332,5 +338,150 @@ public final class ConvertConfigurationJobTest {
             hasText(
                 "Removing reference to undefined track 'missing' on static route for prefix"
                     + " 0.0.0.0/0 in vrf 'default'")));
+  }
+
+  @Test
+  public void testVerifyInterfaces() {
+    InterfaceAddress address = ConcreteInterfaceAddress.parse("1.1.1.1/24");
+
+    Configuration c =
+        Configuration.builder()
+            .setHostname("c")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setDefaultCrossZoneAction(LineAction.PERMIT)
+            .setDefaultInboundAction(LineAction.PERMIT)
+            .build();
+    Vrf v = Vrf.builder().setName("v").setOwner(c).build();
+    // good
+    Interface.builder()
+        .setName("switchportOnModeAccess")
+        .setSwitchport(true)
+        .setSwitchportMode(SwitchportMode.ACCESS)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // bad
+    Interface.builder()
+        .setName("switchportOnModeNone")
+        .setSwitchport(true)
+        .setSwitchportMode(SwitchportMode.NONE)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // bad
+    Interface.builder()
+        .setName("switchportOffModeAccess")
+        .setSwitchport(false)
+        .setSwitchportMode(SwitchportMode.ACCESS)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // bad
+    Interface.builder()
+        .setName("switchportAndL3")
+        .setSwitchport(true)
+        .setSwitchportMode(SwitchportMode.ACCESS)
+        .setAddress(address)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // bad
+    Interface.builder()
+        .setName("vlanNoVlan")
+        .setType(InterfaceType.VLAN)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // good
+    Interface.builder()
+        .setName("vlanWithVlan")
+        .setType(InterfaceType.VLAN)
+        .setVlan(5)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // bad
+    Interface.builder()
+        .setName("channelGroupAndL3")
+        .setType(InterfaceType.PHYSICAL)
+        .setChannelGroup("aggregated")
+        .setAddress(address)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // good
+    Interface.builder()
+        .setName("aggregated")
+        .setType(InterfaceType.AGGREGATED)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // good
+    Interface.builder()
+        .setName("channelGroup")
+        .setType(InterfaceType.PHYSICAL)
+        .setChannelGroup("aggregated")
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // bad
+    Interface.builder()
+        .setName("l3AndParentChannelGroup")
+        .setType(InterfaceType.LOGICAL)
+        .setDependencies(ImmutableSet.of(new Dependency("channelGroup", DependencyType.BIND)))
+        .setAddress(address)
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // bad
+    Interface.builder()
+        .setName("missingBindDep")
+        .setType(InterfaceType.LOGICAL)
+        .setDependencies(ImmutableSet.of(new Dependency("undefined", DependencyType.BIND)))
+        .setVrf(v)
+        .setOwner(c)
+        .build();
+    // bad
+    Interface missingAggregateDep =
+        Interface.builder()
+            .setName("missingAggregateDep")
+            .setType(InterfaceType.AGGREGATED)
+            .setDependencies(ImmutableSet.of(new Dependency("undefined", DependencyType.AGGREGATE)))
+            .setVrf(v)
+            .setOwner(c)
+            .build();
+
+    Warnings w = new Warnings(false, true, false);
+    finalizeConfiguration(c, w);
+
+    assertThat(
+        w.getRedFlagWarnings(),
+        containsInAnyOrder(
+            hasText("Interface switchportOnModeNone has switchport true but switchport mode NONE"),
+            hasText(
+                "Interface switchportOffModeAccess has switchport false but switchport mode"
+                    + " ACCESS"),
+            hasText("Interface switchportAndL3 is a switchport, but it has L3 addresses"),
+            hasText("Interface vlanNoVlan is a VLAN interface but has no vlan set"),
+            hasText(
+                "Interface channelGroupAndL3 is a member of AGGREGATED interface aggregated but it"
+                    + " has L3 addresses"),
+            hasText(
+                "Interface l3AndParentChannelGroup is a child of a member of AGGREGATED interface"
+                    + " aggregated but it has L3 addresses"),
+            hasText(
+                "Interface missingBindDep has a bind dependency on missing interface undefined"),
+            hasText(
+                "Interface missingAggregateDep has an aggregate dependency on missing interface"
+                    + " undefined")));
+    assertThat(
+        c.getAllInterfaces(),
+        hasKeys(
+            "switchportOnModeAccess",
+            "vlanWithVlan",
+            "aggregated",
+            "channelGroup",
+            "missingAggregateDep"));
+    assertThat(missingAggregateDep.getDependencies(), empty());
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/eos-port-channel
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/eos-port-channel
@@ -18,3 +18,4 @@ interface Port-Channel1
 !
 interface Port-Channel2
 !
+interface Port-Channel3

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_vrf_references
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_vrf_references
@@ -7,6 +7,7 @@ net add bond bond1 vrf vrf1
 net add interface eth0 clag backup-ip 192.0.2.1 vrf vrf1
 net add interface eth0 vrf vrf1
 net add vlan 2 vrf vrf1
+net add vlan 2 vlan-id 2
 net add routing route-map rm1 permit 1 match interface vrf1
 net add vrf vrf1
 net add interface swp0 vrf vrf2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/f5_bigip_imish/testconfigs/f5_bigip_imish_ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/f5_bigip_imish/testconfigs/f5_bigip_imish_ospf
@@ -51,16 +51,19 @@ net vlan /Common/vlan_active {
     interfaces {
         1.1 { }
     }
+    tag 1
 }
 net vlan /Common/vlan_active_nbma {
     interfaces {
         1.2 { }
     }
+    tag 2
 }
 net vlan /Common/vlan_passive {
     interfaces {
         2.1 { }
     }
+    tag 3
 }
 
 security firewall rule-list /Common/_sys_self_allow_defaults {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/f5_bigip_structured/testconfigs/f5_bigip_structured_vlan
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/f5_bigip_structured/testconfigs/f5_bigip_structured_vlan
@@ -15,12 +15,21 @@ net interface 3.0 {
     bundle enabled
     bundle-speed 40G
 }
+net interface 4.0 {
+    bundle enabled
+    bundle-speed 40G
+}
 net vlan /Common/MYVLAN {
     interfaces {
         1.0 { }
         trunk1 { }
     }
     tag 123
+}
+net vlan /Common/MISSINGTAG {
+    interfaces {
+        4.0 { }
+    }
 }
 net self /Common/MYSELF {
     address 10.0.0.1/24

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-range
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-range
@@ -13,3 +13,5 @@ set interfaces interface-range ae2-members description dodo
 set interfaces interface-range ae2-members member xe-8/1/2
 set interfaces interface-range ae2-members gigether-options redundant-parent reth0
 set interfaces interface-range ae2-members gigether-options 802.3ad ae1
+
+set interfaces reth0 mtu 1500

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/paloalto_vlan_tunnel_units
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/paloalto_vlan_tunnel_units
@@ -1,0 +1,29 @@
+!RANCID-CONTENT-TYPE: paloalto
+config {
+  devices {
+    localhost.localdomain {
+      deviceconfig {
+        system {
+          hostname "paloalto_vlan_tunnel_units";
+        }
+      }
+      network {
+        interface {
+          tunnel {
+            units {
+              tunnel.3 {
+                comment "tunnel.3 comment";
+              }
+            }
+          }
+          vlan {
+            comment "vlan comment";
+            units {
+              vlan.1;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1380,6 +1380,13 @@
         "Comment" : "This feature is not currently supported"
       },
       {
+        "Filename" : "configs/palo_alto/interfaces",
+        "Line" : 49,
+        "Text" : "vlan.1",
+        "Parser_Context" : "[sniv_unit sniv_units sni_vlan sn_interface s_network statement_config_devices set_line_config_devices set_line_tail set_line palo_alto_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
         "Filename" : "configs/palo_alto/nat",
         "Line" : 19,
         "Text" : "active-active-device-binding primary",
@@ -1409,10 +1416,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 195 results",
+      "notes" : "Found 196 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 195
+      "numResults" : 196
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -70576,6 +70576,16 @@
             }
           ]
         },
+        "configs/palo_alto/interfaces" : {
+          "Parse warnings" : [
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 49,
+              "Parser_Context" : "[sniv_unit sniv_units sni_vlan sn_interface s_network statement_config_devices set_line_config_devices set_line_tail set_line palo_alto_configuration]",
+              "Text" : "vlan.1"
+            }
+          ]
+        },
         "configs/palo_alto/nat" : {
           "Parse warnings" : [
             {
@@ -70673,7 +70683,7 @@
         "cisco_enable" : "PASSED",
         "cisco_flow" : "PASSED",
         "cisco_hardware" : "PASSED",
-        "cisco_interface" : "PASSED",
+        "cisco_interface" : "WARNINGS",
         "cisco_ios_neighbor" : "PASSED",
         "cisco_ip" : "PASSED",
         "cisco_ip_nat" : "PASSED",
@@ -70755,7 +70765,7 @@
         "host1" : "PASSED",
         "host2" : "PASSED",
         "if_tag_is" : "PASSED",
-        "interface-reth" : "PASSED",
+        "interface-reth" : "WARNINGS",
         "interface_exit" : "PASSED",
         "interface_sdr" : "PASSED",
         "interfacemtu" : "PASSED",
@@ -70875,7 +70885,7 @@
         "variables" : "PASSED",
         "variables_dos" : "PASSED",
         "vlan_access_map4" : "PASSED",
-        "vmx4" : "PASSED",
+        "vmx4" : "WARNINGS",
         "xr_dhcp" : "PASSED",
         "xr_ipsla" : "PASSED",
         "xr_multicast" : "PASSED",
@@ -85334,6 +85344,14 @@
             }
           ]
         },
+        "cisco_interface" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Deactivating interface Ethernet0 that refers to undefined channel-group Port-channel1"
+            }
+          ]
+        },
         "cisco_ip_route" : {
           "Red flags" : [
             {
@@ -85384,6 +85402,18 @@
         },
         "cumulus_nclu" : {
           "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Disabling invalid interface 'swp1' because has L3 settings but is a bond slave of 'bond1'"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Disabling invalid interface 'swp2' because has L3 settings but is a bond slave of 'bond1'"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Disabling invalid interface 'swp3' because has L3 settings but is a bond slave of 'bond1'"
+            },
             {
               "tag" : "MISCELLANEOUS",
               "text" : "No support for VLAN switching options on non-'bridge bridge' port: 'bond1'"
@@ -85499,6 +85529,18 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Could not determine update source for BGP neighbor: '10.0.0.1'"
+            }
+          ]
+        },
+        "interface-reth" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Refusing to convert illegal unit 'ge-0/0/0.0' on parent that is a member of a redundant ethernet group 'reth0'"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Refusing to convert illegal unit 'ge-0/0/1.0' on parent that is a member of a redundant ethernet group 'reth0'"
             }
           ]
         },
@@ -85628,6 +85670,10 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Configuration will not actually commit. Cannot create VRRP group for vrid 5 on interface 'irb.5' because no virtual-address is assigned."
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Deactivating irb.5 because it has no assigned vlan"
             }
           ]
         },
@@ -85768,6 +85814,14 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "NAT rule MISSING_TO ignored because it has no to zone configured"
+            }
+          ]
+        },
+        "vmx4" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Deactivating irb.100 because it has no assigned vlan"
             }
           ]
         }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -70885,7 +70885,7 @@
         "variables" : "PASSED",
         "variables_dos" : "PASSED",
         "vlan_access_map4" : "PASSED",
-        "vmx4" : "WARNINGS",
+        "vmx4" : "PASSED",
         "xr_dhcp" : "PASSED",
         "xr_ipsla" : "PASSED",
         "xr_multicast" : "PASSED",
@@ -85404,18 +85404,6 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Disabling invalid interface 'swp1' because has L3 settings but is a bond slave of 'bond1'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Disabling invalid interface 'swp2' because has L3 settings but is a bond slave of 'bond1'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Disabling invalid interface 'swp3' because has L3 settings but is a bond slave of 'bond1'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "No support for VLAN switching options on non-'bridge bridge' port: 'bond1'"
             },
             {
@@ -85429,6 +85417,18 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "No support for VLAN switching options on non-'bridge bridge' port: 'swp2'"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Refusing to add slave swp1 to bond bond1 because it is used for BGP unnumbered"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Refusing to add slave swp2 to bond bond1 because it is used for BGP unnumbered"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Refusing to add slave swp3 to bond bond1 because it is used for BGP unnumbered"
             },
             {
               "tag" : "MISCELLANEOUS",
@@ -85814,14 +85814,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "NAT rule MISSING_TO ignored because it has no to zone configured"
-            }
-          ]
-        },
-        "vmx4" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Deactivating irb.100 because it has no assigned vlan"
             }
           ]
         }


### PR DESCRIPTION
- Update verifyInterfaces to:
  - disable VLAN interfaces without vlan set
  - disable members or children of members of an aggregate/redundant interface that have L3 settings
  - remove undefined aggregate dependencies
  - remove interfaces with undefined bind dependencies
- Fix conversion on various vendors to avoid interfaces being disabled in verifyInterfaces

Differences from original PR batfish/batfish#8174:
- `CumulusNcluConfiguration`:
  - Instead of removing bonds with invalid slaves, just don't add invalid slaves
    - prevents undefined BIND dependency on bond subinterfaces
  - Also consider slave used for BGP unnumbered as invalid slave
  - Remove accidental extraneous interface disabling code