### PR TITLE
AWS: fix ICMPv6 handling code

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -98,7 +98,7 @@ public final class IpPermissions implements Serializable {
       return new IpRange(description, prefix);
     }
 
-    public IpRange(String description, Prefix prefix) {
+    public IpRange(@Nullable String description, Prefix prefix) {
       _description = description;
       _prefix = prefix;
     }
@@ -519,7 +519,6 @@ public final class IpPermissions implements Serializable {
     return Objects.equals(_fromPort, that._fromPort)
         && Objects.equals(_toPort, that._toPort)
         && Objects.equals(_ipProtocol, that._ipProtocol)
-        && Objects.equals(_ipRanges, that._ipRanges)
         && Objects.equals(_ipRanges, that._ipRanges)
         && Objects.equals(_prefixList, that._prefixList)
         && Objects.equals(_userIdGroupPairs, that._userIdGroupPairs);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -209,7 +209,8 @@ public final class Utils {
       case "icmp":
         return IpProtocol.ICMP;
       case "icmpv6":
-        return IpProtocol.IPV6_ICMP;
+        throw new IllegalStateException(
+            "icmpv6 protocol should have been handled before calling this function.");
       case "-1":
         return null;
       default:

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/UtilsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/UtilsTest.java
@@ -244,9 +244,14 @@ public class UtilsTest {
     assertThat(Utils.toIpProtocol("tcp"), equalTo(IpProtocol.TCP));
     assertThat(Utils.toIpProtocol("udp"), equalTo(IpProtocol.UDP));
     assertThat(Utils.toIpProtocol("icmp"), equalTo(IpProtocol.ICMP));
-    assertThat(Utils.toIpProtocol("icmpv6"), equalTo(IpProtocol.IPV6_ICMP));
     // Should convert custom protocols from protocol numbers
     assertThat(Utils.toIpProtocol("132"), equalTo(IpProtocol.SCTP));
+  }
+
+  @Test
+  public void testToIpProtocolError() {
+    _thrown.expectMessage("icmpv6 protocol should have been handled before calling this function");
+    Utils.toIpProtocol("icmpv6");
   }
 
   @Test(expected = BatfishException.class)


### PR DESCRIPTION
Remove depdendence on the (invalid) IpProtocol.IPV6_ICMP enum entry, which is not valid
for IPv4 packets.