### PR TITLE
BDDPacket.getFlow: don't set irrelevant fields

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -23,6 +23,7 @@ import net.sf.javabdd.JFactory;
 import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
 
 /**
@@ -425,26 +426,33 @@ public class BDDPacket implements Serializable {
   }
 
   public Flow.Builder getFromFromAssignment(BitSet bits) {
+    IpProtocol protocol = _ipProtocol.satAssignmentToValue(bits);
     Flow.Builder fb = Flow.builder();
     fb.setDstIp(Ip.create(_dstIp.getVar().satAssignmentToLong(bits)));
     fb.setSrcIp(Ip.create(_srcIp.getVar().satAssignmentToLong(bits)));
-    fb.setDstPort(_dstPort.getVar().satAssignmentToInt(bits));
-    fb.setSrcPort(_srcPort.getVar().satAssignmentToInt(bits));
-    fb.setIpProtocol(_ipProtocol.satAssignmentToValue(bits));
-    fb.setIcmpCode(_icmpCode.satAssignmentToValue(bits));
-    fb.setIcmpType(_icmpType.satAssignmentToValue(bits));
-    fb.setTcpFlagsAck(bits.get(_tcpAck.level()));
-    fb.setTcpFlagsCwr(bits.get(_tcpCwr.level()));
-    fb.setTcpFlagsEce(bits.get(_tcpEce.level()));
-    fb.setTcpFlagsFin(bits.get(_tcpFin.level()));
-    fb.setTcpFlagsPsh(bits.get(_tcpPsh.level()));
-    fb.setTcpFlagsRst(bits.get(_tcpRst.level()));
-    fb.setTcpFlagsSyn(bits.get(_tcpSyn.level()));
-    fb.setTcpFlagsUrg(bits.get(_tcpUrg.level()));
+    fb.setIpProtocol(protocol);
     fb.setDscp(_dscp.satAssignmentToInt(bits));
     fb.setEcn(_ecn.satAssignmentToInt(bits));
     fb.setFragmentOffset(_fragmentOffset.satAssignmentToInt(bits));
     fb.setPacketLength(_packetLength.satAssignmentToValue(bits));
+    if (IpProtocol.IP_PROTOCOLS_WITH_PORTS.contains(protocol)) {
+      fb.setDstPort(_dstPort.getVar().satAssignmentToInt(bits));
+      fb.setSrcPort(_srcPort.getVar().satAssignmentToInt(bits));
+    }
+    if (protocol == IpProtocol.ICMP) {
+      fb.setIcmpCode(_icmpCode.satAssignmentToValue(bits));
+      fb.setIcmpType(_icmpType.satAssignmentToValue(bits));
+    }
+    if (protocol == IpProtocol.TCP) {
+      fb.setTcpFlagsAck(bits.get(_tcpAck.level()));
+      fb.setTcpFlagsCwr(bits.get(_tcpCwr.level()));
+      fb.setTcpFlagsEce(bits.get(_tcpEce.level()));
+      fb.setTcpFlagsFin(bits.get(_tcpFin.level()));
+      fb.setTcpFlagsPsh(bits.get(_tcpPsh.level()));
+      fb.setTcpFlagsRst(bits.get(_tcpRst.level()));
+      fb.setTcpFlagsSyn(bits.get(_tcpSyn.level()));
+      fb.setTcpFlagsUrg(bits.get(_tcpUrg.level()));
+    }
     return fb;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
@@ -8,17 +8,11 @@ import static org.batfish.datamodel.matchers.FlowMatchers.hasIcmpType;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIpProtocol;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcPort;
-import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsAck;
-import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsCwr;
-import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsEce;
-import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsFin;
-import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsPsh;
-import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsRst;
-import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsUrg;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -32,6 +26,7 @@ import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.NamedPort;
+import org.batfish.datamodel.TcpFlags;
 import org.junit.Test;
 
 public class BDDPacketTest {
@@ -119,27 +114,26 @@ public class BDDPacketTest {
     BDD bdd =
         pkt.getDstIp()
             .value(dstIp.asLong())
+            .and(pkt.getSrcIp().value(srcIp.asLong()))
+            .and(pkt.getIpProtocol().value(ipProtocol))
             .and(pkt.getIcmpCode().value(icmpCode))
             .and(pkt.getIcmpType().value(icmpType))
-            .and(pkt.getIpProtocol().value(ipProtocol))
-            .and(pkt.getSrcIp().value(srcIp.asLong()))
-            .and(pkt.getTcpAck().not())
-            .and(pkt.getTcpCwr())
-            .and(pkt.getTcpEce().not())
-            .and(pkt.getTcpFin())
-            .and(pkt.getTcpPsh().not())
-            .and(pkt.getTcpRst())
-            .and(pkt.getTcpUrg().not());
+            .randomFullSatOne(7654321);
 
     Optional<Flow.Builder> flowBuilder = pkt.getFlow(bdd);
     assertTrue("Unsat", flowBuilder.isPresent());
     Flow flow = flowBuilder.get().setIngressNode("ingressNode").build();
 
     assertThat(flow, hasDstIp(dstIp));
+    assertThat(flow, hasSrcIp(srcIp));
+    assertThat(flow, hasIpProtocol(ipProtocol));
     assertThat(flow, hasIcmpCode(icmpCode));
     assertThat(flow, hasIcmpType(icmpType));
-    assertThat(flow, hasIpProtocol(ipProtocol));
-    assertThat(flow, hasSrcIp(srcIp));
+    assertThat(flow.getDstPort(), nullValue());
+    assertThat(flow.getSrcPort(), nullValue());
+    assertThat(
+        flow.getTcpFlags(),
+        equalTo(new TcpFlags(false, false, false, false, false, false, false, false)));
   }
 
   @Test
@@ -152,20 +146,13 @@ public class BDDPacketTest {
     int srcPort = 0xFF;
 
     IpProtocol ipProtocol = IpProtocol.TCP;
-    boolean tcpAck = false;
-    boolean tcpCwr = true;
-    boolean tcpEce = false;
-    boolean tcpFin = true;
-    boolean tcpPsh = false;
-    boolean tcpRst = true;
-    boolean tcpUrg = false;
 
     BDD bdd =
         pkt.getDstIp()
             .value(dstIp.asLong())
-            .and(pkt.getDstPort().value(dstPort))
-            .and(pkt.getIpProtocol().value(ipProtocol))
             .and(pkt.getSrcIp().value(srcIp.asLong()))
+            .and(pkt.getIpProtocol().value(ipProtocol))
+            .and(pkt.getDstPort().value(dstPort))
             .and(pkt.getSrcPort().value(srcPort))
             .and(pkt.getTcpAck().not())
             .and(pkt.getTcpCwr())
@@ -173,7 +160,9 @@ public class BDDPacketTest {
             .and(pkt.getTcpFin())
             .and(pkt.getTcpPsh().not())
             .and(pkt.getTcpRst())
-            .and(pkt.getTcpUrg().not());
+            .and(pkt.getTcpSyn().not())
+            .and(pkt.getTcpUrg())
+            .randomFullSatOne(7654321);
 
     Optional<Flow.Builder> flowBuilder = pkt.getFlow(bdd);
     assertTrue("Unsat", flowBuilder.isPresent());
@@ -184,13 +173,47 @@ public class BDDPacketTest {
     assertThat(flow, hasIpProtocol(ipProtocol));
     assertThat(flow, hasSrcIp(srcIp));
     assertThat(flow, hasSrcPort(srcPort));
-    assertThat(flow, hasTcpFlagsAck(tcpAck));
-    assertThat(flow, hasTcpFlagsCwr(tcpCwr));
-    assertThat(flow, hasTcpFlagsEce(tcpEce));
-    assertThat(flow, hasTcpFlagsFin(tcpFin));
-    assertThat(flow, hasTcpFlagsPsh(tcpPsh));
-    assertThat(flow, hasTcpFlagsRst(tcpRst));
-    assertThat(flow, hasTcpFlagsUrg(tcpUrg));
+    assertThat(
+        flow.getTcpFlags(),
+        equalTo(new TcpFlags(false, true, false, true, false, true, false, true)));
+    assertThat(flow.getIcmpType(), nullValue());
+    assertThat(flow.getIcmpCode(), nullValue());
+  }
+
+  @Test
+  public void testGetFlow_UDP() {
+    BDDPacket pkt = new BDDPacket();
+    Ip dstIp = Ip.parse("123.45.78.0");
+    int dstPort = 0xA0;
+
+    Ip srcIp = Ip.parse("255.255.255.255");
+    int srcPort = 0xFF;
+
+    IpProtocol ipProtocol = IpProtocol.UDP;
+
+    BDD bdd =
+        pkt.getDstIp()
+            .value(dstIp.asLong())
+            .and(pkt.getSrcIp().value(srcIp.asLong()))
+            .and(pkt.getIpProtocol().value(ipProtocol))
+            .and(pkt.getDstPort().value(dstPort))
+            .and(pkt.getSrcPort().value(srcPort))
+            .randomFullSatOne(7654321);
+
+    Optional<Flow.Builder> flowBuilder = pkt.getFlow(bdd);
+    assertTrue("Unsat", flowBuilder.isPresent());
+    Flow flow = flowBuilder.get().setIngressNode("ingressNode").build();
+
+    assertThat(flow, hasDstIp(dstIp));
+    assertThat(flow, hasDstPort(dstPort));
+    assertThat(flow, hasIpProtocol(ipProtocol));
+    assertThat(flow, hasSrcIp(srcIp));
+    assertThat(flow, hasSrcPort(srcPort));
+    assertThat(flow.getIcmpType(), nullValue());
+    assertThat(flow.getIcmpCode(), nullValue());
+    assertThat(
+        flow.getTcpFlags(),
+        equalTo(new TcpFlags(false, false, false, false, false, false, false, false)));
   }
 
   @Test
@@ -333,5 +356,25 @@ public class BDDPacketTest {
     BDD orig = mkBdd.apply(dstIp, srcIp).apply(dstPort);
     BDD swapped = mkBdd.apply(srcIp, dstIp).apply(srcPort);
     assertThat(pkt.swapSourceAndDestinationFields(orig), equalTo(swapped));
+  }
+
+  @Test
+  public void testGetRepresentativeFlowIgnoresIrrelevantBits() {
+    BDDPacket pkt = new BDDPacket();
+    // A random flow that cannot have ports, icmp type/code, or tcp flags.
+    BDD randomAssignment = pkt.getIpProtocol().value(IpProtocol.OSPF).randomFullSatOne(76451234);
+    Flow flow =
+        pkt.getFlow(randomAssignment)
+            .map(fb -> fb.setIngressNode("n").setIngressVrf("v").build())
+            .orElse(null);
+    assertThat(flow, notNullValue());
+    assertThat(flow.getDstPort(), nullValue());
+    assertThat(flow.getSrcPort(), nullValue());
+    assertThat(flow.getIcmpType(), nullValue());
+    assertThat(flow.getIcmpCode(), nullValue());
+    // TODO: why is this required?
+    assertThat(
+        flow.getTcpFlags(),
+        equalTo(new TcpFlags(false, false, false, false, false, false, false, false)));
   }
 }


### PR DESCRIPTION
Setting fields not related to the IP Protocol can be
confusing for downstream users of the Flow.

commit-id:64681fe7