### PR TITLE
BDDFactory: add transform operator

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
@@ -20,6 +20,7 @@ public final class BDDPairingFactory {
 
   // lazy init
   @Nullable BDDPairing _swapPairing;
+  @Nullable BDDPairing _primeToUnprimePairing;
   @Nullable BDD _domainVars;
 
   public BDDPairingFactory(BDDFactory bddFactory, Set<BDDVarPair> varPairs) {
@@ -44,6 +45,18 @@ public final class BDDPairingFactory {
       _swapPairing = swapPairing(_bddFactory, _varPairs);
     }
     return _swapPairing;
+  }
+
+  /** Create a {@link BDDPairing} that maps codomain variables to domain variables. */
+  public BDDPairing getPrimeToUnprimePairing() {
+    if (_primeToUnprimePairing == null) {
+      _primeToUnprimePairing =
+          _bddFactory.getPair(
+              _varPairs.stream()
+                  .map(p -> new BDDVarPair(p.getNewVar(), p.getOldVar()))
+                  .collect(ImmutableSet.toImmutableSet()));
+    }
+    return _primeToUnprimePairing;
   }
 
   public BDDPairingFactory composeWith(BDDPairingFactory other) {

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
@@ -43,6 +43,7 @@ public class Transform implements Transition {
 
   private void init() {
     _pairingFactory.getDomainVarsBdd(); // pairing factory computes this lazily
+    _pairingFactory.getPrimeToUnprimePairing();
     _reverseRelation = _forwardRelation.replace(_pairingFactory.getSwapPairing());
   }
 
@@ -56,8 +57,7 @@ public class Transform implements Transition {
 
   @Override
   public BDD transitForward(BDD bdd) {
-    return bdd.applyEx(_forwardRelation, BDDFactory.and, _pairingFactory.getDomainVarsBdd())
-        .replaceWith(_pairingFactory.getSwapPairing());
+    return bdd.transform(_forwardRelation, _pairingFactory.getPrimeToUnprimePairing());
   }
 
   @Override
@@ -65,8 +65,7 @@ public class Transform implements Transition {
     if (_reverseRelation == null) {
       init();
     }
-    return bdd.applyEx(_reverseRelation, BDDFactory.and, _pairingFactory.getDomainVarsBdd())
-        .replaceWith(_pairingFactory.getSwapPairing());
+    return bdd.transform(_reverseRelation, _pairingFactory.getPrimeToUnprimePairing());
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
@@ -1,7 +1,6 @@
 package org.batfish.bddreachability.transition;
 
 import static org.batfish.common.bdd.BDDUtils.bddFactory;
-import static org.batfish.common.bdd.BDDUtils.bitvector;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -44,10 +43,14 @@ public class TransformTest {
 
     _xPrimedInt =
         new PrimedBDDInteger(
-            _factory, bitvector(_factory, 2, 0, false), bitvector(_factory, 2, 2, false));
+            _factory,
+            new BDD[] {_factory.ithVar(0), _factory.ithVar(2)},
+            new BDD[] {_factory.ithVar(1), _factory.ithVar(3)});
     _yPrimedInt =
         new PrimedBDDInteger(
-            _factory, bitvector(_factory, 2, 4, false), bitvector(_factory, 2, 6, false));
+            _factory,
+            new BDD[] {_factory.ithVar(4), _factory.ithVar(6)},
+            new BDD[] {_factory.ithVar(5), _factory.ithVar(7)});
 
     _x = _xPrimedInt.getVar();
     BDDInteger xPrime = _xPrimedInt.getPrimeVar();

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
@@ -743,6 +743,24 @@ public abstract class BDD {
   public abstract BDD applyEx(BDD that, BDDFactory.BDDOp opr, BDD var);
 
   /**
+   * Shorthand for {@code this.applyEx(rel, BDDFactory.and, vars).replace(pair)}, where
+   *
+   * <ol>
+   *   <li>vars is a varset BDD representation of the codomain of pair
+   *   <li>if pair maps variable V1 to V2, then LEVEL(V1) == LEVEL(V2)+1
+   * </ol>
+   *
+   * <p>Use case: {@code rel} represents a relation (multi-valued or nondeterministic function) as a
+   * constraint over unprimed and and primed variables (unprimed variables represent inputs and
+   * primed variables represent outputs), {@code x} represents a set of values as a constraint over
+   * unprimed variables, and {@code pair} maps the primed variables to their corresponding unprimed
+   * variables. {@code x.transform(rel, pair)} returns the image of {@code x} under {@code rel},
+   * i.e. the set containing all possible results of apply {@code rel} to a value in {@code x},
+   * represented as a constraint over unprimed variables.
+   */
+  public abstract BDD transform(BDD rel, BDDPairing pair);
+
+  /**
    * Applies the binary operator <tt>opr</tt> to two BDDs and then performs a unique quantification
    * of the variables from the variable set <tt>var</tt>.
    *

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -352,6 +352,14 @@ public class JFactory extends BDDFactory {
     }
 
     @Override
+    public BDD transform(BDD rel, BDDPairing pair) {
+      int x = _index;
+      int y = ((BDDImpl) rel)._index;
+
+      return makeBDD(bdd_transform(x, y, (bddPair) pair));
+    }
+
+    @Override
     public BDD applyUni(BDD that, BDDOp opr, BDD var) {
       int x = _index;
       int y = ((BDDImpl) that)._index;
@@ -837,6 +845,10 @@ public class JFactory extends BDDFactory {
     return r;
   }
 
+  private static int TRANSFORMHASH(int cacheid, int l, int r) {
+    return TRIPLE(cacheid, l, r);
+  }
+
   private static int REPLACEHASH(int cacheid, int r) {
     return PAIR(cacheid, r);
   }
@@ -1164,7 +1176,7 @@ public class JFactory extends BDDFactory {
     }
     replacepair = pair.result;
     replacelast = pair.last;
-    replaceid = (pair.id << 2) | CACHEID_REPLACE;
+    replaceid = (pair.id << 3) | CACHEID_REPLACE;
 
     INITREF();
     int res = replace_rec(r);
@@ -1207,7 +1219,7 @@ public class JFactory extends BDDFactory {
        * the bdd_correctify calls and restore when it returns.
        */
       int tmp = replaceid;
-      replaceid = (level << 2) | CACHEID_CORRECTIFY;
+      replaceid = (level << 3) | CACHEID_CORRECTIFY;
       res = bdd_correctify(level, READREF(2), READREF(1));
       replaceid = tmp;
     }
@@ -2155,6 +2167,97 @@ public class JFactory extends BDDFactory {
     return res;
   }
 
+  private int bdd_transform(int l, int r, bddPair pair) {
+    CHECK(l);
+    CHECK(r);
+
+    if (applycache == null) {
+      applycache = BddCacheI_init(cachesize);
+    }
+    if (replacecache == null) {
+      replacecache = BddCacheI_init(cachesize);
+    }
+    replacepair = pair.result;
+    replacelast = pair.last;
+    replaceid = (pair.id << 3) | CACHEID_REPLACE;
+
+    INITREF();
+    int res = transform_rec(l, r);
+    checkresize();
+
+    return res;
+  }
+
+  private int transform_rec(int l, int r) {
+    BddCacheDataI entry;
+    int res;
+
+    if (ISZERO(l) || ISZERO(r)) {
+      return BDDZERO;
+    }
+    if (LEVEL(l) > replacelast && LEVEL(r) > replacelast) {
+      return and_rec(l, r);
+    }
+    int hash = TRANSFORMHASH(replaceid, l, r);
+    entry = BddCache_lookupI(replacecache, hash);
+    if (entry.a == l && entry.b == r && entry.c == replaceid) {
+      if (CACHESTATS) {
+        cachestats.opHit++;
+      }
+      return entry.res;
+    }
+    if (CACHESTATS) {
+      cachestats.opMiss--;
+    }
+
+    int level;
+    if (LEVEL(l) == LEVEL(r)) {
+      level = LEVEL(l);
+      PUSHREF(transform_rec(LOW(l), LOW(r)));
+      PUSHREF(transform_rec(HIGH(l), HIGH(r)));
+    } else if (LEVEL(l) < LEVEL(r)) {
+      level = LEVEL(l);
+      PUSHREF(transform_rec(LOW(l), r));
+      PUSHREF(transform_rec(HIGH(l), r));
+    } else {
+      level = LEVEL(r);
+      PUSHREF(transform_rec(l, LOW(r)));
+      PUSHREF(transform_rec(l, HIGH(r)));
+    }
+
+    int lo = READREF(2);
+    int hi = READREF(1);
+
+    assert LEVEL(lo) >= level && LEVEL(hi) >= level : "Cannot transform up more than one level";
+
+    // check if this level is replaced, i.e. if it's in the codomain of the replacepair. If it is,
+    // it must be mapped from the next level.
+    int nextLevel = level + 1;
+    if (nextLevel < replacepair.length && LEVEL(replacepair[nextLevel]) == level) {
+      // this level has been replaced, i.e. existentially quantified. OR hi and lo
+      res = or_rec(lo, hi);
+    } else {
+      // two cases: replace at this level or keep the level. If replaced, it must be mapped to the
+      // previous level.
+      int codomLevel = LEVEL(replacepair[level]);
+      assert codomLevel == level || codomLevel == level - 1
+          : "Transform can only replace variables to the previous level";
+      res = bdd_makenode(codomLevel, lo, hi);
+    }
+    POPREF(2);
+
+    if (CACHESTATS && entry.a != -1) {
+      cachestats.opOverwrite++;
+    }
+    entry.a = l;
+    entry.b = r;
+    entry.c = replaceid;
+    entry.res = res;
+    entry.hash = hash;
+
+    return res;
+  }
+
   private int varset2vartable(int r) {
     if (r < 2) {
       return bdd_error(BDD_VARSET);
@@ -2823,7 +2926,7 @@ public class JFactory extends BDDFactory {
       applycache = BddCacheI_init(cachesize);
     }
     composelevel = bddvar2level[var];
-    replaceid = (composelevel << 2) | CACHEID_COMPOSE;
+    replaceid = (composelevel << 3) | CACHEID_COMPOSE;
 
     INITREF();
     int res = compose_rec(f, g);
@@ -2893,7 +2996,7 @@ public class JFactory extends BDDFactory {
       replacecache = BddCacheI_init(cachesize);
     }
     replacepair = pair.result;
-    replaceid = (pair.id << 2) | CACHEID_VECCOMPOSE;
+    replaceid = (pair.id << 3) | CACHEID_VECCOMPOSE;
     replacelast = pair.last;
 
     INITREF();
@@ -4095,11 +4198,12 @@ public class JFactory extends BDDFactory {
   private static final int CACHEID_SATCOULN = 0x3;
   private static final int CACHEID_PATHCOU = 0x4;
 
-  /* Hash value modifiers for replace/compose */
+  /* Hash value modifiers for replace/compose. Max 8 values */
   private static final int CACHEID_REPLACE = 0x0;
   private static final int CACHEID_COMPOSE = 0x1;
   private static final int CACHEID_VECCOMPOSE = 0x2;
   private static final int CACHEID_CORRECTIFY = 0x3;
+  private static final int CACHEID_TRANSFORM = 0x4;
 
   /* Hash value modifiers for quantification. Max 8 values */
   private static final int CACHEID_EXIST = 0x0;
@@ -4570,13 +4674,22 @@ public class JFactory extends BDDFactory {
   private int update_pairsid() {
     pairsid++;
 
-    if (pairsid == (INT_MAX >> 2)) {
+    int numIds = INT_MAX >> 3;
+
+    if (pairsid == numIds) {
+      // we use more pair IDs than there are pair objects -- each time we mutate a pair we give it a
+      // new ID. so
+      // if we run out, search for an unused one. have to clear the cache too
       pairsid = 0;
       for (bddPair p = pairs; p != null; p = p.next) {
         p.id = pairsid++;
       }
       // bdd_operator_reset();
       BddCache_reset(replacecache);
+    }
+
+    if (pairsid >= numIds) {
+      throw new IllegalStateException("too many pairings");
     }
 
     return pairsid;

--- a/projects/bdd/src/main/java/net/sf/javabdd/TracingFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/TracingFactory.java
@@ -665,6 +665,11 @@ public final class TracingFactory extends JFactory {
     }
 
     @Override
+    public BDD transform(BDD rel, BDDPairing pair) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public TracedBDDImpl applyUni(BDD that, BDDOp opr, BDD var) {
       throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Shorthand for x.applyEx(rel, BDDFactory.and, vars).replace(pair), where
1. vars is a varset BDD representation of the codomain of pair
2. pair maps each variable in its domain to the variable one level higher.

Use case: rel represents a relation (multi-valued or nondeterministic function) as a constraint over unprimed and and primed variables (unprimed variables represent inputs and primed variables represent outputs), x represents a set of values as a constraint over unprimed variables, and pair maps the primed variables to their corresponding unprimed variables. x.transform(rel, pair) returns the image of x under rel, i.e. the set containing all possible results of apply rel to a value in x, represented as a constraint over unprimed variables.