### PR TITLE
MemoizedIpSpaceToBDD chaining

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -168,8 +168,8 @@ public class BDDPacket {
             BDDUtils.concatBitvectors(dstIpBitvec, dstPortBitvec),
             BDDUtils.concatBitvectors(srcIpBitvec, srcPortBitvec));
 
-    _dstIpSpaceToBDD = new MemoizedIpSpaceToBDD(_dstIp, ImmutableMap.of());
-    _srcIpSpaceToBDD = new MemoizedIpSpaceToBDD(_srcIp, ImmutableMap.of());
+    _dstIpSpaceToBDD = new MemoizedIpSpaceToBDD(_dstIp);
+    _srcIpSpaceToBDD = new MemoizedIpSpaceToBDD(_srcIp);
   }
 
   public @Nonnull BDD getSaneFlowConstraint() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/HeaderSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/HeaderSpaceToBDD.java
@@ -34,11 +34,11 @@ public final class HeaderSpaceToBDD {
     _dstIpSpaceToBdd =
         namedIpSpaces.isEmpty()
             ? bddPacket.getDstIpSpaceToBDD()
-            : new MemoizedIpSpaceToBDD(_bddPacket.getDstIp(), namedIpSpaces);
+            : new MemoizedIpSpaceToBDD(bddPacket.getDstIpSpaceToBDD(), namedIpSpaces);
     _srcIpSpaceToBdd =
         namedIpSpaces.isEmpty()
             ? bddPacket.getSrcIpSpaceToBDD()
-            : new MemoizedIpSpaceToBDD(_bddPacket.getSrcIp(), namedIpSpaces);
+            : new MemoizedIpSpaceToBDD(bddPacket.getSrcIpSpaceToBDD(), namedIpSpaces);
   }
 
   /** Returns bdd.not() or {@code null} if given {@link BDD} is null. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpSpaceToBDD;
-import org.batfish.common.bdd.MemoizedIpSpaceToBDD;
 import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.specifier.InterfaceLinkLocation;
@@ -76,9 +75,9 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
       IpOwners ipOwners) {
     List<Map.Entry<String, String>> allVrfs = sparseKeys(fibs);
 
-    // TODO accept IpSpaceToBDD as parameter
-    IpSpaceToBDD ipSpaceToBDD =
-        new MemoizedIpSpaceToBDD(new BDDPacket().getDstIp(), ImmutableMap.of());
+    // TODO accept IpSpaceToBDD as parameter to reuse work when we build forwarding analysis
+    // multiple times.
+    IpSpaceToBDD ipSpaceToBDD = new BDDPacket().getDstIpSpaceToBDD();
 
     LOGGER.info("Computing owned and unowned IPs");
     // IPs belonging to any interface in the network, even inactive interfaces

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceCanContainReferences.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceCanContainReferences.java
@@ -1,0 +1,59 @@
+package org.batfish.datamodel.visitors;
+
+import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.IpIpSpace;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpSpaceReference;
+import org.batfish.datamodel.IpWildcardIpSpace;
+import org.batfish.datamodel.IpWildcardSetIpSpace;
+import org.batfish.datamodel.PrefixIpSpace;
+import org.batfish.datamodel.UniverseIpSpace;
+
+public final class IpSpaceCanContainReferences implements GenericIpSpaceVisitor<Boolean> {
+  private static final IpSpaceCanContainReferences INSTANCE = new IpSpaceCanContainReferences();
+
+  public static boolean ipSpaceCanContainReferences(IpSpace ipSpace) {
+    return ipSpace.accept(INSTANCE);
+  }
+
+  @Override
+  public Boolean visitAclIpSpace(AclIpSpace aclIpSpace) {
+    return true;
+  }
+
+  @Override
+  public Boolean visitEmptyIpSpace(EmptyIpSpace emptyIpSpace) {
+    return false;
+  }
+
+  @Override
+  public Boolean visitIpIpSpace(IpIpSpace ipIpSpace) {
+    return false;
+  }
+
+  @Override
+  public Boolean visitIpSpaceReference(IpSpaceReference ipSpaceReference) {
+    return true;
+  }
+
+  @Override
+  public Boolean visitIpWildcardIpSpace(IpWildcardIpSpace ipWildcardIpSpace) {
+    return false;
+  }
+
+  @Override
+  public Boolean visitIpWildcardSetIpSpace(IpWildcardSetIpSpace ipWildcardSetIpSpace) {
+    return false;
+  }
+
+  @Override
+  public Boolean visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
+    return false;
+  }
+
+  @Override
+  public Boolean visitUniverseIpSpace(UniverseIpSpace universeIpSpace) {
+    return false;
+  }
+}


### PR DESCRIPTION
BDDPacket has MemoizedIpSpaceToBDD instances for src/dst IpSpaces that have no IpSpaceReferences. With this PR, the
per-node instances will delegate to those for IpSpaces that cannot contain references (recursively). This will reduce RAM
usage caused by caching IpSpaces multiple times and improve performance by using cached results more.