### PR TITLE
Verify interface references in OSPF areas

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfArea.java
@@ -210,6 +210,19 @@ public class OspfArea implements Serializable {
   @Nonnull private final SortedMap<Prefix, OspfAreaSummary> _summaries;
   @Nullable private final String _summaryFilter;
 
+  public @Nonnull Builder toBuilder() {
+    return builder()
+        .setNumber(_areaNumber)
+        .setInjectDefaultRoute(_injectDefaultRoute)
+        .setInterfaces(_interfaces)
+        .setMetricOfDefaultRoute(_metricOfDefaultRoute)
+        .setNssa(_nssa)
+        .setStub(_stub)
+        .setStubType(_stubType)
+        .setSummaries(_summaries)
+        .setSummaryFilter(_summaryFilter);
+  }
+
   public OspfArea(
       long areaNumber,
       boolean injectDefaultRoute,


### PR DESCRIPTION
- remove references to undefined interfaces in OSPF areas during `finalizeConfiguration`