### PR TITLE
IOS: Enable OSPF for interfaces defined after router OSPF

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -8818,7 +8818,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitS_router_ospf(S_router_ospfContext ctx) {
-    _currentOspfProcess.computeNetworks(_configuration.getInterfaces().values());
     _currentOspfProcess = null;
     _currentVrf = Configuration.DEFAULT_VRF_NAME;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -4544,6 +4544,15 @@ public final class CiscoGrammarTest {
     assertThat(c2, hasInterface(iface2Name, isOspfPassive(equalTo(true))));
   }
 
+  /** Check that OSPF is enabled even when interfaces are after the router OSPF stanza. */
+  @Test
+  public void testOspfInterfaceAfterOspf() throws IOException {
+    Configuration c = parseConfig("ios-ospf-interface-after-ospf");
+    String iface1Name = "Ethernet1";
+    Map<String, Interface> ifaces = c.getAllInterfaces();
+    assertThat(ifaces.get(iface1Name).getOspfProcess(), equalTo("1"));
+  }
+
   @Test
   public void testOspfProcessInference() throws IOException {
     Configuration c = parseConfig("ios-ospf-process-inference");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-ospf-interface-after-ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-ospf-interface-after-ospf
@@ -1,0 +1,11 @@
+!
+hostname ios-ospf-interface-after-ospf
+!
+router ospf 1
+ router-id 1.2.3.4
+ network 10.0.1.0 0.0.0.255 area 1
+!
+interface Ethernet1
+ ip address 10.0.1.1 255.255.255.0
+ no shutdown
+!


### PR DESCRIPTION
Before: While parsing `router ospf` stanza, the set of OSPF networks were being computed based on the interfaces defined at the time. This meant that any interfaces defined after the OSPF stanza were ignored. This PR changes that behavior. 

A user reported that when they defined interface after router OSPF, as in append to the original config, OSPF is enabled on that interface. This behavior is consistent with what Batfish does for other vendors. 

No other change in this PR. 