### PR TITLE
Sonic: Move parsing logic inside its extractor

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/FileParseResult.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/FileParseResult.java
@@ -1,0 +1,63 @@
+package org.batfish.grammar;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.ParseTreeSentences;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.answers.ParseStatus;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+
+/**
+ * Represents results of parsing a file (which may be one of many in parsing job for a device). The
+ * warnings object will have file-specific warnings, not job-level warnings that are not file
+ * specific.
+ */
+@ParametersAreNonnullByDefault
+public class FileParseResult implements Serializable {
+  @Nonnull private ParseTreeSentences _parseTreeSentences;
+  @Nonnull private final SilentSyntaxCollection _silentSyntax;
+  @Nonnull private final Warnings _warnings;
+  @Nullable private ParseStatus _parseStatus;
+
+  public FileParseResult(
+      ParseTreeSentences parseTreeSentences,
+      SilentSyntaxCollection silentSyntax,
+      Warnings warnings) {
+    _parseTreeSentences = parseTreeSentences;
+    _silentSyntax = silentSyntax;
+    _warnings = warnings;
+  }
+
+  public @Nonnull FileParseResult setParseStatus(ParseStatus parseStatus) {
+    _parseStatus = parseStatus;
+    return this;
+  }
+
+  @Nonnull
+  public FileParseResult setParseTreeSentences(ParseTreeSentences parseTreeSentences) {
+    _parseTreeSentences = parseTreeSentences;
+    return this;
+  }
+
+  @Nonnull
+  public ParseTreeSentences getParseTreeSentences() {
+    return _parseTreeSentences;
+  }
+
+  @Nonnull
+  public SilentSyntaxCollection getSilentSyntax() {
+    return _silentSyntax;
+  }
+
+  @Nonnull
+  public Warnings getWarnings() {
+    return _warnings;
+  }
+
+  @Nullable
+  public ParseStatus getParseStatus() {
+    return _parseStatus;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseResult.java
@@ -13,7 +13,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.answers.ParseStatus;
-import org.batfish.job.ParseVendorConfigurationJob.FileResult;
+import org.batfish.grammar.FileParseResult;
 import org.batfish.vendor.VendorConfiguration;
 
 /** An intermediate class that holds a cacheable result of parsing input configuration files. */
@@ -22,14 +22,14 @@ public class ParseResult implements Serializable {
 
   @Nullable private final VendorConfiguration _config;
   @Nullable private final Throwable _failureCause;
-  @Nonnull private final Map<String, FileResult> _fileResults;
+  @Nonnull private final Map<String, FileParseResult> _fileResults;
   @Nonnull private final ConfigurationFormat _format;
   @Nonnull private final Warnings _warnings;
 
   public ParseResult(
       @Nullable VendorConfiguration config,
       @Nullable Throwable failureCause,
-      Map<String, FileResult> fileResults,
+      Map<String, FileParseResult> fileResults,
       ConfigurationFormat format,
       Warnings warnings) {
     checkArgument(
@@ -58,7 +58,7 @@ public class ParseResult implements Serializable {
    */
   // TODO: Make package private after downstreams are ported off
   @Nonnull
-  public Map<String, FileResult> getFileResults() {
+  public Map<String, FileParseResult> getFileResults() {
     return _fileResults;
   }
 
@@ -81,12 +81,12 @@ public class ParseResult implements Serializable {
    * warnings can be accessed via {@link #getWarnings()}
    */
   public @Nonnull Optional<Warnings> getWarnings(String filename) {
-    return Optional.ofNullable(_fileResults.get(filename)).map(FileResult::getWarnings);
+    return Optional.ofNullable(_fileResults.get(filename)).map(FileParseResult::getWarnings);
   }
 
   /** Get ParseStatus for the specified file, or an empty optional if the file is not found. */
   public @Nonnull Optional<ParseStatus> getParseStatus(String filename) {
-    return Optional.ofNullable(_fileResults.get(filename)).map(FileResult::getParseStatus);
+    return Optional.ofNullable(_fileResults.get(filename)).map(FileParseResult::getParseStatus);
   }
 
   /** Get names of all constituent files. */

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationResult.java
@@ -18,7 +18,7 @@ import org.batfish.common.Warnings;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
-import org.batfish.job.ParseVendorConfigurationJob.FileResult;
+import org.batfish.grammar.FileParseResult;
 import org.batfish.vendor.VendorConfiguration;
 
 public class ParseVendorConfigurationResult
@@ -28,7 +28,7 @@ public class ParseVendorConfigurationResult
   /** Information about duplicate hostnames is collected here */
   private Multimap<String, String> _duplicateHostnames;
 
-  private final Map<String, FileResult> _fileResults;
+  private final Map<String, FileParseResult> _fileResults;
 
   private final @Nonnull ConfigurationFormat _format;
 
@@ -40,7 +40,7 @@ public class ParseVendorConfigurationResult
   public ParseVendorConfigurationResult(
       long elapsedTime,
       BatfishLoggerHistory history,
-      @Nonnull Map<String, FileResult> fileResults,
+      @Nonnull Map<String, FileParseResult> fileResults,
       @Nonnull ConfigurationFormat format,
       @Nonnull Warnings warnings,
       @Nonnull Throwable failureCause) {
@@ -53,7 +53,7 @@ public class ParseVendorConfigurationResult
   public ParseVendorConfigurationResult(
       long elapsedTime,
       BatfishLoggerHistory history,
-      @Nonnull Map<String, FileResult> fileResults,
+      @Nonnull Map<String, FileParseResult> fileResults,
       @Nonnull ConfigurationFormat format,
       VendorConfiguration vc,
       @Nonnull Warnings warnings,
@@ -69,7 +69,7 @@ public class ParseVendorConfigurationResult
   public ParseVendorConfigurationResult(
       long elapsedTime,
       BatfishLoggerHistory history,
-      @Nonnull Map<String, FileResult> fileResults,
+      @Nonnull Map<String, FileParseResult> fileResults,
       @Nonnull ConfigurationFormat format,
       @Nonnull Warnings warnings) {
     super(elapsedTime, history);
@@ -172,9 +172,9 @@ public class ParseVendorConfigurationResult
 
   /**
    * Returns the parsing results for individual files in the {@link ParseVendorConfigurationJob}, as
-   * a map from the filename to {@link FileResult}.
+   * a map from the filename to {@link FileParseResult}.
    */
-  public Map<String, FileResult> getFileResults() {
+  public Map<String, FileParseResult> getFileResults() {
     return _fileResults;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/grammar/SonicControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/grammar/SonicControlPlaneExtractor.java
@@ -1,44 +1,52 @@
 package org.batfish.vendor.sonic.grammar;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.batfish.common.NetworkSnapshot;
-import org.batfish.common.Warnings;
 import org.batfish.grammar.BatfishParseTreeWalker;
 import org.batfish.grammar.ControlPlaneExtractor;
+import org.batfish.grammar.FileParseResult;
 import org.batfish.grammar.ImplementedRules;
 import org.batfish.grammar.frr.FrrCombinedParser;
 import org.batfish.grammar.frr.FrrConfigurationBuilder;
-import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
 import org.batfish.vendor.VendorConfiguration;
 import org.batfish.vendor.sonic.representation.ConfigDb;
 import org.batfish.vendor.sonic.representation.SonicConfiguration;
 
 public class SonicControlPlaneExtractor implements ControlPlaneExtractor {
-  private @Nonnull final String _configDbText;
-  private @Nonnull final Warnings _configDbWarnings;
-  private @Nonnull final String _frrFileText;
-  private @Nonnull final FrrCombinedParser _frrParser;
-  private @Nonnull final Warnings _frrWarnings;
-  private @Nonnull final SilentSyntaxCollection _frrSilentSyntax;
 
+  public enum SonicFileType {
+    CONFIG_DB_JSON,
+    FRR_CONF,
+    RESOLVE_CONF,
+    SNMP_YML
+  }
+
+  private @Nonnull final Map<String, String> _fileTexts;
+  private @Nonnull final Map<SonicFileType, String> _fileTypes;
+  private @Nonnull final Map<String, FileParseResult> _fileResults;
+  private @Nonnull final FrrCombinedParser _frrParser;
   private @Nonnull final SonicConfiguration _configuration;
 
   public SonicControlPlaneExtractor(
-      String configDbText,
-      Warnings configDbWarnings,
-      String frrText,
-      FrrCombinedParser frrParser,
-      Warnings frrWarnings,
-      SilentSyntaxCollection frrSilentSyntax) {
-    _configDbText = configDbText;
-    _configDbWarnings = configDbWarnings;
-    _frrFileText = frrText;
+      Map<SonicFileType, String> fileTypes,
+      Map<String, String> fileTexts,
+      Map<String, FileParseResult> fileResults,
+      FrrCombinedParser frrParser) {
+    _fileTypes = fileTypes;
+    _fileTexts = fileTexts;
+    _fileResults = fileResults;
     _frrParser = frrParser;
-    _frrWarnings = frrWarnings;
-    _frrSilentSyntax = frrSilentSyntax;
     _configuration = new SonicConfiguration();
   }
 
@@ -52,18 +60,133 @@ public class SonicControlPlaneExtractor implements ControlPlaneExtractor {
     return ImplementedRules.getImplementedRules(FrrConfigurationBuilder.class);
   }
 
-  public void processConfigDb() throws JsonProcessingException {
-    ConfigDb configDb = ConfigDb.deserialize(_configDbText, _configDbWarnings);
+  public void processNonFrrFiles() throws JsonProcessingException {
+    String configDbFilename = _fileTypes.get(SonicFileType.CONFIG_DB_JSON); // must exist
+    ConfigDb configDb =
+        ConfigDb.deserialize(
+            _fileTexts.get(configDbFilename), _fileResults.get(configDbFilename).getWarnings());
     _configuration.setConfigDb(configDb);
     configDb.getHostname().ifPresent(_configuration::setHostname);
+
+    // TODO: snmp.yml and resolve.conf
   }
 
   /** This method is called for FRR parsing, after configDb processing */
   @Override
   public void processParseTree(NetworkSnapshot snapshot, ParserRuleContext tree) {
+    String frrFilename = _fileTypes.get(SonicFileType.FRR_CONF); // must exist
+
     FrrConfigurationBuilder cb =
         new FrrConfigurationBuilder(
-            _configuration, _frrParser, _frrWarnings, _frrFileText, _frrSilentSyntax);
+            _configuration,
+            _frrParser,
+            _fileResults.get(frrFilename).getWarnings(),
+            _fileTexts.get(frrFilename),
+            _fileResults.get(frrFilename).getSilentSyntax());
     new BatfishParseTreeWalker(_frrParser).walk(cb, tree);
   }
+
+  /**
+   * Given filename to text map for a device, returns a map from {@link SonicFileType} to filename.
+   *
+   * <p>Expects exactly one config_db.json file and exactly one frr.conf file. Other filetypes are
+   * optional, but expects at most one file of each type.
+   *
+   * <p>Throws {@link IllegalArgumentException} if these expectations are violated or if the type of
+   * a file cannot be determined.
+   */
+  public static Map<SonicFileType, String> getSonicFileMap(Map<String, String> fileTexts) {
+    Map<SonicFileType, String> fileTypeMap = new HashMap<>();
+
+    // Filetype detection is based on the tail of the filename
+
+    for (String filename : fileTexts.keySet()) {
+      String filenameLower = filename.toLowerCase();
+      SonicFileType fileType = null;
+      if (filenameLower.endsWith("config_db.json")) {
+        fileType = SonicFileType.CONFIG_DB_JSON;
+      } else if (filenameLower.endsWith("frr.conf") || filenameLower.endsWith("frr.cfg")) {
+        fileType = SonicFileType.FRR_CONF;
+      } else if (filenameLower.endsWith("resolve.conf")) {
+        fileType = SonicFileType.RESOLVE_CONF;
+      } else if (filenameLower.endsWith("snmp.yml")) {
+        fileType = SonicFileType.SNMP_YML;
+      }
+      if (fileType != null) {
+        // duplicate type?
+        if (fileTypeMap.containsKey(fileType)) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Found two %s SONiC files: '%s', '%s'",
+                  fileType, filename, fileTypeMap.get(fileType)));
+        }
+        fileTypeMap.put(fileType, filename);
+      }
+    }
+    // for the 2-file case, try the deprecated content-based method if we didn't find both files
+    if (fileTexts.size() == 2
+        && (!fileTypeMap.containsKey(SonicFileType.CONFIG_DB_JSON)
+            || !fileTypeMap.containsKey(SonicFileType.FRR_CONF))) {
+      String frrFilename = getSonicFrrFilename(fileTexts);
+      String configDbFilename =
+          Sets.difference(fileTexts.keySet(), ImmutableSet.of(frrFilename)).iterator().next();
+      fileTypeMap =
+          ImmutableMap.of(
+              SonicFileType.FRR_CONF, frrFilename, SonicFileType.CONFIG_DB_JSON, configDbFilename);
+    }
+    if (!fileTypeMap.containsKey(SonicFileType.CONFIG_DB_JSON)) {
+      throw new IllegalArgumentException(
+          String.format("config_db file not found among: %s", fileTexts.keySet()));
+    }
+    if (!fileTypeMap.containsKey(SonicFileType.FRR_CONF)) {
+      throw new IllegalArgumentException(
+          String.format("frr configuration file not found among: %s", fileTexts.keySet()));
+    }
+    Set<String> unknownFiles =
+        Sets.difference(fileTexts.keySet(), ImmutableSet.copyOf(fileTypeMap.values()));
+    if (!unknownFiles.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot determine the type of SONiC files: '%s'. Make sure that they have legal"
+                  + " names.",
+              unknownFiles));
+    }
+    return ImmutableMap.copyOf(fileTypeMap);
+  }
+
+  /**
+   * Given filename to text map for a device, return which of the two files is frr.conf.
+   *
+   * <p>This method is deprecated. Use {@link #getSonicFileMap(Map)}.
+   */
+  @VisibleForTesting
+  static String getSonicFrrFilename(Map<String, String> fileTexts) {
+    if (fileTexts.size() != 2) {
+      // Batfish pairs up files -- but we double check
+      throw new IllegalArgumentException(
+          String.format(
+              "SONiC files should come in pairs. Got %d files: %s",
+              fileTexts.size(), fileTexts.keySet()));
+    }
+    Iterator<String> fileIterator = fileTexts.keySet().iterator();
+    String filename1 = fileIterator.next();
+    String filename2 = fileIterator.next();
+    // The file starting with '{' is a cheap way to check if it is configdb.json. Valid frr.conf
+    // files cannot start with '{'.
+    boolean fileText1IsJson = LIKELY_JSON.matcher(fileTexts.get(filename1)).find();
+    boolean fileText2IsJson = LIKELY_JSON.matcher(fileTexts.get(filename2)).find();
+    if (fileText1IsJson && !fileText2IsJson) {
+      return filename2;
+    }
+    if (!fileText1IsJson && fileText2IsJson) {
+      return filename1;
+    }
+    if (fileText1IsJson) { // if this is true fileText2 must also be JSON
+      throw new IllegalArgumentException("Neither SONiC file appears to be frr configuration");
+    }
+    // both start with '{'
+    throw new IllegalArgumentException("Neither SONiC file appears to be configdb JSON file");
+  }
+
+  private static final Pattern LIKELY_JSON = Pattern.compile("^\\s*\\{", Pattern.DOTALL);
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/grammar/SonicControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/grammar/SonicControlPlaneExtractor.java
@@ -95,7 +95,7 @@ public class SonicControlPlaneExtractor implements ControlPlaneExtractor {
    * <p>Throws {@link IllegalArgumentException} if these expectations are violated or if the type of
    * a file cannot be determined.
    */
-  public static Map<SonicFileType, String> getSonicFileMap(Map<String, String> fileTexts) {
+  public @Nonnull static Map<SonicFileType, String> getSonicFileMap(Map<String, String> fileTexts) {
     Map<SonicFileType, String> fileTypeMap = new HashMap<>();
 
     // Filetype detection is based on the tail of the filename
@@ -160,6 +160,7 @@ public class SonicControlPlaneExtractor implements ControlPlaneExtractor {
    * <p>This method is deprecated. Use {@link #getSonicFileMap(Map)}.
    */
   @VisibleForTesting
+  @Nonnull
   static String getSonicFrrFilename(Map<String, String> fileTexts) {
     if (fileTexts.size() != 2) {
       // Batfish pairs up files -- but we double check

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationResultTest.java
@@ -17,9 +17,9 @@ import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
+import org.batfish.grammar.FileParseResult;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection.SilentSyntaxElem;
-import org.batfish.job.ParseVendorConfigurationJob.FileResult;
 import org.batfish.representation.cisco.CiscoConfiguration;
 import org.batfish.vendor.VendorConfiguration;
 import org.junit.Test;
@@ -47,7 +47,7 @@ public class ParseVendorConfigurationResultTest {
             new BatfishLoggerHistory(),
             ImmutableMap.of(
                 filename,
-                new FileResult(parseTree, silentSyntax, fileWarnings)
+                new FileParseResult(parseTree, silentSyntax, fileWarnings)
                     .setParseStatus(ParseStatus.PARTIALLY_UNRECOGNIZED)),
             ConfigurationFormat.CISCO_IOS,
             config,
@@ -103,10 +103,10 @@ public class ParseVendorConfigurationResultTest {
             new BatfishLoggerHistory(),
             ImmutableMap.of(
                 filenames.get(0),
-                new FileResult(parseTrees.get(0), silentSyntaxes.get(0), fileWarnings.get(0))
+                new FileParseResult(parseTrees.get(0), silentSyntaxes.get(0), fileWarnings.get(0))
                     .setParseStatus(ParseStatus.PARTIALLY_UNRECOGNIZED),
                 filenames.get(1),
-                new FileResult(parseTrees.get(1), silentSyntaxes.get(1), fileWarnings.get(1))
+                new FileParseResult(parseTrees.get(1), silentSyntaxes.get(1), fileWarnings.get(1))
                     .setParseStatus(ParseStatus.PASSED)),
             ConfigurationFormat.CISCO_IOS,
             config,

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicControlPlaneExtractorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicControlPlaneExtractorTest.java
@@ -1,0 +1,172 @@
+package org.batfish.vendor.sonic.grammar;
+
+import static org.batfish.vendor.sonic.grammar.SonicControlPlaneExtractor.getSonicFileMap;
+import static org.batfish.vendor.sonic.grammar.SonicControlPlaneExtractor.getSonicFrrFilename;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import org.batfish.vendor.sonic.grammar.SonicControlPlaneExtractor.SonicFileType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SonicControlPlaneExtractorTest {
+
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  @Test
+  public void testGetSonicFileMap() {
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF, "frr.conf", SonicFileType.CONFIG_DB_JSON, "config_db.json"),
+        getSonicFileMap(ImmutableMap.of("frr.conf", "hello", "config_db.json", "{}")));
+
+    // cfg variant for frr
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF, "frr.cfg", SonicFileType.CONFIG_DB_JSON, "config_db.json"),
+        getSonicFileMap(ImmutableMap.of("frr.cfg", "hello", "config_db.json", "{}")));
+
+    // non-empty prefixes
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF,
+            "device_frr.cfg",
+            SonicFileType.CONFIG_DB_JSON,
+            "device_config_db.json"),
+        getSonicFileMap(ImmutableMap.of("device_frr.cfg", "hello", "device_config_db.json", "{}")));
+  }
+
+  @Test
+  public void testGetSonicFileMap_Snmp() {
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF,
+            "frr.conf",
+            SonicFileType.CONFIG_DB_JSON,
+            "config_db.json",
+            SonicFileType.SNMP_YML,
+            "snmp.yml"),
+        getSonicFileMap(
+            ImmutableMap.of("frr.conf", "hello", "config_db.json", "{}", "snmp.yml", "blah")));
+
+    // non-empty prefix
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF,
+            "frr.conf",
+            SonicFileType.CONFIG_DB_JSON,
+            "config_db.json",
+            SonicFileType.SNMP_YML,
+            "device_snmp.yml"),
+        getSonicFileMap(
+            ImmutableMap.of(
+                "frr.conf", "hello", "config_db.json", "{}", "device_snmp.yml", "blah")));
+  }
+
+  @Test
+  public void testGetSonicFileMap_Resolve() {
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF,
+            "frr.conf",
+            SonicFileType.CONFIG_DB_JSON,
+            "config_db.json",
+            SonicFileType.RESOLVE_CONF,
+            "resolve.conf"),
+        getSonicFileMap(
+            ImmutableMap.of("frr.conf", "hello", "config_db.json", "{}", "resolve.conf", "blah")));
+
+    // non-empty prefix
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF,
+            "frr.conf",
+            SonicFileType.CONFIG_DB_JSON,
+            "config_db.json",
+            SonicFileType.RESOLVE_CONF,
+            "device_resolve.conf"),
+        getSonicFileMap(
+            ImmutableMap.of(
+                "frr.conf", "hello", "config_db.json", "{}", "device_resolve.conf", "blah")));
+  }
+
+  @Test
+  public void testGetSonicFileMap_missingConfigDb() {
+    _thrown.expect(IllegalArgumentException.class);
+    getSonicFileMap(ImmutableMap.of("frr.conf", "hello"));
+  }
+
+  @Test
+  public void testGetSonicFileMap_missingFrr() {
+    _thrown.expect(IllegalArgumentException.class);
+    getSonicFileMap(ImmutableMap.of("config_db.json", "{}"));
+  }
+
+  @Test
+  public void testGetSonicFileMap_duplicateType() {
+    _thrown.expect(IllegalArgumentException.class);
+    getSonicFileMap(ImmutableMap.of("config_db.json", "{}", "device_config_db.json", "{}"));
+  }
+
+  @Test
+  public void testGetSonicFileMap_unknownType() {
+    _thrown.expect(IllegalArgumentException.class);
+    // frr is not a valid tail, and config_db's content is not json
+    getSonicFileMap(ImmutableMap.of("frr", "hello", "config_db,json", "not json"));
+  }
+
+  @Test
+  public void testGetSonicFileMap_deprecated() {
+    // this will delegate to getSonicFrrFilename because frr filename is not legal
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF, "frr", SonicFileType.CONFIG_DB_JSON, "config_db.json"),
+        getSonicFileMap(ImmutableMap.of("frr", "hello", "config_db.json", "{}")));
+
+    // this will delegate to getSonicFrrFilename because config_db filename is not legal
+    assertEquals(
+        ImmutableMap.of(
+            SonicFileType.FRR_CONF, "frr.conf", SonicFileType.CONFIG_DB_JSON, "config_db"),
+        getSonicFileMap(ImmutableMap.of("frr.conf", "hello", "config_db", "{}")));
+
+    // fail -- don't delegate when there are more than 2 files
+    _thrown.expect(IllegalArgumentException.class);
+    getSonicFileMap(
+        ImmutableMap.of("frr", "hello", "config_db.json", "{}", "resolve.conf", "blah"));
+  }
+
+  @Test
+  public void testGetSonicFrrFilename() {
+    assertEquals(
+        "frr", getSonicFrrFilename(ImmutableMap.of("frr", "hello", "configdb.json", "{}")));
+
+    // leading whitespace
+    assertEquals(
+        "frr", getSonicFrrFilename(ImmutableMap.of("frr", "hello", "configdb.json", " \n  {}")));
+  }
+
+  @Test
+  public void testGetSonicFrrFilename_twoJsonFiles() {
+    _thrown.expect(IllegalArgumentException.class);
+    getSonicFrrFilename(ImmutableMap.of("f1", "{}", "f2", "{}"));
+  }
+
+  @Test
+  public void testGetSonicFrrFilename_noJsonFiles() {
+    _thrown.expect(IllegalArgumentException.class);
+    getSonicFrrFilename(ImmutableMap.of("f1", "aa", "f2", "ab"));
+  }
+
+  @Test
+  public void testGetSonicFrrFilename_oneFile() {
+    _thrown.expect(IllegalArgumentException.class);
+    getSonicFrrFilename(ImmutableMap.of("frr", "hello"));
+  }
+
+  @Test
+  public void testGetSonicFrrFilename_manyFiles() {
+    _thrown.expect(IllegalArgumentException.class);
+    getSonicFrrFilename(ImmutableMap.of("frr", "hello", "a", "{}", "b", "{}"));
+  }
+}


### PR DESCRIPTION
Following up to #8180, this PR moves most sonic-specific parsing logic to its extractor and changes its interface to be independent of number and types of files. This required moving the previously-internal FileResult class to outside of ParseVendorConfigurationJob. 

No functional change in this PR. 