### PR TITLE
Juniper fix apply-path

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
@@ -876,32 +876,10 @@ public final class Hierarchy {
   }
 
   private static boolean isIpOrIp6(String text) {
-    try {
-      Ip.parse(text);
-      return true;
-    } catch (IllegalArgumentException e) {
-      try {
-        Ip6.parse(text);
-        return true;
-      } catch (BatfishException e1) {
-        // TODO: should throw IllegalArgumentException instead.
-        return false;
-      }
-    }
+    return Ip.tryParse(text).isPresent() || Ip6.tryParse(text).isPresent();
   }
 
   private static boolean isPrefixOrPrefix6(String text) {
-    try {
-      Prefix.parse(text);
-      return true;
-    } catch (IllegalArgumentException e) {
-      try {
-        Prefix6.parse(text);
-        return true;
-      } catch (BatfishException e1) {
-        // TODO: should throw IllegalArgumentException instead.
-        return false;
-      }
-    }
+    return Prefix.tryParse(text).isPresent() || Prefix6.tryParse(text).isPresent();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -7226,5 +7226,39 @@ public final class FlatJuniperGrammarTest {
     assertThat(ccae, hasNumReferrers(filename, INTERFACE, "irb.1", 2));
   }
 
+  private static final List<String> APPLY_PATH_NO_MATCH_CONFIGS =
+      ImmutableList.of(
+          "apply-path-no-match",
+          "apply-path-no-match-not-ip-or-prefix",
+          "apply-path-from-apply-groups-no-match");
+
+  @Test
+  public void testApplyPathNoMatchExtraction() {
+    for (String hostname : APPLY_PATH_NO_MATCH_CONFIGS) {
+      JuniperConfiguration vc = parseJuniperConfig(hostname);
+      assertThat(vc.getMasterLogicalSystem().getPrefixLists().get("pl1").getPrefixes(), empty());
+      assertFalse(vc.getMasterLogicalSystem().getPrefixLists().get("pl1").getHasIpv6());
+    }
+  }
+
+  @Test
+  public void testApplyPathNoMatchConversion() {
+    for (String hostname : APPLY_PATH_NO_MATCH_CONFIGS) {
+      Configuration c = parseConfig(hostname);
+      // TODO: determine whether this should be empty or permit all
+      assertThat(c.getRouteFilterLists().get("pl1").getLines(), empty());
+    }
+  }
+
+  @Test
+  public void testApplyPathMixedIpAndNotIpOrPrefixExtraction() {
+    String hostname = "apply-path-mixed-ip-and-not-ip-or-prefix";
+    JuniperConfiguration vc = parseJuniperConfig(hostname);
+    assertThat(
+        vc.getMasterLogicalSystem().getPrefixLists().get("pl1").getPrefixes(),
+        contains(Prefix.strict("192.0.2.1/32")));
+    assertFalse(vc.getMasterLogicalSystem().getPrefixLists().get("pl1").getHasIpv6());
+  }
+
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-path-from-apply-groups-no-match
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-path-from-apply-groups-no-match
@@ -1,0 +1,7 @@
+#RANCID-CONTENT-TYPE: juniper
+set system host-name apply-path-from-apply-groups-no-match
+#
+set groups g1 services service-set <*> ipsec-vpn-options local-gateway routing-instance ri1
+set services apply-groups g1
+set policy-options prefix-list pl1 apply-path "services service-set <*> ipsec-vpn-options local-gateway <*>"
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-path-mixed-ip-and-not-ip-or-prefix
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-path-mixed-ip-and-not-ip-or-prefix
@@ -1,0 +1,9 @@
+#RANCID-CONTENT-TYPE: juniper
+set system host-name apply-path-mixed-ip-and-not-ip-or-prefix
+#
+set groups g1 services service-set <*> tcp-mss 1398
+set groups g1 services service-set <*> ipsec-vpn-options local-gateway 192.0.2.1
+set groups g1 services service-set <*> ipsec-vpn-options local-gateway routing-instance ri1
+set services apply-groups g1
+set policy-options prefix-list pl1 apply-path "services service-set <*> ipsec-vpn-options local-gateway <*>"
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-path-no-match
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-path-no-match
@@ -1,0 +1,9 @@
+#RANCID-CONTENT-TYPE: juniper
+set system host-name apply-path-no-match
+#
+set policy-options prefix-list pl1 apply-path "services service-set <*> ipsec-vpn-options local-gateway <*>"
+
+
+set services service-set <*> ipsec-vpn-options local-gateway routing-instance ri1
+
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-path-no-match-not-ip-or-prefix
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-path-no-match-not-ip-or-prefix
@@ -1,0 +1,6 @@
+#RANCID-CONTENT-TYPE: juniper
+set system host-name apply-path-no-match-not-ip-or-prefix
+#
+set services service-set foo ipsec-vpn-options local-gateway routing-instance ri1
+set policy-options prefix-list pl1 apply-path "services service-set <*> ipsec-vpn-options local-gateway <*>"
+#


### PR DESCRIPTION
- only generate lines for matches that end in IP or Prefix
- don't crash otherwise