### PR TITLE
BDDFactory: cache BDDPairings

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
@@ -42,14 +42,18 @@ public class BDDUtils {
     checkArgument(bv1.length > 0, "Cannot build swapPairing for empty bitvectors");
     checkArgument(bv1.length == bv2.length, "Bitvector lengths must be equal");
 
-    BDDFactory factory = bv1[0].getFactory();
-    BDDPairing pairing = factory.makePair();
-
-    for (int i = 0; i < bv1.length; i++) {
-      pairing.set(bv1[i].var(), bv2[i].var());
-      pairing.set(bv2[i].var(), bv1[i].var());
+    int l = bv1.length;
+    BDD[] oldvars = new BDD[l * 2];
+    BDD[] newvars = new BDD[l * 2];
+    for (int i = 0; i < l; i++) {
+      // forward
+      oldvars[i] = bv1[i];
+      newvars[i] = bv2[i];
+      // reverse
+      oldvars[l + i] = bv2[i];
+      newvars[l + i] = bv1[i];
     }
 
-    return pairing;
+    return bv1[0].getFactory().getPair(oldvars, newvars);
   }
 }

--- a/projects/bdd/BUILD
+++ b/projects/bdd/BUILD
@@ -11,6 +11,7 @@ java_library(
     deps = [
         "@maven//:com_carrotsearch_hppc",
         "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
         "@maven//:org_apache_logging_log4j_log4j_api",
     ],
 )


### PR DESCRIPTION
Add a getPair method that computes a BDDPairing that maps variables to
variables. The BDDPairing is cached to improve cache performance of
BDD#replace(BDDPairing), BDD#replaceWith(BDDPairing), etc. Without caching,
two equivalent pairings will have different IDs, and JFactory's replacecache
will not share their work.

Caveat: BDDPairings are mutable, and mutating cached pairings is not safe.
We should improve the API to guard against that. (We currently never mutate
a pairing after creating it).

Motivation: as we build and merge `Transform` transitions in the reachability graph, 
we can create many the same BDDPairing many times. 