### PR TITLE
finalizeConfiguration: check invariants on converted ACLs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/util/AclPacketMatchValidityChecker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/util/AclPacketMatchValidityChecker.java
@@ -1,0 +1,92 @@
+package org.batfish.common.bdd.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.common.bdd.IpAccessListToBddImpl;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpProtocol;
+
+/** Checks ACLs for validity with respect to which IPv4 variables they test. */
+public final class AclPacketMatchValidityChecker {
+  public static AclPacketMatchValidityChecker checkerFor(Configuration c) {
+    BDDPacket pkt = new BDDPacket();
+    IpAccessListToBdd toBdd =
+        new IpAccessListToBddImpl(
+            pkt,
+            BDDSourceManager.forInterfaces(pkt, c.getAllInterfaces().keySet()),
+            c.getIpAccessLists(),
+            c.getIpSpaces());
+    return new AclPacketMatchValidityChecker(pkt, toBdd);
+  }
+
+  /**
+   * Checks that the given BDD obeys packet invariants about which fields can be tested
+   * independently vs must be tested together (e.g., ICMP Code should only be tested if this is an
+   * ICMP packet).
+   */
+  public boolean check(IpAccessList acl) {
+    BDD aclBdd = _toBdd.toBdd(acl);
+    return aclMeetsPacketMatchInvariants(aclBdd);
+  }
+
+  @VisibleForTesting
+  boolean aclMeetsPacketMatchInvariants(BDD aclBdd) {
+    // TCP Flags should only be set for TCP packets
+    BDD notTcp = aclBdd.and(_notTcp);
+    boolean tcpOk = !notTcp.testsVars(_pkt.getTcpFlagsVars());
+    notTcp.free();
+    if (!tcpOk) {
+      return false;
+    }
+
+    // ICMP type/code should only be set for ICMP packets
+    BDD notIcmp = _notIcmp.and(aclBdd);
+    boolean icmpOk = !notIcmp.testsVars(_icmpVars);
+    notIcmp.free();
+    if (!icmpOk) {
+      return false;
+    }
+
+    // Ports should only be set for protocols with ports
+    BDD notPorts = aclBdd.and(_notPorts);
+    boolean portsOk = !notPorts.testsVars(_portVars);
+    notPorts.free();
+    if (!portsOk) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @VisibleForTesting
+  AclPacketMatchValidityChecker(@Nonnull BDDPacket pkt, @Nonnull IpAccessListToBdd toBdd) {
+    _pkt = pkt;
+    _toBdd = toBdd;
+    _notTcp = _pkt.getIpProtocol().value(IpProtocol.TCP).notEq();
+    _notIcmp = _pkt.getIpProtocol().value(IpProtocol.ICMP).notEq();
+    BDD[] portProtocols =
+        IpProtocol.IP_PROTOCOLS_WITH_PORTS.stream()
+            .map(pkt.getIpProtocol()::value)
+            .toArray(BDD[]::new);
+    _notPorts = pkt.getFactory().orAllAndFree(portProtocols).notEq();
+    _icmpVars =
+        _pkt.getIcmpType()
+            .getBDDInteger()
+            .getVars()
+            .and(_pkt.getIcmpCode().getBDDInteger().getVars());
+    _portVars = _pkt.getDstPort().getVars().and(_pkt.getSrcPort().getVars());
+  }
+
+  private final @Nonnull BDDPacket _pkt;
+  private final @Nonnull IpAccessListToBdd _toBdd;
+  private final @Nonnull BDD _notTcp;
+  private final @Nonnull BDD _notIcmp;
+  private final @Nonnull BDD _notPorts;
+  private final @Nonnull BDD _icmpVars;
+  private final @Nonnull BDD _portVars;
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/util/AclPacketMatchValidityCheckerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/util/AclPacketMatchValidityCheckerTest.java
@@ -1,0 +1,66 @@
+package org.batfish.common.bdd.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.HeaderSpaceToBDD;
+import org.batfish.common.bdd.IpAccessListToBddImpl;
+import org.batfish.datamodel.IpProtocol;
+import org.junit.Test;
+
+public class AclPacketMatchValidityCheckerTest {
+  @Test
+  public void testAclHasPacketInvariants() {
+    BDDPacket pkt = new BDDPacket();
+    AclPacketMatchValidityChecker checker =
+        new AclPacketMatchValidityChecker(
+            pkt,
+            new IpAccessListToBddImpl(
+                pkt,
+                BDDSourceManager.empty(pkt),
+                new HeaderSpaceToBDD(pkt, Collections.emptyMap()),
+                Collections.emptyMap()));
+    // The fullSat functions constrain every bit, so violate invariants.
+    assertFalse(checker.aclMeetsPacketMatchInvariants(pkt.getFactory().one().fullSatOne()));
+    assertFalse(
+        checker.aclMeetsPacketMatchInvariants(pkt.getFactory().one().randomFullSatOne(7654321)));
+
+    BDD icmp = pkt.getIpProtocol().value(IpProtocol.ICMP);
+    BDD tcp = pkt.getIpProtocol().value(IpProtocol.TCP);
+    BDD udp = pkt.getIpProtocol().value(IpProtocol.UDP);
+    BDD ospf = pkt.getIpProtocol().value(IpProtocol.OSPF);
+    BDD code5 = pkt.getIcmpCode().value(5);
+    BDD type6 = pkt.getIcmpType().value(6);
+    BDD dport7 = pkt.getDstPort().value(7);
+    BDD sport8 = pkt.getSrcPort().value(8);
+    BDD tcpFlag = pkt.getTcpAck();
+
+    // Some valid packets
+    assertTrue(checker.aclMeetsPacketMatchInvariants(icmp));
+    assertTrue(checker.aclMeetsPacketMatchInvariants(icmp.and(type6).and(code5)));
+    assertTrue(checker.aclMeetsPacketMatchInvariants(tcp));
+    assertTrue(checker.aclMeetsPacketMatchInvariants(tcp.and(dport7).and(sport8).and(tcpFlag)));
+    assertTrue(checker.aclMeetsPacketMatchInvariants(udp));
+    assertTrue(checker.aclMeetsPacketMatchInvariants(udp.and(dport7).and(sport8)));
+    assertTrue(checker.aclMeetsPacketMatchInvariants(ospf));
+
+    // Some invalid packets
+    assertFalse(checker.aclMeetsPacketMatchInvariants(icmp.and(dport7)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(icmp.and(sport8)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(icmp.and(tcpFlag)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(udp.and(code5)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(udp.and(type6)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(udp.and(tcpFlag)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(tcp.and(code5)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(tcp.and(type6)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(ospf.and(code5)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(ospf.and(type6)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(ospf.and(dport7)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(ospf.and(sport8)));
+    assertFalse(checker.aclMeetsPacketMatchInvariants(ospf.and(tcpFlag)));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/util/BUILD
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/util/BUILD
@@ -1,0 +1,20 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("@batfish//skylark:pmd_test.bzl", "pmd_test")
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "//projects/bdd",
+        "@maven//:junit_junit",
+    ],
+)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeGroupTypeLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeGroupTypeLine.java
@@ -2,6 +2,7 @@ package org.batfish.representation.cisco_asa;
 
 import com.google.common.collect.ImmutableList;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
@@ -21,6 +22,9 @@ public class IcmpTypeGroupTypeLine implements IcmpTypeObjectGroupLine {
   @Override
   public AclLineMatchExpr toAclLineMatchExpr() {
     return new MatchHeaderSpace(
-        HeaderSpace.builder().setIcmpTypes(ImmutableList.of(new SubRange(_type))).build());
+        HeaderSpace.builder()
+            .setIpProtocols(IpProtocol.ICMP)
+            .setIcmpTypes(ImmutableList.of(new SubRange(_type)))
+            .build());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -219,6 +219,7 @@ public class F5BigipConfiguration extends VendorConfiguration {
     return Optional.of(
         HeaderSpace.builder()
             .setDstIps(address.toIpSpace())
+            .setIpProtocols(IpProtocol.ICMP)
             .setIcmpTypes(ImmutableList.of(SubRange.singleton(IcmpType.ECHO_REQUEST)))
             .setIcmpCodes(ImmutableList.of(SubRange.singleton(0)))
             .build());


### PR DESCRIPTION
We have had a number of issues (see batfish/batfish#8388 for example)
where an ACL checks a protocol-specific property but does not actually
restrict to packets of the correct protocol. This can lead to strange
behavior, such as allowing flows that have ICMP Type 128 but are not
ICMP packets - mainly in symbolic tools like reachability.

Check converted ACLs when assertions are enabled. Note that we only check ACLs,
rather than individual MatchExprs -- because the latter can be composed and
it's difficult to tell when we're at an abstraction boundary when these
invariants should be enforced.

ASA's object groups are not that well formed, so skip this validation
on ASA for now.

commit-id:aca59b81

**Issue references**: 

 - batfish/batfish#8388