### PR TITLE
WorkMgr: validate the set of requested columns and provide a good err…

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1751,6 +1751,15 @@ public class WorkMgr extends AbstractCoordinator {
     Map<Row, Integer> rowIds = Maps.newIdentityHashMap();
     CommonUtil.forEachWithIndex(rawTable.getRowsList(), (i, row) -> rowIds.put(row, i));
     Map<String, ColumnMetadata> rawColumnMap = rawTable.getMetadata().toColumnMap();
+
+    for (String c : options.getColumns()) {
+      if (!rawColumnMap.containsKey(c)) {
+        Collection<String> sortedColumnNames = new TreeSet<>(rawColumnMap.keySet());
+        throw new IllegalArgumentException(
+            String.format("Column %s is not in the answer: %s", c, sortedColumnNames));
+      }
+    }
+
     List<Row> filteredRows =
         rawTable.getRowsList().stream()
             .filter(row -> options.getFilters().stream().allMatch(filter -> filter.matches(row)))

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -1994,6 +1994,29 @@ public final class WorkMgrTest {
   }
 
   @Test
+  public void testProcessAnswerTable2ProjectWrongColumn() {
+    TableMetadata metadata =
+        new TableMetadata(
+            ImmutableList.of(
+                // Also tests that the columns are sorted in error message.
+                new ColumnMetadata("zcol", Schema.INTEGER, "first column but lex last"),
+                new ColumnMetadata("col", Schema.INTEGER, "last column but lex first")));
+    TableAnswerElement table = new TableAnswerElement(metadata);
+    AnswerRowsOptions optionsProject =
+        new AnswerRowsOptions(
+            ImmutableSet.of("missing"),
+            ImmutableList.of(),
+            Integer.MAX_VALUE,
+            0,
+            ImmutableList.of(),
+            false);
+
+    _thrown.expectMessage("Column missing is not in the answer: [col, zcol]");
+    _thrown.expect(IllegalArgumentException.class);
+    _manager.processAnswerTable2(table, optionsProject);
+  }
+
+  @Test
   public void testProcessAnswerTableUniqueRows() {
     String columnName = "val";
     TableAnswerElement table =


### PR DESCRIPTION
…or message

Example:

    java.lang.IllegalArgumentException: Column Path_ID is not in the answer: [AS_Path, Cluster_List, Communities, Local_Pref, Metric, Network, Next_Hop, Next_Hop_IP, Next_Hop_Interface, Node, Origin_Protocol, Origin_Type, Originator_Id, Protocol, Received_From_IP, Received_Path_Id, Status, Tag, Tunnel_Encapsulation_Attribute, VRF, Weight]

commit-id:e4c13d83