### PR TITLE
Transform: use identity relations to merge more

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
@@ -94,7 +94,7 @@ public final class BDDPairingFactory {
    * unprimed and primed variables.
    */
   public BDD identityRelation(Predicate<BDD> includeDomainVar) {
-    return _bddFactory.andAll(
+    return _bddFactory.andAllAndFree(
         _varPairs.stream()
             .map(
                 varPair -> {
@@ -112,7 +112,7 @@ public final class BDDPairingFactory {
   }
 
   public BDDPairingFactory union(BDDPairingFactory other) {
-    if (this.equals(other)) {
+    if (this.includes(other)) {
       return this;
     }
     return new BDDPairingFactory(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
@@ -98,10 +98,12 @@ public final class BDDPairingFactory {
         _varPairs.stream()
             .map(
                 varPair -> {
-                  BDD domVar = _bddFactory.ithVar(varPair.getOldVar());
-                  return includeDomainVar.test(domVar)
-                      ? domVar.biimp(_bddFactory.ithVar(varPair.getNewVar()))
-                      : null;
+                  BDD oldVar = _bddFactory.ithVar(varPair.getOldVar());
+                  if (includeDomainVar.test(oldVar)) {
+                    return oldVar.biimpWith(_bddFactory.ithVar(varPair.getNewVar()));
+                  }
+                  oldVar.free();
+                  return null;
                 })
             .filter(Objects::nonNull)
             .collect(Collectors.toList()));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPairingFactory.java
@@ -3,9 +3,13 @@ package org.batfish.common.bdd;
 import static org.batfish.common.bdd.BDDUtils.swapPairing;
 import static org.parboiled.common.Preconditions.checkArgument;
 
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -78,6 +82,54 @@ public final class BDDPairingFactory {
   }
 
   /**
+   * Return the identity function on this' domain, encoded as a relation between unprimed and primed
+   * variables.
+   */
+  public BDD identityRelation() {
+    return identityRelation(Predicates.alwaysTrue());
+  }
+
+  /**
+   * Return the identity function on a subset of this' domain, encoded as a relation between
+   * unprimed and primed variables.
+   */
+  public BDD identityRelation(Predicate<BDD> includeDomainVar) {
+    return _bddFactory.andAll(
+        _varPairs.stream()
+            .map(
+                varPair -> {
+                  BDD domVar = _bddFactory.ithVar(varPair.getOldVar());
+                  return includeDomainVar.test(domVar)
+                      ? domVar.biimp(_bddFactory.ithVar(varPair.getNewVar()))
+                      : null;
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList()));
+  }
+
+  public boolean domainIncludes(BDD var) {
+    return _domainVars.testsVars(var);
+  }
+
+  public BDDPairingFactory union(BDDPairingFactory other) {
+    if (this.equals(other)) {
+      return this;
+    }
+    return new BDDPairingFactory(
+        _bddFactory, ImmutableSet.copyOf(Sets.union(_varPairs, other._varPairs)));
+  }
+
+  public static BDDPairingFactory union(List<BDDPairingFactory> factories) {
+    checkArgument(!factories.isEmpty(), "factories cannot be empty");
+    BDDFactory bddFactory = factories.iterator().next()._bddFactory;
+    Set<BDDVarPair> varPairs =
+        factories.stream()
+            .flatMap(factory -> factory._varPairs.stream())
+            .collect(ImmutableSet.toImmutableSet());
+    return new BDDPairingFactory(bddFactory, varPairs);
+  }
+
+  /**
    * Return a {@link BDD} of the variables in the pairing's domain, suitable for use with {@link
    * BDD#exist(BDD)}. The caller does not own the {@link BDD} and must not mutate or free it.
    */
@@ -107,5 +159,10 @@ public final class BDDPairingFactory {
   @Override
   public int hashCode() {
     return _varPairs.hashCode();
+  }
+
+  public boolean includes(BDDPairingFactory other) {
+    checkArgument(_bddFactory == other._bddFactory, "BDD factories must be identical");
+    return this._varPairs.containsAll(other._varPairs);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
@@ -67,19 +67,4 @@ public class BDDUtils {
                 .flatMap(Function.identity())
                 .collect(ImmutableSet.toImmutableSet()));
   }
-
-  /** Create a {@link BDDPairing} for swapping variables. */
-  public static BDDPairing pairing(BDD[] from, BDD[] to) {
-    checkArgument(from.length > 0, "Cannot build pairing for empty bitvectors");
-    checkArgument(from.length == to.length, "Bitvector lengths must be equal");
-
-    BDDFactory factory = from[0].getFactory();
-    BDDPairing pairing = factory.makePair();
-
-    for (int i = 0; i < from.length; i++) {
-      pairing.set(from[i].var(), to[i].var());
-    }
-
-    return pairing;
-  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
@@ -67,4 +67,19 @@ public class BDDUtils {
                 .flatMap(Function.identity())
                 .collect(ImmutableSet.toImmutableSet()));
   }
+
+  /** Create a {@link BDDPairing} for swapping variables. */
+  public static BDDPairing pairing(BDD[] from, BDD[] to) {
+    checkArgument(from.length > 0, "Cannot build pairing for empty bitvectors");
+    checkArgument(from.length == to.length, "Bitvector lengths must be equal");
+
+    BDDFactory factory = from[0].getFactory();
+    BDDPairing pairing = factory.makePair();
+
+    for (int i = 0; i < from.length; i++) {
+      pairing.set(from[i].var(), to[i].var());
+    }
+
+    return pairing;
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
@@ -102,18 +102,12 @@ public class Transform implements Transition {
    * transforms, the effect of merging is to non-deterministically choose between them. Requires the
    * two transforms to have equal domains.
    */
-  public Optional<Transform> tryOr(Transform other) {
+  public Transform or(Transform other) {
     if (!_pairingFactory.equals(other._pairingFactory)) {
-      BDD idRel =
-          _pairingFactory.identityRelation(var -> !other._pairingFactory.domainIncludes(var));
-      BDD otherIdRel =
-          other._pairingFactory.identityRelation(var -> !_pairingFactory.domainIncludes(var));
-      BDD newRel = idRel.andEq(_forwardRelation);
-      BDD otherNewRel = otherIdRel.andEq(other._forwardRelation);
-      return Optional.of(
-          new Transform(newRel.orWith(otherNewRel), _pairingFactory.union(other._pairingFactory)));
+      BDDPairingFactory unionPairingFactory = _pairingFactory.union(other._pairingFactory);
+      return this.expandTo(unionPairingFactory).or(other.expandTo(unionPairingFactory));
     }
-    return Optional.of(new Transform(_forwardRelation.or(other._forwardRelation), _pairingFactory));
+    return new Transform(_forwardRelation.or(other._forwardRelation), _pairingFactory);
   }
 
   private static Transform orAllEqualPairingFactory(List<Transform> transforms) {

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transform.java
@@ -3,7 +3,9 @@ package org.batfish.bddreachability.transition;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Table;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -102,9 +104,32 @@ public class Transform implements Transition {
    */
   public Optional<Transform> tryOr(Transform other) {
     if (!_pairingFactory.equals(other._pairingFactory)) {
-      return Optional.empty();
+      BDD idRel =
+          _pairingFactory.identityRelation(var -> !other._pairingFactory.domainIncludes(var));
+      BDD otherIdRel =
+          other._pairingFactory.identityRelation(var -> !_pairingFactory.domainIncludes(var));
+      BDD newRel = idRel.andEq(_forwardRelation);
+      BDD otherNewRel = otherIdRel.andEq(other._forwardRelation);
+      return Optional.of(
+          new Transform(newRel.orWith(otherNewRel), _pairingFactory.union(other._pairingFactory)));
     }
     return Optional.of(new Transform(_forwardRelation.or(other._forwardRelation), _pairingFactory));
+  }
+
+  private static Transform orAllEqualPairingFactory(List<Transform> transforms) {
+    assert transforms.stream().map(Transform::getPairingFactory).distinct().count() == 1
+        : "All transforms must have the same pairing factory";
+    Transform transform = transforms.get(0);
+    if (transforms.size() == 1) {
+      return transform;
+    }
+    BDDFactory bddFactory = transform._forwardRelation.getFactory();
+    BDD forwardRel =
+        bddFactory.orAll(
+            transforms.stream()
+                .map(t -> t._forwardRelation)
+                .collect(ImmutableList.toImmutableList()));
+    return new Transform(forwardRel, transform._pairingFactory);
   }
 
   /** Reduce the input list of transforms by combining those with equal domain variables. */
@@ -113,29 +138,40 @@ public class Transform implements Transition {
     if (transforms.size() == 1) {
       return transforms;
     }
-    Map<BDDPairingFactory, List<Transform>> transformsByPairingFactory =
+    Collection<Transform> reducedTransforms =
         transforms.stream()
-            .collect(Collectors.groupingBy(t -> t._pairingFactory, Collectors.toList()));
-    if (transformsByPairingFactory.size() == transforms.size()) {
-      // no two Transforms had the same BDDPairingFactory
-      return transforms;
+            .collect(
+                Collectors.groupingBy(
+                    t -> t._pairingFactory,
+                    Collectors.collectingAndThen(
+                        Collectors.toList(), Transform::orAllEqualPairingFactory)))
+            .values();
+    if (reducedTransforms.size() == 1) {
+      return ImmutableList.of(Iterables.getOnlyElement(reducedTransforms));
     }
-    return transformsByPairingFactory.values().stream()
-        .map(
-            transforms1 -> {
-              Transform transform = transforms1.get(0);
-              if (transforms1.size() == 1) {
-                return transform;
-              }
-              BDDFactory bddFactory = transform._forwardRelation.getFactory();
-              BDD forwardRel =
-                  bddFactory.orAll(
-                      transforms1.stream()
-                          .map(t -> t._forwardRelation)
-                          .collect(ImmutableList.toImmutableList()));
-              return new Transform(forwardRel, transform._pairingFactory);
-            })
-        .collect(Collectors.toList());
+    BDDPairingFactory unionPairingFactory =
+        BDDPairingFactory.union(
+            reducedTransforms.stream()
+                .map(Transform::getPairingFactory)
+                .collect(Collectors.toList()));
+    return ImmutableList.of(
+        orAllEqualPairingFactory(
+            reducedTransforms.stream()
+                .map(transform -> transform.expandTo(unionPairingFactory))
+                .collect(Collectors.toList())));
+  }
+
+  public Transform expandTo(BDDPairingFactory factory) {
+    assert factory.includes(_pairingFactory)
+        : "Cannot expand to a factory that does not include all transformed vars";
+    if (factory.equals(_pairingFactory)) {
+      return this;
+    }
+
+    // compute the identity relation on variables that only exist in the expanded factory
+    BDD idRel = factory.identityRelation(var -> !_pairingFactory.domainIncludes(var));
+    // TODO: ensure we can use andWith (i.e. free bdds from this)
+    return new Transform(idRel.andEq(_forwardRelation), factory);
   }
 
   @Override
@@ -148,8 +184,7 @@ public class Transform implements Transition {
     }
     Transform transform = (Transform) o;
     // Exclude _reverseRelations, _swapPairing and _vars, which are lazy initialized and/or
-    // determined by
-    // _forwardRelation and _pairingFactory.
+    // determined by _forwardRelation and _pairingFactory.
     return _forwardRelation.equals(transform._forwardRelation)
         && _pairingFactory.equals(transform._pairingFactory);
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -371,15 +371,37 @@ public final class Transitions {
     // only add a constraint if we didn't find identity
     if (foundIdentity) {
       disjuncts.add(IDENTITY);
-    } else if (constraints != null) {
-      disjuncts.add(orConstraints(constraints));
+      constraints = null;
     }
 
     if (eraseAndSets != null) {
       disjuncts.addAll(orEraseAndSets(eraseAndSets));
     }
     if (transforms != null) {
-      disjuncts.addAll(Transform.reduceWithOr(transforms));
+      Transform transform = Iterables.getOnlyElement(Transform.reduceWithOr(transforms));
+
+      if (constraints != null) {
+        // convert constraints into a transform
+        BDDFactory factory = constraints.get(0).getConstraint().getFactory();
+        BDD constraint =
+            constraints.size() == 1
+                ? Iterables.getOnlyElement(constraints).getConstraint()
+                : factory.orAll(
+                    constraints.stream()
+                        .map(Constraint::getConstraint)
+                        .collect(Collectors.toList()));
+        BDD idRel = transform.getPairingFactory().identityRelation(var -> true);
+        Transform constraintTransform =
+            new Transform(constraint.and(idRel), transform.getPairingFactory());
+        disjuncts.add(transform.tryOr(constraintTransform).get());
+        constraints = null;
+      } else {
+        disjuncts.add(transform);
+      }
+    }
+
+    if (constraints != null) {
+      disjuncts.add(orConstraints(constraints));
     }
 
     if (disjuncts.isEmpty()) {

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -393,7 +393,7 @@ public final class Transitions {
         BDD idRel = transform.getPairingFactory().identityRelation(var -> true);
         Transform constraintTransform =
             new Transform(constraint.and(idRel), transform.getPairingFactory());
-        disjuncts.add(transform.tryOr(constraintTransform).get());
+        disjuncts.add(transform.or(constraintTransform));
         constraints = null;
       } else {
         disjuncts.add(transform);

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
@@ -2,7 +2,7 @@ package org.batfish.bddreachability.transition;
 
 import static org.batfish.common.bdd.BDDUtils.bddFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -10,6 +10,7 @@ import com.google.common.testing.EqualsTester;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.common.bdd.BDDInteger;
+import org.batfish.common.bdd.BDDPairingFactory;
 import org.batfish.common.bdd.PrimedBDDInteger;
 import org.junit.Before;
 import org.junit.Test;
@@ -209,9 +210,27 @@ public class TransformTest {
 
   @Test
   public void testReduceWithOr() {
+    /*
     assertThat(
         Transform.reduceWithOr(ImmutableList.of(_transformX0, _transformX1, _transformY)),
         containsInAnyOrder(_transformX0.tryOr(_transformX1).get(), _transformY));
+     */
+
+    BDDPairingFactory xPairingFactory = _xPrimedInt.getPairingFactory();
+    BDDPairingFactory yPairingFactory = _yPrimedInt.getPairingFactory();
+    BDD yIdRel = yPairingFactory.identityRelation(var -> true);
+    BDD xIdRel = xPairingFactory.identityRelation(var -> true);
+
+    assertThat(
+        Transform.reduceWithOr(ImmutableList.of(_transformX0, _transformX1, _transformY)),
+        contains(
+            new Transform(
+                _transformX0
+                    .getForwardRelation()
+                    .or(_transformX1.getForwardRelation())
+                    .and(yIdRel)
+                    .or(_transformY.getForwardRelation().and(xIdRel)),
+                BDDPairingFactory.union(ImmutableList.of(xPairingFactory, yPairingFactory)))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
@@ -103,7 +103,7 @@ public class TransformTest {
     assertEquals(_x0, _transformX1.transitForward(x01));
 
     // merging unions outputs
-    Transform merged = _transformX0.tryOr(_transformX1).get();
+    Transform merged = _transformX0.or(_transformX1);
     assertEquals(x12, merged.transitForward(_x0));
     assertEquals(_x0, merged.transitForward(_x1));
     assertEquals(x012, merged.transitForward(x01));

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformTest.java
@@ -210,26 +210,19 @@ public class TransformTest {
 
   @Test
   public void testReduceWithOr() {
-    /*
-    assertThat(
-        Transform.reduceWithOr(ImmutableList.of(_transformX0, _transformX1, _transformY)),
-        containsInAnyOrder(_transformX0.tryOr(_transformX1).get(), _transformY));
-     */
-
     BDDPairingFactory xPairingFactory = _xPrimedInt.getPairingFactory();
     BDDPairingFactory yPairingFactory = _yPrimedInt.getPairingFactory();
-    BDD yIdRel = yPairingFactory.identityRelation(var -> true);
-    BDD xIdRel = xPairingFactory.identityRelation(var -> true);
+    BDD yIdRel = yPairingFactory.identityRelation();
+    BDD xIdRel = xPairingFactory.identityRelation();
 
     assertThat(
         Transform.reduceWithOr(ImmutableList.of(_transformX0, _transformX1, _transformY)),
         contains(
             new Transform(
-                _transformX0
-                    .getForwardRelation()
-                    .or(_transformX1.getForwardRelation())
-                    .and(yIdRel)
-                    .or(_transformY.getForwardRelation().and(xIdRel)),
+                _factory.orAll(
+                    _transformX0.getForwardRelation().and(yIdRel),
+                    _transformX1.getForwardRelation().and(yIdRel),
+                    _transformY.getForwardRelation().and(xIdRel)),
                 BDDPairingFactory.union(ImmutableList.of(xPairingFactory, yPairingFactory)))));
   }
 


### PR DESCRIPTION
Identity functions are encoded as a relation between unprimed and primed variables by `unprimedVar.biimp(primedVar)` (biimp is "if and only if").

We use them to merge two Transform transitions that operate on different domains: we use identity relations to expand each transition to operate on the union of the two domains.