### PR TITLE
Generate path IDs independently per prefix

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -142,7 +142,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   private final boolean _generateAggregatesFromMainRib;
 
   /** Source for assigning path IDs to routes upon export when sending additional paths. */
-  @Nonnull private final AtomicInteger _pathIdGenerator;
+  @Nonnull private final ConcurrentMap<Prefix, AtomicInteger> _pathIdGenerators;
   /**
    * Map indicating what path ID this process uses when exporting a given route. Keys can be:
    *
@@ -319,7 +319,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     _exportFromBgpRib = configuration.getExportBgpFromBgpRib();
     _generateAggregatesFromMainRib = configuration.getGenerateBgpAggregatesFromMainRib();
 
-    _pathIdGenerator = new AtomicInteger();
+    _pathIdGenerators = new ConcurrentHashMap<>();
     _routesToPathIds = new ConcurrentHashMap<>();
 
     // Message queues start out empty
@@ -1706,7 +1706,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         ourSessionProperties,
         addressFamily,
         exportCandidate.getNextHopIp(),
-        _pathIdGenerator,
+        _pathIdGenerators,
         _routesToPathIds);
     // Successfully exported route
     R transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
@@ -1801,7 +1801,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         ourSessionProperties,
         v4Family,
         Route.UNSET_ROUTE_NEXT_HOP_IP,
-        _pathIdGenerator,
+        _pathIdGenerators,
         _routesToPathIds);
 
     // Successfully exported route

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -45,7 +45,6 @@ import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -141,8 +140,11 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
    */
   private final boolean _generateAggregatesFromMainRib;
 
-  /** Source for assigning path IDs to routes upon export when sending additional paths. */
-  @Nonnull private final ConcurrentMap<Prefix, AtomicInteger> _pathIdGenerators;
+  /**
+   * Source for assigning path IDs to routes upon export when sending additional paths. The values
+   * indicate the last path ID generated for a route with the keyed prefix.
+   */
+  @Nonnull private final ConcurrentMap<Prefix, Integer> _pathIdGenerators;
   /**
    * Map indicating what path ID this process uses when exporting a given route. Keys can be:
    *

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -32,6 +32,7 @@ import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginMechanism;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.ReceivedFrom;
 import org.batfish.datamodel.ReceivedFromInterface;
 import org.batfish.datamodel.ReceivedFromIp;
@@ -408,7 +409,7 @@ public final class BgpProtocolHelper {
    * @param af sender's address family configuration
    * @param originalRouteNhip BGP next hop IP of the original route, or {@link
    *     Route#UNSET_ROUTE_NEXT_HOP_IP} if original route is not BGP
-   * @param pathIdGenerator Used for generating a path ID for the outgoing advertisement if needed
+   * @param pathIdGenerators Used for generating a path ID for the outgoing advertisement if needed
    * @param routesToPathIds Routes we have already exported, mapped to the path IDs with which we
    *     exported them. If the outgoing route needs a path ID, we will look up {@code originalRoute}
    *     in this map to find the correct path ID, and add a new entry if it isn't already there.
@@ -420,13 +421,18 @@ public final class BgpProtocolHelper {
           BgpSessionProperties ourSessionProperties,
           AddressFamily af,
           Ip originalRouteNhip,
-          AtomicInteger pathIdGenerator,
+          Map<Prefix, AtomicInteger> pathIdGenerators,
           Map<AbstractRouteDecorator, Integer> routesToPathIds) {
     // Determine path ID to export, if any.
     Integer pathId = null;
     if (ourSessionProperties.getAdditionalPaths()) {
       pathId =
-          routesToPathIds.computeIfAbsent(originalRoute, k -> pathIdGenerator.incrementAndGet());
+          routesToPathIds.computeIfAbsent(
+              originalRoute,
+              k ->
+                  pathIdGenerators
+                      .computeIfAbsent(originalRoute.getNetwork(), k2 -> new AtomicInteger())
+                      .incrementAndGet());
     }
     transformBgpRoutePostExport(
         routeBuilder,


### PR DESCRIPTION
This greatly reduces route churn in differential BGP RIB outputs when a route has been added or removed between snapshots.