### PR TITLE
IOS: fix parsing of rt extended communities

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -7820,6 +7820,11 @@ M_Extcommunity_UINT16
    F_Uint16 -> type ( UINT16 )
 ;
 
+M_Extcommunity_UINT32
+:
+   F_Uint32 -> type ( UINT32 )
+;
+
 M_Extcommunity_WS
 :
    F_Whitespace+ -> channel ( HIDDEN )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_common.g4
@@ -93,12 +93,15 @@ ec_ga_la_literal
 :
    ecgalal_asdot_colon
    | ecgalal_colon
+   | ecgalal4_colon
    | ecgalal_ip_colon
 ;
 
 ecgalal_asdot_colon: ga_high16 = uint16 PERIOD ga_low16 = uint16 COLON la = uint16;
 
 ecgalal_colon: ga = uint32 COLON la = uint16;
+
+ecgalal4_colon: ga = uint16 COLON la = uint32;
 
 ecgalal_ip_colon: ga = IP_ADDRESS COLON la = uint16;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -567,6 +567,7 @@ import org.batfish.grammar.cisco.CiscoParser.Dt_protect_tunnelContext;
 import org.batfish.grammar.cisco.CiscoParser.Eacl_port_specifierContext;
 import org.batfish.grammar.cisco.CiscoParser.Ebgp_multihop_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Ec_ga_la_literalContext;
+import org.batfish.grammar.cisco.CiscoParser.Ecgalal4_colonContext;
 import org.batfish.grammar.cisco.CiscoParser.Ecgalal_asdot_colonContext;
 import org.batfish.grammar.cisco.CiscoParser.Ecgalal_colonContext;
 import org.batfish.grammar.cisco.CiscoParser.Ecgalal_ip_colonContext;
@@ -9048,6 +9049,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       return toExtendedCommunity(ctx.ecgalal_asdot_colon());
     } else if (ctx.ecgalal_colon() != null) {
       return toExtendedCommunity(ctx.ecgalal_colon());
+    } else if (ctx.ecgalal4_colon() != null) {
+      return toExtendedCommunity(ctx.ecgalal4_colon());
     } else {
       assert ctx.ecgalal_ip_colon() != null;
       return toExtendedCommunity(ctx.ecgalal_ip_colon());
@@ -9066,6 +9069,12 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   private @Nonnull ExtendedCommunity toExtendedCommunity(Ecgalal_colonContext ctx) {
     long ga = toUint32(ctx.ga);
     int la = toUint16(ctx.la);
+    return ExtendedCommunity.target(ga, la);
+  }
+
+  private @Nonnull ExtendedCommunity toExtendedCommunity(Ecgalal4_colonContext ctx) {
+    int ga = toUint16(ctx.ga);
+    long la = toUint32(ctx.la);
     return ExtendedCommunity.target(ga, la);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -6172,6 +6172,8 @@ public final class CiscoGrammarTest {
           line.getCommunities(),
           contains(
               ExtendedCommunity.target(65000, 1),
+              ExtendedCommunity.target(65000, 1048576),
+              ExtendedCommunity.target(1048576, 1),
               ExtendedCommunity.target(Ip.parse("10.0.0.1").asLong(), 2),
               ExtendedCommunity.target((12 << 16) | 34, 5)));
     }
@@ -6186,6 +6188,8 @@ public final class CiscoGrammarTest {
           line.getCommunities(),
           contains(
               ExtendedCommunity.target(65000, 1),
+              ExtendedCommunity.target(65000, 1048576),
+              ExtendedCommunity.target(1048576, 1),
               ExtendedCommunity.target(Ip.parse("10.0.0.1").asLong(), 2),
               ExtendedCommunity.target((12 << 16) | 34, 5)));
     }
@@ -6216,6 +6220,8 @@ public final class CiscoGrammarTest {
           hasCommunities(
               StandardCommunity.of(1L),
               ExtendedCommunity.target(65000, 1),
+              ExtendedCommunity.target(65000, 1048576),
+              ExtendedCommunity.target(1048576, 1),
               ExtendedCommunity.target(Ip.parse("10.0.0.1").asLong(), 2),
               ExtendedCommunity.target((12 << 16) | 34, 5)));
     }
@@ -6233,6 +6239,8 @@ public final class CiscoGrammarTest {
               StandardCommunity.of(1L),
               ExtendedCommunity.target(99, 99),
               ExtendedCommunity.target(65000, 1),
+              ExtendedCommunity.target(65000, 1048576),
+              ExtendedCommunity.target(1048576, 1),
               ExtendedCommunity.target(Ip.parse("10.0.0.1").asLong(), 2),
               ExtendedCommunity.target((12 << 16) | 34, 5)));
     }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-route-map-set-extcommunity-rt
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-route-map-set-extcommunity-rt
@@ -4,9 +4,9 @@
 hostname ios-route-map-set-extcommunity-rt
 !
 route-map rm1 permit 100
- set extcommunity rt 65000:1 10.0.0.1:2 12.34:5
+ set extcommunity rt 65000:1 65000:1048576 1048576:1 10.0.0.1:2 12.34:5
 !
 
 route-map rm2 permit 100
- set extcommunity rt 65000:1 10.0.0.1:2 12.34:5 additive
+ set extcommunity rt 65000:1 65000:1048576 1048576:1 10.0.0.1:2 12.34:5 additive
 !


### PR DESCRIPTION
Both GA and LA can be 16-bit or 32-bit, as long as they aren't both 32-bit.
See ExtendedCommunity#target for how this is signaled on the wire.

Fix batfish/batfish#8266.

commit-id:4d8b2632

**Issue references**: 

 - Fix batfish/batfish#8266