### PR TITLE
Juniper: fix application TraceElements/VendorStructureIds

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2328,7 +2328,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _currentApplication =
         _currentLogicalSystem
             .getApplications()
-            .computeIfAbsent(name, n -> new BaseApplication(name));
+            .computeIfAbsent(name, n -> new BaseApplication(name, false));
     _currentApplicationTerm = _currentApplication.getMainTerm();
     _configuration.defineFlattenedStructure(APPLICATION, name, ctx, _parser);
   }
@@ -2339,7 +2339,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _currentApplicationSet =
         _currentLogicalSystem
             .getApplicationSets()
-            .computeIfAbsent(name, n -> new ApplicationSet(name));
+            .computeIfAbsent(name, n -> new ApplicationSet(name, false));
     _configuration.defineFlattenedStructure(APPLICATION_SET, name, ctx, _parser);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationSet.java
@@ -13,12 +13,14 @@ import org.batfish.datamodel.acl.OrMatchExpr;
 
 public class ApplicationSet implements ApplicationSetMember, Serializable {
 
+  private final boolean _builtIn;
   private List<ApplicationSetMemberReference> _members;
   private String _name;
 
-  public ApplicationSet(String name) {
+  public ApplicationSet(String name, boolean builtIn) {
     _name = name;
     _members = ImmutableList.of();
+    _builtIn = builtIn;
   }
 
   @Override
@@ -46,8 +48,15 @@ public class ApplicationSet implements ApplicationSetMember, Serializable {
             .filter(Predicates.notNull())
             .map(member -> member.toAclLineMatchExpr(jc, w))
             .collect(ImmutableList.toImmutableList()),
-        ApplicationSetMember.getTraceElementForUserApplication(
-            jc.getFilename(), JuniperStructureType.APPLICATION_SET, _name));
+        isBuiltIn()
+            ? JunosApplicationSet.getTraceElement(_name)
+            : ApplicationSetMember.getTraceElementForUserApplication(
+                jc.getFilename(), JuniperStructureType.APPLICATION_SET, _name));
+  }
+
+  @Override
+  public boolean isBuiltIn() {
+    return _builtIn;
   }
 
   public void setMembers(List<ApplicationSetMemberReference> members) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationSetMember.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ApplicationSetMember.java
@@ -28,4 +28,10 @@ public interface ApplicationSetMember {
             new VendorStructureId(filename, structureType.getDescription(), structureName))
         .build();
   }
+
+  /**
+   * Returns a boolean indicating if this member is a built-in member. If false, the member is
+   * user-defined.
+   */
+  boolean isBuiltIn();
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BaseApplication.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BaseApplication.java
@@ -77,6 +77,8 @@ public final class BaseApplication implements Application, Serializable {
     }
   }
 
+  private final boolean _builtIn;
+
   private boolean _ipv6;
 
   private Term _mainTerm;
@@ -85,10 +87,11 @@ public final class BaseApplication implements Application, Serializable {
 
   private final String _name;
 
-  public BaseApplication(String name) {
+  public BaseApplication(String name, boolean builtIn) {
     _mainTerm = new Term();
     _terms = new LinkedHashMap<>();
     _name = name;
+    _builtIn = builtIn;
   }
 
   @Override
@@ -160,9 +163,16 @@ public final class BaseApplication implements Application, Serializable {
 
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Warnings w) {
-    TraceElement userDefinedApplicationTraceElement =
-        ApplicationSetMember.getTraceElementForUserApplication(
-            jc.getFilename(), JuniperStructureType.APPLICATION, _name);
-    return toAclLineMatchExpr(userDefinedApplicationTraceElement);
+    TraceElement traceElement =
+        isBuiltIn()
+            ? JunosApplication.getTraceElementForBuiltInApplication(_name)
+            : ApplicationSetMember.getTraceElementForUserApplication(
+                jc.getFilename(), JuniperStructureType.APPLICATION, _name);
+    return toAclLineMatchExpr(traceElement);
+  }
+
+  @Override
+  public boolean isBuiltIn() {
+    return _builtIn;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromApplicationOrApplicationSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromApplicationOrApplicationSet.java
@@ -51,12 +51,7 @@ public final class FwFromApplicationOrApplicationSet implements FwFromApplicatio
               _applicationOrApplicationSetName));
 
       // match nothing
-      return new MatchHeaderSpace(
-          HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build(),
-          ApplicationSetMember.getTraceElementForUserApplication(
-              jc.getFilename(),
-              JuniperStructureType.APPLICATION,
-              _applicationOrApplicationSetName));
+      return new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build());
     }
 
     return application.toAclLineMatchExpr(jc, w);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromJunosApplicationSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromJunosApplicationSet.java
@@ -36,12 +36,8 @@ public final class FwFromJunosApplicationSet implements FwFromApplicationSetMemb
     if (!_junosApplicationSet.hasDefinition()) {
       w.redFlag("Reference to undefined application: \"" + _junosApplicationSet.name() + "\"");
       // match nothing
-      return new MatchHeaderSpace(
-          HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build(),
-          ApplicationSetMember.getTraceElementForUserApplication(
-              jc.getFilename(), JuniperStructureType.APPLICATION, _junosApplicationSet.name()));
+      return new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build());
     }
-
     return _junosApplicationSet.getApplicationSet().toAclLineMatchExpr(jc, w);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JunosApplication.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JunosApplication.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
@@ -243,11 +244,15 @@ public enum JunosApplication implements Application {
   }
 
   public String getJuniperName() {
-    return name().toLowerCase().replace("_", "-");
+    return getJuniperName(name());
+  }
+
+  private static String getJuniperName(String name) {
+    return name.toLowerCase().replace("_", "-");
   }
 
   private BaseApplication init() {
-    BaseApplication baseApplication = new BaseApplication(getJuniperName());
+    BaseApplication baseApplication = new BaseApplication(getJuniperName(), true);
     Map<String, Term> terms = baseApplication.getTerms();
 
     Integer portRangeStart = null;
@@ -1144,7 +1149,8 @@ public enum JunosApplication implements Application {
 
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Warnings w) {
-    TraceElement builtinApplicationTraceElement = getTraceElementForBuiltInApplication(this);
+    TraceElement builtinApplicationTraceElement =
+        getTraceElementForBuiltInApplication(getJuniperName());
     if (!hasDefinition()) {
       w.redFlag(String.format("Built-in application %s is not implemented", getJuniperName()));
       return new FalseExpr(builtinApplicationTraceElement);
@@ -1152,7 +1158,13 @@ public enum JunosApplication implements Application {
     return _baseApplication.get().toAclLineMatchExpr(builtinApplicationTraceElement);
   }
 
-  public static TraceElement getTraceElementForBuiltInApplication(JunosApplication app) {
-    return TraceElement.of("Matched built-in application " + app.getJuniperName());
+  @Override
+  public boolean isBuiltIn() {
+    return true;
+  }
+
+  @VisibleForTesting
+  public static TraceElement getTraceElementForBuiltInApplication(String appName) {
+    return TraceElement.of("Matched built-in application " + getJuniperName(appName));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JunosApplicationSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JunosApplicationSet.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
@@ -57,7 +58,7 @@ public enum JunosApplicationSet implements ApplicationSetMember {
   }
 
   private ApplicationSet init() {
-    ApplicationSet applicationSet = new ApplicationSet(convertToJuniperName());
+    ApplicationSet applicationSet = new ApplicationSet(convertToJuniperName(), true);
 
     List<JunosApplication> applications;
 
@@ -369,8 +370,18 @@ public enum JunosApplicationSet implements ApplicationSetMember {
     if (!hasDefinition()) {
       return new MatchHeaderSpace(
           HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build(),
-          TraceElement.of(String.format("Matched application-set %s", convertToJuniperName())));
+          getTraceElement(convertToJuniperName()));
     }
     return _applicationSet.get().toAclLineMatchExpr(jc, w);
+  }
+
+  @Override
+  public boolean isBuiltIn() {
+    return true;
+  }
+
+  @VisibleForTesting
+  public static TraceElement getTraceElement(String name) {
+    return TraceElement.of(String.format("Matched built-in application-set %s", name));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/ApplicationSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/ApplicationSetTest.java
@@ -23,15 +23,15 @@ public class ApplicationSetTest {
 
     JuniperConfiguration jc = new JuniperConfiguration();
     jc.setFilename("host");
-    jc.getMasterLogicalSystem().getApplications().put("app2", new BaseApplication("app2"));
+    jc.getMasterLogicalSystem().getApplications().put("app2", new BaseApplication("app2", false));
 
-    ApplicationSet appSet = new ApplicationSet("appSet");
+    ApplicationSet appSet = new ApplicationSet("appSet", false);
     appSet.setMembers(ImmutableList.of(new ApplicationReference("app2")));
     jc.getMasterLogicalSystem().getApplicationSets().put("appSet", appSet);
 
-    jc.getMasterLogicalSystem().getApplications().put("app1", new BaseApplication("app1"));
+    jc.getMasterLogicalSystem().getApplications().put("app1", new BaseApplication("app1", false));
 
-    ApplicationSet masterAppSet = new ApplicationSet("masterAppSet");
+    ApplicationSet masterAppSet = new ApplicationSet("masterAppSet", false);
     List<ApplicationSetMemberReference> members =
         ImmutableList.of(new ApplicationReference("app1"), new ApplicationSetReference("appSet"));
     masterAppSet.setMembers(members);
@@ -54,5 +54,18 @@ public class ApplicationSetTest {
                         "host", JuniperStructureType.APPLICATION_SET, "appSet"))),
             ApplicationSetMember.getTraceElementForUserApplication(
                 "host", JuniperStructureType.APPLICATION_SET, "masterAppSet")));
+  }
+
+  @Test
+  public void testToAclLineMatchExpr_builtIn() {
+    JuniperConfiguration jc = new JuniperConfiguration();
+    jc.setFilename("host");
+    String parentAppSetName = "PARENT_BUILT_IN";
+    ApplicationSet appSet = new ApplicationSet(parentAppSetName, true);
+    jc.getMasterLogicalSystem().getApplicationSets().put(parentAppSetName, appSet);
+
+    assertEquals(
+        appSet.toAclLineMatchExpr(jc, null),
+        new OrMatchExpr(ImmutableList.of(), JunosApplicationSet.getTraceElement(parentAppSetName)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/BaseApplicationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/BaseApplicationTest.java
@@ -53,7 +53,7 @@ public class BaseApplicationTest {
 
   @Test
   public void testToAclLineMatchExpr_noTerms() {
-    BaseApplication app = new BaseApplication("APP");
+    BaseApplication app = new BaseApplication("APP", false);
     assertEquals(
         app.toAclLineMatchExpr(jc, null),
         new MatchHeaderSpace(
@@ -63,7 +63,7 @@ public class BaseApplicationTest {
 
   @Test
   public void testToAclLineMatchExpr_hasTerms() {
-    BaseApplication app = new BaseApplication("APP");
+    BaseApplication app = new BaseApplication("APP", false);
     Term term1 = new Term("TERM1");
     Term term2 = new Term("TERM2");
     app.getTerms().put("TERM1", term1);
@@ -75,5 +75,15 @@ public class BaseApplicationTest {
             ImmutableList.of(term1.toAclLineMatchExpr(), term2.toAclLineMatchExpr()),
             getTraceElementForUserApplication(
                 jc.getFilename(), JuniperStructureType.APPLICATION, "APP")));
+  }
+
+  @Test
+  public void testToAclLineMatchExpr_builtIn() {
+    BaseApplication app = new BaseApplication("BUILT_IN_APP", true);
+    assertEquals(
+        app.toAclLineMatchExpr(jc, null),
+        new MatchHeaderSpace(
+            app.getMainTerm().toHeaderSpace(),
+            JunosApplication.getTraceElementForBuiltInApplication("BUILT_IN_APP")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromApplicationOrApplicationSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromApplicationOrApplicationSetTest.java
@@ -28,7 +28,7 @@ public class FwFromApplicationOrApplicationSetTest {
 
   @Test
   public void testApplyTo_application() {
-    BaseApplication app = new BaseApplication("app");
+    BaseApplication app = new BaseApplication("app", false);
     app.getTerms()
         .putAll(
             ImmutableMap.of(
@@ -64,12 +64,12 @@ public class FwFromApplicationOrApplicationSetTest {
 
   @Test
   public void testApplyTo_applicationSet() {
-    ApplicationSet appSet = new ApplicationSet("appSet");
+    ApplicationSet appSet = new ApplicationSet("appSet", false);
     appSet.setMembers(
         ImmutableList.of(new ApplicationReference("app1"), new ApplicationReference("app2")));
     jc.getMasterLogicalSystem().getApplicationSets().put("appSet", appSet);
-    BaseApplication app1 = new BaseApplication("app1");
-    BaseApplication app2 = new BaseApplication("app2");
+    BaseApplication app1 = new BaseApplication("app1", false);
+    BaseApplication app2 = new BaseApplication("app2", false);
     jc.getMasterLogicalSystem()
         .getApplications()
         .putAll(ImmutableMap.of("app1", app1, "app2", app2));
@@ -101,7 +101,7 @@ public class FwFromApplicationOrApplicationSetTest {
 
   @Test
   public void testToAclLineMatchExpr_application() {
-    BaseApplication app = new BaseApplication("app");
+    BaseApplication app = new BaseApplication("app", false);
     app.getTerms()
         .putAll(
             ImmutableMap.of(
@@ -126,12 +126,12 @@ public class FwFromApplicationOrApplicationSetTest {
   @Test
   public void testToAclLineMatchExpr_applicationSet() {
 
-    ApplicationSet appSet = new ApplicationSet("appSet");
+    ApplicationSet appSet = new ApplicationSet("appSet", false);
     appSet.setMembers(
         ImmutableList.of(new ApplicationReference("app1"), new ApplicationReference("app2")));
     jc.getMasterLogicalSystem().getApplicationSets().put("appSet", appSet);
-    BaseApplication app1 = new BaseApplication("app1");
-    BaseApplication app2 = new BaseApplication("app2");
+    BaseApplication app1 = new BaseApplication("app1", false);
+    BaseApplication app2 = new BaseApplication("app2", false);
     jc.getMasterLogicalSystem()
         .getApplications()
         .putAll(ImmutableMap.of("app1", app1, "app2", app2));

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JunosApplicationSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JunosApplicationSetTest.java
@@ -19,7 +19,6 @@ public class JunosApplicationSetTest {
             ImmutableList.of(
                 JunosApplication.JUNOS_NETBIOS_SESSION.toAclLineMatchExpr(jc, null),
                 JunosApplication.JUNOS_SMB_SESSION.toAclLineMatchExpr(jc, null)),
-            ApplicationSetMember.getTraceElementForUserApplication(
-                "host", JuniperStructureType.APPLICATION_SET, "junos-cifs")));
+            JunosApplicationSet.getTraceElement("junos-cifs")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JunosApplicationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JunosApplicationTest.java
@@ -38,7 +38,8 @@ public class JunosApplicationTest {
                             .setDstPorts(
                                 ImmutableSet.of(SubRange.singleton(NamedPort.BGP.number())))
                             .build())),
-                getTraceElementForBuiltInApplication(JunosApplication.JUNOS_BGP))));
+                getTraceElementForBuiltInApplication(
+                    JunosApplication.JUNOS_BGP.getJuniperName()))));
   }
 
   @Test
@@ -63,7 +64,8 @@ public class JunosApplicationTest {
                             .setDstPorts(
                                 ImmutableSet.of(SubRange.singleton(NamedPort.NETBIOS_SSN.number())))
                             .build())),
-                getTraceElementForBuiltInApplication(JunosApplication.JUNOS_SMB))));
+                getTraceElementForBuiltInApplication(
+                    JunosApplication.JUNOS_SMB.getJuniperName()))));
   }
 
   @Test
@@ -73,6 +75,6 @@ public class JunosApplicationTest {
         equalTo(
             new OrMatchExpr(
                 ImmutableList.of(new MatchHeaderSpace(HeaderSpace.builder().build())),
-                getTraceElementForBuiltInApplication(JunosApplication.ANY))));
+                getTraceElementForBuiltInApplication(JunosApplication.ANY.getJuniperName()))));
   }
 }


### PR DESCRIPTION
* Don't add `TraceElements` for undefined/unmatchable apps
* Add `builtIn` bool for apps to indicate if they're user-defined or built-in
* Generate different `TraceElements` for built-in apps
