### PR TITLE
BGP always use bestpath comparison between routes with same next hop

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
@@ -17,11 +18,14 @@ import org.batfish.datamodel.HasReadableLocalPreference;
 import org.batfish.datamodel.HasReadableOriginType;
 import org.batfish.datamodel.HasReadableWeight;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.ReceivedFrom;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasAsPath;
+import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasClusterList;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasCommunities;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasLocalPreference;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasOriginType;
+import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasReceivedFrom;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasWeight;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.IsBgpv4RouteThat;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.IsEvpnType3RouteThat;
@@ -38,6 +42,11 @@ public final class BgpRouteMatchers {
    */
   public static @Nonnull Matcher<HasReadableAsPath> hasAsPath(Matcher<? super AsPath> subMatcher) {
     return new HasAsPath(subMatcher);
+  }
+
+  public static @Nonnull Matcher<BgpRoute<?, ?>> hasClusterList(
+      Matcher<? super Set<Long>> subMatcher) {
+    return new HasClusterList(subMatcher);
   }
 
   /**
@@ -82,6 +91,11 @@ public final class BgpRouteMatchers {
 
   public static @Nonnull Matcher<BgpRoute<?, ?>> hasNoPathId() {
     return hasPathId(nullValue());
+  }
+
+  public static @Nonnull Matcher<BgpRoute<?, ?>> hasReceivedFrom(
+      Matcher<? super ReceivedFrom> subMatcher) {
+    return new HasReceivedFrom(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.matchers;
 
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
@@ -14,6 +15,7 @@ import org.batfish.datamodel.HasReadableLocalPreference;
 import org.batfish.datamodel.HasReadableOriginType;
 import org.batfish.datamodel.HasReadableWeight;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.ReceivedFrom;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -28,6 +30,17 @@ final class BgpRouteMatchersImpl {
     @Override
     protected AsPath featureValueOf(HasReadableAsPath actual) {
       return actual.getAsPath();
+    }
+  }
+
+  static final class HasClusterList extends FeatureMatcher<BgpRoute<?, ?>, Set<Long>> {
+    HasClusterList(@Nonnull Matcher<? super Set<Long>> subMatcher) {
+      super(subMatcher, "A BgpRoute with cluster-list:", "cluster-list");
+    }
+
+    @Override
+    protected Set<Long> featureValueOf(BgpRoute<?, ?> actual) {
+      return actual.getClusterList();
     }
   }
 
@@ -72,6 +85,17 @@ final class BgpRouteMatchersImpl {
     @Override
     protected Integer featureValueOf(BgpRoute<?, ?> actual) {
       return actual.getPathId();
+    }
+  }
+
+  static final class HasReceivedFrom extends FeatureMatcher<BgpRoute<?, ?>, ReceivedFrom> {
+    HasReceivedFrom(@Nonnull Matcher<? super ReceivedFrom> subMatcher) {
+      super(subMatcher, "A BgpRoute with receivedFrom:", "receivedFrom");
+    }
+
+    @Override
+    protected ReceivedFrom featureValueOf(BgpRoute<?, ?> actual) {
+      return actual.getReceivedFrom();
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -170,7 +170,10 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
             // Evaluate AS path compatibility for multipath
             .thenComparing(this::compareRouteAsPath)
             .compare(lhs, rhs);
-    if (multipathCompare != 0 || isMultipath()) {
+    if (multipathCompare != 0
+        || (
+        // For two routes with the same next hop, at most one may be ECMP-best
+        isMultipath() && !lhs.getNextHop().equals(rhs.getNextHop()))) {
       return multipathCompare;
     } else {
       return Comparator.comparing(Function.identity(), this::bestPathComparator).compare(lhs, rhs);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathDuplicateTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathDuplicateTest.java
@@ -41,8 +41,8 @@ public final class BgpAddPathDuplicateTest {
    - as2border sets next-hop-self when advertising to as2leaf
    - as2border should have 2 routes in its BGP RIB, and 2 in its main RIB
    - as2border should advertise 2 routes to as2leaf that are identical post-export modulo path-id
-   - as2leaf should have 2 routes identical modulo rx path-id in its BGP RIB; and 1 route in its
-     main RIB
+   - as2leaf should have 2 routes identical modulo rx path-id in its BGP RIB, with one being active
+     and one being backup; and therefore 1 route in its main RIB
   */
   @Before
   public void setup() throws IOException {
@@ -67,7 +67,8 @@ public final class BgpAddPathDuplicateTest {
     assertThat(bgpRoutes.get("as2border", DEFAULT_VRF_NAME), hasSize(2));
 
     // as2leaf
-    assertThat(bgpRoutes.get("as2leaf", DEFAULT_VRF_NAME), hasSize(2));
+    assertThat(bgpRoutes.get("as2leaf", DEFAULT_VRF_NAME), hasSize(1));
+    assertThat(_dp.getBgpBackupRoutes().get("as2leaf", DEFAULT_VRF_NAME), hasSize(1));
   }
 
   @Test
@@ -78,9 +79,6 @@ public final class BgpAddPathDuplicateTest {
     assertThat(ribs.get("as2border", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(2));
 
     // as2leaf
-    // TODO Even with multipath on, as2leaf should only put one of the received routes in its main
-    //  RIB, because they have the same prefix and next-hop.
-    _thrown.expect(AssertionError.class);
     assertThat(ribs.get("as2leaf", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(1));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathDuplicateTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathDuplicateTest.java
@@ -17,7 +17,6 @@ import org.batfish.main.TestrigText;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -28,7 +27,6 @@ public final class BgpAddPathDuplicateTest {
 
   private static final Prefix PREFIX = Prefix.strict("10.0.0.0/32");
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
-  @Rule public ExpectedException _thrown = ExpectedException.none();
   private DataPlane _dp;
 
   /*

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathUniqueNextHopTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathUniqueNextHopTest.java
@@ -21,7 +21,6 @@ import org.batfish.main.TestrigText;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -32,7 +31,6 @@ public final class BgpAddPathUniqueNextHopTest {
 
   private static final Prefix PREFIX = Prefix.strict("10.0.0.0/32");
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
-  @Rule public ExpectedException _thrown = ExpectedException.none();
   private DataPlane _dp;
 
   /*

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathUniqueNextHopTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpAddPathUniqueNextHopTest.java
@@ -48,7 +48,7 @@ public final class BgpAddPathUniqueNextHopTest {
    - as2border routers set next-hop-self to respective as2rr routers
    - as2border1 should advertise 2 routes to as2rr
    - as2border2 should advertise 1 routes to as2rr
-   - as2rr should have 3 ECMP-best routes in its BGP RIB, and 3 in its main RIB
+   - as2rr should have 2 ECMP-best routes and 1 backup route in its BGP RIB; and 2 in its main RIB
    - as2rr should advertise 1 route from as2border1 and 1 route from as2border2 to as2leaf
    - as2leaf should have 2 routes in its BGP RIB, and 2 routes in its main RIB
   */
@@ -80,10 +80,8 @@ public final class BgpAddPathUniqueNextHopTest {
     Table<String, String, Set<Bgpv4Route>> bgpRoutes = _dp.getBgpRoutes();
     assertThat(bgpRoutes.get("as2border1", DEFAULT_VRF_NAME), hasSize(2));
     assertThat(bgpRoutes.get("as2border2", DEFAULT_VRF_NAME), hasSize(1));
-    assertThat(bgpRoutes.get("as2rr", DEFAULT_VRF_NAME), hasSize(3));
-
-    // TODO: with add-path for a given prefix, only advertise one path per unique next-hop
-    _thrown.expect(AssertionError.class);
+    assertThat(bgpRoutes.get("as2rr", DEFAULT_VRF_NAME), hasSize(2));
+    assertThat(_dp.getBgpBackupRoutes().get("as2rr", DEFAULT_VRF_NAME), hasSize(1));
     assertThat(
         bgpRoutes.get("as2leaf", DEFAULT_VRF_NAME),
         containsInAnyOrder(
@@ -96,12 +94,7 @@ public final class BgpAddPathUniqueNextHopTest {
     Table<String, String, FinalMainRib> ribs = _dp.getRibs();
     assertThat(ribs.get("as2border1", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(2));
     assertThat(ribs.get("as2border2", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(1));
-
-    // This should be 2, but this is separate issue from add-path
-    assertThat(ribs.get("as2rr", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(3));
-
-    // TODO: with add-path for a given prefix, only advertise one path per unique next-hop
-    _thrown.expect(AssertionError.class);
+    assertThat(ribs.get("as2rr", DEFAULT_VRF_NAME).getRoutes(PREFIX), hasSize(2));
     assertThat(
         ribs.get("as2leaf", DEFAULT_VRF_NAME).getRoutes(PREFIX),
         containsInAnyOrder(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
@@ -1,6 +1,7 @@
 package org.batfish.dataplane.rib;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
@@ -23,6 +24,7 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker;
 import org.batfish.datamodel.bgp.NextHopIpTieBreaker;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopIp;
 import org.junit.Test;
 
 /** Tests of {@link BgpRib} */
@@ -97,6 +99,48 @@ public class BgpRibTest {
   }
 
   @Test
+  public void testMultipathMerge_sameNextHopUseBestPathCompare() {
+    Bgpv4Rib bgpRib =
+        new Bgpv4Rib(
+            null,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false,
+            LocalOriginationTypeTieBreaker.NO_PREFERENCE,
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+    Bgpv4Route.Builder rb = Bgpv4Route.testBuilder().setNetwork(Prefix.ZERO);
+
+    Bgpv4Route nh1EcmpBest =
+        rb.setNextHop(NextHopIp.of(Ip.parse("1.1.1.1")))
+            .setLocalPreference(100)
+            .setOriginatorIp(Ip.parse("1.0.0.1"))
+            .build();
+
+    // ecmp-equal to nh1EcmpBest, but same next-hop so backup via best-path comparison on router-id
+    Bgpv4Route nh1Backup = nh1EcmpBest.toBuilder().setOriginatorIp(Ip.parse("1.0.0.2")).build();
+
+    Bgpv4Route nh2EcmpBest =
+        nh1EcmpBest.toBuilder().setNextHop(NextHopIp.of(Ip.parse("2.2.2.2"))).build();
+
+    // backup because of local preference
+    Bgpv4Route nh3Backup =
+        nh1EcmpBest.toBuilder()
+            .setNextHop(NextHopIp.of(Ip.parse("3.3.3.3")))
+            .setLocalPreference(1)
+            .build();
+
+    bgpRib.mergeRoute(nh1EcmpBest);
+    bgpRib.mergeRoute(nh1Backup);
+    bgpRib.mergeRoute(nh2EcmpBest);
+    bgpRib.mergeRoute(nh3Backup);
+
+    // nh1Backup and nh3Backup should not be ECMP-best
+    assertThat(bgpRib.getRoutes(Prefix.ZERO), containsInAnyOrder(nh1EcmpBest, nh2EcmpBest));
+  }
+
+  @Test
   public void testMultipathMergeAndRemove_multipath() {
     Bgpv4Rib bgpRib =
         new Bgpv4Rib(
@@ -110,9 +154,18 @@ public class BgpRibTest {
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
     Bgpv4Route.Builder rb = Bgpv4Route.testBuilder().setNetwork(Prefix.ZERO);
 
-    Bgpv4Route good = rb.setOriginatorIp(Ip.parse("1.1.1.40")).build();
-    Bgpv4Route better = rb.setOriginatorIp(Ip.parse("1.1.1.30")).build();
-    Bgpv4Route best = rb.setOriginatorIp(Ip.parse("1.1.1.20")).build();
+    Bgpv4Route good =
+        rb.setOriginatorIp(Ip.parse("1.1.1.40"))
+            .setNextHop(NextHopIp.of(Ip.parse("1.1.1.40")))
+            .build();
+    Bgpv4Route better =
+        rb.setOriginatorIp(Ip.parse("1.1.1.30"))
+            .setNextHop(NextHopIp.of(Ip.parse("1.1.1.30")))
+            .build();
+    Bgpv4Route best =
+        rb.setOriginatorIp(Ip.parse("1.1.1.20"))
+            .setNextHop(NextHopIp.of(Ip.parse("1.1.1.20")))
+            .build();
     {
       // Merge into empty RIB
       BgpRib.MultipathRibDelta<Bgpv4Route> delta = bgpRib.multipathMergeRouteGetDelta(good);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
@@ -446,8 +446,14 @@ public class Bgpv4RibTest {
   @Test
   public void testMultipathDiffOriginator() {
     Bgpv4Route bestPath = _rb.build();
-    _multiPathRib.mergeRoute(_rb.setOriginatorIp(Ip.parse("2.2.2.2")).build());
-    _multiPathRib.mergeRoute(_rb.setOriginatorIp(Ip.parse("2.2.2.3")).build());
+    _multiPathRib.mergeRoute(
+        _rb.setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.2")))
+            .build());
+    _multiPathRib.mergeRoute(
+        _rb.setOriginatorIp(Ip.parse("2.2.2.3"))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
+            .build());
     _multiPathRib.mergeRoute(bestPath);
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
@@ -465,10 +471,16 @@ public class Bgpv4RibTest {
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
-    Bgpv4Route best = _rb.build();
-    Bgpv4Route earliest = _rb.setOriginatorIp(Ip.parse("2.2.2.2")).build();
+    Bgpv4Route best = _rb.setNextHop(NextHopIp.of(Ip.parse("2.2.2.1"))).build();
+    Bgpv4Route earliest =
+        _rb.setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.2")))
+            .build();
     _multiPathRib.mergeRoute(earliest);
-    _multiPathRib.mergeRoute(_rb.setOriginatorIp(Ip.parse("2.2.2.3")).build());
+    _multiPathRib.mergeRoute(
+        _rb.setOriginatorIp(Ip.parse("2.2.2.3"))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
+            .build());
     _multiPathRib.mergeRoute(best);
 
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
@@ -478,10 +490,16 @@ public class Bgpv4RibTest {
   @Test
   public void testMultipathDiffClusterList() {
     _rb.setProtocol(RoutingProtocol.IBGP).setClusterList(ImmutableSortedSet.of());
-    Bgpv4Route bestPath = _rb.build();
+    Bgpv4Route bestPath = _rb.setNextHop(NextHopIp.of(Ip.parse("2.2.2.2"))).build();
     _multiPathRib.mergeRoute(bestPath);
-    _multiPathRib.mergeRoute(_rb.setClusterList(ImmutableSortedSet.of(11L)).build());
-    _multiPathRib.mergeRoute(_rb.setClusterList(ImmutableSortedSet.of(22L, 33L)).build());
+    _multiPathRib.mergeRoute(
+        _rb.setClusterList(ImmutableSortedSet.of(11L))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
+            .build());
+    _multiPathRib.mergeRoute(
+        _rb.setClusterList(ImmutableSortedSet.of(22L, 33L))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.4")))
+            .build());
 
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
@@ -490,8 +508,14 @@ public class Bgpv4RibTest {
   @Test
   public void testMultipathDiffNeighbor() {
     Bgpv4Route bestPath = _rb.build();
-    _multiPathRib.mergeRoute(_rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.2"))).build());
-    _multiPathRib.mergeRoute(_rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3"))).build());
+    _multiPathRib.mergeRoute(
+        _rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.2")))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.2")))
+            .build());
+    _multiPathRib.mergeRoute(
+        _rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3")))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
+            .build());
     _multiPathRib.mergeRoute(bestPath);
 
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
@@ -511,9 +535,18 @@ public class Bgpv4RibTest {
 
   @Test
   public void testMultipathEviction() {
-    _multiPathRib.mergeRoute(_rb.setOriginatorIp(Ip.parse("4.4.4.4")).build());
-    _multiPathRib.mergeRoute(_rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.2"))).build());
-    _multiPathRib.mergeRoute(_rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3"))).build());
+    _multiPathRib.mergeRoute(
+        _rb.setOriginatorIp(Ip.parse("4.4.4.4"))
+            .setNextHop(NextHopIp.of(Ip.parse("4.4.4.4")))
+            .build());
+    _multiPathRib.mergeRoute(
+        _rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.2")))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.2")))
+            .build());
+    _multiPathRib.mergeRoute(
+        _rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3")))
+            .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
+            .build());
 
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
     assertThat(_multiPathRib.getBestPathRoutes(), hasSize(1));
@@ -557,6 +590,7 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(
         _rb.setNetwork(Prefix.parse("10.1.1.0/24"))
             .setOriginatorIp(Ip.parse("22.22.22.22"))
+            .setNextHop(NextHopIp.of(Ip.parse("22.22.22.22")))
             .build());
     assertThat(_multiPathRib.getRoutes(), hasSize(4));
     assertThat(_multiPathRib.getBestPathRoutes(), hasSize(3));
@@ -997,7 +1031,7 @@ public class Bgpv4RibTest {
             .setReceivedFrom(ReceivedFromSelf.instance());
     Bgpv4Route.Builder b2 =
         Bgpv4Route.testBuilder()
-            .setNextHop(NextHopIp.of(Ip.parse("3.3.3.3")))
+            .setNextHop(NextHopIp.of(Ip.parse("3.3.3.4")))
             .setOriginType(OriginType.INCOMPLETE)
             .setOriginatorIp(Ip.MAX)
             .setProtocol(RoutingProtocol.BGP)
@@ -1081,13 +1115,16 @@ public class Bgpv4RibTest {
         ebgpBuilder
             .setOriginatorIp(Ip.MAX)
             .setReceivedFrom(ReceivedFromIp.of(Ip.parse("1.1.1.1")))
+            .setNextHop(NextHopIp.of(Ip.parse("1.1.1.1")))
             .build();
     Bgpv4Route ebgpNewerHigherOriginator =
         ebgpBuilder
             .setOriginatorIp(Ip.MAX)
             .setReceivedFrom(ReceivedFromIp.of(Ip.parse("1.1.1.2")))
+            .setNextHop(NextHopIp.of(Ip.parse("1.1.1.2")))
             .build();
-    Bgpv4Route ebgpLowerOriginator = ebgpBuilder.setOriginatorIp(Ip.ZERO).build();
+    Bgpv4Route ebgpLowerOriginator =
+        ebgpBuilder.setOriginatorIp(Ip.ZERO).setNextHop(NextHopIp.of(Ip.parse("1.1.1.3"))).build();
     // ibgp
     Bgpv4Rib ibgpBpr =
         new Bgpv4Rib(
@@ -1110,13 +1147,16 @@ public class Bgpv4RibTest {
         ibgpBuilder
             .setOriginatorIp(Ip.MAX)
             .setReceivedFrom(ReceivedFromIp.of(Ip.parse("1.1.1.1")))
+            .setNextHop(NextHopIp.of(Ip.parse("1.1.2.1")))
             .build();
     Bgpv4Route ibgpNewerHigherOriginator =
         ibgpBuilder
             .setOriginatorIp(Ip.MAX)
             .setReceivedFrom(ReceivedFromIp.of(Ip.parse("1.1.1.2")))
+            .setNextHop(NextHopIp.of(Ip.parse("1.1.2.2")))
             .build();
-    Bgpv4Route ibgpLowerOriginator = ibgpBuilder.setOriginatorIp(Ip.ZERO).build();
+    Bgpv4Route ibgpLowerOriginator =
+        ibgpBuilder.setOriginatorIp(Ip.ZERO).setNextHop(NextHopIp.of(Ip.parse("1.1.2.3"))).build();
 
     ebgpBpr.mergeRoute(ebgpOlderHigherOriginator);
     ibgpBpr.mergeRoute(ibgpOlderHigherOriginator);

--- a/tests/basic/genDp.ref
+++ b/tests/basic/genDp.ref
@@ -11,18 +11,18 @@
       },
       "bgpMultipathRibRoutesByIteration" : {
         "1" : 24,
-        "2" : 88,
-        "3" : 117,
-        "4" : 118,
-        "5" : 118
+        "2" : 72,
+        "3" : 99,
+        "4" : 100,
+        "5" : 100
       },
       "dependentRoutesIterations" : 5,
       "mainRibRoutesByIteration" : {
         "1" : 207,
-        "2" : 307,
-        "3" : 338,
-        "4" : 339,
-        "5" : 339
+        "2" : 291,
+        "3" : 320,
+        "4" : 321,
+        "5" : 321
       },
       "ospfInternalIterations" : 3,
       "version" : "0.36.0",

--- a/tests/basic/routes.ref
+++ b/tests/basic/routes.ref
@@ -1323,24 +1323,6 @@
         "Network" : "2.128.0.0/24",
         "Next_Hop" : {
           "type" : "ip",
-          "ip" : "2.34.101.4"
-        },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
           "ip" : "2.34.201.4"
         },
         "Next_Hop_IP" : "2.34.201.4",
@@ -1362,24 +1344,6 @@
           "ip" : "2.34.201.4"
         },
         "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "2.34.101.4"
-        },
-        "Next_Hop_IP" : "2.34.101.4",
         "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
@@ -1447,42 +1411,6 @@
         },
         "VRF" : "default",
         "Network" : "3.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.23.21.3"
-        },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "3.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.23.21.3"
-        },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "3.0.2.0/24",
         "Next_Hop" : {
           "type" : "ip",
           "ip" : "10.23.21.3"
@@ -1593,42 +1521,6 @@
         },
         "VRF" : "default",
         "Network" : "1.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.12.11.1"
-        },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.12.11.1"
-        },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.2.0/24",
         "Next_Hop" : {
           "type" : "ip",
           "ip" : "10.12.11.1"
@@ -2134,24 +2026,6 @@
         "Network" : "2.128.0.0/24",
         "Next_Hop" : {
           "type" : "ip",
-          "ip" : "2.34.101.4"
-        },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
           "ip" : "2.34.201.4"
         },
         "Next_Hop_IP" : "2.34.201.4",
@@ -2173,24 +2047,6 @@
           "ip" : "2.34.201.4"
         },
         "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "2.34.101.4"
-        },
-        "Next_Hop_IP" : "2.34.101.4",
         "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
@@ -3983,42 +3839,6 @@
           "name" : "as2dist1"
         },
         "VRF" : "default",
-        "Network" : "1.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.12.11.1"
-        },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.2.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.12.11.1"
-        },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
         "Network" : "1.0.2.0/24",
         "Next_Hop" : {
           "type" : "ip",
@@ -4488,24 +4308,6 @@
         "Network" : "2.128.0.0/16",
         "Next_Hop" : {
           "type" : "ip",
-          "ip" : "2.1.1.1"
-        },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/16",
-        "Next_Hop" : {
-          "type" : "ip",
           "ip" : "2.1.1.2"
         },
         "Next_Hop_IP" : "2.1.1.2",
@@ -4593,42 +4395,6 @@
           "name" : "as2dist1"
         },
         "VRF" : "default",
-        "Network" : "3.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.23.21.3"
-        },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "3.0.2.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.23.21.3"
-        },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
         "Network" : "3.0.2.0/24",
         "Next_Hop" : {
           "type" : "ip",
@@ -4724,42 +4490,6 @@
         },
         "VRF" : "default",
         "Network" : "1.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.12.11.1"
-        },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.12.11.1"
-        },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.2.0/24",
         "Next_Hop" : {
           "type" : "ip",
           "ip" : "10.12.11.1"
@@ -5246,24 +4976,6 @@
         "Network" : "2.128.0.0/16",
         "Next_Hop" : {
           "type" : "ip",
-          "ip" : "2.1.1.1"
-        },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/16",
-        "Next_Hop" : {
-          "type" : "ip",
           "ip" : "2.1.1.2"
         },
         "Next_Hop_IP" : "2.1.1.2",
@@ -5334,42 +5046,6 @@
         },
         "VRF" : "default",
         "Network" : "3.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.23.21.3"
-        },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "3.0.1.0/24",
-        "Next_Hop" : {
-          "type" : "ip",
-          "ip" : "10.23.21.3"
-        },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "3.0.2.0/24",
         "Next_Hop" : {
           "type" : "ip",
           "ip" : "10.23.21.3"
@@ -6319,10 +5995,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 339 results",
+      "notes" : "Found 321 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 339
+      "numResults" : 321
     }
   }
 ]


### PR DESCRIPTION
- Routes with the same prefix (NLRI) and next-hop may not be
ECMP-equivalent
- So if multipath compare considers them equal, pick one to be better
using bestpath comparison regardless of whether RIB is multipath