### PR TITLE
Add tunnel attribute in BgpRoute

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -153,11 +153,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
         h = h * 31 + _protocol;
         h = h * 31 + Boolean.hashCode(_receivedFromRouteReflectorClient);
         h = h * 31 + _srcProtocol;
-        h =
-            h * 31
-                + (_tunnelEncapsulationAttribute == null
-                    ? 0
-                    : _tunnelEncapsulationAttribute.hashCode());
+        h = h * 31 + Objects.hashCode(_tunnelEncapsulationAttribute);
         h = h * 31 + _weight;
         _hashCode = h;
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Bgpv4Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Bgpv4Route.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
@@ -60,6 +61,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
               _protocol,
               _receivedFromRouteReflectorClient,
               _srcProtocol,
+              _tunnelEncapsulationAttribute,
               _weight),
           _receivedFromIp,
           getNetwork(),
@@ -102,6 +104,8 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
       @Nullable @JsonProperty(PROP_RECEIVED_FROM_IP) Ip receivedFromIp,
       @Nullable @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
       @JsonProperty(PROP_TAG) long tag,
+      @Nullable @JsonProperty(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE)
+          TunnelEncapsulationAttribute tunnelEncapsulationAttribute,
       @JsonProperty(PROP_WEIGHT) int weight) {
     checkArgument(originatorIp != null, "Missing %s", PROP_ORIGINATOR_IP);
     checkArgument(originMechanism != null, "Missing %s", PROP_ORIGIN_MECHANISM);
@@ -123,6 +127,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
             protocol,
             receivedFromRouteReflectorClient,
             srcProtocol,
+            tunnelEncapsulationAttribute,
             weight),
         receivedFromIp,
         network,
@@ -184,6 +189,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
         .setReceivedFromRouteReflectorClient(_attributes._receivedFromRouteReflectorClient)
         .setSrcProtocol(_attributes.getSrcProtocol())
         .setTag(_tag)
+        .setTunnelEncapsulationAttribute(_attributes._tunnelEncapsulationAttribute)
         .setWeight(_attributes._weight);
   }
 
@@ -246,6 +252,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
         .add("_receivedFromIp", _receivedFromIp)
         .add("_receivedFromRouteReflectorClient", _attributes._receivedFromRouteReflectorClient)
         .add("_srcProtocol", _attributes._srcProtocol)
+        .add("_tunnelEncapsulationAttribute", _attributes._tunnelEncapsulationAttribute)
         .add("_weight", _attributes._weight)
         .toString();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
@@ -64,6 +65,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
               _protocol,
               _receivedFromRouteReflectorClient,
               _srcProtocol,
+              _tunnelEncapsulationAttribute,
               _weight),
           _receivedFromIp,
           _nextHop,
@@ -132,6 +134,8 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
       @Nullable @JsonProperty(PROP_VNI) Integer vni,
       @Nullable @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
       @JsonProperty(PROP_TAG) long tag,
+      @Nullable @JsonProperty(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE)
+          TunnelEncapsulationAttribute tunnelEncapsulationAttribute,
       @JsonProperty(PROP_WEIGHT) int weight) {
     checkArgument(admin == EVPN_ADMIN, "Cannot create EVPN route with non-default admin");
     checkArgument(ip != null, "Missing %s", PROP_IP);
@@ -157,6 +161,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
             protocol,
             receivedFromRouteReflectorClient,
             srcProtocol,
+            tunnelEncapsulationAttribute,
             weight),
         receivedFromIp,
         NextHop.legacyConverter(nextHopInterface, nextHopIp),
@@ -223,6 +228,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
         .setVni(_vni)
         .setSrcProtocol(_attributes.getSrcProtocol())
         .setTag(_tag)
+        .setTunnelEncapsulationAttribute(_attributes._tunnelEncapsulationAttribute)
         .setWeight(_attributes._weight);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
@@ -63,6 +64,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
               _protocol,
               _receivedFromRouteReflectorClient,
               _srcProtocol,
+              _tunnelEncapsulationAttribute,
               _weight),
           _receivedFromIp,
           _nextHop,
@@ -117,6 +119,8 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
       @Nullable @JsonProperty(PROP_VNI) Integer vni,
       @Nullable @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
       @JsonProperty(PROP_TAG) long tag,
+      @Nullable @JsonProperty(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE)
+          TunnelEncapsulationAttribute tunnelEncapsulationAttribute,
       @Nullable @JsonProperty(PROP_VNI_IP) Ip vniIp,
       @JsonProperty(PROP_WEIGHT) int weight) {
     checkArgument(admin == EVPN_ADMIN, "Cannot create EVPN route with non-default admin");
@@ -143,6 +147,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
             protocol,
             receivedFromRouteReflectorClient,
             srcProtocol,
+            tunnelEncapsulationAttribute,
             weight),
         receivedFromIp,
         NextHop.legacyConverter(nextHopInterface, nextHopIp),
@@ -198,6 +203,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
         .setRouteDistinguisher(_routeDistinguisher)
         .setSrcProtocol(_attributes.getSrcProtocol())
         .setTag(_tag)
+        .setTunnelEncapsulationAttribute(_attributes._tunnelEncapsulationAttribute)
         .setVni(_vni)
         .setVniIp(_vniIp)
         .setWeight(_attributes._weight);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
@@ -61,6 +62,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
               _protocol,
               _receivedFromRouteReflectorClient,
               _srcProtocol,
+              _tunnelEncapsulationAttribute,
               _weight),
           _receivedFromIp,
           getNetwork(),
@@ -102,6 +104,8 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
       @Nullable @JsonProperty(PROP_VNI) Integer vni,
       @Nullable @JsonProperty(PROP_SRC_PROTOCOL) RoutingProtocol srcProtocol,
       @JsonProperty(PROP_TAG) long tag,
+      @Nullable @JsonProperty(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE)
+          TunnelEncapsulationAttribute tunnelEncapsulationAttribute,
       @JsonProperty(PROP_WEIGHT) int weight) {
     checkArgument(admin == EVPN_ADMIN, "Cannot create EVPN route with non-default admin");
     checkArgument(network != null, "Missing %s", PROP_NETWORK);
@@ -127,6 +131,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
             protocol,
             receivedFromRouteReflectorClient,
             srcProtocol,
+            tunnelEncapsulationAttribute,
             weight),
         receivedFromIp,
         network,
@@ -172,6 +177,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         .setRouteDistinguisher(_routeDistinguisher)
         .setSrcProtocol(_attributes.getSrcProtocol())
         .setTag(_tag)
+        .setTunnelEncapsulationAttribute(_attributes._tunnelEncapsulationAttribute)
         .setVni(_vni)
         .setWeight(_attributes._weight);
   }
@@ -235,6 +241,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
             _attributes._receivedFromRouteReflectorClient)
         .add(PROP_SRC_PROTOCOL, _attributes._srcProtocol)
         .add(PROP_TAG, _tag)
+        .add(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE, _attributes._tunnelEncapsulationAttribute)
         .add(PROP_WEIGHT, _attributes._weight)
         .toString();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/TunnelEncapsulationAttribute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/TunnelEncapsulationAttribute.java
@@ -1,0 +1,51 @@
+package org.batfish.datamodel.bgp;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+
+/**
+ * A tunnel attribute that can be applied to BGP routes by routing policies. Currently assumed to be
+ * type IP-IP as that is the only supported type.
+ */
+public class TunnelEncapsulationAttribute implements Serializable {
+  private static final String PROP_REMOTE_ENDPOINT = "remoteEndpoint";
+  private final @Nonnull Ip _remoteEndpoint;
+
+  public TunnelEncapsulationAttribute(Ip remoteEndpoint) {
+    _remoteEndpoint = remoteEndpoint;
+  }
+
+  @JsonCreator
+  private static TunnelEncapsulationAttribute create(
+      @Nullable @JsonProperty(PROP_REMOTE_ENDPOINT) Ip remoteEndpoint) {
+    checkNotNull(remoteEndpoint, "%s cannot be null", PROP_REMOTE_ENDPOINT);
+    return new TunnelEncapsulationAttribute(remoteEndpoint);
+  }
+
+  @JsonProperty(PROP_REMOTE_ENDPOINT)
+  public @Nonnull Ip getRemoteEndpoint() {
+    return _remoteEndpoint;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof TunnelEncapsulationAttribute)) {
+      return false;
+    }
+    TunnelEncapsulationAttribute o = (TunnelEncapsulationAttribute) obj;
+    return _remoteEndpoint.equals(o.getRemoteEndpoint());
+  }
+
+  @Override
+  public int hashCode() {
+    return _remoteEndpoint.hashCode();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
@@ -93,6 +93,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.RemoveTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
@@ -106,6 +107,7 @@ import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetTag;
+import org.batfish.datamodel.routing_policy.statement.SetTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.SetVarMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetWeight;
 import org.batfish.datamodel.routing_policy.statement.StatementVisitor;
@@ -699,6 +701,13 @@ public final class CommunityStructuresVerifier {
     }
 
     @Override
+    public Void visitRemoveTunnelEncapsulationAttribute(
+        RemoveTunnelEncapsulationAttribute removeTunnelAttribute,
+        CommunityStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
     public Void visitSetAdministrativeCost(
         SetAdministrativeCost setAdministrativeCost, CommunityStructuresVerifierContext arg) {
       return null;
@@ -770,6 +779,13 @@ public final class CommunityStructuresVerifier {
     @Override
     public Void visitSetDefaultTag(
         SetDefaultTag setDefaultTag, CommunityStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitSetTunnelEncapsulationAttribute(
+        SetTunnelEncapsulationAttribute setTunnelEncapsulationAttribute,
+        CommunityStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
@@ -48,6 +48,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.RemoveTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
@@ -61,6 +62,7 @@ import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetTag;
+import org.batfish.datamodel.routing_policy.statement.SetTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.SetVarMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetWeight;
 import org.batfish.datamodel.routing_policy.statement.StatementVisitor;
@@ -430,6 +432,13 @@ public final class AsPathStructuresVerifier {
     }
 
     @Override
+    public Void visitRemoveTunnelEncapsulationAttribute(
+        RemoveTunnelEncapsulationAttribute removeTunnelAttribute,
+        AsPathStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
     public Void visitSetAdministrativeCost(
         SetAdministrativeCost setAdministrativeCost, AsPathStructuresVerifierContext arg) {
       return null;
@@ -499,6 +508,12 @@ public final class AsPathStructuresVerifier {
     @Override
     public Void visitSetDefaultTag(
         SetDefaultTag setDefaultTag, AsPathStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitSetTunnelEncapsulationAttribute(
+        SetTunnelEncapsulationAttribute setTunnelAttribute, AsPathStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralTunnelEncapsulationAttribute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/LiteralTunnelEncapsulationAttribute.java
@@ -1,0 +1,55 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.Environment;
+
+public class LiteralTunnelEncapsulationAttribute extends TunnelEncapsulationAttributeExpr {
+  private static final String PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE = "tunnelEncapsulationAttribute";
+  @Nonnull private final TunnelEncapsulationAttribute _tunnelEncapsulationAttribute;
+
+  @JsonCreator
+  private static LiteralTunnelEncapsulationAttribute jsonCreator(
+      @Nullable @JsonProperty(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE)
+          TunnelEncapsulationAttribute tunnelEncapsulationAttribute) {
+    checkNotNull(tunnelEncapsulationAttribute, "Missing %s", PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE);
+    return new LiteralTunnelEncapsulationAttribute(tunnelEncapsulationAttribute);
+  }
+
+  public LiteralTunnelEncapsulationAttribute(
+      TunnelEncapsulationAttribute tunnelEncapsulationAttribute) {
+    _tunnelEncapsulationAttribute = tunnelEncapsulationAttribute;
+  }
+
+  @Override
+  public TunnelEncapsulationAttribute evaluate(Environment environment) {
+    return _tunnelEncapsulationAttribute;
+  }
+
+  @JsonProperty(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE)
+  public @Nonnull TunnelEncapsulationAttribute getTunnelEncapsulationAttribute() {
+    return _tunnelEncapsulationAttribute;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof LiteralTunnelEncapsulationAttribute)) {
+      return false;
+    }
+    LiteralTunnelEncapsulationAttribute o = (LiteralTunnelEncapsulationAttribute) obj;
+    return _tunnelEncapsulationAttribute.equals(o._tunnelEncapsulationAttribute);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(_tunnelEncapsulationAttribute);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/TunnelEncapsulationAttributeExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/TunnelEncapsulationAttributeExpr.java
@@ -1,0 +1,11 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serializable;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.Environment;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+public abstract class TunnelEncapsulationAttributeExpr implements Serializable {
+  public abstract TunnelEncapsulationAttribute evaluate(Environment environment);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/RemoveTunnelEncapsulationAttribute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/RemoveTunnelEncapsulationAttribute.java
@@ -1,0 +1,56 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+
+/** Removes {@link org.batfish.datamodel.bgp.TunnelEncapsulationAttribute} on a BGP route */
+@ParametersAreNonnullByDefault
+public final class RemoveTunnelEncapsulationAttribute extends Statement {
+  private static final RemoveTunnelEncapsulationAttribute INSTANCE =
+      new RemoveTunnelEncapsulationAttribute();
+
+  @JsonCreator
+  public static @Nonnull RemoveTunnelEncapsulationAttribute instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public <T, U> T accept(StatementVisitor<T, U> visitor, U arg) {
+    return visitor.visitRemoveTunnelEncapsulationAttribute(this, arg);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof RemoveTunnelEncapsulationAttribute;
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().getCanonicalName().hashCode();
+  }
+
+  @Override
+  @Nonnull
+  public Result execute(Environment environment) {
+    if (!(environment.getOutputRoute() instanceof BgpRoute.Builder<?, ?>)) {
+      // Do nothing for non-BGP routes
+      return new Result();
+    }
+    BgpRoute.Builder<?, ?> outputRoute = (BgpRoute.Builder<?, ?>) environment.getOutputRoute();
+    outputRoute.setTunnelEncapsulationAttribute(null);
+    if (environment.getWriteToIntermediateBgpAttributes()) {
+      environment.getIntermediateBgpAttributes().setTunnelEncapsulationAttribute(null);
+    }
+    return new Result();
+  }
+
+  private RemoveTunnelEncapsulationAttribute() {}
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetTunnelEncapsulationAttribute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetTunnelEncapsulationAttribute.java
@@ -1,0 +1,85 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+import org.batfish.datamodel.routing_policy.expr.TunnelEncapsulationAttributeExpr;
+
+/** Sets {@link TunnelEncapsulationAttribute} on a BGP route */
+@ParametersAreNonnullByDefault
+public final class SetTunnelEncapsulationAttribute extends Statement {
+  private static final String PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE_EXPR =
+      "tunnelEncapsulationAttributeExpr";
+
+  @Nonnull private final TunnelEncapsulationAttributeExpr _expr;
+
+  @JsonCreator
+  private static SetTunnelEncapsulationAttribute jsonCreator(
+      @Nullable @JsonProperty(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE_EXPR)
+          TunnelEncapsulationAttributeExpr expr) {
+    checkArgument(expr != null, "Missing %s", PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE_EXPR);
+    return new SetTunnelEncapsulationAttribute(expr);
+  }
+
+  public SetTunnelEncapsulationAttribute(@Nonnull TunnelEncapsulationAttributeExpr expr) {
+    _expr = expr;
+  }
+
+  @Override
+  public <T, U> T accept(StatementVisitor<T, U> visitor, U arg) {
+    return visitor.visitSetTunnelEncapsulationAttribute(this, arg);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SetTunnelEncapsulationAttribute)) {
+      return false;
+    }
+    SetTunnelEncapsulationAttribute other = (SetTunnelEncapsulationAttribute) o;
+    return _expr.equals(other._expr);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(_expr);
+  }
+
+  @Override
+  @Nonnull
+  public Result execute(Environment environment) {
+    if (!(environment.getOutputRoute() instanceof BgpRoute.Builder<?, ?>)) {
+      // Do nothing for non-BGP routes
+      return new Result();
+    }
+    BgpRoute.Builder<?, ?> outputRoute = (BgpRoute.Builder<?, ?>) environment.getOutputRoute();
+    TunnelEncapsulationAttribute tunnelEncapsulationAttribute = _expr.evaluate(environment);
+    if (tunnelEncapsulationAttribute == null) {
+      // TODO Currently this shouldn't be possible. If it becomes possible, update with comment.
+      return new Result();
+    }
+    outputRoute.setTunnelEncapsulationAttribute(tunnelEncapsulationAttribute);
+    if (environment.getWriteToIntermediateBgpAttributes()) {
+      environment
+          .getIntermediateBgpAttributes()
+          .setTunnelEncapsulationAttribute(tunnelEncapsulationAttribute);
+    }
+    return new Result();
+  }
+
+  @JsonProperty(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE_EXPR)
+  public TunnelEncapsulationAttributeExpr getTunnelEncapsulationAttributeExpr() {
+    return _expr;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/StatementVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/StatementVisitor.java
@@ -18,6 +18,9 @@ public interface StatementVisitor<T, U> {
 
   T visitExcludeAsPath(ExcludeAsPath excludeAsPath, U arg);
 
+  T visitRemoveTunnelEncapsulationAttribute(
+      RemoveTunnelEncapsulationAttribute removeTunnelEncapsulationAttribute, U arg);
+
   T visitSetAdministrativeCost(SetAdministrativeCost setAdministrativeCost, U arg);
 
   T visitSetCommunities(SetCommunities setCommunities, U arg);
@@ -41,6 +44,9 @@ public interface StatementVisitor<T, U> {
   T visitSetOspfMetricType(SetOspfMetricType setOspfMetricType, U arg);
 
   T visitSetTag(SetTag setTag, U arg);
+
+  T visitSetTunnelEncapsulationAttribute(
+      SetTunnelEncapsulationAttribute setTunnelEncapsulationAttribute, U arg);
 
   T visitSetDefaultTag(SetDefaultTag setDefaultTag, U arg);
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpRouteTest.java
@@ -1,0 +1,100 @@
+package org.batfish.datamodel;
+
+import static org.batfish.datamodel.OriginMechanism.GENERATED;
+import static org.batfish.datamodel.OriginMechanism.LEARNED;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.junit.Test;
+
+public class BgpRouteTest {
+  @Test
+  public void testBgpRouteAttributesJavaSerialization() {
+    BgpRoute.BgpRouteAttributes attributes =
+        BgpRoute.BgpRouteAttributes.create(
+            AsPath.ofSingletonAsSets(1L, 1L),
+            ImmutableSet.of(1L),
+            CommunitySet.of(StandardCommunity.of(1L)),
+            10,
+            11,
+            Ip.parse("1.1.1.1"),
+            LEARNED,
+            OriginType.IGP,
+            RoutingProtocol.BGP,
+            true,
+            RoutingProtocol.STATIC,
+            new TunnelEncapsulationAttribute(Ip.parse("1.1.1.1")),
+            1);
+    assertThat(SerializationUtils.clone(attributes), equalTo(attributes));
+  }
+
+  @Test
+  public void testBgpRouteAttributesJsonSerialization() {
+    // Test using a Bgpv4Route since BgpRouteAttributes does not have JSON tags
+    Bgpv4Route br =
+        Bgpv4Route.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setAsPath(AsPath.ofSingletonAsSets(1L, 1L))
+            .setClusterList(ImmutableSet.of(1L))
+            .setCommunities(ImmutableSet.of(StandardCommunity.of(1L)))
+            .setLocalPreference(10)
+            .setMetric(11)
+            .setOriginatorIp(Ip.parse("1.1.1.1"))
+            .setOriginMechanism(LEARNED)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setReceivedFromRouteReflectorClient(true)
+            .setSrcProtocol(RoutingProtocol.STATIC)
+            .setTunnelEncapsulationAttribute(new TunnelEncapsulationAttribute(Ip.parse("1.1.1.1")))
+            .setWeight(1)
+            .build();
+    assertThat(BatfishObjectMapper.clone(br, Bgpv4Route.class), equalTo(br));
+  }
+
+  @Test
+  public void testBgpRouteAttributesEquals() {
+    // Test using a Bgpv4Route since BgpRouteAttributes does not have a builder
+    Bgpv4Route.Builder brb =
+        Bgpv4Route.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setAsPath(AsPath.ofSingletonAsSets(1L, 1L))
+            .setClusterList(ImmutableSet.of(1L))
+            .setCommunities(ImmutableSet.of(StandardCommunity.of(1L)))
+            .setLocalPreference(10)
+            .setMetric(11)
+            .setOriginatorIp(Ip.parse("1.1.1.1"))
+            .setOriginMechanism(LEARNED)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setReceivedFromRouteReflectorClient(true)
+            .setSrcProtocol(RoutingProtocol.STATIC)
+            .setTunnelEncapsulationAttribute(new TunnelEncapsulationAttribute(Ip.parse("1.1.1.1")))
+            .setWeight(1);
+    new EqualsTester()
+        .addEqualityGroup(brb.build(), brb.build())
+        .addEqualityGroup(brb.setAsPath(AsPath.ofSingletonAsSets(2L, 2L)).build())
+        .addEqualityGroup(brb.setClusterList(ImmutableSet.of(2L)).build())
+        .addEqualityGroup(brb.setCommunities(ImmutableSet.of(StandardCommunity.of(2L))).build())
+        .addEqualityGroup(brb.setLocalPreference(12).build())
+        .addEqualityGroup(brb.setMetric(13).build())
+        .addEqualityGroup(brb.setOriginatorIp(Ip.parse("2.2.2.2")).build())
+        .addEqualityGroup(brb.setOriginMechanism(GENERATED).build())
+        .addEqualityGroup(brb.setOriginType(OriginType.INCOMPLETE).build())
+        .addEqualityGroup(brb.setProtocol(RoutingProtocol.IBGP).build())
+        .addEqualityGroup(brb.setReceivedFromRouteReflectorClient(false).build())
+        .addEqualityGroup(brb.setSrcProtocol(RoutingProtocol.CONNECTED).build())
+        .addEqualityGroup(
+            brb.setTunnelEncapsulationAttribute(
+                    new TunnelEncapsulationAttribute(Ip.parse("2.2.2.2")))
+                .build())
+        .addEqualityGroup(brb.setWeight(2).build())
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/TunnelEncapsulationAttributeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/TunnelEncapsulationAttributeTest.java
@@ -1,0 +1,38 @@
+package org.batfish.datamodel.bgp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
+import org.junit.Test;
+
+/** Test for {@link TunnelEncapsulationAttribute}. */
+public final class TunnelEncapsulationAttributeTest {
+
+  @Test
+  public void testJsonSerialization() {
+    TunnelEncapsulationAttribute ta = new TunnelEncapsulationAttribute(Ip.parse("1.2.3.4"));
+    TunnelEncapsulationAttribute clone =
+        BatfishObjectMapper.clone(ta, TunnelEncapsulationAttribute.class);
+    assertEquals(ta, clone);
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    TunnelEncapsulationAttribute ta = new TunnelEncapsulationAttribute(Ip.parse("1.2.3.4"));
+    assertThat(SerializationUtils.clone(ta), equalTo(ta));
+  }
+
+  @Test
+  public void testEquals() {
+    TunnelEncapsulationAttribute ta = new TunnelEncapsulationAttribute(Ip.parse("1.2.3.4"));
+    new EqualsTester()
+        .addEqualityGroup(ta, ta, new TunnelEncapsulationAttribute(Ip.parse("1.2.3.4")))
+        .addEqualityGroup(new TunnelEncapsulationAttribute(Ip.parse("5.6.7.8")))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/RemoveTunnelEncapsulationAttributeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/RemoveTunnelEncapsulationAttributeTest.java
@@ -1,0 +1,77 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNull;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.junit.Test;
+
+/** Tests of {@link RemoveTunnelEncapsulationAttribute} */
+public class RemoveTunnelEncapsulationAttributeTest {
+  @Test
+  public void testEquals() {
+    RemoveTunnelEncapsulationAttribute rta = RemoveTunnelEncapsulationAttribute.instance();
+    new EqualsTester()
+        .addEqualityGroup(rta, rta, RemoveTunnelEncapsulationAttribute.instance())
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    RemoveTunnelEncapsulationAttribute rta = RemoveTunnelEncapsulationAttribute.instance();
+    assertThat(SerializationUtils.clone(rta), equalTo(rta));
+  }
+
+  @Test
+  public void testJsonSerialization() {
+    RemoveTunnelEncapsulationAttribute rta = RemoveTunnelEncapsulationAttribute.instance();
+    assertThat(
+        BatfishObjectMapper.clone(rta, RemoveTunnelEncapsulationAttribute.class), equalTo(rta));
+  }
+
+  @Test
+  public void testExecute() {
+    RemoveTunnelEncapsulationAttribute rta = RemoveTunnelEncapsulationAttribute.instance();
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_NX)
+            .setHostname("c")
+            .build();
+    {
+      // Don't crash when applied to a non-BGP route
+      StaticRoute nonBgpRoute = StaticRoute.testBuilder().setNetwork(Prefix.ZERO).build();
+      rta.execute(
+          Environment.builder(c)
+              .setOriginalRoute(nonBgpRoute)
+              .setOutputRoute(nonBgpRoute.toBuilder())
+              .build());
+    }
+    {
+      // Update tunnel attribute correctly
+      TunnelEncapsulationAttribute foo = new TunnelEncapsulationAttribute(Ip.parse("1.1.1.1"));
+      Bgpv4Route route =
+          Bgpv4Route.testBuilder()
+              .setNetwork(Prefix.ZERO)
+              .setTunnelEncapsulationAttribute(foo)
+              .build();
+      Bgpv4Route.Builder outputRoute = route.toBuilder();
+      rta.execute(
+          Environment.builder(c).setOriginalRoute(route).setOutputRoute(outputRoute).build());
+      assertNull(outputRoute.build().getTunnelEncapsulationAttribute());
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/SetTunnelEncapsulationAttributeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/SetTunnelEncapsulationAttributeTest.java
@@ -1,0 +1,87 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.expr.LiteralTunnelEncapsulationAttribute;
+import org.junit.Test;
+
+/** Tests of {@link SetTunnelEncapsulationAttribute} */
+public class SetTunnelEncapsulationAttributeTest {
+  @Test
+  public void testEquals() {
+    LiteralTunnelEncapsulationAttribute tunnelEncapAttrExpr =
+        new LiteralTunnelEncapsulationAttribute(
+            new TunnelEncapsulationAttribute(Ip.parse("1.1.1.1")));
+    SetTunnelEncapsulationAttribute sta = new SetTunnelEncapsulationAttribute(tunnelEncapAttrExpr);
+    new EqualsTester()
+        .addEqualityGroup(sta, sta, new SetTunnelEncapsulationAttribute(tunnelEncapAttrExpr))
+        .addEqualityGroup(
+            new SetTunnelEncapsulationAttribute(
+                new LiteralTunnelEncapsulationAttribute(
+                    new TunnelEncapsulationAttribute(Ip.parse("2.2.2.2")))))
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    LiteralTunnelEncapsulationAttribute tunnelEncapAttrExpr =
+        new LiteralTunnelEncapsulationAttribute(
+            new TunnelEncapsulationAttribute(Ip.parse("1.1.1.1")));
+    SetTunnelEncapsulationAttribute sta = new SetTunnelEncapsulationAttribute(tunnelEncapAttrExpr);
+    assertThat(SerializationUtils.clone(sta), equalTo(sta));
+  }
+
+  @Test
+  public void testJsonSerialization() {
+    LiteralTunnelEncapsulationAttribute tunnelEncapAttrExpr =
+        new LiteralTunnelEncapsulationAttribute(
+            new TunnelEncapsulationAttribute(Ip.parse("1.1.1.1")));
+    SetTunnelEncapsulationAttribute sta = new SetTunnelEncapsulationAttribute(tunnelEncapAttrExpr);
+    assertThat(BatfishObjectMapper.clone(sta, SetTunnelEncapsulationAttribute.class), equalTo(sta));
+  }
+
+  @Test
+  public void testExecute() {
+    TunnelEncapsulationAttribute tunnelEncapAttr =
+        new TunnelEncapsulationAttribute(Ip.parse("1.1.1.1"));
+    LiteralTunnelEncapsulationAttribute tunnelEncapAttrExpr =
+        new LiteralTunnelEncapsulationAttribute(tunnelEncapAttr);
+    SetTunnelEncapsulationAttribute sta = new SetTunnelEncapsulationAttribute(tunnelEncapAttrExpr);
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.FLAT_JUNIPER)
+            .setHostname("c")
+            .build();
+    {
+      // Don't crash when applied to a non-BGP route
+      StaticRoute nonBgpRoute = StaticRoute.testBuilder().setNetwork(Prefix.ZERO).build();
+      sta.execute(
+          Environment.builder(c)
+              .setOriginalRoute(nonBgpRoute)
+              .setOutputRoute(nonBgpRoute.toBuilder())
+              .build());
+    }
+    {
+      // Update tunnel attribute correctly
+      Bgpv4Route route = Bgpv4Route.testBuilder().setNetwork(Prefix.ZERO).build();
+      Bgpv4Route.Builder outputRoute = route.toBuilder();
+      sta.execute(
+          Environment.builder(c).setOriginalRoute(route).setOutputRoute(outputRoute).build());
+      assertThat(outputRoute.build().getTunnelEncapsulationAttribute(), equalTo(tunnelEncapAttr));
+    }
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.RemoveTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
@@ -25,6 +26,7 @@ import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetTag;
+import org.batfish.datamodel.routing_policy.statement.SetTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.SetVarMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetWeight;
 import org.batfish.datamodel.routing_policy.statement.Statement;
@@ -86,6 +88,12 @@ public class RoutePolicyStatementAsPathCollector
   public Set<SymbolicAsPathRegex> visitExcludeAsPath(
       ExcludeAsPath excludeAsPath, Configuration arg) {
     // if/when TransferBDD gets updated to support AS-path excluding, this will have to be updated
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<SymbolicAsPathRegex> visitRemoveTunnelEncapsulationAttribute(
+      RemoveTunnelEncapsulationAttribute removeTunnelAttribute, Configuration arg) {
     return ImmutableSet.of();
   }
 
@@ -159,6 +167,12 @@ public class RoutePolicyStatementAsPathCollector
   @Override
   public Set<SymbolicAsPathRegex> visitSetDefaultTag(
       SetDefaultTag setDefaultTag, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<SymbolicAsPathRegex> visitSetTunnelEncapsulationAttribute(
+      SetTunnelEncapsulationAttribute setTunnelAttribute, Configuration arg) {
     return ImmutableSet.of();
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollector.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.RemoveTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
@@ -25,6 +26,7 @@ import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetTag;
+import org.batfish.datamodel.routing_policy.statement.SetTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.SetVarMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetWeight;
 import org.batfish.datamodel.routing_policy.statement.Statement;
@@ -79,6 +81,12 @@ public class RoutePolicyStatementVarCollector
   @Override
   public Set<CommunityVar> visitExcludeAsPath(ExcludeAsPath excludeAsPath, Configuration arg) {
     // if/when TransferBDD gets updated to support AS-path excluding, this will have to be updated
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<CommunityVar> visitRemoveTunnelEncapsulationAttribute(
+      RemoveTunnelEncapsulationAttribute removeTunnelAttribute, Configuration arg) {
     return ImmutableSet.of();
   }
 
@@ -149,6 +157,12 @@ public class RoutePolicyStatementVarCollector
 
   @Override
   public Set<CommunityVar> visitSetDefaultTag(SetDefaultTag setDefaultTag, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<CommunityVar> visitSetTunnelEncapsulationAttribute(
+      SetTunnelEncapsulationAttribute setTunnelAttribute, Configuration arg) {
     return ImmutableSet.of();
   }
 

--- a/projects/question/src/main/java/org/batfish/question/TracingHintsStripper.java
+++ b/projects/question/src/main/java/org/batfish/question/TracingHintsStripper.java
@@ -9,6 +9,7 @@ import org.batfish.datamodel.routing_policy.statement.Comment;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
+import org.batfish.datamodel.routing_policy.statement.RemoveTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.ReplaceAsesInAsSequence;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
@@ -22,6 +23,7 @@ import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetTag;
+import org.batfish.datamodel.routing_policy.statement.SetTunnelEncapsulationAttribute;
 import org.batfish.datamodel.routing_policy.statement.SetVarMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetWeight;
 import org.batfish.datamodel.routing_policy.statement.Statement;
@@ -80,6 +82,12 @@ public final class TracingHintsStripper implements StatementVisitor<Statement, V
   @Override
   public Statement visitExcludeAsPath(ExcludeAsPath excludeAsPath, Void arg) {
     return excludeAsPath;
+  }
+
+  @Override
+  public Statement visitRemoveTunnelEncapsulationAttribute(
+      RemoveTunnelEncapsulationAttribute removeTunnelEncapsulationAttribute, Void arg) {
+    return removeTunnelEncapsulationAttribute;
   }
 
   @Override
@@ -146,6 +154,12 @@ public final class TracingHintsStripper implements StatementVisitor<Statement, V
   @Override
   public Statement visitSetDefaultTag(SetDefaultTag setDefaultTag, Void arg) {
     return setDefaultTag;
+  }
+
+  @Override
+  public Statement visitSetTunnelEncapsulationAttribute(
+      SetTunnelEncapsulationAttribute setTunnelEncapsulationAttribute, Void arg) {
+    return setTunnelEncapsulationAttribute;
   }
 
   @Override


### PR DESCRIPTION
Adds a tunnel attribute field in `BgpRoute` and routing policy statements to set and clear it. No vendors currently create these statements in conversion.

After #8350, just because it relies on the `TunnelAttribute` class existing.