### PR TITLE
BDD ACL caching improvements

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
@@ -99,7 +99,7 @@ public final class BDDFiniteDomain<V> {
     checkArgument(!values.isEmpty(), "empty values map");
     int maxSize = values.values().stream().mapToInt(Set::size).max().getAsInt();
     int bitsRequired = computeBitsRequired(maxSize);
-    ImmutableBDDInteger var = pkt.allocateBDDInteger(varName, bitsRequired);
+    ImmutableBDDInteger var = pkt.allocateBDDInteger(varName, bitsRequired, preferBeforePacketVars);
     return toImmutableMap(
         values, Entry::getKey, entry -> new BDDFiniteDomain<>(var, entry.getValue()));
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
@@ -99,7 +99,7 @@ public final class BDDFiniteDomain<V> {
     checkArgument(!values.isEmpty(), "empty values map");
     int maxSize = values.values().stream().mapToInt(Set::size).max().getAsInt();
     int bitsRequired = computeBitsRequired(maxSize);
-    ImmutableBDDInteger var = pkt.allocateBDDInteger(varName, bitsRequired, preferBeforePacketVars);
+    ImmutableBDDInteger var = pkt.allocateBDDInteger(varName, bitsRequired);
     return toImmutableMap(
         values, Entry::getKey, entry -> new BDDFiniteDomain<>(var, entry.getValue()));
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
@@ -143,7 +143,7 @@ public abstract class IpAccessListToBdd {
                 .map(this::toPermitAndDenyBdds)
                 .collect(ImmutableList.toImmutableList()));
     t = System.currentTimeMillis() - t;
-    LOGGER.info(
+    LOGGER.debug(
         "toPermitAndDenyBdds({}): {}ms  ({} lines, {} values for tracking sources)",
         acl.getName(),
         t,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
@@ -143,7 +143,12 @@ public abstract class IpAccessListToBdd {
                 .map(this::toPermitAndDenyBdds)
                 .collect(ImmutableList.toImmutableList()));
     t = System.currentTimeMillis() - t;
-    LOGGER.info("toPermitAndDenyBdds({}): {}ms", acl.getName(), t);
+    LOGGER.info(
+        "toPermitAndDenyBdds({}): {}ms  ({} lines, {} values for tracking sources)",
+        acl.getName(),
+        t,
+        acl.getLines().size(),
+        _bddSrcManager.getFiniteDomain().getValueBdds().size());
     return result;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
@@ -1,13 +1,9 @@
 package org.batfish.common.bdd;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +13,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.batfish.common.BatfishException;
 import org.batfish.common.util.NonRecursiveSupplier;
 import org.batfish.common.util.NonRecursiveSupplier.NonRecursiveSupplierException;
@@ -46,25 +44,13 @@ import org.batfish.datamodel.acl.TrueExpr;
  */
 @ParametersAreNonnullByDefault
 public abstract class IpAccessListToBdd {
-
-  /** Converts the given {@code aclsToConvert} to {@link BDD BDDs} using the given context. */
-  public static Map<String, BDD> toBdds(
-      BDDPacket pkt,
-      Collection<IpAccessList> aclsToConvert,
-      Map<String, IpAccessList> aclEnv,
-      Map<String, IpSpace> ipSpaceEnv,
-      BDDSourceManager bddSrcManager) {
-    IpAccessListToBdd converter = new IpAccessListToBddImpl(pkt, bddSrcManager, aclEnv, ipSpaceEnv);
-    return toImmutableMap(aclsToConvert, IpAccessList::getName, converter::toBdd);
-  }
+  private static final Logger LOGGER = LogManager.getLogger(IpAccessListToBdd.class);
 
   /**
    * Converts the given {@link IpAccessList} to a {@link BDD} using the given context.
    *
    * <p>Note that if converting multiple {@link IpAccessList ACLs} with the same context,
    * considerable work can be saved by creating a single {@link IpAccessListToBdd} and reusing it.
-   *
-   * @see #toBdds(BDDPacket, Collection, Map, Map, BDDSourceManager)
    */
   public static BDD toBDD(
       BDDPacket pkt,
@@ -73,22 +59,6 @@ public abstract class IpAccessListToBdd {
       Map<String, IpSpace> ipSpaceEnv,
       BDDSourceManager bddSrcManager) {
     return new IpAccessListToBddImpl(pkt, bddSrcManager, aclEnv, ipSpaceEnv).toBdd(acl);
-  }
-
-  /**
-   * Converts the given {@link IpAccessList} to a {@link BDD}.
-   *
-   * <p>The {@link IpAccessList} must be self-contained, with no references to source {@link
-   * org.batfish.datamodel.Interface}, named {@link IpAccessList ACLs} or {@link IpSpace IP spaces}.
-   *
-   * <p>Note that if converting multiple {@link IpAccessList ACLs} with the same context,
-   * considerable work can be saved by creating a single {@link IpAccessListToBdd} and reusing it.
-   *
-   * @see #toBdds(BDDPacket, Collection, Map, Map, BDDSourceManager)
-   * @see #toBDD(BDDPacket, IpAccessList, Map, Map, BDDSourceManager)
-   */
-  public static BDD toBDD(BDDPacket pkt, IpAccessList acl) {
-    return toBDD(pkt, acl, ImmutableMap.of(), ImmutableMap.of(), BDDSourceManager.empty(pkt));
   }
 
   /** Map of ACL name to {@link PermitAndDenyBdds} of the packets explicitly matched by that ACL */
@@ -162,15 +132,19 @@ public abstract class IpAccessListToBdd {
    */
   @Nonnull
   public final BDD toBdd(IpAccessList acl) {
-    return toPermitAndDenyBdds(acl).getPermitBdd();
+    return getPermitAndDenyBdds(acl.getName()).getPermitBdd();
   }
 
-  @VisibleForTesting
-  public PermitAndDenyBdds toPermitAndDenyBdds(IpAccessList acl) {
-    return _bddOps.bddAclLines(
-        acl.getLines().stream()
-            .map(this::toPermitAndDenyBdds)
-            .collect(ImmutableList.toImmutableList()));
+  private PermitAndDenyBdds toPermitAndDenyBdds(IpAccessList acl) {
+    long t = System.currentTimeMillis();
+    PermitAndDenyBdds result =
+        _bddOps.bddAclLines(
+            acl.getLines().stream()
+                .map(this::toPermitAndDenyBdds)
+                .collect(ImmutableList.toImmutableList()));
+    t = System.currentTimeMillis() - t;
+    LOGGER.info("toPermitAndDenyBdds({}): {}ms", acl.getName(), t);
+    return result;
   }
 
   private PermitAndDenyBdds getPermitAndDenyBdds(String aclName) {

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -876,7 +876,7 @@ public final class BDDReachabilityAnalysisFactory {
                                         _ipsRoutesOutInterfacesFactory.getIpsRoutedOutInterfaces(
                                             nodeName, vrfName)));
                         t = System.currentTimeMillis() - t;
-                        LOGGER.info(
+                        LOGGER.debug(
                             "converted packet policy on {}/{} to BDD: {}ms", nodeName, vrfName, t);
 
                         PacketPolicyActionToEdges actionToEdges =

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -292,7 +292,10 @@ public final class BDDReachabilityAnalysisFactory {
           toImmutableMap(configs.keySet(), Function.identity(), k -> empty);
     } else {
       _bddOutgoingOriginalFlowFilterManagers =
-          BDDOutgoingOriginalFlowFilterManager.forNetwork(_bddPacket, configs, _aclPermitBDDs);
+          BDDOutgoingOriginalFlowFilterManager.forNetwork(
+              _bddPacket,
+              configs,
+              (hostname, aclName) -> _aclPermitBDDs.get(hostname).get(aclName).get());
     }
 
     _bddIncomingTransformations = computeBDDIncomingTransformations();

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -47,6 +47,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.batfish.bddreachability.IpsRoutedOutInterfacesFactory.IpsRoutedOutInterfaces;
 import org.batfish.bddreachability.transition.TransformationToTransition;
 import org.batfish.bddreachability.transition.Transition;
@@ -152,6 +154,8 @@ import org.batfish.symbolic.state.VrfAccept;
  */
 @ParametersAreNonnullByDefault
 public final class BDDReachabilityAnalysisFactory {
+  private static final Logger LOGGER = LogManager.getLogger(BDDReachabilityAnalysisFactory.class);
+
   // node name --> acl name --> set of packets denied by the acl.
   private final Map<String, Map<String, Supplier<BDD>>> _aclDenyBDDs;
 
@@ -271,6 +275,14 @@ public final class BDDReachabilityAnalysisFactory {
             : null;
     _requiredTransitNodeBDD = _bddPacket.allocateBDDBit("requiredTransitNodes");
     _bddSourceManagers = BDDSourceManager.forNetwork(_bddPacket, configs, initializeSessions);
+
+    _configs = configs;
+    _dstIpSpaceToBDD = _bddPacket.getDstIpSpaceToBDD();
+    _srcIpSpaceToBDD = _bddPacket.getSrcIpSpaceToBDD();
+
+    _aclPermitBDDs = computeAclBDDs(this::ipAccessListToBddForNode, configs);
+    _aclDenyBDDs = computeAclDenyBDDs(_aclPermitBDDs);
+
     if (_ignoreFilters) {
       // If ignoring filters, make all BDDOutgoingOriginalFlowFilterManagers trivial; they should
       // never enforce any constraints.
@@ -280,14 +292,8 @@ public final class BDDReachabilityAnalysisFactory {
           toImmutableMap(configs.keySet(), Function.identity(), k -> empty);
     } else {
       _bddOutgoingOriginalFlowFilterManagers =
-          BDDOutgoingOriginalFlowFilterManager.forNetwork(_bddPacket, configs, _bddSourceManagers);
+          BDDOutgoingOriginalFlowFilterManager.forNetwork(_bddPacket, configs, _aclPermitBDDs);
     }
-    _configs = configs;
-    _dstIpSpaceToBDD = _bddPacket.getDstIpSpaceToBDD();
-    _srcIpSpaceToBDD = _bddPacket.getSrcIpSpaceToBDD();
-
-    _aclPermitBDDs = computeAclBDDs(this::ipAccessListToBddForNode, configs);
-    _aclDenyBDDs = computeAclDenyBDDs(_aclPermitBDDs);
 
     _bddIncomingTransformations = computeBDDIncomingTransformations();
     _bddOutgoingTransformations = computeBDDOutgoingTransformations();
@@ -415,37 +421,47 @@ public final class BDDReachabilityAnalysisFactory {
   }
 
   private Map<String, Map<String, Transition>> computeBDDIncomingTransformations() {
-    return toImmutableMap(
-        _configs,
-        Entry::getKey, /* node */
-        nodeEntry -> {
-          Configuration node = nodeEntry.getValue();
-          TransformationToTransition toTransition =
-              new TransformationToTransition(_bddPacket, ipAccessListToBddForNode(node));
-          return node.activeL3Interfaces()
-              .filter(Interface::canReceiveIpTraffic)
-              .collect(
-                  ImmutableMap.toImmutableMap(
-                      Interface::getName,
-                      iface -> toTransition.toTransition(iface.getIncomingTransformation())));
-        });
+    long start = System.currentTimeMillis();
+    Map<String, Map<String, Transition>> result =
+        toImmutableMap(
+            _configs,
+            Entry::getKey, /* node */
+            nodeEntry -> {
+              Configuration node = nodeEntry.getValue();
+              TransformationToTransition toTransition =
+                  new TransformationToTransition(_bddPacket, ipAccessListToBddForNode(node));
+              return node.activeL3Interfaces()
+                  .filter(Interface::canReceiveIpTraffic)
+                  .collect(
+                      ImmutableMap.toImmutableMap(
+                          Interface::getName,
+                          iface -> toTransition.toTransition(iface.getIncomingTransformation())));
+            });
+    long t = System.currentTimeMillis() - start;
+    LOGGER.info("computeBDDIncomingTransformations: {}ms", t);
+    return result;
   }
 
   private Map<String, Map<String, Transition>> computeBDDOutgoingTransformations() {
-    return toImmutableMap(
-        _configs,
-        Entry::getKey, /* node */
-        nodeEntry -> {
-          Configuration node = nodeEntry.getValue();
-          TransformationToTransition toTransition =
-              new TransformationToTransition(_bddPacket, ipAccessListToBddForNode(node));
-          return node.activeL3Interfaces()
-              .filter(Interface::canSendIpTraffic)
-              .collect(
-                  ImmutableMap.toImmutableMap(
-                      Interface::getName,
-                      iface -> toTransition.toTransition(iface.getOutgoingTransformation())));
-        });
+    long start = System.currentTimeMillis();
+    Map<String, Map<String, Transition>> result =
+        toImmutableMap(
+            _configs,
+            Entry::getKey, /* node */
+            nodeEntry -> {
+              Configuration node = nodeEntry.getValue();
+              TransformationToTransition toTransition =
+                  new TransformationToTransition(_bddPacket, ipAccessListToBddForNode(node));
+              return node.activeL3Interfaces()
+                  .filter(Interface::canSendIpTraffic)
+                  .collect(
+                      ImmutableMap.toImmutableMap(
+                          Interface::getName,
+                          iface -> toTransition.toTransition(iface.getOutgoingTransformation())));
+            });
+    long t = System.currentTimeMillis() - start;
+    LOGGER.info("computeBDDOutgoingTransformations: {}ms", t);
+    return result;
   }
 
   private static @Nonnull Map<String, Map<String, BDD>> computeVrfForwardingBehaviorBDDs(
@@ -844,6 +860,7 @@ public final class BDDReachabilityAnalysisFactory {
                           return Stream.of(enterPolicyEdge);
                         }
 
+                        long t = System.currentTimeMillis();
                         PacketPolicyToBdd.BddPacketPolicy bddPacketPolicy =
                             PacketPolicyToBdd.evaluate(
                                 nodeName,
@@ -855,6 +872,9 @@ public final class BDDReachabilityAnalysisFactory {
                                     (key) ->
                                         _ipsRoutesOutInterfacesFactory.getIpsRoutedOutInterfaces(
                                             nodeName, vrfName)));
+                        t = System.currentTimeMillis() - t;
+                        LOGGER.info(
+                            "converted packet policy on {}/{} to BDD: {}ms", nodeName, vrfName, t);
 
                         PacketPolicyActionToEdges actionToEdges =
                             new PacketPolicyActionToEdges(nodeName, policyName, vrfName);

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDMultipathInconsistencyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDMultipathInconsistencyTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.datamodel.DataPlane;
@@ -172,7 +173,13 @@ public class BDDMultipathInconsistencyTest {
             .getIngressLocationReachableBDDs();
 
     BDD natAclIpBDD = srcIpBDD(SOURCE_NAT_ACL_IP);
-    BDD srcNatAclBDD = IpAccessListToBdd.toBDD(_pkt, _net._link2SrcSourceNatAcl);
+    BDD srcNatAclBDD =
+        IpAccessListToBdd.toBDD(
+            _pkt,
+            _net._link2SrcSourceNatAcl,
+            _net._srcNode.getIpAccessLists(),
+            _net._srcNode.getIpSpaces(),
+            BDDSourceManager.empty(_pkt));
     assertThat(srcNatAclBDD, equalTo(natAclIpBDD));
 
     /*

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1842,6 +1842,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
 
     IpAccessList originalFlowFilter =
         nf.aclBuilder()
+            .setOwner(c1)
             .setLines(ExprAclLine.accepting(AclLineMatchExprs.matchDst(Ip.parse("1.1.1.1"))))
             .build();
 
@@ -1912,6 +1913,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
 
     IpAccessList originalFlowFilter =
         nf.aclBuilder()
+            .setOwner(c1)
             .setLines(ExprAclLine.accepting(AclLineMatchExprs.matchDst(Ip.parse("1.1.1.1"))))
             .build();
 

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -159,7 +159,7 @@ public final class SessionInstrumentationTest {
 
       _srcMgrs = ImmutableMap.of(FW, _fwSrcMgr, SOURCE1, _source1SrcMgr);
       _outgoingOriginalFlowFilterMgrs =
-          forNetwork(_pkt, ImmutableMap.of(FW, _fw, SOURCE1, _source1), _srcMgrs);
+          forNetwork(_pkt, ImmutableMap.of(FW, _fw, SOURCE1, _source1), null);
     }
 
     // Setup filter BDDs

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -160,9 +160,7 @@ public final class SessionInstrumentationTest {
       _srcMgrs = ImmutableMap.of(FW, _fwSrcMgr, SOURCE1, _source1SrcMgr);
       _outgoingOriginalFlowFilterMgrs =
           forNetwork(
-              _pkt,
-              ImmutableMap.of(FW, _fw, SOURCE1, _source1),
-              ImmutableMap.of(FW, ImmutableMap.of(), SOURCE1, ImmutableMap.of()));
+              _pkt, ImmutableMap.of(FW, _fw, SOURCE1, _source1), (hostname, aclName) -> null);
     }
 
     // Setup filter BDDs

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -159,7 +159,10 @@ public final class SessionInstrumentationTest {
 
       _srcMgrs = ImmutableMap.of(FW, _fwSrcMgr, SOURCE1, _source1SrcMgr);
       _outgoingOriginalFlowFilterMgrs =
-          forNetwork(_pkt, ImmutableMap.of(FW, _fw, SOURCE1, _source1), null);
+          forNetwork(
+              _pkt,
+              ImmutableMap.of(FW, _fw, SOURCE1, _source1),
+              ImmutableMap.of(FW, ImmutableMap.of(), SOURCE1, ImmutableMap.of()));
     }
 
     // Setup filter BDDs

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/AddOutgoingOriginalFlowFiltersConstraintTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/AddOutgoingOriginalFlowFiltersConstraintTest.java
@@ -8,13 +8,12 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.BiFunction;
 import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.BDDOutgoingOriginalFlowFilterManager;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.IpAccessListToBddImpl;
-import org.batfish.common.util.CollectionUtil;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -67,13 +66,9 @@ public class AddOutgoingOriginalFlowFiltersConstraintTest {
     IpAccessListToBddImpl aclToBdd =
         new IpAccessListToBddImpl(
             PKT, srcMgrs.get(c.getHostname()), c.getIpAccessLists(), c.getIpSpaces());
-    Map<String, Map<String, Supplier<BDD>>> aclPermitBdds =
-        ImmutableMap.of(
-            c.getHostname(),
-            CollectionUtil.toImmutableMap(
-                c.getIpAccessLists().values(),
-                IpAccessList::getName,
-                (acl) -> () -> aclToBdd.toBdd(acl)));
+    BiFunction<String, String, BDD> aclPermitBdds =
+        (hostname, aclName) ->
+            aclToBdd.toBdd(configs.get(hostname).getIpAccessLists().get(aclName));
     Map<String, BDDOutgoingOriginalFlowFilterManager> mgrs =
         BDDOutgoingOriginalFlowFilterManager.forNetwork(PKT, configs, aclPermitBdds);
     return mgrs.get(c.getHostname());

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/AddOutgoingOriginalFlowFiltersConstraintTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/AddOutgoingOriginalFlowFiltersConstraintTest.java
@@ -8,10 +8,13 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.BDDOutgoingOriginalFlowFilterManager;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.IpAccessListToBddImpl;
+import org.batfish.common.util.CollectionUtil;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -61,8 +64,18 @@ public class AddOutgoingOriginalFlowFiltersConstraintTest {
   private static BDDOutgoingOriginalFlowFilterManager getMgrForConfig(Configuration c) {
     Map<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
     Map<String, BDDSourceManager> srcMgrs = BDDSourceManager.forNetwork(PKT, configs);
+    IpAccessListToBddImpl aclToBdd =
+        new IpAccessListToBddImpl(
+            PKT, srcMgrs.get(c.getHostname()), c.getIpAccessLists(), c.getIpSpaces());
+    Map<String, Map<String, Supplier<BDD>>> aclPermitBdds =
+        ImmutableMap.of(
+            c.getHostname(),
+            CollectionUtil.toImmutableMap(
+                c.getIpAccessLists().values(),
+                IpAccessList::getName,
+                (acl) -> () -> aclToBdd.toBdd(acl)));
     Map<String, BDDOutgoingOriginalFlowFilterManager> mgrs =
-        BDDOutgoingOriginalFlowFilterManager.forNetwork(PKT, configs, srcMgrs);
+        BDDOutgoingOriginalFlowFilterManager.forNetwork(PKT, configs, aclPermitBdds);
     return mgrs.get(c.getHostname());
   }
 

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/RemoveOutgoingInterfaceConstraintsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/RemoveOutgoingInterfaceConstraintsTest.java
@@ -9,13 +9,12 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.BiFunction;
 import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.BDDOutgoingOriginalFlowFilterManager;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.IpAccessListToBddImpl;
-import org.batfish.common.util.CollectionUtil;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -68,13 +67,9 @@ public class RemoveOutgoingInterfaceConstraintsTest {
     IpAccessListToBddImpl aclToBdd =
         new IpAccessListToBddImpl(
             PKT, srcMgrs.get(c.getHostname()), c.getIpAccessLists(), c.getIpSpaces());
-    Map<String, Map<String, Supplier<BDD>>> aclPermitBdds =
-        ImmutableMap.of(
-            c.getHostname(),
-            CollectionUtil.toImmutableMap(
-                c.getIpAccessLists().values(),
-                IpAccessList::getName,
-                (acl) -> () -> aclToBdd.toBdd(acl)));
+    BiFunction<String, String, BDD> aclPermitBdds =
+        (hostname, aclName) ->
+            aclToBdd.toBdd(configs.get(hostname).getIpAccessLists().get(aclName));
     Map<String, BDDOutgoingOriginalFlowFilterManager> mgrs =
         BDDOutgoingOriginalFlowFilterManager.forNetwork(PKT, configs, aclPermitBdds);
     return mgrs.get(c.getHostname());

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/RemoveOutgoingInterfaceConstraintsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/RemoveOutgoingInterfaceConstraintsTest.java
@@ -9,10 +9,13 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.BDDOutgoingOriginalFlowFilterManager;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.IpAccessListToBddImpl;
+import org.batfish.common.util.CollectionUtil;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -62,8 +65,18 @@ public class RemoveOutgoingInterfaceConstraintsTest {
   private static BDDOutgoingOriginalFlowFilterManager getMgrForConfig(Configuration c) {
     Map<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
     Map<String, BDDSourceManager> srcMgrs = BDDSourceManager.forNetwork(PKT, configs);
+    IpAccessListToBddImpl aclToBdd =
+        new IpAccessListToBddImpl(
+            PKT, srcMgrs.get(c.getHostname()), c.getIpAccessLists(), c.getIpSpaces());
+    Map<String, Map<String, Supplier<BDD>>> aclPermitBdds =
+        ImmutableMap.of(
+            c.getHostname(),
+            CollectionUtil.toImmutableMap(
+                c.getIpAccessLists().values(),
+                IpAccessList::getName,
+                (acl) -> () -> aclToBdd.toBdd(acl)));
     Map<String, BDDOutgoingOriginalFlowFilterManager> mgrs =
-        BDDOutgoingOriginalFlowFilterManager.forNetwork(PKT, configs, srcMgrs);
+        BDDOutgoingOriginalFlowFilterManager.forNetwork(PKT, configs, aclPermitBdds);
     return mgrs.get(c.getHostname());
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
@@ -142,6 +142,7 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.common.bdd.BDDMatchers;
 import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AbstractRoute;
@@ -706,24 +707,31 @@ public final class CiscoAsaGrammarTest {
   public void testAsaGh5875() throws IOException {
     Configuration c = parseConfig("asa-gh-5875");
     BDDPacket p = new BDDPacket();
+    BDDSourceManager srcManager = BDDSourceManager.empty(p);
 
     {
       String aclName = computeServiceObjectGroupAclName("IP_GROUP");
       assertThat(c, hasIpAccessList(aclName));
       IpAccessList acl = c.getIpAccessLists().get(aclName);
-      assertThat(IpAccessListToBdd.toBDD(p, acl), BDDMatchers.isOne());
+      assertThat(
+          IpAccessListToBdd.toBDD(p, acl, c.getIpAccessLists(), c.getIpSpaces(), srcManager),
+          BDDMatchers.isOne());
     }
     {
       String aclName = computeServiceObjectGroupAclName("TCP_GROUP");
       assertThat(c, hasIpAccessList(aclName));
       IpAccessList acl = c.getIpAccessLists().get(aclName);
-      assertThat(IpAccessListToBdd.toBDD(p, acl), equalTo(p.getIpProtocol().value(IpProtocol.TCP)));
+      assertThat(
+          IpAccessListToBdd.toBDD(p, acl, c.getIpAccessLists(), c.getIpSpaces(), srcManager),
+          equalTo(p.getIpProtocol().value(IpProtocol.TCP)));
     }
     {
       String aclName = computeServiceObjectGroupAclName("AH_GROUP");
       assertThat(c, hasIpAccessList(aclName));
       IpAccessList acl = c.getIpAccessLists().get(aclName);
-      assertThat(IpAccessListToBdd.toBDD(p, acl), equalTo(p.getIpProtocol().value(IpProtocol.AHP)));
+      assertThat(
+          IpAccessListToBdd.toBDD(p, acl, c.getIpAccessLists(), c.getIpSpaces(), srcManager),
+          equalTo(p.getIpProtocol().value(IpProtocol.AHP)));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
@@ -257,7 +257,7 @@ public final class F5BigipImishGrammarTest {
     String acl2Name = "acl2";
 
     // setup
-    IpAccessListToBdd toBDD = toBDD();
+    IpAccessListToBdd toBDD = toBDD(c);
 
     // acl1
     assertThat(c.getIpAccessLists(), hasKey(acl1Name));
@@ -1321,10 +1321,10 @@ public final class F5BigipImishGrammarTest {
     assertThat(peer4.getLocalIp(), equalTo(Ip.parse("10.0.4.1")));
   }
 
-  private @Nonnull IpAccessListToBdd toBDD() {
+  private @Nonnull IpAccessListToBdd toBDD(Configuration c) {
     BDDPacket pkt = new BDDPacket();
     BDDSourceManager mgr = BDDSourceManager.forInterfaces(pkt, ImmutableSet.of("dummy"));
-    return new IpAccessListToBddImpl(pkt, mgr, ImmutableMap.of(), ImmutableMap.of());
+    return new IpAccessListToBddImpl(pkt, mgr, c.getIpAccessLists(), c.getIpSpaces());
   }
 
   @Test

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
@@ -74,9 +74,9 @@ public class SearchFiltersAnswererDifferentialTest {
         .build();
     _ib.setOwner(refConfig).build();
     String aclName = "aclName";
-    IpAccessList refAcl = _ab.setName(aclName).setOwner(config).build();
+    IpAccessList refAcl = _ab.setName(aclName).setOwner(refConfig).build();
     IpAccessList acl =
-        _ab.setOwner(refConfig)
+        _ab.setOwner(config)
             .setLines(
                 ImmutableList.of(
                     accepting()
@@ -114,7 +114,7 @@ public class SearchFiltersAnswererDifferentialTest {
             getBatfish(refConfig, config),
             DEFAULT_PARAMS,
             _pkt);
-    result = getDiffResult(refAcl, acl, configContext, PERMIT_QUERY);
+    result = getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertFalse("Expected no increased result", result.getIncreasedFlow().isPresent());
     assertTrue("Expected decreased result", result.getDecreasedFlow().isPresent());
     assertThat(result.getDecreasedFlow().get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));


### PR DESCRIPTION
1. Use the cache in `IpAccessToBdd::toBdd(IpAccessList)`. This requires updating some tests to ensure ACLs are in their configuration's map
2. `BDDOutgoingOriginalFlowFilterManager::forNetwork`: use `IpAccessToBdd` infra from caller, rather than creating new instances (with separate caches).

Also added some logging to see where time is being spent.