### PR TITLE
OWASP: upgrade and suppress false positive

### DIFF
--- a/projects/build-tools/src/main/resources/org/batfish/owasp/suppressions.xml
+++ b/projects/build-tools/src/main/resources/org/batfish/owasp/suppressions.xml
@@ -4,4 +4,8 @@
     <notes>This is a SUSE packaging bug, nothing to do with jar.</notes>
     <cve>CVE-2020-8022</cve>
   </suppress>
+  <suppress>
+    <notes>This is an extremely low quality CVE relating to Python flask, usually in example code or project websites. See: https://github.com/jeremylong/DependencyCheck/issues/4671</notes>
+    <cve>CVE-2022-31569</cve>
+  </suppress>
 </suppressions>

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -27,7 +27,7 @@
 
         <!-- The versions of Apache Maven plugins used. Please keep alphabetical.-->
         <antlr4-maven-plugin.version>4.7.2</antlr4-maven-plugin.version>
-        <dependency-check-plugin.version>6.2.0</dependency-check-plugin.version>
+        <dependency-check-plugin.version>7.1.1</dependency-check-plugin.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>


### PR DESCRIPTION
1. upgrade OWASP to latest. Noticed when I ran manually, seems to improve
   reliability if downloads fail.
2. Suppress this false-positive CVE-2022-31569. Tl;dr: the CVE is in Flask (python),
   and this is a Java project. The author of the CVE appears to have filed CVEs for
   all artifacts produced by any organization that used Flask improperly in their
   GitHub repo, regardless of what it actually affects.

commit-id:51c92d56