### PR TITLE
Frr: Remove DNS servers

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConfiguration.java
@@ -9,14 +9,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.vendor.VendorConfiguration;
 
@@ -31,8 +28,6 @@ public class FrrConfiguration implements Serializable {
   private @Nullable OspfProcess _ospfProcess;
   private @Nonnull Map<String, FrrInterface> _interfaces;
   private List<String> _interfaceInitOrder;
-  private final @Nonnull List<Ip> _ipv4Nameservers;
-  private final @Nonnull List<Ip6> _ipv6Nameservers;
   private final @Nonnull Map<String, RouteMap> _routeMaps;
   private final @Nonnull Set<StaticRoute> _staticRoutes;
   private @Nonnull Map<String, Vrf> _vrfs;
@@ -47,8 +42,6 @@ public class FrrConfiguration implements Serializable {
     _ipPrefixLists = new HashMap<>();
     _ipv6PrefixLists = new HashMap<>();
     _bgpCommunityLists = new HashMap<>();
-    _ipv4Nameservers = new LinkedList<>();
-    _ipv6Nameservers = new LinkedList<>();
     _routeMaps = new HashMap<>();
     _staticRoutes = new HashSet<>();
     _vrfs = new HashMap<>();
@@ -122,16 +115,6 @@ public class FrrConfiguration implements Serializable {
   @Nonnull
   public Map<String, RouteMap> getRouteMaps() {
     return _routeMaps;
-  }
-
-  @Nonnull
-  public List<Ip> getIpv4Nameservers() {
-    return _ipv4Nameservers;
-  }
-
-  @Nonnull
-  public List<Ip6> getIpv6Nameservers() {
-    return _ipv6Nameservers;
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import java.util.Collection;
@@ -232,7 +231,6 @@ public final class FrrConversions {
     convertIpPrefixLists(c, frrConfiguration.getIpPrefixLists(), vc.getFilename());
     convertBgpCommunityLists(c, frrConfiguration.getBgpCommunityLists());
     convertRouteMaps(c, frrConfiguration, vc.getFilename(), vc.getWarnings());
-    convertDnsServers(c, frrConfiguration.getIpv4Nameservers());
 
     convertOspfProcess(c, vc, frrConfiguration, vc.getWarnings());
     addOspfUnnumberedLLAs(c);
@@ -1765,13 +1763,6 @@ public final class FrrConversions {
     vc.getRouteMaps()
         .forEach(
             (name, routeMap) -> new RouteMapConvertor(c, vc, routeMap, filename, w).toRouteMap());
-  }
-
-  private static void convertDnsServers(Configuration c, List<Ip> ipv4Nameservers) {
-    c.setDnsServers(
-        ipv4Nameservers.stream()
-            .map(Object::toString)
-            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
   }
 
   public static @Nonnull String computeRouteMapEntryName(String routeMapName, int sequence) {


### PR DESCRIPTION
DNS servers cannot be configured in FRR. Batfish had vestiges probably from Cumulus NCLU.