### PR TITLE
NX-OS: fix configuration for a test

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_eigrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_eigrp
@@ -13,6 +13,9 @@ interface loopback99
   ip authentication key-chain eigrp EIGRP1234 KEYCHAIN
   ip address 99.99.99.99/32
 !
+route-map RM permit 10
+route-map RMV permit 10
+!
 vrf context VRF
   ! defined so it will be converted
 !


### PR DESCRIPTION
The referenced route-maps need to exist for the code to trigger.

commit-id:30d2293e