### PR TITLE
JunOS: add app junos-rdp, remove invalid test for app junos-host

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -4437,6 +4437,7 @@ M_Application_JUNOS_PRINTER: 'junos-printer' -> type(JUNOS_PRINTER), popMode;
 M_Application_JUNOS_R2CP: 'junos-r2cp' -> type(JUNOS_R2CP), popMode;
 M_Application_JUNOS_RADACCT: 'junos-radacct' -> type(JUNOS_RADACCT), popMode;
 M_Application_JUNOS_RADIUS: 'junos-radius' -> type(JUNOS_RADIUS), popMode;
+M_Application_JUNOS_RDP: 'junos-rdp' -> type(JUNOS_RDP), popMode;
 M_Application_JUNOS_REALAUDIO: 'junos-realaudio' -> type(JUNOS_REALAUDIO), popMode;
 M_Application_JUNOS_RIP: 'junos-rip' -> type(JUNOS_RIP), popMode;
 M_Application_JUNOS_RSH: 'junos-rsh' -> type(JUNOS_RSH), popMode;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5599,7 +5599,11 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testPredefinedJunosApplicationsConverted() throws IOException {
     // conversion failure will cause an exception
-    parseConfig("pre-defined-junos-applications-converted");
+    String hostname = "pre-defined-junos-applications-converted";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    assertThat(ccae.getUndefinedReferences().get("configs/" + hostname), anEmptyMap());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/pre-defined-junos-applications-converted
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/pre-defined-junos-applications-converted
@@ -28,7 +28,6 @@ set security policies global policy policy-name match application junos-gprs-sct
 set security policies global policy policy-name match application junos-gre
 set security policies global policy policy-name match application junos-gtp
 set security policies global policy policy-name match application junos-h323
-set security policies global policy policy-name match application junos-host
 set security policies global policy policy-name match application junos-http
 set security policies global policy policy-name match application junos-http-ext
 set security policies global policy policy-name match application junos-https


### PR DESCRIPTION
Without junos-rdp in the list, it was lexing as NAME and resulting
in an undefined reference.

This fix also caught the improper use of junos-host, which is not
an application but rather a zone.

commit-id:e99ff3ec