### PR TITLE
VI Interfaces: store `IpAccessList` names instead of references

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.datamodel.InactiveReason.ADMIN_DOWN;
 import static org.batfish.datamodel.InactiveReason.BLACKLISTED;
@@ -2221,6 +2222,8 @@ public final class Interface extends ComparableStructure<String> {
   /** Helper to get an IpAccessList object given its name. */
   @Nullable
   private IpAccessList getIpAccessList(@Nullable String name) {
-    return _owner == null || name == null ? null : _owner.getIpAccessLists().get(name);
+    return _owner == null || name == null
+        ? null
+        : checkNotNull(_owner.getIpAccessLists().get(name));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InterfacePropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InterfacePropertySpecifierTest.java
@@ -11,6 +11,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Iterator;
 import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
@@ -64,12 +66,14 @@ public class InterfacePropertySpecifierTest {
 
   @Test
   public void testIncomingFilterReturnsName() {
+    Configuration c = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     IpAccessList acl =
         IpAccessList.builder()
+            .setOwner(c)
             .setName("MY_ACL")
             .setLines(ImmutableList.of(ExprAclLine.ACCEPT_ALL))
             .build();
-    Interface i1 = Interface.builder().setName("i1").setIncomingFilter(acl).build();
+    Interface i1 = Interface.builder().setOwner(c).setName("i1").setIncomingFilter(acl).build();
     assertThat(
         InterfacePropertySpecifier.getPropertyDescriptor(INCOMING_FILTER_NAME)
             .getGetter()

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConversions.java
@@ -426,7 +426,7 @@ public class SonicConversions {
               Optional.ofNullable(aclNameToRules.get(aclName)).orElse(ImmutableSortedSet.of()),
               w);
       AclTable aclTable = aclTables.get(aclName);
-      attachAcl(c, aclName, ipAccessList, aclTable, w);
+      attachAcl(c, ipAccessList, aclTable, w);
     }
   }
 
@@ -437,8 +437,7 @@ public class SonicConversions {
    * <p>The {@link IpAccessList} should already exist in the specified configuration.
    */
   @VisibleForTesting
-  static void attachAcl(
-      Configuration c, String aclName, IpAccessList ipAccessList, AclTable aclTable, Warnings w) {
+  static void attachAcl(Configuration c, IpAccessList ipAccessList, AclTable aclTable, Warnings w) {
     if (aclTable.getType().orElse(null) != Type.L3) {
       // All ACLs are added to the configuration, but only type L3 ones are attached to interfaces
       return;
@@ -454,7 +453,8 @@ public class SonicConversions {
         if (!aclTable.isControlPlanePort(port)) {
           w.redFlag(
               String.format(
-                  "Port '%s' referenced in ACL_TABLE '%s' does not exist.", port, aclName));
+                  "Port '%s' referenced in ACL_TABLE '%s' does not exist.",
+                  port, ipAccessList.getName()));
         }
         continue;
       }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/representation/SonicConversions.java
@@ -433,6 +433,8 @@ public class SonicConversions {
   /**
    * Attaches the {@code ipAccessList} derived from {@code aclTable} to the appropriate interfaces
    * in {@code c}.
+   *
+   * <p>The {@link IpAccessList} should already exist in the specified configuration.
    */
   @VisibleForTesting
   static void attachAcl(

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
@@ -110,7 +110,8 @@ public class BDDReverseTransformationRangesImplTest {
     // with incoming filter
     {
       String aclName = "ACL";
-      iface.setIncomingFilter(IpAccessList.builder().setName(aclName).build());
+      IpAccessList acl = IpAccessList.builder().setOwner(iface.getOwner()).setName(aclName).build();
+      iface.setIncomingFilter(acl);
       BDD fwdAclBdd =
           _headerSpaceToBDD.toBDD(
               HeaderSpace.builder().setDstPorts(ImmutableList.of(new SubRange(100, 200))).build());
@@ -169,7 +170,8 @@ public class BDDReverseTransformationRangesImplTest {
     // with pre-transformation outgoing filter
     {
       String aclName = "ACL";
-      iface.setPreTransformationOutgoingFilter(IpAccessList.builder().setName(aclName).build());
+      IpAccessList acl = IpAccessList.builder().setOwner(iface.getOwner()).setName(aclName).build();
+      iface.setPreTransformationOutgoingFilter(acl);
       BDD fwdAclBdd =
           _headerSpaceToBDD.toBDD(
               HeaderSpace.builder().setDstPorts(ImmutableList.of(new SubRange(100, 200))).build());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -1800,12 +1800,10 @@ public final class FlowTracerTest {
         nf.interfaceBuilder()
             .setOwner(n1)
             .setOutgoingFilter(
-                IpAccessList.builder().setName("Deny-from-i1").setLines(lines).build())
+                IpAccessList.builder().setOwner(n1).setName("Deny-from-i1").setLines(lines).build())
             .setVrf(v1)
             .setAddress(ConcreteInterfaceAddress.parse("2.0.0.0/31"))
             .build();
-    // Make sure that n1 knows that this filter is applied.
-    n1.setIpAccessLists(ImmutableMap.of(i2.getOutgoingFilter().getName(), i2.getOutgoingFilter()));
     v1.setStaticRoutes(
         ImmutableSortedSet.of(
             StaticRoute.testBuilder()
@@ -2012,6 +2010,7 @@ public final class FlowTracerTest {
     // Filter denies src IP blockedSrcIp, permits everything else
     IpAccessList filter =
         nf.aclBuilder()
+            .setOwner(c)
             .setLines(
                 ExprAclLine.rejecting(AclLineMatchExprs.matchSrc(blockedSrcIp)),
                 ExprAclLine.ACCEPT_ALL)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -2491,7 +2491,7 @@ public class TracerouteEngineImplTest {
     // denies all
     IpAccessList postTransformationFilter =
         nf.aclBuilder()
-            .setOwner(c1)
+            .setOwner(c2)
             .setName("postTransformationAcl")
             .setLines(ImmutableList.of())
             .build();

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/NatGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/NatGatewayTest.java
@@ -311,7 +311,7 @@ public class NatGatewayTest {
   @Test
   public void testInstallIncomingFilter() {
     Configuration cfg = new Configuration("cfg", ConfigurationFormat.AWS);
-    Interface iface = Interface.builder().setName("test").build();
+    Interface iface = Interface.builder().setOwner(cfg).setName("test").build();
 
     Ip blockedIp = Ip.parse("8.8.8.8");
     IpAccessList nacl =

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -878,9 +878,6 @@ public class SubnetTest {
     String nlbHostname = LoadBalancer.getNodeId(lbDnsName, subnet.getAvailabilityZone());
     String instanceHostname = Instance.instanceHostname(instanceId);
 
-    IpAccessList ingressAcl = IpAccessList.builder().setName("ingress").build();
-    IpAccessList egressAcl = IpAccessList.builder().setName("egress").build();
-
     // Subnet has an NLB, no instance targets: Should create VRFs on subnet and VPC, connect subnet
     // to NLB and VPC
     Map<String, Configuration> configs =
@@ -901,6 +898,10 @@ public class SubnetTest {
         Region.builder("region")
             .setSubnets(ImmutableMap.of(subnet.getId(), subnet, otherSubnetId, otherSubnet))
             .build();
+
+    IpAccessList ingressAcl = IpAccessList.builder().setOwner(subnetCfg).setName("ingress").build();
+    IpAccessList egressAcl = IpAccessList.builder().setOwner(subnetCfg).setName("egress").build();
+
     subnet.addNlbInstanceTargetInterfaces(
         awsConf, region, subnetCfg, vpcCfg, ingressAcl, egressAcl);
 
@@ -1007,9 +1008,6 @@ public class SubnetTest {
     String nlbHostname = LoadBalancer.getNodeId(lbDnsName, subnet.getAvailabilityZone());
     String instanceHostname = Instance.instanceHostname(instanceId);
 
-    IpAccessList ingressAcl = IpAccessList.builder().setName("ingress").build();
-    IpAccessList egressAcl = IpAccessList.builder().setName("egress").build();
-
     // Subnet has an instance target, no NLBs: Should create VRFs on subnet and VPC, connect subnet
     // to VPC and instance target
     Map<String, Configuration> configs =
@@ -1028,6 +1026,10 @@ public class SubnetTest {
             ImmutableMultimap.of(lbArn, instanceInSubnet)); // NLBs to targets
     Region region =
         Region.builder("region").setSubnets(ImmutableMap.of(subnet.getId(), subnet)).build();
+
+    IpAccessList ingressAcl = IpAccessList.builder().setOwner(subnetCfg).setName("ingress").build();
+    IpAccessList egressAcl = IpAccessList.builder().setOwner(subnetCfg).setName("egress").build();
+
     subnet.addNlbInstanceTargetInterfaces(
         awsConf, region, subnetCfg, vpcCfg, ingressAcl, egressAcl);
 
@@ -1136,9 +1138,6 @@ public class SubnetTest {
     String nlbHostname = LoadBalancer.getNodeId(lbDnsName, subnet.getAvailabilityZone());
     String instanceHostname = Instance.instanceHostname(instanceId);
 
-    IpAccessList ingressAcl = IpAccessList.builder().setName("ingress").build();
-    IpAccessList egressAcl = IpAccessList.builder().setName("egress").build();
-
     // Subnet has an instance target and its NLB: Should create VRFs on subnet and VPC, connect
     // subnet to instance target, NLB, and VPC
     Map<String, Configuration> configs =
@@ -1157,6 +1156,10 @@ public class SubnetTest {
             ImmutableMultimap.of(lbArn, instanceInSubnet)); // NLBs to targets
     Region region =
         Region.builder("region").setSubnets(ImmutableMap.of(subnet.getId(), subnet)).build();
+
+    IpAccessList ingressAcl = IpAccessList.builder().setOwner(subnetCfg).setName("ingress").build();
+    IpAccessList egressAcl = IpAccessList.builder().setOwner(subnetCfg).setName("egress").build();
+
     subnet.addNlbInstanceTargetInterfaces(
         awsConf, region, subnetCfg, vpcCfg, ingressAcl, egressAcl);
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/SonicConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/SonicConversionsTest.java
@@ -476,7 +476,7 @@ public class SonicConversionsTest {
     Interface.builder().setOwner(c).setName(ifaceName).setType(InterfaceType.PHYSICAL).build();
 
     String aclName = "testAcl";
-    IpAccessList ipAccessList = IpAccessList.builder().setName(aclName).build();
+    IpAccessList ipAccessList = IpAccessList.builder().setOwner(c).setName(aclName).build();
 
     {
       // non-L3 ACLs are not attached to interfaces

--- a/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/SonicConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sonic/representation/SonicConversionsTest.java
@@ -488,7 +488,7 @@ public class SonicConversionsTest {
               .build();
 
       Warnings warnings = new Warnings(true, true, true);
-      attachAcl(c, aclName, ipAccessList, aclTable, warnings);
+      attachAcl(c, ipAccessList, aclTable, warnings);
 
       assertTrue(warnings.getRedFlagWarnings().isEmpty());
       assertNull(c.getAllInterfaces().get(ifaceName).getIncomingFilter());
@@ -499,7 +499,7 @@ public class SonicConversionsTest {
           AclTable.builder().setPorts(ImmutableList.of(ifaceName)).setType(Type.L3).build();
 
       Warnings warnings = new Warnings(true, true, true);
-      attachAcl(c, aclName, ipAccessList, aclTable, warnings);
+      attachAcl(c, ipAccessList, aclTable, warnings);
 
       assertThat(warnings.getRedFlagWarnings(), contains(hasText("Unimplemented ACL stage: null")));
       assertNull(c.getAllInterfaces().get(ifaceName).getIncomingFilter());
@@ -514,7 +514,7 @@ public class SonicConversionsTest {
               .build();
 
       Warnings warnings = new Warnings(true, true, true);
-      attachAcl(c, aclName, ipAccessList, aclTable, warnings);
+      attachAcl(c, ipAccessList, aclTable, warnings);
 
       // warn about 'other', not about 'ctrlplane'
       assertThat(


### PR DESCRIPTION
After this PR, interfaces' `IpAccessList`s must exist in their owner `Configuration` (this should already be the case, except in some tests that had to be updated in this PR).

This means that we can now, e.g. overwrite `IpAccessList`s during `finalizeConfiguration` and the updated ACL would take effect as desired.

