### PR TITLE
BDDRepresentativePicker: more efficient encoding of preferences

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -43,6 +43,11 @@ public final class BDDFlowConstraintGenerator {
     BDD refine(BDD bdd);
   }
 
+  /**
+   * A {@link PreferenceRefiner} that returns after the first sub-refiner successfully refines the
+   * input. This is useful for an ordered list of mutually-exclusive preferences: once the first
+   * preference consistent with the input is found, we can skip the rest.
+   */
   static final class RefineFirst implements PreferenceRefiner {
     private final @Nullable BDD _guard;
     private final List<PreferenceRefiner> _children;
@@ -88,6 +93,16 @@ public final class BDDFlowConstraintGenerator {
     }
   }
 
+  /**
+   * A {@link PreferenceRefiner} that tries to refine the input using an ordered list of
+   * sub-refiners. Each refiner is considered in order. At each step, if that sub-refiner is
+   * consistent with the current BDD, its refinement is adopted and we continue to the next
+   * sub-refiner. If it is inconsistent, ignore it and continue.
+   *
+   * <p>This is useful for a collection of preferences that are not mutually-exclusive. Note that
+   * order is still important, because the input BDD may be consistent with two preferences
+   * separately but not together.
+   */
   static final class RefineAll implements PreferenceRefiner {
     private final @Nullable BDD _guard;
     private final List<PreferenceRefiner> _children;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -70,18 +70,21 @@ public final class BDDFlowConstraintGenerator {
 
     @Override
     public BDD refine(BDD bdd) {
-      BDD tmp = _guard == null ? bdd.id() : _guard.and(bdd);
-      if (tmp.isZero()) {
-        return tmp;
+      BDD matchGuard = _guard == null ? bdd.id() : _guard.and(bdd);
+      if (matchGuard.isZero()) {
+        return matchGuard;
       }
       for (PreferenceRefiner child : _children) {
-        BDD res = child.refine(tmp);
-        if (!res.isZero()) {
-          tmp.free();
-          return res;
+        BDD matchChild = child.refine(matchGuard);
+        if (matchChild.isZero()) {
+          matchChild.free();
+        } else {
+          matchGuard.free();
+          return matchChild;
         }
       }
-      return tmp;
+      // guard matched, but no child did.
+      return matchGuard;
     }
   }
 
@@ -104,21 +107,21 @@ public final class BDDFlowConstraintGenerator {
 
     @Override
     public BDD refine(BDD bdd) {
-      BDD tmp = _guard == null ? bdd.id() : _guard.and(bdd);
-      if (tmp.isZero()) {
-        return tmp;
+      BDD res = _guard == null ? bdd.id() : _guard.and(bdd);
+      if (res.isZero()) {
+        return res;
       }
 
       for (PreferenceRefiner child : _children) {
-        BDD tmp2 = child.refine(tmp);
-        if (tmp2.isZero()) {
-          tmp2.free();
-        } else {
+        BDD tmp = child.refine(res);
+        if (tmp.isZero()) {
           tmp.free();
-          tmp = tmp2;
+        } else {
+          res.free();
+          res = tmp;
         }
       }
-      return tmp;
+      return res;
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -1,10 +1,14 @@
 package org.batfish.common.bdd;
 
+import static org.batfish.common.bdd.BDDFlowConstraintGenerator.RefineAll.refineAll;
+import static org.batfish.common.bdd.BDDFlowConstraintGenerator.RefineFirst.refineFirst;
 import static org.batfish.datamodel.PacketHeaderConstraintsUtil.DEFAULT_PACKET_LENGTH;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import java.util.EnumMap;
 import java.util.List;
+import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.IcmpType;
@@ -30,6 +34,90 @@ public final class BDDFlowConstraintGenerator {
     TRACEROUTE
   }
 
+  public interface PreferenceRefiner {
+    BDD refine(BDD bdd);
+  }
+
+  static final class RefineFirst implements PreferenceRefiner {
+    private final @Nullable BDD _guard;
+    private final List<PreferenceRefiner> _children;
+
+    private RefineFirst(BDD guard, List<PreferenceRefiner> children) {
+      _guard = guard;
+      _children = ImmutableList.copyOf(children);
+    }
+
+    static RefineFirst refineFirst(List<PreferenceRefiner> children) {
+      return new RefineFirst(null, children);
+    }
+
+    static RefineFirst refineFirst(BDD guard, List<PreferenceRefiner> children) {
+      return new RefineFirst(guard, children);
+    }
+
+    static RefineFirst refineFirst(BDD guard, PreferenceRefiner... children) {
+      return new RefineFirst(guard, ImmutableList.copyOf(children));
+    }
+
+    static RefineFirst refineFirst(PreferenceRefiner... children) {
+      return new RefineFirst(null, ImmutableList.copyOf(children));
+    }
+
+    public BDD refine(BDD bdd) {
+      BDD tmp = _guard == null ? bdd : _guard.and(bdd);
+      if (tmp.isZero()) {
+        return tmp;
+      }
+      for (PreferenceRefiner child : _children) {
+        BDD res = child.refine(tmp);
+        if (!res.isZero()) {
+          return res;
+        }
+      }
+      return tmp;
+    }
+  }
+
+  static final class RefineAll implements PreferenceRefiner {
+    private final @Nullable BDD _guard;
+    private final List<PreferenceRefiner> _children;
+
+    private RefineAll(@Nullable BDD guard, List<PreferenceRefiner> children) {
+      _guard = guard;
+      _children = ImmutableList.copyOf(children);
+    }
+
+    static RefineAll refineAll(BDD guard, PreferenceRefiner... children) {
+      return new RefineAll(guard, ImmutableList.copyOf(children));
+    }
+
+    static RefineAll refineAll(PreferenceRefiner... children) {
+      return new RefineAll(null, ImmutableList.copyOf(children));
+    }
+
+    @Override
+    public BDD refine(BDD bdd) {
+      BDD tmp = _guard == null ? bdd.id() : _guard.and(bdd);
+      if (tmp.isZero()) {
+        return tmp;
+      }
+
+      for (PreferenceRefiner child : _children) {
+        BDD tmp2 = child.refine(tmp);
+        if (tmp2.isZero()) {
+          continue;
+        }
+        //        tmp.free();
+        tmp = tmp2;
+      }
+      return tmp;
+    }
+  }
+
+  static RefineFirst refine(BDD guard) {
+    return new RefineFirst(guard, ImmutableList.of());
+  }
+
   @VisibleForTesting static final Prefix PRIVATE_SUBNET_10 = Prefix.parse("10.0.0.0/8");
   @VisibleForTesting static final Prefix PRIVATE_SUBNET_172 = Prefix.parse("172.16.0.0/12");
   @VisibleForTesting static final Prefix PRIVATE_SUBNET_192 = Prefix.parse("192.168.0.0/16");
@@ -47,17 +135,20 @@ public final class BDDFlowConstraintGenerator {
 
   private final BDDPacket _bddPacket;
   private final BDDOps _bddOps;
-  private final List<BDD> _icmpConstraints;
-  private final List<BDD> _udpConstraints;
-  private final List<BDD> _tcpConstraints;
-  private final BDD _defaultPacketLength;
-  private final List<BDD> _ipConstraints;
+  private final PreferenceRefiner _icmpConstraints;
+  private final PreferenceRefiner _udpConstraints;
+  private final PreferenceRefiner _tcpConstraints;
+  private final PreferenceRefiner _defaultPacketLength;
+  private final PreferenceRefiner _ipConstraints;
   private final BDD _udpTraceroute;
+
+  private final EnumMap<FlowPreference, PreferenceRefiner> _refinerCache =
+      new EnumMap<>(FlowPreference.class);
 
   BDDFlowConstraintGenerator(BDDPacket pkt) {
     _bddPacket = pkt;
     _bddOps = new BDDOps(pkt.getFactory());
-    _defaultPacketLength = _bddPacket.getPacketLength().value(DEFAULT_PACKET_LENGTH);
+    _defaultPacketLength = refine(_bddPacket.getPacketLength().value(DEFAULT_PACKET_LENGTH));
     _udpTraceroute = computeUdpTraceroute();
     _icmpConstraints = computeICMPConstraint();
     _udpConstraints = computeUDPConstraints();
@@ -65,50 +156,63 @@ public final class BDDFlowConstraintGenerator {
     _ipConstraints = computeIpConstraints();
   }
 
-  private List<BDD> computeICMPConstraint() {
+  private PreferenceRefiner computeICMPConstraint() {
     BDD icmp = _bddPacket.getIpProtocol().value(IpProtocol.ICMP);
     BDDIcmpType type = _bddPacket.getIcmpType();
     BDD codeZero = _bddPacket.getIcmpCode().value(0);
     // Prefer ICMP Echo_Request, then anything with code 0, then anything ICMP/
-    return ImmutableList.of(
-        _bddOps.and(icmp, type.value(IcmpType.ECHO_REQUEST), codeZero),
-        _bddOps.and(icmp, codeZero),
-        icmp);
+    return refineFirst(
+        icmp, refine(_bddOps.and(type.value(IcmpType.ECHO_REQUEST), codeZero)), refine(codeZero));
   }
 
   private BDD emphemeralPort(BDDInteger portInteger) {
     return portInteger.geq(NamedPort.EPHEMERAL_LOWEST.number());
   }
 
-  private List<BDD> tcpPortPreferences(BDD tcp, BDDInteger tcpPort) {
-    return ImmutableList.of(
-        _bddOps.and(tcp, tcpPort.value(NamedPort.HTTP.number())),
-        _bddOps.and(tcp, tcpPort.value(NamedPort.HTTPS.number())),
-        _bddOps.and(tcp, tcpPort.value(NamedPort.SSH.number())),
+  private PreferenceRefiner tcpNonEphemeralPortPreferences(BDDInteger tcpPort) {
+    return refineFirst(
+        refine(tcpPort.value(NamedPort.HTTP.number())),
+        refine(tcpPort.value(NamedPort.HTTPS.number())),
+        refine(tcpPort.value(NamedPort.SSH.number())),
         // at least not zero if possible
-        _bddOps.and(tcp, tcpPort.value(0).not()));
+        refine(tcpPort.value(0).not()));
   }
 
-  private List<BDD> tcpFlagPreferences(BDD tcp) {
-    return ImmutableList.of(
-        // Force all the rarely used flags off
-        _bddOps.and(tcp, _bddPacket.getTcpCwr().not()),
-        _bddOps.and(tcp, _bddPacket.getTcpEce().not()),
-        _bddOps.and(tcp, _bddPacket.getTcpPsh().not()),
-        _bddOps.and(tcp, _bddPacket.getTcpUrg().not()),
-        // Less rarely used flags
-        _bddOps.and(tcp, _bddPacket.getTcpFin().not()),
-        // Sometimes used flags
-        _bddOps.and(tcp, _bddPacket.getTcpRst().not()),
-        // Prefer SYN, SYN_ACK, ACK
-        _bddOps.and(tcp, _bddPacket.getTcpSyn(), _bddPacket.getTcpAck().not()),
-        _bddOps.and(tcp, _bddPacket.getTcpAck(), _bddPacket.getTcpSyn()),
-        _bddOps.and(tcp, _bddPacket.getTcpAck()));
+  private PreferenceRefiner tcpFlagPreferences() {
+    BDD syn = _bddPacket.getTcpSyn();
+    BDD ack = _bddPacket.getTcpAck();
+    BDD notAck = ack.not();
+    BDD notCwr = _bddPacket.getTcpCwr().not();
+    BDD notEce = _bddPacket.getTcpEce().not();
+    BDD notPsh = _bddPacket.getTcpPsh().not();
+    BDD notUrg = _bddPacket.getTcpUrg().not();
+    BDD notFin = _bddPacket.getTcpFin().not();
+    BDD notRst = _bddPacket.getTcpRst().not();
+    return refineFirst(
+        // syn only
+        refine(_bddOps.and(syn, notAck, notCwr, notEce, notPsh, notUrg, notFin, notRst)),
+        // syn+ack only
+        refine(_bddOps.and(syn, notAck, notCwr, notEce, notPsh, notUrg, notFin, notRst)),
+        // fall back to slow search
+        refineAll(
+            // Force all the rarely used flags off
+            refine(notCwr),
+            refine(notEce),
+            refine(notPsh),
+            refine(notUrg),
+            // Less rarely used flags
+            refine(notFin),
+            // Sometimes used flags
+            refine(notRst),
+            // Prefer SYN, SYN_ACK, ACK
+            refine(_bddOps.and(syn, notAck)),
+            refine(_bddOps.and(ack, syn)),
+            refine(_bddOps.and(ack))));
   }
 
   // Get TCP packets with special named ports, trying to find cases where only one side is
   // ephemeral.
-  private List<BDD> computeTCPConstraints() {
+  private PreferenceRefiner computeTCPConstraints() {
     BDDInteger dstPort = _bddPacket.getDstPort();
     BDDInteger srcPort = _bddPacket.getSrcPort();
     BDD tcp = _bddPacket.getIpProtocol().value(IpProtocol.TCP);
@@ -116,27 +220,31 @@ public final class BDDFlowConstraintGenerator {
     BDD srcPortEphemeral = emphemeralPort(srcPort);
     BDD dstPortEphemeral = emphemeralPort(dstPort);
 
-    return ImmutableList.<BDD>builder()
-        // First, try to nudge src and dst port apart. E.g., if one is ephemeral the other is not.
-        .add(_bddOps.and(tcp, srcPortEphemeral, dstPortEphemeral.not()))
-        .add(_bddOps.and(tcp, srcPortEphemeral.not(), dstPortEphemeral))
-        // Next, execute port preferences.
-        .addAll(tcpPortPreferences(tcp, srcPort))
-        .addAll(tcpPortPreferences(tcp, dstPort))
-        // Next execute flag preferences.
-        .addAll(tcpFlagPreferences(tcp))
-        // Anything TCP.
-        .add(tcp)
-        .build();
+    PreferenceRefiner nonEphemeralDstPortPreferences = tcpNonEphemeralPortPreferences(dstPort);
+    PreferenceRefiner nonEphemeralSrcPortPreferences = tcpNonEphemeralPortPreferences(srcPort);
+
+    return refineAll(
+        tcp,
+        refineFirst(
+            // First, try to nudge src and dst port apart. E.g., if one is ephemeral the other is
+            // not.
+            refineFirst(srcPortEphemeral.diff(dstPortEphemeral), nonEphemeralDstPortPreferences),
+            refineFirst(dstPortEphemeral.diff(srcPortEphemeral), nonEphemeralSrcPortPreferences),
+            // If both are non-ephemeral, apply port preferences
+            refineAll(
+                dstPortEphemeral.nor(srcPortEphemeral),
+                refineFirst(nonEphemeralDstPortPreferences),
+                refineFirst(nonEphemeralSrcPortPreferences))),
+        tcpFlagPreferences());
   }
 
-  private List<BDD> udpPortPreferences(BDD udp, BDDInteger tcpPort) {
-    return ImmutableList.of(
-        _bddOps.and(udp, tcpPort.value(NamedPort.DOMAIN.number())),
-        _bddOps.and(udp, tcpPort.value(NamedPort.SNMP.number())),
-        _bddOps.and(udp, tcpPort.value(NamedPort.SNMPTRAP.number())),
+  private PreferenceRefiner udpNonEphemeralPortPreferences(BDDInteger tcpPort) {
+    return refineFirst(
+        refine(tcpPort.value(NamedPort.DOMAIN.number())),
+        refine(tcpPort.value(NamedPort.SNMP.number())),
+        refine(tcpPort.value(NamedPort.SNMPTRAP.number())),
         // at least not zero if possible
-        _bddOps.and(udp, tcpPort.value(0).not()));
+        refine(tcpPort.value(0).not()));
   }
 
   private BDD computeUdpTraceroute() {
@@ -151,7 +259,7 @@ public final class BDDFlowConstraintGenerator {
 
   // Get UDP packets with special named ports, trying to find cases where only one side is
   // ephemeral.
-  private List<BDD> computeUDPConstraints() {
+  private PreferenceRefiner computeUDPConstraints() {
     BDDInteger dstPort = _bddPacket.getDstPort();
     BDDInteger srcPort = _bddPacket.getSrcPort();
     BDD udp = _bddPacket.getIpProtocol().value(IpProtocol.UDP);
@@ -159,18 +267,19 @@ public final class BDDFlowConstraintGenerator {
     BDD srcPortEphemeral = emphemeralPort(srcPort);
     BDD dstPortEphemeral = emphemeralPort(dstPort);
 
-    return ImmutableList.<BDD>builder()
+    PreferenceRefiner nonEphemeralDstPortPreferences = udpNonEphemeralPortPreferences(dstPort);
+    PreferenceRefiner nonEphemeralSrcPortPreferences = udpNonEphemeralPortPreferences(srcPort);
+    return refineFirst(
+        udp,
         // Try for UDP traceroute.
-        .add(_udpTraceroute)
+        refine(_udpTraceroute),
         // Next, try to nudge src and dst port apart. E.g., if one is ephemeral the other is not.
-        .add(_bddOps.and(udp, srcPortEphemeral, dstPortEphemeral.not()))
-        .add(_bddOps.and(udp, srcPortEphemeral.not(), dstPortEphemeral))
+        refineFirst(srcPortEphemeral.diff(dstPortEphemeral), nonEphemeralDstPortPreferences),
+        refineFirst(dstPortEphemeral.diff(srcPortEphemeral), nonEphemeralSrcPortPreferences),
         // Next, execute port preferences
-        .addAll(udpPortPreferences(udp, srcPort))
-        .addAll(udpPortPreferences(udp, dstPort))
-        // Anything UDP.
-        .add(udp)
-        .build();
+        refineAll(
+            refineFirst(nonEphemeralDstPortPreferences),
+            refineFirst(nonEphemeralSrcPortPreferences)));
   }
 
   @VisibleForTesting
@@ -187,62 +296,60 @@ public final class BDDFlowConstraintGenerator {
         ip.toBDD(RESERVED_DOCUMENTATION_203));
   }
 
-  private static List<BDD> ipPreferences(BDDInteger ipInteger) {
-    return ImmutableList.of(
+  private static PreferenceRefiner publicIpPreferences(BDDInteger ipInteger) {
+    return refineFirst(
         // First, one of the special IPs.
-        ipInteger.value(Ip.parse("8.8.8.8").asLong()),
-        ipInteger.value(Ip.parse("1.1.1.1").asLong()),
+        refine(ipInteger.value(Ip.parse("8.8.8.8").asLong())),
+        refine(ipInteger.value(Ip.parse("1.1.1.1").asLong())),
         // Next, at least don't start with 0.
-        ipInteger.geq(Ip.parse("1.0.0.0").asLong()),
+        refine(ipInteger.geq(Ip.parse("1.0.0.0").asLong())),
         // Next, try to be in class A.
-        ipInteger.leq(Ip.parse("126.255.255.254").asLong()));
+        refine(ipInteger.leq(Ip.parse("126.255.255.254").asLong())));
   }
 
-  private List<BDD> computeIpConstraints() {
+  private PreferenceRefiner computeIpConstraints() {
     BDD srcIpPrivate = isPrivateIp(_bddOps, _bddPacket.getSrcIpSpaceToBDD());
     BDD dstIpPrivate = isPrivateIp(_bddOps, _bddPacket.getDstIpSpaceToBDD());
 
-    return ImmutableList.<BDD>builder()
+    return refineAll(
         // 0. Try to not use documentation IPs if that is possible.
-        .add(isDocumentationIp(_bddOps, _bddPacket.getSrcIpSpaceToBDD()).not())
-        .add(isDocumentationIp(_bddOps, _bddPacket.getDstIpSpaceToBDD()).not())
+        refine(isDocumentationIp(_bddOps, _bddPacket.getSrcIpSpaceToBDD()).not()),
+        refine(isDocumentationIp(_bddOps, _bddPacket.getDstIpSpaceToBDD()).not()),
+
         // First, try to nudge src and dst IP apart. E.g., if one is private the other should be
         // public.
-        .add(_bddOps.and(srcIpPrivate, dstIpPrivate.not()))
-        .add(_bddOps.and(srcIpPrivate.not(), dstIpPrivate))
-        // Next, execute IP preferences
-        .addAll(ipPreferences(_bddPacket.getSrcIp()))
-        .addAll(ipPreferences(_bddPacket.getDstIp()))
-        .build();
+        refineFirst(
+            refineFirst(
+                srcIpPrivate.diff(dstIpPrivate), publicIpPreferences(_bddPacket.getDstIp())),
+            refineFirst(
+                dstIpPrivate.diff(srcIpPrivate), publicIpPreferences(_bddPacket.getSrcIp()))));
   }
 
-  public List<BDD> generateFlowPreference(FlowPreference preference) {
+  public PreferenceRefiner getFlowPreference(FlowPreference preference) {
+    return _refinerCache.computeIfAbsent(preference, this::generateFlowPreference);
+  }
+
+  private PreferenceRefiner generateFlowPreference(FlowPreference preference) {
     switch (preference) {
       case DEBUGGING:
-        return ImmutableList.<BDD>builder()
-            .addAll(_icmpConstraints)
-            .addAll(_udpConstraints)
-            .addAll(_tcpConstraints)
-            .addAll(_ipConstraints)
-            .add(_defaultPacketLength)
-            .build();
+        return refineAll(
+            // application preferences
+            refineFirst(_icmpConstraints, _udpConstraints, _tcpConstraints),
+            _ipConstraints,
+            _defaultPacketLength);
       case APPLICATION:
       case TESTFILTER:
-        return ImmutableList.<BDD>builder()
-            .addAll(_tcpConstraints)
-            .addAll(_udpConstraints)
-            .addAll(_icmpConstraints)
-            .addAll(_ipConstraints)
-            .add(_defaultPacketLength)
-            .build();
+        return refineAll(
+            // application preferences
+            refineFirst(_tcpConstraints, _udpConstraints, _icmpConstraints),
+            _ipConstraints,
+            _defaultPacketLength);
       case TRACEROUTE:
-        return ImmutableList.<BDD>builder()
-            .addAll(_udpConstraints)
-            .addAll(_tcpConstraints)
-            .addAll(_icmpConstraints)
-            .addAll(_ipConstraints)
-            .add(_defaultPacketLength)
-            .build();
+        return refineAll(
+            // application preferences
+            refineFirst(_udpConstraints, _tcpConstraints, _icmpConstraints),
+            _ipConstraints,
+            _defaultPacketLength);
       default:
         throw new BatfishException("Not supported flow preference");
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -384,7 +384,7 @@ public class BDDPacket {
       return saneBDD;
     }
     return BDDRepresentativePicker.pickRepresentative(
-        saneBDD, _flowConstraintGeneratorSupplier.get().generateFlowPreference(preference));
+        saneBDD, _flowConstraintGeneratorSupplier.get().getFlowPreference(preference));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
@@ -15,7 +15,7 @@ public final class BDDRepresentativePicker {
    * Picks a representative assignment, possibly from a combination of the given preference BDDs.
    */
   public static @Nonnull BDD pickRepresentative(
-      BDD bdd, BDDFlowConstraintGenerator.PreferenceRefiner preference) {
+      BDD bdd, BDDFlowConstraintGenerator.BddRefiner preference) {
     if (bdd.isZero()) {
       return bdd;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
@@ -1,6 +1,5 @@
 package org.batfish.common.bdd;
 
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
@@ -15,22 +14,14 @@ public final class BDDRepresentativePicker {
   /**
    * Picks a representative assignment, possibly from a combination of the given preference BDDs.
    */
-  public static @Nonnull BDD pickRepresentative(BDD bdd, List<BDD> preference) {
+  public static @Nonnull BDD pickRepresentative(
+      BDD bdd, BDDFlowConstraintGenerator.PreferenceRefiner preference) {
     if (bdd.isZero()) {
       return bdd;
     }
-
-    BDD curBDD = bdd.id(); // clone so we can free.
-    for (BDD preferredBDD : preference) {
-      BDD newBDD = preferredBDD.and(curBDD);
-      if (newBDD.isZero()) {
-        continue;
-      }
-      curBDD.free();
-      curBDD = newBDD;
-    }
-
-    return curBDD.satOne();
+    BDD refinedBdd = preference.refine(bdd);
+    BDD curBdd = refinedBdd.isZero() ? bdd : refinedBdd;
+    return curBdd.satOne();
   }
 
   private BDDRepresentativePicker() {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
@@ -12,7 +12,8 @@ import net.sf.javabdd.BDD;
 public final class BDDRepresentativePicker {
 
   /**
-   * Picks a representative assignment, possibly from a combination of the given preference BDDs.
+   * Picks a representative assignment using the input {@link
+   * BDDFlowConstraintGenerator.BddRefiner}.
    */
   public static @Nonnull BDD pickRepresentative(
       BDD bdd, BDDFlowConstraintGenerator.BddRefiner preference) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFlowConstraintGeneratorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFlowConstraintGeneratorTest.java
@@ -49,7 +49,7 @@ public class BDDFlowConstraintGeneratorTest {
     BDDIpProtocol ipProtocol = pkt.getIpProtocol();
     BDD tcp = ipProtocol.value(IpProtocol.TCP);
 
-    BDDFlowConstraintGenerator.PreferenceRefiner refiner =
+    BDDFlowConstraintGenerator.BddRefiner refiner =
         refineFirst(
             // guard
             tcp,
@@ -81,7 +81,7 @@ public class BDDFlowConstraintGeneratorTest {
     BDD ack = pkt.getTcpAck();
     BDD notAck = ack.not();
 
-    BDDFlowConstraintGenerator.PreferenceRefiner refiner = refineAll(tcp, refine(syn), refine(ack));
+    BDDFlowConstraintGenerator.BddRefiner refiner = refineAll(tcp, refine(syn), refine(ack));
 
     // both children match
     assertEquals(factory.andAll(tcp, syn, ack), refiner.refine(factory.one()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFlowConstraintGeneratorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDFlowConstraintGeneratorTest.java
@@ -3,10 +3,18 @@ package org.batfish.common.bdd;
 import static org.batfish.common.bdd.BDDFlowConstraintGenerator.PRIVATE_SUBNET_10;
 import static org.batfish.common.bdd.BDDFlowConstraintGenerator.PRIVATE_SUBNET_172;
 import static org.batfish.common.bdd.BDDFlowConstraintGenerator.PRIVATE_SUBNET_192;
+import static org.batfish.common.bdd.BDDFlowConstraintGenerator.RefineAll.refineAll;
+import static org.batfish.common.bdd.BDDFlowConstraintGenerator.RefineFirst.refineFirst;
 import static org.batfish.common.bdd.BDDFlowConstraintGenerator.isPrivateIp;
+import static org.batfish.common.bdd.BDDFlowConstraintGenerator.refine;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.Prefix;
 import org.junit.Test;
 
 public class BDDFlowConstraintGeneratorTest {
@@ -22,5 +30,72 @@ public class BDDFlowConstraintGeneratorTest {
     BDD privateSubnet192 = dstIp.toBDD(PRIVATE_SUBNET_192);
 
     assertEquals(privateSubnet10.or(privateSubnet172).or(privateSubnet192), isPrivateIp);
+  }
+
+  @Test
+  public void testRefineFirst() {
+    BDDPacket pkt = new BDDPacket();
+    BDDFactory factory = pkt.getFactory();
+
+    IpSpaceToBDD dst = pkt.getDstIpSpaceToBDD();
+    BDD p8 = dst.toBDD(Prefix.parse("1.0.0.0/8"));
+    BDD p16 = dst.toBDD(Prefix.parse("1.1.0.0/16"));
+    BDD port1 = pkt.getDstPort().value(1);
+    BDD port2 = pkt.getDstPort().value(2);
+
+    BDD ip1_1 = dst.toBDD(Ip.parse("1.1.1.1"));
+    BDD ip1_2 = dst.toBDD(Ip.parse("1.2.2.2"));
+    BDD ip2 = dst.toBDD(Ip.parse("2.2.2.2"));
+    BDDIpProtocol ipProtocol = pkt.getIpProtocol();
+    BDD tcp = ipProtocol.value(IpProtocol.TCP);
+
+    BDDFlowConstraintGenerator.PreferenceRefiner refiner =
+        refineFirst(
+            // guard
+            tcp,
+            // child refiners
+            refine(p16.and(port1)),
+            refine(p8.and(port2)));
+
+    // p16 matches and takes precedence
+    assertEquals(factory.andAll(tcp, ip1_1, port1), refiner.refine(ip1_1));
+
+    // p8 matches
+    assertEquals(factory.andAll(tcp, ip1_2, port2), refiner.refine(ip1_2));
+
+    // neither child matches
+    assertEquals(factory.andAll(tcp, ip2), refiner.refine(ip2));
+
+    // guard doesn't match
+    assertTrue(refiner.refine(ipProtocol.value(IpProtocol.ICMP)).isZero());
+  }
+
+  @Test
+  public void testRefineAll() {
+    BDDPacket pkt = new BDDPacket();
+    BDDFactory factory = pkt.getFactory();
+    BDDIpProtocol ipProtocol = pkt.getIpProtocol();
+    BDD tcp = ipProtocol.value(IpProtocol.TCP);
+    BDD syn = pkt.getTcpSyn();
+    BDD notSyn = syn.not();
+    BDD ack = pkt.getTcpAck();
+    BDD notAck = ack.not();
+
+    BDDFlowConstraintGenerator.PreferenceRefiner refiner = refineAll(tcp, refine(syn), refine(ack));
+
+    // both children match
+    assertEquals(factory.andAll(tcp, syn, ack), refiner.refine(factory.one()));
+
+    // only first child matches
+    assertEquals(factory.andAll(tcp, syn, notAck), refiner.refine(notAck));
+
+    // only second child matches
+    assertEquals(factory.andAll(tcp, notSyn, ack), refiner.refine(notSyn));
+
+    // neither child matches
+    assertEquals(factory.andAll(tcp, notSyn, notAck), refiner.refine(notSyn.and(notAck)));
+
+    // guard does not match
+    assertTrue(refiner.refine(ipProtocol.value(IpProtocol.UDP)).isZero());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDRepresentativePickerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDRepresentativePickerTest.java
@@ -1,9 +1,10 @@
 package org.batfish.common.bdd;
 
+import static org.batfish.common.bdd.BDDFlowConstraintGenerator.RefineFirst.refineFirst;
+import static org.batfish.common.bdd.BDDFlowConstraintGenerator.refine;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import net.sf.javabdd.BDD;
 import org.batfish.datamodel.IpProtocol;
 import org.junit.Test;
@@ -15,7 +16,8 @@ public class BDDRepresentativePickerTest {
     BDD bdd1 = pkt.getIpProtocol().value(IpProtocol.UDP);
     BDD bdd2 = pkt.getIpProtocol().value(IpProtocol.TCP);
     BDD bdd = pkt.getIpProtocol().value(IpProtocol.UDP);
-    BDD pickedBDD = BDDRepresentativePicker.pickRepresentative(bdd, ImmutableList.of(bdd1, bdd2));
+    BDD pickedBDD =
+        BDDRepresentativePicker.pickRepresentative(bdd, refineFirst(refine(bdd1), refine(bdd2)));
     // check pickedBDD is in bdd
     assertThat(pickedBDD.and(bdd), equalTo(pickedBDD));
   }
@@ -26,7 +28,8 @@ public class BDDRepresentativePickerTest {
     BDD bdd1 = pkt.getIpProtocol().value(IpProtocol.UDP);
     BDD bdd2 = pkt.getIpProtocol().value(IpProtocol.TCP);
     BDD bdd = pkt.getIpProtocol().value(IpProtocol.TCP);
-    BDD pickedBDD = BDDRepresentativePicker.pickRepresentative(bdd, ImmutableList.of(bdd1, bdd2));
+    BDD pickedBDD =
+        BDDRepresentativePicker.pickRepresentative(bdd, refineFirst(refine(bdd1), refine(bdd2)));
     // check pickedBDD is in bdd
     assertThat(pickedBDD.and(bdd), equalTo(pickedBDD));
   }


### PR DESCRIPTION
Preferences are now encoded using a tree structure that allows us to skip applying preferences that are guaranteed to fail. There are two types of nodes: `RefineFirst`, which stops after the of its (ordered) children successfully refines the input, and which is useful for encoding mutually-exclusive lists of preferences, and `RefineAll`, which attempts to refine with each of its children, keeping any successful refinements. `RefineAll` is useful for non-mutually-exclusive preferences. Each node can optionally have a guard that refines the input before considering children.