### PR TITLE
BDDFactory: make getPair cache insensitive to order of variables

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
@@ -24,12 +24,7 @@ public final class BDDPairingFactory {
 
   public BDDPairingFactory(BDDFactory bddFactory, Set<BDDVarPair> varPairs) {
     checkArgument(!varPairs.isEmpty(), "BDDPairingFactory must have at least one variable pair.");
-    assert varPairsInvariants(varPairs);
-    _bddFactory = bddFactory;
-    _varPairs = ImmutableSet.copyOf(varPairs);
-  }
 
-  private boolean varPairsInvariants(Set<BDDVarPair> varPairs) {
     Set<Integer> oldVars = varPairs.stream().map(BDDVarPair::getOldVar).collect(Collectors.toSet());
     checkArgument(oldVars.size() == varPairs.size(), "domain must have distinct variables");
 
@@ -39,7 +34,8 @@ public final class BDDPairingFactory {
     checkArgument(
         Sets.intersection(oldVars, newVars).isEmpty(), "domain and codomain must be disjoint");
 
-    return true;
+    _bddFactory = bddFactory;
+    _varPairs = ImmutableSet.copyOf(varPairs);
   }
 
   /** Create a {@link BDDPairing} that swaps domain and codomain variables. */
@@ -54,8 +50,9 @@ public final class BDDPairingFactory {
     checkArgument(
         _bddFactory == other._bddFactory,
         "Cannot compose with a BDDPairingFactory for a different BDDFactory");
-    assert Sets.intersection(_varPairs, other._varPairs).isEmpty()
-        : "Cannot compose two BDDPairingFactories with overlapping var pairs";
+    checkArgument(
+        Sets.intersection(_varPairs, other._varPairs).isEmpty(),
+        "Cannot compose two BDDPairingFactories with overlapping var pairs");
     return new BDDPairingFactory(
         _bddFactory,
         Stream.of(_varPairs, other._varPairs)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
@@ -1,60 +1,85 @@
 package org.batfish.common.bdd;
 
-import static org.batfish.common.bdd.BDDUtils.concatBitvectors;
 import static org.batfish.common.bdd.BDDUtils.swapPairing;
 import static org.parboiled.common.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
+import net.sf.javabdd.BDDVarPair;
 
 public final class BDDPairingFactory {
-  private final BDD[] _domain;
-  private final BDD[] _codomain;
-  private final BDD _domainVars;
+  private final BDDFactory _bddFactory;
+  private final Set<BDDVarPair> _varPairs;
 
   // lazy init
   @Nullable BDDPairing _swapPairing;
+  @Nullable BDD _domainVars;
 
-  public BDDPairingFactory(BDD[] domain, BDD[] codomain) {
-    checkArgument(domain.length == codomain.length, "domain and codomain must have equal size");
-    checkArgument(domain.length > 0, "domain and codomain must contain at least one variable");
-    checkArgument(hasDistinctElements(domain), "domain must have distinct variables");
-    checkArgument(hasDistinctElements(codomain), "codomain must have distinct variables");
-    checkArgument(
-        Sets.intersection(Sets.newHashSet(domain), Sets.newHashSet(codomain)).isEmpty(),
-        "domain and codomain must be disjoint");
-    _domain = domain;
-    _codomain = codomain;
-    _domainVars = domain[0].getFactory().andAll(domain);
+  public BDDPairingFactory(BDDFactory bddFactory, Set<BDDVarPair> varPairs) {
+    checkArgument(!varPairs.isEmpty(), "BDDPairingFactory must have at least one variable pair.");
+    assert varPairsInvariants(varPairs);
+    _bddFactory = bddFactory;
+    _varPairs = ImmutableSet.copyOf(varPairs);
   }
 
-  private static boolean hasDistinctElements(BDD[] vars) {
-    return Arrays.stream(vars).distinct().count() == vars.length;
+  private boolean varPairsInvariants(Set<BDDVarPair> varPairs) {
+    Set<Integer> oldVars = varPairs.stream().map(BDDVarPair::getOldVar).collect(Collectors.toSet());
+    checkArgument(oldVars.size() == varPairs.size(), "domain must have distinct variables");
+
+    Set<Integer> newVars = varPairs.stream().map(BDDVarPair::getNewVar).collect(Collectors.toSet());
+    checkArgument(newVars.size() == varPairs.size(), "codomain must have distinct variables");
+
+    checkArgument(
+        Sets.intersection(oldVars, newVars).isEmpty(), "domain and codomain must be disjoint");
+
+    return true;
   }
 
   /** Create a {@link BDDPairing} that swaps domain and codomain variables. */
   public BDDPairing getSwapPairing() {
     if (_swapPairing == null) {
-      _swapPairing = swapPairing(_domain, _codomain);
+      _swapPairing = swapPairing(_bddFactory, _varPairs);
     }
     return _swapPairing;
   }
 
   public BDDPairingFactory composeWith(BDDPairingFactory other) {
+    checkArgument(
+        _bddFactory == other._bddFactory,
+        "Cannot compose with a BDDPairingFactory for a different BDDFactory");
+    assert Sets.intersection(_varPairs, other._varPairs).isEmpty()
+        : "Cannot compose two BDDPairingFactories with overlapping var pairs";
     return new BDDPairingFactory(
-        concatBitvectors(_domain, other._domain), concatBitvectors(_codomain, other._codomain));
+        _bddFactory,
+        Stream.of(_varPairs, other._varPairs)
+            .flatMap(Set::stream)
+            .collect(ImmutableSet.toImmutableSet()));
+  }
+
+  public boolean overlapsWith(BDDPairingFactory other) {
+    return !Sets.intersection(_varPairs, other._varPairs).isEmpty();
   }
 
   /**
    * Return a {@link BDD} of the variables in the pairing's domain, suitable for use with {@link
-   * BDD#exist(BDD)}. The caller owns the {@link BDD} and must free it.
+   * BDD#exist(BDD)}. The caller does not own the {@link BDD} and must not mutate or free it.
    */
   public BDD getDomainVarsBdd() {
-    return _domainVars.id(); // defensive copy
+    if (_domainVars == null) {
+      _domainVars =
+          _bddFactory.andAll(
+              _varPairs.stream()
+                  .map(varPair -> _bddFactory.ithVar(varPair.getOldVar()))
+                  .toArray(BDD[]::new));
+    }
+    return _domainVars;
   }
 
   @Override
@@ -66,16 +91,11 @@ public final class BDDPairingFactory {
       return false;
     }
     BDDPairingFactory that = (BDDPairingFactory) o;
-    // only consider domainVars, since 1) the domain is a function of it, and 2) the codomain is a
-    // function of the domain (assuming no accidental variable reuse, etc).
-    assert !_domainVars.equals(that._domainVars)
-        || (ImmutableSet.copyOf(_domain).equals(ImmutableSet.copyOf(that._domain))
-            && ImmutableSet.copyOf(_codomain).equals(ImmutableSet.copyOf(that._codomain)));
-    return _domainVars.equals(that._domainVars);
+    return _varPairs.equals(that._varPairs);
   }
 
   @Override
   public int hashCode() {
-    return _domainVars.hashCode();
+    return _varPairs.hashCode();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/PrimedBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/PrimedBDDInteger.java
@@ -2,9 +2,11 @@ package org.batfish.common.bdd;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Arrays;
+import com.google.common.collect.ImmutableSet;
+import java.util.stream.IntStream;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
+import net.sf.javabdd.BDDVarPair;
 
 /** A wrapper around an {@link ImmutableBDDInteger} with primed variables for encoding relations. */
 public final class PrimedBDDInteger {
@@ -13,9 +15,17 @@ public final class PrimedBDDInteger {
   private final BDDPairingFactory _pairingFactory;
 
   public PrimedBDDInteger(BDDFactory factory, BDD[] bitvec, BDD[] primeBitvec) {
+    checkArgument(
+        bitvec.length == primeBitvec.length,
+        "Must have equal number of primed and unprimed variables");
     _var = new ImmutableBDDInteger(factory, bitvec);
     _primeVar = new ImmutableBDDInteger(factory, primeBitvec);
-    _pairingFactory = new BDDPairingFactory(bitvec, primeBitvec);
+    _pairingFactory =
+        new BDDPairingFactory(
+            factory,
+            IntStream.range(0, bitvec.length)
+                .mapToObj(i -> new BDDVarPair(bitvec[i], primeBitvec[i]))
+                .collect(ImmutableSet.toImmutableSet()));
   }
 
   public ImmutableBDDInteger getVar() {
@@ -37,6 +47,9 @@ public final class PrimedBDDInteger {
       return _pairingFactory;
     }
     return new BDDPairingFactory(
-        Arrays.copyOf(_var._bitvec, n), Arrays.copyOf(_primeVar._bitvec, n));
+        _var.getFactory(),
+        IntStream.range(0, n)
+            .mapToObj(i -> new BDDVarPair(_var._bitvec[i], _primeVar._bitvec[i]))
+            .collect(ImmutableSet.toImmutableSet()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPairingFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPairingFactoryTest.java
@@ -4,10 +4,13 @@ import static org.batfish.common.bdd.BDDUtils.bddFactory;
 import static org.batfish.common.bdd.BDDUtils.bitvector;
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
+import java.util.Set;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
+import net.sf.javabdd.BDDVarPair;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,13 +64,15 @@ public final class BDDPairingFactoryTest {
 
   @Test
   public void testEquals() {
-    BDD[] dom1 = {_factory.ithVar(0)};
-    BDD[] dom2 = {_factory.ithVar(2)};
-    BDD[] codom1 = {_factory.ithVar(1)};
-    BDD[] codom2 = {_factory.ithVar(3)};
+    Set<BDDVarPair> pairs1 =
+        ImmutableSet.of(new BDDVarPair(_factory.ithVar(0), _factory.ithVar(1)));
+    Set<BDDVarPair> pairs2 =
+        ImmutableSet.of(new BDDVarPair(_factory.ithVar(2), _factory.ithVar(3)));
+
     new EqualsTester()
-        .addEqualityGroup(new BDDPairingFactory(dom1, codom1), new BDDPairingFactory(dom1, codom1))
-        .addEqualityGroup(new BDDPairingFactory(dom2, codom2))
+        .addEqualityGroup(
+            new BDDPairingFactory(_factory, pairs1), new BDDPairingFactory(_factory, pairs1))
+        .addEqualityGroup(new BDDPairingFactory(_factory, pairs2))
         .testEquals();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
@@ -38,11 +38,11 @@ public class Transform implements Transition {
    */
   private boolean initIfAssertionsEnabled() {
     init();
-    _pairingFactory.getDomainVarsBdd(); // pairing factory computes this lazily
     return true;
   }
 
   private void init() {
+    _pairingFactory.getDomainVarsBdd(); // pairing factory computes this lazily
     _reverseRelation = _forwardRelation.replace(_pairingFactory.getSwapPairing());
   }
 

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransitionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransitionsTest.java
@@ -20,8 +20,10 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
+import net.sf.javabdd.BDDVarPair;
 import org.batfish.common.bdd.BDDFiniteDomain;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDPairingFactory;
@@ -46,6 +48,10 @@ public class TransitionsTest {
 
   private Transition setSrcIp(Ip value) {
     return constraint(_pkt.getSrcIp().value(value.asLong()));
+  }
+
+  private static Set<BDDVarPair> makeVarPairs(BDD v1, BDD v2) {
+    return ImmutableSet.of(new BDDVarPair(v1, v2));
   }
 
   // Any composition containing ZERO is zero
@@ -201,7 +207,7 @@ public class TransitionsTest {
     BDD v0Prime = var(1);
     BDD v1 = var(2);
     BDD v2 = var(3);
-    BDDPairingFactory pairFactory = new BDDPairingFactory(new BDD[] {v0}, new BDD[] {v0Prime});
+    BDDPairingFactory pairFactory = new BDDPairingFactory(_factory, makeVarPairs(v0, v0Prime));
     Transition t1 = new Transform(v0.xor(v0Prime), pairFactory);
     Transition t2 = constraint(v1);
     Transition or = or(t1, t2);
@@ -279,9 +285,9 @@ public class TransitionsTest {
     BDD v1 = var(2);
     BDD v1Prime = var(3);
     BDD v2 = var(4);
-    BDDPairingFactory pairFactory0 = new BDDPairingFactory(new BDD[] {v0}, new BDD[] {v0Prime});
+    BDDPairingFactory pairFactory0 = new BDDPairingFactory(_factory, makeVarPairs(v0, v0Prime));
     Transform transform0 = new Transform(v0.xor(v0Prime), pairFactory0);
-    BDDPairingFactory pairFactory1 = new BDDPairingFactory(new BDD[] {v1}, new BDD[] {v1Prime});
+    BDDPairingFactory pairFactory1 = new BDDPairingFactory(_factory, makeVarPairs(v1, v1Prime));
     Transform transform1 = new Transform(v1.xor(v1Prime), pairFactory1);
     Transition constraint = constraint(v2);
     Transition or = or(transform0, constraint);
@@ -328,9 +334,9 @@ public class TransitionsTest {
     BDD v1 = var(2);
     BDD v1Prime = var(3);
     BDD v2 = var(4);
-    BDDPairingFactory pairFactory0 = new BDDPairingFactory(new BDD[] {v0}, new BDD[] {v0Prime});
+    BDDPairingFactory pairFactory0 = new BDDPairingFactory(_factory, makeVarPairs(v0, v0Prime));
     Transform transform0 = new Transform(v0.xor(v0Prime), pairFactory0);
-    BDDPairingFactory pairFactory1 = new BDDPairingFactory(new BDD[] {v1}, new BDD[] {v1Prime});
+    BDDPairingFactory pairFactory1 = new BDDPairingFactory(_factory, makeVarPairs(v1, v1Prime));
     Transform transform1 = new Transform(v1.xor(v1Prime), pairFactory1);
     Transition constraint = constraint(v2);
     Transition or = or(transform0, constraint);
@@ -376,7 +382,7 @@ public class TransitionsTest {
     BDD v0Prime = var(1);
     BDD v1 = var(2);
 
-    BDDPairingFactory pairFactory = new BDDPairingFactory(new BDD[] {v0}, new BDD[] {v0Prime});
+    BDDPairingFactory pairFactory = new BDDPairingFactory(_factory, makeVarPairs(v0, v0Prime));
 
     BDD xorRel = v0.xor(v0Prime); // flip the bit
     Transform xorTransform = new Transform(xorRel, pairFactory);
@@ -405,8 +411,8 @@ public class TransitionsTest {
     BDD v1 = var(2);
     BDD v1Prime = var(3);
 
-    BDDPairingFactory pairingFactory0 = new BDDPairingFactory(new BDD[] {v0}, new BDD[] {v0Prime});
-    BDDPairingFactory pairingFactory1 = new BDDPairingFactory(new BDD[] {v1}, new BDD[] {v1Prime});
+    BDDPairingFactory pairingFactory0 = new BDDPairingFactory(_factory, makeVarPairs(v0, v0Prime));
+    BDDPairingFactory pairingFactory1 = new BDDPairingFactory(_factory, makeVarPairs(v1, v1Prime));
 
     BDD rel0 = v0.and(v0Prime);
     Transform transformV0 = new Transform(rel0, pairingFactory0);
@@ -471,8 +477,8 @@ public class TransitionsTest {
     BDD v0Prime = var(2);
     BDD v1Prime = var(3);
 
-    BDDPairingFactory pairingFactory0 = new BDDPairingFactory(new BDD[] {v0}, new BDD[] {v0Prime});
-    BDDPairingFactory pairingFactory1 = new BDDPairingFactory(new BDD[] {v1}, new BDD[] {v1Prime});
+    BDDPairingFactory pairingFactory0 = new BDDPairingFactory(_factory, makeVarPairs(v0, v0Prime));
+    BDDPairingFactory pairingFactory1 = new BDDPairingFactory(_factory, makeVarPairs(v1, v1Prime));
 
     Transform transformV0_1 = new Transform(v0.and(v0Prime), pairingFactory0);
     Transform transformV0_2 = new Transform(v0.not().and(v0Prime.not()), pairingFactory0);

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
@@ -30,7 +30,7 @@ package net.sf.javabdd;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringTokenizer;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
@@ -575,43 +576,7 @@ public abstract class BDDFactory {
     return p;
   }
 
-  private static final class PairCacheKey {
-    private final BDD[] _oldvars;
-    private final BDD[] _newvars;
-
-    private PairCacheKey(BDD[] oldvars, BDD[] newvars) {
-      _oldvars = oldvars;
-      _newvars = newvars;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof PairCacheKey)) {
-        return false;
-      }
-      PairCacheKey that = (PairCacheKey) o;
-      return Arrays.equals(_oldvars, that._oldvars) && Arrays.equals(_newvars, that._newvars);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(Arrays.hashCode(_oldvars), Arrays.hashCode(_newvars));
-    }
-  }
-
-  /** Copy the input array of BDDs (the array and each individual {@link BDD} is copied). */
-  private static BDD[] copy(BDD[] bdds) {
-    BDD[] result = new BDD[bdds.length];
-    for (int i = 0; i < bdds.length; i++) {
-      result[i] = bdds[i].id();
-    }
-    return result;
-  }
-
-  private Map<PairCacheKey, BDDPairing> _pairCache = null; // lazy init
+  private Map<ImmutableSet<BDDVarPair>, BDDPairing> _pairCache = null; // lazy init
 
   /**
    * Compute a {@link BDDPairing} mapping {@code oldvars} to {@code newvars}. The returned pairing
@@ -622,23 +587,21 @@ public abstract class BDDFactory {
    * <p>The returned {@link BDDPairing} must not be mutated -- it is unsafe to call {@link
    * BDDPairing#set} or {@link BDDPairing#reset()}.
    */
-  public BDDPairing getPair(BDD[] oldvars, BDD[] newvars) {
-    checkArgument(
-        oldvars.length == newvars.length, "getPair: oldvars and newvars must have the same length");
+  public BDDPairing getPair(Set<BDDVarPair> varPairs) {
+    checkArgument(!varPairs.isEmpty(), "getPair: need at least one pair");
     if (_pairCache == null) {
       _pairCache = new HashMap<>();
     }
-    @Nullable BDDPairing pair = _pairCache.get(new PairCacheKey(oldvars, newvars));
+    ImmutableSet<BDDVarPair> key = ImmutableSet.copyOf(varPairs);
+    @Nullable BDDPairing pair = _pairCache.get(key);
     if (pair != null) {
       return pair;
     }
     pair = makePair();
-    for (int i = 0; i < oldvars.length; i++) {
-      pair.set(oldvars[i].var(), newvars[i].var());
+    for (BDDVarPair varPair : varPairs) {
+      pair.set(varPair.getOldVar(), varPair.getNewVar());
     }
-    _pairCache.put(
-        new PairCacheKey(copy(oldvars), copy(newvars)), // defensive copy
-        pair);
+    _pairCache.put(key, pair);
     return pair;
   }
 

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDVarPair.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDVarPair.java
@@ -1,16 +1,29 @@
 package net.sf.javabdd;
 
-import com.google.common.base.Objects;
+import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Objects;
+import java.util.Set;
+
+/**
+ * A pair of BDD variables (i.e. created by {@link BDDFactory#ithVar(int)}). For building {@link
+ * BDDPairing BDDPairings} via {@link BDDFactory#getPair(Set)}. .
+ */
 public final class BDDVarPair {
   private final int _oldVar;
   private final int _newVar;
 
+  /**
+   * Build a {@link BDDVarPair} for two single-variable BDDs (i.e. BDDs returned from {@link
+   * BDDFactory#ithVar(int)}.
+   */
   public BDDVarPair(BDD oldVar, BDD newVar) {
-    this(oldVar.var(), newVar.var());
+    this(bddVarId(oldVar), bddVarId(newVar));
   }
 
   public BDDVarPair(int oldVar, int newVar) {
+    // disallow identity pairings -- they are no-ops, but would break caching in BDDFactory#getPair.
+    checkArgument(oldVar != newVar, "Cannot pair a variable with itself");
     this._oldVar = oldVar;
     this._newVar = newVar;
   }
@@ -38,5 +51,10 @@ public final class BDDVarPair {
   @Override
   public int hashCode() {
     return Objects.hashCode(_oldVar, _newVar);
+  }
+
+  private static int bddVarId(BDD bdd) {
+    checkArgument(bdd.high().isOne() && bdd.low().isZero(), "bdd is not a single variable");
+    return bdd.var();
   }
 }

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDVarPair.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDVarPair.java
@@ -1,0 +1,42 @@
+package net.sf.javabdd;
+
+import com.google.common.base.Objects;
+
+public final class BDDVarPair {
+  private final int _oldVar;
+  private final int _newVar;
+
+  public BDDVarPair(BDD oldVar, BDD newVar) {
+    this(oldVar.var(), newVar.var());
+  }
+
+  public BDDVarPair(int oldVar, int newVar) {
+    this._oldVar = oldVar;
+    this._newVar = newVar;
+  }
+
+  public int getOldVar() {
+    return _oldVar;
+  }
+
+  public int getNewVar() {
+    return _newVar;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BDDVarPair)) {
+      return false;
+    }
+    BDDVarPair that = (BDDVarPair) o;
+    return _oldVar == that._oldVar && _newVar == that._newVar;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(_oldVar, _newVar);
+  }
+}


### PR DESCRIPTION
getPair caches the BDDPairings it creates to improve cache performance of BDD::replace. Previously, this cache was sensitive to the order of the oldvars/newvars arrays, which is sensitive to the order in which BDDPairingFactory objects are composed.

We now use an unordered set of BDDVarPair objects as the cache key. This allows us to simplify BDDPairingFactory and Transform.