### PR TITLE
PacketPolicyToBdd: merge parallel edges

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
@@ -8,12 +8,13 @@ import static org.batfish.bddreachability.transition.Transitions.mergeComposed;
 import static org.batfish.bddreachability.transition.Transitions.or;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -59,7 +60,7 @@ class PacketPolicyToBdd {
   @Nonnull private final TransformationToTransition _transformationToTransition;
   private final String _hostname;
   private final String _vrf;
-  private final Map<StateExpr, Map<StateExpr, List<Transition>>> _edges;
+  private final Table<StateExpr, StateExpr, List<Transition>> _edges;
   private final ImmutableSet.Builder<PacketPolicyAction> _actions;
 
   /**
@@ -108,22 +109,20 @@ class PacketPolicyToBdd {
     PacketPolicyToBdd evaluator =
         new PacketPolicyToBdd(hostname, vrf, policy, ipAccessListToBdd, ipsRoutedOutInterfaces);
     evaluator.process(policy);
-    return new BddPacketPolicy(evaluator.getEdges(), evaluator._actions.build());
+    return new BddPacketPolicy(buildEdges(evaluator._edges), evaluator._actions.build());
   }
 
-  private List<Edge> getEdges() {
-    return _edges.entrySet().stream()
-        .flatMap(
-            srcEntry -> {
-              StateExpr src = srcEntry.getKey();
-              return srcEntry.getValue().entrySet().stream()
-                  .map(
-                      tgtEntry -> {
-                        StateExpr tgt = tgtEntry.getKey();
-                        return new Edge(src, tgt, Transitions.or(tgtEntry.getValue()));
-                      });
-            })
-        .collect(Collectors.toList());
+  /**
+   * Build a list of Edges (with no parallel edges) from the input transition table. All parallel
+   * transitions are merged using {@link Transitions#or(Collection)}.
+   */
+  private static List<Edge> buildEdges(
+      Table<StateExpr, StateExpr, List<Transition>> transitionTable) {
+    return transitionTable.cellSet().stream()
+        .map(
+            cell ->
+                new Edge(cell.getRowKey(), cell.getColumnKey(), Transitions.or(cell.getValue())))
+        .collect(ImmutableList.toImmutableList());
   }
 
   private PacketPolicyToBdd(
@@ -138,7 +137,7 @@ class PacketPolicyToBdd {
     _boolExprToBdd = new BoolExprToBdd(ipAccessListToBdd, ipsRoutedOutInterfaces);
     _transformationToTransition =
         new TransformationToTransition(ipAccessListToBdd.getBDDPacket(), ipAccessListToBdd);
-    _edges = new HashMap<>();
+    _edges = HashBasedTable.create();
     _actions = ImmutableSet.builder();
   }
 
@@ -165,10 +164,12 @@ class PacketPolicyToBdd {
     if (transition == ZERO) {
       return;
     }
-    _edges
-        .computeIfAbsent(source, s -> new HashMap<>())
-        .computeIfAbsent(target, t -> new ArrayList<>())
-        .add(transition);
+    List<Transition> transitions = _edges.get(source, target);
+    if (transitions == null) {
+      transitions = new ArrayList<>();
+      _edges.put(source, target, transitions);
+    }
+    transitions.add(transition);
     if (target instanceof PacketPolicyAction) {
       _actions.add((PacketPolicyAction) target);
     }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -288,12 +288,6 @@ public final class Transitions {
     }
   }
 
-  @Deprecated
-  public static Transition or() {
-    throw new IllegalArgumentException(
-        "Don't call or() with no Transitions -- just use Zero instead.");
-  }
-
   public static Transition or(Transition... transitions) {
     return or(Arrays.stream(transitions));
   }
@@ -302,7 +296,7 @@ public final class Transitions {
     return or(transitions.stream());
   }
 
-  public static Transition or(Stream<Transition> transitions) {
+  private static Transition or(Stream<Transition> transitions) {
     Iterator<Transition> flatTransitions =
         transitions
             .flatMap(t -> t instanceof Or ? ((Or) t).getTransitions().stream() : Stream.of(t))

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -295,8 +295,16 @@ public final class Transitions {
   }
 
   public static Transition or(Transition... transitions) {
+    return or(Arrays.stream(transitions));
+  }
+
+  public static Transition or(Collection<Transition> transitions) {
+    return or(transitions.stream());
+  }
+
+  public static Transition or(Stream<Transition> transitions) {
     Iterator<Transition> flatTransitions =
-        Stream.of(transitions)
+        transitions
             .flatMap(t -> t instanceof Or ? ((Or) t).getTransitions().stream() : Stream.of(t))
             .iterator();
     boolean foundIdentity = false;


### PR DESCRIPTION
PacketPolicyToBdd now creates many parallel edges, which previously were being returned directly, and later merged by repeatedly merging two edges using Transitions::or in BDDReaachabilityUtils::computeForwardEdgeTable. Now it accumulates all parallel edges into lists and makes one call to Transitions::or, which is more efficient.

We could do the same thing in computeForwardEdgeTable, but parallel edges are rare outside of PacketPolicyToBdd, so that might not be a win.