### PR TITLE
BGP: remove warning about static update-source inference

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -346,11 +346,6 @@ final class AristaConversions {
       /* TODO: Warn here? Seems like this may be standard practice, e.g., for a /31. */
       return firstMatchingInterfaceAddress.get();
     }
-
-    warnings.redFlag(
-        String.format(
-            "BGP neighbor %s in vrf %s: could not determine update source",
-            prefix.getStartIp(), vrfName));
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -853,9 +853,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
           }
         }
       }
-      if (updateSource == null && lpg.getNeighborPrefix().getStartIp().valid()) {
-        _w.redFlag("Could not determine update source for BGP neighbor: '" + lpg.getName() + "'");
-      }
     }
     return updateSource;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -931,9 +931,6 @@ public final class AsaConfiguration extends VendorConfiguration {
           }
         }
       }
-      if (updateSource == null && lpg.getNeighborPrefix().getStartIp().valid()) {
-        _w.redFlag("Could not determine update source for BGP neighbor: '" + lpg.getName() + "'");
-      }
     }
     return updateSource;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -375,11 +375,6 @@ public final class Conversions {
       /* TODO: Warn here? Seems like this may be standard practice, e.g., for a /31. */
       return firstMatchingInterfaceAddress.get();
     }
-
-    warnings.redFlag(
-        String.format(
-            "BGP neighbor %s in vrf %s: could not determine update source",
-            prefix.getStartIp(), vrfName));
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -717,9 +717,6 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
           }
         }
       }
-      if (updateSource == null && lpg.getNeighborPrefix().getStartIp().valid()) {
-        _w.redFlag("Could not determine update source for BGP neighbor: '" + lpg.getName() + "'");
-      }
     }
     return updateSource;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -935,8 +935,6 @@ public class F5BigipConfiguration extends VendorConfiguration {
         }
       }
     }
-
-    _w.redFlag("Could not determine update source for BGP neighbor: '" + neighbor.getName() + "'");
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Conversion.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Conversion.java
@@ -827,7 +827,6 @@ public class A10Conversion {
     if (firstMatchingInterfaceAddress.isPresent()) {
       return firstMatchingInterfaceAddress.get();
     }
-    warnings.redFlag(String.format("BGP neighbor %s: could not determine update source", remoteIp));
     return null;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/representation/A10ConversionTest.java
@@ -908,9 +908,6 @@ public class A10ConversionTest {
       // no matching interface, no explicit update source
       Warnings warnings = new Warnings(false, true, true);
       assertNull(computeUpdateSource(ImmutableMap.of(), remoteIp, null, warnings));
-      assertThat(
-          warnings,
-          hasRedFlag(hasText("BGP neighbor 10.0.0.2: could not determine update source")));
     }
   }
 

--- a/tests/basic/init-candidate.ref
+++ b/tests/basic/init-candidate.ref
@@ -98,7 +98,7 @@
     {
       "class" : "org.batfish.datamodel.answers.ConvertConfigurationAnswerElement",
       "convertStatus" : {
-        "as1border1" : "WARNINGS",
+        "as1border1" : "PASSED",
         "as1border2" : "PASSED",
         "as1core1" : "PASSED",
         "as2border1" : "PASSED",
@@ -3247,18 +3247,6 @@
       },
       "version" : "0.36.0",
       "warnings" : {
-        "as1border1" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '3.2.2.2'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '5.6.7.8'"
-            }
-          ]
-        },
         "internet" : { }
       }
     },

--- a/tests/basic/init-with-ba.ref
+++ b/tests/basic/init-with-ba.ref
@@ -98,7 +98,7 @@
     {
       "class" : "org.batfish.datamodel.answers.ConvertConfigurationAnswerElement",
       "convertStatus" : {
-        "as1border1" : "WARNINGS",
+        "as1border1" : "PASSED",
         "as1border2" : "PASSED",
         "as1core1" : "PASSED",
         "as2border1" : "PASSED",
@@ -3247,18 +3247,6 @@
       },
       "version" : "0.36.0",
       "warnings" : {
-        "as1border1" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '3.2.2.2'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '5.6.7.8'"
-            }
-          ]
-        },
         "internet" : { }
       }
     },

--- a/tests/basic/init.ref
+++ b/tests/basic/init.ref
@@ -98,7 +98,7 @@
     {
       "class" : "org.batfish.datamodel.answers.ConvertConfigurationAnswerElement",
       "convertStatus" : {
-        "as1border1" : "WARNINGS",
+        "as1border1" : "PASSED",
         "as1border2" : "PASSED",
         "as1core1" : "PASSED",
         "as2border1" : "PASSED",
@@ -3239,18 +3239,6 @@
       },
       "version" : "0.36.0",
       "warnings" : {
-        "as1border1" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '3.2.2.2'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '5.6.7.8'"
-            }
-          ]
-        },
         "internet" : { }
       }
     },

--- a/tests/parsing-errors-tests/recovery-no-verbose.ref
+++ b/tests/parsing-errors-tests/recovery-no-verbose.ref
@@ -9,14 +9,6 @@
         "configs/cumulus_nclu_range" : "PARTIALLY_UNRECOGNIZED"
       },
       "warnings" : {
-        "as1r1" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '10.12.11.2'"
-            }
-          ]
-        },
         "configs/as1r1.cfg" : {
           "Parse warnings" : [
             {

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -70651,7 +70651,7 @@
         "aaa_authentication_login_default_tacacs_local" : "PASSED",
         "aaa_group_server_source_interface" : "PASSED",
         "access_list" : "PASSED",
-        "address_family" : "WARNINGS",
+        "address_family" : "PASSED",
         "aggaddress" : "PASSED",
         "arista-event-handler" : "PASSED",
         "arista_acl" : "PASSED",
@@ -70681,7 +70681,7 @@
         "bgp-allow" : "PASSED",
         "bgp-disable" : "PASSED",
         "bgp-enforce-first-as" : "PASSED",
-        "bgp_address_family" : "WARNINGS",
+        "bgp_address_family" : "PASSED",
         "bgp_default_originate_policy" : "PASSED",
         "bgp_nsr" : "PASSED",
         "bgp_route_policy" : "WARNINGS",
@@ -70690,7 +70690,7 @@
         "cisco_acl" : "PASSED",
         "cisco_additional_paths" : "PASSED",
         "cisco_authentication" : "PASSED",
-        "cisco_bgp" : "WARNINGS",
+        "cisco_bgp" : "PASSED",
         "cisco_bgp_confederation" : "PASSED",
         "cisco_cable" : "PASSED",
         "cisco_callhome" : "PASSED",
@@ -70775,7 +70775,7 @@
         "cumulus_nclu_stp" : "PASSED",
         "eos_mlag" : "PASSED",
         "eos_trunk_group" : "PASSED",
-        "f5_bigip_imish_malformed" : "WARNINGS",
+        "f5_bigip_imish_malformed" : "PASSED",
         "f5_bigip_structured_cm" : "PASSED",
         "f5_bigip_structured_ltm" : "WARNINGS",
         "f5_bigip_structured_malformed" : "WARNINGS",
@@ -70785,7 +70785,7 @@
         "f5_bigip_structured_net_routing_route_map" : "PASSED",
         "f5_bigip_structured_sys" : "PASSED",
         "f5_bigip_structured_sys_ha_group" : "PASSED",
-        "f5_bigip_structured_with_imish" : "WARNINGS",
+        "f5_bigip_structured_with_imish" : "PASSED",
         "host1" : "PASSED",
         "host2" : "PASSED",
         "if_tag_is" : "PASSED",
@@ -70808,7 +70808,7 @@
         "ios_xe_bgp" : "WARNINGS",
         "ios_xr_acl" : "PASSED",
         "ios_xr_bgp" : "WARNINGS",
-        "ios_xr_bgp_neighbor_group" : "WARNINGS",
+        "ios_xr_bgp_neighbor_group" : "PASSED",
         "ios_xr_class_map" : "PASSED",
         "ios_xr_isis" : "WARNINGS",
         "ios_xr_logging" : "PASSED",
@@ -70869,7 +70869,7 @@
         "no_ip_name_server" : "PASSED",
         "no_mask_reply" : "PASSED",
         "no_snmp_server" : "PASSED",
-        "non_nexus_neighbor_af" : "WARNINGS",
+        "non_nexus_neighbor_af" : "PASSED",
         "nxos_acl" : "PASSED",
         "nxos_bgp" : "WARNINGS",
         "nxos_interface" : "PASSED",
@@ -85339,14 +85339,6 @@
             }
           ]
         },
-        "address_family" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '1.2.3.4'"
-            }
-          ]
-        },
         "arista_bgp" : {
           "Red flags" : [
             {
@@ -85371,35 +85363,11 @@
             }
           ]
         },
-        "bgp_address_family" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '1.10.1.1'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '10.12.11.2'"
-            }
-          ]
-        },
         "bgp_route_policy" : {
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '64.57.21.1'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Ignoring undefined route-policy static-connected-to-bgp in connected -> BGP redistribution"
-            }
-          ]
-        },
-        "cisco_bgp" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '10.0.1.2'"
             }
           ]
         },
@@ -85559,14 +85527,6 @@
             }
           ]
         },
-        "f5_bigip_imish_malformed" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '3.3.3.3'"
-            }
-          ]
-        },
         "f5_bigip_structured_ltm" : {
           "Red flags" : [
             {
@@ -85599,19 +85559,7 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '192.0.2.1'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Ignoring reference to missing outbound route-map: /Common/MY_IPV4_OUT"
-            }
-          ]
-        },
-        "f5_bigip_structured_with_imish" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '10.0.0.1'"
             }
           ]
         },
@@ -85645,22 +85593,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Ignoring undefined route-policy REDISTRIBUTE_STATIC_POLICY in static -> BGP redistribution"
-            }
-          ]
-        },
-        "ios_xr_bgp_neighbor_group" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '1.2.1.1'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '1.2.1.2'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '1.2.1.3'"
             }
           ]
         },
@@ -85816,20 +85748,8 @@
             }
           ]
         },
-        "non_nexus_neighbor_af" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not determine update source for BGP neighbor: '10.0.0.0'"
-            }
-          ]
-        },
         "nxos_bgp" : {
           "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "BGP neighbor 1.1.1.1 in vrf default: could not determine update source"
-            },
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Router-id is not manually configured for BGP process in VRF default. Unable to infer default router-id as no interfaces have IP addresses"


### PR DESCRIPTION
After batfish/batfish#7217, this can be inferred dynamically. May not be a bug.

**Issue references**: 

 - batfish/batfish#7217