### PR TITLE
Juniper: fix firewall filter VSIDs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -6820,6 +6820,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _currentZoneInboundFilter.getTerms().put(termName, newTerm);
     newTerm.getFromHostProtocols().add(protocol);
     newTerm.getThens().add(FwThenAccept.INSTANCE);
+
+    String defName = computeFirewallFilterTermName(_currentZoneInboundFilter.getName(), termName);
+    _configuration.defineFlattenedStructure(FIREWALL_FILTER_TERM, defName, ctx, _parser);
+    _configuration.referenceStructure(
+        FIREWALL_FILTER_TERM, defName, FIREWALL_FILTER_TERM_DEFINITION, getLine(ctx.getStart()));
   }
 
   @Override
@@ -6830,6 +6835,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _currentZoneInboundFilter.getTerms().put(termName, newTerm);
     newTerm.getFromHostServices().add(service);
     newTerm.getThens().add(FwThenAccept.INSTANCE);
+
+    String defName = computeFirewallFilterTermName(_currentZoneInboundFilter.getName(), termName);
+    _configuration.defineFlattenedStructure(FIREWALL_FILTER_TERM, defName, ctx, _parser);
+    _configuration.referenceStructure(
+        FIREWALL_FILTER_TERM, defName, FIREWALL_FILTER_TERM_DEFINITION, getLine(ctx.getStart()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Zone.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Zone.java
@@ -43,12 +43,16 @@ public final class Zone implements Serializable {
     _name = name;
     _addressBook = globalAddressBook;
     _addressBookType = AddressBookType.GLOBAL;
-    _inboundFilter = new ConcreteFirewallFilter("~INBOUND_ZONE_FILTER~" + name, Family.INET);
+    _inboundFilter = new ConcreteFirewallFilter(getInboundFilterName(name), Family.INET);
     _inboundInterfaceFilters = new TreeMap<>();
     _interfaces = new ArrayList<>();
     _fromZonePolicies = new TreeMap<>();
     _toZonePolicies = new TreeMap<>();
     _screens = new TreeSet<>();
+  }
+
+  public static String getInboundFilterName(String zoneName) {
+    return "~INBOUND_ZONE_FILTER~" + zoneName;
   }
 
   public void attachAddressBook(AddressBook addressBook) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -152,6 +152,7 @@ import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_G
 import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_SECURITY_POLICY;
 import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_ISIS_COST;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeConditionRoutingPolicyName;
+import static org.batfish.representation.juniper.JuniperConfiguration.computeFirewallFilterTermName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeOspfExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePeerExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePolicyStatementTermName;
@@ -188,6 +189,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_ST
 import static org.batfish.representation.juniper.JuniperStructureUsage.SECURITY_POLICY_MATCH_APPLICATION;
 import static org.batfish.representation.juniper.RoutingInformationBase.RIB_IPV4_UNICAST;
 import static org.batfish.representation.juniper.RoutingInstance.OSPF_INTERNAL_SUMMARY_DISCARD_METRIC;
+import static org.batfish.representation.juniper.Zone.getInboundFilterName;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -1759,6 +1761,24 @@ public final class FlatJuniperGrammarTest {
     /* esfilter should be referred, while esfilter2 should be unreferred */
     assertThat(ccae, hasNumReferrers(filename, FIREWALL_FILTER, "esfilter", 1));
     assertThat(ccae, hasNumReferrers(filename, FIREWALL_FILTER, "esfilter2", 0));
+  }
+
+  @Test
+  public void testSecurityZoneTermReference() throws IOException {
+    String hostname = "security-zone-term-refs";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Term is defined and has a self-reference
+    assertThat(
+        ccae,
+        hasNumReferrers(
+            filename,
+            FIREWALL_FILTER_TERM,
+            computeFirewallFilterTermName(getInboundFilterName("ZONE_NAME"), "ALL"),
+            1));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/security-zone-term-refs
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/security-zone-term-refs
@@ -1,0 +1,6 @@
+####BATFISH FLATTENED JUNIPER CONFIG####
+#
+set system host-name security-zone-term-refs
+#
+set security zones security-zone ZONE_NAME host-inbound-traffic protocols all
+#

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -6245,6 +6245,52 @@
               "numReferrers" : 1
             }
           },
+          "firewall filter term" : {
+            "~INBOUND_ZONE_FILTER~hostos PING" : {
+              "definitionLines" : "91",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~hostos SSH" : {
+              "definitionLines" : "92",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~loopback PING" : {
+              "definitionLines" : "94",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust BGP" : {
+              "definitionLines" : "81",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust PING" : {
+              "definitionLines" : "78",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust SSH" : {
+              "definitionLines" : "79",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust TELNET" : {
+              "definitionLines" : "80",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust BGP" : {
+              "definitionLines" : "88",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust IKE" : {
+              "definitionLines" : "87",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust PING" : {
+              "definitionLines" : "85",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust SSH" : {
+              "definitionLines" : "86",
+              "numReferrers" : 1
+            }
+          },
           "ike gateway" : {
             "gateway-2" : {
               "definitionLines" : "28-30",
@@ -6411,6 +6457,52 @@
               "numReferrers" : 1
             }
           },
+          "firewall filter term" : {
+            "~INBOUND_ZONE_FILTER~hostos PING" : {
+              "definitionLines" : "79",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~hostos SSH" : {
+              "definitionLines" : "80",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~loopback PING" : {
+              "definitionLines" : "77",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust BGP" : {
+              "definitionLines" : "67",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust PING" : {
+              "definitionLines" : "64",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust SSH" : {
+              "definitionLines" : "65",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust TELNET" : {
+              "definitionLines" : "66",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust BGP" : {
+              "definitionLines" : "74",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust IKE" : {
+              "definitionLines" : "73",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust PING" : {
+              "definitionLines" : "71",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust SSH" : {
+              "definitionLines" : "72",
+              "numReferrers" : 1
+            }
+          },
           "ike gateway" : {
             "gateway-1" : {
               "definitionLines" : "25-27",
@@ -6526,6 +6618,52 @@
             },
             "10.23.0.2 (VRF default)" : {
               "definitionLines" : "87",
+              "numReferrers" : 1
+            }
+          },
+          "firewall filter term" : {
+            "~INBOUND_ZONE_FILTER~hostos PING" : {
+              "definitionLines" : "73",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~hostos SSH" : {
+              "definitionLines" : "74",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~loopback PING" : {
+              "definitionLines" : "71",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust BGP" : {
+              "definitionLines" : "61",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust PING" : {
+              "definitionLines" : "58",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust SSH" : {
+              "definitionLines" : "59",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~trust TELNET" : {
+              "definitionLines" : "60",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust BGP" : {
+              "definitionLines" : "68",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust IKE" : {
+              "definitionLines" : "67",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust PING" : {
+              "definitionLines" : "65",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~untrust SSH" : {
+              "definitionLines" : "66",
               "numReferrers" : 1
             }
           },
@@ -6661,6 +6799,63 @@
             "10.13.0.3 (VRF default)" : {
               "bgp neighbor self ref" : [
                 114
+              ]
+            }
+          },
+          "firewall filter term" : {
+            "~INBOUND_ZONE_FILTER~hostos PING" : {
+              "firewall filter term" : [
+                91
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~hostos SSH" : {
+              "firewall filter term" : [
+                92
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~loopback PING" : {
+              "firewall filter term" : [
+                94
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust BGP" : {
+              "firewall filter term" : [
+                81
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust PING" : {
+              "firewall filter term" : [
+                78
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust SSH" : {
+              "firewall filter term" : [
+                79
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust TELNET" : {
+              "firewall filter term" : [
+                80
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust BGP" : {
+              "firewall filter term" : [
+                88
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust IKE" : {
+              "firewall filter term" : [
+                87
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust PING" : {
+              "firewall filter term" : [
+                85
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust SSH" : {
+              "firewall filter term" : [
+                86
               ]
             }
           },
@@ -6944,6 +7139,63 @@
               ]
             }
           },
+          "firewall filter term" : {
+            "~INBOUND_ZONE_FILTER~hostos PING" : {
+              "firewall filter term" : [
+                79
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~hostos SSH" : {
+              "firewall filter term" : [
+                80
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~loopback PING" : {
+              "firewall filter term" : [
+                77
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust BGP" : {
+              "firewall filter term" : [
+                67
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust PING" : {
+              "firewall filter term" : [
+                64
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust SSH" : {
+              "firewall filter term" : [
+                65
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust TELNET" : {
+              "firewall filter term" : [
+                66
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust BGP" : {
+              "firewall filter term" : [
+                74
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust IKE" : {
+              "firewall filter term" : [
+                73
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust PING" : {
+              "firewall filter term" : [
+                71
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust SSH" : {
+              "firewall filter term" : [
+                72
+              ]
+            }
+          },
           "ike gateway" : {
             "gateway-1" : {
               "ipsec vpn ike gateway" : [
@@ -7124,6 +7376,63 @@
             "10.23.0.2 (VRF default)" : {
               "bgp neighbor self ref" : [
                 87
+              ]
+            }
+          },
+          "firewall filter term" : {
+            "~INBOUND_ZONE_FILTER~hostos PING" : {
+              "firewall filter term" : [
+                73
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~hostos SSH" : {
+              "firewall filter term" : [
+                74
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~loopback PING" : {
+              "firewall filter term" : [
+                71
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust BGP" : {
+              "firewall filter term" : [
+                61
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust PING" : {
+              "firewall filter term" : [
+                58
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust SSH" : {
+              "firewall filter term" : [
+                59
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~trust TELNET" : {
+              "firewall filter term" : [
+                60
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust BGP" : {
+              "firewall filter term" : [
+                68
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust IKE" : {
+              "firewall filter term" : [
+                67
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust PING" : {
+              "firewall filter term" : [
+                65
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~untrust SSH" : {
+              "firewall filter term" : [
+                66
               ]
             }
           },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -74551,6 +74551,16 @@
               "numReferrers" : 0
             }
           },
+          "firewall filter term" : {
+            "~INBOUND_ZONE_FILTER~ZONE-protocols ALL" : {
+              "definitionLines" : "24",
+              "numReferrers" : 1
+            },
+            "~INBOUND_ZONE_FILTER~ZONE-system-services ALL" : {
+              "definitionLines" : "25",
+              "numReferrers" : 1
+            }
+          },
           "ike policy" : {
             "1.2.3.4" : {
               "definitionLines" : "14",
@@ -81729,6 +81739,18 @@
             "notglobalAttached" : {
               "address-book attach zone" : [
                 10
+              ]
+            }
+          },
+          "firewall filter term" : {
+            "~INBOUND_ZONE_FILTER~ZONE-protocols ALL" : {
+              "firewall filter term" : [
+                24
+              ]
+            },
+            "~INBOUND_ZONE_FILTER~ZONE-system-services ALL" : {
+              "firewall filter term" : [
+                25
               ]
             }
           },


### PR DESCRIPTION
In Juniper VS -> VI conversion, `VendorStructureIds` are created for each firewall filter term.

This PR just adds definitions for firewall filter terms for zone inbound filters, so the VSIDs no longer point to non-existent structure definitions.
