### PR TITLE
Warning for the use of ttl in ACLs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -4790,6 +4790,11 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
           if (feature.icmp_message_code != null) {
             icmpCode = toInteger(feature.icmp_message_code);
           }
+        } else if (feature.TTL() != null) {
+          // special case this warning to reduce user confusion
+          // "ttl eq 255" is a common pattern to limit traffic to neighboring routers
+          warn(ctx, "Batfish does not model packet TTLs");
+          return UnimplementedAccessListServiceSpecifier.INSTANCE;
         } else {
           warn(ctx, "Unsupported clause in extended access list: " + feature.getText());
           return UnimplementedAccessListServiceSpecifier.INSTANCE;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -4958,6 +4958,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
           if (feature.icmp_message_code != null) {
             icmpCode = toInteger(feature.icmp_message_code);
           }
+        } else if (feature.TTL() != null) {
+          // special case this warning to reduce user confusion
+          // "ttl eq 255" is a common pattern to limit traffic to neighboring routers
+          warn(ctx, "Batfish does not model packet TTLs");
+          return UnimplementedAccessListServiceSpecifier.INSTANCE;
         } else {
           warn(ctx, "Unsupported clause in extended access list: " + feature.getText());
           return UnimplementedAccessListServiceSpecifier.INSTANCE;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
@@ -4649,6 +4649,11 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
           if (feature.icmp_message_code != null) {
             icmpCode = toInteger(feature.icmp_message_code);
           }
+        } else if (feature.TTL() != null) {
+          // special case this warning to reduce user confusion
+          // "ttl eq 255" is a common pattern to limit traffic to neighboring routers
+          warn(ctx, "Batfish does not model packet TTLs");
+          return UnimplementedAccessListServiceSpecifier.INSTANCE;
         } else {
           warn(ctx, "Unsupported clause in extended access list: " + feature.getText());
           return UnimplementedAccessListServiceSpecifier.INSTANCE;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -3772,6 +3772,11 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
           if (feature.icmp_message_code != null) {
             icmpCode = toInteger(feature.icmp_message_code);
           }
+        } else if (feature.TTL() != null) {
+          // special case this warning to reduce user confusion
+          // "ttl eq 255" is a common pattern to limit traffic to neighboring routers
+          warn(ctx, "Batfish does not model packet TTLs");
+          return UnimplementedAccessListServiceSpecifier.INSTANCE;
         } else {
           warn(ctx, "Unsupported clause in extended access list: " + feature.getText());
           return UnimplementedAccessListServiceSpecifier.INSTANCE;

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -222,14 +222,14 @@
         "Line" : 10,
         "Text" : "60 permit tcp any any eq mlag ttl eq 255",
         "Parser_Context" : "[extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in extended access list: ttleq255"
+        "Comment" : "Batfish does not model packet TTLs"
       },
       {
         "Filename" : "configs/cisco_acl",
         "Line" : 11,
         "Text" : "70 permit udp any any eq mlag ttl eq 255",
         "Parser_Context" : "[extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in extended access list: ttleq255"
+        "Comment" : "Batfish does not model packet TTLs"
       },
       {
         "Filename" : "configs/cisco_acl",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -69171,13 +69171,13 @@
               "Text" : "20 permit ip any any tracked"
             },
             {
-              "Comment" : "Unsupported clause in extended access list: ttleq255",
+              "Comment" : "Batfish does not model packet TTLs",
               "Line" : 10,
               "Parser_Context" : "[extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
               "Text" : "60 permit tcp any any eq mlag ttl eq 255"
             },
             {
-              "Comment" : "Unsupported clause in extended access list: ttleq255",
+              "Comment" : "Batfish does not model packet TTLs",
               "Line" : 11,
               "Parser_Context" : "[extended_access_list_tail extended_access_list_stanza stanza cisco_configuration]",
               "Text" : "70 permit udp any any eq mlag ttl eq 255"


### PR DESCRIPTION
A more targeted warning when ttl appears in ACLs. Meant to reduce user confusion like that in https://github.com/batfish/batfish/issues/8232

