### PR TITLE
IspModelingUtils: add explanations when ISP-side generation fails

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
@@ -162,8 +162,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
               _remoteAsns,
               _ipv4UnicastAddressFamily,
               _evpnAddressFamily);
-      if (_bgpProcess != null) {
-        _bgpProcess.getActiveNeighbors().put(Objects.requireNonNull(_peerAddress), bgpPeerConfig);
+      if (_bgpProcess != null && _peerAddress != null) {
+        _bgpProcess.getActiveNeighbors().put(_peerAddress, bgpPeerConfig);
       }
       return bgpPeerConfig;
     }


### PR DESCRIPTION
Help users debug ISP configuration, and also document current gaps, which
we are in the process of fixing.