### PR TITLE
ZipUtility: rewrite using newer APIs

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -799,6 +799,17 @@ public class Client extends AbstractClient implements IClient {
     this(new Settings(args));
   }
 
+  /** Zip {@code srcFolder} and write to {@code destZipFile} */
+  private static void zipFiles(Path srcFolder, Path destZipFile) {
+    try (OutputStream fos = Files.newOutputStream(destZipFile)) {
+      ZipUtility.zipToStream(srcFolder, fos);
+    } catch (Exception e) {
+      // Catch Throwable in case of things like AccessError
+      throw new BatfishException(
+          "Could not zip folder: '" + srcFolder + "' into: '" + destZipFile + "'", e);
+    }
+  }
+
   private boolean addBatfishOption(String[] words, List<String> options, List<String> parameters) {
     if (!isValidArgument(
         options, parameters, 0, 1, Integer.MAX_VALUE, Command.ADD_BATFISH_OPTION)) {
@@ -2225,7 +2236,7 @@ public class Client extends AbstractClient implements IClient {
     boolean createZip = Files.isDirectory(initialUploadTarget);
     if (createZip) {
       uploadTarget = CommonUtil.createTempFile("testrig", "zip");
-      ZipUtility.zipFiles(initialUploadTarget.toAbsolutePath(), uploadTarget.toAbsolutePath());
+      zipFiles(initialUploadTarget.toAbsolutePath(), uploadTarget.toAbsolutePath());
     }
     try {
       boolean result =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/ZipUtility.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/ZipUtility.java
@@ -1,137 +1,64 @@
 package org.batfish.common.util;
 
-import com.google.common.io.Closer;
-import com.google.errorprone.annotations.MustBeClosed;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Stack;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import javax.annotation.Nonnull;
-import org.batfish.common.BatfishException;
+import org.apache.commons.lang3.StringUtils;
 
-// code from
-// http://stackoverflow.com/questions/740375/directories-in-a-zip-file-when-using-java-util-zip-zipoutputstream
-// minor local changes -- search for ratul
+public final class ZipUtility {
 
-public class ZipUtility {
-  /*
-   * recursively add files to the zip files
-   */
-  private static void addFileToZip(String path, String srcFile, ZipOutputStream zip, boolean flag)
-      throws Exception {
-    /*
-     * create the file object for inputs
-     */
-    File folder = new File(srcFile);
+  /** Appends a zip of the given folder to the input {@link OutputStream}. */
+  public static void zipToStream(Path srcFolder, OutputStream outputStream) throws IOException {
+    ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream);
+    try {
+      Files.walkFileTree(
+          srcFolder,
+          new FileVisitor<Path>() {
+            /** A list of parent directory names. */
+            private final Stack<String> _path = new Stack<>();
 
-    /*
-     * if the folder is empty add empty folder to the Zip file
-     */
-    if (flag) {
-      zip.putNextEntry(new ZipEntry(path + "/" + folder.getName() + "/"));
-    } else {
-      /*
-       * if the current name is directory, recursively traverse it to get
-       * the files
-       */
-      if (folder.isDirectory()) {
-        /*
-         * if folder is not empty
-         */
-        addFolderToZip(path, srcFile, zip);
-      } else {
-        /*
-         * write the file to the output
-         */
-        byte[] buf = new byte[1024];
-        int len;
-        try (FileInputStream in = new FileInputStream(srcFile)) {
-          zip.putNextEntry(new ZipEntry(path + "/" + folder.getName()));
-          while ((len = in.read(buf)) > 0) {
-            /*
-             * Write the Result
-             */
-            zip.write(buf, 0, len);
-          }
-        }
-      }
+            /** Memoized _path joined with "/"; does not contain a trailing '/'. */
+            private String _pathStr = "";
+
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                throws IOException {
+              _path.push(dir.getFileName().toString());
+              _pathStr = StringUtils.join(_path, "/");
+              zipOutputStream.putNextEntry(new ZipEntry(_pathStr + '/'));
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                throws IOException {
+              zipOutputStream.putNextEntry(new ZipEntry(_pathStr + '/' + file.getFileName()));
+              Files.copy(file, zipOutputStream);
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+              throw new IOException(
+                  "Failed to access " + srcFolder.relativize(file) + " for zipping");
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+              _path.pop();
+              _pathStr = StringUtils.join(_path, "/");
+              return FileVisitResult.CONTINUE;
+            }
+          });
+    } finally {
+      zipOutputStream.finish();
     }
-  }
-
-  /*
-   * add folder to the zip file
-   */
-  private static void addFolderToZip(String path, String srcFolder, ZipOutputStream zip)
-      throws Exception {
-    File folder = new File(srcFolder);
-
-    /*
-     * check the empty folder
-     */
-
-    // ratul comments the lines below
-    // if (folder.list().length == 0) {
-    // System.out.println(folder.getName());
-    addFileToZip(path, srcFolder, zip, true);
-    // } else {
-    /*
-     * list the files in the folder
-     */
-    for (String fileName : folder.list()) {
-      if (path.equals("")) {
-        addFileToZip(folder.getName(), srcFolder + "/" + fileName, zip, false);
-      } else {
-        addFileToZip(path + "/" + folder.getName(), srcFolder + "/" + fileName, zip, false);
-      }
-    }
-    // }
-  }
-
-  /** Zip {@code srcFolder} and write to {@code destZipFile} */
-  @SuppressWarnings("PMD.CloseResource") // PMD does not understand Closer
-  public static void zipFiles(Path srcFolder, Path destZipFile) {
-    try (Closer closer = Closer.create()) {
-      OutputStream fos = closer.register(Files.newOutputStream(destZipFile));
-      zipFolder(srcFolder.toString(), fos, closer);
-    } catch (Exception e) {
-      throw new BatfishException(
-          "Could not zip folder: '" + srcFolder + "' into: '" + destZipFile + "'", e);
-    }
-  }
-
-  /** Zip {@code srcFolder} in memory and return input stream from which zip may be read. */
-  @MustBeClosed
-  public static @Nonnull InputStream zipFilesToInputStream(Path srcFolder) {
-    ByteArrayOutputStream baos;
-    try (Closer closer = Closer.create()) {
-      baos = closer.register(new ByteArrayOutputStream());
-      zipFolder(srcFolder.toString(), baos, closer);
-    } catch (Exception e) {
-      throw new BatfishException("Could not zip folder: '" + srcFolder + "'", e);
-    }
-    return new ByteArrayInputStream(baos.toByteArray());
-  }
-
-  /*
-   * zip the folders
-   */
-  @SuppressWarnings("PMD.CloseResource") // PMD does not understand Closer
-  private static void zipFolder(String srcFolder, OutputStream outputStream, Closer closer)
-      throws Exception {
-    ZipOutputStream zip = null;
-    /*
-     * create the output stream to zip file result
-     */
-    zip = closer.register(new ZipOutputStream(outputStream));
-    /*
-     * add the folder to the zip
-     */
-    addFolderToZip("", srcFolder, zip);
   }
 }


### PR DESCRIPTION
The old ZipUtility used ancient code from StackOverflow.

Rewrite it using the nice clean FileVisitor API.

commit-id:6727282e