### PR TITLE
Migrate BDDRoute off BDDFiniteDomain

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -47,6 +47,11 @@ public class BDDDomain<T> {
     return _integer.value(idx);
   }
 
+  public T satAssignmentToValue(BDD satAssignment) {
+    Long idx = _integer.satAssignmentToLong(satAssignment);
+    return _values.get(idx.intValue());
+  }
+
   public void setValue(T value) {
     int idx = _values.indexOf(value);
     _integer.setValue(idx);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -1,5 +1,6 @@
 package org.batfish.minesweeper.bdd;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.math.IntMath;
 import java.math.RoundingMode;
@@ -14,7 +15,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
-import org.batfish.common.bdd.BDDFiniteDomain;
 import org.batfish.common.bdd.BDDInteger;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.RoutingProtocol;
@@ -101,7 +101,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
 
   private final BDDInteger _prefixLength;
 
-  private final BDDFiniteDomain<RoutingProtocol> _protocolHistory;
+  private final BDDDomain<RoutingProtocol> _protocolHistory;
 
   private BDDInteger _tag;
 
@@ -148,8 +148,8 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
 
     int idx = 0;
     _protocolHistory =
-        new BDDFiniteDomain<>(factory, idx, ImmutableSet.copyOf(RoutingProtocol.values()));
-    int len = _protocolHistory.getVar().size();
+        new BDDDomain<>(factory, ImmutableList.copyOf(RoutingProtocol.values()), idx);
+    int len = _protocolHistory.getInteger().size();
     addBitNames("proto", len, idx, false);
     idx += len;
     // Initialize integer values
@@ -217,9 +217,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     _med = new BDDInteger(other._med);
     _tag = new BDDInteger(other._tag);
     _localPref = new BDDInteger(other._localPref);
-    _protocolHistory =
-        new BDDFiniteDomain<>(
-            other._protocolHistory.getVar(), other._protocolHistory.getValueBdds().keySet());
+    _protocolHistory = new BDDDomain<>(other._protocolHistory);
     _ospfMetric = new BDDDomain<>(other._ospfMetric);
     _bitNames = other._bitNames;
   }
@@ -265,9 +263,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    */
   public BDD anyProtocolIn(Set<RoutingProtocol> protocols) {
     return _factory.orAll(
-        protocols.stream()
-            .map(_protocolHistory::getConstraintForValue)
-            .collect(Collectors.toList()));
+        protocols.stream().map(_protocolHistory::value).collect(Collectors.toList()));
   }
 
   /**
@@ -444,7 +440,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     return _prefixLength;
   }
 
-  public BDDFiniteDomain<RoutingProtocol> getProtocolHistory() {
+  public BDDDomain<RoutingProtocol> getProtocolHistory() {
     return _protocolHistory;
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -1124,7 +1124,7 @@ public class TransferBDD {
     for (int i = 0; i < rec.getAsPathRegexAtomicPredicates().length; i++) {
       rec.getAsPathRegexAtomicPredicates()[i] = _factory.zero();
     }
-    rec.getProtocolHistory().getVar().setValue(0);
+    rec.getProtocolHistory().getInteger().setValue(0);
     return rec;
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
@@ -255,8 +254,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     builder.setAdmin((int) (long) r.getAdminDist().satAssignmentToLong(fullModel));
     builder.setMetric(r.getMed().satAssignmentToLong(fullModel));
     builder.setTag(r.getTag().satAssignmentToLong(fullModel));
-
-    builder.setProtocol(r.getProtocolHistory().getValueFromAssignment(fullModel));
+    builder.setProtocol(r.getProtocolHistory().satAssignmentToValue(fullModel));
 
     Set<Community> communities = satAssignmentToCommunities(fullModel, r, configAPs);
     builder.setCommunities(communities);
@@ -280,7 +278,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
   private BDD constraintsToModel(BDD constraints, ConfigAtomicPredicates configAPs) {
     BDDRoute route = new BDDRoute(constraints.getFactory(), configAPs);
     // set the protocol field to BGP if it is consistent with the constraints
-    BDD isBGP = route.getProtocolHistory().getConstraintForValue(RoutingProtocol.BGP);
+    BDD isBGP = route.getProtocolHistory().value(RoutingProtocol.BGP);
     BDD augmentedConstraints = constraints.and(isBGP);
     if (!augmentedConstraints.isZero()) {
       return augmentedConstraints.fullSatOne();
@@ -550,28 +548,6 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     TableAnswerElement answerElement = new TableAnswerElement(TestRoutePoliciesAnswerer.metadata());
     answerElement.postProcessAnswer(_question, rows);
     return answerElement;
-  }
-
-  @Nullable
-  private static org.batfish.datamodel.questions.BgpRoute toQuestionsBgpRoute(
-      @Nullable Bgpv4Route dataplaneBgpRoute) {
-    if (dataplaneBgpRoute == null) {
-      return null;
-    }
-    return org.batfish.datamodel.questions.BgpRoute.builder()
-        .setNextHopIp(dataplaneBgpRoute.getNextHopIp())
-        .setProtocol(dataplaneBgpRoute.getProtocol())
-        .setSrcProtocol(dataplaneBgpRoute.getSrcProtocol())
-        .setOriginType(dataplaneBgpRoute.getOriginType())
-        .setOriginatorIp(dataplaneBgpRoute.getOriginatorIp())
-        .setMetric(dataplaneBgpRoute.getMetric())
-        .setLocalPreference(dataplaneBgpRoute.getLocalPreference())
-        .setTag(dataplaneBgpRoute.getTag())
-        .setWeight(dataplaneBgpRoute.getWeight())
-        .setNetwork(dataplaneBgpRoute.getNetwork())
-        .setCommunities(dataplaneBgpRoute.getCommunities().getCommunities())
-        .setAsPath(dataplaneBgpRoute.getAsPath())
-        .build();
   }
 
   @Nonnull

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -20,7 +20,6 @@ import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.JFactory;
 import org.batfish.common.NetworkSnapshot;
-import org.batfish.common.bdd.BDDFiniteDomain;
 import org.batfish.common.bdd.BDDInteger;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.common.plugin.IBatfish;
@@ -1354,12 +1353,10 @@ public class TransferBDDTest {
 
     BDDRoute anyRoute = anyRoute(tbdd.getFactory());
 
-    BDDFiniteDomain<RoutingProtocol> protocol = anyRoute.getProtocolHistory();
+    BDDDomain<RoutingProtocol> protocol = anyRoute.getProtocolHistory();
     assertEquals(
         acceptedAnnouncements,
-        protocol
-            .getConstraintForValue(RoutingProtocol.BGP)
-            .or(protocol.getConstraintForValue(RoutingProtocol.OSPF)));
+        protocol.value(RoutingProtocol.BGP).or(protocol.value(RoutingProtocol.OSPF)));
     assertEquals(tbdd.iteZero(acceptedAnnouncements, anyRoute), outAnnouncements);
   }
 


### PR DESCRIPTION
BDDRoute was using BDDDomain and BDDFiniteDomain, which are currently similar but will soon diverge. Standardize on BDDDomain.