### PR TITLE
BDDFactory: introduce andLiterals operation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/ImmutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/ImmutableBDDInteger.java
@@ -14,9 +14,15 @@ import org.batfish.datamodel.Prefix;
 
 public class ImmutableBDDInteger extends BDDInteger implements Serializable {
   private BDD _vars;
+  private BDD[] _negBitvec;
 
   public ImmutableBDDInteger(BDDFactory factory, BDD[] bitvec) {
     super(factory, bitvec);
+
+    _negBitvec = new BDD[bitvec.length];
+    for (int i = 0; i < _negBitvec.length; i++) {
+      _negBitvec[i] = bitvec[i].not();
+    }
   }
 
   /**
@@ -51,17 +57,17 @@ public class ImmutableBDDInteger extends BDDInteger implements Serializable {
   @Override
   protected BDD firstBitsEqual(long value, int length) {
     checkArgument(length <= _bitvec.length, "Not enough bits");
-    BDD ret = _factory.one();
     long val = value >> (_bitvec.length - length);
+    BDD[] literals = new BDD[length];
     for (int i = length - 1; i >= 0; i--) {
       if ((val & 1) == 1) {
-        ret.andEq(_bitvec[i]);
+        literals[i] = _bitvec[i];
       } else {
-        ret.diffEq(_bitvec[i]);
+        literals[i] = _negBitvec[i];
       }
       val >>= 1;
     }
-    return ret;
+    return _factory.andLiterals(literals);
   }
 
   @Override

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
@@ -338,6 +338,12 @@ public abstract class BDDFactory {
   }
 
   /**
+   * Returns the logical 'and' of zero or more BDD literals (constraints on exactly one variable --
+   * i.e. the variable must be true or must be false).
+   */
+  public abstract BDD andLiterals(BDD... literals);
+
+  /**
    * Returns the logical 'and' of zero or more BDDs. None of the input BDDs are consumed or mutated.
    * More efficient than using {@link BDD::and} or {@link BDD::andWith} iteratively, especially for
    * large numbers of operands, because it creates fewer intermediate BDDs.

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
@@ -340,6 +340,8 @@ public abstract class BDDFactory {
   /**
    * Returns the logical 'and' of zero or more BDD literals (constraints on exactly one variable --
    * i.e. the variable must be true or must be false).
+   *
+   * <p>Precondition: The variables' levels must be strictly increasing.
    */
   public abstract BDD andLiterals(BDD... literals);
 

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -941,11 +941,14 @@ public class JFactory extends BDDFactory implements Serializable {
     return bdd;
   }
 
-  public int bdd_andLiterals(int[] literals) {
+  private int bdd_andLiterals(int[] literals) {
     assert literals.length > 0; // empty array handled in caller
     INITREF();
 
-    // build bottom-up
+    /* build bottom-up, skipping the operator cache at each level since this construction is very cheap (and we don't
+     * want to evict a more valuable cache entry. We could consider using the multip cache to cache the entire
+     * andLiterals operation.
+     */
     int last = -1;
     int lastLevel = -1;
     for (int i = literals.length - 1; i >= 0; i--) {

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -920,6 +920,63 @@ public class JFactory extends BDDFactory implements Serializable {
   private static final int bddop_ite = 14;
 
   @Override
+  public BDD andLiterals(BDD... literals) {
+    if (literals.length == 0) {
+      return makeBDD(BDDONE);
+    }
+    if (literals.length == 1) {
+      return literals[0];
+    }
+
+    int[] ids = new int[literals.length];
+    for (int i = 0; i < literals.length; i++) {
+      int id = ((BDDImpl) literals[i])._index;
+      if (ISCONST(id)) {
+        throw new IllegalArgumentException("Illegal constant " + id);
+      }
+      ids[i] = id;
+    }
+
+    BDDImpl bdd = makeBDD(bdd_andLiterals(ids));
+    return bdd;
+  }
+
+  public int bdd_andLiterals(int[] literals) {
+    assert literals.length > 0; // empty array handled in caller
+    INITREF();
+
+    // build bottom-up
+    int last = -1;
+    int lastLevel = -1;
+    for (int i = literals.length - 1; i >= 0; i--) {
+      int n = literals[i];
+      int level = LEVEL(n);
+      int var = bddlevel2var[level];
+      boolean positive = n == bddvarset[var * 2];
+      if (!(positive || n == bddvarset[var * 2 + 1])) {
+        throw new IllegalArgumentException(String.format("argument %s is not a literal", i));
+      }
+
+      if (last == -1) {
+        last = n;
+      } else {
+        if (level >= lastLevel) {
+          throw new IllegalArgumentException("Levels are not strictly increasing");
+        }
+        PUSHREF(last);
+        if (positive) {
+          last = bdd_makenode(level, BDDZERO, last);
+        } else {
+          last = bdd_makenode(level, last, BDDZERO);
+        }
+        POPREF(1);
+      }
+      lastLevel = level;
+    }
+    return last;
+  }
+
+  @Override
   public BDD andAll(Iterable<BDD> bddOperands, boolean free) {
     int[] operands =
         StreamSupport.stream(bddOperands.spliterator(), false)

--- a/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -15,10 +15,14 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashSet;
 import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /** Tests of {@link JFactory}. */
 public class JFactoryTest {
+  @Rule public ExpectedException _exception = ExpectedException.none();
+
   private JFactory _factory = (JFactory) JFactory.init(10000, 10000);
 
   @Test
@@ -569,6 +573,48 @@ public class JFactoryTest {
     assertEquals(one, ite.project(_factory.ithVar(5)));
     assertEquals(one, ite.project(_factory.ithVar(7)));
     assertEquals(one, ite.project(_factory.ithVar(9))); // last var
+  }
+
+  @Test
+  public void testAndLiterals() {
+    _factory.setVarNum(4);
+    BDD v0 = _factory.ithVar(0);
+    BDD v1 = _factory.ithVar(1);
+    BDD v2 = _factory.ithVar(2);
+    BDD v3 = _factory.ithVar(3);
+
+    assertEquals(
+        v0.and(v1.not()).and(v2).and(v3.not()), _factory.andLiterals(v0, v1.not(), v2, v3.not()));
+  }
+
+  @Test
+  public void testAndLiterals_varOrder() {
+    _factory.setVarNum(4);
+    BDD v0 = _factory.ithVar(0);
+    BDD v1 = _factory.ithVar(1);
+
+    _exception.expect(IllegalArgumentException.class);
+    _factory.andLiterals(v1, v0);
+  }
+
+  @Test
+  public void testAndLiterals_constants() {
+    _factory.setVarNum(4);
+    BDD v1 = _factory.ithVar(1);
+
+    _exception.expect(IllegalArgumentException.class);
+    _factory.andLiterals(v1, _factory.zero());
+  }
+
+  @Test
+  public void testAndLiterals_complex() {
+    _factory.setVarNum(4);
+    BDD v0 = _factory.ithVar(0);
+    BDD v1 = _factory.ithVar(1);
+    BDD v2 = _factory.ithVar(2);
+
+    _exception.expect(IllegalArgumentException.class);
+    _factory.andLiterals(v0.and(v1), v2);
   }
 
   @Test


### PR DESCRIPTION
Introduce a new operation that computes the logical AND of some number of literals (constraints on exactly one variable -- i.e. the variable must be true or must be false), and use it in `ImmutableBDDInteger#firstBitsEqual`. 

The `andLiterals` implementation does the same bottom-up construction we were doing in `firstBitsEqual`, but without caching in the operator cache. This avoids evicting more valuable entries (i.e. expensive operations) for these low-value ones (adding a node to the root of a BDD is very cheap).

We could consider caching the entire `andLiterals` operations in the multi-op cache, but that would be redundant with the cache in IpSpaceToBDD.
