### PR TITLE
FileBasedStorage: stripe dataplane by host

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
@@ -1,9 +1,10 @@
 package org.batfish.datamodel;
 
+import java.io.Serializable;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
-public interface ForwardingAnalysis {
+public interface ForwardingAnalysis extends Serializable {
   /** Mapping: hostname -&gt; inInterface -&gt; ipsToArpReplyTo */
   Map<String, Map<String, IpSpace>> getArpReplies();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/PerHostDataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/PerHostDataPlane.java
@@ -1,0 +1,87 @@
+package org.batfish.storage;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.EvpnRoute;
+import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
+
+final class PerHostDataPlane implements Serializable {
+  private final @Nonnull Map<String, Set<Bgpv4Route>> _bgpRoutes;
+  private final @Nonnull Map<String, Set<Bgpv4Route>> _bgpBackupRoutes;
+  private final @Nonnull Map<String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
+  private final @Nonnull Map<String, Set<EvpnRoute<?, ?>>> _evpnBackupRoutes;
+  private final @Nonnull Map<String, Fib> _fibs;
+  private final @Nonnull Map<String, Set<Layer2Vni>> _layer2Vnis;
+  private final @Nonnull Map<String, Set<Layer3Vni>> _layer3Vnis;
+  private final @Nonnull SortedMap<String, Map<Prefix, Map<String, Set<String>>>>
+      _prefixTracingInfoSummary;
+  private final @Nonnull SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> _ribs;
+
+  public PerHostDataPlane(
+      @Nonnull Map<String, Set<Bgpv4Route>> bgpRoutes,
+      @Nonnull Map<String, Set<Bgpv4Route>> bgpBackupRoutes,
+      @Nonnull Map<String, Set<EvpnRoute<?, ?>>> evpnRoutes,
+      @Nonnull Map<String, Set<EvpnRoute<?, ?>>> evpnBackupRoutes,
+      @Nonnull Map<String, Fib> fibs,
+      @Nonnull Map<String, Set<Layer2Vni>> layer2Vnis,
+      @Nonnull Map<String, Set<Layer3Vni>> layer3Vnis,
+      @Nonnull SortedMap<String, Map<Prefix, Map<String, Set<String>>>> prefixTracingInfoSummary,
+      @Nonnull SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> ribs) {
+    _bgpRoutes = bgpRoutes;
+    _bgpBackupRoutes = bgpBackupRoutes;
+    _evpnRoutes = evpnRoutes;
+    _evpnBackupRoutes = evpnBackupRoutes;
+    _fibs = fibs;
+    _layer2Vnis = layer2Vnis;
+    _layer3Vnis = layer3Vnis;
+    _prefixTracingInfoSummary = prefixTracingInfoSummary;
+    _ribs = ribs;
+  }
+
+  public @Nonnull Map<String, Set<Bgpv4Route>> getBgpRoutes() {
+    return _bgpRoutes;
+  }
+
+  public @Nonnull Map<String, Set<Bgpv4Route>> getBgpBackupRoutes() {
+    return _bgpBackupRoutes;
+  }
+
+  public @Nonnull Map<String, Set<EvpnRoute<?, ?>>> getEvpnRoutes() {
+    return _evpnRoutes;
+  }
+
+  public @Nonnull Map<String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes() {
+    return _evpnBackupRoutes;
+  }
+
+  public @Nonnull Map<String, Fib> getFibs() {
+    return _fibs;
+  }
+
+  public @Nonnull Map<String, Set<Layer2Vni>> getLayer2Vnis() {
+    return _layer2Vnis;
+  }
+
+  public @Nonnull Map<String, Set<Layer3Vni>> getLayer3Vnis() {
+    return _layer3Vnis;
+  }
+
+  public @Nonnull SortedMap<String, Map<Prefix, Map<String, Set<String>>>>
+      getPrefixTracingInfoSummary() {
+    return _prefixTracingInfoSummary;
+  }
+
+  public @Nonnull SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> getRibs() {
+    return _ribs;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/SimpleFieldsDataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/SimpleFieldsDataPlane.java
@@ -1,0 +1,136 @@
+package org.batfish.storage;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Table;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.EvpnRoute;
+import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.ForwardingAnalysis;
+import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Layer3Vni;
+
+final class SimpleFieldsDataPlane implements DataPlane {
+  private final @Nonnull Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
+  private final @Nonnull Table<String, String, Set<Bgpv4Route>> _bgpBackupRoutes;
+  private final @Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
+  private final @Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> _evpnBackupRoutes;
+  private final @Nonnull Map<String, Map<String, Fib>> _fibs;
+  private final @Nonnull ForwardingAnalysis _forwardingAnalysis;
+  private final @Nonnull Table<String, String, Set<Layer2Vni>> _layer2Vnis;
+  private final @Nonnull Table<String, String, Set<Layer3Vni>> _layer3Vnis;
+  private final @Nonnull SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
+      _prefixTracingInfoSummary;
+  private final @Nonnull SortedMap<
+          String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
+      _ribs;
+
+  private static <T> Table<String, String, T> toTable(
+      Map<String, PerHostDataPlane> perHostDataPlane,
+      Function<PerHostDataPlane, Map<String, T>> getter) {
+    ImmutableTable.Builder<String, String, T> ret = ImmutableTable.builder();
+    perHostDataPlane.forEach(
+        (hostname, hostDataPlane) ->
+            getter.apply(hostDataPlane).forEach((key, t) -> ret.put(hostname, key, t)));
+    return ret.build();
+  }
+
+  public SimpleFieldsDataPlane(
+      @Nonnull Map<String, PerHostDataPlane> perHostDataPlanes,
+      @Nonnull ForwardingAnalysis forwardingAnalysis) {
+    _bgpRoutes = toTable(perHostDataPlanes, PerHostDataPlane::getBgpRoutes);
+    _bgpBackupRoutes = toTable(perHostDataPlanes, PerHostDataPlane::getBgpBackupRoutes);
+    _evpnRoutes = toTable(perHostDataPlanes, PerHostDataPlane::getEvpnRoutes);
+    _evpnBackupRoutes = toTable(perHostDataPlanes, PerHostDataPlane::getEvpnBackupRoutes);
+    _fibs =
+        perHostDataPlanes.entrySet().parallelStream()
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getFibs()));
+    _forwardingAnalysis = forwardingAnalysis;
+    _layer2Vnis = toTable(perHostDataPlanes, PerHostDataPlane::getLayer2Vnis);
+    _layer3Vnis = toTable(perHostDataPlanes, PerHostDataPlane::getLayer3Vnis);
+    _prefixTracingInfoSummary =
+        perHostDataPlanes.entrySet().parallelStream()
+            .collect(
+                ImmutableSortedMap
+                    .<Entry<String, PerHostDataPlane>, String,
+                        SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
+                        toImmutableSortedMap(
+                            Ordering.natural(),
+                            Entry::getKey,
+                            e -> e.getValue().getPrefixTracingInfoSummary()));
+
+    _ribs =
+        perHostDataPlanes.entrySet().parallelStream()
+            .collect(
+                ImmutableSortedMap
+                    .<Entry<String, PerHostDataPlane>, String,
+                        SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
+                        toImmutableSortedMap(
+                            Ordering.natural(), Entry::getKey, e -> e.getValue().getRibs()));
+  }
+
+  @Override
+  public @Nonnull Table<String, String, Set<Bgpv4Route>> getBgpRoutes() {
+    return _bgpRoutes;
+  }
+
+  @Override
+  public @Nonnull Table<String, String, Set<Bgpv4Route>> getBgpBackupRoutes() {
+    return _bgpBackupRoutes;
+  }
+
+  @Override
+  public @Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes() {
+    return _evpnRoutes;
+  }
+
+  @Override
+  public @Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnBackupRoutes() {
+    return _evpnBackupRoutes;
+  }
+
+  @Override
+  public @Nonnull Map<String, Map<String, Fib>> getFibs() {
+    return _fibs;
+  }
+
+  @Override
+  public @Nonnull ForwardingAnalysis getForwardingAnalysis() {
+    return _forwardingAnalysis;
+  }
+
+  @Override
+  public @Nonnull Table<String, String, Set<Layer2Vni>> getLayer2Vnis() {
+    return _layer2Vnis;
+  }
+
+  @Override
+  public @Nonnull Table<String, String, Set<Layer3Vni>> getLayer3Vnis() {
+    return _layer3Vnis;
+  }
+
+  @Override
+  public @Nonnull SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
+      getPrefixTracingInfoSummary() {
+    return _prefixTracingInfoSummary;
+  }
+
+  @Override
+  public @Nonnull SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
+      getRibs() {
+    return _ribs;
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -2,11 +2,21 @@ package org.batfish.datamodel;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 
 public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
+  private static class DefaultSameRoutePreference
+      implements Comparator<AnnotatedRoute<AbstractRoute>>, Serializable {
+    private static final DefaultSameRoutePreference INSTANCE = new DefaultSameRoutePreference();
+
+    @Override
+    public int compare(AnnotatedRoute<AbstractRoute> o1, AnnotatedRoute<AbstractRoute> o2) {
+      return 0;
+    }
+  }
 
   public static class Builder {
 
@@ -19,7 +29,7 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
     private Builder() {
       _longestPrefixMatchResults = ImmutableMap.of();
       _mergeRouteTrues = ImmutableSet.of();
-      _routePreferenceComparator = (a, b) -> 0;
+      _routePreferenceComparator = DefaultSameRoutePreference.INSTANCE;
       _routes = ImmutableSet.of();
       _backupRoutes = ImmutableSet.of();
     }


### PR DESCRIPTION
DataPlane is one big ball of complexity which takes a long time to serialize
and deserialize. To improve on this, stripe it by host. This enables less work
by the Java serialization framework (which keeps all serialized objects in an
identity hashmap) and by also enables use of many cores (CPU overhead for
serializing objects) and better pipelining of CPU with I/O.

Note that Java serialization will only serialize pointed-to objects once no
matter how many times they are referenced. Striping means that each object
is now serialized many times, increasing both a) on-disk storage (after
serialization) and b) in-memory storage (after de-serialization of the same
object used in different devices).

These penalties are overcome via the followng insights:

a) in practice, the largest objects are things like routes that are not likely
to be identical across different devices (e.g., they reflect next-hop IP or AS
Path). So pointer equality is kept within a device's data plane. This reduces
blow-up of both on-disk and in-memory storage.

b) the small, numerous objects are written to many files but are interned after
deserialization preventing in-memory blowup.

I ran experiments with one BGP intensive network. I found that striping:

1. increases serialized, compressed size by about 10%, from 36 MB to 40 MB
2. decreases store time by 3x: on a 4-core 2-threads laptop from 10s to 3s
3. results in essentially the same in-memory use after cache expiry and reload
4. has a negligible effect on dataplane load time, about 3s either method

In another, larger BGP intensive network:

1. Serialized compressed size from 385 MB to 387 MB.
2. Serialization time from 2.5m to 3.5s (40x)

commit-id:d199f19c