### PR TITLE
BDDPacket: support allocating variables before packet header variables

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
@@ -83,10 +83,23 @@ public final class BDDFiniteDomain<V> {
    */
   public static <K, V> Map<K, BDDFiniteDomain<V>> domainsWithSharedVariable(
       BDDPacket pkt, String varName, Map<K, Set<V>> values) {
+    return domainsWithSharedVariable(pkt, varName, values, false);
+  }
+
+  /**
+   * Create multiple domains (never in use at the same time) backed by the same variable. For
+   * example, we can use this to track domains that are per-node.
+   *
+   * @param preferBeforePacketVars Whether the {@link BDD BDD} variables should be allocated before
+   *     the variables used to encode packet headers. If true, and there are no remaining variables
+   *     before the packet headers, will try to allocate after.
+   */
+  public static <K, V> Map<K, BDDFiniteDomain<V>> domainsWithSharedVariable(
+      BDDPacket pkt, String varName, Map<K, Set<V>> values, boolean preferBeforePacketVars) {
     checkArgument(!values.isEmpty(), "empty values map");
     int maxSize = values.values().stream().mapToInt(Set::size).max().getAsInt();
     int bitsRequired = computeBitsRequired(maxSize);
-    ImmutableBDDInteger var = pkt.allocateBDDInteger(varName, bitsRequired);
+    ImmutableBDDInteger var = pkt.allocateBDDInteger(varName, bitsRequired, preferBeforePacketVars);
     return toImmutableMap(
         values, Entry::getKey, entry -> new BDDFiniteDomain<>(var, entry.getValue()));
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -68,6 +68,7 @@ public class BDDPacket {
 
   private final Map<Integer, String> _bitNames;
   private final BDDFactory _factory;
+  private int _nextFreeBDDVarIdxBeforePacketVars = 0;
   private int _nextFreeBDDVarIdx = FIRST_PACKET_VAR;
 
   // Packet bits
@@ -199,12 +200,48 @@ public class BDDPacket {
    * @return A {@link BDD} representing the sentence "this variable is true" for the new variable.
    */
   public BDD allocateBDDBit(String name) {
+    return allocateBDDBitAfterPacketVars(name);
+  }
+
+  /**
+   * Allocate a new single-bit {@link BDD} variable.
+   *
+   * @param name Used for debugging.
+   * @param preferBeforePacketVars Whether the variable should be allocated before the variables
+   *     used to encode packet headers. If true, and there are no remaining variables before the
+   *     packet headers, will try to allocate after.
+   * @return A {@link BDD} representing the sentence "this variable is true" for the new variable.
+   */
+  public BDD allocateBDDBit(String name, boolean preferBeforePacketVars) {
+    return preferBeforePacketVars && _nextFreeBDDVarIdxBeforePacketVars < FIRST_PACKET_VAR
+        ? allocateBDDBitBeforePacketVars(name)
+        : allocateBDDBitAfterPacketVars(name);
+  }
+
+  private BDD allocateBDDBitAfterPacketVars(String name) {
     if (_factory.varNum() < _nextFreeBDDVarIdx + 1) {
       _factory.setVarNum(_nextFreeBDDVarIdx + 1);
     }
     _bitNames.put(_nextFreeBDDVarIdx, name);
     BDD bdd = _factory.ithVar(_nextFreeBDDVarIdx);
     _nextFreeBDDVarIdx++;
+    return bdd;
+  }
+
+  /**
+   * Allocate a new single-bit {@link BDD} variable before the variables used to encode packet
+   * headers. Requires such a variable is available.
+   *
+   * @param name Used for debugging.
+   * @return A {@link BDD} representing the sentence "this variable is true" for the new variable.
+   */
+  public BDD allocateBDDBitBeforePacketVars(String name) {
+    checkArgument(
+        _nextFreeBDDVarIdxBeforePacketVars < FIRST_PACKET_VAR,
+        "No unassigned variable before packet vars");
+    _bitNames.put(_nextFreeBDDVarIdxBeforePacketVars, name);
+    BDD bdd = _factory.ithVar(_nextFreeBDDVarIdxBeforePacketVars);
+    _nextFreeBDDVarIdxBeforePacketVars++;
     return bdd;
   }
 
@@ -216,7 +253,47 @@ public class BDDPacket {
    * @return The new variable.
    */
   public ImmutableBDDInteger allocateBDDInteger(String name, int bits) {
-    return new ImmutableBDDInteger(_factory, allocateBDDBits(name, bits));
+    return allocateBDDInteger(name, bits, false);
+  }
+
+  /**
+   * Allocate a new {@link ImmutableBDDInteger} variable.
+   *
+   * @param name Used for debugging.
+   * @param bits The number of bits to allocate.
+   * @param preferBeforePacketVars Whether the variable should be allocated before the variables
+   *     used to encode packet headers. If true, and there are no remaining variables before the
+   *     packet headers, will try to allocate after.
+   * @return The new variable.
+   */
+  public ImmutableBDDInteger allocateBDDInteger(
+      String name, int bits, boolean preferBeforePacketVars) {
+    BDD[] vars =
+        preferBeforePacketVars && _nextFreeBDDVarIdxBeforePacketVars + bits < FIRST_PACKET_VAR
+            ? allocateBDDBitsBeforePacketVars(name, bits)
+            : allocateBDDBits(name, bits);
+    return new ImmutableBDDInteger(_factory, vars);
+  }
+
+  /**
+   * Allocate {@link BDD} variables before the variables used to encode packet headers. Requires
+   * there are enough such variables available.
+   *
+   * @param name Used for debugging.
+   * @param bits The number of bits to allocate.
+   * @return An array of the new {@link BDD} variables.
+   */
+  private BDD[] allocateBDDBitsBeforePacketVars(String name, int bits) {
+    checkArgument(
+        _nextFreeBDDVarIdxBeforePacketVars + bits < FIRST_PACKET_VAR,
+        "not enough unassigned variables before packet vars");
+    BDD[] bdds = new BDD[bits];
+    for (int i = 0; i < bits; i++) {
+      bdds[i] = _factory.ithVar(_nextFreeBDDVarIdxBeforePacketVars + i);
+    }
+    addBitNames(name, bits, _nextFreeBDDVarIdxBeforePacketVars);
+    _nextFreeBDDVarIdxBeforePacketVars += bits;
+    return bdds;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -235,7 +235,7 @@ public class BDDPacket {
    * @param name Used for debugging.
    * @return A {@link BDD} representing the sentence "this variable is true" for the new variable.
    */
-  public BDD allocateBDDBitBeforePacketVars(String name) {
+  private BDD allocateBDDBitBeforePacketVars(String name) {
     checkArgument(
         _nextFreeBDDVarIdxBeforePacketVars < FIRST_PACKET_VAR,
         "No unassigned variable before packet vars");
@@ -271,7 +271,7 @@ public class BDDPacket {
     BDD[] vars =
         preferBeforePacketVars && _nextFreeBDDVarIdxBeforePacketVars + bits < FIRST_PACKET_VAR
             ? allocateBDDBitsBeforePacketVars(name, bits)
-            : allocateBDDBits(name, bits);
+            : allocateBDDBitsAfterPacketVars(name, bits);
     return new ImmutableBDDInteger(_factory, vars);
   }
 
@@ -303,7 +303,7 @@ public class BDDPacket {
    * @param bits The number of bits to allocate.
    * @return An array of the new {@link BDD} variables.
    */
-  private BDD[] allocateBDDBits(String name, int bits) {
+  private BDD[] allocateBDDBitsAfterPacketVars(String name, int bits) {
     if (_factory.varNum() < _nextFreeBDDVarIdx + bits) {
       _factory.setVarNum(_nextFreeBDDVarIdx + bits);
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -179,7 +179,7 @@ public final class BDDSourceManager {
             });
 
     Map<String, BDDFiniteDomain<String>> finiteDomains =
-        BDDFiniteDomain.domainsWithSharedVariable(pkt, VAR_NAME, valuesToTrack);
+        BDDFiniteDomain.domainsWithSharedVariable(pkt, VAR_NAME, valuesToTrack, true);
 
     return toImmutableMap(
         finiteDomains,

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFiniteDomainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFiniteDomainTest.java
@@ -1,10 +1,13 @@
 package org.batfish.common.bdd;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,5 +61,15 @@ public final class BDDFiniteDomainTest {
     assertThat(fd.getValueFromAssignment(fd.getConstraintForValue(1)), equalTo(1));
     assertThat(fd.getValueFromAssignment(fd.getConstraintForValue(2)), equalTo(2));
     assertThat(fd.getValueFromAssignment(fd.getConstraintForValue(3)), equalTo(3));
+  }
+
+  @Test
+  public void testDomainsWithSharedVariable_preferBeforePacketVars() {
+    Map<String, BDDFiniteDomain<String>> domains =
+        BDDFiniteDomain.domainsWithSharedVariable(
+            _pkt, "name", ImmutableMap.of("n1", ImmutableSet.of("v1", "v2")), true);
+    assertThat(
+        domains.values().iterator().next().getConstraintForValue("v1").var(),
+        lessThan(_pkt.getDstIp().value(0).var()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
@@ -16,6 +16,7 @@ import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsPsh;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsRst;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsUrg;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
@@ -44,12 +45,28 @@ public class BDDPacketTest {
   }
 
   @Test
+  public void testAllocateBDDBit_beforePacketVars() {
+    BDDPacket pkt = new BDDPacket();
+    BDD bdd = pkt.allocateBDDBit("foo", true);
+    assertThat(bdd, notNullValue());
+    assertThat(bdd.var(), lessThan(pkt.getDstIp().value(0).var()));
+  }
+
+  @Test
   public void testAllocateBDDInteger() {
     BDDPacket pkt = new BDDPacket();
     int varNum = pkt.getFactory().varNum();
     BDDInteger var = pkt.allocateBDDInteger("foo", 5);
     assertThat(var, notNullValue());
     assertThat(pkt.getFactory().varNum(), equalTo(varNum + 5));
+  }
+
+  @Test
+  public void testAllocateBDDInteger_beforePacketVars() {
+    BDDPacket pkt = new BDDPacket();
+    BDDInteger var = pkt.allocateBDDInteger("foo", 5, true);
+    assertThat(var, notNullValue());
+    assertThat(var.value(0).var(), lessThan(pkt.getDstIp().value(0).var()));
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
@@ -1,6 +1,5 @@
 package org.batfish.bddreachability;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.immutableEntry;
 import static org.batfish.common.bdd.IpAccessListToBdd.toBdds;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
@@ -94,9 +93,7 @@ public final class BDDOutgoingOriginalFlowFilterManager {
   }
 
   private static BDD allocatePermitVar(BDDPacket pkt) {
-    // Allocate permit var
-    checkState(BDDPacket.FIRST_PACKET_VAR > 0, "Can't allocate permit BDD variable");
-    return pkt.getFactory().ithVar(0);
+    return pkt.allocateBDDBit("Outgoing Original Flow Filter permit/deny bit", true);
   }
 
   /** Returns an empty {@link BDDOutgoingOriginalFlowFilterManager}. */
@@ -157,7 +154,7 @@ public final class BDDOutgoingOriginalFlowFilterManager {
     }
 
     Map<String, BDDFiniteDomain<String>> finiteDomains =
-        BDDFiniteDomain.domainsWithSharedVariable(pkt, VAR_NAME, finiteDomainValues.build());
+        BDDFiniteDomain.domainsWithSharedVariable(pkt, VAR_NAME, finiteDomainValues.build(), true);
 
     // Allocate permit var
     BDD permitVar = allocatePermitVar(pkt);


### PR DESCRIPTION
BDD performance is sensitive to variable order, so allowing variables to be allocated
before packet header variables can be important. In particular, the finite domains used
by BDDSourceManager and BDDOutgoingOriginalFlowFilterManager should be before the header
variables (if possible).