### PR TITLE
Juniper: Convert set/remove tunnel attrs in policy

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2269,6 +2269,8 @@ REMOTE: 'remote';
 
 REMOTE_END_POINT: 'remote-end-point';
 
+REMOVE: 'remove' -> pushMode(M_Remove);
+
 REMOVE_PRIVATE: 'remove-private';
 
 REMOVED: 'Removed';
@@ -2467,7 +2469,7 @@ SET
 :
   'set'
   {
-    if (lastTokenType() == COMMUNITY) {
+    if (lastTokenType() == COMMUNITY || lastTokenType() == TUNNEL_ATTRIBUTE) {
       pushMode(M_Name);
     }
   }
@@ -2766,7 +2768,15 @@ TTL_EQ_ZERO_DURING_TRANSIT: 'ttl-eq-zero-during-transit';
 
 TUNNEL: 'tunnel';
 
-TUNNEL_ATTRIBUTE: 'tunnel-attribute' -> pushMode(M_Name);
+TUNNEL_ATTRIBUTE
+:
+  'tunnel-attribute'
+  {
+    if (lastTokenType() == POLICY_OPTIONS) {
+      pushMode(M_Name);
+    }
+  }
+;
 
 TUNNEL_ENCAPSULATION_LIMIT_OPTION: 'tunnel-encapsulation-limit-option';
 
@@ -4172,6 +4182,14 @@ M_MetricType_WS
 :
    F_WhitespaceChar+ -> channel ( HIDDEN )
 ;
+
+
+
+mode M_Remove;
+M_Remove_ALL: 'all' -> type(ALL), popMode;
+M_Remove_WS: F_WhitespaceChar+ -> skip;
+M_Remove_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+M_Remove_NAME: F_Name -> type(NAME), popMode;
 
 mode M_RouteDistinguisher;
 M_RouteDistinguisher_COLON: ':' -> type(COLON);

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -510,6 +510,7 @@ popst_common
    | popst_priority
    | popst_reject
    | popst_tag
+   | popst_tunnel_attribute
 ;
 
 popst_community_add
@@ -691,6 +692,19 @@ popst_tag
 :
    TAG uint32
 ;
+
+popst_tunnel_attribute
+:
+   TUNNEL_ATTRIBUTE
+   (
+      popstta_remove
+      | popstta_set
+   )
+;
+
+popstta_remove: REMOVE (ALL | name = junos_name);
+
+popstta_set: SET name = junos_name;
 
 popsto_level
 :

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5784,7 +5784,17 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitPopstta_remove(FlatJuniperParser.Popstta_removeContext ctx) {
-    _currentPsThens.add(PsThenTunnelAttributeRemove.INSTANCE);
+    if (ctx.ALL() != null) {
+      _currentPsThens.add(PsThenTunnelAttributeRemove.INSTANCE);
+    } else {
+      assert ctx.name != null;
+      warn(ctx, "Removing specific tunnel-attributes is not yet supported");
+      _configuration.referenceStructure(
+          TUNNEL_ATTRIBUTE,
+          toString(ctx.name),
+          POLICY_STATEMENT_THEN_TUNNEL_ATTRIBUTE,
+          getLine(ctx.name.getStop()));
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -41,6 +41,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.ROUTING_IN
 import static org.batfish.representation.juniper.JuniperStructureType.SECURITY_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureType.SECURITY_POLICY_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.SECURITY_PROFILE;
+import static org.batfish.representation.juniper.JuniperStructureType.TUNNEL_ATTRIBUTE;
 import static org.batfish.representation.juniper.JuniperStructureType.VLAN;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ADDRESS_BOOK_ATTACH_ZONE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.AGGREGATE_ROUTE_POLICY;
@@ -108,6 +109,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_ST
 import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_STATEMENT_THEN_ADD_COMMUNITY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_STATEMENT_THEN_DELETE_COMMUNITY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_STATEMENT_THEN_SET_COMMUNITY;
+import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_STATEMENT_THEN_TUNNEL_ATTRIBUTE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.RESOLUTION_RIB_IMPORT_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_INSTANCE_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_INSTANCE_SELF_REFERENCE;
@@ -887,6 +889,8 @@ import org.batfish.representation.juniper.PsThenOrigin;
 import org.batfish.representation.juniper.PsThenPreference;
 import org.batfish.representation.juniper.PsThenReject;
 import org.batfish.representation.juniper.PsThenTag;
+import org.batfish.representation.juniper.PsThenTunnelAttributeRemove;
+import org.batfish.representation.juniper.PsThenTunnelAttributeSet;
 import org.batfish.representation.juniper.QualifiedNextHop;
 import org.batfish.representation.juniper.RegexCommunityMember;
 import org.batfish.representation.juniper.Resolution;
@@ -5779,12 +5783,29 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
+  public void exitPopstta_remove(FlatJuniperParser.Popstta_removeContext ctx) {
+    _currentPsThens.add(PsThenTunnelAttributeRemove.INSTANCE);
+  }
+
+  @Override
+  public void exitPopstta_set(FlatJuniperParser.Popstta_setContext ctx) {
+    String tunnelAttrName = toString(ctx.name);
+    _currentPsThens.add(new PsThenTunnelAttributeSet(tunnelAttrName));
+    _configuration.referenceStructure(
+        TUNNEL_ATTRIBUTE,
+        tunnelAttrName,
+        POLICY_STATEMENT_THEN_TUNNEL_ATTRIBUTE,
+        getLine(ctx.name.getStop()));
+  }
+
+  @Override
   public void enterPo_tunnel_attribute(FlatJuniperParser.Po_tunnel_attributeContext ctx) {
     String name = toString(ctx.name);
     _currentTunnelAttribute =
         _currentLogicalSystem
             .getTunnelAttributes()
             .computeIfAbsent(name, k -> new TunnelAttribute());
+    _configuration.defineFlattenedStructure(TUNNEL_ATTRIBUTE, name, ctx, _parser);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3839,6 +3839,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
     markConcreteStructure(JuniperStructureType.SECURITY_POLICY);
     markConcreteStructure(JuniperStructureType.SECURITY_POLICY_TERM);
+    markConcreteStructure(JuniperStructureType.TUNNEL_ATTRIBUTE);
 
     warnEmptyPrefixLists();
     warnIllegalNamedCommunitiesUsedForSet();

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
@@ -47,6 +47,7 @@ public enum JuniperStructureType implements StructureType {
    */
   SECURITY_POLICY_TERM("security policy term"),
   SECURITY_PROFILE("security-profile"),
+  TUNNEL_ATTRIBUTE("tunnel-attribute"),
   VLAN("vlan");
 
   private final String _description;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -69,6 +69,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   POLICY_STATEMENT_THEN_ADD_COMMUNITY("policy-statement then add community"),
   POLICY_STATEMENT_THEN_DELETE_COMMUNITY("policy-statement then delete community"),
   POLICY_STATEMENT_THEN_SET_COMMUNITY("policy-statement then set community"),
+  POLICY_STATEMENT_THEN_TUNNEL_ATTRIBUTE("policy-statement then tunnel-attribute"),
   RESOLUTION_RIB_IMPORT_POLICY("routing-instance resolution rib import"),
   ROUTING_OPTIONS_RIB_GROUPS_IMPORT_POLICY("routing-options rib-groups import-policy"),
   ROUTING_INSTANCE_INTERFACE("routing-instance interface"),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenTunnelAttributeRemove.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenTunnelAttributeRemove.java
@@ -1,0 +1,38 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.statement.RemoveTunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/** A {@link Statement} that clears tunnel attributes on the route. */
+public final class PsThenTunnelAttributeRemove extends PsThen {
+
+  public static final PsThenTunnelAttributeRemove INSTANCE = new PsThenTunnelAttributeRemove();
+
+  private PsThenTunnelAttributeRemove() {}
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings w) {
+    statements.add(RemoveTunnelEncapsulationAttribute.instance());
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    return obj instanceof PsThenTunnelAttributeRemove;
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().getCanonicalName().hashCode();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenTunnelAttributeSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenTunnelAttributeSet.java
@@ -1,0 +1,74 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.expr.LiteralTunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.statement.SetTunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * Represents the action in Juniper's routing policy (policy statement) which sets the tunnel
+ * attribute for a matched route.
+ */
+public final class PsThenTunnelAttributeSet extends PsThen {
+
+  private final String _tunnelAttrName;
+
+  public PsThenTunnelAttributeSet(String tunnelAttrName) {
+    _tunnelAttrName = tunnelAttrName;
+  }
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings warnings) {
+    TunnelAttribute tunnelAttribute =
+        juniperVendorConfiguration
+            .getMasterLogicalSystem()
+            .getTunnelAttributes()
+            .get(_tunnelAttrName);
+    if (tunnelAttribute == null) {
+      // The missing tunnel attribute will show up as an undefined reference
+      return;
+    }
+    TunnelAttribute.Type type = tunnelAttribute.getType();
+    Ip remoteEndpoint = tunnelAttribute.getRemoteEndPoint();
+    if (type == null || remoteEndpoint == null) {
+      warnings.redFlag(
+          String.format(
+              "Ignoring tunnel-attribute %s because its %s is not set",
+              _tunnelAttrName, type == null ? "tunnel-type" : "remote-end-point"));
+      return;
+    }
+    statements.add(
+        new SetTunnelEncapsulationAttribute(
+            new LiteralTunnelEncapsulationAttribute(
+                new TunnelEncapsulationAttribute(remoteEndpoint))));
+  }
+
+  public String getTunnelAttributeName() {
+    return _tunnelAttrName;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenTunnelAttributeSet)) {
+      return false;
+    }
+    PsThenTunnelAttributeSet psThenTunnelAttributeSet = (PsThenTunnelAttributeSet) o;
+    return _tunnelAttrName.equals(psThenTunnelAttributeSet._tunnelAttrName);
+  }
+
+  @Override
+  public int hashCode() {
+    return _tunnelAttrName.hashCode();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4578,6 +4578,10 @@ public final class FlatJuniperGrammarTest {
         ccae,
         hasDefinedStructureWithDefinitionLines(
             filename, TUNNEL_ATTRIBUTE, "SET", containsInAnyOrder(10, 11)));
+    assertThat(
+        ccae,
+        hasDefinedStructureWithDefinitionLines(
+            filename, TUNNEL_ATTRIBUTE, "REMOVE", containsInAnyOrder(12, 13)));
 
     // defined references
     assertThat(ccae, hasNumReferrers(filename, COMMUNITY, "MATCHED", 1));
@@ -4586,13 +4590,14 @@ public final class FlatJuniperGrammarTest {
     assertThat(ccae, hasNumReferrers(filename, COMMUNITY, "DELETED", 1));
     assertThat(ccae, hasNumReferrers(filename, COMMUNITY, "SET", 1));
     assertThat(ccae, hasNumReferrers(filename, TUNNEL_ATTRIBUTE, "SET", 1));
+    assertThat(ccae, hasNumReferrers(filename, TUNNEL_ATTRIBUTE, "REMOVE", 1));
     assertThat(ccae, hasNumReferrers(filename, TUNNEL_ATTRIBUTE, "UNUSED", 0));
 
     // undefined references
     assertThat(
         ccae,
         hasUndefinedReferenceWithReferenceLines(
-            filename, COMMUNITY, "UNDEFINED", POLICY_STATEMENT_FROM_COMMUNITY, contains(16)));
+            filename, COMMUNITY, "UNDEFINED", POLICY_STATEMENT_FROM_COMMUNITY, contains(18)));
     assertThat(
         ccae,
         hasUndefinedReferenceWithReferenceLines(
@@ -4600,7 +4605,7 @@ public final class FlatJuniperGrammarTest {
             TUNNEL_ATTRIBUTE,
             "UNDEFINED",
             POLICY_STATEMENT_THEN_TUNNEL_ATTRIBUTE,
-            contains(21)));
+            containsInAnyOrder(23, 25)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenTunnelAttributeRemoveTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenTunnelAttributeRemoveTest.java
@@ -1,0 +1,45 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.LinkedList;
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.routing_policy.statement.RemoveTunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.junit.Test;
+
+public class PsThenTunnelAttributeRemoveTest {
+  @Test
+  public void testEquals() {
+    PsThenTunnelAttributeRemove then = PsThenTunnelAttributeRemove.INSTANCE;
+    new EqualsTester()
+        .addEqualityGroup(5L)
+        .addEqualityGroup(then, PsThenTunnelAttributeRemove.INSTANCE)
+        .testEquals();
+  }
+
+  List<Statement> getStatements(PsThenTunnelAttributeRemove p) {
+    List<Statement> statements = new LinkedList<>();
+    JuniperConfiguration fakeVsConfig = new JuniperConfiguration();
+    fakeVsConfig.setHostname("c");
+    Configuration fakeConfig =
+        Configuration.builder()
+            .setHostname("c")
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .build();
+    p.applyTo(statements, fakeVsConfig, fakeConfig, new Warnings());
+    return statements;
+  }
+
+  @Test
+  public void testConversion() {
+    assertThat(
+        getStatements(PsThenTunnelAttributeRemove.INSTANCE),
+        contains(RemoveTunnelEncapsulationAttribute.instance()));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenTunnelAttributeSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenTunnelAttributeSetTest.java
@@ -1,0 +1,116 @@
+package org.batfish.representation.juniper;
+
+import static org.batfish.common.matchers.WarningMatchers.hasText;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.LinkedList;
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.expr.LiteralTunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.statement.SetTunnelEncapsulationAttribute;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.junit.Test;
+
+public class PsThenTunnelAttributeSetTest {
+
+  @Test
+  public void testEquals() {
+    PsThenTunnelAttributeSet then = new PsThenTunnelAttributeSet("foo");
+    new EqualsTester()
+        .addEqualityGroup(5L)
+        .addEqualityGroup(then, then, new PsThenTunnelAttributeSet("foo"))
+        .addEqualityGroup(new PsThenTunnelAttributeSet("bar"))
+        .testEquals();
+  }
+
+  @Test
+  public void testConversion() {
+    JuniperConfiguration vsConfig = new JuniperConfiguration();
+    vsConfig.setHostname("c");
+    Configuration viConfig =
+        Configuration.builder()
+            .setHostname("c")
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .build();
+    {
+      // Generates correct statement for a valid tunnel attribute
+      String tunnelAttrName = "valid";
+      Ip remoteEndPoint = Ip.parse("1.1.1.1");
+      TunnelAttribute ta = createTunnelAttribute(TunnelAttribute.Type.IPIP, remoteEndPoint);
+      vsConfig.getMasterLogicalSystem().getTunnelAttributes().put(tunnelAttrName, ta);
+
+      List<Statement> statements = new LinkedList<>();
+      PsThenTunnelAttributeSet psThenSet = new PsThenTunnelAttributeSet(tunnelAttrName);
+      Warnings warnings = new Warnings(true, true, true);
+      psThenSet.applyTo(statements, vsConfig, viConfig, warnings);
+      assertThat(
+          statements,
+          contains(
+              new SetTunnelEncapsulationAttribute(
+                  new LiteralTunnelEncapsulationAttribute(
+                      new TunnelEncapsulationAttribute(remoteEndPoint)))));
+      assertThat(warnings.getRedFlagWarnings(), empty());
+    }
+    {
+      // Does not generate a statement and files a warning for a tunnel attribute with no type set
+      String tunnelAttrName = "no-type";
+      TunnelAttribute ta = createTunnelAttribute(null, Ip.parse("1.1.1.1"));
+      vsConfig.getMasterLogicalSystem().getTunnelAttributes().put(tunnelAttrName, ta);
+
+      List<Statement> statements = new LinkedList<>();
+      PsThenTunnelAttributeSet psThenSet = new PsThenTunnelAttributeSet(tunnelAttrName);
+      Warnings warnings = new Warnings(true, true, true);
+      psThenSet.applyTo(statements, vsConfig, viConfig, warnings);
+      assertThat(statements, empty());
+      assertThat(
+          warnings.getRedFlagWarnings(),
+          hasItem(hasText("Ignoring tunnel-attribute no-type because its tunnel-type is not set")));
+    }
+    {
+      // Does not generate a statement and files a warning for a tunnel attribute with no remote
+      // endpoint set
+      String tunnelAttrName = "no-remote-endpoint";
+      TunnelAttribute ta = createTunnelAttribute(TunnelAttribute.Type.IPIP, null);
+      vsConfig.getMasterLogicalSystem().getTunnelAttributes().put(tunnelAttrName, ta);
+
+      List<Statement> statements = new LinkedList<>();
+      PsThenTunnelAttributeSet psThenSet = new PsThenTunnelAttributeSet(tunnelAttrName);
+      Warnings warnings = new Warnings(true, true, true);
+      psThenSet.applyTo(statements, vsConfig, viConfig, warnings);
+      assertThat(statements, empty());
+      assertThat(
+          warnings.getRedFlagWarnings(),
+          hasItem(
+              hasText(
+                  "Ignoring tunnel-attribute no-remote-endpoint because its remote-end-point is not"
+                      + " set")));
+    }
+    {
+      // Does not generate a statement or warnings if the tunnel attribute is undefined (the issue
+      // will show up as an undefined reference)
+      String tunnelAttrName = "undefined";
+      List<Statement> statements = new LinkedList<>();
+      PsThenTunnelAttributeSet psThenSet = new PsThenTunnelAttributeSet(tunnelAttrName);
+      Warnings warnings = new Warnings(true, true, true);
+      psThenSet.applyTo(statements, vsConfig, viConfig, warnings);
+      assertThat(statements, empty());
+      assertThat(warnings.getRedFlagWarnings(), empty());
+    }
+  }
+
+  private static TunnelAttribute createTunnelAttribute(
+      TunnelAttribute.Type type, Ip remoteEndPoint) {
+    TunnelAttribute ta = new TunnelAttribute();
+    ta.setType(type);
+    ta.setRemoteEndPoint(remoteEndPoint);
+    return ta;
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-then
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-then
@@ -1,6 +1,9 @@
 #
 set system host-name juniper-policy-statement-then
 #
+set policy-options tunnel-attribute TA remote-end-point 1.1.1.1
+set policy-options tunnel-attribute TA tunnel-type ipip
+#
 set policy-options policy-statement COLOR_POLICY term TSETMIN then color 0
 set policy-options policy-statement COLOR_POLICY term TADDMAX then color add 4294967295
 set policy-options policy-statement COLOR_POLICY term TSUB3 then color subtract 3
@@ -15,3 +18,5 @@ set policy-options policy-statement LOCAL_PREFERENCE_POLICY term TSUB3 then loca
 set policy-options policy-statement TAG_POLICY term TMIN then tag 0
 set policy-options policy-statement TAG_POLICY term TMAX then tag 4294967295
 #
+set policy-options policy-statement TUNNEL_ATTR_POLICY term SET_TUNNEL_ATTR then tunnel-attribute set TA
+set policy-options policy-statement TUNNEL_ATTR_POLICY term REMOVE_TUNNEL_ATTR then tunnel-attribute remove all

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-references-in-policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-references-in-policy
@@ -1,5 +1,5 @@
 #
-set system host-name juniper-community-reference
+set system host-name juniper-references-in-policy
 #
 set policy-options community MATCHED members 1
 set policy-options community UNUSED invert-match
@@ -7,10 +7,16 @@ set policy-options community UNUSED members 2
 set policy-options community ADDED members 1
 set policy-options community DELETED members 1
 set policy-options community SET members 1
+set policy-options tunnel-attribute SET remote-end-point 1.1.1.1
+set policy-options tunnel-attribute SET tunnel-type ipip
+set policy-options tunnel-attribute UNUSED remote-end-point 2.2.2.2
+set policy-options tunnel-attribute UNUSED tunnel-type ipip
 #
 set policy-options policy-statement COMMUNITY_POLICY term T1 from community MATCHED
 set policy-options policy-statement COMMUNITY_POLICY term T1 from community UNDEFINED
 set policy-options policy-statement COMMUNITY_POLICY term T1 then community add ADDED
 set policy-options policy-statement COMMUNITY_POLICY term T1 then community delete DELETED
 set policy-options policy-statement COMMUNITY_POLICY term T1 then community set SET
+set policy-options policy-statement COMMUNITY_POLICY term T1 then tunnel-attribute set SET
+set policy-options policy-statement COMMUNITY_POLICY term T1 then tunnel-attribute set UNDEFINED
 set policy-options policy-statement COMMUNITY_POLICY term T1 then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-references-in-policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-references-in-policy
@@ -9,6 +9,8 @@ set policy-options community DELETED members 1
 set policy-options community SET members 1
 set policy-options tunnel-attribute SET remote-end-point 1.1.1.1
 set policy-options tunnel-attribute SET tunnel-type ipip
+set policy-options tunnel-attribute REMOVE remote-end-point 1.1.1.1
+set policy-options tunnel-attribute REMOVE tunnel-type ipip
 set policy-options tunnel-attribute UNUSED remote-end-point 2.2.2.2
 set policy-options tunnel-attribute UNUSED tunnel-type ipip
 #
@@ -19,4 +21,6 @@ set policy-options policy-statement COMMUNITY_POLICY term T1 then community dele
 set policy-options policy-statement COMMUNITY_POLICY term T1 then community set SET
 set policy-options policy-statement COMMUNITY_POLICY term T1 then tunnel-attribute set SET
 set policy-options policy-statement COMMUNITY_POLICY term T1 then tunnel-attribute set UNDEFINED
+set policy-options policy-statement COMMUNITY_POLICY term T1 then tunnel-attribute remove REMOVE
+set policy-options policy-statement COMMUNITY_POLICY term T1 then tunnel-attribute remove UNDEFINED
 set policy-options policy-statement COMMUNITY_POLICY term T1 then accept


### PR DESCRIPTION
Adds support for the following `then` statements (inside or outside of a term):
```
set policy-options policy-statement PNAME then tunnel-attribute set TUNNEL_ATTR_NAME
set policy-options policy-statement PNAME then tunnel-attribute remove all
```
Not yet supported, but also valid:
```
set policy-options policy-statement PNAME then tunnel-attribute remove TUNNEL_ATTR_NAME
set policy-options policy-statement PNAME then tunnel-attribute TUNNEL_ATTR_NAME set
set policy-options policy-statement PNAME then tunnel-attribute TUNNEL_ATTR_NAME remove
```
After #8352.