### PR TITLE
Arista: fix ACL line VSIDs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -1498,7 +1498,6 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
     // structure definition tracking
     String lineName = getFullText(ctx).trim();
     String structName = aclLineStructureName(_currentStandardAcl.getName(), lineName);
-    ;
     int configLine = ctx.start.getLine();
     _configuration.defineSingleLineStructure(IP_ACCESS_LIST_STANDARD_LINE, structName, configLine);
     _configuration.referenceStructure(

--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -1496,8 +1496,9 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
       _currentAclSeq = lastKey + 10;
     }
     // structure definition tracking
-    String structName =
-        aclLineStructureName(_currentStandardAcl.getName(), _currentAclSeq.toString());
+    String lineName = getFullText(ctx).trim();
+    String structName = aclLineStructureName(_currentStandardAcl.getName(), lineName);
+    ;
     int configLine = ctx.start.getLine();
     _configuration.defineSingleLineStructure(IP_ACCESS_LIST_STANDARD_LINE, structName, configLine);
     _configuration.referenceStructure(

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/StandardAccessListActionLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/StandardAccessListActionLine.java
@@ -45,7 +45,7 @@ public class StandardAccessListActionLine implements StandardAccessListLine {
   public @Nonnull Optional<ExtendedAccessListLine> toExtendedAccessListLine() {
     return Optional.ofNullable(
         ExtendedAccessListLine.builder()
-            .setName(Long.toString(_seq)) // Use sequence number instead of line content (_name)
+            .setName(_name)
             .setAction(_action)
             .setSrcAddressSpecifier(new WildcardAddressSpecifier(_sourceIps))
             .setDstAddressSpecifier(new WildcardAddressSpecifier(IpWildcard.ANY))

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/StandardAccessListActionLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/StandardAccessListActionLine.java
@@ -45,7 +45,7 @@ public class StandardAccessListActionLine implements StandardAccessListLine {
   public @Nonnull Optional<ExtendedAccessListLine> toExtendedAccessListLine() {
     return Optional.ofNullable(
         ExtendedAccessListLine.builder()
-            .setName(_name)
+            .setName(String.valueOf(_seq)) // Use sequence number instead of line content (_name)
             .setAction(_action)
             .setSrcAddressSpecifier(new WildcardAddressSpecifier(_sourceIps))
             .setDstAddressSpecifier(new WildcardAddressSpecifier(IpWildcard.ANY))

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/StandardAccessListActionLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/StandardAccessListActionLine.java
@@ -45,7 +45,7 @@ public class StandardAccessListActionLine implements StandardAccessListLine {
   public @Nonnull Optional<ExtendedAccessListLine> toExtendedAccessListLine() {
     return Optional.ofNullable(
         ExtendedAccessListLine.builder()
-            .setName(String.valueOf(_seq)) // Use sequence number instead of line content (_name)
+            .setName(Long.toString(_seq)) // Use sequence number instead of line content (_name)
             .setAction(_action)
             .setSrcAddressSpecifier(new WildcardAddressSpecifier(_sourceIps))
             .setDstAddressSpecifier(new WildcardAddressSpecifier(IpWildcard.ANY))

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -3003,17 +3003,15 @@ public class AristaGrammarTest {
     // Tests that the ACLs parse and their lines have correct VSIDs
     String standardAclName = "SOME_ACL";
     assertThat(c, hasIpAccessList(standardAclName, hasLines(hasSize(1))));
-    // TODO: re-add once VSID is valid
-    // VSID is currently invalid, so it is pruned during configuration finalization
-    //    AclLine standard = c.getIpAccessLists().get(standardAclName).getLines().get(0);
-    //    assertThat(
-    //        standard.getVendorStructureId(),
-    //        equalTo(
-    //            Optional.of(
-    //                new VendorStructureId(
-    //                    filename,
-    //                    AristaStructureType.IP_ACCESS_LIST_STANDARD_LINE.getDescription(),
-    //                    aclLineStructureName(standardAclName, standard.getName())))));
+    AclLine standard = c.getIpAccessLists().get(standardAclName).getLines().get(0);
+    assertThat(
+        standard.getVendorStructureId(),
+        equalTo(
+            Optional.of(
+                new VendorStructureId(
+                    filename,
+                    AristaStructureType.IP_ACCESS_LIST_STANDARD_LINE.getDescription(),
+                    aclLineStructureName(standardAclName, standard.getName())))));
 
     String extendedAclName = "SOME_EXT_ACL";
     assertThat(c, hasIpAccessList(extendedAclName, hasLines(hasSize(1))));

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71097,7 +71097,7 @@
             }
           },
           "ip access-list standard line" : {
-            "sshabc: 10" : {
+            "sshabc: 10 permit 1.2.4.8/16" : {
               "definitionLines" : "31",
               "numReferrers" : 1
             }
@@ -76597,7 +76597,7 @@
         },
         "configs/arista_misc" : {
           "ip access-list standard line" : {
-            "sshabc: 10" : {
+            "sshabc: 10 permit 1.2.4.8/16" : {
               "ip access-list standard line" : [
                 31
               ]


### PR DESCRIPTION
Fix Standard ACL line conversion/naming to line up with structure definition; fixes VSIDs based on that conversion.
