### PR TITLE
Sonic: Support for secondary interface addresses

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/ConfigDb.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/ConfigDb.java
@@ -215,18 +215,34 @@ public class ConfigDb implements Serializable {
    * address, or with a v6 address.
    */
   @VisibleForTesting
-  static Map<String, L3Interface> createInterfaces(Set<String> interfaceKeys) {
+  static Map<String, L3Interface> createInterfaces(
+      Map<String, InterfaceKeyProperties> interfaceKeyMap, Warnings warnings) {
     Map<String, L3Interface> interfaces = new HashMap<>();
-    for (String key : interfaceKeys) {
+    for (String key : interfaceKeyMap.keySet()) {
       String[] parts = key.split("\\|", 2);
-      interfaces.computeIfAbsent(parts[0], i -> new L3Interface(null));
+      L3Interface l3Interface =
+          interfaces.computeIfAbsent(parts[0], i -> new L3Interface(ImmutableMap.of()));
       if (parts.length == 2) {
         try {
-          // if the interface appears with a v4 address, overwrite with that version
           ConcreteInterfaceAddress v4Address = ConcreteInterfaceAddress.parse(parts[1]);
-          interfaces.put(parts[0], new L3Interface(v4Address));
+          InterfaceKeyProperties interfaceKeyProperties = interfaceKeyMap.get(key);
+          l3Interface.addAddress(v4Address, interfaceKeyMap.get(key));
+
+          // warn about unimplemented properties
+          if (interfaceKeyProperties.getForcedMgmtRoutes() != null) {
+            warnings.unimplemented(
+                String.format("Property 'forced_mgmt_routes' of '%s' is not implemented", key));
+          }
+          if (interfaceKeyProperties.getGwAddr() != null) {
+            warnings.unimplemented(
+                String.format("Property 'gwaddr' of '%s' is not implemented", key));
+          }
         } catch (IllegalArgumentException e) {
-          Prefix6.parse(parts[1]); // try to parse as v6; Will throw an exception upon failure
+          Optional<Prefix6> prefix6 = Prefix6.tryParse(parts[1]);
+          if (!prefix6.isPresent()) {
+            // part[1] is neither v4 nor v6
+            warnings.redFlag(String.format("Could not parse interface key '%s", key));
+          }
         }
       }
     }
@@ -426,9 +442,9 @@ public class ConfigDb implements Serializable {
             case PROP_INTERFACE:
               configDb.setInterfaces(
                   createInterfaces(
-                      mapper
-                          .convertValue(value, new TypeReference<Map<String, Object>>() {})
-                          .keySet()));
+                      mapper.convertValue(
+                          value, new TypeReference<Map<String, InterfaceKeyProperties>>() {}),
+                      _warnings));
               break;
             case PROP_LOOPBACK:
               configDb.setLoopbacks(
@@ -437,24 +453,17 @@ public class ConfigDb implements Serializable {
             case PROP_LOOPBACK_INTERFACE:
               configDb.setLoopbackInterfaces(
                   createInterfaces(
-                      mapper
-                          .convertValue(value, new TypeReference<Map<String, Object>>() {})
-                          .keySet()));
+                      mapper.convertValue(
+                          value, new TypeReference<Map<String, InterfaceKeyProperties>>() {}),
+                      _warnings));
               break;
             case PROP_MGMT_INTERFACE:
               {
-                Map<String, Map<String, Object>> mgmtInterfaceMap =
-                    mapper.convertValue(
-                        value, new TypeReference<Map<String, Map<String, Object>>>() {});
-                configDb.setMgmtInterfaces(createInterfaces(mgmtInterfaceMap.keySet()));
-                Set<String> innerProperties =
-                    mgmtInterfaceMap.values().stream()
-                        .flatMap(map -> map.keySet().stream())
-                        .collect(ImmutableSet.toImmutableSet());
-                innerProperties.forEach(
-                    key ->
-                        _warnings.unimplemented(
-                            String.format("Unimplemented MGMT_INTERFACE property '%s'", key)));
+                configDb.setMgmtInterfaces(
+                    createInterfaces(
+                        mapper.convertValue(
+                            value, new TypeReference<Map<String, InterfaceKeyProperties>>() {}),
+                        _warnings));
                 break;
               }
             case PROP_MGMT_PORT:
@@ -493,9 +502,9 @@ public class ConfigDb implements Serializable {
             case PROP_VLAN_INTERFACE:
               configDb.setVlanInterfaces(
                   createInterfaces(
-                      mapper
-                          .convertValue(value, new TypeReference<Map<String, Object>>() {})
-                          .keySet()));
+                      mapper.convertValue(
+                          value, new TypeReference<Map<String, InterfaceKeyProperties>>() {}),
+                      _warnings));
               break;
             case PROP_VLAN_MEMBER:
               configDb.setVlanMembers(

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/InterfaceKeyProperties.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/InterfaceKeyProperties.java
@@ -1,0 +1,120 @@
+package org.batfish.vendor.sonic.representation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Represents the value of the key in SONiC's multi-level interface|address (e.g.,
+ * Ethernet1|1.1.1.1) encoding.
+ */
+public class InterfaceKeyProperties implements Serializable {
+
+  /** Returns null if the property was not set */
+  public @Nullable List<String> getForcedMgmtRoutes() {
+    return _forcedMgmtRoutes;
+  }
+
+  public @Nullable String getGwAddr() {
+    return _gwAddr;
+  }
+
+  public @Nullable Boolean getSecondary() {
+    return _secondary;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof InterfaceKeyProperties)) {
+      return false;
+    }
+    InterfaceKeyProperties that = (InterfaceKeyProperties) o;
+    return Objects.equals(_forcedMgmtRoutes, that._forcedMgmtRoutes)
+        && Objects.equals(_gwAddr, that._gwAddr)
+        && Objects.equals(_secondary, that._secondary);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_forcedMgmtRoutes, _gwAddr, _secondary);
+  }
+
+  @JsonCreator
+  private static InterfaceKeyProperties create(
+      @Nullable @JsonProperty(PROP_FORCED_MGMT_ROUTES) List<String> forcedMgmtRoutes,
+      @Nullable @JsonProperty(PROP_GWADDR) String gwaddr,
+      @Nullable @JsonProperty(PROP_SECONDARY) String secondary) {
+    // we do not parse strings inside forcedMgmtRoutes and gwAddr (which are v4 or v6 address)
+    // they are not convert these properties
+    return InterfaceKeyProperties.builder()
+        .setForcedMgmtRoutes(forcedMgmtRoutes)
+        .setGwAddr(gwaddr)
+        .setSecondary(Optional.ofNullable(secondary).map("true"::equals).orElse(null))
+        .build();
+  }
+
+  private InterfaceKeyProperties(
+      @Nullable List<String> forcedMgmtRoutes,
+      @Nullable String gwAddr,
+      @Nullable Boolean secondary) {
+    _forcedMgmtRoutes = forcedMgmtRoutes;
+    _gwAddr = gwAddr;
+    _secondary = secondary;
+  }
+
+  private static final String PROP_FORCED_MGMT_ROUTES = "forced_mgmt_routes";
+  private static final String PROP_GWADDR = "gwaddr";
+  private static final String PROP_SECONDARY = "secondary";
+
+  private @Nullable final List<String> _forcedMgmtRoutes;
+  private @Nullable final String _gwAddr;
+  private @Nullable final Boolean _secondary;
+
+  public @Nonnull static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .omitNullValues()
+        .add("forcedMgmtRoutes", _forcedMgmtRoutes)
+        .add("gwAddr", _gwAddr)
+        .add("secondary", _secondary)
+        .toString();
+  }
+
+  public static final class Builder {
+    private @Nullable List<String> _forcedMgmtRoutes;
+    private @Nullable String _gwAddr;
+    private @Nullable Boolean _secondary;
+
+    public @Nonnull Builder setForcedMgmtRoutes(@Nullable List<String> forcedMgmtRoutes) {
+      _forcedMgmtRoutes = forcedMgmtRoutes;
+      return this;
+    }
+
+    public @Nonnull Builder setGwAddr(@Nullable String gwAddr) {
+      _gwAddr = gwAddr;
+      return this;
+    }
+
+    public @Nonnull Builder setSecondary(@Nullable Boolean secondary) {
+      this._secondary = secondary;
+      return this;
+    }
+
+    public @Nonnull InterfaceKeyProperties build() {
+      return new InterfaceKeyProperties(_forcedMgmtRoutes, _gwAddr, _secondary);
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/L3Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/L3Interface.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor.sonic.representation;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 
@@ -13,15 +16,22 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
  * <p>This object is created by parsing the multi-level key encoding in those objects.
  */
 public class L3Interface implements Serializable {
-  // TODO: Does Sonic permit multiple addresses?
-  private final @Nullable ConcreteInterfaceAddress _address;
+  private @Nonnull Map<ConcreteInterfaceAddress, InterfaceKeyProperties> _addresses;
 
-  public L3Interface(@Nullable ConcreteInterfaceAddress address) {
-    _address = address;
+  public L3Interface(Map<ConcreteInterfaceAddress, InterfaceKeyProperties> addresses) {
+    _addresses = ImmutableMap.copyOf(addresses);
   }
 
-  public @Nullable ConcreteInterfaceAddress getAddress() {
-    return _address;
+  public void addAddress(ConcreteInterfaceAddress address, InterfaceKeyProperties properties) {
+    _addresses =
+        ImmutableMap.<ConcreteInterfaceAddress, InterfaceKeyProperties>builder()
+            .putAll(_addresses)
+            .put(address, properties)
+            .build();
+  }
+
+  public @Nonnull Map<ConcreteInterfaceAddress, InterfaceKeyProperties> getAddresses() {
+    return _addresses;
   }
 
   @Override
@@ -33,16 +43,16 @@ public class L3Interface implements Serializable {
       return false;
     }
     L3Interface that = (L3Interface) o;
-    return Objects.equals(_address, that._address);
+    return _addresses.equals(that._addresses);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_address);
+    return Objects.hash(_addresses);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).omitNullValues().add("address", _address).toString();
+    return MoreObjects.toStringHelper(this).add("addresses", _addresses).toString();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConfiguration.java
@@ -203,24 +203,23 @@ public class SonicConfiguration extends FrrVendorConfiguration {
     }
     if (_configDb.getPorts().containsKey(ifaceName)) {
       return Optional.ofNullable(_configDb.getInterfaces().get(ifaceName))
-          .flatMap(iface -> Optional.ofNullable(iface.getAddress()).map(ImmutableList::of))
+          .map(iface -> ImmutableList.copyOf(iface.getAddresses().keySet()))
           .orElse(ImmutableList.of());
     }
     if (_configDb.getLoopbackInterfaces().containsKey(ifaceName)) {
       return Optional.ofNullable(_configDb.getLoopbackInterfaces().get(ifaceName))
-          .flatMap(iface -> Optional.ofNullable(iface.getAddress()).map(ImmutableList::of))
+          .map(iface -> ImmutableList.copyOf(iface.getAddresses().keySet()))
           .orElse(ImmutableList.of());
     }
     if (_configDb.getMgmtPorts().containsKey(ifaceName)) {
       return Optional.ofNullable(_configDb.getMgmtInterfaces().get(ifaceName))
-          .flatMap(iface -> Optional.ofNullable(iface.getAddress()).map(ImmutableList::of))
+          .map(iface -> ImmutableList.copyOf(iface.getAddresses().keySet()))
           .orElse(ImmutableList.of());
     }
     if (_configDb.getVlans().containsKey(ifaceName)
         && _configDb.getVlanInterfaces().containsKey(ifaceName)) {
-      return Optional.ofNullable(_configDb.getVlanInterfaces().get(ifaceName).getAddress())
-          .map(ImmutableList::of)
-          .orElse(ImmutableList.of());
+      return ImmutableList.copyOf(
+          _configDb.getVlanInterfaces().get(ifaceName).getAddresses().keySet());
     }
     // should never get here
     throw new NoSuchElementException("Interface " + ifaceName + " does not exist");

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/grammar/SonicGrammarTest.java
@@ -57,6 +57,7 @@ import org.batfish.vendor.sonic.representation.AclTable;
 import org.batfish.vendor.sonic.representation.AclTable.Stage;
 import org.batfish.vendor.sonic.representation.AclTable.Type;
 import org.batfish.vendor.sonic.representation.DeviceMetadata;
+import org.batfish.vendor.sonic.representation.InterfaceKeyProperties;
 import org.batfish.vendor.sonic.representation.L3Interface;
 import org.batfish.vendor.sonic.representation.MgmtVrf;
 import org.batfish.vendor.sonic.representation.Port;
@@ -99,7 +100,11 @@ public class SonicGrammarTest {
         vc.getConfigDb().getInterfaces(),
         equalTo(
             ImmutableMap.of(
-                "Ethernet0", new L3Interface(ConcreteInterfaceAddress.parse("1.1.1.1/24")))));
+                "Ethernet0",
+                new L3Interface(
+                    ImmutableMap.of(
+                        ConcreteInterfaceAddress.parse("1.1.1.1/24"),
+                        InterfaceKeyProperties.builder().build())))));
     assertThat(vc.getFrrConfiguration().getRouteMaps().keySet(), equalTo(ImmutableSet.of("TEST")));
 
     Configuration c = getOnlyElement(vc.toVendorIndependentConfigurations());
@@ -145,7 +150,12 @@ public class SonicGrammarTest {
         ImmutableMap.of("localhost", new DeviceMetadata("mgmt")),
         vc.getConfigDb().getDeviceMetadata());
     assertEquals(
-        ImmutableMap.of("eth0", new L3Interface(ConcreteInterfaceAddress.parse("1.1.1.1/24"))),
+        ImmutableMap.of(
+            "eth0",
+            new L3Interface(
+                ImmutableMap.of(
+                    ConcreteInterfaceAddress.parse("1.1.1.1/24"),
+                    InterfaceKeyProperties.builder().setGwAddr("10.11.0.1").build()))),
         vc.getConfigDb().getMgmtInterfaces());
     assertEquals(
         ImmutableMap.of("eth0", Port.builder().setAdminStatusUp(true).build()),
@@ -178,7 +188,12 @@ public class SonicGrammarTest {
         ImmutableMap.of("localhost", new DeviceMetadata("mgmt")),
         vc.getConfigDb().getDeviceMetadata());
     assertEquals(
-        ImmutableMap.of("eth0", new L3Interface(ConcreteInterfaceAddress.parse("1.1.1.1/24"))),
+        ImmutableMap.of(
+            "eth0",
+            new L3Interface(
+                ImmutableMap.of(
+                    ConcreteInterfaceAddress.parse("1.1.1.1/24"),
+                    InterfaceKeyProperties.builder().setGwAddr("10.11.0.1").build()))),
         vc.getConfigDb().getMgmtInterfaces());
     assertEquals(
         ImmutableMap.of("eth0", Port.builder().setAdminStatusUp(true).build()),

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/InterfaceKeyPropertiesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/InterfaceKeyPropertiesTest.java
@@ -1,0 +1,49 @@
+package org.batfish.vendor.sonic.representation;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class InterfaceKeyPropertiesTest {
+
+  @Test
+  public void testJavaSerialization() {
+    InterfaceKeyProperties obj =
+        InterfaceKeyProperties.builder()
+            .setForcedMgmtRoutes(ImmutableList.of())
+            .setGwAddr("1.1.1.1")
+            .setSecondary(true)
+            .build();
+    assertEquals(obj, SerializationUtils.clone(obj));
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  @Test
+  public void testEquals() {
+    InterfaceKeyProperties.Builder builder = InterfaceKeyProperties.builder();
+    new EqualsTester()
+        .addEqualityGroup(builder.build(), builder.build())
+        .addEqualityGroup(builder.setForcedMgmtRoutes(ImmutableList.of("1.1.1.1")).build())
+        .addEqualityGroup(builder.setGwAddr("2.2.2.2").build())
+        .addEqualityGroup(builder.setSecondary(true).build())
+        .testEquals();
+  }
+
+  @Test
+  public void testJacksonDeserialization() throws JsonProcessingException {
+    String input =
+        "{\"secondary\": \"true\", \"forced_mgmt_routes\": [\"1.1.1.1\"], \"gwaddr\": \"2.2.2.2\"}";
+    assertEquals(
+        InterfaceKeyProperties.builder()
+            .setForcedMgmtRoutes(ImmutableList.of("1.1.1.1"))
+            .setGwAddr("2.2.2.2")
+            .setSecondary(true)
+            .build(),
+        BatfishObjectMapper.mapper().readValue(input, InterfaceKeyProperties.class));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/L3InterfaceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/L3InterfaceTest.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.sonic.representation;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -11,7 +12,11 @@ public class L3InterfaceTest {
 
   @Test
   public void testJavaSerialization() {
-    L3Interface obj = new L3Interface(ConcreteInterfaceAddress.parse("172.19.93.0/31"));
+    L3Interface obj =
+        new L3Interface(
+            ImmutableMap.of(
+                ConcreteInterfaceAddress.parse("172.19.93.0/31"),
+                InterfaceKeyProperties.builder().setSecondary(true).build()));
     assertEquals(obj, SerializationUtils.clone(obj));
   }
 
@@ -19,8 +24,12 @@ public class L3InterfaceTest {
   @Test
   public void testEquals() {
     new EqualsTester()
-        .addEqualityGroup(new L3Interface(null), new L3Interface(null))
-        .addEqualityGroup(new L3Interface(ConcreteInterfaceAddress.parse("172.19.93.0/31")))
+        .addEqualityGroup(new L3Interface(ImmutableMap.of()), new L3Interface(ImmutableMap.of()))
+        .addEqualityGroup(
+            new L3Interface(
+                ImmutableMap.of(
+                    ConcreteInterfaceAddress.parse("172.19.93.0/31"),
+                    InterfaceKeyProperties.builder().build())))
         .testEquals();
   }
 }


### PR DESCRIPTION
Before this PR, Batfish was 
1/ ignoring all properties associated with interface keys like 'Ethernet|1.1.1.1/24'
2/ recording only one address per interface

This PR fixes these issues and removes special handling of properties inside MGMT_INTERFACE table. 