### PR TITLE
FRR: allow neighbors to be defined out of order

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/frr/BgpIpv4UnicastAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/BgpIpv4UnicastAddressFamily.java
@@ -12,11 +12,13 @@ public class BgpIpv4UnicastAddressFamily implements Serializable {
 
   private final @Nonnull Map<Prefix, BgpVrfAddressFamilyAggregateNetworkConfiguration>
       _aggregateNetworks;
+  private final @Nonnull Map<String, BgpNeighborIpv4UnicastAddressFamily> _neighbors;
   private final @Nonnull Map<Prefix, BgpNetwork> _networks;
   private final @Nonnull Map<FrrRoutingProtocol, BgpRedistributionPolicy> _redistributionPolicies;
 
   public BgpIpv4UnicastAddressFamily() {
     _aggregateNetworks = new HashMap<>();
+    _neighbors = new HashMap<>();
     _networks = new HashMap<>();
     _redistributionPolicies = new TreeMap<>();
   }
@@ -24,6 +26,10 @@ public class BgpIpv4UnicastAddressFamily implements Serializable {
   @Nonnull
   public Map<Prefix, BgpVrfAddressFamilyAggregateNetworkConfiguration> getAggregateNetworks() {
     return _aggregateNetworks;
+  }
+
+  public @Nonnull Map<String, BgpNeighborIpv4UnicastAddressFamily> getNeighbors() {
+    return _neighbors;
   }
 
   public @Nonnull Map<Prefix, BgpNetwork> getNetworks() {

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/BgpL2vpnEvpnAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/BgpL2vpnEvpnAddressFamily.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.frr;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** L2VPN EVPN settings for BGP */
@@ -9,6 +12,11 @@ public class BgpL2vpnEvpnAddressFamily implements Serializable {
   private boolean _advertiseAllVni;
   private boolean _advertiseDefaultGw;
   private @Nullable BgpL2VpnEvpnIpv4Unicast _advertiseIpv4Unicast;
+  private final @Nonnull Map<String, BgpNeighborL2vpnEvpnAddressFamily> _neighbors;
+
+  public BgpL2vpnEvpnAddressFamily() {
+    _neighbors = new HashMap<>();
+  }
 
   /** Whether to generate type 3 VTEP reachability advertisements for all defined VNIs */
   public boolean getAdvertiseAllVni() {
@@ -38,5 +46,9 @@ public class BgpL2vpnEvpnAddressFamily implements Serializable {
 
   public void setAdvertiseIpv4Unicast(@Nullable BgpL2VpnEvpnIpv4Unicast advertiseIpv4Unicast) {
     _advertiseIpv4Unicast = advertiseIpv4Unicast;
+  }
+
+  public @Nonnull Map<String, BgpNeighborL2vpnEvpnAddressFamily> getNeighbors() {
+    return _neighbors;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/BgpNeighborIpv4UnicastAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/BgpNeighborIpv4UnicastAddressFamily.java
@@ -82,11 +82,13 @@ public class BgpNeighborIpv4UnicastAddressFamily implements Serializable {
     }
 
     if (_defaultOriginate == null) {
-      _defaultOriginate = other.getDefaultOriginate();
+      _defaultOriginate = other._defaultOriginate;
+      _defaultOriginateRouteMap = other._defaultOriginateRouteMap;
     }
 
-    if (_defaultOriginateRouteMap == null) {
-      _defaultOriginateRouteMap = other.getDefaultOriginateRouteMap();
+    if (_nextHopSelf == null) {
+      _nextHopSelf = other._nextHopSelf;
+      _nextHopSelfAll = other._nextHopSelfAll;
     }
 
     if (_removePrivateAsMode == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/BgpVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/BgpVrf.java
@@ -131,6 +131,15 @@ public class BgpVrf implements Serializable {
     _confederationId = confederationId;
   }
 
+  public @Nullable BgpNeighborIpv4UnicastAddressFamily getIpv4UnicastConfiguration(
+      String neighbor) {
+    return _ipv4Unicast == null ? null : _ipv4Unicast.getNeighbors().get(neighbor);
+  }
+
+  public @Nullable BgpNeighborL2vpnEvpnAddressFamily getL2EvpnConfiguration(String neighbor) {
+    return _l2VpnEvpn == null ? null : _l2VpnEvpn.getNeighbors().get(neighbor);
+  }
+
   @Nonnull
   public Map<Prefix, BgpNetwork> getNetworks() {
     return _networks;

--- a/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
@@ -1,9 +1,7 @@
 package org.batfish.grammar.frr;
 
-import static junit.framework.TestCase.assertEquals;
 import static org.batfish.common.matchers.ParseWarningMatchers.hasComment;
 import static org.batfish.common.matchers.ParseWarningMatchers.hasText;
-import static org.batfish.common.matchers.WarningsMatchers.hasParseWarning;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
@@ -39,6 +37,7 @@ import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -112,7 +111,9 @@ import org.batfish.representation.frr.BgpInterfaceNeighbor;
 import org.batfish.representation.frr.BgpIpNeighbor;
 import org.batfish.representation.frr.BgpNeighbor;
 import org.batfish.representation.frr.BgpNeighbor.RemoteAs;
+import org.batfish.representation.frr.BgpNeighborIpv4UnicastAddressFamily;
 import org.batfish.representation.frr.BgpNeighborIpv4UnicastAddressFamily.RemovePrivateAsMode;
+import org.batfish.representation.frr.BgpNeighborL2vpnEvpnAddressFamily;
 import org.batfish.representation.frr.BgpNeighborSourceAddress;
 import org.batfish.representation.frr.BgpNeighborSourceInterface;
 import org.batfish.representation.frr.BgpNetwork;
@@ -332,12 +333,7 @@ public class FrrGrammarTest {
         "exit-address-family");
 
     assertFalse(
-        _frr.getBgpProcess()
-            .getDefaultVrf()
-            .getNeighbors()
-            .get("N")
-            .getIpv4UnicastAddressFamily()
-            .getActivated());
+        _frr.getBgpProcess().getDefaultVrf().getIpv4UnicastConfiguration("N").getActivated());
   }
 
   @Test
@@ -558,9 +554,10 @@ public class FrrGrammarTest {
         "neighbor n activate",
         "neighbor 1.2.3.4 activate",
         "exit-address-family");
-    Map<String, BgpNeighbor> neighbors = _frr.getBgpProcess().getDefaultVrf().getNeighbors();
-    assertTrue(neighbors.get("n").getL2vpnEvpnAddressFamily().getActivated());
-    assertTrue(neighbors.get("1.2.3.4").getL2vpnEvpnAddressFamily().getActivated());
+    Map<String, BgpNeighborL2vpnEvpnAddressFamily> neighbors =
+        _frr.getBgpProcess().getDefaultVrf().getL2VpnEvpn().getNeighbors();
+    assertTrue(neighbors.get("n").getActivated());
+    assertTrue(neighbors.get("1.2.3.4").getActivated());
   }
 
   @Test
@@ -597,8 +594,8 @@ public class FrrGrammarTest {
         "address-family l2vpn evpn",
         "neighbor n route-reflector-client",
         "exit-address-family");
-    Map<String, BgpNeighbor> neighbors = _frr.getBgpProcess().getDefaultVrf().getNeighbors();
-    assertTrue(neighbors.get("n").getL2vpnEvpnAddressFamily().getRouteReflectorClient());
+    assertTrue(
+        _frr.getBgpProcess().getDefaultVrf().getL2EvpnConfiguration("n").getRouteReflectorClient());
   }
 
   @Test
@@ -611,9 +608,10 @@ public class FrrGrammarTest {
         "   neighbor n activate",
         " address-family l2vpn evpn",
         "   neighbor 1.2.3.4 activate");
-    Map<String, BgpNeighbor> neighbors = _frr.getBgpProcess().getDefaultVrf().getNeighbors();
-    assertTrue(neighbors.get("n").getL2vpnEvpnAddressFamily().getActivated());
-    assertTrue(neighbors.get("1.2.3.4").getL2vpnEvpnAddressFamily().getActivated());
+    Map<String, BgpNeighborL2vpnEvpnAddressFamily> neighbors =
+        _frr.getBgpProcess().getDefaultVrf().getL2VpnEvpn().getNeighbors();
+    assertTrue(neighbors.get("n").getActivated());
+    assertTrue(neighbors.get("1.2.3.4").getActivated());
   }
 
   @Test
@@ -627,9 +625,7 @@ public class FrrGrammarTest {
     assertTrue(
         _frr.getBgpProcess()
             .getDefaultVrf()
-            .getNeighbors()
-            .get("10.0.0.1")
-            .getIpv4UnicastAddressFamily()
+            .getIpv4UnicastConfiguration("10.0.0.1")
             .getNextHopSelf());
   }
 
@@ -647,12 +643,7 @@ public class FrrGrammarTest {
         "neighbor N activate",
         "exit-address-family");
     assertTrue(
-        _frr.getBgpProcess()
-            .getDefaultVrf()
-            .getNeighbors()
-            .get("N")
-            .getIpv4UnicastAddressFamily()
-            .getActivated());
+        _frr.getBgpProcess().getDefaultVrf().getIpv4UnicastConfiguration("N").getActivated());
   }
 
   @Test
@@ -664,12 +655,7 @@ public class FrrGrammarTest {
         "neighbor N allowas-in 5",
         "exit-address-family");
     assertThat(
-        _frr.getBgpProcess()
-            .getDefaultVrf()
-            .getNeighbors()
-            .get("N")
-            .getIpv4UnicastAddressFamily()
-            .getAllowAsIn(),
+        _frr.getBgpProcess().getDefaultVrf().getIpv4UnicastConfiguration("N").getAllowAsIn(),
         equalTo(5));
   }
 
@@ -682,12 +668,7 @@ public class FrrGrammarTest {
         "neighbor N allowas-in",
         "exit-address-family");
     assertThat(
-        _frr.getBgpProcess()
-            .getDefaultVrf()
-            .getNeighbors()
-            .get("N")
-            .getIpv4UnicastAddressFamily()
-            .getAllowAsIn(),
+        _frr.getBgpProcess().getDefaultVrf().getIpv4UnicastConfiguration("N").getAllowAsIn(),
         equalTo(3));
   }
 
@@ -701,12 +682,12 @@ public class FrrGrammarTest {
         "    neighbor N default-originate",
         "    neighbor N2 default-originate route-map RM",
         "  exit-address-family");
-    Map<String, BgpNeighbor> bgpNeighbors = _frr.getBgpProcess().getDefaultVrf().getNeighbors();
-    assertTrue(bgpNeighbors.get("N").getIpv4UnicastAddressFamily().getDefaultOriginate());
-    assertNull(bgpNeighbors.get("N").getIpv4UnicastAddressFamily().getDefaultOriginateRouteMap());
-    assertTrue(bgpNeighbors.get("N2").getIpv4UnicastAddressFamily().getDefaultOriginate());
-    assertEquals(
-        "RM", bgpNeighbors.get("N2").getIpv4UnicastAddressFamily().getDefaultOriginateRouteMap());
+    Map<String, BgpNeighborIpv4UnicastAddressFamily> bgpNeighbors =
+        _frr.getBgpProcess().getDefaultVrf().getIpv4Unicast().getNeighbors();
+    assertTrue(bgpNeighbors.get("N").getDefaultOriginate());
+    assertNull(bgpNeighbors.get("N").getDefaultOriginateRouteMap());
+    assertTrue(bgpNeighbors.get("N2").getDefaultOriginate());
+    assertEquals("RM", bgpNeighbors.get("N2").getDefaultOriginateRouteMap());
   }
 
   @Test
@@ -875,25 +856,19 @@ public class FrrGrammarTest {
     assertThat(
         _frr.getBgpProcess()
             .getDefaultVrf()
-            .getNeighbors()
-            .get("N1")
-            .getIpv4UnicastAddressFamily()
+            .getIpv4UnicastConfiguration("N1")
             .getRemovePrivateAsMode(),
         equalTo(RemovePrivateAsMode.BASIC));
     assertThat(
         _frr.getBgpProcess()
             .getDefaultVrf()
-            .getNeighbors()
-            .get("N2")
-            .getIpv4UnicastAddressFamily()
+            .getIpv4UnicastConfiguration("N2")
             .getRemovePrivateAsMode(),
         equalTo(RemovePrivateAsMode.ALL));
     assertThat(
         _frr.getBgpProcess()
             .getDefaultVrf()
-            .getNeighbors()
-            .get("N3")
-            .getIpv4UnicastAddressFamily()
+            .getIpv4UnicastConfiguration("N3")
             .getRemovePrivateAsMode(),
         equalTo(RemovePrivateAsMode.REPLACE_AS));
   }
@@ -909,9 +884,7 @@ public class FrrGrammarTest {
     assertTrue(
         _frr.getBgpProcess()
             .getDefaultVrf()
-            .getNeighbors()
-            .get("N")
-            .getIpv4UnicastAddressFamily()
+            .getIpv4UnicastConfiguration("N")
             .getRouteReflectorClient());
   }
 
@@ -2031,10 +2004,26 @@ public class FrrGrammarTest {
         "address-family ipv4 unicast",
         "neighbor N route-map R in",
         "exit-address-family");
+  }
+
+  /** FRR allows route-map to be configured before neighbor exists. */
+  @Test
+  public void testIp4vUnicastRoutemap_out_of_order() {
+    parseLines(
+        "router bgp 10000",
+        "address-family ipv4 unicast",
+        "neighbor N route-map R in",
+        "exit-address-family",
+        "neighbor N peer-group");
     assertThat(
-        _warnings,
-        hasParseWarning(
-            allOf(hasComment("neighbor N does not exist"), hasText("neighbor N route-map R in"))));
+        _frr.getBgpProcess().getDefaultVrf().getIpv4UnicastConfiguration("N").getRouteMapIn(),
+        equalTo("R"));
+    assertThat(
+        getStructureReferences(
+            FrrStructureType.ROUTE_MAP,
+            "R",
+            FrrStructureUsage.BGP_IPV4_UNICAST_NEIGHBOR_ROUTE_MAP_IN),
+        contains(3));
   }
 
   @Test
@@ -2046,12 +2035,7 @@ public class FrrGrammarTest {
         "neighbor N route-map R in",
         "exit-address-family");
     assertThat(
-        _frr.getBgpProcess()
-            .getDefaultVrf()
-            .getNeighbors()
-            .get("N")
-            .getIpv4UnicastAddressFamily()
-            .getRouteMapIn(),
+        _frr.getBgpProcess().getDefaultVrf().getIpv4UnicastConfiguration("N").getRouteMapIn(),
         equalTo("R"));
     assertThat(
         getStructureReferences(
@@ -2070,12 +2054,7 @@ public class FrrGrammarTest {
         "neighbor N2 route-map R out",
         "exit-address-family");
     assertThat(
-        _frr.getBgpProcess()
-            .getDefaultVrf()
-            .getNeighbors()
-            .get("N2")
-            .getIpv4UnicastAddressFamily()
-            .getRouteMapOut(),
+        _frr.getBgpProcess().getDefaultVrf().getIpv4UnicastConfiguration("N2").getRouteMapOut(),
         equalTo("R"));
     assertThat(
         getStructureReferences(


### PR DESCRIPTION
It seems that FRR does not apply address-family configuration until after all
top-level neighbors are defined, even if those declarations come after the
address-family section.

Support this, and also no longer warn at parsing time for such cases.

commit-id:fac91090