### PR TITLE
Juniper basic add-path conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -588,6 +588,25 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
       boolean allowLocalAsIn = loops > 0;
       AddressFamilyCapabilities.Builder ipv4AfSettingsBuilder = AddressFamilyCapabilities.builder();
+
+      // add-path
+      AddPath addPath = ig.getAddPath();
+      if (addPath != null) {
+        ipv4AfSettingsBuilder.setAdditionalPathsReceive(addPath.getReceive());
+        AddPathSend send = addPath.getSend();
+        if (send != null && send.getPathCount() != null) {
+          // path count must be set for add-path send to be enabled on Juniper
+          ipv4AfSettingsBuilder.setAdditionalPathsSend(true);
+          // TODO: Datamodel property additionalPathsSelectAll needs to be split into at least:
+          //       1. select all paths
+          //       - use if Juniper path-selection-mode is ALL_PATHS, or neither path-selection-mode
+          //         nor multipath is set
+          //       2. select all ECMP-best paths
+          //       - use if Juniper path-selection-mode is EQUAL_COST_PATHS, or multipath is set
+          ipv4AfSettingsBuilder.setAdditionalPathsSelectAll(true);
+          // TODO: implement max additional-paths to send in datamodel and populate here
+        }
+      }
       ipv4AfSettingsBuilder.setAllowLocalAsIn(allowLocalAsIn);
       Boolean advertisePeerAs = ig.getAdvertisePeerAs();
       if (advertisePeerAs == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -594,17 +594,26 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (addPath != null) {
         ipv4AfSettingsBuilder.setAdditionalPathsReceive(addPath.getReceive());
         AddPathSend send = addPath.getSend();
-        if (send != null && send.getPathCount() != null) {
-          // path count must be set for add-path send to be enabled on Juniper
-          ipv4AfSettingsBuilder.setAdditionalPathsSend(true);
-          // TODO: Datamodel property additionalPathsSelectAll needs to be split into at least:
-          //       1. select all paths
-          //       - use if Juniper path-selection-mode is ALL_PATHS, or neither path-selection-mode
-          //         nor multipath is set
-          //       2. select all ECMP-best paths
-          //       - use if Juniper path-selection-mode is EQUAL_COST_PATHS, or multipath is set
-          ipv4AfSettingsBuilder.setAdditionalPathsSelectAll(true);
-          // TODO: implement max additional-paths to send in datamodel and populate here
+        if (send != null) {
+          if (send.getPathCount() != null) {
+            // path count must be set for add-path send to be enabled on Juniper
+            ipv4AfSettingsBuilder.setAdditionalPathsSend(true);
+            // TODO: Datamodel property additionalPathsSelectAll needs to be split into at least:
+            //       1. select all paths
+            //       - use if Juniper path-selection-mode is ALL_PATHS, or neither
+            // path-selection-mode
+            //         nor multipath is set
+            //       2. select all ECMP-best paths
+            //       - use if Juniper path-selection-mode is EQUAL_COST_PATHS, or multipath is set
+            ipv4AfSettingsBuilder.setAdditionalPathsSelectAll(true);
+            // TODO: implement max additional-paths to send in datamodel and populate here
+          } else {
+            _w.redFlag(
+                String.format(
+                    "add-path send disabled because add-path send path-count not configured for"
+                        + " neighbor %s",
+                    prefix));
+          }
         }
       }
       ipv4AfSettingsBuilder.setAllowLocalAsIn(allowLocalAsIn);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -324,6 +324,7 @@ import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.InitInfoAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
+import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.BgpConfederation;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
@@ -1291,6 +1292,54 @@ public final class FlatJuniperGrammarTest {
             POLICY_STATEMENT,
             "appp",
             JuniperStructureUsage.ADD_PATH_SEND_PREFIX_POLICY));
+  }
+
+  @Test
+  public void testBgpAddPathConversion() {
+    String hostname = "juniper-bgp-add-path";
+    Configuration c = parseConfig(hostname);
+    Map<Ip, BgpActivePeerConfig> activeNeighbors =
+        c.getDefaultVrf().getBgpProcess().getActiveNeighbors();
+    {
+      AddressFamilyCapabilities afc =
+          activeNeighbors
+              .get(Ip.parse("10.0.0.1"))
+              .getIpv4UnicastAddressFamily()
+              .getAddressFamilyCapabilities();
+      assertFalse(afc.getAdditionalPathsReceive());
+      assertTrue(afc.getAdditionalPathsSend());
+      assertTrue(afc.getAdditionalPathsSelectAll());
+    }
+    {
+      AddressFamilyCapabilities afc =
+          activeNeighbors
+              .get(Ip.parse("10.0.0.2"))
+              .getIpv4UnicastAddressFamily()
+              .getAddressFamilyCapabilities();
+      assertFalse(afc.getAdditionalPathsReceive());
+      assertFalse(afc.getAdditionalPathsSend());
+      assertFalse(afc.getAdditionalPathsSelectAll());
+    }
+    {
+      AddressFamilyCapabilities afc =
+          activeNeighbors
+              .get(Ip.parse("10.0.0.3"))
+              .getIpv4UnicastAddressFamily()
+              .getAddressFamilyCapabilities();
+      assertFalse(afc.getAdditionalPathsReceive());
+      assertFalse(afc.getAdditionalPathsSend());
+      assertFalse(afc.getAdditionalPathsSelectAll());
+    }
+    {
+      AddressFamilyCapabilities afc =
+          activeNeighbors
+              .get(Ip.parse("10.0.0.4"))
+              .getIpv4UnicastAddressFamily()
+              .getAddressFamilyCapabilities();
+      assertTrue(afc.getAdditionalPathsReceive());
+      assertTrue(afc.getAdditionalPathsSend());
+      assertTrue(afc.getAdditionalPathsSelectAll());
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1295,6 +1295,23 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testBgpAddPathWarnings() throws IOException {
+    String hostname = "juniper-bgp-add-path";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    assertThat(
+        ccae.getWarnings().get(hostname).getRedFlagWarnings(),
+        containsInAnyOrder(
+            WarningMatchers.hasText(
+                "add-path send disabled because add-path send path-count not configured for"
+                    + " neighbor 10.0.0.2/32"),
+            WarningMatchers.hasText(
+                "add-path send disabled because add-path send path-count not configured for"
+                    + " neighbor 10.0.0.3/32")));
+  }
+
+  @Test
   public void testBgpAddPathConversion() {
     String hostname = "juniper-bgp-add-path";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-bgp-add-path
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-bgp-add-path
@@ -28,4 +28,9 @@ set protocols bgp group g3 neighbor 10.0.0.3 family inet unicast add-path send p
 set protocols bgp group g3 neighbor 10.0.0.3 family inet unicast add-path send prefix-policy appp
 set protocols bgp group g3 type internal
 set protocols bgp group g3 peer-as 65500
+
+# BGP group g4
+set protocols bgp group g4 neighbor 10.0.0.4
+set protocols bgp group g4 type internal
+set protocols bgp group g4 peer-as 65500
 #


### PR DESCRIPTION
- initial add-path conversion given limited VI model

Follow-on work:
- Finer grained add-path control once VI model is updated