### PR TITLE
Add xfail BGP additional-paths tests

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathDuplicateTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathDuplicateTest.java
@@ -62,7 +62,6 @@ public final class BgpAddPathDuplicateTest {
   @Test
   public void testBgpRib() {
     Table<String, String, Set<Bgpv4Route>> bgpRoutes = _dp.getBgpRoutes();
-    Table<String, String, Set<Bgpv4Route>> backupRoutes = _dp.getBgpBackupRoutes();
 
     // as2border
     assertThat(bgpRoutes.get("as2border", DEFAULT_VRF_NAME), hasSize(2));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathDuplicateTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathDuplicateTest.java
@@ -1,0 +1,86 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Table;
+import java.io.IOException;
+import java.util.Set;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.FinalMainRib;
+import org.batfish.datamodel.Prefix;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests that a router that sends all additional-paths will advertise multiple routes that are
+ * duplicate post-export, and that both will be present in the BGP RIB on the receiver.
+ */
+public final class BgpAddPathDuplicateTest {
+
+  private static final Prefix PREFIX = Prefix.strict("10.0.0.0/32");
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+  private DataPlane _dp;
+
+  /*
+   Topology: {as1r1,as1r2} <=> as2border <=> as2leaf
+
+   - as1 to as2border links are eBGP sesssions
+   - as2border to as2leaf link is iBGP session
+   - Both as1 routers originate and advertise 10.0.0.0/32
+   - Both as2 routers have bgp multipath and add-path enabled
+   - as2border sets next-hop-self when advertising to as2leaf
+   - as2border should have 2 routes in its BGP RIB, and 2 in its main RIB
+   - as2border should advertise 2 routes to as2leaf that are identical post-export modulo path-id
+   - as2leaf should have 2 routes identical modulo rx path-id in its BGP RIB; and 1 route in its
+     main RIB
+  */
+  @Before
+  public void setup() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/add-path/duplicate";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(snapshotPath, "as1r1", "as1r2", "as2border", "as2leaf")
+                .build(),
+            _folder);
+    // TODO: parse neighbor xxx additional-paths send receive
+    batfish.getSettings().setDisableUnrecognized(false);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    _dp = batfish.loadDataPlane(batfish.getSnapshot());
+  }
+
+  @Test
+  public void testBgpRib() {
+    Table<String, String, Set<Bgpv4Route>> bgpRoutes = _dp.getBgpRoutes();
+    Table<String, String, Set<Bgpv4Route>> backupRoutes = _dp.getBgpBackupRoutes();
+
+    // as2border
+    assertThat(bgpRoutes.get("as2border", DEFAULT_VRF_NAME), hasSize(2));
+
+    // as2leaf
+    // TODO: support distinct routes identical modulo rx path-id in BGP RIB
+    _thrown.expect(AssertionError.class);
+    assertThat(bgpRoutes.get("as2leaf", DEFAULT_VRF_NAME), hasSize(2));
+  }
+
+  @Test
+  public void testMainRib() {
+    Table<String, String, FinalMainRib> ribs = _dp.getRibs();
+
+    // as2border
+    assertThat(ribs.get("as2border", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(2));
+
+    // as2leaf
+    assertThat(ribs.get("as2leaf", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(1));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathNonEcmpBestTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathNonEcmpBestTest.java
@@ -1,0 +1,103 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHop;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Table;
+import java.io.IOException;
+import java.util.Set;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.FinalMainRib;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests that a router that sends all additional-paths will advertise routes that are not ECMP-best,
+ * and that both will be present in the BGP RIB on a receiver.
+ */
+public final class BgpAddPathNonEcmpBestTest {
+
+  private static final Prefix PREFIX = Prefix.strict("10.0.0.0/32");
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+  private DataPlane _dp;
+
+  /*
+   Topology: {as1r1,as1r2} <=> as2border <=> as2leaf
+
+   - as1 to as2border links are eBGP sesssions
+   - as2border to as2leaf link is iBGP session
+   - Both as1 routers originate and advertise 10.0.0.0/32
+   - as2border sets distinct communities and local pref for routes learned from each as1
+   - Both as2 routers have bgp multipath and add-path enabled
+   - as2border preserves external next hop when advertising to as2leaf
+   - as2border should have 1 best and 1 backup route in its BGP RIB; and 1 route in its main RIB
+   - as2border should advertise 2 routes to as2leaf
+   - as2leaf should have 1 best and 1 backup route in its BGP RIB; and 1 routes in its main RIB
+  */
+  @Before
+  public void setup() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/add-path/non-ecmp-best";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(snapshotPath, "as1r1", "as1r2", "as2border", "as2leaf")
+                .build(),
+            _folder);
+    // TODO: parse neighbor xxx additional-paths send receive
+    batfish.getSettings().setDisableUnrecognized(false);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    _dp = batfish.loadDataPlane(batfish.getSnapshot());
+  }
+
+  @Test
+  public void testBgpRib() {
+    Table<String, String, Set<Bgpv4Route>> bgpRoutes = _dp.getBgpRoutes();
+    Table<String, String, Set<Bgpv4Route>> backupRoutes = _dp.getBgpBackupRoutes();
+
+    // as2border
+    assertThat(
+        bgpRoutes.get("as2border", DEFAULT_VRF_NAME),
+        contains(hasNextHop(NextHopIp.of(Ip.parse("10.12.2.1")))));
+    assertThat(
+        backupRoutes.get("as2border", DEFAULT_VRF_NAME),
+        contains(hasNextHop(NextHopIp.of(Ip.parse("10.12.1.1")))));
+
+    // as2leaf
+    assertThat(
+        bgpRoutes.get("as2leaf", DEFAULT_VRF_NAME),
+        contains(hasNextHop(NextHopIp.of(Ip.parse("10.12.2.1")))));
+    // TODO: with add-path, advertise non-ecmp-best routes
+    _thrown.expect(AssertionError.class);
+    assertThat(
+        backupRoutes.get("as2leaf", DEFAULT_VRF_NAME),
+        contains(hasNextHop(NextHopIp.of(Ip.parse("10.12.1.1")))));
+  }
+
+  @Test
+  public void testMainRib() {
+    Table<String, String, FinalMainRib> ribs = _dp.getRibs();
+
+    // as2border
+    assertThat(
+        ribs.get("as2border", DEFAULT_VRF_NAME).getRoutes(PREFIX),
+        contains(hasNextHop(NextHopIp.of(Ip.parse("10.12.2.1")))));
+
+    // as2leaf
+    assertThat(
+        ribs.get("as2leaf", DEFAULT_VRF_NAME).getRoutes(PREFIX),
+        contains(hasNextHop(NextHopIp.of(Ip.parse("10.12.2.1")))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathUniqueNextHopTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathUniqueNextHopTest.java
@@ -1,0 +1,111 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHop;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Table;
+import java.io.IOException;
+import java.util.Set;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.FinalMainRib;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests that a route reflector with multiple routes for a prefix will advertise only one route per
+ * unique next hop for that given prefix.
+ */
+public final class BgpAddPathUniqueNextHopTest {
+
+  private static final Prefix PREFIX = Prefix.strict("10.0.0.0/32");
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+  private DataPlane _dp;
+
+  /*
+   Topology: {as1r1,as1r2} <=> as2border1 \
+                                           as2rr <=> as2leaf
+                     as1r3 <=> as2border2 /
+
+   - as1 to as2border links are eBGP sesssions
+   - as2 to as2 links are iBGP sessions
+   - All as1 routers originate and advertise 10.0.0.0/32 with distinct communities
+   - as2border sets distinct communities for routes learned from each as1 device
+   - All as2 routers have bgp multipath and add-path enabled
+   - as2border routers set next-hop-self to respective as2rr routers
+   - as2border1 should advertise 2 routes to as2rr
+   - as2border2 should advertise 1 routes to as2rr
+   - as2rr should have 3 ECMP-best routes in its BGP RIB, and 3 in its main RIB
+   - as2rr should advertise 1 route from as2border1 and 1 route from as2border2 to as2leaf
+   - as2leaf should have 2 routes in its BGP RIB, and 2 routes in its main RIB
+  */
+  @Before
+  public void setup() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/add-path/unique-next-hop";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(
+                    snapshotPath,
+                    "as1r1",
+                    "as1r2",
+                    "as1r3",
+                    "as2border1",
+                    "as2border2",
+                    "as2rr",
+                    "as2leaf")
+                .build(),
+            _folder);
+    // TODO: parse neighbor xxx additional-paths send receive
+    batfish.getSettings().setDisableUnrecognized(false);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    _dp = batfish.loadDataPlane(batfish.getSnapshot());
+  }
+
+  @Test
+  public void testBgpRib() {
+    Table<String, String, Set<Bgpv4Route>> bgpRoutes = _dp.getBgpRoutes();
+    assertThat(bgpRoutes.get("as2border1", DEFAULT_VRF_NAME), hasSize(2));
+    assertThat(bgpRoutes.get("as2border2", DEFAULT_VRF_NAME), hasSize(1));
+    assertThat(bgpRoutes.get("as2rr", DEFAULT_VRF_NAME), hasSize(3));
+
+    // TODO: with add-path for a given prefix, only advertise one path per unique next-hop
+    _thrown.expect(AssertionError.class);
+    assertThat(
+        bgpRoutes.get("as2leaf", DEFAULT_VRF_NAME),
+        containsInAnyOrder(
+            hasNextHop(NextHopIp.of(Ip.parse("10.0.2.1"))),
+            hasNextHop(NextHopIp.of(Ip.parse("10.0.2.2")))));
+  }
+
+  @Test
+  public void testMainRib() {
+    Table<String, String, FinalMainRib> ribs = _dp.getRibs();
+    assertThat(ribs.get("as2border1", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(2));
+    assertThat(ribs.get("as2border2", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(1));
+
+    // This should be 2, but this is separate issue from add-path
+    assertThat(ribs.get("as2rr", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(3));
+
+    // TODO: with add-path for a given prefix, only advertise one path per unique next-hop
+    _thrown.expect(AssertionError.class);
+    assertThat(
+        ribs.get("as2leaf", DEFAULT_VRF_NAME).getRoutes(PREFIX),
+        containsInAnyOrder(
+            hasNextHop(NextHopIp.of(Ip.parse("10.0.2.1"))),
+            hasNextHop(NextHopIp.of(Ip.parse("10.0.2.2")))));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/duplicate/configs/as1r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/duplicate/configs/as1r1
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as1r1
+
+interface Loopback0
+  ip address 10.0.0.0 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border1:GigabitEthernet0/0
+  ip address 10.12.1.1 255.255.255.0
+  no shutdown
+!
+
+router bgp 1
+  bgp router-id 10.12.1.1
+  network 10.0.0.0 mask 255.255.255.255
+  neighbor 10.12.1.2 remote-as 2
+  address-family ipv4 unicast
+    neighbor 10.12.1.2 activate
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/duplicate/configs/as1r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/duplicate/configs/as1r2
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as1r2
+
+interface Loopback0
+  ip address 10.0.0.0 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border1:GigabitEthernet0/1
+  ip address 10.12.2.1 255.255.255.0
+  no shutdown
+!
+
+router bgp 1
+  bgp router-id 10.12.2.1
+  network 10.0.0.0 mask 255.255.255.255
+  neighbor 10.12.2.2 remote-as 2
+  address-family ipv4 unicast
+    neighbor 10.12.2.2 activate
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/duplicate/configs/as2border
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/duplicate/configs/as2border
@@ -1,0 +1,46 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as2border
+
+interface Loopback0
+  ip address 10.0.2.1 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as1r1:GigabitEthernet0/0
+  ip address 10.12.1.2 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/1
+  description as1r2:GigabitEthernet0/0
+  ip address 10.12.2.2 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/2
+  description as2leaf:GigabitEthernet0/0
+  ip address 10.2.12.1 255.255.255.0
+  no shutdown
+!
+
+ip route 10.0.2.2 255.255.255.255 10.2.12.2
+
+router bgp 2
+  bgp router-id 10.0.2.1
+  neighbor 10.12.1.1 remote-as 1
+  neighbor 10.12.2.1 remote-as 1
+  neighbor 10.0.2.2 remote-as 2
+  neighbor 10.0.2.2 update-source Loopback0
+  address-family ipv4 unicast
+    bgp additional-paths send receive
+    bgp additional-paths select all
+    bgp additional-paths install
+    maximum-paths eibgp 32
+    neighbor 10.12.1.1 activate
+    neighbor 10.12.2.1 activate
+    neighbor 10.0.2.2 activate
+    neighbor 10.0.2.2 advertise additional-paths all
+    neighbor 10.0.2.2 additional-paths send receive
+    neighbor 10.0.2.2 send-community both
+    neighbor 10.0.2.2 next-hop-self
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/duplicate/configs/as2leaf
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/duplicate/configs/as2leaf
@@ -1,0 +1,33 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as2leaf
+
+interface Loopback0
+  ip address 10.0.2.2 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border:GigabitEthernet0/2
+  ip address 10.2.12.2 255.255.255.0
+  no shutdown
+!
+
+! as1r1<=>as2border link
+ip route 10.12.1.0 255.255.255.0 10.2.12.1
+! as1r2<=>as2border link
+ip route 10.12.2.0 255.255.255.0 10.2.12.1
+! as2border loopback
+ip route 10.0.2.1 255.255.255.255 10.2.12.1
+
+router bgp 2
+  bgp router-id 10.0.2.2
+  neighbor 10.0.2.1 remote-as 2
+  neighbor 10.0.2.1 update-source Loopback0
+  address-family ipv4 unicast
+    bgp additional-paths send receive
+    bgp additional-paths select all
+    bgp additional-paths install
+    maximum-paths eibgp 32
+    neighbor 10.0.2.1 activate
+    neighbor 10.0.2.1 advertise additional-paths all
+    neighbor 10.0.2.1 additional-paths send receive
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/non-ecmp-best/configs/as1r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/non-ecmp-best/configs/as1r1
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as1r1
+
+interface Loopback0
+  ip address 10.0.0.0 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border1:GigabitEthernet0/0
+  ip address 10.12.1.1 255.255.255.0
+  no shutdown
+!
+
+router bgp 1
+  bgp router-id 10.12.1.1
+  network 10.0.0.0 mask 255.255.255.255
+  neighbor 10.12.1.2 remote-as 2
+  address-family ipv4 unicast
+    neighbor 10.12.1.2 activate
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/non-ecmp-best/configs/as1r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/non-ecmp-best/configs/as1r2
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as1r2
+
+interface Loopback0
+  ip address 10.0.0.0 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border1:GigabitEthernet0/1
+  ip address 10.12.2.1 255.255.255.0
+  no shutdown
+!
+
+router bgp 1
+  bgp router-id 10.12.2.1
+  network 10.0.0.0 mask 255.255.255.255
+  neighbor 10.12.2.2 remote-as 2
+  address-family ipv4 unicast
+    neighbor 10.12.2.2 activate
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/non-ecmp-best/configs/as2border
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/non-ecmp-best/configs/as2border
@@ -1,0 +1,55 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as2border
+
+interface Loopback0
+  ip address 10.0.2.1 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as1r1:GigabitEthernet0/0
+  ip address 10.12.1.2 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/1
+  description as1r2:GigabitEthernet0/0
+  ip address 10.12.2.2 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/2
+  description as2leaf:GigabitEthernet0/0
+  ip address 10.2.12.1 255.255.255.0
+  no shutdown
+!
+
+ip route 10.0.2.2 255.255.255.255 10.2.12.2
+
+route-map from1 permit 100
+  set community 1
+  set local-preference 1
+
+route-map from2 permit 100
+  set community 2
+  set local-preference 2
+
+router bgp 2
+  bgp router-id 10.0.2.1
+  neighbor 10.12.1.1 remote-as 1
+  neighbor 10.12.2.1 remote-as 1
+  neighbor 10.0.2.2 remote-as 2
+  neighbor 10.0.2.2 update-source Loopback0
+  address-family ipv4 unicast
+    bgp additional-paths send receive
+    bgp additional-paths select all
+    bgp additional-paths install
+    maximum-paths eibgp 32
+    neighbor 10.12.1.1 activate
+    neighbor 10.12.1.1 route-map from1 in
+    neighbor 10.12.2.1 activate
+    neighbor 10.12.2.1 route-map from2 in
+    neighbor 10.0.2.2 activate
+    neighbor 10.0.2.2 advertise additional-paths all
+    neighbor 10.0.2.2 additional-paths send receive
+    neighbor 10.0.2.2 send-community both
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/non-ecmp-best/configs/as2leaf
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/non-ecmp-best/configs/as2leaf
@@ -1,0 +1,33 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as2leaf
+
+interface Loopback0
+  ip address 10.0.2.2 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border:GigabitEthernet0/2
+  ip address 10.2.12.2 255.255.255.0
+  no shutdown
+!
+
+! as1r1<=>as2border link
+ip route 10.12.1.0 255.255.255.0 10.2.12.1
+! as1r2<=>as2border link
+ip route 10.12.2.0 255.255.255.0 10.2.12.1
+! as2border loopback
+ip route 10.0.2.1 255.255.255.255 10.2.12.1
+
+router bgp 2
+  bgp router-id 10.0.2.2
+  neighbor 10.0.2.1 remote-as 2
+  neighbor 10.0.2.1 update-source Loopback0
+  address-family ipv4 unicast
+    bgp additional-paths send receive
+    bgp additional-paths select all
+    bgp additional-paths install
+    maximum-paths eibgp 32
+    neighbor 10.0.2.1 activate
+    neighbor 10.0.2.1 advertise additional-paths all
+    neighbor 10.0.2.1 additional-paths send receive
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as1r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as1r1
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as1r1
+
+interface Loopback0
+  ip address 10.0.0.0 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border1:GigabitEthernet0/0
+  ip address 10.12.1.1 255.255.255.0
+  no shutdown
+!
+
+router bgp 1
+  bgp router-id 10.12.1.1
+  network 10.0.0.0 mask 255.255.255.255
+  neighbor 10.12.1.2 remote-as 2
+  address-family ipv4 unicast
+    neighbor 10.12.1.2 activate
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as1r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as1r2
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as1r2
+
+interface Loopback0
+  ip address 10.0.0.0 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border1:GigabitEthernet0/1
+  ip address 10.12.2.1 255.255.255.0
+  no shutdown
+!
+
+router bgp 1
+  bgp router-id 10.12.2.1
+  network 10.0.0.0 mask 255.255.255.255
+  neighbor 10.12.2.2 remote-as 2
+  address-family ipv4 unicast
+    neighbor 10.12.2.2 activate
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as1r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as1r3
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as1r3
+
+interface Loopback0
+  ip address 10.0.0.0 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border2:GigabitEthernet0/0
+  ip address 10.12.3.1 255.255.255.0
+  no shutdown
+!
+
+router bgp 1
+  bgp router-id 10.12.3.1
+  network 10.0.0.0 mask 255.255.255.255
+  neighbor 10.12.3.2 remote-as 2
+  address-family ipv4 unicast
+    neighbor 10.12.3.2 activate
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as2border1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as2border1
@@ -1,0 +1,54 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as2border1
+
+interface Loopback0
+  ip address 10.0.2.1 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as1r1:GigabitEthernet0/0
+  ip address 10.12.1.2 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/1
+  description as1r2:GigabitEthernet0/0
+  ip address 10.12.2.2 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/2
+  description as2rr:GigabitEthernet0/0
+  ip address 10.2.13.1 255.255.255.0
+  no shutdown
+!
+
+ip route 10.0.2.3 255.255.255.255 10.2.13.3
+
+route-map comm1 permit 100
+  set community 1
+
+route-map comm2 permit 100
+  set community 2
+
+router bgp 2
+  bgp router-id 10.0.2.1
+  neighbor 10.12.1.1 remote-as 1
+  neighbor 10.12.2.1 remote-as 1
+  neighbor 10.0.2.3 remote-as 2
+  neighbor 10.0.2.3 update-source Loopback0
+  address-family ipv4 unicast
+    bgp additional-paths send receive
+    bgp additional-paths select all
+    bgp additional-paths install
+    maximum-paths eibgp 32
+    neighbor 10.12.1.1 activate
+    neighbor 10.12.1.1 route-map comm1 in
+    neighbor 10.12.2.1 activate
+    neighbor 10.12.2.1 route-map comm2 in
+    neighbor 10.0.2.3 activate
+    neighbor 10.0.2.3 advertise additional-paths all
+    neighbor 10.0.2.3 additional-paths send receive
+    neighbor 10.0.2.3 next-hop-self
+    neighbor 10.0.2.3 send-community both
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as2border2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as2border2
@@ -1,0 +1,43 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as2border2
+
+interface Loopback0
+  ip address 10.0.2.2 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as1r3:GigabitEthernet0/0
+  ip address 10.12.3.2 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/2
+  description as2rr:GigabitEthernet0/1
+  ip address 10.2.23.2 255.255.255.0
+  no shutdown
+!
+
+! as2rr loopback
+ip route 10.0.2.3 255.255.255.255 10.2.23.3
+
+route-map comm3 permit 100
+  set community 3
+
+router bgp 2
+  bgp router-id 10.0.2.2
+  neighbor 10.12.3.1 remote-as 1
+  neighbor 10.0.2.3 remote-as 2
+  neighbor 10.0.2.3 update-source Loopback0
+  address-family ipv4 unicast
+    bgp additional-paths send receive
+    bgp additional-paths select all
+    bgp additional-paths install
+    maximum-paths eibgp 32
+    neighbor 10.12.3.1 activate
+    neighbor 10.12.3.1 route-map comm3 in
+    neighbor 10.0.2.3 activate
+    neighbor 10.0.2.3 advertise additional-paths all
+    neighbor 10.0.2.3 additional-paths send receive
+    neighbor 10.0.2.3 next-hop-self
+    neighbor 10.0.2.3 send-community both
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as2leaf
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as2leaf
@@ -1,0 +1,33 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as2leaf
+
+interface Loopback0
+  ip address 10.0.2.4 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2rr:GigabitEthernet0/2
+  ip address 10.2.34.4 255.255.255.0
+  no shutdown
+!
+
+! as2border1 loopback
+ip route 10.0.2.1 255.255.255.255 10.2.34.3
+! as2border2 loopback
+ip route 10.0.2.2 255.255.255.255 10.2.34.3
+! as2rr loopback
+ip route 10.0.2.3 255.255.255.255 10.2.34.3
+
+router bgp 2
+  bgp router-id 10.0.2.4
+  neighbor 10.0.2.3 remote-as 2
+  neighbor 10.0.2.3 update-source Loopback0
+  address-family ipv4 unicast
+    bgp additional-paths send receive
+    bgp additional-paths select all
+    bgp additional-paths install
+    maximum-paths eibgp 32
+    neighbor 10.0.2.3 activate
+    neighbor 10.0.2.3 advertise additional-paths all
+    neighbor 10.0.2.3 additional-paths send receive
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as2rr
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/add-path/unique-next-hop/configs/as2rr
@@ -1,0 +1,64 @@
+!RANCID-CONTENT-TYPE: cisco
+
+hostname as2rr
+
+interface Loopback0
+  ip address 10.0.2.3 255.255.255.255
+
+interface GigabitEthernet0/0
+  description as2border1:GigabitEthernet0/2
+  ip address 10.2.13.3 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/1
+  description as2border2:GigabitEthernet0/1
+  ip address 10.2.23.3 255.255.255.0
+  no shutdown
+!
+
+interface GigabitEthernet0/2
+  description as2leaf:GigabitEthernet0/0
+  ip address 10.2.34.3 255.255.255.0
+  no shutdown
+!
+
+! as2border1 loopback
+ip route 10.0.2.1 255.255.255.255 10.2.13.1
+! as2border2 loopback
+ip route 10.0.2.2 255.255.255.255 10.2.23.2
+! as2leaf loopback
+ip route 10.0.2.4 255.255.255.255 10.2.34.4
+
+route-map drop deny 100
+!
+
+router bgp 2
+  bgp router-id 10.0.2.3
+  neighbor 10.0.2.1 remote-as 2
+  neighbor 10.0.2.1 update-source Loopback0
+  neighbor 10.0.2.2 remote-as 2
+  neighbor 10.0.2.2 update-source Loopback0
+  neighbor 10.0.2.4 remote-as 2
+  neighbor 10.0.2.4 update-source Loopback0
+  address-family ipv4 unicast
+    bgp additional-paths send receive
+    bgp additional-paths select all
+    bgp additional-paths install
+    maximum-paths eibgp 32
+    neighbor 10.0.2.1 activate
+    neighbor 10.0.2.1 route-reflector-client
+    neighbor 10.0.2.1 advertise additional-paths all
+    neighbor 10.0.2.1 additional-paths send receive
+    neighbor 10.0.2.1 route-map drop out
+    neighbor 10.0.2.2 activate
+    neighbor 10.0.2.2 route-reflector-client
+    neighbor 10.0.2.2 advertise additional-paths all
+    neighbor 10.0.2.2 additional-paths send receive
+    neighbor 10.0.2.2 route-map drop out
+    neighbor 10.0.2.4 activate
+    neighbor 10.0.2.4 route-reflector-client
+    neighbor 10.0.2.4 advertise additional-paths all
+    neighbor 10.0.2.4 additional-paths send receive
+    neighbor 10.0.2.4 send-community both
+!


### PR DESCRIPTION
IOS-based e2e add-path tests:
- Test that a router that sends all additional-paths will advertise multiple routes that are
  duplicate post-export, and that both will be present in the BGP RIB on the receiver
- Test that a router that sends all additional-paths will advertise routes that are not ECMP-best,
  and that both will be present in the BGP RIB on a receiver
- Test that a router with multiple routes for a prefix will advertise only one route per
  unique next hop for that given prefix

Tests will pass without xfail when add-path is implemented properly