### PR TITLE
PAN: fix `application-override rule` TraceElements/VendorStructureIDs

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -4371,6 +4371,7 @@ public final class PaloAltoGrammarTest {
     Configuration firewall1 =
         viConfigs.stream().filter(vi -> vi.getHostname().equals(firewallId1)).findFirst().get();
 
+    // Arbitrarily choose one zone pair to test (rule should be applied to all zone pairs)
     IpAccessList z1ToZ2Filter =
         firewall1
             .getIpAccessLists()

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -4352,6 +4352,85 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testApplicationOverrideRuleDiffVsysVSIDs() {
+    String panoramaHostname = "application-override-diff-vsys-vsids";
+    String filename = TESTCONFIGS_PREFIX + panoramaHostname;
+    PaloAltoConfiguration panConfig = parsePaloAltoConfig(panoramaHostname);
+    List<Configuration> viConfigs = panConfig.toVendorIndependentConfigurations();
+
+    String firewallId1 = "00000001";
+    String vsysName = "vsys1";
+    String zone1Name = "z1";
+    String zone2Name = "z2";
+    String if1name = "ethernet1/1";
+
+    // Should get two nodes from the one Panorama config
+    assertThat(
+        viConfigs.stream().map(Configuration::getHostname).collect(Collectors.toList()),
+        containsInAnyOrder(panoramaHostname, firewallId1));
+    Configuration firewall1 =
+        viConfigs.stream().filter(vi -> vi.getHostname().equals(firewallId1)).findFirst().get();
+
+    IpAccessList z1ToZ2Filter =
+        firewall1
+            .getIpAccessLists()
+            .get(
+                zoneToZoneFilter(
+                    computeObjectName(vsysName, zone1Name),
+                    computeObjectName(vsysName, zone2Name)));
+
+    // Matches RULE1
+    Flow flowRULE1 =
+        Flow.builder()
+            .setIngressNode(firewall1.getHostname())
+            // Arbitrary source port
+            .setSrcPort(12345)
+            .setDstPort(22)
+            .setIpProtocol(IpProtocol.TCP)
+            .setIngressInterface(if1name)
+            .setSrcIp(Ip.parse("10.0.1.2"))
+            .setDstIp(Ip.parse("10.0.2.2"))
+            .build();
+    List<TraceTree> flowTraceRULE1 =
+        AclTracer.trace(
+            z1ToZ2Filter,
+            flowRULE1,
+            if1name,
+            firewall1.getIpAccessLists(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+
+    // App-override VSID should point to the correct vsys
+    // Even though it is in a different vsys (Panorama) than the interfaces/zones (vsys1)
+    assertThat(
+        flowTraceRULE1,
+        contains(
+            isTraceTree(
+                matchSecurityRuleTraceElement("RULE1", PANORAMA_VSYS_NAME, filename),
+                isTraceTree(
+                    matchSourceAddressTraceElement(), isTraceTree(matchAddressAnyTraceElement())),
+                isTraceTree(
+                    matchDestinationAddressTraceElement(),
+                    isTraceTree(matchAddressAnyTraceElement())),
+                isTraceTree(
+                    matchServiceApplicationDefaultTraceElement(),
+                    isTraceTree(
+                        matchApplicationObjectTraceElement(
+                            "OVERRIDE_SSH", SHARED_VSYS_NAME, filename),
+                        isTraceTree(
+                            matchApplicationOverrideRuleTraceElement(
+                                "OVERRIDE_APP_RULE1", PANORAMA_VSYS_NAME, filename),
+                            isTraceTree(
+                                matchSourceAddressTraceElement(),
+                                isTraceTree(matchAddressAnyTraceElement())),
+                            isTraceTree(
+                                matchDestinationAddressTraceElement(),
+                                isTraceTree(matchAddressAnyTraceElement())),
+                            TraceTreeMatchers.hasTraceElement("Matched protocol TCP"),
+                            TraceTreeMatchers.hasTraceElement("Matched port")))))));
+  }
+
+  @Test
   public void testApplicationOverrideRuleTraceElements() {
     String hostname = "application-override-tracing";
     String filename = "configs/" + hostname;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/application-override-diff-vsys-vsids
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/application-override-diff-vsys-vsids
@@ -1,0 +1,42 @@
+set deviceconfig system hostname application-override-diff-vsys-vsids
+#
+#
+# Panorama configuration
+#
+# Some definition must exist for app-override
+set shared application OVERRIDE_SSH default port tcp/22
+#
+#
+# Managed-device configuration
+#
+set device-group DG1 devices 00000001
+set device-group DG1 application-group app_group2 members [ app_group1 dns ]
+#
+# Network configuration required to make device 00000001 allow traffic through
+set template T1 config devices localhost.localdomain vsys vsys1 zone z1 network layer3 ethernet1/1
+set template T1 config devices localhost.localdomain vsys vsys1 zone z2 network layer3 ethernet1/2
+set template T1 config devices localhost.localdomain vsys vsys1 import network interface [ ethernet1/1 ethernet1/2 ]
+set template T1 config devices localhost.localdomain network interface ethernet ethernet1/1 layer3 ip 10.0.1.1/24
+set template T1 config devices localhost.localdomain network interface ethernet ethernet1/2 layer3 ip 10.0.2.1/24
+set template T1 config devices localhost.localdomain network virtual-router default interface [ ethernet1/1 ethernet1/2 ]
+set template-stack TS1 templates T1
+set template-stack TS1 devices 00000001
+#
+set device-group DG1 pre-rulebase application-override rules OVERRIDE_APP_RULE1 from any
+set device-group DG1 pre-rulebase application-override rules OVERRIDE_APP_RULE1 to any
+set device-group DG1 pre-rulebase application-override rules OVERRIDE_APP_RULE1 source any
+set device-group DG1 pre-rulebase application-override rules OVERRIDE_APP_RULE1 destination any
+set device-group DG1 pre-rulebase application-override rules OVERRIDE_APP_RULE1 port 22
+set device-group DG1 pre-rulebase application-override rules OVERRIDE_APP_RULE1 protocol tcp
+set device-group DG1 pre-rulebase application-override rules OVERRIDE_APP_RULE1 application OVERRIDE_SSH
+#
+# Allow app-override (tcp/22)
+set device-group DG1 pre-rulebase security rules RULE1 from any
+set device-group DG1 pre-rulebase security rules RULE1 to any
+set device-group DG1 pre-rulebase security rules RULE1 source any
+set device-group DG1 pre-rulebase security rules RULE1 source-user any
+set device-group DG1 pre-rulebase security rules RULE1 destination any
+set device-group DG1 pre-rulebase security rules RULE1 service application-default
+set device-group DG1 pre-rulebase security rules RULE1 application OVERRIDE_SSH
+set device-group DG1 pre-rulebase security rules RULE1 action allow
+#


### PR DESCRIPTION
Before this PR, `application-override rule` VSIDs used the vsys for the current zone-pair/flattened security rule.

This isn't correct for `application-override rule`s defined in the Panorama vsys; this PR fixes this and fixes broken TraceElements/VSIDs for these rules.
