### PR TITLE
JunOS: remove IPv6 options from ip_protocol

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpProtocol.java
@@ -71,9 +71,7 @@ public enum IpProtocol {
   IPLT(129),
   IPPC(67),
   IPV6(41),
-  IPV6_FRAG(44),
   IPV6_ICMP(58),
-  IPV6_OPTS(60),
   IPX_IN_IP(111),
   IRTP(28),
   ISIS(124),
@@ -145,8 +143,12 @@ public enum IpProtocol {
   UDP_LITE(136),
   /** Is allocated by IANA as Routing Header for IPv6, but this is an IPv4 enum. */
   UNNAMED_43(43),
+  /** Is allocated by IANA as Fragment Header for IPv6, but this is an IPv4 enum. */
+  UNNAMED_44(44),
   /** Is allocated by IANA as No Next Header for IPv6, but this is an IPv4 enum. */
   UNNAMED_59(59),
+  /** Is allocated by IANA as Destination Options for IPv6, but this is an IPv4 enum. */
+  UNNAMED_60(60),
   UNNAMED_143(143),
   UNNAMED_144(144),
   UNNAMED_145(145),

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
@@ -212,18 +212,13 @@ ip_protocol
 :
   AH
   | dec
-  | DSTOPTS
   | EGP
   | ESP
-  | FRAGMENT
   | GRE
   | HOP_BY_HOP
   | ICMP
-  | ICMP6
-  | ICMPV6
   | IGMP
   | IPIP
-  | IPV6
   | OSPF
   | PIM
   | RSVP

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1941,30 +1941,20 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       return IpProtocol.fromNumber(protocolNum);
     } else if (ctx.AH() != null) {
       return IpProtocol.AHP;
-    } else if (ctx.DSTOPTS() != null) {
-      return IpProtocol.IPV6_OPTS;
     } else if (ctx.EGP() != null) {
       return IpProtocol.EGP;
     } else if (ctx.ESP() != null) {
       return IpProtocol.ESP;
-    } else if (ctx.FRAGMENT() != null) {
-      return IpProtocol.IPV6_FRAG;
     } else if (ctx.GRE() != null) {
       return IpProtocol.GRE;
     } else if (ctx.HOP_BY_HOP() != null) {
       return IpProtocol.HOPOPT;
     } else if (ctx.ICMP() != null) {
       return IpProtocol.ICMP;
-    } else if (ctx.ICMP6() != null) {
-      return IpProtocol.IPV6_ICMP;
-    } else if (ctx.ICMPV6() != null) {
-      return IpProtocol.IPV6_ICMP;
     } else if (ctx.IGMP() != null) {
       return IpProtocol.IGMP;
     } else if (ctx.IPIP() != null) {
       return IpProtocol.IPINIP;
-    } else if (ctx.IPV6() != null) {
-      return IpProtocol.IPV6;
     } else if (ctx.OSPF() != null) {
       return IpProtocol.OSPF;
     } else if (ctx.PIM() != null) {


### PR DESCRIPTION
ip_protocol is used for identifying IPv4 protocols in family inet
firewall-filter.

The same rule is abused for family inet6 as well as family inet, but fixing
that is a bigger journey I'm punting for now.