### PR TITLE
WorkMgrTestUtils: simplify zip creation

### DIFF
--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -1125,7 +1125,8 @@ public final class WorkMgrTest {
 
   private byte[] createSnapshotZip(String snapshot, String fileName, String fileContents)
       throws IOException {
-    Path zipPath = WorkMgrTestUtils.createSnapshotZip(snapshot, fileName, fileContents, _folder);
+    Path zipPath =
+        WorkMgrTestUtils.createSingleFileSnapshotZip(snapshot, fileName, fileContents, _folder);
     return FileUtils.readFileToByteArray(zipPath.toFile());
   }
 


### PR DESCRIPTION
For a single-file snapshot, we don't need all that machinery to handle
folders, etc., we can just directly write a single file zip.

commit-id:f4c0125e

---

**Stack**:
- #8435
- #8434 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*