### PR TITLE
IOS: parse and reference standard ACLS in mpls ldp password required for

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -2165,7 +2165,12 @@ FLUSH_AT_ACTIVATION: 'flush-at-activation';
 
 FLUSH_R1_ON_NEW_R0: 'flush-r1-on-new-r0';
 
-FOR: 'for';
+FOR: 'for'
+{
+  if (lastTokenType() == REQUIRED) {
+    pushMode(M_Name);
+  }
+};
 
 FORCE: 'force';
 
@@ -4670,6 +4675,7 @@ REQUEST: 'request';
 REQUEST_DATA_SIZE: 'request-data-size';
 
 REQUIRE_WPA: 'require-wpa';
+REQUIRED: 'required';
 RESET: 'reset';
 RESOURCE: 'resource';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoParser.g4
@@ -14,6 +14,7 @@ Cisco_interface,
 Cisco_isis,
 Cisco_line,
 Cisco_logging,
+Cisco_mpls,
 Cisco_nat,
 Cisco_ntp,
 Cisco_ospf,
@@ -3376,6 +3377,7 @@ stanza
    | s_media_termination
    | s_monitor
    | s_monitor_session
+   | s_mpls
    | s_name
    | s_netdestination
    | s_netdestination6

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_mpls.g4
@@ -1,0 +1,27 @@
+parser grammar Cisco_mpls;
+
+import Cisco_common;
+
+options {
+   tokenVocab = CiscoLexer;
+}
+
+s_mpls
+:
+  MPLS
+  (
+    mpls_ldp
+  )
+;
+
+mpls_ldp
+:
+  LDP
+  (
+    mldp_password
+  )
+;
+
+mldp_password: PASSWORD mldp_pw_required;
+
+mldp_pw_required: REQUIRED FOR acl = variable NEWLINE;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -222,6 +222,7 @@ import static org.batfish.representation.cisco.CiscoStructureUsage.LINE_ACCESS_C
 import static org.batfish.representation.cisco.CiscoStructureUsage.LINE_ACCESS_CLASS_LIST6;
 import static org.batfish.representation.cisco.CiscoStructureUsage.MANAGEMENT_SSH_ACCESS_GROUP;
 import static org.batfish.representation.cisco.CiscoStructureUsage.MANAGEMENT_TELNET_ACCESS_GROUP;
+import static org.batfish.representation.cisco.CiscoStructureUsage.MPLS_LDP_PASSWORD_REQUIRED_FOR;
 import static org.batfish.representation.cisco.CiscoStructureUsage.MSDP_PEER_SA_LIST;
 import static org.batfish.representation.cisco.CiscoStructureUsage.NAMED_RSA_PUB_KEY_SELF_REF;
 import static org.batfish.representation.cisco.CiscoStructureUsage.NETWORK_OBJECT_GROUP_GROUP_OBJECT;
@@ -739,6 +740,7 @@ import org.batfish.grammar.cisco.CiscoParser.Match_source_protocol_rm_stanzaCont
 import org.batfish.grammar.cisco.CiscoParser.Match_tag_rm_stanzaContext;
 import org.batfish.grammar.cisco.CiscoParser.Maximum_paths_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Maximum_peers_bgp_tailContext;
+import org.batfish.grammar.cisco.CiscoParser.Mldp_pw_requiredContext;
 import org.batfish.grammar.cisco.CiscoParser.Named_portContext;
 import org.batfish.grammar.cisco.CiscoParser.Neighbor_flat_rb_stanzaContext;
 import org.batfish.grammar.cisco.CiscoParser.Neighbor_group_rb_stanzaContext;
@@ -6928,6 +6930,16 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitMaximum_peers_bgp_tail(Maximum_peers_bgp_tailContext ctx) {
     todo(ctx);
+  }
+
+  @Override
+  public void exitMldp_pw_required(Mldp_pw_requiredContext ctx) {
+    String name = toString(ctx.acl);
+    _configuration.referenceStructure(
+        IPV4_ACCESS_LIST_STANDARD,
+        name,
+        MPLS_LDP_PASSWORD_REQUIRED_FOR,
+        ctx.acl.getStart().getLine());
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3113,7 +3113,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
         CiscoStructureUsage.WCCP_GROUP_LIST,
         CiscoStructureUsage.WCCP_REDIRECT_LIST,
         CiscoStructureUsage.WCCP_SERVICE_LIST);
+    markConcreteStructure(CiscoStructureType.IPV4_ACCESS_LIST_EXTENDED);
     markConcreteStructure(CiscoStructureType.IPV4_ACCESS_LIST_EXTENDED_LINE);
+    markConcreteStructure(CiscoStructureType.IPV4_ACCESS_LIST_STANDARD);
     markConcreteStructure(CiscoStructureType.IPV4_ACCESS_LIST_STANDARD_LINE);
 
     markCommunityLists(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoStructureUsage.java
@@ -150,6 +150,7 @@ public enum CiscoStructureUsage implements StructureUsage {
   LINE_ACCESS_CLASS_LIST6("line access-class ipv6 list"),
   MANAGEMENT_SSH_ACCESS_GROUP("management ssh ip access-group"),
   MANAGEMENT_TELNET_ACCESS_GROUP("management telnet ip access-group"),
+  MPLS_LDP_PASSWORD_REQUIRED_FOR("mpls ldp password required for"),
   MSDP_PEER_SA_LIST("msdp peer sa-list"),
   NAMED_RSA_PUB_KEY_SELF_REF("named rsa pubkey"),
   NETWORK_OBJECT_GROUP_GROUP_OBJECT("object-group network group-object"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -528,6 +528,17 @@ public final class CiscoGrammarTest {
   }
 
   @Test
+  public void testMplsReferences() throws IOException {
+    String hostname = "mpls_references";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    assertThat(
+        ccae, hasNumReferrers("configs/" + hostname, IPV4_ACCESS_LIST_STANDARD, "MPLS_ACL", 1));
+  }
+
+  @Test
   public void testAaaAuthenticationLogin() throws IOException {
     // test IOS config
     Configuration aaaAuthIosConfiguration = parseConfig("aaaAuthenticationIos");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/mpls_references
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/mpls_references
@@ -1,0 +1,7 @@
+!
+hostname mpls_references
+!
+ip access-list standard MPLS_ACL
+!
+mpls ldp password required for MPLS_ACL
+!


### PR DESCRIPTION
Though MPLS is not supported at all, it's worth getting reference tracking
correct.

Fix batfish/batfish#8274

commit-id:e63b9eb0

**Issue references**: 

 - Fix batfish/batfish#8274