### PR TITLE
PAN: fix rulebase `VendorStructureId`s

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1663,7 +1663,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
         .setName(rule.getName())
         .setAction(rule.getAction())
         .setMatchCondition(new AndMatchExpr(conjuncts))
-        .setTraceElement(matchSecurityRuleTraceElement(rule.getName(), namespaceVsys))
+        .setTraceElement(matchSecurityRuleTraceElement(rule.getName(), ruleVsys))
         .setVendorStructureId(
             securityRuleVendorStructureId(rule.getName(), ruleVsys.getName(), _filename))
         .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -978,8 +978,9 @@ public class PaloAltoConfiguration extends VendorConfiguration {
    *
    * <p>Note: two VSYSes must be specified: one where the rule exists and one for the VSYS/namespace
    * containing objects the rule relies on. These VSYSes are usually the same, but are different for
-   * rules that exist in a Shared VSYS. A rule in a Shared VSYS prefers objects in the Panorama
-   * namespace over objects in its own (the Shared) namespace.
+   * rules that exist in the Shared VSYS. A rule in the Shared VSYS effectively uses the Panorama
+   * namespace; it looks for objects in the Panorama namespace first and falls back to the Shared
+   * namespace just like a Panorama rule would.
    */
   private void addSecurityRulesToMap(
       Rulebase rulebase,

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -915,11 +915,25 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     // Note: using map to avoid duplicating rulenames (not allowed on PAN devices)
     Map<String, ExprAclLine> ruleToExprAclLine = new LinkedHashMap<>();
     Vsys panorama = getPanorama();
+    Vsys shared = getShared();
 
-    // PreRulebase solely comes from Panorama, if it exists
+    // PreRulebase comes from Panorama and shared vsyses, if they exist
+    // Shared pre-rulebase is applied first
+    if (shared != null) {
+      addSecurityRulesToMap(
+          shared.getPreRulebase(),
+          shared,
+          panorama, // Shared rules can use Panorama-namepsace objects (and fallback to
+          // Shared-namespace)
+          fromZone,
+          toZone,
+          appOverrideAcls,
+          ruleToExprAclLine);
+    }
     if (panorama != null) {
       addSecurityRulesToMap(
           panorama.getPreRulebase(),
+          panorama,
           panorama,
           fromZone,
           toZone,
@@ -929,13 +943,26 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
     // Regular Rulebase comes solely from this vsys
     addSecurityRulesToMap(
-        vsys.getRulebase(), vsys, fromZone, toZone, appOverrideAcls, ruleToExprAclLine);
+        vsys.getRulebase(), vsys, vsys, fromZone, toZone, appOverrideAcls, ruleToExprAclLine);
 
-    // PostRulebase solely comes from Panorama, if it exists
+    // PostRulebase comes from Panorama and shared vsyses, if they exist
+    // Panorama post-rulebase is applied first
     if (panorama != null) {
       addSecurityRulesToMap(
           panorama.getPostRulebase(),
           panorama,
+          panorama,
+          fromZone,
+          toZone,
+          appOverrideAcls,
+          ruleToExprAclLine);
+    }
+    if (shared != null) {
+      addSecurityRulesToMap(
+          shared.getPostRulebase(),
+          shared,
+          panorama, // Shared rules can use Panorama-namepsace objects (and fallback to
+          // Shared-namespace)
           fromZone,
           toZone,
           appOverrideAcls,
@@ -948,10 +975,16 @@ public class PaloAltoConfiguration extends VendorConfiguration {
   /**
    * Helper to build ExprAclLines from SecurityRules between zones in the specified Rulebase. Adds
    * these to the specified map.
+   *
+   * <p>Note: two VSYSes must be specified: one where the rule exists and one for the VSYS/namespace
+   * containing objects the rule relies on. These VSYSes are usually the same, but are different for
+   * rules that exist in a Shared VSYS. A rule in a Shared VSYS prefers objects in the Panorama
+   * namespace over objects in its own (the Shared) namespace.
    */
   private void addSecurityRulesToMap(
       Rulebase rulebase,
-      Vsys vsys,
+      Vsys ruleVsys,
+      Vsys namespaceVsys,
       String fromZone,
       String toZone,
       Map<String, AclLineMatchExpr> appOverrideAcls,
@@ -960,7 +993,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       String name = entry.getKey();
       SecurityRule rule = entry.getValue();
       if (securityRuleApplies(fromZone, toZone, rule, _w) && !ruleToExprAclLine.containsKey(name)) {
-        ruleToExprAclLine.put(name, toIpAccessListLine(rule, vsys, appOverrideAcls));
+        ruleToExprAclLine.put(
+            name, toIpAccessListLine(rule, ruleVsys, namespaceVsys, appOverrideAcls));
       }
     }
   }
@@ -1582,7 +1616,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
   //   However, services are a bit complicated when `service application-default` is used. In that
   //   case, we extract service definitions from the application that matches.
   private ExprAclLine toIpAccessListLine(
-      SecurityRule rule, Vsys vsys, Map<String, AclLineMatchExpr> appOverrideAcls) {
+      SecurityRule rule,
+      Vsys ruleVsys,
+      Vsys namespaceVsys,
+      Map<String, AclLineMatchExpr> appOverrideAcls) {
     assert !rule.getDisabled(); // handled by caller.
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -1592,7 +1629,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     //////////////////////////////////////////////////////////////////////////////////////////
     // 2. Match SRC IPs if specified.
     List<MatchHeaderSpace> srcExprs =
-        aclLineMatchExprsFromRuleEndpointSources(rule.getSource(), vsys, _w, _filename);
+        aclLineMatchExprsFromRuleEndpointSources(rule.getSource(), namespaceVsys, _w, _filename);
     if (!srcExprs.isEmpty()) {
       conjuncts.add(
           rule.getNegateSource()
@@ -1605,7 +1642,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     //////////////////////////////////////////////////////////////////////////////////////////
     // 3. Match DST IPs if specified.
     List<MatchHeaderSpace> dstExprs =
-        aclLineMatchExprsFromRuleEndpointDestinations(rule.getDestination(), vsys, _w, _filename);
+        aclLineMatchExprsFromRuleEndpointDestinations(
+            rule.getDestination(), namespaceVsys, _w, _filename);
     if (!dstExprs.isEmpty()) {
       conjuncts.add(
           rule.getNegateDestination()
@@ -1618,15 +1656,15 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // 4. Match services.
-    getServiceExpr(rule, vsys, appOverrideAcls).ifPresent(conjuncts::add);
+    getServiceExpr(rule, namespaceVsys, appOverrideAcls).ifPresent(conjuncts::add);
 
     return ExprAclLine.builder()
         .setName(rule.getName())
         .setAction(rule.getAction())
         .setMatchCondition(new AndMatchExpr(conjuncts))
-        .setTraceElement(matchSecurityRuleTraceElement(rule.getName(), vsys))
+        .setTraceElement(matchSecurityRuleTraceElement(rule.getName(), namespaceVsys))
         .setVendorStructureId(
-            securityRuleVendorStructureId(rule.getName(), vsys.getName(), _filename))
+            securityRuleVendorStructureId(rule.getName(), ruleVsys.getName(), _filename))
         .build();
   }
 
@@ -3008,10 +3046,9 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     _panorama = new Vsys(PANORAMA_VSYS_NAME, NamespaceType.PANORAMA);
     _shared = new Vsys(SHARED_VSYS_NAME, NamespaceType.SHARED);
 
-    // Keep shared objects in their own namespace
+    // Keep shared objects and rules in their own namespace
     applyVsysObjects(shared, _shared);
-    // Merge shared rules into Panorama rules, to keep conversion simpler
-    applyVsysRulebase(shared, _panorama);
+    applyVsysRulebase(shared, _shared);
 
     List<DeviceGroup> inheritedDeviceGroups = new ArrayList<>();
     inheritedDeviceGroups.add(template);

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
@@ -24,7 +24,8 @@ public final class PaloAltoTraceElementCreators {
         .build();
   }
 
-  static VendorStructureId securityRuleVendorStructureId(
+  @VisibleForTesting
+  public static VendorStructureId securityRuleVendorStructureId(
       String ruleName, String vsysName, String filename) {
     return new VendorStructureId(
         filename,

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3807,6 +3807,9 @@ public final class PaloAltoGrammarTest {
     assertThat(
         sharedLine.getVendorStructureId().get(),
         equalTo(securityRuleVendorStructureId(sharedRuleName, SHARED_VSYS_NAME, filename)));
+    assertThat(
+        sharedLine.getTraceElement(),
+        equalTo(matchSecurityRuleTraceElement(sharedRuleName, SHARED_VSYS_NAME, filename)));
 
     // Security rule from Panorama vsys has the correct VSID (pointing to Panorama vsys)
     AclLine panoramaLine = z1ToZ2Filter.getLines().get(1);
@@ -3814,6 +3817,9 @@ public final class PaloAltoGrammarTest {
     assertThat(
         panoramaLine.getVendorStructureId().get(),
         equalTo(securityRuleVendorStructureId(panoramaRuleName, PANORAMA_VSYS_NAME, filename)));
+    assertThat(
+        panoramaLine.getTraceElement(),
+        equalTo(matchSecurityRuleTraceElement(panoramaRuleName, PANORAMA_VSYS_NAME, filename)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -105,6 +105,7 @@ import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceApplicationDefaultTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSourceAddressTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.originatedFromDeviceTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.securityRuleVendorStructureId;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.unzonedIfaceRejectTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneMatchTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneRejectTraceElement;
@@ -3772,6 +3773,47 @@ public final class PaloAltoGrammarTest {
     assertThat(ccae, hasNumReferrers(filename, TEMPLATE, "T1", 1));
     assertThat(ccae, hasNumReferrers(filename, TEMPLATE, "T2", 1));
     assertThat(ccae, hasNumReferrers(filename, TEMPLATE, "T3", 1));
+  }
+
+  @Test
+  public void testDeviceGroupSharedInheritanceVSIDs() {
+    String panoramaHostname = "device-group-shared-inheritance";
+    String filename = TESTCONFIGS_PREFIX + panoramaHostname;
+    String firewallId1 = "00000001";
+    PaloAltoConfiguration panConfig = parsePaloAltoConfig(panoramaHostname);
+    List<Configuration> viConfigs = panConfig.toVendorIndependentConfigurations();
+    // Should get two nodes from the one Panorama config
+    assertThat(
+        viConfigs.stream().map(Configuration::getHostname).collect(Collectors.toList()),
+        containsInAnyOrder(panoramaHostname, firewallId1));
+    Configuration c =
+        viConfigs.stream().filter(vi -> vi.getHostname().equals(firewallId1)).findFirst().get();
+
+    String sharedRuleName = "PRE_RULE_SHARED";
+    String panoramaRuleName = "PRE_RULE_DG";
+    String vsysName = "vsys1";
+    String zone1Name = "Z1";
+    String zone2Name = "Z2";
+    IpAccessList z1ToZ2Filter =
+        c.getIpAccessLists()
+            .get(
+                zoneToZoneFilter(
+                    computeObjectName(vsysName, zone1Name),
+                    computeObjectName(vsysName, zone2Name)));
+
+    // Security rule from Shared vsys has the correct VSID (pointing to Shared vsys)
+    AclLine sharedLine = z1ToZ2Filter.getLines().get(0);
+    assertThat(sharedLine.getName(), equalTo(sharedRuleName));
+    assertThat(
+        sharedLine.getVendorStructureId().get(),
+        equalTo(securityRuleVendorStructureId(sharedRuleName, SHARED_VSYS_NAME, filename)));
+
+    // Security rule from Panorama vsys has the correct VSID (pointing to Panorama vsys)
+    AclLine panoramaLine = z1ToZ2Filter.getLines().get(1);
+    assertThat(panoramaLine.getName(), equalTo(panoramaRuleName));
+    assertThat(
+        panoramaLine.getVendorStructureId().get(),
+        equalTo(securityRuleVendorStructureId(panoramaRuleName, PANORAMA_VSYS_NAME, filename)));
   }
 
   @Test


### PR DESCRIPTION
Before this PR, `shared` rules were shoved into the `panorama` vsys. After this PR, they're kept in the `shared` vsys, which also fixes some broken VSIDs.
