### PR TITLE
Junos: Define a structure type for BGP neighbor

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -55,6 +55,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.BGP_EXPOR
 import static org.batfish.representation.juniper.JuniperStructureUsage.BGP_FAMILY_INET_UNICAST_RIB_GROUP;
 import static org.batfish.representation.juniper.JuniperStructureUsage.BGP_IMPORT_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.BGP_NEIGHBOR;
+import static org.batfish.representation.juniper.JuniperStructureUsage.BGP_NEIGHBOR_SELF_REFERENCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.BRIDGE_DOMAINS_ROUTING_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.BRIDGE_DOMAIN_SELF_REF;
 import static org.batfish.representation.juniper.JuniperStructureUsage.DHCP_RELAY_GROUP_ACTIVE_SERVER_GROUP;
@@ -2483,9 +2484,23 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
         ipBgpGroups.put(remoteAddress, ipBgpGroup);
       }
       _currentBgpGroup = ipBgpGroup;
+      _configuration.defineStructure(
+          JuniperStructureType.BGP_NEIGHBOR, remoteAddress.toString(), ctx);
+      _configuration.referenceStructure(
+          JuniperStructureType.BGP_NEIGHBOR,
+          remoteAddress.toString(),
+          BGP_NEIGHBOR_SELF_REFERENCE,
+          getLine(ctx.ip_address().start));
     } else if (ctx.ipv6_address() != null) {
       _currentBgpGroup.setIpv6(true);
       _currentBgpGroup = DUMMY_BGP_GROUP;
+      String remoteAddress = toIp6(ctx.ipv6_address()).toString();
+      _configuration.defineStructure(JuniperStructureType.BGP_NEIGHBOR, remoteAddress, ctx);
+      _configuration.referenceStructure(
+          JuniperStructureType.BGP_NEIGHBOR,
+          remoteAddress,
+          BGP_NEIGHBOR_SELF_REFERENCE,
+          getLine(ctx.ipv6_address().start));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2484,8 +2484,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
         ipBgpGroups.put(remoteAddress, ipBgpGroup);
       }
       _currentBgpGroup = ipBgpGroup;
-      _configuration.defineStructure(
-          JuniperStructureType.BGP_NEIGHBOR, remoteAddress.toString(), ctx);
+      _configuration.defineFlattenedStructure(
+          JuniperStructureType.BGP_NEIGHBOR, remoteAddress.toString(), ctx, _parser);
       _configuration.referenceStructure(
           JuniperStructureType.BGP_NEIGHBOR,
           remoteAddress.toString(),
@@ -2495,7 +2495,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       _currentBgpGroup.setIpv6(true);
       _currentBgpGroup = DUMMY_BGP_GROUP;
       String remoteAddress = toIp6(ctx.ipv6_address()).toString();
-      _configuration.defineStructure(JuniperStructureType.BGP_NEIGHBOR, remoteAddress, ctx);
+      _configuration.defineFlattenedStructure(
+          JuniperStructureType.BGP_NEIGHBOR, remoteAddress, ctx, _parser);
       _configuration.referenceStructure(
           JuniperStructureType.BGP_NEIGHBOR,
           remoteAddress,

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3825,6 +3825,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         JuniperStructureType.BGP_GROUP,
         JuniperStructureUsage.BGP_ALLOW,
         JuniperStructureUsage.BGP_NEIGHBOR);
+    markConcreteStructure(JuniperStructureType.BGP_NEIGHBOR);
     markConcreteStructure(JuniperStructureType.BRIDGE_DOMAIN);
     markConcreteStructure(
         JuniperStructureType.CLASS_OF_SERVICE_CODE_POINT_ALIAS,

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
@@ -12,6 +12,7 @@ public enum JuniperStructureType implements StructureType {
   AS_PATH_GROUP_AS_PATH("as-path-group as-path"),
   AUTHENTICATION_KEY_CHAIN("authentication-key-chain"),
   BGP_GROUP("bgp group"),
+  BGP_NEIGHBOR("bgp neighbor"),
   BRIDGE_DOMAIN("bridge-domain"),
   CLASS_OF_SERVICE_CODE_POINT_ALIAS("class-of-service code-point-alias"),
   COMMUNITY("community"),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -14,6 +14,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   BGP_EXPORT_POLICY("bgp export policy-statement"),
   BGP_IMPORT_POLICY("bgp import policy-statement"),
   BGP_NEIGHBOR("bgp group neighbor"),
+  BGP_NEIGHBOR_SELF_REFERENCE("bgp neighbor"),
   BGP_FAMILY_INET_UNICAST_RIB_GROUP("bgp family inet unicast rib-group"),
   BRIDGE_DOMAIN_SELF_REF("bridge-domain self reference"),
   BRIDGE_DOMAINS_ROUTING_INTERFACE("bridge-domains routing-interface"),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -14,7 +14,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   BGP_EXPORT_POLICY("bgp export policy-statement"),
   BGP_IMPORT_POLICY("bgp import policy-statement"),
   BGP_NEIGHBOR("bgp group neighbor"),
-  BGP_NEIGHBOR_SELF_REFERENCE("bgp neighbor"),
+  BGP_NEIGHBOR_SELF_REFERENCE("bgp neighbor self ref"),
   BGP_FAMILY_INET_UNICAST_RIB_GROUP("bgp family inet unicast rib-group"),
   BRIDGE_DOMAIN_SELF_REF("bridge-domain self reference"),
   BRIDGE_DOMAINS_ROUTING_INTERFACE("bridge-domains routing-interface"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1140,11 +1140,11 @@ public final class FlatJuniperGrammarTest {
 
     assertThat(
         ccae,
-        hasDefinedStructureWithDefinitionLines(filename, BGP_GROUP, "G", containsInAnyOrder(5)));
+        hasDefinedStructureWithDefinitionLines(filename, BGP_GROUP, "G", containsInAnyOrder(4)));
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(
-            filename, BGP_NEIGHBOR, "1.2.3.4/32", containsInAnyOrder(5)));
+            filename, BGP_NEIGHBOR, "1.2.3.4/32", containsInAnyOrder(4)));
 
     assertThat(ccae, hasNumReferrers(filename, BGP_GROUP, "G", 1));
     assertThat(ccae, hasNumReferrers(filename, BGP_NEIGHBOR, "1.2.3.4/32", 1));

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -165,6 +165,8 @@ import static org.batfish.representation.juniper.JuniperStructureType.APPLICATIO
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION_OR_APPLICATION_SET;
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION_SET;
 import static org.batfish.representation.juniper.JuniperStructureType.AUTHENTICATION_KEY_CHAIN;
+import static org.batfish.representation.juniper.JuniperStructureType.BGP_GROUP;
+import static org.batfish.representation.juniper.JuniperStructureType.BGP_NEIGHBOR;
 import static org.batfish.representation.juniper.JuniperStructureType.BRIDGE_DOMAIN;
 import static org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_CODE_POINT_ALIAS;
 import static org.batfish.representation.juniper.JuniperStructureType.COMMUNITY;
@@ -1126,6 +1128,26 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         parseConfig("bgp-multipath-none").getDefaultVrf(),
         hasBgpProcess(allOf(hasMultipathEbgp(false), hasMultipathIbgp(false))));
+  }
+
+  @Test
+  public void testBgpNeighborExtraction() throws IOException {
+    String hostname = "bgp-neighbor";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    assertThat(
+        ccae,
+        hasDefinedStructureWithDefinitionLines(filename, BGP_GROUP, "G", containsInAnyOrder(5)));
+    assertThat(
+        ccae,
+        hasDefinedStructureWithDefinitionLines(
+            filename, BGP_NEIGHBOR, "1.2.3.4/32", containsInAnyOrder(5)));
+
+    assertThat(ccae, hasNumReferrers(filename, BGP_GROUP, "G", 1));
+    assertThat(ccae, hasNumReferrers(filename, BGP_NEIGHBOR, "1.2.3.4/32", 1));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-neighbor
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-neighbor
@@ -1,0 +1,5 @@
+#
+set system host-name bgp-neighbor
+#
+set routing-options autonomous-system 1
+set protocols bgp group G neighbor 1.2.3.4

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-neighbor
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-neighbor
@@ -1,5 +1,4 @@
 #
 set system host-name bgp-neighbor
 #
-set routing-options autonomous-system 1
 set protocols bgp group G neighbor 1.2.3.4

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -11295,6 +11295,24 @@
               "numReferrers" : 1
             }
           },
+          "bgp neighbor" : {
+            "1.10.1.1/32" : {
+              "definitionLines" : "14",
+              "numReferrers" : 1
+            },
+            "10.12.11.2/32" : {
+              "definitionLines" : "19",
+              "numReferrers" : 1
+            },
+            "3.2.2.2/32" : {
+              "definitionLines" : "27",
+              "numReferrers" : 1
+            },
+            "5.6.7.8/32" : {
+              "definitionLines" : "23",
+              "numReferrers" : 1
+            }
+          },
           "community" : {
             "as1_to_as2_community" : {
               "definitionLines" : "51",
@@ -11402,6 +11420,20 @@
             },
             "as4" : {
               "definitionLines" : "21-25",
+              "numReferrers" : 1
+            }
+          },
+          "bgp neighbor" : {
+            "1.10.1.1/32" : {
+              "definitionLines" : "15",
+              "numReferrers" : 1
+            },
+            "10.13.22.3/32" : {
+              "definitionLines" : "20",
+              "numReferrers" : 1
+            },
+            "10.14.22.4/32" : {
+              "definitionLines" : "25",
               "numReferrers" : 1
             }
           },
@@ -12605,6 +12637,28 @@
               ]
             }
           },
+          "bgp neighbor" : {
+            "1.10.1.1/32" : {
+              "bgp neighbor" : [
+                14
+              ]
+            },
+            "10.12.11.2/32" : {
+              "bgp neighbor" : [
+                19
+              ]
+            },
+            "3.2.2.2/32" : {
+              "bgp neighbor" : [
+                27
+              ]
+            },
+            "5.6.7.8/32" : {
+              "bgp neighbor" : [
+                23
+              ]
+            }
+          },
           "community" : {
             "as1_to_as2_community" : {
               "policy-statement then add community" : [
@@ -12756,6 +12810,23 @@
             },
             "as4" : {
               "bgp group neighbor" : [
+                25
+              ]
+            }
+          },
+          "bgp neighbor" : {
+            "1.10.1.1/32" : {
+              "bgp neighbor" : [
+                15
+              ]
+            },
+            "10.13.22.3/32" : {
+              "bgp neighbor" : [
+                20
+              ]
+            },
+            "10.14.22.4/32" : {
+              "bgp neighbor" : [
                 25
               ]
             }

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -12639,22 +12639,22 @@
           },
           "bgp neighbor" : {
             "1.10.1.1/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 14
               ]
             },
             "10.12.11.2/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 19
               ]
             },
             "3.2.2.2/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 27
               ]
             },
             "5.6.7.8/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 23
               ]
             }
@@ -12816,17 +12816,17 @@
           },
           "bgp neighbor" : {
             "1.10.1.1/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 15
               ]
             },
             "10.13.22.3/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 20
               ]
             },
             "10.14.22.4/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 25
               ]
             }

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -6235,6 +6235,16 @@
               "numReferrers" : 2
             }
           },
+          "bgp neighbor" : {
+            "10.12.0.2/32" : {
+              "definitionLines" : "113",
+              "numReferrers" : 1
+            },
+            "10.13.0.3/32" : {
+              "definitionLines" : "114",
+              "numReferrers" : 1
+            }
+          },
           "ike gateway" : {
             "gateway-2" : {
               "definitionLines" : "28-30",
@@ -6391,6 +6401,16 @@
               "numReferrers" : 2
             }
           },
+          "bgp neighbor" : {
+            "10.12.0.1/32" : {
+              "definitionLines" : "92",
+              "numReferrers" : 1
+            },
+            "10.23.0.3/32" : {
+              "definitionLines" : "93",
+              "numReferrers" : 1
+            }
+          },
           "ike gateway" : {
             "gateway-1" : {
               "definitionLines" : "25-27",
@@ -6497,6 +6517,16 @@
             "physical" : {
               "definitionLines" : "85-87",
               "numReferrers" : 2
+            }
+          },
+          "bgp neighbor" : {
+            "10.13.0.1/32" : {
+              "definitionLines" : "86",
+              "numReferrers" : 1
+            },
+            "10.23.0.2/32" : {
+              "definitionLines" : "87",
+              "numReferrers" : 1
             }
           },
           "ike gateway" : {
@@ -6618,6 +6648,18 @@
             "physical" : {
               "bgp group neighbor" : [
                 113,
+                114
+              ]
+            }
+          },
+          "bgp neighbor" : {
+            "10.12.0.2/32" : {
+              "bgp neighbor" : [
+                113
+              ]
+            },
+            "10.13.0.3/32" : {
+              "bgp neighbor" : [
                 114
               ]
             }
@@ -6890,6 +6932,18 @@
               ]
             }
           },
+          "bgp neighbor" : {
+            "10.12.0.1/32" : {
+              "bgp neighbor" : [
+                92
+              ]
+            },
+            "10.23.0.3/32" : {
+              "bgp neighbor" : [
+                93
+              ]
+            }
+          },
           "ike gateway" : {
             "gateway-1" : {
               "ipsec vpn ike gateway" : [
@@ -7057,6 +7111,18 @@
             "physical" : {
               "bgp group neighbor" : [
                 86,
+                87
+              ]
+            }
+          },
+          "bgp neighbor" : {
+            "10.13.0.1/32" : {
+              "bgp neighbor" : [
+                86
+              ]
+            },
+            "10.23.0.2/32" : {
+              "bgp neighbor" : [
                 87
               ]
             }

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -6654,12 +6654,12 @@
           },
           "bgp neighbor" : {
             "10.12.0.2/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 113
               ]
             },
             "10.13.0.3/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 114
               ]
             }
@@ -6934,12 +6934,12 @@
           },
           "bgp neighbor" : {
             "10.12.0.1/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 92
               ]
             },
             "10.23.0.3/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 93
               ]
             }
@@ -7117,12 +7117,12 @@
           },
           "bgp neighbor" : {
             "10.13.0.1/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 86
               ]
             },
             "10.23.0.2/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 87
               ]
             }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -79629,37 +79629,37 @@
           },
           "bgp neighbor" : {
             "172.16.3.2/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 126
               ]
             },
             "172.16.5.2/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 129
               ]
             },
             "172.16.7.2/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 132
               ]
             },
             "192.168.1.1/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 152
               ]
             },
             "192.168.1.3/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 149
               ]
             },
             "192.168.1.44/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 150
               ]
             },
             "192.168.1.5/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 151
               ]
             }
@@ -80784,29 +80784,29 @@
           },
           "bgp neighbor" : {
             "1.2.3.5/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 33,
                 34
               ]
             },
             "3.4.5.6/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 15
               ]
             },
             "3.4.5.7/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 16,
                 17
               ]
             },
             "beef:dead:0:0:0:0:0:2" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 42
               ]
             },
             "dead:beef:0:0:0:0:0:1" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 25
               ]
             }
@@ -80866,12 +80866,12 @@
           },
           "bgp neighbor" : {
             "172.16.2.1/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 8
               ]
             },
             "172.16.2.2/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 22
               ]
             }
@@ -80887,7 +80887,7 @@
           },
           "bgp neighbor" : {
             "1.1.1.1/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 7
               ]
             }
@@ -81437,7 +81437,7 @@
           },
           "bgp neighbor" : {
             "1.1.1.1/32" : {
-              "bgp neighbor" : [
+              "bgp neighbor self ref" : [
                 16,
                 19,
                 22,

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -73123,6 +73123,36 @@
               "numReferrers" : 3
             }
           },
+          "bgp neighbor" : {
+            "172.16.3.2/32" : {
+              "definitionLines" : "126-128",
+              "numReferrers" : 1
+            },
+            "172.16.5.2/32" : {
+              "definitionLines" : "129-131",
+              "numReferrers" : 1
+            },
+            "172.16.7.2/32" : {
+              "definitionLines" : "132-134",
+              "numReferrers" : 1
+            },
+            "192.168.1.1/32" : {
+              "definitionLines" : "152",
+              "numReferrers" : 1
+            },
+            "192.168.1.3/32" : {
+              "definitionLines" : "149",
+              "numReferrers" : 1
+            },
+            "192.168.1.44/32" : {
+              "definitionLines" : "150",
+              "numReferrers" : 1
+            },
+            "192.168.1.5/32" : {
+              "definitionLines" : "151",
+              "numReferrers" : 1
+            }
+          },
           "bridge-domain" : {
             "bd_100" : {
               "definitionLines" : "221-228,236",
@@ -73910,6 +73940,28 @@
               "definitionLines" : "21-27",
               "numReferrers" : 1
             }
+          },
+          "bgp neighbor" : {
+            "1.2.3.5/32" : {
+              "definitionLines" : "33-34",
+              "numReferrers" : 2
+            },
+            "3.4.5.6/32" : {
+              "definitionLines" : "15",
+              "numReferrers" : 1
+            },
+            "3.4.5.7/32" : {
+              "definitionLines" : "16-17",
+              "numReferrers" : 2
+            },
+            "beef:dead:0:0:0:0:0:2" : {
+              "definitionLines" : "42",
+              "numReferrers" : 1
+            },
+            "dead:beef:0:0:0:0:0:1" : {
+              "definitionLines" : "25",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_bgp_allow" : {
@@ -73936,6 +73988,16 @@
               "definitionLines" : "20-23",
               "numReferrers" : 1
             }
+          },
+          "bgp neighbor" : {
+            "172.16.2.1/32" : {
+              "definitionLines" : "8",
+              "numReferrers" : 1
+            },
+            "172.16.2.2/32" : {
+              "definitionLines" : "22",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_bgp_disable" : {
@@ -73950,6 +74012,12 @@
           "bgp group" : {
             "MYGROUP" : {
               "definitionLines" : "5-8",
+              "numReferrers" : 1
+            }
+          },
+          "bgp neighbor" : {
+            "1.1.1.1/32" : {
+              "definitionLines" : "7",
               "numReferrers" : 1
             }
           }
@@ -74322,6 +74390,12 @@
           "bgp group" : {
             "BGP_GROUP" : {
               "definitionLines" : "15-16,18-19,21-22,24-25",
+              "numReferrers" : 4
+            }
+          },
+          "bgp neighbor" : {
+            "1.1.1.1/32" : {
+              "definitionLines" : "16,19,22,25",
               "numReferrers" : 4
             }
           },
@@ -79553,6 +79627,43 @@
               ]
             }
           },
+          "bgp neighbor" : {
+            "172.16.3.2/32" : {
+              "bgp neighbor" : [
+                126
+              ]
+            },
+            "172.16.5.2/32" : {
+              "bgp neighbor" : [
+                129
+              ]
+            },
+            "172.16.7.2/32" : {
+              "bgp neighbor" : [
+                132
+              ]
+            },
+            "192.168.1.1/32" : {
+              "bgp neighbor" : [
+                152
+              ]
+            },
+            "192.168.1.3/32" : {
+              "bgp neighbor" : [
+                149
+              ]
+            },
+            "192.168.1.44/32" : {
+              "bgp neighbor" : [
+                150
+              ]
+            },
+            "192.168.1.5/32" : {
+              "bgp neighbor" : [
+                151
+              ]
+            }
+          },
           "bridge-domain" : {
             "bd_100" : {
               "bridge-domain self reference" : [
@@ -80671,6 +80782,35 @@
               ]
             }
           },
+          "bgp neighbor" : {
+            "1.2.3.5/32" : {
+              "bgp neighbor" : [
+                33,
+                34
+              ]
+            },
+            "3.4.5.6/32" : {
+              "bgp neighbor" : [
+                15
+              ]
+            },
+            "3.4.5.7/32" : {
+              "bgp neighbor" : [
+                16,
+                17
+              ]
+            },
+            "beef:dead:0:0:0:0:0:2" : {
+              "bgp neighbor" : [
+                42
+              ]
+            },
+            "dead:beef:0:0:0:0:0:1" : {
+              "bgp neighbor" : [
+                25
+              ]
+            }
+          },
           "policy-statement" : {
             "someexportpolicy" : {
               "bgp export policy-statement" : [
@@ -80723,12 +80863,31 @@
                 22
               ]
             }
+          },
+          "bgp neighbor" : {
+            "172.16.2.1/32" : {
+              "bgp neighbor" : [
+                8
+              ]
+            },
+            "172.16.2.2/32" : {
+              "bgp neighbor" : [
+                22
+              ]
+            }
           }
         },
         "configs/juniper_bgp_enforce_fist_as" : {
           "bgp group" : {
             "MYGROUP" : {
               "bgp group neighbor" : [
+                7
+              ]
+            }
+          },
+          "bgp neighbor" : {
+            "1.1.1.1/32" : {
+              "bgp neighbor" : [
                 7
               ]
             }
@@ -81269,6 +81428,16 @@
           "bgp group" : {
             "BGP_GROUP" : {
               "bgp group neighbor" : [
+                16,
+                19,
+                22,
+                25
+              ]
+            }
+          },
+          "bgp neighbor" : {
+            "1.1.1.1/32" : {
+              "bgp neighbor" : [
                 16,
                 19,
                 22,


### PR DESCRIPTION
Helps pull out the neighbor definitions in the config file. 

(If this makes sense, will do other vendors in separate PRs.) 