### PR TITLE
RoutesAnswerer: faster main rib exact match

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -187,11 +187,15 @@ public class RoutesAnswererUtil {
       // everything matches if there is not user input
       return rib.getRoutes().stream();
     }
-    if (prefixMatchType == PrefixMatchType.LONGEST_PREFIX_MATCH) {
-      return rib.longestPrefixMatch(network).stream();
+    switch (prefixMatchType) {
+      case EXACT:
+        return rib.getRoutes(network).stream();
+      case LONGEST_PREFIX_MATCH:
+        return rib.longestPrefixMatch(network).stream();
+      default:
+        return rib.getRoutes().stream()
+            .filter(r -> prefixMatches(prefixMatchType, network, r.getNetwork()));
     }
-    return rib.getRoutes().stream()
-        .filter(r -> prefixMatches(prefixMatchType, network, r.getNetwork()));
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This was an existing inefficiency made easier to see and fix by
batfish/batfish#8354. No reason to scan the entire RIB to get matching routes.

commit-id:2d938ad2

**Issue references**: 

 - batfish/batfish#8354