### PR TITLE
Transitions.or: merge Transforms when possible

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
@@ -6,6 +6,7 @@ import static org.parboiled.common.Preconditions.checkArgument;
 
 import com.google.common.collect.Sets;
 import java.util.Arrays;
+import java.util.Objects;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDPairing;
 
@@ -65,8 +66,7 @@ public final class BDDPairingFactory {
 
   @Override
   public int hashCode() {
-    return Arrays.hashCode(_domain)
-        + 31 * Arrays.hashCode(_codomain)
-        + 31 * 31 * _domainVars.hashCode();
+    return Objects.hash(
+        Arrays.hashCode(_domain), Arrays.hashCode(_codomain), _domainVars.hashCode());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
@@ -48,4 +48,25 @@ public final class BDDPairingFactory {
   public BDD getDomainVarsBdd() {
     return _domainVars.id(); // defensive copy
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BDDPairingFactory)) {
+      return false;
+    }
+    BDDPairingFactory that = (BDDPairingFactory) o;
+    return Arrays.equals(_domain, that._domain)
+        && Arrays.equals(_codomain, that._codomain)
+        && _domainVars.equals(that._domainVars);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(_domain)
+        + 31 * Arrays.hashCode(_codomain)
+        + 31 * 31 * _domainVars.hashCode();
+  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPairingFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPairingFactoryTest.java
@@ -4,23 +4,30 @@ import static org.batfish.common.bdd.BDDUtils.bddFactory;
 import static org.batfish.common.bdd.BDDUtils.bitvector;
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.testing.EqualsTester;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
+import org.junit.Before;
 import org.junit.Test;
 
 /** Test for {@link BDDPairingFactory}. */
 public final class BDDPairingFactoryTest {
+  private BDDFactory _factory;
+
+  @Before
+  public void setup() {
+    _factory = bddFactory(8);
+  }
 
   @Test
   public void testBasic() {
-    BDDFactory factory = bddFactory(8);
     PrimedBDDInteger primedInteger1 =
         new PrimedBDDInteger(
-            factory, bitvector(factory, 2, 0, false), bitvector(factory, 2, 2, false));
+            _factory, bitvector(_factory, 2, 0, false), bitvector(_factory, 2, 2, false));
     PrimedBDDInteger primedInteger2 =
         new PrimedBDDInteger(
-            factory, bitvector(factory, 2, 4, false), bitvector(factory, 2, 6, false));
+            _factory, bitvector(_factory, 2, 4, false), bitvector(_factory, 2, 6, false));
 
     BDDInteger x = primedInteger1.getVar();
     BDDInteger xPrime = primedInteger1.getPrimeVar();
@@ -50,5 +57,18 @@ public final class BDDPairingFactoryTest {
     assertEquals(
         x0.and(xPrime1).and(y2).and(yPrime3),
         xPrime0.and(x1).and(yPrime2).and(y3).replace(swapBoth));
+  }
+
+  @Test
+  public void testEquals() {
+    BDD[] dom1 = {_factory.ithVar(0)};
+    BDD[] dom2 = {_factory.ithVar(2)};
+    BDD[] codom1 = {_factory.ithVar(1)};
+    BDD[] codom2 = {_factory.ithVar(3)};
+    new EqualsTester()
+        .addEqualityGroup(new BDDPairingFactory(dom1, codom1), new BDDPairingFactory(dom1, codom1))
+        .addEqualityGroup(new BDDPairingFactory(dom2, codom1))
+        .addEqualityGroup(new BDDPairingFactory(dom1, codom2))
+        .testEquals();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BUILD
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BUILD
@@ -39,6 +39,7 @@ junit_tests(
         "//projects/bdd",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
         "@maven//:junit_junit",
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
@@ -2,10 +2,10 @@ package org.batfish.bddreachability.transition;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -133,13 +133,12 @@ public class Transform implements Transition {
     return _forwardRelation.equals(transform._forwardRelation)
         && _pairingFactory.equals(transform._pairingFactory)
         && _vars.equals(transform._vars)
-        && Objects.equal(_reverseRelation, transform._reverseRelation)
-        && Objects.equal(_swapPairing, transform._swapPairing);
+        && Objects.equals(_reverseRelation, transform._reverseRelation)
+        && Objects.equals(_swapPairing, transform._swapPairing);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
-        _forwardRelation, _pairingFactory, _vars, _reverseRelation, _swapPairing);
+    return Objects.hash(_forwardRelation, _pairingFactory, _vars, _reverseRelation, _swapPairing);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
@@ -130,15 +130,16 @@ public class Transform implements Transition {
       return false;
     }
     Transform transform = (Transform) o;
+    // Exclude _reverseRelations and _swapPairing, which are lazy initialized and determined by
+    // _forwardRelation and
+    // _vars.
     return _forwardRelation.equals(transform._forwardRelation)
         && _pairingFactory.equals(transform._pairingFactory)
-        && _vars.equals(transform._vars)
-        && Objects.equals(_reverseRelation, transform._reverseRelation)
-        && Objects.equals(_swapPairing, transform._swapPairing);
+        && _vars.equals(transform._vars);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_forwardRelation, _pairingFactory, _vars, _reverseRelation, _swapPairing);
+    return Objects.hash(_forwardRelation, _pairingFactory, _vars);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
@@ -1,20 +1,30 @@
 package org.batfish.bddreachability.transition;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
 import org.batfish.common.bdd.BDDPairingFactory;
 
 /** Apply a transformation encoded as a relation over unprimed and primed variables. */
+@ParametersAreNonnullByDefault
 public class Transform implements Transition {
   private final BDD _forwardRelation;
   private final BDDPairingFactory _pairingFactory;
   private final BDD _vars;
 
   // lazy init
-  private BDD _reverseRelation;
-  private BDDPairing _swapPairing;
+  private @Nullable BDD _reverseRelation;
+  private @Nullable BDDPairing _swapPairing;
 
   public Transform(BDD relation, BDDPairingFactory pairingFactory) {
     _forwardRelation = relation;
@@ -79,5 +89,57 @@ public class Transform implements Transition {
       return Optional.empty();
     }
     return Optional.of(new Transform(_forwardRelation.or(other._forwardRelation), _pairingFactory));
+  }
+
+  /** Reduce the input list of transforms by combining those with equal domain variables. */
+  public static List<Transform> reduceWithOr(List<Transform> transforms) {
+    checkArgument(!transforms.isEmpty(), "orTransforms: transforms list must be non-empty");
+    if (transforms.size() == 1) {
+      return transforms;
+    }
+    Map<BDD, List<Transform>> transformsByVars =
+        transforms.stream().collect(Collectors.groupingBy(t -> t._vars, Collectors.toList()));
+    if (transformsByVars.size() == transforms.size()) {
+      // no two Transforms had the same vars
+      return transforms;
+    }
+    return transformsByVars.values().stream()
+        .map(
+            transforms1 -> {
+              Transform transform = transforms1.get(0);
+              if (transforms1.size() == 1) {
+                return transform;
+              }
+              BDDFactory bddFactory = transform._forwardRelation.getFactory();
+              BDD forwardRel =
+                  bddFactory.orAll(
+                      transforms1.stream()
+                          .map(t -> t._forwardRelation)
+                          .collect(ImmutableList.toImmutableList()));
+              return new Transform(forwardRel, transform._pairingFactory);
+            })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Transform)) {
+      return false;
+    }
+    Transform transform = (Transform) o;
+    return _forwardRelation.equals(transform._forwardRelation)
+        && _pairingFactory.equals(transform._pairingFactory)
+        && _vars.equals(transform._vars)
+        && Objects.equal(_reverseRelation, transform._reverseRelation)
+        && Objects.equal(_swapPairing, transform._swapPairing);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        _forwardRelation, _pairingFactory, _vars, _reverseRelation, _swapPairing);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -243,6 +243,7 @@ public final class Transitions {
     List<Transition> disjuncts = new ArrayList<>();
     List<Constraint> constraints = null;
     List<EraseAndSet> eraseAndSets = null;
+    List<Transform> transforms = null;
 
     while (flatTransitions.hasNext()) {
       Transition t = flatTransitions.next();
@@ -262,6 +263,11 @@ public final class Transitions {
           eraseAndSets = new ArrayList<>();
         }
         eraseAndSets.add((EraseAndSet) t);
+      } else if (t instanceof Transform) {
+        if (transforms == null) {
+          transforms = new ArrayList<>();
+        }
+        transforms.add((Transform) t);
       } else if (t != ZERO) { // ignore ZERO
         // unmergable
         disjuncts.add(t);
@@ -277,6 +283,9 @@ public final class Transitions {
 
     if (eraseAndSets != null) {
       disjuncts.addAll(orEraseAndSets(eraseAndSets));
+    }
+    if (transforms != null) {
+      disjuncts.addAll(Transform.reduceWithOr(transforms));
     }
 
     if (disjuncts.isEmpty()) {

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/BUILD
@@ -19,6 +19,7 @@ junit_tests(
         "//projects/batfish-common-protocol:common_testlib",
         "//projects/bdd",
         "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
         "@maven//:junit_junit",
         "@maven//:org_hamcrest_hamcrest",
     ],

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.common.bdd.BDDInteger;
@@ -208,5 +209,18 @@ public class TransformTest {
     assertThat(
         Transform.reduceWithOr(ImmutableList.of(_transformX0, _transformX1, _transformY)),
         containsInAnyOrder(_transformX0.tryOr(_transformX1).get(), _transformY));
+  }
+
+  @Test
+  public void testEquals() {
+    // transiting initializes _reverseRelation and _swapPairing, but does not affect equality
+    Transform transited = new Transform(_x0, _xPrimedInt.getPairingFactory());
+    transited.transitForward(_one);
+
+    new EqualsTester()
+        .addEqualityGroup(transited, new Transform(_x0, _xPrimedInt.getPairingFactory()))
+        .addEqualityGroup(new Transform(_x1, _xPrimedInt.getPairingFactory()))
+        .addEqualityGroup(new Transform(_x0, _yPrimedInt.getPairingFactory()))
+        .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
@@ -2,8 +2,11 @@ package org.batfish.bddreachability.transition;
 
 import static org.batfish.common.bdd.BDDUtils.bddFactory;
 import static org.batfish.common.bdd.BDDUtils.bitvector;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableList;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.common.bdd.BDDInteger;
@@ -198,5 +201,12 @@ public class TransformTest {
 
     assertEquals(x1y3, composite.transitForward(_one));
     assertEquals(x0y2, composite.transitBackward(_one));
+  }
+
+  @Test
+  public void testReduceWithOr() {
+    assertThat(
+        Transform.reduceWithOr(ImmutableList.of(_transformX0, _transformX1, _transformY)),
+        containsInAnyOrder(_transformX0.tryOr(_transformX1).get(), _transformY));
   }
 }


### PR DESCRIPTION
Transitions.or is a smart factory method that simplifies/optimizes the input set of disjuncts. Add a case for the Transform transitions, merging any that transform the same set of variables.