### PR TITLE
PrefixTreeMultiMap: reduce serialized size

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.datamodel.PrefixTrieMultiMap.FoldOperator;
 import org.junit.Rule;
 import org.junit.Test;
@@ -519,6 +520,21 @@ public class PrefixTrieMultiMapTest {
     assertEquals(ImmutableSet.of(p111), getOverlappingKeys.apply("1.1.1.1/32"));
     assertEquals(ImmutableSet.of(p123, p1234), getOverlappingKeys.apply("1.2.3.4/32"));
     assertEquals(ImmutableSet.of(p123), getOverlappingKeys.apply("1.2.3.5/32"));
+  }
+
+  @Test
+  public void testSerialization() {
+    PrefixTrieMultiMap<Integer> ptmm = new PrefixTrieMultiMap<>();
+    int i = 0;
+    ptmm.put(Prefix.ZERO, ++i);
+    ptmm.put(Prefix.parse("10.0.0.0/24"), ++i);
+    ptmm.put(Prefix.parse("10.0.0.1/24"), ++i);
+    ptmm.put(Prefix.parse("10.0.0.0/26"), ++i);
+    ptmm.put(Prefix.parse("10.0.0.0/26"), ++i);
+    ptmm.put(Prefix.parse("10.0.0.64/26"), ++i);
+    ptmm.put(Prefix.parse("20.0.0.0/8"), ++i);
+    ptmm.put(Prefix.parse("192.168.0.0/16"), ++i);
+    assertThat(ptmm, equalTo(SerializationUtils.clone(ptmm)));
   }
 
   private static RangeSet<Ip> toRangeSet(Prefix prefix) {


### PR DESCRIPTION
In a simple unit test, this saves 14%: 881 bytes to 762.

In a larger network, this reduces serialized dataplane size by about 12%:
* 40928 kB to 35980 kB (compressed size on disk)
* largest file 624992 bytes to 545781 bytes (decompressed size)

commit-id:b13b4e71

---

**Stack**:
- #8345
- #8344 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*