### PR TITLE
IspModeling: enable not-configured local IP for BgpPeerInfo

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/e2e/isp/IspModelingTest.java
+++ b/projects/allinone/src/test/java/org/batfish/e2e/isp/IspModelingTest.java
@@ -61,6 +61,15 @@ public class IspModelingTest {
   }
 
   @Test
+  public void testBasicBgpPeerInfoInferredLocalIp() throws IOException {
+    IBatfish batfish = setup("basic-bgppeerinfo-implicit", ImmutableList.of("border1.cfg"), false);
+    BgpTopology bgpTopology = batfish.getTopologyProvider().getBgpTopology(batfish.getSnapshot());
+
+    // internet to ISP and ISP to border (4 uni edges)
+    assertThat(bgpTopology.getGraph().edges(), hasSize(4));
+  }
+
+  @Test
   public void testSviPeering() throws IOException {
     IBatfish batfish = setup("svi-peering", ImmutableList.of("border1.cfg", "border2.cfg"), true);
     BgpTopology bgpTopology = batfish.getTopologyProvider().getBgpTopology(batfish.getSnapshot());

--- a/projects/allinone/src/test/resources/org/batfish/e2e/isp/basic-bgppeerinfo-implicit/batfish/isp_config.json
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/isp/basic-bgppeerinfo-implicit/batfish/isp_config.json
@@ -1,0 +1,11 @@
+{
+  "bgpPeers": [
+    {
+      "hostname": "border1",
+      "peerAddress": "240.2.2.3",
+      "ispAttachment": {
+        "interface": "GigabitEthernet0/0"
+      }
+    }
+  ]
+}

--- a/projects/allinone/src/test/resources/org/batfish/e2e/isp/basic-bgppeerinfo-implicit/configs/border1.cfg
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/isp/basic-bgppeerinfo-implicit/configs/border1.cfg
@@ -1,0 +1,23 @@
+!
+version 15.2
+!
+hostname border1
+!
+interface Loopback0
+ ip address 10.1.1.1 255.255.255.255
+!
+interface GigabitEthernet0/0
+ ip address 240.2.2.2/31
+!
+router bgp 666
+ bgp router-id 10.1.1.1
+ neighbor isp peer-group
+ neighbor isp remote-as 667
+ neighbor 240.2.2.3 peer-group isp
+ !
+ address-family ipv4
+  neighbor 240.2.2.3 activate
+ exit-address-family
+!
+!
+end

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/isp/IspModelingUtilsTest.java
@@ -320,7 +320,7 @@ public class IspModelingUtilsTest {
             .setLocalAs(2L)
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build());
 
-    // wrong explict local IP
+    // wrong explicit local IP
     assertFalse(
         isValidBgpPeerForBorderInterfaceInfo(
             bgpActivePeerConfig.setLocalIp(Ip.parse("2.2.2.2")).build(),
@@ -822,6 +822,7 @@ public class IspModelingUtilsTest {
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
                 _snapshotHostname,
+                null,
                 _ispIp,
                 null,
                 new IspAttachment(null, _snapshotInterfaceName, null)),
@@ -837,7 +838,7 @@ public class IspModelingUtilsTest {
   public void testGetSnapshotConnectionForBgpPeerInfo_noAttachment() {
     Optional<SnapshotConnection> snapshotConnection =
         getSnapshotConnectionForBgpPeerInfo(
-            new BgpPeerInfo(_snapshotHostname, _ispIp, null, null),
+            new BgpPeerInfo(_snapshotHostname, null, _ispIp, null, null),
             ImmutableSet.of(),
             ALL_AS_NUMBERS,
             ImmutableMap.of(_snapshotHostname, _snapshotHost),
@@ -858,6 +859,7 @@ public class IspModelingUtilsTest {
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
                 _snapshotHostname,
+                null,
                 _ispIp,
                 null,
                 new IspAttachment(null, attachIface.getName(), null)),
@@ -892,6 +894,7 @@ public class IspModelingUtilsTest {
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
                 _snapshotHostname,
+                null,
                 _ispIp,
                 null,
                 new IspAttachment(attachHost.getHostname(), attachIface.getName(), null)),
@@ -919,6 +922,7 @@ public class IspModelingUtilsTest {
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
                 _snapshotHostname,
+                null,
                 _ispIp,
                 null,
                 new IspAttachment(null, _snapshotInterfaceName, 23)),
@@ -946,7 +950,7 @@ public class IspModelingUtilsTest {
     Optional<SnapshotConnection> connection =
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
-                "other", _ispIp, null, new IspAttachment(null, _snapshotInterfaceName, null)),
+                "other", null, _ispIp, null, new IspAttachment(null, _snapshotInterfaceName, null)),
             ImmutableSet.of(),
             ALL_AS_NUMBERS,
             ImmutableMap.of(_snapshotHostname, _snapshotHost),
@@ -964,6 +968,7 @@ public class IspModelingUtilsTest {
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
                 _snapshotHostname,
+                null,
                 Ip.ZERO,
                 null,
                 new IspAttachment(null, _snapshotInterfaceName, null)),
@@ -995,6 +1000,7 @@ public class IspModelingUtilsTest {
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
                 _snapshotHostname,
+                null,
                 bgpPeer.getPeerAddress(),
                 null,
                 new IspAttachment(null, _snapshotInterfaceName, null)),
@@ -1061,11 +1067,6 @@ public class IspModelingUtilsTest {
                 correctBuilder().build(), ImmutableSet.of(Ip.ZERO), ALL_AS_NUMBERS)
             .get(),
         containsString("remote IP " + _ispIp + " is not allowed by the filter"));
-    assertThat(
-        validateOrExplainProblemCreatingIspConfig(
-                correctBuilder().setLocalIp(null).build(), ImmutableSet.of(), ALL_AS_NUMBERS)
-            .get(),
-        containsString("unable to determine local IP address"));
   }
 
   @Test
@@ -1075,6 +1076,7 @@ public class IspModelingUtilsTest {
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
                 _snapshotHostname,
+                null,
                 _ispIp,
                 null,
                 new IspAttachment("other", _snapshotInterfaceName, null)),
@@ -1094,7 +1096,7 @@ public class IspModelingUtilsTest {
     Optional<SnapshotConnection> connection =
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
-                _snapshotHostname, _ispIp, null, new IspAttachment(null, "other", null)),
+                _snapshotHostname, null, _ispIp, null, new IspAttachment(null, "other", null)),
             ImmutableSet.of(),
             ALL_AS_NUMBERS,
             ImmutableMap.of(_snapshotHostname, _snapshotHost),
@@ -1118,6 +1120,7 @@ public class IspModelingUtilsTest {
         getSnapshotConnectionForBgpPeerInfo(
             new BgpPeerInfo(
                 _snapshotHostname,
+                null,
                 _ispIp,
                 null,
                 new IspAttachment(null, attachIface.getName(), null)),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/BgpPeerInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/BgpPeerInfoTest.java
@@ -14,20 +14,21 @@ public class BgpPeerInfoTest {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new BgpPeerInfo("host", Ip.ZERO, null, null),
-            new BgpPeerInfo("host", Ip.ZERO, null, null),
-            new BgpPeerInfo("HoSt", Ip.ZERO, null, null)) // hostname is canonicalized
-        .addEqualityGroup(new BgpPeerInfo("other", Ip.ZERO, null, null))
-        .addEqualityGroup(new BgpPeerInfo("host", Ip.MAX, null, null))
-        .addEqualityGroup(new BgpPeerInfo("host", Ip.ZERO, "vrf", null))
+            new BgpPeerInfo("host", null, Ip.ZERO, null, null),
+            new BgpPeerInfo("host", null, Ip.ZERO, null, null),
+            new BgpPeerInfo("HoSt", null, Ip.ZERO, null, null)) // hostname is canonicalized
+        .addEqualityGroup(new BgpPeerInfo("other", null, Ip.ZERO, null, null))
+        .addEqualityGroup(new BgpPeerInfo("other", Ip.MAX, Ip.ZERO, null, null))
+        .addEqualityGroup(new BgpPeerInfo("host", null, Ip.MAX, null, null))
+        .addEqualityGroup(new BgpPeerInfo("host", null, Ip.ZERO, "vrf", null))
         .addEqualityGroup(
-            new BgpPeerInfo("host", Ip.ZERO, null, new IspAttachment(null, "iface", null)))
+            new BgpPeerInfo("host", null, Ip.ZERO, null, new IspAttachment(null, "iface", null)))
         .testEquals();
   }
 
   @Test
   public void testJsonSerialization() {
-    BgpPeerInfo bgpPeerInfo = new BgpPeerInfo("host", Ip.ZERO, null, null);
+    BgpPeerInfo bgpPeerInfo = new BgpPeerInfo("host", null, Ip.ZERO, null, null);
     assertThat(BatfishObjectMapper.clone(bgpPeerInfo, BgpPeerInfo.class), equalTo(bgpPeerInfo));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/IspConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/IspConfigurationTest.java
@@ -58,7 +58,7 @@ public class IspConfigurationTest {
             new IspConfiguration(
                 ImmutableList.of(
                     new BorderInterfaceInfo(NodeInterfacePair.of("node", "interface"))),
-                ImmutableList.of(new BgpPeerInfo("other", Ip.ZERO, null, null)),
+                ImmutableList.of(new BgpPeerInfo("other", null, Ip.ZERO, null, null)),
                 new IspFilter(ImmutableList.of(1234L), ImmutableList.of(Ip.parse("1.1.1.1"))),
                 ImmutableList.of(new IspNodeInfo(42, "n1")),
                 ImmutableList.of()))
@@ -86,7 +86,7 @@ public class IspConfigurationTest {
     IspConfiguration ispConfiguration =
         new IspConfiguration(
             ImmutableList.of(new BorderInterfaceInfo(NodeInterfacePair.of("node", "interface"))),
-            ImmutableList.of(new BgpPeerInfo("node", Ip.ZERO, null, null)),
+            ImmutableList.of(new BgpPeerInfo("node", null, Ip.ZERO, null, null)),
             new IspFilter(ImmutableList.of(1234L), ImmutableList.of(Ip.parse("1.1.1.1"))),
             ImmutableList.of(new IspNodeInfo(42, "n1")),
             ImmutableList.of(new IspPeeringInfo(new Peer(1L), new Peer(2L))));


### PR DESCRIPTION
During ISP modeling, we need to generate correct ISP-side BGP configuration.
This requires, in particular, specifying the neighbor on that side -- aka,
the local IP on the node in the snapshot. This is usually configured via
an explicit update source or local address command, but may not always be.

To support ISP modeling for these cases, we:

1. provide a way to force local IP in the BgpPeerInfo
2. improve default local IP inference to include local
connected routes (same VRF) for eBGP singlehop sessions.