### PR TITLE
Differential BGP RIB: Make receivedFromIp a key

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -27,7 +27,6 @@ import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
-import org.batfish.datamodel.visitors.LegacyReceivedFromToIpConverter;
 
 /** A generic BGP route containing the common properties among different types of BGP routes */
 @ParametersAreNonnullByDefault
@@ -606,18 +605,6 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
   @Nonnull
   public ReceivedFrom getReceivedFrom() {
     return _receivedFrom;
-  }
-
-  /**
-   * The {@link Ip} address of the (I)BGP peer from which the route was learned, or {@link Ip#ZERO}
-   * if the BGP route was originated locally.
-   *
-   * <p>Set on origination and on import.
-   */
-  @Nullable
-  @JsonIgnore
-  public Ip getReceivedFromIp() {
-    return LegacyReceivedFromToIpConverter.convert(_receivedFrom);
   }
 
   @JsonProperty(PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT)

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -1104,9 +1104,12 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
                   r ->
                       // Withdrawals
                       r.isWithdrawn()
-                          // Received from 0.0.0.0 indicates local origination
+                          // Locally originated
                           || (_exportFromBgpRib
-                              && Ip.ZERO.equals(r.getRoute().getRoute().getReceivedFromIp()))
+                              && r.getRoute()
+                                  .getRoute()
+                                  .getReceivedFrom()
+                                  .equals(ReceivedFromSelf.instance()))
                           // RIB-failure routes included
                           || isReflectable(r.getRoute(), ourSession, ourConfig)
                           // RIB-failure routes excluded

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -144,7 +144,7 @@ public final class BgpProtocolHelper {
     }
 
     builder.setClusterList(ImmutableSet.of());
-    boolean routeOriginatedLocally = Ip.ZERO.equals(route.getReceivedFromIp());
+    boolean routeOriginatedLocally = route.getReceivedFrom().equals(ReceivedFromSelf.instance());
     if (routeProtocol.equals(RoutingProtocol.IBGP) && !localSessionProperties.isEbgp()) {
       /*
        * The remote route is iBGP. The session is iBGP. We consider whether to reflect, and

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -32,6 +32,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ReceivedFromIp;
 import org.batfish.datamodel.ReceivedFromSelf;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.AllowRemoteAsOutMode;
@@ -166,13 +167,13 @@ public class BgpProtocolHelperTest {
   }
 
   @Test
-  public void testTransformOnImportReceivedFromIp() {
+  public void testTransformOnImportReceivedFrom() {
     assertThat(
         transformBgpRouteOnImport(
                 _baseBgpRouteBuilder.build(), 1L, false, false, _process, Ip.parse("1.2.3.4"), null)
             .build()
-            .getReceivedFromIp(),
-        equalTo(Ip.parse("1.2.3.4")));
+            .getReceivedFrom(),
+        equalTo(ReceivedFromIp.of(Ip.parse("1.2.3.4"))));
   }
 
   @Test

--- a/projects/question/src/main/java/org/batfish/question/routes/BgpRouteRowSecondaryKey.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/BgpRouteRowSecondaryKey.java
@@ -1,0 +1,47 @@
+package org.batfish.question.routes;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.route.nh.NextHop;
+
+/** Class representing the secondary key used for grouping {@link Bgpv4Route}s */
+@ParametersAreNonnullByDefault
+public class BgpRouteRowSecondaryKey extends RouteRowSecondaryKey {
+  @Nullable private final Ip _receivedFromIp;
+
+  public BgpRouteRowSecondaryKey(NextHop nextHop, String protocol, @Nullable Ip receivedFromIp) {
+    super(nextHop, protocol);
+    _receivedFromIp = receivedFromIp;
+  }
+
+  @Override
+  public <R> R accept(RouteRowSecondaryKeyVisitor<R> visitor) {
+    return visitor.visitBgpRouteRowSecondaryKey(this);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BgpRouteRowSecondaryKey that = (BgpRouteRowSecondaryKey) o;
+    return _nextHop.equals(that._nextHop)
+        && _protocol.equals(that._protocol)
+        && Objects.equals(_receivedFromIp, that._receivedFromIp);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_nextHop, _protocol, _receivedFromIp);
+  }
+
+  public @Nullable Ip getReceivedFromIp() {
+    return _receivedFromIp;
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/routes/BgpRouteRowSecondaryKey.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/BgpRouteRowSecondaryKey.java
@@ -1,6 +1,7 @@
 package org.batfish.question.routes;
 
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Bgpv4Route;
@@ -10,9 +11,9 @@ import org.batfish.datamodel.route.nh.NextHop;
 /** Class representing the secondary key used for grouping {@link Bgpv4Route}s */
 @ParametersAreNonnullByDefault
 public class BgpRouteRowSecondaryKey extends RouteRowSecondaryKey {
-  @Nullable private final Ip _receivedFromIp;
+  @Nonnull private final Ip _receivedFromIp;
 
-  public BgpRouteRowSecondaryKey(NextHop nextHop, String protocol, @Nullable Ip receivedFromIp) {
+  public BgpRouteRowSecondaryKey(NextHop nextHop, String protocol, Ip receivedFromIp) {
     super(nextHop, protocol);
     _receivedFromIp = receivedFromIp;
   }
@@ -33,7 +34,7 @@ public class BgpRouteRowSecondaryKey extends RouteRowSecondaryKey {
     BgpRouteRowSecondaryKey that = (BgpRouteRowSecondaryKey) o;
     return _nextHop.equals(that._nextHop)
         && _protocol.equals(that._protocol)
-        && Objects.equals(_receivedFromIp, that._receivedFromIp);
+        && _receivedFromIp.equals(that._receivedFromIp);
   }
 
   @Override
@@ -41,7 +42,7 @@ public class BgpRouteRowSecondaryKey extends RouteRowSecondaryKey {
     return Objects.hash(_nextHop, _protocol, _receivedFromIp);
   }
 
-  public @Nullable Ip getReceivedFromIp() {
+  public @Nonnull Ip getReceivedFromIp() {
     return _receivedFromIp;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/routes/MainRibRouteRowSecondaryKey.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/MainRibRouteRowSecondaryKey.java
@@ -1,0 +1,39 @@
+package org.batfish.question.routes;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.route.nh.NextHop;
+
+/**
+ * Class representing the secondary key used for grouping {@link
+ * org.batfish.datamodel.AbstractRoute}s
+ */
+@ParametersAreNonnullByDefault
+public final class MainRibRouteRowSecondaryKey extends RouteRowSecondaryKey {
+  public MainRibRouteRowSecondaryKey(NextHop nextHop, String protocol) {
+    super(nextHop, protocol);
+  }
+
+  @Override
+  public <R> R accept(RouteRowSecondaryKeyVisitor<R> visitor) {
+    return visitor.visitMainRibRouteRowSecondaryKey(this);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MainRibRouteRowSecondaryKey that = (MainRibRouteRowSecondaryKey) o;
+    return _nextHop.equals(that._nextHop) && _protocol.equals(that._protocol);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_nextHop, _protocol);
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
@@ -15,7 +15,6 @@ import javax.annotation.ParametersAreNullableByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpRoute;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginMechanism;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Route;
@@ -29,30 +28,17 @@ import org.batfish.datamodel.questions.BgpRouteStatus;
 @ParametersAreNullableByDefault
 public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   @Nullable private final String _nextHopInterface;
-
   @Nullable private final AsPath _asPath;
-
   @Nullable private final Integer _adminDistance;
-
   @Nonnull private final List<String> _communities;
-
   @Nullable private final Long _localPreference;
-
   @Nullable private final Long _metric;
-
   @Nullable private final String _originProtocol;
-
   @Nullable private final OriginMechanism _originMechanism;
-
   @Nullable private final OriginType _originType;
-
-  @Nullable private final Ip _receivedFromIp;
-
   @Nullable private final Long _tag;
-
   @Nullable private final BgpRouteStatus _status;
   @Nullable private final TunnelEncapsulationAttribute _tunnelEncapsulationAttribute;
-
   @Nullable private final Integer _weight;
 
   private RouteRowAttribute(
@@ -65,7 +51,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
       String originalProtocol,
       OriginMechanism originMechanism,
       OriginType originType,
-      Ip receivedFromIp,
       Long tag,
       BgpRouteStatus status,
       @Nullable TunnelEncapsulationAttribute tunnelEncapsulationAttribute,
@@ -79,7 +64,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
     _originProtocol = originalProtocol;
     _originMechanism = originMechanism;
     _originType = originType;
-    _receivedFromIp = receivedFromIp;
     _tag = tag;
     _status = status;
     _tunnelEncapsulationAttribute = tunnelEncapsulationAttribute;
@@ -131,10 +115,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
     return _originType;
   }
 
-  public @Nullable Ip getReceivedFromIp() {
-    return _receivedFromIp;
-  }
-
   @Nullable
   public Long getTag() {
     return _tag;
@@ -169,7 +149,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
           .thenComparing(
               RouteRowAttribute::getOriginMechanism, nullsLast(OriginMechanism::compareTo))
           .thenComparing(RouteRowAttribute::getOriginType, nullsLast(OriginType::compareTo))
-          .thenComparing(RouteRowAttribute::getReceivedFromIp, nullsLast(Ip::compareTo))
           .thenComparing(RouteRowAttribute::getTag, nullsLast(Long::compareTo))
           .thenComparing(RouteRowAttribute::getStatus, nullsLast(BgpRouteStatus::compareTo))
           .thenComparing(
@@ -206,7 +185,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
         && Objects.equals(_originProtocol, that._originProtocol)
         && Objects.equals(_originMechanism, that._originMechanism)
         && Objects.equals(_originType, that._originType)
-        && Objects.equals(_receivedFromIp, that._receivedFromIp)
         && Objects.equals(_tag, that._tag)
         && Objects.equals(_status, that._status)
         && Objects.equals(_tunnelEncapsulationAttribute, that._tunnelEncapsulationAttribute)
@@ -224,7 +202,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
         _communities,
         _originProtocol,
         _originType == null ? 0 : _originType.ordinal(),
-        _receivedFromIp,
         _tag,
         _status == null ? 0 : _status.ordinal(),
         _tunnelEncapsulationAttribute,
@@ -242,7 +219,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
     @Nullable private String _originProtocol;
     @Nullable private OriginMechanism _originMechanism;
     @Nullable private OriginType _originType;
-    @Nullable private Ip _receivedFromIp;
     @Nullable private Long _tag;
     @Nullable private BgpRouteStatus _status;
     @Nullable private TunnelEncapsulationAttribute _tunnelEncapsulationAttribute;
@@ -262,7 +238,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
           _originProtocol,
           _originMechanism,
           _originType,
-          _receivedFromIp,
           _tag,
           _status,
           _tunnelEncapsulationAttribute,
@@ -311,11 +286,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
 
     public Builder setOriginType(OriginType originType) {
       _originType = originType;
-      return this;
-    }
-
-    public Builder setReceivedFromIp(Ip receivedFromIp) {
-      _receivedFromIp = receivedFromIp;
       return this;
     }
 

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKey.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKey.java
@@ -19,11 +19,11 @@ public abstract class RouteRowSecondaryKey {
     _protocol = protocol;
   }
 
-  public @Nonnull NextHop getNextHop() {
+  public final @Nonnull NextHop getNextHop() {
     return _nextHop;
   }
 
-  public @Nonnull String getProtocol() {
+  public final @Nonnull String getProtocol() {
     return _protocol;
   }
 

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKey.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKey.java
@@ -1,6 +1,5 @@
 package org.batfish.question.routes;
 
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute;
@@ -11,32 +10,13 @@ import org.batfish.datamodel.route.nh.NextHop;
  * org.batfish.datamodel.AbstractRoute}s and {@link BgpRoute}s
  */
 @ParametersAreNonnullByDefault
-public class RouteRowSecondaryKey {
+public abstract class RouteRowSecondaryKey {
+  @Nonnull protected final NextHop _nextHop;
+  @Nonnull protected final String _protocol;
 
-  @Nonnull private final NextHop _nextHop;
-
-  @Nonnull private final String _protocol;
-
-  public RouteRowSecondaryKey(NextHop nextHop, String protocol) {
+  protected RouteRowSecondaryKey(NextHop nextHop, String protocol) {
     _nextHop = nextHop;
     _protocol = protocol;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    RouteRowSecondaryKey that = (RouteRowSecondaryKey) o;
-    return _nextHop.equals(that._nextHop) && _protocol.equals(that._protocol);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_nextHop, _protocol);
   }
 
   public @Nonnull NextHop getNextHop() {
@@ -46,4 +26,6 @@ public class RouteRowSecondaryKey {
   public @Nonnull String getProtocol() {
     return _protocol;
   }
+
+  public abstract <R> R accept(RouteRowSecondaryKeyVisitor<R> visitor);
 }

--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKeyVisitor.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowSecondaryKeyVisitor.java
@@ -1,0 +1,7 @@
+package org.batfish.question.routes;
+
+public interface RouteRowSecondaryKeyVisitor<R> {
+  R visitBgpRouteRowSecondaryKey(BgpRouteRowSecondaryKey bgpRouteRowSecondaryKey);
+
+  R visitMainRibRouteRowSecondaryKey(MainRibRouteRowSecondaryKey mainRibRouteRowSecondaryKey);
+}

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -34,6 +34,7 @@ import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.NextHopComparator;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
@@ -148,7 +149,7 @@ public class RoutesAnswerer extends Answerer {
                 protocolSpec,
                 ImmutableSet.of(BEST, BACKUP),
                 question.getPrefixMatchType()));
-        rows.sort(BGP_COMPARATOR);
+        rows.sort(EVPN_COMPARATOR);
         break;
       case MAIN:
         rows.addAll(
@@ -244,6 +245,14 @@ public class RoutesAnswerer extends Answerer {
           .thenComparing(row -> row.getNextHop(COL_NEXT_HOP), NextHopComparator.instance());
 
   private static final Comparator<Row> BGP_COMPARATOR =
+      Comparator.<Row, String>comparing(row -> row.getNode(COL_NODE).getName())
+          .thenComparing(row -> row.getString(COL_VRF_NAME))
+          .thenComparing(row -> row.getPrefix(COL_NETWORK))
+          .thenComparing(row -> row.getNextHop(COL_NEXT_HOP), NextHopComparator.instance())
+          .thenComparing(
+              row -> row.getIp(COL_RECEIVED_FROM_IP), Comparator.nullsFirst(Ip::compareTo));
+
+  private static final Comparator<Row> EVPN_COMPARATOR =
       Comparator.<Row, String>comparing(row -> row.getNode(COL_NODE).getName())
           .thenComparing(row -> row.getString(COL_VRF_NAME))
           .thenComparing(row -> row.getPrefix(COL_NETWORK))

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -34,7 +34,6 @@ import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.NextHopComparator;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
@@ -249,8 +248,7 @@ public class RoutesAnswerer extends Answerer {
           .thenComparing(row -> row.getString(COL_VRF_NAME))
           .thenComparing(row -> row.getPrefix(COL_NETWORK))
           .thenComparing(row -> row.getNextHop(COL_NEXT_HOP), NextHopComparator.instance())
-          .thenComparing(
-              row -> row.getIp(COL_RECEIVED_FROM_IP), Comparator.nullsFirst(Ip::compareTo));
+          .thenComparing(row -> row.getIp(COL_RECEIVED_FROM_IP));
 
   private static final Comparator<Row> EVPN_COMPARATOR =
       Comparator.<Row, String>comparing(row -> row.getNode(COL_NODE).getName())

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -74,7 +74,6 @@ import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.questions.BgpRouteStatus;
 import org.batfish.datamodel.route.nh.LegacyNextHops;
-import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.Row.RowBuilder;
@@ -565,29 +564,59 @@ public class RoutesAnswererUtil {
       RouteRowSecondaryKey routeRowSecondaryKey,
       KeyPresenceStatus secondaryKeyPresence,
       RowBuilder rowBuilder) {
-    NextHop nextHop = routeRowSecondaryKey.getNextHop();
-    String protocol = routeRowSecondaryKey.getProtocol();
+    SecondaryKeyPopulator secondaryKeyPopulator = new SecondaryKeyPopulator();
     // populating base columns for secondary key if it is present in base snapshot or in both
     // snapshots
     if (secondaryKeyPresence == KeyPresenceStatus.IN_BOTH
         || secondaryKeyPresence == KeyPresenceStatus.ONLY_IN_SNAPSHOT) {
-      rowBuilder
-          .put(COL_BASE_PREFIX + COL_NEXT_HOP, nextHop)
-          .put(
-              COL_BASE_PREFIX + COL_NEXT_HOP_IP,
-              LegacyNextHops.getNextHopIp(nextHop).orElse(Route.UNSET_ROUTE_NEXT_HOP_IP))
-          .put(COL_BASE_PREFIX + COL_PROTOCOL, protocol);
+      secondaryKeyPopulator.populateSecondaryKeyAttrs(
+          routeRowSecondaryKey, rowBuilder, COL_BASE_PREFIX);
     }
     // populating reference columns for secondary key if it is present in reference snapshot or in
     // both snapshots
     if (secondaryKeyPresence == KeyPresenceStatus.IN_BOTH
         || secondaryKeyPresence == KeyPresenceStatus.ONLY_IN_REFERENCE) {
+      secondaryKeyPopulator.populateSecondaryKeyAttrs(
+          routeRowSecondaryKey, rowBuilder, COL_DELTA_PREFIX);
+    }
+  }
+
+  private static class SecondaryKeyPopulator implements RouteRowSecondaryKeyVisitor<Void> {
+    private String _columnPrefix;
+    private RowBuilder _rowBuilder;
+
+    /**
+     * Populates the given {@link RowBuilder} with the attributes of the given {@link
+     * RouteRowSecondaryKey} with column names prefixed with the given {@code columnPrefix}
+     * (expected to be {@link TableDiff#COL_BASE_PREFIX} or {@link TableDiff#COL_DELTA_PREFIX}).
+     */
+    public void populateSecondaryKeyAttrs(
+        RouteRowSecondaryKey routeRowSecondaryKey, RowBuilder rowBuilder, String columnPrefix) {
+      // First populate attributes shared by all types of secondary key
       rowBuilder
-          .put(COL_DELTA_PREFIX + COL_NEXT_HOP, nextHop)
+          .put(columnPrefix + COL_NEXT_HOP, routeRowSecondaryKey.getNextHop())
           .put(
-              COL_DELTA_PREFIX + COL_NEXT_HOP_IP,
-              LegacyNextHops.getNextHopIp(nextHop).orElse(Route.UNSET_ROUTE_NEXT_HOP_IP))
-          .put(COL_DELTA_PREFIX + COL_PROTOCOL, protocol);
+              columnPrefix + COL_NEXT_HOP_IP,
+              LegacyNextHops.getNextHopIp(routeRowSecondaryKey.getNextHop())
+                  .orElse(Route.UNSET_ROUTE_NEXT_HOP_IP))
+          .put(columnPrefix + COL_PROTOCOL, routeRowSecondaryKey.getProtocol());
+      // Now let visitor fill in route-type-specific columns
+      _rowBuilder = rowBuilder;
+      _columnPrefix = columnPrefix;
+      routeRowSecondaryKey.accept(this);
+    }
+
+    @Override
+    public Void visitBgpRouteRowSecondaryKey(BgpRouteRowSecondaryKey bgpRouteRowSecondaryKey) {
+      _rowBuilder.put(
+          _columnPrefix + COL_RECEIVED_FROM_IP, bgpRouteRowSecondaryKey.getReceivedFromIp());
+      return null;
+    }
+
+    @Override
+    public Void visitMainRibRouteRowSecondaryKey(
+        MainRibRouteRowSecondaryKey mainRibRouteRowSecondaryKey) {
+      return null; // no additional columns
     }
   }
 
@@ -644,9 +673,6 @@ public class RoutesAnswererUtil {
         .put(
             prefix + COL_ORIGIN_TYPE,
             routeRowAttribute != null ? routeRowAttribute.getOriginType() : null)
-        .put(
-            prefix + COL_RECEIVED_FROM_IP,
-            routeRowAttribute != null ? routeRowAttribute.getReceivedFromIp() : null)
         .put(prefix + COL_TAG, routeRowAttribute != null ? routeRowAttribute.getTag() : null)
         .put(
             prefix + COL_TUNNEL_ENCAPSULATION_ATTRIBUTE,
@@ -724,9 +750,9 @@ public class RoutesAnswererUtil {
   }
 
   /**
-   * Given a {@link Map} of all RIBs groups the routes in them by the fields of {@link RouteRowKey}
-   * and further sub-groups them by {@link RouteRowSecondaryKey} and for routes in the same
-   * sub-group, sorts them according to {@link RouteRowAttribute}s
+   * Given a {@link Map} of all main RIBs, groups the routes in them by the fields of {@link
+   * RouteRowKey} and further sub-groups them by {@link RouteRowSecondaryKey} and for routes in the
+   * same sub-group, sorts them according to {@link RouteRowAttribute}s
    *
    * @param ribs {@link Map} of the RIBs
    * @param matchingNodes {@link Set} of nodes to be matched
@@ -768,7 +794,7 @@ public class RoutesAnswererUtil {
                             new RouteRowKey(node, vrfName, route.getNetwork()),
                             k -> new HashMap<>())
                         .computeIfAbsent(
-                            new RouteRowSecondaryKey(
+                            new MainRibRouteRowSecondaryKey(
                                 route.getNextHop(), route.getProtocol().protocolName()),
                             k -> new TreeSet<>())
                         .add(
@@ -848,9 +874,10 @@ public class RoutesAnswererUtil {
                                                         route.getNetwork()),
                                                     k -> new HashMap<>())
                                                 .computeIfAbsent(
-                                                    new RouteRowSecondaryKey(
+                                                    new BgpRouteRowSecondaryKey(
                                                         route.getNextHop(),
-                                                        route.getProtocol().protocolName()),
+                                                        route.getProtocol().protocolName(),
+                                                        route.getReceivedFromIp()),
                                                     k -> new TreeSet<>())
                                                 .add(
                                                     RouteRowAttribute.builder()
@@ -874,8 +901,6 @@ public class RoutesAnswererUtil {
                                                                 .map(Community::toString)
                                                                 .collect(toImmutableList()))
                                                         .setOriginType(route.getOriginType())
-                                                        .setReceivedFromIp(
-                                                            route.getReceivedFromIp())
                                                         .setTag(
                                                             route.getTag() == Route.UNSET_ROUTE_TAG
                                                                 ? null

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -78,6 +78,7 @@ import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.Row.RowBuilder;
 import org.batfish.datamodel.table.TableDiff;
+import org.batfish.datamodel.visitors.LegacyReceivedFromToIpConverter;
 import org.batfish.question.routes.DiffRoutesOutput.KeyPresenceStatus;
 import org.batfish.question.routes.RoutesQuestion.PrefixMatchType;
 import org.batfish.question.routes.RoutesQuestion.RibProtocol;
@@ -447,7 +448,9 @@ public class RoutesAnswererUtil {
         .put(COL_ORIGIN_PROTOCOL, bgpv4Route.getSrcProtocol())
         .put(COL_ORIGIN_TYPE, bgpv4Route.getOriginType())
         .put(COL_ORIGINATOR_ID, bgpv4Route.getOriginatorIp())
-        .put(COL_RECEIVED_FROM_IP, bgpv4Route.getReceivedFromIp())
+        .put(
+            COL_RECEIVED_FROM_IP,
+            LegacyReceivedFromToIpConverter.convert(bgpv4Route.getReceivedFrom()))
         .put(
             COL_CLUSTER_LIST,
             bgpv4Route.getClusterList().isEmpty() ? null : bgpv4Route.getClusterList())
@@ -877,7 +880,8 @@ public class RoutesAnswererUtil {
                                                     new BgpRouteRowSecondaryKey(
                                                         route.getNextHop(),
                                                         route.getProtocol().protocolName(),
-                                                        route.getReceivedFromIp()),
+                                                        LegacyReceivedFromToIpConverter.convert(
+                                                            route.getReceivedFrom())),
                                                     k -> new TreeSet<>())
                                                 .add(
                                                     RouteRowAttribute.builder()


### PR DESCRIPTION
Makes `receivedFromIp` part of the `RouteRowSecondaryKey` for differential BGP RIB, so that if there is a similar route across two snapshots with different `receivedFromIp`, they will be considered different routes for diffing purposes. Paving the way for a received path ID column, which will also be a key.

Also added `receivedFromIp` to the comparator that sorts BGP RIB rows. The sort order is now: node, VRF, network, next hop, receivedFromIp. Once the received path ID column is added, that will go into the sort order after receivedFromIp.

Because `receivedFromIp` isn't an attribute of main RIB routes (and path ID won't be either), made `RouteRowSecondaryKey` abstract with separate implementations to represent a main RIB key and a BGP RIB key.