### PR TITLE
Split BDDInteger into two classes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
@@ -25,7 +25,7 @@ public final class BDDFiniteDomain<V> {
   private @Nonnull final BiMap<BDD, V> _bddToValue;
   private @Nonnull final BDD _isValidValue;
   private @Nullable final BDD _varBits;
-  private @Nonnull final BDDInteger _var;
+  private @Nonnull final ImmutableBDDInteger _var;
 
   /** Allocate a variable sufficient for the given set of values. */
   public BDDFiniteDomain(BDDPacket pkt, String varName, Set<V> values) {
@@ -38,12 +38,13 @@ public final class BDDFiniteDomain<V> {
    */
   public BDDFiniteDomain(BDDFactory factory, int index, Set<V> values) {
     this(
-        BDDInteger.makeFromIndex(factory, computeBitsRequired(values.size()), index, false),
+        ImmutableBDDInteger.makeFromIndex(
+            factory, computeBitsRequired(values.size()), index, false),
         values);
   }
 
   /** Use the given variable to represent the given set of values. */
-  public BDDFiniteDomain(BDDInteger var, Set<V> values) {
+  public BDDFiniteDomain(ImmutableBDDInteger var, Set<V> values) {
     int size = values.size();
     BDD one = var.getFactory().one();
     _var = var;
@@ -86,7 +87,7 @@ public final class BDDFiniteDomain<V> {
     checkArgument(!values.isEmpty(), "empty values map");
     int maxSize = values.values().stream().mapToInt(Set::size).max().getAsInt();
     int bitsRequired = computeBitsRequired(maxSize);
-    BDDInteger var = pkt.allocateBDDInteger(varName, bitsRequired);
+    ImmutableBDDInteger var = pkt.allocateBDDInteger(varName, bitsRequired);
     return toImmutableMap(
         values, Entry::getKey, entry -> new BDDFiniteDomain<>(var, entry.getValue()));
   }
@@ -114,7 +115,7 @@ public final class BDDFiniteDomain<V> {
     checkArgument(bdd.isAssignment());
 
     // Exist turns the assignment into just the finite domain.
-    V ret = _bddToValue.get(bdd.project(_var.getVars()));
+    V ret = _bddToValue.get(bdd.project(_varBits));
     checkArgument(ret != null, "No value for valid assignment");
     return ret;
   }
@@ -128,7 +129,7 @@ public final class BDDFiniteDomain<V> {
   }
 
   @Nonnull
-  public BDDInteger getVar() {
+  public ImmutableBDDInteger getVar() {
     return _var;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpCode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpCode.java
@@ -8,9 +8,9 @@ import org.batfish.datamodel.IcmpCode;
 
 /** Symbolic {@link IcmpCode} variable represented by an 8-bit BDD. */
 public final class BDDIcmpCode {
-  private final BDDInteger _var;
+  private final ImmutableBDDInteger _var;
 
-  public BDDIcmpCode(BDDInteger var) {
+  public BDDIcmpCode(ImmutableBDDInteger var) {
     checkArgument(var.size() == 8, "IcmpCode field requires 8 bits");
     _var = var;
   }
@@ -54,8 +54,8 @@ public final class BDDIcmpCode {
     return end == IcmpCode.UNSET ? _var.getFactory().one() : _var.leq(end);
   }
 
-  /** Returns the {@link BDDInteger} backing this. */
-  public BDDInteger getBDDInteger() {
+  /** Returns the {@link ImmutableBDDInteger} backing this. */
+  public ImmutableBDDInteger getBDDInteger() {
     return _var;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpType.java
@@ -8,9 +8,9 @@ import org.batfish.datamodel.IcmpType;
 
 /** Symbolic IcmpType variable represented by an 8-bit BDD. */
 public final class BDDIcmpType {
-  private final BDDInteger _var;
+  private final ImmutableBDDInteger _var;
 
-  public BDDIcmpType(BDDInteger var) {
+  public BDDIcmpType(ImmutableBDDInteger var) {
     checkArgument(var.size() == 8, "IcmpType field requires 8 bits");
     _var = var;
   }
@@ -20,15 +20,6 @@ public final class BDDIcmpType {
    */
   public BDD value(int icmpType) {
     return icmpType == IcmpType.UNSET ? _var.getFactory().one() : _var.value(icmpType);
-  }
-
-  /**
-   * Extract the value from a satisfying assignment.
-   *
-   * @param satAssignment a satisfying assignment (i.e. produced by fullSat, allSat, etc)
-   */
-  public int satAssignmentToValue(BDD satAssignment) {
-    return _var.satAssignmentToLong(satAssignment).intValue();
   }
 
   /**
@@ -54,8 +45,8 @@ public final class BDDIcmpType {
     return end == IcmpType.UNSET ? _var.getFactory().one() : _var.leq(end);
   }
 
-  /** Returns the {@link BDDInteger} backing this. */
-  public BDDInteger getBDDInteger() {
+  /** Returns the {@link ImmutableBDDInteger} backing this. */
+  public ImmutableBDDInteger getBDDInteger() {
     return _var;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -1,72 +1,33 @@
 package org.batfish.common.bdd;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import net.sf.javabdd.BDD;
-import net.sf.javabdd.BDDException;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 
-public class BDDInteger {
-
-  private final BDDFactory _factory;
-  private final BDD[] _bitvec;
-  private final long _maxVal;
+public abstract class BDDInteger {
+  protected final BDDFactory _factory;
+  protected final BDD[] _bitvec;
+  protected final long _maxVal;
 
   // Temporary ArrayLists used to optimize some internal computations.
   private final List<BDD> _trues;
   private final List<BDD> _falses;
 
-  /** Certain API calls are only valid when this BDD has only variables in it. */
-  private boolean _hasVariablesOnly;
-
-  private BDD _vars;
-
-  /*
-   * Create an integer, but don't initialize its bit values
-   */
-  private BDDInteger(BDDFactory factory, int length) {
-    checkArgument(length < 64, "Only lengths up to 63 are supported");
+  protected BDDInteger(BDDFactory factory, BDD[] bitvec) {
+    checkArgument(bitvec.length < 64, "Only lengths up to 63 are supported");
     _factory = factory;
-    _bitvec = new BDD[length];
-    _maxVal = 0xFFFF_FFFF_FFFF_FFFFL >>> (64 - length);
-    _hasVariablesOnly = false;
-    _trues = new ArrayList<>(length);
-    _falses = new ArrayList<>(length);
-  }
-
-  public BDDInteger(BDDFactory factory, BDD[] bitvec) {
-    this(factory, bitvec.length);
-    _hasVariablesOnly = true; // TODO enforce this
-    for (int i = 0; i < bitvec.length; i++) {
-      _bitvec[i] = bitvec[i];
-    }
-  }
-
-  public BDDInteger(BDDInteger other) {
-    this(other._factory, other._bitvec.length);
-    setValue(other);
-  }
-
-  /**
-   * Returns true if this {@link BDDInteger} has only variables in its bitvec, as opposed to
-   * zero/one and more complex BDDs.
-   *
-   * <p>This is typically true only for {@link BDDInteger} values constructed from {@link
-   * BDDInteger#makeFromIndex(BDDFactory, int, int, boolean)} or copied from them.
-   */
-  public boolean hasVariablesOnly() {
-    return _hasVariablesOnly;
+    _bitvec = bitvec;
+    _maxVal = 0xFFFF_FFFF_FFFF_FFFFL >>> (64 - bitvec.length);
+    _trues = new ArrayList<>(bitvec.length);
+    _falses = new ArrayList<>(bitvec.length);
   }
 
   /** Returns the number of bits in this {@link BDDInteger}. */
@@ -74,90 +35,10 @@ public class BDDInteger {
     return _bitvec.length;
   }
 
-  /**
-   * Create an integer, and initialize its values as "don't care" This requires knowing the start
-   * index variables the bitvector will use.
-   */
-  public static BDDInteger makeFromIndex(
-      BDDFactory factory, int length, int start, boolean reverse) {
-    assert factory.varNum() >= start + length;
-
-    BDDInteger bdd = new BDDInteger(factory, length);
-    for (int i = 0; i < length; i++) {
-      int idx;
-      if (reverse) {
-        idx = start + length - i - 1;
-      } else {
-        idx = start + i;
-      }
-      bdd._bitvec[i] = bdd._factory.ithVar(idx);
-    }
-    bdd._hasVariablesOnly = true;
-    return bdd;
-  }
-
   /** Find a representative value of the represented integer that satisfies a given constraint. */
-  public Optional<Long> getValueSatisfying(BDD bdd) {
-    if (bdd.isZero()) {
-      return Optional.empty();
-    }
-    if (_hasVariablesOnly) {
-      return Optional.of(satAssignmentToLong(bdd.minAssignmentBits()));
-    }
-    return Optional.of(satAssignmentToLong(bdd.satOne()));
-  }
+  public abstract Optional<Long> getValueSatisfying(BDD bdd);
 
-  /**
-   * Returns the smallest long consistent with the input assignment and this {@link BDDInteger}.
-   *
-   * <p>When this {@link BDDInteger#hasVariablesOnly()} is {@code false}, this function will perform
-   * better if the assignment {@link BDD} is smaller, i.e., is produced by {@link BDD#satOne()}
-   * instead of {@link BDD#fullSatOne()}.
-   */
-  public Long satAssignmentToLong(BDD satAssignment) {
-    checkArgument(satAssignment.isAssignment(), "not a satisfying assignment");
-
-    if (_hasVariablesOnly) {
-      // Shortcut for performance.
-      return satAssignmentToLong(satAssignment.minAssignmentBits());
-    }
-
-    if (_bitvec.length > Long.SIZE) {
-      throw new IllegalArgumentException(
-          "Can't get a representative of a BDDInteger with more than Long.SIZE bits");
-    }
-
-    long value = 0;
-    for (int i = 0; i < _bitvec.length; i++) {
-      BDD bitBDD = _bitvec[_bitvec.length - i - 1];
-      // a.diff(b) is a.and(b.not()). When the input is only a partial assignment (like satOne),
-      // this biases towards lexicographically smaller solutions: set a 1 only if you can't set 0.
-      if (!satAssignment.diffSat(bitBDD)) {
-        value |= 1L << i;
-      }
-    }
-    return value;
-  }
-
-  public Long satAssignmentToLong(BitSet bits) {
-    checkState(
-        _hasVariablesOnly,
-        "satAssignmentToLong can only be called on a BDDInteger with hasVariablesOnly() true");
-
-    if (_bitvec.length > Long.SIZE) {
-      throw new IllegalArgumentException(
-          "Can't get a representative of a BDDInteger with more than Long.SIZE bits");
-    }
-
-    long value = 0;
-    for (int i = 0; i < _bitvec.length; i++) {
-      BDD bitBDD = _bitvec[_bitvec.length - i - 1];
-      if (bits.get(bitBDD.level())) {
-        value |= 1L << i;
-      }
-    }
-    return value;
-  }
+  public abstract Long satAssignmentToLong(BDD satAssignment);
 
   /**
    * Return a list of values satisfying the input {@link BDD}, up to some maximum number.
@@ -183,14 +64,6 @@ public class BDDInteger {
       num++;
     }
     return values.build();
-  }
-
-  /** Create an integer and initialize it to a concrete value */
-  public static BDDInteger makeFromValue(BDDFactory factory, int length, long value) {
-    BDDInteger bdd = new BDDInteger(factory, length);
-    bdd.setValue(value);
-    bdd._hasVariablesOnly = false;
-    return bdd;
   }
 
   /** Build a constraint that matches the set of IPs contained by the input {@link Prefix}. */
@@ -239,18 +112,6 @@ public class BDDInteger {
       }
     }
     return _factory.andAll(_trues).diffWith(_factory.orAll(_falses));
-  }
-
-  /*
-   * Map an if-then-else over each bit in the bitvector
-   */
-  public BDDInteger ite(BDD b, BDDInteger other) {
-    BDDInteger val = new BDDInteger(this);
-    for (int i = 0; i < _bitvec.length; i++) {
-      val._bitvec[i] = b.ite(_bitvec[i], other._bitvec[i]);
-    }
-    val._hasVariablesOnly = false;
-    return val;
   }
 
   /*
@@ -366,127 +227,7 @@ public class BDDInteger {
     return between;
   }
 
-  /*
-   * Set this BDD to have an exact value
-   */
-  public void setValue(long val) {
-    checkArgument(val >= 0, "Cannot set a negative value");
-    checkArgument(val <= _maxVal, "value %s is out of range [0, %s]", val, _maxVal);
-    long currentVal = val;
-    for (int i = _bitvec.length - 1; i >= 0; i--) {
-      if ((currentVal & 1) != 0) {
-        _bitvec[i] = _factory.one();
-      } else {
-        _bitvec[i] = _factory.zero();
-      }
-      currentVal >>= 1;
-    }
-    _hasVariablesOnly = false;
-  }
-
-  /*
-   * Set this BDD to be equal to another BDD
-   */
-  public void setValue(BDDInteger other) {
-    for (int i = 0; i < _bitvec.length; ++i) {
-      _bitvec[i] = other._bitvec[i].id();
-    }
-    _hasVariablesOnly = other._hasVariablesOnly;
-  }
-
-  /*
-   * Add two BDDs bitwise to create a new BDD
-   */
-  public BDDInteger add(BDDInteger other) {
-    BDD[] as = _bitvec;
-    BDD[] bs = other._bitvec;
-
-    checkArgument(as.length > 0, "Cannot add BDDIntegers of length 0");
-    checkArgument(as.length == bs.length, "Cannot add BDDIntegers of different length");
-
-    BDD carry = _factory.zero();
-    BDDInteger sum = new BDDInteger(_factory, as.length);
-    BDD[] cs = sum._bitvec;
-    for (int i = cs.length - 1; i > 0; --i) {
-      cs[i] = as[i].xor(bs[i]).xor(carry);
-      carry = as[i].and(bs[i]).or(carry.and(as[i].or(bs[i])));
-    }
-    cs[0] = as[0].xor(bs[0]).xor(carry);
-    sum._hasVariablesOnly = false;
-    return sum;
-  }
-
-  /*
-   * Subtract one BDD from another bitwise to create a new BDD
-   */
-  public BDDInteger sub(BDDInteger var1) {
-    if (_bitvec.length != var1._bitvec.length) {
-      throw new BDDException();
-    } else {
-      BDD var3 = _factory.zero();
-      BDDInteger var4 = new BDDInteger(_factory, _bitvec.length);
-      for (int var5 = var4._bitvec.length - 1; var5 >= 0; --var5) {
-        var4._bitvec[var5] = _bitvec[var5].xor(var1._bitvec[var5]);
-        var4._bitvec[var5] = var4._bitvec[var5].xor(var3.id());
-        BDD var6 = var1._bitvec[var5].or(var3);
-        BDD var7 = _bitvec[var5].less(var6);
-        var6.free();
-        var6 = _bitvec[var5].and(var1._bitvec[var5]);
-        var6 = var6.and(var3);
-        var6 = var6.or(var7);
-        var3 = var6;
-      }
-      var3.free();
-      var4._hasVariablesOnly = false;
-      return var4;
-    }
-  }
-
-  /** Returns a {@link BDD} containing all the variables of this {@link BDDInteger}. */
-  public @Nonnull BDD getVars() {
-    checkState(
-        _hasVariablesOnly,
-        "getVars can only be called on a BDDInteger with hasVariablesOnly() true");
-    if (_vars == null) {
-      _vars = _factory.andAll(_bitvec);
-    }
-    return _vars;
-  }
-
-  /**
-   * Returns a {@link BDD} containing the {@code n} high-order variables of this {@link BDDInteger}.
-   */
-  public @Nonnull BDD getMostSignificantVars(int n) {
-    checkState(
-        _hasVariablesOnly,
-        "getMostSignificantVars can only be called on a BDDInteger with hasVariablesOnly() true");
-    checkArgument(
-        n <= _bitvec.length,
-        "getMostSignificantVars(%s) called on a BDDInteger with only %s variables",
-        n,
-        _bitvec.length);
-    if (n == _bitvec.length) {
-      return getVars();
-    }
-    return _factory.andAll(Arrays.asList(_bitvec).subList(0, n));
-  }
-
   public BDDFactory getFactory() {
     return _factory;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (!(o instanceof BDDInteger)) {
-      return false;
-    }
-    BDDInteger other = (BDDInteger) o;
-    // No need to check _factory, and _hasVariablesOnly is 1-1 with _bitvec.
-    return Arrays.equals(_bitvec, other._bitvec);
-  }
-
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(_bitvec);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIpProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIpProtocol.java
@@ -9,9 +9,9 @@ import org.batfish.datamodel.IpProtocol;
 
 /** Symbolic IpProtocol variable represented by an 8-bit BDD. */
 public final class BDDIpProtocol {
-  private final BDDInteger _var;
+  private final ImmutableBDDInteger _var;
 
-  public BDDIpProtocol(BDDInteger var) {
+  public BDDIpProtocol(ImmutableBDDInteger var) {
     checkArgument(var.size() == 8, "IpProtocol field requires 8 bits");
     _var = var;
   }
@@ -43,9 +43,9 @@ public final class BDDIpProtocol {
   }
 
   /**
-   * @return the {@link BDDInteger} backing this.
+   * @return the {@link ImmutableBDDInteger} backing this.
    */
-  public BDDInteger getBDDInteger() {
+  public ImmutableBDDInteger getBDDInteger() {
     return _var;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -71,17 +71,17 @@ public class BDDPacket {
   private int _nextFreeBDDVarIdx = FIRST_PACKET_VAR;
 
   // Packet bits
-  private final @Nonnull BDDInteger _dscp;
-  private final @Nonnull BDDInteger _dstIp;
-  private final @Nonnull BDDInteger _dstPort;
-  private final @Nonnull BDDInteger _ecn;
-  private final @Nonnull BDDInteger _fragmentOffset;
+  private final @Nonnull ImmutableBDDInteger _dscp;
+  private final @Nonnull ImmutableBDDInteger _dstIp;
+  private final @Nonnull ImmutableBDDInteger _dstPort;
+  private final @Nonnull ImmutableBDDInteger _ecn;
+  private final @Nonnull ImmutableBDDInteger _fragmentOffset;
   private final @Nonnull BDDIcmpCode _icmpCode;
   private final @Nonnull BDDIcmpType _icmpType;
   private final @Nonnull BDDIpProtocol _ipProtocol;
   private final @Nonnull BDDPacketLength _packetLength;
-  private final @Nonnull BDDInteger _srcIp;
-  private final @Nonnull BDDInteger _srcPort;
+  private final @Nonnull ImmutableBDDInteger _srcIp;
+  private final @Nonnull ImmutableBDDInteger _srcPort;
   private final @Nonnull BDD _tcpAck;
   private final @Nonnull BDD _tcpCwr;
   private final @Nonnull BDD _tcpEce;
@@ -143,10 +143,10 @@ public class BDDPacket {
     BDD[] srcIpBitvec = allocateBDDBits("srcIp", IP_LENGTH);
     BDD[] dstPortBitvec = allocateBDDBits("dstPort", PORT_LENGTH);
     BDD[] srcPortBitvec = allocateBDDBits("srcPort", PORT_LENGTH);
-    _dstIp = new BDDInteger(_factory, dstIpBitvec);
-    _srcIp = new BDDInteger(_factory, srcIpBitvec);
-    _dstPort = new BDDInteger(_factory, dstPortBitvec);
-    _srcPort = new BDDInteger(_factory, srcPortBitvec);
+    _dstIp = new ImmutableBDDInteger(_factory, dstIpBitvec);
+    _srcIp = new ImmutableBDDInteger(_factory, srcIpBitvec);
+    _dstPort = new ImmutableBDDInteger(_factory, dstPortBitvec);
+    _srcPort = new ImmutableBDDInteger(_factory, srcPortBitvec);
     _ipProtocol = new BDDIpProtocol(allocateBDDInteger("ipProtocol", IP_PROTOCOL_LENGTH));
     _icmpCode = new BDDIcmpCode(allocateBDDInteger("icmpCode", ICMP_CODE_LENGTH));
     _icmpType = new BDDIcmpType(allocateBDDInteger("icmpType", ICMP_TYPE_LENGTH));
@@ -212,14 +212,14 @@ public class BDDPacket {
   }
 
   /**
-   * Allocate a new {@link BDDInteger} variable.
+   * Allocate a new {@link ImmutableBDDInteger} variable.
    *
    * @param name Used for debugging.
    * @param bits The number of bits to allocate.
    * @return The new variable.
    */
-  public BDDInteger allocateBDDInteger(String name, int bits) {
-    return new BDDInteger(_factory, allocateBDDBits(name, bits));
+  public ImmutableBDDInteger allocateBDDInteger(String name, int bits) {
+    return new ImmutableBDDInteger(_factory, allocateBDDBits(name, bits));
   }
 
   /**
@@ -346,27 +346,27 @@ public class BDDPacket {
   }
 
   @Nonnull
-  public BDDInteger getDscp() {
+  public ImmutableBDDInteger getDscp() {
     return _dscp;
   }
 
   @Nonnull
-  public BDDInteger getDstIp() {
+  public ImmutableBDDInteger getDstIp() {
     return _dstIp;
   }
 
   @Nonnull
-  public BDDInteger getDstPort() {
+  public ImmutableBDDInteger getDstPort() {
     return _dstPort;
   }
 
   @Nonnull
-  public BDDInteger getEcn() {
+  public ImmutableBDDInteger getEcn() {
     return _ecn;
   }
 
   @Nonnull
-  public BDDInteger getFragmentOffset() {
+  public ImmutableBDDInteger getFragmentOffset() {
     return _fragmentOffset;
   }
 
@@ -391,12 +391,12 @@ public class BDDPacket {
   }
 
   @Nonnull
-  public BDDInteger getSrcIp() {
+  public ImmutableBDDInteger getSrcIp() {
     return _srcIp;
   }
 
   @Nonnull
-  public BDDInteger getSrcPort() {
+  public ImmutableBDDInteger getSrcPort() {
     return _srcPort;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacketLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacketLength.java
@@ -7,9 +7,9 @@ import net.sf.javabdd.BDD;
 
 /** Symbolic packet length variable represented by a 16-bit {@link BDD}. */
 public final class BDDPacketLength {
-  private final BDDInteger _var;
+  private final ImmutableBDDInteger _var;
 
-  public BDDPacketLength(BDDInteger var) {
+  public BDDPacketLength(ImmutableBDDInteger var) {
     checkArgument(var.size() == 16, "Packet length field requires 16 bits");
     _var = var;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -95,7 +95,7 @@ public final class BDDSourceManager {
    * Create a {@link BDDSourceManager} that tracks the specified interfaces as sources, plus the
    * device itself.
    */
-  public static BDDSourceManager forInterfaces(BDDInteger var, Set<String> interfaces) {
+  public static BDDSourceManager forInterfaces(ImmutableBDDInteger var, Set<String> interfaces) {
     Set<String> sources =
         ImmutableSet.<String>builder()
             .addAll(interfaces)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
@@ -18,6 +18,21 @@ public class BDDUtils {
     return factory;
   }
 
+  public static BDD[] bitvector(BDDFactory factory, int length, int start, boolean reverse) {
+    checkArgument(factory.varNum() >= start + length, "Not enough variables to create bitvector");
+    BDD[] bitvec = new BDD[length];
+    for (int i = 0; i < length; i++) {
+      int idx;
+      if (reverse) {
+        idx = start + length - i - 1;
+      } else {
+        idx = start + i;
+      }
+      bitvec[i] = factory.ithVar(idx);
+    }
+    return bitvec;
+  }
+
   public static BDD[] concatBitvectors(BDD[]... arrays) {
     return Arrays.stream(arrays).flatMap(Arrays::stream).toArray(BDD[]::new);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/ImmutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/ImmutableBDDInteger.java
@@ -1,0 +1,78 @@
+package org.batfish.common.bdd;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static org.batfish.common.bdd.BDDUtils.bitvector;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+
+public class ImmutableBDDInteger extends BDDInteger {
+  private BDD _vars;
+
+  public ImmutableBDDInteger(BDDFactory factory, BDD[] bitvec) {
+    super(factory, bitvec);
+  }
+
+  /*
+   * Create an integer, and initialize its values as "don't care"
+   * This requires knowing the start index variables the bitvector
+   * will use.
+   */
+  public static ImmutableBDDInteger makeFromIndex(
+      BDDFactory factory, int length, int start, boolean reverse) {
+    return new ImmutableBDDInteger(factory, bitvector(factory, length, start, reverse));
+  }
+
+  @Override
+  public Optional<Long> getValueSatisfying(BDD bdd) {
+    return bdd.isZero()
+        ? Optional.empty()
+        : Optional.of(satAssignmentToLong(bdd.minAssignmentBits()));
+  }
+
+  /** Returns a {@link BDD} containing all the variables of this {@link BDDInteger}. */
+  public @Nonnull BDD getVars() {
+    if (_vars == null) {
+      _vars = _factory.andAll(_bitvec);
+    }
+    return _vars;
+  }
+
+  /**
+   * Returns a {@link BDD} containing the {@code n} high-order variables of this {@link BDDInteger}.
+   */
+  public @Nonnull BDD getMostSignificantVars(int n) {
+    checkState(n <= _bitvec.length);
+    if (n == _bitvec.length) {
+      return getVars();
+    }
+    return _factory.andAll(Arrays.copyOf(_bitvec, n));
+  }
+
+  @Override
+  public Long satAssignmentToLong(BDD satAssignment) {
+    checkArgument(satAssignment.isAssignment(), "not a satisfying assignment");
+    return satAssignmentToLong(satAssignment.minAssignmentBits());
+  }
+
+  public Long satAssignmentToLong(BitSet bits) {
+    if (_bitvec.length > Long.SIZE) {
+      throw new IllegalArgumentException(
+          "Can't get a representative of a BDDInteger with more than Long.SIZE bits");
+    }
+
+    long value = 0;
+    for (int i = 0; i < _bitvec.length; i++) {
+      BDD bitBDD = _bitvec[_bitvec.length - i - 1];
+      if (bits.get(bitBDD.level())) {
+        value |= 1L << i;
+      }
+    }
+    return value;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -1,0 +1,165 @@
+package org.batfish.common.bdd;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.common.bdd.BDDUtils.bitvector;
+
+import java.util.Arrays;
+import java.util.Optional;
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDException;
+import net.sf.javabdd.BDDFactory;
+
+public final class MutableBDDInteger extends BDDInteger {
+  public MutableBDDInteger(BDDFactory factory, BDD[] bitvec) {
+    super(factory, bitvec);
+  }
+
+  public MutableBDDInteger(BDDFactory factory, int length) {
+    this(factory, new BDD[length]);
+  }
+
+  public MutableBDDInteger(MutableBDDInteger other) {
+    this(other._factory, other._bitvec.length);
+    setValue(other);
+  }
+  /*
+   * Create an integer, and initialize its values as "don't care"
+   * This requires knowing the start index variables the bitvector
+   * will use.
+   */
+  public static MutableBDDInteger makeFromIndex(
+      BDDFactory factory, int length, int start, boolean reverse) {
+    return new MutableBDDInteger(factory, bitvector(factory, length, start, reverse));
+  }
+
+  /*
+   * Create an integer and initialize it to a concrete value
+   */
+  public static MutableBDDInteger makeFromValue(BDDFactory factory, int length, long value) {
+    MutableBDDInteger bdd = new MutableBDDInteger(factory, length);
+    bdd.setValue(value);
+    return bdd;
+  }
+
+  /*
+   * Set this BDD to have an exact value
+   */
+  public void setValue(long val) {
+    checkArgument(val >= 0, "Cannot set a negative value");
+    checkArgument(val <= _maxVal, "value %s is out of range [0, %s]", val, _maxVal);
+    long currentVal = val;
+    for (int i = _bitvec.length - 1; i >= 0; i--) {
+      if ((currentVal & 1) != 0) {
+        _bitvec[i] = _factory.one();
+      } else {
+        _bitvec[i] = _factory.zero();
+      }
+      currentVal >>= 1;
+    }
+  }
+
+  @Override
+  public Optional<Long> getValueSatisfying(BDD bdd) {
+    return bdd.isZero() ? Optional.empty() : Optional.of(satAssignmentToLong(bdd.satOne()));
+  }
+
+  @Override
+  public Long satAssignmentToLong(BDD satAssignment) {
+    checkArgument(satAssignment.isAssignment(), "not a satisfying assignment");
+    checkArgument(
+        _bitvec.length <= Long.SIZE,
+        "Can't get a representative of a BDDInteger with more than Long.SIZE bits");
+
+    long value = 0;
+    for (int i = 0; i < _bitvec.length; i++) {
+      BDD bitBDD = _bitvec[_bitvec.length - i - 1];
+      // a.diff(b) is a.and(b.not()). When the input is only a partial assignment (like satOne),
+      // this biases towards lexicographically smaller solutions: set a 1 only if you can't set 0.
+      if (!satAssignment.diffSat(bitBDD)) {
+        value |= 1L << i;
+      }
+    }
+    return value;
+  }
+
+  /*
+   * Add two BDDs bitwise to create a new BDD
+   */
+  public BDDInteger add(BDDInteger other) {
+    BDD[] as = _bitvec;
+    BDD[] bs = other._bitvec;
+
+    checkArgument(as.length > 0, "Cannot add BDDIntegers of length 0");
+    checkArgument(as.length == bs.length, "Cannot add BDDIntegers of different length");
+
+    BDD carry = _factory.zero();
+    BDDInteger sum = new MutableBDDInteger(_factory, as.length);
+    BDD[] cs = sum._bitvec;
+    for (int i = cs.length - 1; i > 0; --i) {
+      cs[i] = as[i].xor(bs[i]).xor(carry);
+      carry = as[i].and(bs[i]).or(carry.and(as[i].or(bs[i])));
+    }
+    cs[0] = as[0].xor(bs[0]).xor(carry);
+    return sum;
+  }
+
+  /*
+   * Map an if-then-else over each bit in the bitvector
+   */
+  public MutableBDDInteger ite(BDD b, MutableBDDInteger other) {
+    MutableBDDInteger val = new MutableBDDInteger(this);
+    for (int i = 0; i < _bitvec.length; i++) {
+      val._bitvec[i] = b.ite(_bitvec[i], other._bitvec[i]);
+    }
+    return val;
+  }
+
+  /*
+   * Set this BDD to be equal to another BDD
+   */
+  public void setValue(MutableBDDInteger other) {
+    for (int i = 0; i < _bitvec.length; ++i) {
+      _bitvec[i] = other._bitvec[i].id();
+    }
+  }
+
+  /*
+   * Subtract one BDD from another bitwise to create a new BDD
+   */
+  public MutableBDDInteger sub(MutableBDDInteger var1) {
+    if (_bitvec.length != var1._bitvec.length) {
+      throw new BDDException();
+    } else {
+      BDD var3 = _factory.zero();
+      MutableBDDInteger var4 = new MutableBDDInteger(_factory, _bitvec.length);
+      for (int var5 = var4._bitvec.length - 1; var5 >= 0; --var5) {
+        var4._bitvec[var5] = _bitvec[var5].xor(var1._bitvec[var5]);
+        var4._bitvec[var5] = var4._bitvec[var5].xor(var3.id());
+        BDD var6 = var1._bitvec[var5].or(var3);
+        BDD var7 = _bitvec[var5].less(var6);
+        var6.free();
+        var6 = _bitvec[var5].and(var1._bitvec[var5]);
+        var6 = var6.and(var3);
+        var6 = var6.or(var7);
+        var3 = var6;
+      }
+      var3.free();
+      return var4;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof MutableBDDInteger)) {
+      return false;
+    }
+    MutableBDDInteger other = (MutableBDDInteger) o;
+    // No need to check _factory
+    return Arrays.equals(_bitvec, other._bitvec);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(_bitvec);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifier.java
@@ -9,8 +9,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
-import org.batfish.common.bdd.BDDInteger;
 import org.batfish.common.bdd.BDDUtils;
+import org.batfish.common.bdd.ImmutableBDDInteger;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Interface;
@@ -33,7 +33,8 @@ public final class InterfaceWithConnectedIpsSpecifier implements InterfaceSpecif
   public InterfaceWithConnectedIpsSpecifier(@Nonnull IpSpace ipSpace) {
     _ipSpace = ipSpace;
     BDDFactory factory = BDDUtils.bddFactory(Prefix.MAX_PREFIX_LENGTH);
-    BDDInteger integer = BDDInteger.makeFromIndex(factory, Prefix.MAX_PREFIX_LENGTH, 0, true);
+    ImmutableBDDInteger integer =
+        ImmutableBDDInteger.makeFromIndex(factory, Prefix.MAX_PREFIX_LENGTH, 0, true);
     _ipSpaceToBdd = new IpSpaceToBDD(integer);
     _ipSpaceBdd = _ipSpaceToBdd.visit(ipSpace);
   }

--- a/projects/batfish-common-protocol/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -3,6 +3,7 @@ package net.sf.javabdd;
 import static org.junit.Assert.assertEquals;
 
 import org.batfish.common.bdd.BDDInteger;
+import org.batfish.common.bdd.ImmutableBDDInteger;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -13,7 +14,7 @@ public class JFactoryTest {
     JFactory factory = (JFactory) JFactory.init(100000, 10000);
     factory.setVarNum(8);
 
-    BDDInteger var = BDDInteger.makeFromIndex(factory, 8, 0, false);
+    BDDInteger var = ImmutableBDDInteger.makeFromIndex(factory, 8, 0, false);
     BDD bdd1 = var.leq(8);
     BDD bdd2 = var.geq(128);
     BDD bdd3 = var.value(64);
@@ -29,7 +30,7 @@ public class JFactoryTest {
 
     JFactory factory = (JFactory) JFactory.init(100000, 10000);
     factory.setVarNum(bits);
-    BDDInteger var = BDDInteger.makeFromIndex(factory, bits, 0, false);
+    BDDInteger var = ImmutableBDDInteger.makeFromIndex(factory, bits, 0, false);
 
     BDD[] bdds = new BDD[1 << bits];
     for (int i = 0; i < bdds.length; i++) {
@@ -44,7 +45,7 @@ public class JFactoryTest {
 
     factory = (JFactory) JFactory.init(100000, 10000);
     factory.setVarNum(bits);
-    var = BDDInteger.makeFromIndex(factory, bits, 0, false);
+    var = ImmutableBDDInteger.makeFromIndex(factory, bits, 0, false);
 
     for (int i = 0; i < bdds.length; i++) {
       bdds[i] = var.value(i);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFiniteDomainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFiniteDomainTest.java
@@ -31,7 +31,7 @@ public final class BDDFiniteDomainTest {
 
   @Test
   public void testTooLarge() {
-    BDDInteger var = _pkt.allocateBDDInteger("", 1);
+    ImmutableBDDInteger var = _pkt.allocateBDDInteger("", 1);
     _exception.expect(IllegalArgumentException.class);
     new BDDFiniteDomain<>(var, ImmutableSet.of(1, 2, 3));
   }
@@ -39,7 +39,7 @@ public final class BDDFiniteDomainTest {
   @Test
   public void testIsValidConstraint() {
     // 1 bit variable
-    BDDInteger var = _pkt.allocateBDDInteger("", 1);
+    ImmutableBDDInteger var = _pkt.allocateBDDInteger("", 1);
 
     // 1 value
     assertThat(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -1,16 +1,11 @@
 package org.batfish.common.bdd;
 
 import static org.batfish.common.bdd.BDDMatchers.isOne;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
-import java.util.BitSet;
 import java.util.Optional;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
@@ -62,7 +57,7 @@ public class BDDIntegerTest {
   @Test
   public void testGeqOutOfRange() {
     BDDFactory factory = BDDUtils.bddFactory(5);
-    BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
+    ImmutableBDDInteger var = ImmutableBDDInteger.makeFromIndex(factory, 5, 0, false);
     _exception.expect(IllegalArgumentException.class);
     _exception.expectMessage("value 32 is out of range [0, 31]");
     var.geq(32);
@@ -71,7 +66,7 @@ public class BDDIntegerTest {
   @Test
   public void testLeqOutOfRange() {
     BDDFactory factory = BDDUtils.bddFactory(5);
-    BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
+    ImmutableBDDInteger var = ImmutableBDDInteger.makeFromIndex(factory, 5, 0, false);
     _exception.expect(IllegalArgumentException.class);
     _exception.expectMessage("value 32 is out of range [0, 31]");
     var.leq(32);
@@ -80,7 +75,7 @@ public class BDDIntegerTest {
   @Test
   public void testValueOutOfRange() {
     BDDFactory factory = BDDUtils.bddFactory(5);
-    BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
+    ImmutableBDDInteger var = ImmutableBDDInteger.makeFromIndex(factory, 5, 0, false);
     _exception.expect(IllegalArgumentException.class);
     _exception.expectMessage("value 32 is out of range [0, 31]");
     var.value(32);
@@ -89,7 +84,7 @@ public class BDDIntegerTest {
   @Test
   public void testBoundary() {
     BDDFactory factory = BDDUtils.bddFactory(63);
-    BDDInteger var = BDDInteger.makeFromIndex(factory, 63, 0, false);
+    ImmutableBDDInteger var = ImmutableBDDInteger.makeFromIndex(factory, 63, 0, false);
     assertThat(
         var.getValueSatisfying(var.value(Long.MAX_VALUE)), equalTo(Optional.of(Long.MAX_VALUE)));
     assertThat(
@@ -98,30 +93,9 @@ public class BDDIntegerTest {
   }
 
   @Test
-  public void testAdd() {
-    BDDFactory factory = BDDUtils.bddFactory(10);
-    BDDInteger x = BDDInteger.makeFromIndex(factory, 5, 0, false);
-    assertTrue(x.hasVariablesOnly());
-    BDDInteger constant1 = BDDInteger.makeFromValue(factory, 5, 1);
-    assertFalse(constant1.hasVariablesOnly());
-    BDDInteger xPlus1 = x.add(constant1);
-    assertFalse(xPlus1.hasVariablesOnly());
-
-    assertTrue(x.value(0).equals(xPlus1.value(1))); // x == 0 <==> x+1 == 1
-    assertTrue(x.value(1).equals(xPlus1.value(2))); // x == 1 <==> x+1 == 2
-    assertTrue(x.value(31).equals(xPlus1.value(0))); // x == 31 <==> x+1 == 0
-
-    // Check that each variable's bitvec is properly used with satisfying assignment.
-    assertThat(x.getValuesSatisfying(x.value(3L), 100), contains(3L));
-    assertThat(xPlus1.getValuesSatisfying(xPlus1.value(3L), 100), contains(3L));
-    assertThat(xPlus1.getValuesSatisfying(x.value(3L), 100), contains(4L));
-    assertThat(x.getValuesSatisfying(xPlus1.value(3L), 100), contains(2L));
-  }
-
-  @Test
   public void testRange() {
     BDDFactory factory = BDDUtils.bddFactory(10);
-    BDDInteger x = BDDInteger.makeFromIndex(factory, 5, 0, false);
+    ImmutableBDDInteger x = ImmutableBDDInteger.makeFromIndex(factory, 5, 0, false);
     for (int a = 0; a < 32; ++a) {
       for (int b = a; b < 32; ++b) {
         BDD range = x.range(a, b);
@@ -135,67 +109,15 @@ public class BDDIntegerTest {
   public void testRangeBounds() {
     {
       BDDFactory factory = BDDUtils.bddFactory(32);
-      BDDInteger x = BDDInteger.makeFromIndex(factory, 32, 0, false);
+      ImmutableBDDInteger x = ImmutableBDDInteger.makeFromIndex(factory, 32, 0, false);
       assertThat(
           x.range(Prefix.ZERO.getStartIp().asLong(), Prefix.ZERO.getEndIp().asLong()), isOne());
     }
 
     {
       BDDFactory factory = BDDUtils.bddFactory(63);
-      BDDInteger x = BDDInteger.makeFromIndex(factory, 63, 0, false);
+      ImmutableBDDInteger x = ImmutableBDDInteger.makeFromIndex(factory, 63, 0, false);
       assertThat(x.range(0L, 0x7FFF_FFFF_FFFF_FFFFL), isOne());
     }
-  }
-
-  @Test
-  public void testGetVars_emptyVar() {
-    BDDFactory factory = BDDUtils.bddFactory(10);
-    BDDInteger x = BDDInteger.makeFromIndex(factory, 0, 0, false);
-    assertEquals(factory.one(), x.getVars());
-  }
-
-  @Test
-  public void testHasVariablesOnly() {
-    BDDFactory factory = BDDUtils.bddFactory(10);
-    // makeFromIndex
-    BDDInteger x = BDDInteger.makeFromIndex(factory, 5, 0, false);
-    assertTrue(x.hasVariablesOnly());
-    // copy constructor of variables only
-    BDDInteger y = new BDDInteger(x);
-    assertTrue(y.hasVariablesOnly());
-
-    // after setValue
-    x.setValue(5);
-    assertFalse(x.hasVariablesOnly());
-    // copy setValue
-    y = new BDDInteger(x);
-    assertFalse(y.hasVariablesOnly());
-
-    x = BDDInteger.makeFromIndex(factory, 5, 0, false);
-    assertTrue(x.hasVariablesOnly());
-    y = x.add(x);
-    assertFalse(y.hasVariablesOnly());
-    assertTrue(x.hasVariablesOnly());
-
-    y = x.sub(x);
-    assertFalse(y.hasVariablesOnly());
-    assertTrue(x.hasVariablesOnly());
-  }
-
-  @Test
-  public void testThrowsOnGetVars() {
-    BDDFactory factory = BDDUtils.bddFactory(10);
-    BDDInteger x = BDDInteger.makeFromValue(factory, 5, 3);
-    _exception.expect(IllegalStateException.class);
-    x.getVars();
-  }
-
-  @Test
-  public void testThrowsOnBitSet() {
-    BDDFactory factory = BDDUtils.bddFactory(10);
-    BDDInteger x = BDDInteger.makeFromValue(factory, 5, 3);
-    BitSet anything = factory.one().minAssignmentBits();
-    _exception.expect(IllegalStateException.class);
-    x.satAssignmentToLong(anything);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/ImmutableBDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/ImmutableBDDIntegerTest.java
@@ -1,0 +1,16 @@
+package org.batfish.common.bdd;
+
+import static org.junit.Assert.assertEquals;
+
+import net.sf.javabdd.BDDFactory;
+import org.junit.Test;
+
+public class ImmutableBDDIntegerTest {
+
+  @Test
+  public void testGetVars_emptyVar() {
+    BDDFactory factory = BDDUtils.bddFactory(10);
+    ImmutableBDDInteger x = ImmutableBDDInteger.makeFromIndex(factory, 0, 0, false);
+    assertEquals(factory.one(), x.getVars());
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/IpSpaceToBDDTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/IpSpaceToBDDTest.java
@@ -31,7 +31,7 @@ public class IpSpaceToBDDTest {
   private BDDFactory _factory;
   private BDDOps _bddOps;
   private BDD[] _ipAddrBitvec;
-  private BDDInteger _ipAddrBdd;
+  private ImmutableBDDInteger _ipAddrBdd;
   private IpSpaceToBDD _ipSpaceToBdd;
 
   @Before
@@ -39,7 +39,7 @@ public class IpSpaceToBDDTest {
     _factory = BDDUtils.bddFactory(32);
     _bddOps = new BDDOps(_factory);
     _ipAddrBitvec = IntStream.range(0, 32).mapToObj(_factory::ithVar).toArray(BDD[]::new);
-    _ipAddrBdd = new BDDInteger(_factory, _ipAddrBitvec);
+    _ipAddrBdd = new ImmutableBDDInteger(_factory, _ipAddrBitvec);
     _ipSpaceToBdd = new IpSpaceToBDD(_ipAddrBdd);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
@@ -1,0 +1,29 @@
+package org.batfish.common.bdd;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import net.sf.javabdd.BDDFactory;
+import org.junit.Test;
+
+public class MutableBDDIntegerTest {
+
+  @Test
+  public void testAdd() {
+    BDDFactory factory = BDDUtils.bddFactory(10);
+    MutableBDDInteger x = MutableBDDInteger.makeFromIndex(factory, 5, 0, false);
+    MutableBDDInteger constant1 = MutableBDDInteger.makeFromValue(factory, 5, 1);
+    BDDInteger xPlus1 = x.add(constant1);
+
+    assertTrue(x.value(0).equals(xPlus1.value(1))); // x == 0 <==> x+1 == 1
+    assertTrue(x.value(1).equals(xPlus1.value(2))); // x == 1 <==> x+1 == 2
+    assertTrue(x.value(31).equals(xPlus1.value(0))); // x == 31 <==> x+1 == 0
+
+    // Check that each variable's bitvec is properly used with satisfying assignment.
+    assertThat(x.getValuesSatisfying(x.value(3L), 100), contains(3L));
+    assertThat(xPlus1.getValuesSatisfying(xPlus1.value(3L), 100), contains(3L));
+    assertThat(xPlus1.getValuesSatisfying(x.value(3L), 100), contains(4L));
+    assertThat(x.getValuesSatisfying(xPlus1.value(3L), 100), contains(2L));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTest.java
@@ -9,8 +9,8 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import net.sf.javabdd.BDD;
-import org.batfish.common.bdd.BDDInteger;
 import org.batfish.common.bdd.BDDUtils;
+import org.batfish.common.bdd.ImmutableBDDInteger;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.junit.Rule;
 import org.junit.Test;
@@ -98,7 +98,8 @@ public class PrefixTest {
 
   @Test
   public void testToHostIpSpace() {
-    BDDInteger ipAddrBdd = BDDInteger.makeFromIndex(BDDUtils.bddFactory(32), 32, 0, true);
+    ImmutableBDDInteger ipAddrBdd =
+        ImmutableBDDInteger.makeFromIndex(BDDUtils.bddFactory(32), 32, 0, true);
     IpSpaceToBDD toBDD = new IpSpaceToBDD(ipAddrBdd);
     assertThat(
         "/32 host space is preserved",

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/TransformationToTransition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/TransformationToTransition.java
@@ -16,8 +16,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
-import org.batfish.common.bdd.BDDInteger;
 import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.ImmutableBDDInteger;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.datamodel.Ip;
@@ -52,7 +52,7 @@ public class TransformationToTransition {
     _stepToTransition = new TransformationStepToTransition();
   }
 
-  private static Transition assignIpFromPool(BDDInteger var, RangeSet<Ip> ranges) {
+  private static Transition assignIpFromPool(ImmutableBDDInteger var, RangeSet<Ip> ranges) {
     BDD setValue =
         ranges.asRanges().stream()
             .map(
@@ -65,7 +65,7 @@ public class TransformationToTransition {
     return eraseAndSet(var, setValue);
   }
 
-  private Transition assignPortFromPool(BDDInteger var, int poolStart, int poolEnd) {
+  private Transition assignPortFromPool(ImmutableBDDInteger var, int poolStart, int poolEnd) {
     BDD setValue = var.range(poolStart, poolEnd);
     Transition eraseAndSet = eraseAndSet(var, setValue);
     // AssignPortFromPool is a noop on protocols that don't have ports
@@ -73,7 +73,7 @@ public class TransformationToTransition {
   }
 
   private class TransformationStepToTransition implements TransformationStepVisitor<Transition> {
-    private BDDInteger ipField(IpField ipField) {
+    private ImmutableBDDInteger ipField(IpField ipField) {
       switch (ipField) {
         case DESTINATION:
           return _bddPacket.getDstIp();
@@ -95,7 +95,7 @@ public class TransformationToTransition {
       }
     }
 
-    private BDDInteger portField(PortField portField) {
+    private ImmutableBDDInteger portField(PortField portField) {
       switch (portField) {
         case DESTINATION:
           return _bddPacket.getDstPort();
@@ -119,7 +119,7 @@ public class TransformationToTransition {
     @Override
     public Transition visitShiftIpAddressIntoSubnet(ShiftIpAddressIntoSubnet step) {
       Prefix prefix = step.getSubnet();
-      BDDInteger var = ipField(step.getIpField());
+      ImmutableBDDInteger var = ipField(step.getIpField());
       IpSpaceToBDD varToBdd = ipFieldToBDD(step.getIpField());
       int len = prefix.getPrefixLength();
       BDD erase = var.getMostSignificantVars(len);

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -19,8 +19,8 @@ import net.sf.javabdd.BDDFactory;
 import org.batfish.bddreachability.BDDOutgoingOriginalFlowFilterManager;
 import org.batfish.bddreachability.LastHopOutgoingInterfaceManager;
 import org.batfish.common.bdd.BDDFiniteDomain;
-import org.batfish.common.bdd.BDDInteger;
 import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.ImmutableBDDInteger;
 
 /** Smart constructors of {@link Transition}. */
 public final class Transitions {
@@ -199,7 +199,7 @@ public final class Transitions {
           mgr.getFiniteDomain().getVar() == add.getSourceManager().getFiniteDomain().getVar(),
           "all source managers should have the same BDDInteger");
 
-      BDDInteger var = mgr.getFiniteDomain().getVar();
+      ImmutableBDDInteger var = mgr.getFiniteDomain().getVar();
       return eraseAndSet(var, add.getSourceBdd());
     }
     // couldn't merge
@@ -220,7 +220,7 @@ public final class Transitions {
     }
   }
 
-  public static Transition eraseAndSet(BDDInteger var, BDD value) {
+  public static Transition eraseAndSet(ImmutableBDDInteger var, BDD value) {
     if (var.size() == 0) {
       return constraint(value);
     } else {

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -22,9 +22,9 @@ import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.transition.Transition;
 import org.batfish.bddreachability.transition.Transitions;
 import org.batfish.common.bdd.BDDFiniteDomain;
-import org.batfish.common.bdd.BDDInteger;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.ImmutableBDDInteger;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
@@ -148,7 +148,7 @@ public final class SessionInstrumentationTest {
 
     // Setup source managers
     {
-      BDDInteger srcVar = _pkt.allocateBDDInteger("Source", 3);
+      ImmutableBDDInteger srcVar = _pkt.allocateBDDInteger("Source", 3);
       // Setup source tracking for firewall
       _fwSrcMgr = BDDSourceManager.forInterfaces(srcVar, ImmutableSet.of(FW_I1, FAKE_IFACE));
       _invalidSrc = _fwSrcMgr.isValidValue().not();

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
-import org.batfish.common.bdd.BDDInteger;
+import org.batfish.common.bdd.MutableBDDInteger;
 
 /*
  * Class that wraps a BDDInteger around a finite collection of values
@@ -16,19 +16,19 @@ public class BDDDomain<T> {
 
   private List<T> _values;
 
-  private BDDInteger _integer;
+  private MutableBDDInteger _integer;
 
   public BDDDomain(BDDFactory factory, List<T> values, int index) {
     int bits = numBits(values);
     _factory = factory;
     _values = values;
-    _integer = BDDInteger.makeFromIndex(_factory, bits, index, false);
+    _integer = MutableBDDInteger.makeFromIndex(_factory, bits, index, false);
   }
 
   public BDDDomain(BDDDomain<T> other) {
     _factory = other._factory;
     _values = other._values;
-    _integer = new BDDInteger(other._integer);
+    _integer = new MutableBDDInteger(other._integer);
   }
 
   private int numBits(List<T> values) {
@@ -57,11 +57,11 @@ public class BDDDomain<T> {
     _integer.setValue(idx);
   }
 
-  public BDDInteger getInteger() {
+  public MutableBDDInteger getInteger() {
     return _integer;
   }
 
-  public void setInteger(BDDInteger i) {
+  public void setInteger(MutableBDDInteger i) {
     _integer = i;
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
-import org.batfish.common.bdd.BDDInteger;
+import org.batfish.common.bdd.MutableBDDInteger;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
@@ -57,7 +57,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
 
   private final BDDFactory _factory;
 
-  private BDDInteger _adminDist;
+  private MutableBDDInteger _adminDist;
 
   private Map<Integer, String> _bitNames;
 
@@ -83,11 +83,11 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    */
   private BDD[] _asPathRegexAtomicPredicates;
 
-  private BDDInteger _localPref;
+  private MutableBDDInteger _localPref;
 
-  private BDDInteger _med;
+  private MutableBDDInteger _med;
 
-  private BDDInteger _nextHop;
+  private MutableBDDInteger _nextHop;
 
   // to properly determine the next-hop IP that results from each path through a given route-map we
   // need to track a few more pieces of information:  whether the next-hop is explicitly discarded
@@ -97,13 +97,13 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
 
   private BDDDomain<OspfType> _ospfMetric;
 
-  private final BDDInteger _prefix;
+  private final MutableBDDInteger _prefix;
 
-  private final BDDInteger _prefixLength;
+  private final MutableBDDInteger _prefixLength;
 
   private final BDDDomain<RoutingProtocol> _protocolHistory;
 
-  private BDDInteger _tag;
+  private MutableBDDInteger _tag;
 
   /**
    * The routing protocols allowed in a BGP route announcement (see {@link
@@ -153,28 +153,28 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     addBitNames("proto", len, idx, false);
     idx += len;
     // Initialize integer values
-    _med = BDDInteger.makeFromIndex(factory, 32, idx, false);
+    _med = MutableBDDInteger.makeFromIndex(factory, 32, idx, false);
     addBitNames("med", 32, idx, false);
     idx += 32;
-    _nextHop = BDDInteger.makeFromIndex(factory, 32, idx, false);
+    _nextHop = MutableBDDInteger.makeFromIndex(factory, 32, idx, false);
     addBitNames("nextHop", 32, idx, false);
     idx += 32;
     _nextHopSet = factory.zero();
     _nextHopDiscarded = factory.zero();
-    _tag = BDDInteger.makeFromIndex(factory, 32, idx, false);
+    _tag = MutableBDDInteger.makeFromIndex(factory, 32, idx, false);
     addBitNames("tag", 32, idx, false);
     idx += 32;
-    _adminDist = BDDInteger.makeFromIndex(factory, 32, idx, false);
+    _adminDist = MutableBDDInteger.makeFromIndex(factory, 32, idx, false);
     addBitNames("ad", 32, idx, false);
     idx += 32;
-    _localPref = BDDInteger.makeFromIndex(factory, 32, idx, false);
+    _localPref = MutableBDDInteger.makeFromIndex(factory, 32, idx, false);
     addBitNames("lp", 32, idx, false);
     idx += 32;
     // need 6 bits for prefix length because there are 33 possible values, 0 - 32
-    _prefixLength = BDDInteger.makeFromIndex(factory, 6, idx, true);
+    _prefixLength = MutableBDDInteger.makeFromIndex(factory, 6, idx, true);
     addBitNames("pfxLen", 5, idx, true);
     idx += 6;
-    _prefix = BDDInteger.makeFromIndex(factory, 32, idx, true);
+    _prefix = MutableBDDInteger.makeFromIndex(factory, 32, idx, true);
     addBitNames("pfx", 32, idx, true);
     idx += 32;
     // Initialize one BDD per community atomic predicate, each of which has a corresponding
@@ -208,15 +208,15 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
 
     _asPathRegexAtomicPredicates = other._asPathRegexAtomicPredicates.clone();
     _communityAtomicPredicates = other._communityAtomicPredicates.clone();
-    _prefixLength = new BDDInteger(other._prefixLength);
-    _prefix = new BDDInteger(other._prefix);
-    _nextHop = new BDDInteger(other._nextHop);
+    _prefixLength = new MutableBDDInteger(other._prefixLength);
+    _prefix = new MutableBDDInteger(other._prefix);
+    _nextHop = new MutableBDDInteger(other._nextHop);
     _nextHopSet = other._nextHopSet.id();
     _nextHopDiscarded = other._nextHopDiscarded.id();
-    _adminDist = new BDDInteger(other._adminDist);
-    _med = new BDDInteger(other._med);
-    _tag = new BDDInteger(other._tag);
-    _localPref = new BDDInteger(other._localPref);
+    _adminDist = new MutableBDDInteger(other._adminDist);
+    _med = new MutableBDDInteger(other._med);
+    _tag = new MutableBDDInteger(other._tag);
+    _localPref = new MutableBDDInteger(other._localPref);
     _protocolHistory = new BDDDomain<>(other._protocolHistory);
     _ospfMetric = new BDDDomain<>(other._ospfMetric);
     _bitNames = other._bitNames;
@@ -356,11 +356,11 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     dotRec(sb, bdd.high(), visited);
   }
 
-  public BDDInteger getAdminDist() {
+  public MutableBDDInteger getAdminDist() {
     return _adminDist;
   }
 
-  public void setAdminDist(BDDInteger adminDist) {
+  public void setAdminDist(MutableBDDInteger adminDist) {
     _adminDist = adminDist;
   }
 
@@ -384,27 +384,27 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     return _factory;
   }
 
-  public BDDInteger getLocalPref() {
+  public MutableBDDInteger getLocalPref() {
     return _localPref;
   }
 
-  public void setLocalPref(BDDInteger localPref) {
+  public void setLocalPref(MutableBDDInteger localPref) {
     _localPref = localPref;
   }
 
-  public BDDInteger getMed() {
+  public MutableBDDInteger getMed() {
     return _med;
   }
 
-  public void setMed(BDDInteger med) {
+  public void setMed(MutableBDDInteger med) {
     _med = med;
   }
 
-  public BDDInteger getNextHop() {
+  public MutableBDDInteger getNextHop() {
     return _nextHop;
   }
 
-  public void setNextHop(BDDInteger nextHop) {
+  public void setNextHop(MutableBDDInteger nextHop) {
     _nextHop = nextHop;
   }
 
@@ -432,11 +432,11 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     _ospfMetric = ospfMetric;
   }
 
-  public BDDInteger getPrefix() {
+  public MutableBDDInteger getPrefix() {
     return _prefix;
   }
 
-  public BDDInteger getPrefixLength() {
+  public MutableBDDInteger getPrefixLength() {
     return _prefixLength;
   }
 
@@ -444,11 +444,11 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     return _protocolHistory;
   }
 
-  public BDDInteger getTag() {
+  public MutableBDDInteger getTag() {
     return _tag;
   }
 
-  public void setTag(BDDInteger tag) {
+  public void setTag(MutableBDDInteger tag) {
     _tag = tag;
   }
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -22,6 +22,7 @@ import net.sf.javabdd.JFactory;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.bdd.BDDInteger;
 import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.common.bdd.MutableBDDInteger;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.common.topology.TopologyProvider;
@@ -454,9 +455,10 @@ public class TransferBDDTest {
         isRelevantForDestination(
             anyRoute, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(31, 31)));
     BDDRoute expected = tbdd.iteZero(expectedBDD, anyRoute);
-    BDDInteger localPref = expected.getLocalPref();
+    MutableBDDInteger localPref = expected.getLocalPref();
     expected.setLocalPref(
-        BDDInteger.makeFromValue(localPref.getFactory(), 32, 3).ite(reachesSecondIf, localPref));
+        MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 3)
+            .ite(reachesSecondIf, localPref));
 
     assertEquals(expectedBDD, acceptedAnnouncements);
 
@@ -548,8 +550,8 @@ public class TransferBDDTest {
             anyRoute, new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(32, 32)));
 
     BDDRoute expectedOut = new BDDRoute(anyRoute);
-    BDDInteger localPref2 = BDDInteger.makeFromValue(expectedOut.getFactory(), 32, 2);
-    BDDInteger localPref3 = BDDInteger.makeFromValue(expectedOut.getFactory(), 32, 3);
+    MutableBDDInteger localPref2 = MutableBDDInteger.makeFromValue(expectedOut.getFactory(), 32, 2);
+    MutableBDDInteger localPref3 = MutableBDDInteger.makeFromValue(expectedOut.getFactory(), 32, 3);
     expectedOut.setLocalPref(
         localPref2.ite(exitAssigned, localPref3.ite(returnAssigned, expectedOut.getLocalPref())));
 
@@ -719,7 +721,7 @@ public class TransferBDDTest {
     BDDRoute outAnnouncements = result.getFirst();
 
     BDDRoute expectedOut = anyRoute(tbdd.getFactory());
-    expectedOut.setLocalPref(BDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
+    expectedOut.setLocalPref(MutableBDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
 
     // the policy is applicable to all announcements
     assertTrue(acceptedAnnouncements.isOne());
@@ -808,9 +810,10 @@ public class TransferBDDTest {
         isRelevantForDestination(
             anyRoute, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24)));
     BDDRoute expected = new BDDRoute(anyRoute);
-    BDDInteger localPref = expected.getLocalPref();
+    MutableBDDInteger localPref = expected.getLocalPref();
     expected.setLocalPref(
-        BDDInteger.makeFromValue(localPref.getFactory(), 32, 300).ite(firstConjunctBDD, localPref));
+        MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 300)
+            .ite(firstConjunctBDD, localPref));
 
     // the updates in the second conjunct should not occur unless the first conjunct is true
     assertEquals(outAnnouncements, expected);
@@ -914,9 +917,9 @@ public class TransferBDDTest {
         isRelevantForDestination(
             anyRoute, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24)));
     BDDRoute expected = new BDDRoute(anyRoute);
-    BDDInteger localPref = expected.getLocalPref();
+    MutableBDDInteger localPref = expected.getLocalPref();
     expected.setLocalPref(
-        BDDInteger.makeFromValue(localPref.getFactory(), 32, 300)
+        MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 300)
             .ite(firstDisjunctBDD.not(), localPref));
 
     // the updates in the second disjunct should not occur unless the first disjunct is false
@@ -1104,7 +1107,7 @@ public class TransferBDDTest {
     // the local preference is now 42
     BDDRoute expected = anyRoute(tbdd.getFactory());
     BDDInteger localPref = expected.getLocalPref();
-    expected.setLocalPref(BDDInteger.makeFromValue(localPref.getFactory(), 32, 42));
+    expected.setLocalPref(MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 42));
     assertEquals(expected, outAnnouncements);
   }
 
@@ -1126,7 +1129,7 @@ public class TransferBDDTest {
     assertTrue(acceptedAnnouncements.isOne());
 
     // the metric is now 50
-    BDDInteger expectedMed = BDDInteger.makeFromValue(tbdd.getFactory(), 32, 50);
+    BDDInteger expectedMed = MutableBDDInteger.makeFromValue(tbdd.getFactory(), 32, 50);
     assertEquals(expectedMed, outAnnouncements.getMed());
   }
 
@@ -1150,7 +1153,7 @@ public class TransferBDDTest {
     // the tag is now 42
     BDDRoute expected = anyRoute(tbdd.getFactory());
     BDDInteger tag = expected.getTag();
-    expected.setTag(BDDInteger.makeFromValue(tag.getFactory(), 32, 42));
+    expected.setTag(MutableBDDInteger.makeFromValue(tag.getFactory(), 32, 42));
     assertEquals(expected, outAnnouncements);
   }
 
@@ -1210,7 +1213,7 @@ public class TransferBDDTest {
     // the tag is now 42
     BDDRoute expected = new BDDRoute(anyRoute);
     BDDInteger tag = expected.getTag();
-    expected.setTag(BDDInteger.makeFromValue(tag.getFactory(), 32, 42));
+    expected.setTag(MutableBDDInteger.makeFromValue(tag.getFactory(), 32, 42));
     assertEquals(expected, outAnnouncements);
   }
 
@@ -1320,7 +1323,7 @@ public class TransferBDDTest {
     BDDRoute expected = anyRoute(tbdd.getFactory());
     expected.setNextHopSet(expected.getFactory().one());
     expected.setNextHop(
-        BDDInteger.makeFromValue(expected.getFactory(), 32, Ip.parse("1.1.1.1").asLong()));
+        MutableBDDInteger.makeFromValue(expected.getFactory(), 32, Ip.parse("1.1.1.1").asLong()));
     assertEquals(expected, outAnnouncements);
   }
 
@@ -1479,7 +1482,7 @@ public class TransferBDDTest {
     // the local preference is now 42
     BDDRoute expected = anyRoute(tbdd.getFactory());
     BDDInteger localPref = expected.getLocalPref();
-    expected.setLocalPref(BDDInteger.makeFromValue(localPref.getFactory(), 32, 42));
+    expected.setLocalPref(MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 42));
     assertEquals(expected, outAnnouncements);
   }
 
@@ -1934,7 +1937,7 @@ public class TransferBDDTest {
     BDDRoute outAnnouncements = result.getFirst();
 
     BDDRoute expectedOut = anyRoute(tbdd.getFactory());
-    expectedOut.setLocalPref(BDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
+    expectedOut.setLocalPref(MutableBDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
 
     // the policy is applicable to all announcements
     assertTrue(acceptedAnnouncements.isOne());
@@ -1975,7 +1978,7 @@ public class TransferBDDTest {
     BDDRoute outAnnouncements = result.getFirst();
 
     BDDRoute expectedOut = anyRoute(tbdd.getFactory());
-    expectedOut.setLocalPref(BDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
+    expectedOut.setLocalPref(MutableBDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
 
     // the policy is applicable to all announcements
     assertTrue(acceptedAnnouncements.isOne());
@@ -2028,7 +2031,7 @@ public class TransferBDDTest {
         isRelevantForDestination(
             anyRoute, new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(32, 32)));
     BDDRoute expectedOut = new BDDRoute(anyRoute);
-    expectedOut.setLocalPref(BDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
+    expectedOut.setLocalPref(MutableBDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
     expectedOut = tbdd.ite(expected, expectedOut, tbdd.zeroedRecord());
 
     // the policy is applicable to all announcements
@@ -2094,9 +2097,9 @@ public class TransferBDDTest {
     // the tag is now 42 and local pref is 44
     BDDRoute expected = anyRoute(tbdd.getFactory());
     BDDInteger tag = expected.getTag();
-    expected.setTag(BDDInteger.makeFromValue(tag.getFactory(), 32, 42));
+    expected.setTag(MutableBDDInteger.makeFromValue(tag.getFactory(), 32, 42));
     BDDInteger localPref = expected.getLocalPref();
-    expected.setLocalPref(BDDInteger.makeFromValue(localPref.getFactory(), 32, 44));
+    expected.setLocalPref(MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 44));
 
     assertEquals(expected, outAnnouncements);
   }


### PR DESCRIPTION
BDDIntegers provides an abstraction around a BDD bitvector for building BDD constraints on integers, IP addresses, prefixes, etc. We have two very different usage patterns for BDDIntegers in batfish: the data plane analysis (reachability, search filters, etc) only builds BDDIntegers where the bitvector contains individual BDD variables, and never mutates the bitvector. The control plane analysis (minesweeper, search route policies) mutates the bitvector, and the bitvector can contain arbitrary BDDs. This difference has implications for which operations are supported (e.g. existential quantification) and performance of operations (e.g. converting satisfying assignments to values).

This PR splits BDDInteger into two classes: MutableBDDInteger for control plane analysis and ImmutableBDDInteger for data plane analysis. BDDInteger remains as an abstract superclass of them both, though that may change.  No client code operates on BDDInteger itself, so it's simply a repository of shared code.