### PR TITLE
DataPlane: switch from GenericRib to FinalMainRib

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/e2e/bgp/withdrawals/BUILD
+++ b/projects/allinone/src/test/java/org/batfish/e2e/bgp/withdrawals/BUILD
@@ -10,6 +10,7 @@ junit_tests(
     srcs = glob(["*Test.java"]),
     resources = ["//projects/allinone/src/test/resources/org/batfish/e2e/bgp/withdrawals"],
     deps = [
+        "//projects/batfish",
         "//projects/batfish:batfish_testlib",
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -34,9 +34,11 @@ public interface DataPlane extends Serializable {
   @Nonnull
   ForwardingAnalysis getForwardingAnalysis();
 
-  /** Return the set of all (main) RIBs. Map structure: hostname -&gt; VRF name -&gt; GenericRib */
+  /**
+   * Return the set of all (main) RIBs. Table structure: hostname -&gt; VRF name -&gt; FinalMainRib
+   */
   @Nonnull
-  SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> getRibs();
+  Table<String, String, FinalMainRib> getRibs();
 
   /**
    * Return the summary of route prefix propagation. Map structure: Hostname -&gt; VRF name -&gt;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FinalMainRib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FinalMainRib.java
@@ -1,0 +1,134 @@
+package org.batfish.datamodel;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nonnull;
+
+/**
+ * A version of {@link org.batfish.dataplane.rib.Rib} that is used for analyzing the main RIB after
+ * routing simulation is complete.
+ *
+ * <p>It omits things like {@link AnnotatedRoute annotations} of the contained routes, backup
+ * routes, and more.
+ */
+public final class FinalMainRib implements Serializable {
+  public static FinalMainRib of(Iterable<? extends AbstractRoute> routes) {
+    return of(StreamSupport.stream(routes.spliterator(), false));
+  }
+
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public static <T extends AbstractRoute> FinalMainRib of(T... routes) {
+    return of(Arrays.stream(routes));
+  }
+
+  public static FinalMainRib of(Stream<? extends AbstractRoute> routes) {
+    return new FinalMainRib(toPrefixTrie(routes));
+  }
+
+  /**
+   * Returns all the routes in this RIB.
+   *
+   * @see PrefixTrieMultiMap#getAllElements()
+   */
+  public @Nonnull Set<AbstractRoute> getRoutes() {
+    return _routeTree.getAllElements();
+  }
+
+  /**
+   * Returns all the routes in this RIB that advertise the given network.
+   *
+   * @see PrefixTrieMultiMap#get(Prefix)
+   */
+  public @Nonnull Set<AbstractRoute> getRoutes(Prefix p) {
+    return _routeTree.get(p);
+  }
+
+  /**
+   * Performs a longest prefix match on the route tree.
+   *
+   * @see PrefixTrieMultiMap#longestPrefixMatch(Ip)
+   */
+  public @Nonnull Set<AbstractRoute> longestPrefixMatch(@Nonnull Ip address) {
+    return _routeTree.longestPrefixMatch(address);
+  }
+
+  /**
+   * Performs a longest prefix match on the route tree.
+   *
+   * @see PrefixTrieMultiMap#longestPrefixMatch(Ip, int)
+   */
+  public @Nonnull Set<AbstractRoute> longestPrefixMatch(@Nonnull Prefix prefix) {
+    return _routeTree.longestPrefixMatch(prefix.getStartIp(), prefix.getPrefixLength());
+  }
+
+  //
+
+  private final PrefixTrieMultiMap<AbstractRoute> _routeTree;
+
+  private static PrefixTrieMultiMap<AbstractRoute> toPrefixTrie(
+      Stream<? extends AbstractRoute> routes) {
+    PrefixTrieMultiMap<AbstractRoute> ret = new PrefixTrieMultiMap<>();
+    List<AbstractRoute> curRoutes = new LinkedList<>();
+    Prefix[] curPrefix = new Prefix[] {null};
+    routes
+        .sequential() // forEach is not threadsafe
+        .forEach(
+            r -> {
+              if (curPrefix[0] == null) {
+                curPrefix[0] = r.getNetwork();
+              } else if (!r.getNetwork().equals(curPrefix[0])) {
+                ret.putAll(curPrefix[0], curRoutes);
+                curPrefix[0] = r.getNetwork();
+                curRoutes.clear();
+              }
+              curRoutes.add(r);
+            });
+    if (!curRoutes.isEmpty()) {
+      ret.putAll(curPrefix[0], curRoutes);
+    }
+    return ret;
+  }
+
+  private FinalMainRib(PrefixTrieMultiMap<AbstractRoute> tree) {
+    _routeTree = tree;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return new SerializedForm(_routeTree.getAllElements());
+  }
+
+  private static class SerializedForm implements Serializable {
+    final Set<AbstractRoute> _routes;
+
+    public SerializedForm(Set<AbstractRoute> routes) {
+      _routes = routes;
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+      return FinalMainRib.of(_routes);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof FinalMainRib)) {
+      return false;
+    }
+    FinalMainRib that = (FinalMainRib) o;
+    return _routeTree.equals(that._routeTree);
+  }
+
+  @Override
+  public int hashCode() {
+    return _routeTree.hashCode();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -535,21 +535,6 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     _root = null;
   }
 
-  /** Make and return a new (shallow) copy of this. */
-  public PrefixTrieMultiMap<T> copy() {
-    Node<T> root =
-        fold(
-            (prefix, elems, leftResult, rightResult) -> {
-              Node<T> ret = new Node<>(prefix, elems);
-              ret._left = leftResult;
-              ret._right = rightResult;
-              return ret;
-            });
-    PrefixTrieMultiMap<T> ret = new PrefixTrieMultiMap<>();
-    ret._root = root;
-    return ret;
-  }
-
   /**
    * Returns {@code true} iff there is any intersection between the prefixes that are keys of this
    * trie and the provided {@code prefixSpace}.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -1568,7 +1568,7 @@ public class FileBasedStorage implements StorageProvider {
                       dataPlane.getLayer2Vnis().row(hostname),
                       dataPlane.getLayer3Vnis().row(hostname),
                       dataPlane.getPrefixTracingInfoSummary().get(hostname),
-                      dataPlane.getRibs().get(hostname));
+                      dataPlane.getRibs().row(hostname));
               serializeObject(dp, getDataPlaneHostPath(snapshot, hostname));
             });
     serializeObject(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/PerHostDataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/PerHostDataPlane.java
@@ -5,12 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import javax.annotation.Nonnull;
-import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.Fib;
-import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
@@ -25,7 +23,7 @@ final class PerHostDataPlane implements Serializable {
   private final @Nonnull Map<String, Set<Layer3Vni>> _layer3Vnis;
   private final @Nonnull SortedMap<String, Map<Prefix, Map<String, Set<String>>>>
       _prefixTracingInfoSummary;
-  private final @Nonnull SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> _ribs;
+  private final @Nonnull Map<String, FinalMainRib> _ribs;
 
   public PerHostDataPlane(
       @Nonnull Map<String, Set<Bgpv4Route>> bgpRoutes,
@@ -36,7 +34,7 @@ final class PerHostDataPlane implements Serializable {
       @Nonnull Map<String, Set<Layer2Vni>> layer2Vnis,
       @Nonnull Map<String, Set<Layer3Vni>> layer3Vnis,
       @Nonnull SortedMap<String, Map<Prefix, Map<String, Set<String>>>> prefixTracingInfoSummary,
-      @Nonnull SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> ribs) {
+      @Nonnull Map<String, FinalMainRib> ribs) {
     _bgpRoutes = bgpRoutes;
     _bgpBackupRoutes = bgpBackupRoutes;
     _evpnRoutes = evpnRoutes;
@@ -81,7 +79,7 @@ final class PerHostDataPlane implements Serializable {
     return _prefixTracingInfoSummary;
   }
 
-  public @Nonnull SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> getRibs() {
+  public @Nonnull Map<String, FinalMainRib> getRibs() {
     return _ribs;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FinalMainRibTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FinalMainRibTest.java
@@ -1,0 +1,47 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class FinalMainRibTest {
+  @Test
+  public void testEquals() {
+    StaticRoute sr = StaticRoute.testBuilder().setNetwork(Prefix.ZERO).build();
+    StaticRoute sr2 = StaticRoute.testBuilder().setNetwork(Prefix.MULTICAST).build();
+    new EqualsTester()
+        .addEqualityGroup(FinalMainRib.of(sr), FinalMainRib.of(sr))
+        .addEqualityGroup(FinalMainRib.of(sr, sr2), FinalMainRib.of(sr2, sr))
+        .addEqualityGroup(FinalMainRib.of())
+        .testEquals();
+  }
+
+  @Test
+  public void testSerialization() {
+    FinalMainRib empty = FinalMainRib.of();
+    assertThat(empty, equalTo(SerializationUtils.clone(empty)));
+
+    FinalMainRib someRoutes =
+        FinalMainRib.of(
+            StaticRoute.testBuilder().setNetwork(Prefix.ZERO).build(),
+            StaticRoute.testBuilder().setNetwork(Prefix.parse("1.2.3.0/24")).build(),
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.parse("1.2.3.0/24"))
+                .setAdministrativeCost(5)
+                .build(),
+            StaticRoute.testBuilder().setNetwork(Prefix.parse("1.2.3.4/28")).build());
+    assertThat(someRoutes.getRoutes(), hasSize(4));
+    assertThat(someRoutes.getRoutes(Prefix.MULTICAST), empty());
+    assertThat(someRoutes.getRoutes(Prefix.ZERO), hasSize(1));
+    assertThat(someRoutes.getRoutes(Prefix.parse("1.2.3.0/24")), hasSize(2));
+    assertThat(someRoutes, equalTo(SerializationUtils.clone(someRoutes)));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -24,8 +24,7 @@ public class MockDataPlane implements DataPlane {
     @Nonnull private Table<String, String, Set<Layer3Vni>> _layer3VniSettings;
     private @Nonnull SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
         _prefixTracingInfoSummary;
-    private @Nonnull SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
-        _ribs;
+    private @Nonnull Table<String, String, FinalMainRib> _ribs;
 
     private Builder() {
       _bgpRoutes = ImmutableTable.of();
@@ -37,7 +36,7 @@ public class MockDataPlane implements DataPlane {
       _layer2VniSettings = ImmutableTable.of();
       _layer3VniSettings = ImmutableTable.of();
       _prefixTracingInfoSummary = ImmutableSortedMap.of();
-      _ribs = ImmutableSortedMap.of();
+      _ribs = ImmutableTable.of();
     }
 
     public MockDataPlane build() {
@@ -96,8 +95,7 @@ public class MockDataPlane implements DataPlane {
       return this;
     }
 
-    public Builder setRibs(
-        SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs) {
+    public Builder setRibs(Table<String, String, FinalMainRib> ribs) {
       _ribs = ribs;
       return this;
     }
@@ -118,9 +116,7 @@ public class MockDataPlane implements DataPlane {
   @Nonnull private final Table<String, String, Set<Layer3Vni>> _layer3VniSettings;
   private final @Nonnull SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
       _prefixTracingInfoSummary;
-  private final @Nonnull SortedMap<
-          String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
-      _ribs;
+  private final @Nonnull Table<String, String, FinalMainRib> _ribs;
 
   private MockDataPlane(Builder builder) {
     _bgpRoutes = builder._bgpRoutes;
@@ -132,7 +128,7 @@ public class MockDataPlane implements DataPlane {
     _layer2VniSettings = builder._layer2VniSettings;
     _layer3VniSettings = builder._layer3VniSettings;
     _prefixTracingInfoSummary = builder._prefixTracingInfoSummary;
-    _ribs = ImmutableSortedMap.copyOf(builder._ribs);
+    _ribs = ImmutableTable.copyOf(builder._ribs);
   }
 
   @Nonnull
@@ -172,7 +168,7 @@ public class MockDataPlane implements DataPlane {
 
   @Nonnull
   @Override
-  public SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> getRibs() {
+  public Table<String, String, FinalMainRib> getRibs() {
     return _ribs;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -522,7 +522,8 @@ public class PrefixTrieMultiMapTest {
     assertEquals(ImmutableSet.of(p123), getOverlappingKeys.apply("1.2.3.5/32"));
   }
 
-  private static PrefixTrieMultiMap<Integer> makeTestMap() {
+  @Test
+  public void testSerialization() {
     PrefixTrieMultiMap<Integer> ptmm = new PrefixTrieMultiMap<>();
     int i = 0;
     ptmm.put(Prefix.ZERO, ++i);
@@ -533,19 +534,7 @@ public class PrefixTrieMultiMapTest {
     ptmm.put(Prefix.parse("10.0.0.64/26"), ++i);
     ptmm.put(Prefix.parse("20.0.0.0/8"), ++i);
     ptmm.put(Prefix.parse("192.168.0.0/16"), ++i);
-    return ptmm;
-  }
-
-  @Test
-  public void testSerialization() {
-    PrefixTrieMultiMap<Integer> ptmm = makeTestMap();
     assertThat(ptmm, equalTo(SerializationUtils.clone(ptmm)));
-  }
-
-  @Test
-  public void testCopy() {
-    PrefixTrieMultiMap<Integer> ptmm = makeTestMap();
-    assertThat(ptmm, equalTo(ptmm.copy()));
   }
 
   private static RangeSet<Ip> toRangeSet(Prefix prefix) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -69,12 +69,12 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.EvpnType5Route;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MockDataPlane;
 import org.batfish.datamodel.MockFib;
 import org.batfish.datamodel.MockForwardingAnalysis;
-import org.batfish.datamodel.MockRib;
 import org.batfish.datamodel.OriginMechanism;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
@@ -975,8 +975,7 @@ public final class FileBasedStorageTest {
             .setLayer3VniSettings(ImmutableTable.of("n", "v3", ImmutableSet.of()))
             .setPrefixTracingInfoSummary(
                 ImmutableSortedMap.of("n", ImmutableSortedMap.of("vp", ImmutableMap.of())))
-            .setRibs(
-                ImmutableSortedMap.of("n", ImmutableSortedMap.of("vr", MockRib.builder().build())))
+            .setRibs(ImmutableTable.of("n", "vr", FinalMainRib.of()))
             .build();
 
     _storage.storeDataPlane(dp, snapshot);
@@ -996,6 +995,6 @@ public final class FileBasedStorageTest {
     assertThat(dp2.getLayer2Vnis().rowMap(), hasEntry(equalTo("n"), hasKey("v2")));
     assertThat(dp2.getLayer3Vnis().rowMap(), hasEntry(equalTo("n"), hasKey("v3")));
     assertThat(dp2.getPrefixTracingInfoSummary(), hasEntry(equalTo("n"), hasKey("vp")));
-    assertThat(dp2.getRibs(), hasEntry(equalTo("n"), hasKey("vr")));
+    assertThat(dp2.getRibs().rowMap(), hasEntry(equalTo("n"), hasKey("vr")));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
@@ -1,7 +1,6 @@
 package org.batfish.dataplane.ibdp;
 
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
-import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.specifier.LocationInfoUtils.computeLocationInfo;
 
 import com.google.common.collect.ImmutableMap;
@@ -16,21 +15,17 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.batfish.common.topology.IpOwners;
-import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.ForwardingAnalysisImpl;
-import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
@@ -66,18 +61,6 @@ public final class DataplaneUtil {
     LOGGER.info("Computing location info");
     Map<Location, LocationInfo> locationInfo = computeLocationInfo(ipOwners, configs);
     return new ForwardingAnalysisImpl(configs, fibs, layer3Topology, locationInfo, ipOwners);
-  }
-
-  static @Nonnull SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
-      computeRibs(Map<String, Node> nodes) {
-    return toImmutableSortedMap(
-        nodes,
-        Entry::getKey,
-        nodeEntry ->
-            toImmutableSortedMap(
-                nodeEntry.getValue().getVirtualRouters(),
-                VirtualRouter::getName,
-                VirtualRouter::getMainRib));
   }
 
   static @Nonnull Table<String, String, Set<Bgpv4Route>> computeBgpRoutes(List<VirtualRouter> vrs) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -913,7 +913,7 @@ final class IncrementalBdpEngine {
       IncrementalDataPlane dp) {
     // Scan through all Nodes and their virtual routers, retrieve main rib routes
     return toImmutableSortedMap(
-        dp.getRibs(),
+        dp.getRibsForTesting(),
         Entry::getKey,
         nodeEntry ->
             toImmutableSortedMap(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/PartialDataplane.java
@@ -17,15 +17,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.L3Adjacencies;
-import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.ForwardingAnalysis;
-import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.vxlan.Layer2Vni;
@@ -93,8 +91,7 @@ public final class PartialDataplane implements DataPlane {
   }
 
   @Override
-  public @Nonnull SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
-      getRibs() {
+  public @Nonnull Table<String, String, FinalMainRib> getRibs() {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -128,8 +128,6 @@ import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.isp.IspModelingUtils;
 import org.batfish.common.util.isp.IspModelingUtils.ModeledNodes;
 import org.batfish.config.Settings;
-import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
@@ -139,10 +137,10 @@ import org.batfish.datamodel.DeviceType;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.ForwardingAnalysis;
-import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Interface.Dependency;
@@ -687,8 +685,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
         }
 
         @Override
-        public SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
-            getRibs() {
+        public Table<String, String, FinalMainRib> getRibs() {
           throw new UnsupportedOperationException();
         }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/A10KernelRouteTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/A10KernelRouteTest.java
@@ -20,6 +20,7 @@ import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.KernelRoute;
 import org.batfish.datamodel.Prefix;
+import org.batfish.dataplane.ibdp.IncrementalDataPlane;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
@@ -51,13 +52,13 @@ public final class A10KernelRouteTest {
    *    ethernet1 ethernet1
    *    .1  10.0.1.0/24  .2
    *           bgp
-   * - There is a BGP session betwen r1 and r2 on ethernet1
+   * - There is a BGP session between r1 and r2 on ethernet1
    * - There is vrrp-a between r1 and r2 on ethernet2
    * - r1 and r2 both have a floating-ip 10.0.1.10
    * - r1 and r2 redistribute floating IPs into BGP
    * - r1 has higher priority, so:
    *   - 10.0.1.10/32 should appear in r1's BGP RIB as a local route
-   *   - 10.0.1.10/32 should appear in r2's BGP RIB as a receeived route route
+   *   - 10.0.1.10/32 should appear in r2's BGP RIB as a received route route
    */
   @Before
   public void setup() throws IOException {
@@ -75,10 +76,10 @@ public final class A10KernelRouteTest {
 
   @Test
   public void testMainRibRoutes() {
-    DataPlane dp = _batfish.loadDataPlane(_batfish.getSnapshot());
+    IncrementalDataPlane dp = (IncrementalDataPlane) _batfish.loadDataPlane(_batfish.getSnapshot());
 
     assertThat(
-        dp.getRibs().get("r1").get(DEFAULT_VRF_NAME).getRoutes(KERNEL_PREFIX).stream()
+        dp.getRibsForTesting().get("r1").get(DEFAULT_VRF_NAME).getRoutes(KERNEL_PREFIX).stream()
             .map(AnnotatedRoute::getAbstractRoute)
             .collect(ImmutableSet.toImmutableSet()),
         contains(
@@ -88,7 +89,7 @@ public final class A10KernelRouteTest {
                 .setNetwork(KERNEL_PREFIX)
                 .build()));
     assertThat(
-        dp.getRibs().get("r2").get(DEFAULT_VRF_NAME).getRoutes(KERNEL_PREFIX).stream()
+        dp.getRibsForTesting().get("r2").get(DEFAULT_VRF_NAME).getRoutes(KERNEL_PREFIX).stream()
             .map(AnnotatedRoute::getAbstractRoute)
             .collect(ImmutableSet.toImmutableSet()),
         contains(isBgpv4RouteThat(allOf(hasAsPath(equalTo(AsPath.ofSingletonAsSets(1L)))))));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/BgpRibGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/BgpRibGroupsTest.java
@@ -22,7 +22,6 @@ import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
-import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
@@ -43,6 +42,7 @@ import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.batfish.dataplane.ibdp.IncrementalDataPlane;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.junit.Rule;
@@ -268,11 +268,11 @@ public class BgpRibGroupsTest {
 
     Batfish batfish = BatfishTestUtils.getBatfish(configs, folder);
     batfish.computeDataPlane(batfish.getSnapshot());
-    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
 
     // Only 2.2.2.0/24 in VRF2
     Set<AnnotatedRoute<AbstractRoute>> vrf2Routes =
-        dp.getRibs().get("r1").get(VRF_2).getTypedRoutes();
+        dp.getRibsForTesting().get("r1").get(VRF_2).getTypedRoutes();
     assertThat(vrf2Routes, hasSize(1));
     assertThat(
         vrf2Routes,
@@ -295,7 +295,7 @@ public class BgpRibGroupsTest {
 
     // 3.3.3.0/24 as expected in default VRF
     Set<AnnotatedRoute<AbstractRoute>> defaultVrfRoutes =
-        dp.getRibs().get("r1").get(Configuration.DEFAULT_VRF_NAME).getTypedRoutes();
+        dp.getRibsForTesting().get("r1").get(Configuration.DEFAULT_VRF_NAME).getTypedRoutes();
     assertThat(
         defaultVrfRoutes,
         hasItem(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/DynamicBgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/DynamicBgpTest.java
@@ -11,13 +11,11 @@ import com.google.common.graph.ValueGraph;
 import java.io.IOException;
 import java.util.List;
 import org.batfish.common.NetworkSnapshot;
-import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Prefix;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
@@ -65,8 +63,7 @@ public class DynamicBgpTest {
     assertThat(bgpTopology.edges(), hasSize(6));
 
     // Ensure routing info has been exchanged, and routes from r3/r4 exist on r1
-    GenericRib<AnnotatedRoute<AbstractRoute>> r1Rib =
-        dp.getRibs().get("r1").get(Configuration.DEFAULT_VRF_NAME);
+    FinalMainRib r1Rib = dp.getRibs().get("r1", Configuration.DEFAULT_VRF_NAME);
     assertThat(r1Rib.getRoutes(), hasItem(hasPrefix(Prefix.parse("9.9.9.33/32"))));
     assertThat(r1Rib.getRoutes(), hasItem(hasPrefix(Prefix.parse("9.9.9.44/32"))));
   }
@@ -96,8 +93,7 @@ public class DynamicBgpTest {
     assertThat(bgpTopology.edges(), hasSize(6));
 
     // Ensure routing info has been exchanged, and routes from r3/r4 exist on r1
-    GenericRib<AnnotatedRoute<AbstractRoute>> r1Rib =
-        dp.getRibs().get("r1").get(Configuration.DEFAULT_VRF_NAME);
+    FinalMainRib r1Rib = dp.getRibs().get("r1", Configuration.DEFAULT_VRF_NAME);
     assertThat(r1Rib.getRoutes(), hasItem(hasPrefix(Prefix.parse("3.3.3.3/32"))));
     assertThat(r1Rib.getRoutes(), hasItem(hasPrefix(Prefix.parse("4.4.4.4/32"))));
   }
@@ -138,8 +134,7 @@ public class DynamicBgpTest {
     assertThat(bgpTopology.edges(), hasSize(4));
 
     // Ensure routing info has been exchanged, and routes from r3/r4 exist on r1
-    GenericRib<AnnotatedRoute<AbstractRoute>> r1Rib =
-        dp.getRibs().get("r1").get(Configuration.DEFAULT_VRF_NAME);
+    FinalMainRib r1Rib = dp.getRibs().get("r1", Configuration.DEFAULT_VRF_NAME);
     assertThat(r1Rib.getRoutes(), hasItem(hasPrefix(Prefix.parse("9.9.9.33/32"))));
     assertThat(r1Rib.getRoutes(), not(hasItem(hasPrefix(Prefix.parse("9.9.9.44/32")))));
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EigrpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EigrpTest.java
@@ -1,6 +1,5 @@
 package org.batfish.dataplane;
 
-import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasMetric;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHopIp;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
@@ -11,18 +10,15 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Table;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
-import java.util.SortedMap;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
@@ -54,7 +50,7 @@ public class EigrpTest {
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
 
-    Map<String, Map<String, Set<AbstractRoute>>> routes = getRoutes(dp.getRibs());
+    Table<String, String, FinalMainRib> ribs = dp.getRibs();
 
     ////////////////////////
     // All assertions based on GNS3 and output of "show ip route"
@@ -69,56 +65,56 @@ public class EigrpTest {
       String node = "dc1lan";
       // 172.16.1.1 is connected.
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.2.1/32"),
           RoutingProtocol.EIGRP,
           130816,
           Ip.parse("11.11.11.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.3.1/32"),
           RoutingProtocol.EIGRP,
           131072,
           Ip.parse("11.11.11.2"));
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("172.16.4.1/32"),
       //          RoutingProtocol.EIGRP_EX,
       //          5632,
       //          Ip.parse("11.11.11.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.5.1/32"),
           RoutingProtocol.EIGRP_EX,
           5632,
           Ip.parse("11.11.11.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.6.1/32"),
           RoutingProtocol.EIGRP_EX,
           5632,
           Ip.parse("11.11.11.2"));
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("33.33.33.0/24"),
       //          RoutingProtocol.EIGRP_EX,
       //          5632,
       //          Ip.parse("11.11.11.2"));
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("44.44.44.0/24"),
       //          RoutingProtocol.EIGRP_EX,
       //          5632,
       //          Ip.parse("11.11.11.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("55.55.55.0/24"),
           RoutingProtocol.EIGRP_EX,
@@ -132,7 +128,7 @@ public class EigrpTest {
     {
       String node = "dc1";
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.1.1/32"),
           RoutingProtocol.EIGRP,
@@ -140,7 +136,7 @@ public class EigrpTest {
           Ip.parse("11.11.11.1"));
       // 172.16.1.2 is connected.
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.3.1/32"),
           RoutingProtocol.EIGRP,
@@ -148,21 +144,21 @@ public class EigrpTest {
           Ip.parse("22.22.22.2"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("172.16.4.1/32"),
       //          RoutingProtocol.EIGRP_EX,
       //          5376,
       //          Ip.parse("22.22.22.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.5.1/32"),
           RoutingProtocol.EIGRP_EX,
           5376,
           Ip.parse("22.22.22.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.6.1/32"),
           RoutingProtocol.EIGRP_EX,
@@ -170,7 +166,7 @@ public class EigrpTest {
           Ip.parse("22.22.22.2"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("33.33.33.0/24"),
       //          RoutingProtocol.EIGRP_EX,
@@ -178,14 +174,14 @@ public class EigrpTest {
       //          Ip.parse("22.22.22.2"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("44.44.44.0/24"),
       //          RoutingProtocol.EIGRP_EX,
       //          5376,
       //          Ip.parse("22.22.22.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("55.55.55.0/24"),
           RoutingProtocol.EIGRP_EX,
@@ -199,14 +195,14 @@ public class EigrpTest {
     {
       String node = "dc1border";
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.1.1/32"),
           RoutingProtocol.EIGRP,
           131072,
           Ip.parse("22.22.22.1"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.2.1/32"),
           RoutingProtocol.EIGRP,
@@ -215,21 +211,21 @@ public class EigrpTest {
       // 172.16.3.1 is connected.
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("172.16.4.1/32"),
       //          RoutingProtocol.EIGRP_EX,
       //          61440,
       //          Ip.parse("33.33.33.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.5.1/32"),
           RoutingProtocol.EIGRP_EX,
           61440,
           Ip.parse("33.33.33.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.6.1/32"),
           RoutingProtocol.EIGRP_EX,
@@ -237,7 +233,7 @@ public class EigrpTest {
           Ip.parse("33.33.33.2"));
 
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("11.11.11.0/24"),
           RoutingProtocol.EIGRP,
@@ -245,14 +241,14 @@ public class EigrpTest {
           Ip.parse("22.22.22.1"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("44.44.44.0/24"),
       //          RoutingProtocol.EIGRP_EX,
       //          61440,
       //          Ip.parse("33.33.33.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("55.55.55.0/24"),
           RoutingProtocol.EIGRP_EX,
@@ -266,14 +262,14 @@ public class EigrpTest {
     {
       String node = "dc2border";
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.1.1/32"),
           RoutingProtocol.EIGRP_EX,
           61440,
           Ip.parse("33.33.33.1"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.2.1/32"),
           RoutingProtocol.EIGRP_EX,
@@ -281,7 +277,7 @@ public class EigrpTest {
           Ip.parse("33.33.33.1"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("172.16.3.1/32"),
       //          RoutingProtocol.EIGRP_EX,
@@ -289,14 +285,14 @@ public class EigrpTest {
       //          Ip.parse("33.33.33.1"));
       // 172.16.4.1 is connected.
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.5.1/32"),
           RoutingProtocol.EIGRP,
           130816,
           Ip.parse("44.44.44.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.6.1/32"),
           RoutingProtocol.EIGRP,
@@ -304,7 +300,7 @@ public class EigrpTest {
           Ip.parse("44.44.44.2"));
 
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("11.11.11.0/24"),
           RoutingProtocol.EIGRP_EX,
@@ -312,7 +308,7 @@ public class EigrpTest {
           Ip.parse("33.33.33.1"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("22.22.22.0/24"),
       //          RoutingProtocol.EIGRP_EX,
@@ -326,14 +322,14 @@ public class EigrpTest {
     {
       String node = "dc2";
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.1.1/32"),
           RoutingProtocol.EIGRP_EX,
           5376,
           Ip.parse("44.44.44.1"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.2.1/32"),
           RoutingProtocol.EIGRP_EX,
@@ -341,7 +337,7 @@ public class EigrpTest {
           Ip.parse("44.44.44.1"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("172.16.3.1/32"),
       //          RoutingProtocol.EIGRP_EX,
@@ -349,7 +345,7 @@ public class EigrpTest {
       //          Ip.parse("44.44.44.1"));
 
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.4.1/32"),
           RoutingProtocol.EIGRP,
@@ -357,7 +353,7 @@ public class EigrpTest {
           Ip.parse("44.44.44.1"));
       // 172.16.5.1 is connected.
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.6.1/32"),
           RoutingProtocol.EIGRP,
@@ -365,7 +361,7 @@ public class EigrpTest {
           Ip.parse("55.55.55.1"));
 
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("11.11.11.0/24"),
           RoutingProtocol.EIGRP_EX,
@@ -373,7 +369,7 @@ public class EigrpTest {
           Ip.parse("44.44.44.1"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("22.22.22.0/24"),
       //          RoutingProtocol.EIGRP_EX,
@@ -381,7 +377,7 @@ public class EigrpTest {
       //          Ip.parse("44.44.44.1"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("33.33.33.0/24"),
       //          RoutingProtocol.EIGRP_EX,
@@ -395,14 +391,14 @@ public class EigrpTest {
     {
       String node = "dc2lan";
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.1.1/32"),
           RoutingProtocol.EIGRP_EX,
           5632,
           Ip.parse("55.55.55.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.2.1/32"),
           RoutingProtocol.EIGRP_EX,
@@ -410,7 +406,7 @@ public class EigrpTest {
           Ip.parse("55.55.55.2"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("172.16.3.1/32"),
       //          RoutingProtocol.EIGRP_EX,
@@ -418,14 +414,14 @@ public class EigrpTest {
       //          Ip.parse("55.55.55.2"));
 
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.4.1/32"),
           RoutingProtocol.EIGRP,
           131072,
           Ip.parse("55.55.55.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("172.16.5.1/32"),
           RoutingProtocol.EIGRP,
@@ -434,7 +430,7 @@ public class EigrpTest {
       // 172.16.6.1 is connected.
 
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("11.11.11.0/24"),
           RoutingProtocol.EIGRP_EX,
@@ -442,7 +438,7 @@ public class EigrpTest {
           Ip.parse("55.55.55.2"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("22.22.22.0/24"),
       //          RoutingProtocol.EIGRP_EX,
@@ -450,14 +446,14 @@ public class EigrpTest {
       //          Ip.parse("55.55.55.2"));
       // missing
       //      assertRoute(
-      //          routes,
+      //          ribs,
       //          node,
       //          Prefix.parse("33.33.33.0/24"),
       //          RoutingProtocol.EIGRP_EX,
       //          5632,
       //          Ip.parse("55.55.55.2"));
       assertRoute(
-          routes,
+          ribs,
           node,
           Prefix.parse("44.44.44.0/24"),
           RoutingProtocol.EIGRP,
@@ -467,13 +463,13 @@ public class EigrpTest {
   }
 
   private void assertRoute(
-      Map<String, Map<String, Set<AbstractRoute>>> allRoutes,
+      Table<String, String, FinalMainRib> allRoutes,
       String node,
       Prefix prefix,
       RoutingProtocol protocol,
       long metric,
       @Nullable Ip nextHopIp) {
-    Set<AbstractRoute> routes = allRoutes.get(node).get(Configuration.DEFAULT_VRF_NAME);
+    Set<AbstractRoute> routes = allRoutes.get(node, Configuration.DEFAULT_VRF_NAME).getRoutes();
     assertThat(
         routes,
         hasItem(
@@ -482,15 +478,5 @@ public class EigrpTest {
                 hasProtocol(protocol),
                 hasMetric(metric),
                 nextHopIp != null ? hasNextHopIp(nextHopIp) : hasNextHopIp(anything()))));
-  }
-
-  private Map<String, Map<String, Set<AbstractRoute>>> getRoutes(
-      SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs) {
-    return toImmutableMap(
-        ribs,
-        Entry::getKey,
-        nodeEntry ->
-            toImmutableMap(
-                nodeEntry.getValue(), Entry::getKey, vrfEntry -> vrfEntry.getValue().getRoutes()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnNxosOneSidedTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnNxosOneSidedTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Edge;
@@ -122,10 +121,8 @@ public class EvpnNxosOneSidedTest {
             allOf(hasPrefix(Prefix.strict("10.0.2.0/24")), hasNextHop(NextHopDiscard.instance()))));
 
     // test main RIB routes
-    Set<AnnotatedRoute<AbstractRoute>> r1Routes =
-        dp.getRibs().get("r1").get(TENANT_VRF_NAME).getTypedRoutes();
-    Set<AnnotatedRoute<AbstractRoute>> r2Routes =
-        dp.getRibs().get("r2").get(TENANT_VRF_NAME).getTypedRoutes();
+    Set<AbstractRoute> r1Routes = dp.getRibs().get("r1", TENANT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r2Routes = dp.getRibs().get("r2", TENANT_VRF_NAME).getRoutes();
 
     assertThat(
         r1Routes,

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnNxosTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnNxosTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Edge;
@@ -128,10 +127,8 @@ public class EvpnNxosTest {
                 hasNextHop(NextHopVtep.of(L3VNI, Ip.parse("10.0.4.1"))))));
 
     // test main RIB routes
-    Set<AnnotatedRoute<AbstractRoute>> r1Routes =
-        dp.getRibs().get("r1").get(TENANT_VRF_NAME).getTypedRoutes();
-    Set<AnnotatedRoute<AbstractRoute>> r2Routes =
-        dp.getRibs().get("r2").get(TENANT_VRF_NAME).getTypedRoutes();
+    Set<AbstractRoute> r1Routes = dp.getRibs().get("r1", TENANT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r2Routes = dp.getRibs().get("r2", TENANT_VRF_NAME).getRoutes();
 
     assertThat(
         r1Routes,

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
@@ -22,7 +22,6 @@ import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConnectedRoute;
-import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.EvpnType5Route;
 import org.batfish.datamodel.GenericRib;
@@ -36,6 +35,7 @@ import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.batfish.dataplane.ibdp.IncrementalDataPlane;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.representation.arista.AristaConfiguration;
@@ -62,7 +62,7 @@ public class EvpnType5AristaTest {
     Batfish batfish =
         BatfishTestUtils.getBatfishForTextConfigs(_folder, TESTCONFIGS_PATH + hostname);
     batfish.computeDataPlane(batfish.getSnapshot()); // compute and cache the dataPlane
-    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
     String vrf1 = "vrf1";
     String vrf2 = "vrf2";
     Ip originatorIp = Ip.parse("12.12.12.2"); // IP of BGP route originator
@@ -70,7 +70,8 @@ public class EvpnType5AristaTest {
 
     // The connected route that vrf1 redistributes into BGP should be a connected route in vrf1, an
     // EVPN route in the default VRF (so no appearance in main RIB), and a BGPv4 route in vrf2.
-    SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> ribs = dp.getRibs().get(hostname);
+    SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>> ribs =
+        dp.getRibsForTesting().get(hostname);
     assertThat(ribs.get(DEFAULT_VRF_NAME).getRoutes(prefix), empty());
     assertThat(
         ribs.get(vrf1).getRoutes(prefix), contains(hasRoute(instanceOf(ConnectedRoute.class))));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5CumulusTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5CumulusTest.java
@@ -10,15 +10,14 @@ import static org.hamcrest.Matchers.hasItem;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.main.Batfish;
@@ -50,8 +49,7 @@ public class EvpnType5CumulusTest {
     batfish.computeDataPlane(batfish.getSnapshot()); // compute and cache the dataPlane
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
 
-    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
-        dp.getRibs();
+    Table<String, String, FinalMainRib> ribs = dp.getRibs();
     String vrf1 = "vrf1";
     final ImmutableList<String> leafs = ImmutableList.of("leaf1", "leaf2", "leaf3", "leaf4");
 
@@ -71,7 +69,7 @@ public class EvpnType5CumulusTest {
             ImmutableSet.of("swp4", "swp14"));
 
     for (String leaf : leafs) {
-      Set<AbstractRoute> routes = ribs.get(leaf).get(vrf1).getRoutes();
+      Set<AbstractRoute> routes = ribs.get(leaf, vrf1).getRoutes();
       for (Prefix prefix : prefixes) {
         for (String nextHopIface : nextHopInterfaces.get(leaf)) {
           assertThat(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/HmmTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/HmmTest.java
@@ -12,7 +12,6 @@ import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Set;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Prefix;
@@ -65,8 +64,7 @@ public class HmmTest {
     DataPlane dp = _batfish.loadDataPlane(_batfish.getSnapshot());
 
     // test main RIB routes
-    Set<AnnotatedRoute<AbstractRoute>> r1Routes =
-        dp.getRibs().get("r1").get(DEFAULT_VRF_NAME).getTypedRoutes();
+    Set<AbstractRoute> r1Routes = dp.getRibs().get("r1", DEFAULT_VRF_NAME).getRoutes();
 
     assertThat(
         r1Routes,

--- a/projects/batfish/src/test/java/org/batfish/dataplane/RipAndBgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/RipAndBgpTest.java
@@ -4,15 +4,13 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
 import java.io.IOException;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.stream.Collectors;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.main.Batfish;
@@ -42,12 +40,11 @@ public class RipAndBgpTest {
                 .build(),
             _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
-    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
-    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
-        dp.getRibs();
-    Set<AbstractRoute> r1Routes = ribs.get("r1").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> r2Routes = ribs.get("r2").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> r3Routes = ribs.get("r3").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+    Table<String, String, FinalMainRib> ribs =
+        batfish.loadDataPlane(batfish.getSnapshot()).getRibs();
+    Set<AbstractRoute> r1Routes = ribs.get("r1", Configuration.DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r2Routes = ribs.get("r2", Configuration.DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r3Routes = ribs.get("r3", Configuration.DEFAULT_VRF_NAME).getRoutes();
     Set<Prefix> r1Prefixes =
         r1Routes.stream()
             .filter(route -> route.getProtocol() != RoutingProtocol.LOCAL)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
@@ -116,9 +116,10 @@ public class TracerouteEngineTest {
     Batfish batfish = BatfishTestUtils.getBatfish(configs, _tempFolder);
     NetworkSnapshot snapshot = batfish.getSnapshot();
     batfish.computeDataPlane(snapshot);
-    DataPlane dp = batfish.loadDataPlane(snapshot); // Construct flows
-    Builder fb = builder().setDstIp(parse("3.3.3.3")).setIngressNode(config.getHostname());
+    DataPlane dp = batfish.loadDataPlane(snapshot);
 
+    // Construct flows
+    Builder fb = builder().setDstIp(parse("3.3.3.3")).setIngressNode(config.getHostname());
     Flow flow1 = fb.setIngressInterface(i1.getName()).setIngressVrf(vrf1.getName()).build();
     Flow flow2 = fb.setIngressInterface(i2.getName()).setIngressVrf(vrf2.getName()).build();
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/TrackTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/TrackTest.java
@@ -11,7 +11,6 @@ import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Set;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Prefix;
@@ -69,12 +68,11 @@ public class TrackTest {
     DataPlane dp = _batfish.loadDataPlane(_batfish.getSnapshot());
 
     // test main RIB routes
-    Set<AnnotatedRoute<AbstractRoute>> r1Routes =
-        dp.getRibs().get("r1").get(DEFAULT_VRF_NAME).getTypedRoutes();
+    Set<AbstractRoute> r1Routes = dp.getRibs().get("r1", DEFAULT_VRF_NAME).getRoutes();
 
     assertThat(
         r1Routes.stream()
-            .filter(r -> r.getRoute().getProtocol() == RoutingProtocol.STATIC)
+            .filter(r -> r.getProtocol() == RoutingProtocol.STATIC)
             .collect(ImmutableList.toImmutableList()),
         containsInAnyOrder(
             hasPrefix(Prefix.strict("10.0.1.0/24")),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
@@ -217,7 +217,7 @@ public class EvpnTest {
         (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
     Table<String, String, Set<EvpnRoute<?, ?>>> evpnRoutes = dataplane.getEvpnRoutes();
     SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> mainRibRoutes =
-        dataplane.getRibs();
+        dataplane.getRibsForTesting();
 
     String vrf1 = "vrf1";
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Table;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.ValueGraph;
 import java.io.IOException;
@@ -47,7 +48,6 @@ import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.common.topology.IpOwnersBaseImpl;
 import org.batfish.common.topology.L3Adjacencies;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -59,11 +59,11 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.GeneratedRoute.Builder;
-import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
@@ -333,9 +333,9 @@ public class IncrementalDataPlanePluginTest {
 
     // Check main RIB routes
     Set<AbstractRoute> r2MainRibRoutes =
-        dataplane.getRibs().get("r2").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+        dataplane.getRibs().get("r2", Configuration.DEFAULT_VRF_NAME).getRoutes();
     Set<AbstractRoute> r3MainRibRoutes =
-        dataplane.getRibs().get("r3").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+        dataplane.getRibs().get("r3", Configuration.DEFAULT_VRF_NAME).getRoutes();
     assertThat(
         r2MainRibRoutes, hasItem(allOf(hasPrefix(advPrefix), hasProtocol(RoutingProtocol.STATIC))));
     assertThat(
@@ -359,11 +359,10 @@ public class IncrementalDataPlanePluginTest {
     IncrementalDataPlanePlugin dataPlanePlugin = new IncrementalDataPlanePlugin();
     dataPlanePlugin.initialize(batfish);
     ComputeDataPlaneResult dp = dataPlanePlugin.computeDataPlane(batfish.getSnapshot());
-    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
-        dp._dataPlane.getRibs();
+    Table<String, String, FinalMainRib> ribs = dp._dataPlane.getRibs();
 
-    Set<AbstractRoute> r1Routes = ribs.get("r1").get(DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> r3Routes = ribs.get("r3").get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r1Routes = ribs.get("r1", DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r3Routes = ribs.get("r3", DEFAULT_VRF_NAME).getRoutes();
     Set<Prefix> r1Prefixes =
         r1Routes.stream().map(AbstractRoute::getNetwork).collect(Collectors.toSet());
     Set<Prefix> r3Prefixes =
@@ -405,11 +404,10 @@ public class IncrementalDataPlanePluginTest {
             _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
-    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
-        dp.getRibs();
+    Table<String, String, FinalMainRib> ribs = dp.getRibs();
 
-    Set<AbstractRoute> r1Routes = ribs.get("r1").get(DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> r3Routes = ribs.get("r3").get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r1Routes = ribs.get("r1", DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r3Routes = ribs.get("r3", DEFAULT_VRF_NAME).getRoutes();
 
     // r1 and r3's respective static routes were redistributed into BGP and reached each other
     Prefix r1StaticPrefix = Prefix.parse("21.21.21.21/32");
@@ -434,11 +432,10 @@ public class IncrementalDataPlanePluginTest {
             _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
-    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
-        dp.getRibs();
+    Table<String, String, FinalMainRib> ribs = dp.getRibs();
 
-    Set<AbstractRoute> r1Routes = ribs.get("r1").get(DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> r3Routes = ribs.get("r3").get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r1Routes = ribs.get("r1", DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r3Routes = ribs.get("r3", DEFAULT_VRF_NAME).getRoutes();
 
     // r1 and r3's respective static routes were redistributed into BGP and reached each other
     Prefix r1StaticPrefix = Prefix.parse("21.21.21.21/32");
@@ -463,10 +460,9 @@ public class IncrementalDataPlanePluginTest {
     batfish.getSettings().setDataplaneEngineName(IncrementalDataPlanePlugin.PLUGIN_NAME);
     DataPlanePlugin dataPlanePlugin = batfish.getDataPlanePlugin();
     ComputeDataPlaneResult dp = dataPlanePlugin.computeDataPlane(batfish.getSnapshot());
-    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
-        dp._dataPlane.getRibs();
-    Set<AbstractRoute> r2aRoutes = ribs.get("r2a").get(DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> r2bRoutes = ribs.get("r2b").get(DEFAULT_VRF_NAME).getRoutes();
+    Table<String, String, FinalMainRib> ribs = dp._dataPlane.getRibs();
+    Set<AbstractRoute> r2aRoutes = ribs.get("r2a", DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r2bRoutes = ribs.get("r2b", DEFAULT_VRF_NAME).getRoutes();
     Set<Prefix> r2aPrefixes =
         r2aRoutes.stream().map(AbstractRoute::getNetwork).collect(Collectors.toSet());
     Set<Prefix> r2bPrefixes =
@@ -501,11 +497,10 @@ public class IncrementalDataPlanePluginTest {
     batfish.getSettings().setDataplaneEngineName(IncrementalDataPlanePlugin.PLUGIN_NAME);
     DataPlanePlugin dataPlanePlugin = batfish.getDataPlanePlugin();
     ComputeDataPlaneResult dp = dataPlanePlugin.computeDataPlane(batfish.getSnapshot());
-    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
-        dp._dataPlane.getRibs();
+    Table<String, String, FinalMainRib> ribs = dp._dataPlane.getRibs();
 
-    Set<AbstractRoute> r2Routes = ribs.get("r2").get(DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> r3Routes = ribs.get("r3").get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r2Routes = ribs.get("r2", DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r3Routes = ribs.get("r3", DEFAULT_VRF_NAME).getRoutes();
     Set<Prefix> r2Prefixes =
         r2Routes.stream().map(AbstractRoute::getNetwork).collect(Collectors.toSet());
     Set<Prefix> r3Prefixes =
@@ -595,8 +590,7 @@ public class IncrementalDataPlanePluginTest {
             new TestIpOwners(configs, topologyContext.getL3Adjacencies()));
 
     // generating fibs should not crash
-    assertThat(
-        dp._dataPlane.getRibs().get(hostname).get(DEFAULT_VRF_NAME).getRoutes(), contains(sr));
+    assertThat(dp._dataPlane.getRibs().get(hostname, DEFAULT_VRF_NAME).getRoutes(), contains(sr));
   }
 
   @Test
@@ -666,7 +660,7 @@ public class IncrementalDataPlanePluginTest {
     DataPlane dp = dataPlanePlugin.computeDataPlane(batfish.getSnapshot())._dataPlane;
 
     assertThat(
-        dp.getRibs().get(n1.getHostname()).get(vrf.getName()).getRoutes(),
+        dp.getRibs().get(n1.getHostname(), vrf.getName()).getRoutes(),
         hasItem(hasPrefix(genRoutePrefix)));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
@@ -146,7 +146,6 @@ import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -1007,8 +1006,7 @@ public final class CiscoAsaGrammarTest {
     Prefix staticPrefix2 = Prefix.parse("2.2.2.2/32");
 
     // Sanity check: Main RIB should contain both static routes
-    Set<AnnotatedRoute<AbstractRoute>> mainRibRoutes =
-        dp.getRibs().get(hostname).get(DEFAULT_VRF_NAME).getTypedRoutes();
+    Set<AbstractRoute> mainRibRoutes = dp.getRibs().get(hostname, DEFAULT_VRF_NAME).getRoutes();
     assertThat(
         mainRibRoutes,
         containsInAnyOrder(
@@ -1327,7 +1325,7 @@ public final class CiscoAsaGrammarTest {
             aggRoute4General));
 
     Set<AbstractRoute> mainRibRoutes =
-        dp.getRibs().get(hostname).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+        dp.getRibs().get(hostname, Configuration.DEFAULT_VRF_NAME).getRoutes();
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix1)));
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix2)));
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix4General)));
@@ -1397,7 +1395,7 @@ public final class CiscoAsaGrammarTest {
               equalTo(aggRoute1),
               equalTo(aggRoute2)));
       Set<AbstractRoute> mainRibRoutes =
-          dp.getRibs().get(c2).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+          dp.getRibs().get(c2, Configuration.DEFAULT_VRF_NAME).getRoutes();
       assertThat(mainRibRoutes, hasItem(hasPrefix(learnedPrefix1)));
       // Suppressed routes still go in the main RIB and are used for forwarding
       assertThat(mainRibRoutes, hasItem(hasPrefix(learnedPrefix2)));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -198,7 +198,6 @@ import org.batfish.config.Settings;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.AsPathAccessList;
 import org.batfish.datamodel.AsPathAccessListLine;
@@ -928,10 +927,8 @@ public final class CiscoNxosGrammarTest {
 
     // Sanity check: Both VRFs' main RIBs should contain the static route to 1.1.1.1/32,
     // and VRF2 should also have 2.2.2.2/32
-    Set<AnnotatedRoute<AbstractRoute>> vrf1Routes =
-        dp.getRibs().get(hostname).get("VRF1").getTypedRoutes();
-    Set<AnnotatedRoute<AbstractRoute>> vrf2Routes =
-        dp.getRibs().get(hostname).get("VRF2").getTypedRoutes();
+    Set<AbstractRoute> vrf1Routes = dp.getRibs().get(hostname, "VRF1").getRoutes();
+    Set<AbstractRoute> vrf2Routes = dp.getRibs().get(hostname, "VRF2").getRoutes();
     assertThat(
         vrf1Routes, contains(allOf(hasPrefix(staticPrefix1), hasProtocol(RoutingProtocol.STATIC))));
     assertThat(
@@ -9305,7 +9302,7 @@ public final class CiscoNxosGrammarTest {
     batfish.loadConfigurations(batfish.getSnapshot());
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
-    Set<AbstractRoute> routes = dp.getRibs().get(hostname).get("default").getRoutes();
+    Set<AbstractRoute> routes = dp.getRibs().get(hostname, "default").getRoutes();
 
     // Rib should have the static route whose NHI is determined from a non-default route
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/NxosBgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/NxosBgpTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -326,7 +327,8 @@ public class NxosBgpTest {
     batfish.computeDataPlane(batfish.getSnapshot()); // compute and cache the dataPlane
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
 
-    return dp.getRibs().get(listenerName).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+    return dp.getRibs().get(listenerName, Configuration.DEFAULT_VRF_NAME).getRoutes().stream()
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   // Neighbor default-originate overrides outbound route map.

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -2752,7 +2752,7 @@ public final class XrGrammarTest {
 
     // Sanity check: Make sure main RIB has all 3 static routes and no BGP routes
     Set<AbstractRoute> mainRibRoutes =
-        dp.getRibs().get(hostname).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+        dp.getRibs().get(hostname, Configuration.DEFAULT_VRF_NAME).getRoutes();
     assertThat(mainRibRoutes, hasSize(3));
     assertThat(mainRibRoutes, everyItem(instanceOf(StaticRoute.class)));
   }
@@ -3008,7 +3008,7 @@ public final class XrGrammarTest {
             aggRoute4General));
 
     Set<AbstractRoute> mainRibRoutes =
-        dp.getRibs().get(hostname).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+        dp.getRibs().get(hostname, Configuration.DEFAULT_VRF_NAME).getRoutes();
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix1)));
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix2)));
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix4General)));
@@ -3078,7 +3078,7 @@ public final class XrGrammarTest {
               equalTo(aggRoute1),
               equalTo(aggRoute2)));
       Set<AbstractRoute> mainRibRoutes =
-          dp.getRibs().get(c2).get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+          dp.getRibs().get(c2, Configuration.DEFAULT_VRF_NAME).getRoutes();
       assertThat(mainRibRoutes, hasItem(hasPrefix(learnedPrefix1)));
       // Suppressed routes still go in the main RIB and are used for forwarding
       assertThat(mainRibRoutes, hasItem(hasPrefix(learnedPrefix2)));
@@ -3591,7 +3591,7 @@ public final class XrGrammarTest {
     batfish.loadConfigurations(batfish.getSnapshot());
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
-    Set<AbstractRoute> routes = dp.getRibs().get(hostname).get("default").getRoutes();
+    Set<AbstractRoute> routes = dp.getRibs().get(hostname, "default").getRoutes();
 
     // Rib should have the static route whose NHI is determined from a non-default route
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrVrfLeakingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrVrfLeakingTest.java
@@ -14,17 +14,16 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.SortedMap;
 import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
@@ -133,9 +132,9 @@ public final class XrVrfLeakingTest {
   }
 
   private Map<String, Map<String, Set<AbstractRoute>>> getBgpRoutes(
-      SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs) {
+      Table<String, String, FinalMainRib> ribs) {
     return toImmutableMap(
-        ribs,
+        ribs.rowMap(),
         Entry::getKey,
         nodeEntry ->
             toImmutableMap(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -57,7 +57,6 @@ import org.batfish.common.plugin.IBatfish;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AclIpSpace;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BddTestbed;
 import org.batfish.datamodel.BgpActivePeerConfig;
@@ -244,10 +243,8 @@ public class CumulusConcatenatedGrammarTest {
 
     // Sanity check: Both VRFs' main RIBs should contain the static route to 1.1.1.1/32,
     // and VRF2 should also have 2.2.2.2/32
-    Set<AnnotatedRoute<AbstractRoute>> vrf1Routes =
-        dp.getRibs().get(hostname).get("VRF1").getTypedRoutes();
-    Set<AnnotatedRoute<AbstractRoute>> vrf2Routes =
-        dp.getRibs().get(hostname).get("VRF2").getTypedRoutes();
+    Set<AbstractRoute> vrf1Routes = dp.getRibs().get(hostname, "VRF1").getRoutes();
+    Set<AbstractRoute> vrf2Routes = dp.getRibs().get(hostname, "VRF2").getRoutes();
     assertThat(
         vrf1Routes, contains(allOf(hasPrefix(staticPrefix1), hasProtocol(RoutingProtocol.STATIC))));
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -285,8 +285,8 @@ public final class CumulusNcluGrammarTest {
     // Ensure reachability between nodes
     batfish.computeDataPlane(snapshot);
     DataPlane dp = batfish.loadDataPlane(snapshot);
-    Set<AbstractRoute> n1Routes = dp.getRibs().get(node1).get(DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> n2Routes = dp.getRibs().get(node2).get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> n1Routes = dp.getRibs().get(node1, DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> n2Routes = dp.getRibs().get(node2, DEFAULT_VRF_NAME).getRoutes();
 
     assertThat(n1Routes, hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("6.6.6.6/32")))));
     assertThat(n2Routes, hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("5.5.5.5/32")))));

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
@@ -496,10 +496,8 @@ public final class F5BigipImishGrammarTest {
     NetworkSnapshot snapshot = batfish.getSnapshot();
     batfish.computeDataPlane(snapshot);
     DataPlane dp = batfish.loadDataPlane(snapshot);
-    Set<AbstractRoute> routes1 =
-        dp.getRibs().get("r1").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> routes2 =
-        dp.getRibs().get("r2").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> routes1 = dp.getRibs().get("r1", Configuration.DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> routes2 = dp.getRibs().get("r2", Configuration.DEFAULT_VRF_NAME).getRoutes();
 
     // kernel routes should be installed
     assertThat(routes1, hasItem(isKernelRouteThat(hasPrefix(Prefix.strict("10.0.0.1/32")))));

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
@@ -419,10 +419,8 @@ public final class F5BigipStructuredGrammarTest {
     NetworkSnapshot snapshot = batfish.getSnapshot();
     batfish.computeDataPlane(snapshot);
     DataPlane dp = batfish.loadDataPlane(snapshot);
-    Set<AbstractRoute> routes1 =
-        dp.getRibs().get("r1").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> routes2 =
-        dp.getRibs().get("r2").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> routes1 = dp.getRibs().get("r1", Configuration.DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> routes2 = dp.getRibs().get("r2", Configuration.DEFAULT_VRF_NAME).getRoutes();
 
     // kernel routes should be installed
     assertThat(routes1, hasItem(isKernelRouteThat(hasPrefix(Prefix.strict("10.0.0.1/32")))));

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -364,6 +364,7 @@ import org.batfish.datamodel.transformation.IpField;
 import org.batfish.datamodel.transformation.Noop;
 import org.batfish.datamodel.transformation.ShiftIpAddressIntoSubnet;
 import org.batfish.datamodel.transformation.Transformation;
+import org.batfish.dataplane.ibdp.IncrementalDataPlane;
 import org.batfish.grammar.BatfishParseTreeWalker;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Flat_juniper_configurationContext;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
@@ -862,7 +863,7 @@ public final class FlatJuniperGrammarTest {
             _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
-    Set<AbstractRoute> r1Routes = dp.getRibs().get(c1Name).get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r1Routes = dp.getRibs().get(c1Name, DEFAULT_VRF_NAME).getRoutes();
 
     assertThat(r1Routes, not(hasItem(hasPrefix(Prefix.parse("10.20.20.0/24")))));
     assertThat(
@@ -3988,8 +3989,8 @@ public final class FlatJuniperGrammarTest {
             _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
-    Set<AbstractRoute> r1Routes = dp.getRibs().get(r1).get(DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> r2Routes = dp.getRibs().get(r2).get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r1Routes = dp.getRibs().get(r1, DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> r2Routes = dp.getRibs().get(r2, DEFAULT_VRF_NAME).getRoutes();
 
     // 1.2.3.4/30 does not get exported to r2 because r1 has no IS-IS export policy.
     assertThat(r1Routes, hasItem(hasPrefix(Prefix.parse("1.2.3.4/30"))));
@@ -6242,9 +6243,9 @@ public final class FlatJuniperGrammarTest {
     */
     Batfish batfish = BatfishTestUtils.getBatfish(ImmutableSortedMap.of(hostname, c), _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
-    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
     ImmutableMap<String, Set<AnnotatedRoute<AbstractRoute>>> routes =
-        dp.getRibs().get(hostname).entrySet().stream()
+        dp.getRibsForTesting().get(hostname).entrySet().stream()
             .collect(
                 ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getTypedRoutes()));
 
@@ -6262,10 +6263,10 @@ public final class FlatJuniperGrammarTest {
     Configuration c = parseConfig(hostname);
     Batfish batfish = BatfishTestUtils.getBatfish(ImmutableSortedMap.of(hostname, c), _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
-    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
 
     ImmutableMap<String, Set<AnnotatedRoute<AbstractRoute>>> routes =
-        dp.getRibs().get(hostname).entrySet().stream()
+        dp.getRibsForTesting().get(hostname).entrySet().stream()
             .collect(
                 ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getTypedRoutes()));
     String vrf2Name = "VRF2";
@@ -6305,10 +6306,10 @@ public final class FlatJuniperGrammarTest {
     Configuration c = parseConfig(hostname);
     Batfish batfish = BatfishTestUtils.getBatfish(ImmutableSortedMap.of(hostname, c), _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
-    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
 
     ImmutableMap<String, Set<AnnotatedRoute<AbstractRoute>>> routes =
-        dp.getRibs().get(hostname).entrySet().stream()
+        dp.getRibsForTesting().get(hostname).entrySet().stream()
             .collect(
                 ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getTypedRoutes()));
     String vrf2Name = "VRF2";
@@ -6367,10 +6368,10 @@ public final class FlatJuniperGrammarTest {
     Configuration c = parseConfig(hostname);
     Batfish batfish = BatfishTestUtils.getBatfish(ImmutableSortedMap.of(hostname, c), _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
-    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
 
     ImmutableMap<String, Set<AnnotatedRoute<AbstractRoute>>> routes =
-        dp.getRibs().get(hostname).entrySet().stream()
+        dp.getRibsForTesting().get(hostname).entrySet().stream()
             .collect(
                 ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getTypedRoutes()));
     String vrf2Name = "VRF2";
@@ -7026,7 +7027,7 @@ public final class FlatJuniperGrammarTest {
     Batfish batfish = getBatfishForConfigurationNames(hostname);
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
-    Set<AbstractRoute> mainRibRoutes = dp.getRibs().get(hostname).get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> mainRibRoutes = dp.getRibs().get(hostname, DEFAULT_VRF_NAME).getRoutes();
 
     assertThat(mainRibRoutes, hasItem(hasPrefix(Prefix.strict("1.0.0.0/16"))));
     assertThat(mainRibRoutes, not(hasItem(hasPrefix(Prefix.ZERO))));

--- a/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
@@ -722,7 +722,7 @@ public class FrrGrammarTest {
 
     // frr-reoriginator should get a default route from frr-originator
     assertThat(
-        dp.getRibs().get("frr-reoriginator").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-reoriginator", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(
             equalTo(
                 Bgpv4Route.testBuilder()
@@ -740,7 +740,7 @@ public class FrrGrammarTest {
 
     // frr-propagator should get a fresh default route from frr-originator
     assertThat(
-        dp.getRibs().get("frr-propagator").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-propagator", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(
             equalTo(
                 Bgpv4Route.testBuilder()
@@ -758,7 +758,7 @@ public class FrrGrammarTest {
 
     // ios-listener should get a propagated route from frr-propagator
     assertThat(
-        dp.getRibs().get("ios-listener").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("ios-listener", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(
             equalTo(
                 Bgpv4Route.testBuilder()
@@ -804,7 +804,7 @@ public class FrrGrammarTest {
     DataPlane dp = batfish.loadDataPlane(snapshot);
 
     assertThat(
-        dp.getRibs().get("frr-listener1").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-listener1", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(
             equalTo(
                 Bgpv4Route.testBuilder()
@@ -821,7 +821,7 @@ public class FrrGrammarTest {
                     .build())));
 
     assertThat(
-        dp.getRibs().get("frr-listener3").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-listener3", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(
             equalTo(
                 Bgpv4Route.testBuilder()
@@ -837,7 +837,7 @@ public class FrrGrammarTest {
                     .setLocalPreference(100)
                     .build())));
     assertThat(
-        dp.getRibs().get("frr-listener4").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-listener4", DEFAULT_VRF_NAME).getRoutes(),
         not(hasItem(hasPrefix(Prefix.ZERO))));
   }
 
@@ -2492,7 +2492,7 @@ public class FrrGrammarTest {
 
     // frr-reoriginator should get a default route from frr-originator
     assertThat(
-        dp.getRibs().get("frr-listener").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-listener", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(
             equalTo(
                 OspfExternalType2Route.builder()
@@ -2781,7 +2781,7 @@ public class FrrGrammarTest {
     DataPlane dp = batfish.loadDataPlane(snapshot);
 
     assertThat(
-        dp.getRibs().get("frr-listener").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-listener", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(
             equalTo(
                 Bgpv4Route.testBuilder()
@@ -2827,7 +2827,7 @@ public class FrrGrammarTest {
     DataPlane dp = batfish.loadDataPlane(snapshot);
 
     assertThat(
-        dp.getRibs().get("frr-listener").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-listener", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(
             equalTo(
                 Bgpv4Route.testBuilder()
@@ -2864,19 +2864,19 @@ public class FrrGrammarTest {
         batfish.getTopologyProvider().getBgpTopology(snapshot).getGraph().edges(), hasSize(8));
 
     assertThat(
-        dp.getRibs().get("frr-t2-r1").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-t2-r1", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("99.13.80.0/21")))));
 
     assertThat(
-        dp.getRibs().get("frr-t2-r2").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-t2-r2", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("99.13.80.0/21")))));
 
     assertThat(
-        dp.getRibs().get("frr-t2-r1").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-t2-r1", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("99.8.0.0/20")))));
 
     assertThat(
-        dp.getRibs().get("frr-t2-r2").get(DEFAULT_VRF_NAME).getRoutes(),
+        dp.getRibs().get("frr-t2-r2", DEFAULT_VRF_NAME).getRoutes(),
         hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("99.8.0.0/20")))));
   }
 

--- a/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesAnswerer.java
@@ -1,22 +1,20 @@
 package org.batfish.question.lpmroutes;
 
-import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Table;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.regex.Pattern;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Answerer;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.AbstractRouteDecorator;
-import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.AnswerElement;
@@ -62,26 +60,26 @@ public class LpmRoutesAnswerer extends Answerer {
 
   @VisibleForTesting
   static <T extends AbstractRouteDecorator> List<Row> getRows(
-      SortedMap<String, SortedMap<String, GenericRib<T>>> ribs,
+      Table<String, String, FinalMainRib> ribs,
       Ip ip,
       Set<String> nodes,
       Pattern vrfRegex,
       Map<String, ColumnMetadata> columnMap) {
 
     ImmutableList.Builder<Row> builder = ImmutableList.builder();
-    for (Entry<String, SortedMap<String, GenericRib<T>>> nodeEntry : ribs.entrySet()) {
+    for (Entry<String, Map<String, FinalMainRib>> nodeEntry : ribs.rowMap().entrySet()) {
       if (!nodes.contains(nodeEntry.getKey())) {
         continue;
       }
 
-      for (Entry<String, GenericRib<T>> vrfEntry : nodeEntry.getValue().entrySet()) {
+      for (Entry<String, FinalMainRib> vrfEntry : nodeEntry.getValue().entrySet()) {
         if (!vrfRegex.matcher(vrfEntry.getKey()).matches()) {
           continue;
         }
 
         // TODO: implement resolution restriction
         toRow(
-                vrfEntry.getValue().longestPrefixMatch(ip, alwaysTrue()),
+                vrfEntry.getValue().longestPrefixMatch(ip),
                 nodeEntry.getKey(),
                 vrfEntry.getKey(),
                 ip,

--- a/projects/question/src/test/java/org/batfish/question/lpmroutes/LpmRoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/lpmroutes/LpmRoutesAnswererTest.java
@@ -17,14 +17,13 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableTable;
 import java.util.List;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.MockRib;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
@@ -35,17 +34,10 @@ import org.junit.Test;
 /** Tests for {@link LpmRoutesAnswerer} */
 public class LpmRoutesAnswererTest {
 
-  private static MockRib getMockRib(Ip ip) {
-    return MockRib.builder()
-        .setLongestPrefixMatchResults(
-            ImmutableMap.of(
-                ip,
-                ImmutableSet.of(
-                    new AnnotatedRoute<>(
-                        new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Eth0"), "vrf"),
-                    new AnnotatedRoute<>(
-                        new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Eth1"), "vrf"))))
-        .build();
+  private static FinalMainRib getMockRib() {
+    return FinalMainRib.of(
+        new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Eth0"),
+        new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Eth1"));
   }
 
   @Test
@@ -107,15 +99,13 @@ public class LpmRoutesAnswererTest {
         getColumnMetadata().stream()
             .collect(ImmutableMap.toImmutableMap(ColumnMetadata::getName, Function.identity()));
 
-    final Ip lpmIp = Ip.parse("1.1.1.1");
     List<Row> rows =
         getRows(
-            ImmutableSortedMap.of(
-                "node1",
-                ImmutableSortedMap.of("vrf1", getMockRib(lpmIp)),
-                "node2",
-                ImmutableSortedMap.of("vrf2", getMockRib(lpmIp))),
-            lpmIp,
+            ImmutableTable.<String, String, FinalMainRib>builder()
+                .put("node1,", "vrf1", getMockRib())
+                .put("node2", "vrf2", getMockRib())
+                .build(),
+            Ip.parse("1.1.1.1"),
             ImmutableSet.of("node2"),
             Pattern.compile(".*"),
             columnMap);
@@ -129,15 +119,13 @@ public class LpmRoutesAnswererTest {
         getColumnMetadata().stream()
             .collect(ImmutableMap.toImmutableMap(ColumnMetadata::getName, Function.identity()));
 
-    final Ip lpmIp = Ip.parse("1.1.1.1");
     List<Row> rows =
         getRows(
-            ImmutableSortedMap.of(
-                "node1",
-                ImmutableSortedMap.of("vrf1", getMockRib(lpmIp)),
-                "node2",
-                ImmutableSortedMap.of("vrf2", getMockRib(lpmIp))),
-            lpmIp,
+            ImmutableTable.<String, String, FinalMainRib>builder()
+                .put("node1", "vrf1", getMockRib())
+                .put("node2", "vrf2", getMockRib())
+                .build(),
+            Ip.parse("1.1.1.1"),
             ImmutableSet.of("node1", "node2"),
             Pattern.compile("vrf1"),
             columnMap);


### PR DESCRIPTION
FinalMainRib provides only the functionality and stores only the data
that user-facing analyses need. This shrinks the serialized data planes
and speeds up their serialization and deserialization.

Tests that use more information that was previously stored are migrated to
actually using the current intermediate dataplane type.

On one network, shrunk the serialized dataplane by 18%.

commit-id:393b6cd5

---

**Stack**:
- #8355
- #8354 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*