### PR TITLE
PAN: support for template variables

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -131,6 +131,7 @@ statement_config_general
 statement_template
 :
     st_description
+    | st_variable
     | statement_template_config
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -38,6 +38,8 @@ ip_address_or_slash32
     addr = interface_address
 ;
 
+ip_netmask: ip_address | ip_prefix;
+
 ip_prefix
 :
     IP_PREFIX

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_template.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_template.g4
@@ -10,3 +10,20 @@ st_description
 :
     DESCRIPTION description = value
 ;
+
+st_variable: VARIABLE variable_name stv_type;
+
+stv_type
+:
+    TYPE
+    (
+        stvt_ip_netmask
+        | stvt_ip_range
+    )
+;
+
+stvt_ip_netmask: IP_NETMASK ip_netmask;
+
+stvt_ip_range: IP_RANGE_LITERAL ip_range;
+
+variable_name: variable;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -87,6 +87,8 @@ import com.google.common.collect.Range;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -526,6 +528,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   private Tag _currentTag;
   private Template _currentTemplate;
   private TemplateStack _currentTemplateStack;
+  private Optional<String> _currentTemplateVariableName;
   private VirtualRouter _currentVirtualRouter;
   private Vsys _currentVsys;
   private Zone _currentZone;
@@ -1910,6 +1913,57 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   }
 
   @Override
+  public void enterSt_variable(PaloAltoParser.St_variableContext ctx) {
+    _currentTemplateVariableName = toString(ctx, ctx.variable_name());
+  }
+
+  @Override
+  public void exitSt_variable(PaloAltoParser.St_variableContext ctx) {
+    _currentTemplateVariableName = null;
+  }
+
+  @Override
+  public void exitStvt_ip_netmask(PaloAltoParser.Stvt_ip_netmaskContext ctx) {
+    _currentTemplateVariableName.ifPresent(
+        name -> {
+          // Store the variable as an address object, since that is how it is used
+          AddressObject addr = new AddressObject(name);
+          applyIpNetmask(addr, ctx.ip_netmask());
+          getOrCreateDefaultVsys(_currentTemplate).getAddressObjects().put(name, addr);
+
+          defineFlattenedStructure(ADDRESS_OBJECT, computeObjectName(_currentVsys, name), ctx);
+        });
+  }
+
+  /** Apply the ip-netmask (ip addr or prefix) to the specified {@link AddressObject}. */
+  private void applyIpNetmask(AddressObject addressObject, PaloAltoParser.Ip_netmaskContext ctx) {
+    if (ctx.ip_address() != null) {
+      addressObject.setIp(toIp(ctx.ip_address()));
+      return;
+    }
+    assert ctx.ip_prefix() != null;
+    addressObject.setPrefix(toIpPrefix(ctx.ip_prefix()));
+  }
+
+  @Override
+  public void exitStvt_ip_range(PaloAltoParser.Stvt_ip_rangeContext ctx) {
+    _currentTemplateVariableName.ifPresent(
+        name -> {
+          toIpRange(ctx.ip_range())
+              .ifPresent(
+                  range -> {
+                    // Store the variable as an address object, since that is how it is used
+                    AddressObject addr = new AddressObject(name);
+                    addr.setIpRange(range);
+                    getOrCreateDefaultVsys(_currentTemplate).getAddressObjects().put(name, addr);
+
+                    defineFlattenedStructure(
+                        ADDRESS_OBJECT, computeObjectName(_currentVsys, name), ctx);
+                  });
+        });
+  }
+
+  @Override
   public void enterSet_line_template_stack(Set_line_template_stackContext ctx) {
     String templateStackName = getText(ctx.name);
     _currentTemplateStack = _mainConfiguration.getOrCreateTemplateStack(templateStackName);
@@ -3283,6 +3337,10 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
     return panorama;
   }
 
+  private Vsys getOrCreateDefaultVsys(PaloAltoConfiguration config) {
+    return config.getVirtualSystems().computeIfAbsent(DEFAULT_VSYS_NAME, Vsys::new);
+  }
+
   private static ApplicationOverrideRule.Protocol toApplicationOverrideProtocol(
       Tcp_or_udpContext ctx) {
     if (ctx.TCP() != null) {
@@ -3432,6 +3490,33 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
       return Optional.empty();
     }
     return Optional.of(num);
+  }
+
+  private static final Pattern TEMPLATE_VARIABLE_NAME_PATTERN =
+      Pattern.compile("^\\$[A-Za-z0-9._-]{1,62}$");
+
+  private Optional<String> toString(
+      ParserRuleContext messageCtx, PaloAltoParser.Variable_nameContext ctx) {
+    return toString(
+        messageCtx, ctx.variable(), "template variable name", TEMPLATE_VARIABLE_NAME_PATTERN);
+  }
+
+  private @Nonnull Optional<String> toString(
+      ParserRuleContext messageCtx, ParserRuleContext ctx, String type, Pattern pattern) {
+    return toString(messageCtx, ctx, type, s -> pattern.matcher(s).matches());
+  }
+
+  private @Nonnull Optional<String> toString(
+      ParserRuleContext messageCtx,
+      ParserRuleContext ctx,
+      String type,
+      Predicate<String> predicate) {
+    String text = getText(ctx);
+    if (!predicate.test(text)) {
+      warn(messageCtx, String.format("Illegal value for %s", type));
+      return Optional.empty();
+    }
+    return Optional.of(text);
   }
 
   private static final IntegerSpace BGP_PEER_GROUP_NAME_LENGTH_SPACE =

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -3009,6 +3009,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     }
     target.getSyslogServerGroups().putAll(template.getSyslogServerGroups());
     target.getImportedInterfaces().addAll(template.getImportedInterfaces());
+    // Template variables exist as vsys objects in the VS model
+    applyVsysObjects(template, target);
 
     // Overwrite settings
     if (template.getDisplayName() != null) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/template-variable
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/template-variable
@@ -1,0 +1,14 @@
+set deviceconfig system hostname template-variable
+set template T1 variable $range type ip-range 10.0.0.100-10.1.1.1
+set template T1 variable $prefix type ip-netmask 10.10.10.1/24
+set template T1 variable $ip type ip-netmask 10.10.10.10
+set template T1 variable $overwrite type ip-range 10.0.0.100-10.1.1.1
+set template T1 variable $overwrite type ip-netmask 10.100.100.100
+
+# Apply a template variable
+set template T1 config network interface ethernet ethernet1/1 layer3 ip $prefix
+# Necessary configuration for the interface to be active on a firewall
+set template T1 config devices localhost.localdomain vsys vsys1 zone z1 network layer3 ethernet1/1
+set template T1 config network virtual-router default interface ethernet1/1
+set template-stack TS1 templates T1
+set template-stack TS1 devices 00000001

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/template-variable-reference
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/template-variable-reference
@@ -1,0 +1,5 @@
+set deviceconfig system hostname template-variable-reference
+set template T1 variable $prefix type ip-netmask 10.10.10.10/32
+set template T1 variable $UNUSED type ip-netmask 10.10.10.11/32
+set template T1 config network interface ethernet ethernet1/1 layer3 ip $prefix
+set template T1 config network interface ethernet ethernet1/2 layer3 ip $UNDEFINED

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/template-variable-warn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/template-variable-warn
@@ -1,0 +1,3 @@
+set deviceconfig system hostname template-variable-warn
+set template T1 variable $range type ip-range 10.0.0.100-10.0.0.1
+set template T1 variable $thisNameIsTooLong8901234567890123456789012345678901234567890123 type ip-netmask 10.10.10.10


### PR DESCRIPTION
Add support for address-object-like template variables (`ip-netmask` and `ip-range`).

For now, these are treated like `address` objects in the VS model. This is mostly correct but is too permissive of references, as you cannot reference template variables outside of a template on a real device.
