### PR TITLE
Tests: enable assertion to catch invalid VSIDs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -491,9 +491,8 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     verifyVrrpGroups(c, w);
     removeInvalidStaticRoutes(c, w);
     removeUndefinedTrackReferences(c, w);
-    // TODO run this assertion once remaining VI-conversions are fixed
     // Make tests fail if they have invalid VSIDs
-    // assertVendorStructureIdsValid(c, vc, w);
+    assertVendorStructureIdsValid(c, vc, w);
     removeInvalidVendorStructureIds(c, vc, w);
 
     c.setAsPathAccessLists(


### PR DESCRIPTION
Should help us catch new, invalid `VendorStructureId`s in tests.