### PR TITLE
Cisco-ASA: Support for Twice NAT

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -18,6 +18,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
   public static class Builder {
     private int _dscp;
     private Ip _dstIp;
+    private Ip _dstOrgIp;
     @Nullable private Integer _dstPort;
     private int _ecn;
     private int _fragmentOffset;
@@ -43,6 +44,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
     private Builder() {
       _dscp = 0;
       _dstIp = Ip.ZERO;
+      _dstOrgIp = Ip.ZERO;
       _ecn = 0;
       _fragmentOffset = 0;
       _ipProtocol = null;
@@ -58,6 +60,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
       _ingressVrf = flow._ingressVrf;
       _srcIp = flow._srcIp;
       _dstIp = flow._dstIp;
+      _dstOrgIp = flow._dstOrgIp;
       _srcPort = flow._srcPort;
       _dstPort = flow._dstPort;
       _ipProtocol = flow._ipProtocol;
@@ -114,6 +117,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
           _ingressVrf,
           _srcIp,
           _dstIp,
+          _dstOrgIp,
           srcPort,
           dstPort,
           firstNonNull(_ipProtocol, IpProtocol.fromNumber(0)),
@@ -194,6 +198,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
     }
 
     public Builder setDstIp(Ip dstIp) {
+      _dstOrgIp = _dstIp;
       _dstIp = dstIp;
       return this;
     }
@@ -325,6 +330,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
 
   private static final String PROP_DSCP = "dscp";
   static final String PROP_DST_IP = "dstIp";
+  static final String PROP_DST_ORG_IP = "dstOrgIp";
   static final String PROP_DST_PORT = "dstPort";
   private static final String PROP_ECN = "ecn";
   private static final String PROP_FRAGMENT_OFFSET = "fragmentOffset";
@@ -354,6 +360,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
 
   private final int _dscp;
   private final @Nonnull Ip _dstIp;
+  private final @Nonnull Ip _dstOrgIp;
   private final @Nullable Integer _dstPort;
   private final int _ecn;
   private final int _fragmentOffset;
@@ -374,6 +381,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
       @Nullable String ingressVrf,
       @Nonnull Ip srcIp,
       @Nonnull Ip dstIp,
+      @Nonnull Ip dstOrgIp,
       @Nullable Integer srcPort,
       @Nullable Integer dstPort,
       @Nonnull IpProtocol ipProtocol,
@@ -397,6 +405,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
     _dstIp = dstIp;
     _srcPort = srcPort;
     _dstPort = dstPort;
+    _dstOrgIp = dstOrgIp;
     _ipProtocol = ipProtocol;
     _dscp = dscp;
     _ecn = ecn;
@@ -425,6 +434,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
       @JsonProperty(PROP_INGRESS_VRF) String ingressVrf,
       @JsonProperty(PROP_SRC_IP) Ip srcIp,
       @JsonProperty(PROP_DST_IP) Ip dstIp,
+      @JsonProperty(PROP_DST_ORG_IP) Ip dstOrgIp,
       @JsonProperty(PROP_SRC_PORT) @Nullable Integer srcPort,
       @JsonProperty(PROP_DST_PORT) @Nullable Integer dstPort,
       @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
@@ -464,6 +474,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
         ingressVrf,
         requireNonNull(srcIp, PROP_SRC_IP + " must not be null"),
         requireNonNull(dstIp, PROP_DST_IP + " must not be null"),
+        null,
         srcPort,
         dstPort,
         ipProtocol,
@@ -531,6 +542,12 @@ public final class Flow implements Comparable<Flow>, Serializable {
   @JsonProperty(PROP_DST_IP)
   public Ip getDstIp() {
     return _dstIp;
+  }
+
+  @Nonnull
+  @JsonProperty(PROP_DST_ORG_IP)
+  public Ip getDstOrgIp() {
+    return _dstOrgIp;
   }
 
   @JsonProperty(PROP_DST_PORT)
@@ -738,6 +755,8 @@ public final class Flow implements Comparable<Flow>, Serializable {
         + _srcIp
         + " dstIp:"
         + _dstIp
+        + " dstOrgIp:"
+        + _dstOrgIp
         + " ipProtocol:"
         + _ipProtocol
         + srcPortStr

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -29,6 +29,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
   public static class Builder {
     private SortedSet<Integer> _dscps;
     private @Nullable IpSpace _dstIps;
+    private @Nullable IpSpace _dstOrgIps;
     private SortedSet<SubRange> _dstPorts;
     private SortedSet<Integer> _ecns;
     private SortedSet<SubRange> _fragmentOffsets;
@@ -235,6 +236,11 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
 
     public Builder setDstIps(IpSpace dstIps) {
       _dstIps = dstIps;
+      return this;
+    }
+
+    public Builder setDstOrgIps(IpSpace dstOrgIps) {
+      _dstOrgIps = dstOrgIps;
       return this;
     }
 
@@ -472,6 +478,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
           .thenComparing(HeaderSpace::getTcpFlags, Comparators.lexicographical(Ordering.natural()));
   private static final String PROP_DSCPS = "dscps";
   private static final String PROP_DST_IPS = "dstIps";
+  private static final String PROP_DST_ORG_IPS = "dstOrgIps";
   private static final String PROP_DST_PORTS = "dstPorts";
   private static final String PROP_ECNS = "ecns";
   private static final String PROP_FRAGMENT_OFFSETS = "fragmentOffsets";
@@ -504,6 +511,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
 
   private SortedSet<Integer> _dscps;
   private IpSpace _dstIps;
+  private IpSpace _dstOrgIps;
   private SortedSet<SubRange> _dstPorts;
   private SortedSet<Integer> _ecns;
   private SortedSet<SubRange> _fragmentOffsets;
@@ -555,6 +563,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
   private HeaderSpace(Builder builder) {
     _dscps = ImmutableSortedSet.copyOf(builder._dscps);
     _dstIps = builder._dstIps;
+    _dstOrgIps = builder._dstOrgIps;
     _dstPorts = ImmutableSortedSet.copyOf(builder._dstPorts);
     _ecns = ImmutableSortedSet.copyOf(builder._ecns);
     _fragmentOffsets = ImmutableSortedSet.copyOf(builder._fragmentOffsets);
@@ -596,6 +605,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     HeaderSpace other = (HeaderSpace) o;
     return _dscps.equals(other._dscps)
         && Objects.equals(_dstIps, other._dstIps)
+        && Objects.equals(_dstOrgIps, other._dstOrgIps)
         && _dstPorts.equals(other._dstPorts)
         && _ecns.equals(other._ecns)
         && _fragmentOffsets.equals(other._fragmentOffsets)
@@ -791,6 +801,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     return Objects.hash(
         _dscps,
         _dstIps,
+        _dstOrgIps,
         _dstPorts,
         _ecns,
         _fragmentOffsets,
@@ -828,6 +839,9 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
       return false;
     }
     if (_notDstIps != null && _notDstIps.containsIp(flow.getDstIp(), namedIpSpaces)) {
+      return false;
+    }
+    if (_dstOrgIps != null && !_dstOrgIps.containsIp(flow.getDstOrgIp(), namedIpSpaces)) {
       return false;
     }
     if (!_dstPorts.isEmpty()
@@ -1072,6 +1086,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     return builder()
         .setDscps(_dscps)
         .setDstIps(_dstIps)
+        .setDstOrgIps(_dstOrgIps)
         .setDstPorts(_dstPorts)
         .setEcns(_ecns)
         .setFragmentOffsets(_fragmentOffsets)
@@ -1104,6 +1119,7 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
         .omitNullValues()
         .add(PROP_DSCPS, nullIfEmpty(_dscps))
         .add(PROP_DST_IPS, _dstIps)
+        .add(PROP_DST_ORG_IPS, _dstOrgIps)
         .add(PROP_DST_PORTS, nullIfEmpty(_dstPorts))
         .add(PROP_ECNS, nullIfEmpty(_ecns))
         .add(PROP_FRAGMENT_OFFSETS, nullIfEmpty(_fragmentOffsets))

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -177,6 +177,21 @@ public final class AclLineMatchExprs {
     return matchDst(Ip.parse(ip).toIpSpace());
   }
 
+  public static AclLineMatchExpr matchOrgDst(IpSpace ipSpace) {
+    return matchOrgDst(ipSpace, null);
+  }
+
+  public static AclLineMatchExpr matchOrgDst(IpSpace ipSpace, @Nullable TraceElement traceElement) {
+    if (ipSpace.equals(UniverseIpSpace.INSTANCE)) {
+      return traceElement == null ? TRUE : new TrueExpr(traceElement);
+    }
+    return new MatchHeaderSpace(HeaderSpace.builder().setDstOrgIps(ipSpace).build(), traceElement);
+  }
+
+  public static AclLineMatchExpr matchOrgDst(Prefix prefix) {
+    return matchOrgDst(prefix.toIpSpace());
+  }
+
   public static @Nonnull AclLineMatchExpr matchDstPort(int port) {
     checkArgument(0 <= port && port <= 0xFFFF, "Invalid port: %s", port);
     return match(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/IpField.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/IpField.java
@@ -3,13 +3,16 @@ package org.batfish.datamodel.transformation;
 /** Used to indicate which IP address is transformed by a {@link TransformationStep}. */
 public enum IpField {
   SOURCE,
-  DESTINATION;
+  DESTINATION,
+  ORG_DESTINATION;
 
   public IpField opposite() {
     switch (this) {
       case SOURCE:
         return DESTINATION;
       case DESTINATION:
+        return SOURCE;
+      case ORG_DESTINATION:
         return SOURCE;
       default:
         throw new IllegalArgumentException("Unknown IpField " + this);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -181,6 +181,7 @@ import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.tracking.TrackMethod;
+import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.vendor_family.cisco.Aaa;
 import org.batfish.datamodel.vendor_family.cisco.AaaAuthentication;
 import org.batfish.datamodel.vendor_family.cisco.AaaAuthenticationLogin;
@@ -1763,8 +1764,27 @@ public final class AsaConfiguration extends VendorConfiguration {
   private void generateCiscoAsaNatTransformations(
       String ifaceName, org.batfish.datamodel.Interface newIface, List<AsaNat> nats) {
 
-    if (!nats.stream().map(AsaNat::getSection).allMatch(Section.OBJECT::equals)) {
-      _w.unimplemented("No support for Twice NAT");
+    List<Optional<Transformation.Builder>> incomingConvertedNats =
+        new ArrayList<Optional<Transformation.Builder>>();
+    List<Optional<Transformation.Builder>> outgoingConvertedNats =
+        new ArrayList<Optional<Transformation.Builder>>();
+
+    for (AsaNat nat : nats) {
+      if (nat.getSection() == Section.BEFORE) {
+        if (nat.getOutsideInterface().equals(AsaNat.ANY_INTERFACE)
+            || nat.getOutsideInterface().equals(ifaceName)) {
+          incomingConvertedNats.add(nat.toIncomingTransformation(_networkObjects, _w));
+          outgoingConvertedNats.add(
+              nat.toOutgoingTransformationOrgDestination(_networkObjects, _w));
+        } else if (nat.getInsideInterface().equals(AsaNat.ANY_INTERFACE)
+            || nat.getInsideInterface().equals(ifaceName)) {
+          incomingConvertedNats.add(nat.toOutgoingTransformation(_networkObjects, _w));
+          outgoingConvertedNats.add(
+              nat.toIncomingTransformationOrgDestination(_networkObjects, _w));
+        }
+      } else if (nat.getSection() == Section.AFTER) {
+        _w.unimplemented("Twice NAT's AFTER option is not supported.");
+      }
     }
 
     // ASA places incoming and outgoing object NATs as transformations on the outside interface.
@@ -1778,19 +1798,13 @@ public final class AsaConfiguration extends VendorConfiguration {
                         || nat.getOutsideInterface().equals(ifaceName))
             .collect(Collectors.toCollection(TreeSet::new));
 
-    newIface.setIncomingTransformation(
-        objectNats.stream()
-            .map(nat -> nat.toIncomingTransformation(_networkObjects, _w))
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toList(), AsaNatUtil::toTransformationChain)));
+    for (AsaNat nat : objectNats) {
+      incomingConvertedNats.add(nat.toIncomingTransformation(_networkObjects, _w));
+      outgoingConvertedNats.add(nat.toOutgoingTransformation(_networkObjects, _w));
+    }
 
-    newIface.setOutgoingTransformation(
-        objectNats.stream()
-            .map(nat -> nat.toOutgoingTransformation(_networkObjects, _w))
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toList(), AsaNatUtil::toTransformationChain)));
+    newIface.setIncomingTransformation(AsaNatUtil.toTransformationChain(incomingConvertedNats));
+    newIface.setOutgoingTransformation(AsaNatUtil.toTransformationChain(outgoingConvertedNats));
   }
 
   private void applyZoneFilter(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaNat.java
@@ -247,7 +247,13 @@ public final class AsaNat implements Comparable<AsaNat>, Serializable {
   @VisibleForTesting
   public Optional<Transformation.Builder> toIncomingTransformation(
       Map<String, NetworkObject> networkObjects, Warnings w) {
-    return toTransformation(false, networkObjects, w);
+    return toTransformation(false, false, networkObjects, w);
+  }
+
+  @VisibleForTesting
+  public Optional<Transformation.Builder> toIncomingTransformationOrgDestination(
+      Map<String, NetworkObject> networkObjects, Warnings w) {
+    return toTransformation(true, false, networkObjects, w);
   }
 
   /*
@@ -296,7 +302,10 @@ public final class AsaNat implements Comparable<AsaNat>, Serializable {
    * Object NATs do not divert packets in reverse, only forward.
    */
   private Optional<Transformation.Builder> toTransformation(
-      boolean outgoing, Map<String, NetworkObject> networkObjects, Warnings w) {
+      boolean orgDestination,
+      boolean outgoing,
+      Map<String, NetworkObject> networkObjects,
+      Warnings w) {
 
     if (!outgoing && _dynamic) {
       // Inbound dynamic NAT not supported
@@ -324,7 +333,7 @@ public final class AsaNat implements Comparable<AsaNat>, Serializable {
       shiftDestination = _realDestination;
       insideInterface = _insideInterface;
       firstField = IpField.SOURCE;
-      secondField = IpField.DESTINATION;
+      secondField = orgDestination ? IpField.ORG_DESTINATION : IpField.DESTINATION;
     } else {
       // Incoming transformations match the mapped source and real destination and transform into
       // the real source and mapped destination
@@ -333,7 +342,7 @@ public final class AsaNat implements Comparable<AsaNat>, Serializable {
       shiftDestination = _mappedDestination;
       assignOrShiftSrc = _realSource;
       insideInterface = ANY_INTERFACE;
-      firstField = IpField.DESTINATION;
+      firstField = orgDestination ? IpField.ORG_DESTINATION : IpField.DESTINATION;
       secondField = IpField.SOURCE;
     }
 
@@ -393,6 +402,7 @@ public final class AsaNat implements Comparable<AsaNat>, Serializable {
         shiftDestination,
         matchDestination,
         firstTransformationBuilder.build(),
+        orgDestination,
         networkObjects,
         secondField,
         w);
@@ -401,7 +411,12 @@ public final class AsaNat implements Comparable<AsaNat>, Serializable {
   @VisibleForTesting
   public Optional<Transformation.Builder> toOutgoingTransformation(
       Map<String, NetworkObject> networkObjects, Warnings w) {
-    return toTransformation(true, networkObjects, w);
+    return toTransformation(false, true, networkObjects, w);
+  }
+
+  public Optional<Transformation.Builder> toOutgoingTransformationOrgDestination(
+      Map<String, NetworkObject> networkObjects, Warnings w) {
+    return toTransformation(true, true, networkObjects, w);
   }
 
   public enum Section {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
@@ -2295,7 +2295,7 @@ public final class CiscoAsaGrammarTest {
             when(and(
                     and(matchSourceGroup, matchSrcInterface("inside")),
                     matchDst(mappedDestination)))
-                .apply(ImmutableList.of(assignSourceRange, shiftDestinationIp(realDestination)))
+                .apply(ImmutableList.of(shiftDestinationIp(realDestination)))
                 .build()));
 
     // dynamic source NAT, host -> range, no interfaces specified
@@ -2314,7 +2314,7 @@ public final class CiscoAsaGrammarTest {
         twice,
         equalTo(
             when(and(matchSourceSubnet, matchDst(mappedDestination)))
-                .apply(ImmutableList.of(assignSourceRange, shiftDestinationIp(realDestination)))
+                .apply(ImmutableList.of(shiftDestinationIp(realDestination)))
                 .build()));
   }
 
@@ -2325,7 +2325,7 @@ public final class CiscoAsaGrammarTest {
     AsaConfiguration config = parseVendorConfig(hostname);
 
     List<AsaNat> nats = config.getCiscoAsaNats();
-    assertThat(nats, hasSize(9));
+    assertThat(nats, hasSize(8));
 
     AsaNat nat = nats.get(0);
     assertThat(nat.getDynamic(), equalTo(false));
@@ -2358,21 +2358,16 @@ public final class CiscoAsaGrammarTest {
         equalTo(new NetworkObjectGroupAddressSpecifier("source-mapped-group")));
 
     nat = nats.get(3);
-    assertTrue("NAT is active", nat.getInactive());
-    assertThat(nat.getInsideInterface(), equalTo("inside"));
-    assertThat(nat.getOutsideInterface(), equalTo(AsaNat.ANY_INTERFACE));
-
-    nat = nats.get(4);
     assertThat(nat.getInsideInterface(), equalTo(AsaNat.ANY_INTERFACE));
     assertThat(nat.getOutsideInterface(), equalTo("outside"));
 
-    nat = nats.get(5);
+    nat = nats.get(4);
     assertThat(nat.getInsideInterface(), equalTo("outside"));
     assertThat(nat.getOutsideInterface(), equalTo("inside"));
     assertThat(nat.getRealSource(), equalTo(new WildcardAddressSpecifier(IpWildcard.ANY)));
     assertThat(nat.getMappedSource(), equalTo(new WildcardAddressSpecifier(IpWildcard.ANY)));
 
-    nat = nats.get(6);
+    nat = nats.get(5);
     assertThat(
         nat.getRealSource(), equalTo(new NetworkObjectAddressSpecifier("source-real-subnet")));
     assertThat(
@@ -2415,7 +2410,7 @@ public final class CiscoAsaGrammarTest {
             when(matchDst(mappedSourceHost)).apply(shiftDestinationIp(realSourceHost)).build()));
 
     // Identity NAT
-    nat = config.getCiscoAsaNats().get(5);
+    nat = config.getCiscoAsaNats().get(4);
     builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
     assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
     twice = builder.get().build();
@@ -2427,7 +2422,7 @@ public final class CiscoAsaGrammarTest {
                 .build()));
 
     // Subnet source NAT
-    nat = config.getCiscoAsaNats().get(6);
+    nat = config.getCiscoAsaNats().get(5);
     builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
     assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
     twice = builder.get().build();
@@ -2439,7 +2434,7 @@ public final class CiscoAsaGrammarTest {
                 .build()));
 
     // Source NAT with no interfaces specified
-    nat = config.getCiscoAsaNats().get(7);
+    nat = config.getCiscoAsaNats().get(6);
     builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
     assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
     twice = builder.get().build();
@@ -2460,7 +2455,7 @@ public final class CiscoAsaGrammarTest {
                 .build()));
 
     // Source + destination NAT with no interfaces specified
-    nat = config.getCiscoAsaNats().get(8);
+    nat = config.getCiscoAsaNats().get(7);
     builder = nat.toOutgoingTransformation(config.getNetworkObjects(), new Warnings());
     assertThat("No outgoing transformation", builder.isPresent(), equalTo(true));
     twice = builder.get().build();
@@ -2468,9 +2463,7 @@ public final class CiscoAsaGrammarTest {
         twice,
         equalTo(
             when(and(matchSrc(realSourceSubnet), matchDst(mappedDestHost)))
-                .apply(
-                    ImmutableList.of(
-                        shiftSourceIp(mappedSourceSubnet), shiftDestinationIp(realDestHost)))
+                .apply(ImmutableList.of(shiftDestinationIp(realDestHost)))
                 .build()));
     builder = nat.toIncomingTransformation(config.getNetworkObjects(), new Warnings());
     assertThat("No incoming transformation", builder.isPresent(), equalTo(true));
@@ -2479,9 +2472,7 @@ public final class CiscoAsaGrammarTest {
         twice,
         equalTo(
             when(and(matchDst(mappedSourceSubnet), matchSrc(realDestHost)))
-                .apply(
-                    ImmutableList.of(
-                        shiftDestinationIp(realSourceSubnet), shiftSourceIp(mappedDestHost)))
+                .apply(ImmutableList.of(shiftDestinationIp(realSourceSubnet)))
                 .build()));
   }
 
@@ -2507,9 +2498,7 @@ public final class CiscoAsaGrammarTest {
             when(and(
                     and(matchSrc(realSource), matchSrcInterface("inside")),
                     matchDst(mappedDestination)))
-                .apply(
-                    ImmutableList.of(
-                        shiftSourceIp(mappedSource), shiftDestinationIp(realDestination)))
+                .apply(ImmutableList.of(shiftDestinationIp(realDestination)))
                 .build()));
 
     builder = nat.toIncomingTransformation(config.getNetworkObjects(), new Warnings());
@@ -2519,9 +2508,7 @@ public final class CiscoAsaGrammarTest {
         twice,
         equalTo(
             when(and(matchDst(mappedSource), matchSrc(realDestination)))
-                .apply(
-                    ImmutableList.of(
-                        shiftDestinationIp(realSource), shiftSourceIp(mappedDestination)))
+                .apply(ImmutableList.of(shiftDestinationIp(realSource)))
                 .build()));
   }
 
@@ -2535,7 +2522,7 @@ public final class CiscoAsaGrammarTest {
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
 
     // check expected references
-    assertThat(ccae, hasNumReferrers(filename, INTERFACE, "inside", 6));
+    assertThat(ccae, hasNumReferrers(filename, INTERFACE, "inside", 5));
     assertThat(ccae, hasNumReferrers(filename, INTERFACE, "outside", 6));
     assertThat(ccae, hasNumReferrers(filename, NETWORK_OBJECT, "dest-mapped", 2));
     assertThat(ccae, hasNumReferrers(filename, NETWORK_OBJECT, "dest-real", 2));
@@ -2543,7 +2530,7 @@ public final class CiscoAsaGrammarTest {
     assertThat(ccae, hasNumReferrers(filename, NETWORK_OBJECT, "source-mapped-subnet", 3));
     assertThat(ccae, hasNumReferrers(filename, NETWORK_OBJECT, "source-real", 3));
     assertThat(ccae, hasNumReferrers(filename, NETWORK_OBJECT, "source-real-subnet", 3));
-    assertThat(ccae, hasNumReferrers(filename, NETWORK_OBJECT_GROUP, "source-mapped-group", 2));
+    assertThat(ccae, hasNumReferrers(filename, NETWORK_OBJECT_GROUP, "source-mapped-group", 1));
     assertThat(ccae, hasNumReferrers(filename, NETWORK_OBJECT_GROUP, "source-real-group", 2));
 
     assertThat(ccae, not(hasUndefinedReference(filename, INTERFACE, "inside")));
@@ -2559,7 +2546,6 @@ public final class CiscoAsaGrammarTest {
     assertThat(
         ccae, not(hasUndefinedReference(filename, NETWORK_OBJECT_GROUP, "source-real-group")));
     assertThat(ccae, hasUndefinedReference(filename, NETWORK_OBJECT, "undef-source-mapped"));
-    assertThat(ccae, hasUndefinedReference(filename, NETWORK_OBJECT, "undef-source-real"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-nat-twice-static
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-nat-twice-static
@@ -36,7 +36,6 @@ object-group network source-mapped-group
 nat (inside,outside) after-auto source static source-real source-mapped destination static dest-mapped dest-real description Static Twice NAT
 nat (inside,outside) source static source-real source-mapped
 nat source static source-real-group source-mapped-group
-nat (inside,any) source static undef-source-real source-mapped-group inactive
 nat (any,outside) source static source-real-group undef-source-mapped
 nat (outside,inside) source static any any
 nat (inside,outside) source static source-real-subnet source-mapped-subnet


### PR DESCRIPTION
https://github.com/batfish/batfish/issues/8335 (https://github.com/batfish/batfish/issues/8335)
PR for the above issues.

ttps://wwwin-github.cisco.com/MoBillsPoC/batfish/blob/master/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa
/testconfigs/asa-nat-twice-static (https://wwwin-github.cisco.com/MoBillsPoC/batfish/blob/master/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-nattwice-static)
nat (inside,any) source static undef-source-real source-mapped-group inactive
I deleted the above config because it was rejected even by ASA config.