### PR TITLE
Add API version service at /api_version

### DIFF
--- a/projects/allinone/src/main/java/org/batfish/allinone/AllInOne.java
+++ b/projects/allinone/src/main/java/org/batfish/allinone/AllInOne.java
@@ -117,7 +117,7 @@ public class AllInOne {
     if (_settings.getRunClient()) {
       try {
         _client.getSettings().setCoordinatorWorkPort(bindPortFutures.getWorkPort().get());
-        _client.getSettings().setCoordinatorWorkV2Port(bindPortFutures.getWorkV2Port().get());
+        _client.getSettings().setCoordinatorWorkV2Port(bindPortFutures.getServicePort().get());
       } catch (ExecutionException | InterruptedException e) {
         System.err.println("org.batfish.allinone: Worker initialization failed: " + e.getMessage());
         e.printStackTrace();
@@ -202,7 +202,7 @@ public class AllInOne {
               0,
               org.batfish.coordinator.config.Settings.ARG_SERVICE_WORK_PORT,
               0,
-              org.batfish.coordinator.config.Settings.ARG_SERVICE_WORK_V2_PORT,
+              org.batfish.coordinator.config.Settings.ARG_SERVICE_PORT,
               0);
     }
     String[] initialArgArray = getArgArrayFromString(coordinatorArgs);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConsts.java
@@ -55,6 +55,7 @@ public class CoordConsts {
   public static final String SVC_CFG_WORK_MGR = "/batfishworkmgr";
   public static final Integer SVC_CFG_WORK_PORT = 9997;
   public static final String SVC_CFG_WORK_MGR2 = "/v2";
+  public static final String SVC_CFG_API_VERSION = "/api_version";
   public static final Integer SVC_CFG_WORK_V2_PORT = 9996;
   public static final boolean SVC_CFG_WORK_SSL_DISABLE = true;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BindPortFutures.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BindPortFutures.java
@@ -6,12 +6,12 @@ public class BindPortFutures {
 
   private final CompletableFuture<Integer> _poolPort;
   private final CompletableFuture<Integer> _workPort;
-  private final CompletableFuture<Integer> _workV2Port;
+  private final CompletableFuture<Integer> _servicePort;
 
   public BindPortFutures() {
     _poolPort = new CompletableFuture<>();
     _workPort = new CompletableFuture<>();
-    _workV2Port = new CompletableFuture<>();
+    _servicePort = new CompletableFuture<>();
   }
 
   public CompletableFuture<Integer> getPoolPort() {
@@ -22,7 +22,7 @@ public class BindPortFutures {
     return _workPort;
   }
 
-  public CompletableFuture<Integer> getWorkV2Port() {
-    return _workV2Port;
+  public CompletableFuture<Integer> getServicePort() {
+    return _servicePort;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -184,7 +184,7 @@ public class CommonUtil {
     return Hashing.sha256().hashString(saltedSecret, UTF_8).toString();
   }
 
-  public static HttpServer startSslServer(
+  public static @Nonnull HttpServer startSslServer(
       ResourceConfig resourceConfig,
       URI mgrUri,
       Path keystorePath,

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/ApiVersionService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/ApiVersionService.java
@@ -1,0 +1,19 @@
+package org.batfish.coordinator;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.batfish.common.CoordConsts;
+
+/** A RESTful service for providing the current API version(s). */
+@Path(CoordConsts.SVC_CFG_API_VERSION)
+public final class ApiVersionService {
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public @Nonnull ApiVersions getVersions() {
+    return ApiVersions.instance();
+  }
+}

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/ApiVersions.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/ApiVersions.java
@@ -1,0 +1,62 @@
+package org.batfish.coordinator;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Contains hard-coded API semversions. Each Major version num should correspond to an available
+ * /v(num) endpoint. A minor version should be updated whenever a new endpoint is added.
+ */
+@ParametersAreNonnullByDefault
+public final class ApiVersions {
+
+  public static @Nonnull ApiVersions instance() {
+    return INSTANCE;
+  }
+
+  @JsonValue
+  public @Nonnull Map<Integer, String> getVersions() {
+    return _versions;
+  }
+
+  private static final ApiVersions INSTANCE = new ApiVersions();
+
+  private ApiVersions() {
+    _versions = ImmutableMap.of(1, "1.0.0", 2, "2.1.0");
+  }
+
+  private final @Nonnull Map<Integer, String> _versions;
+
+  // BELOW IS FOR TESTING
+  private ApiVersions(Map<Integer, String> versions) {
+    _versions = versions;
+  }
+
+  @JsonCreator
+  private static @Nonnull ApiVersions create(@Nullable Map<Integer, String> versions) {
+    return new ApiVersions(ImmutableMap.copyOf(firstNonNull(versions, ImmutableMap.of())));
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof ApiVersions)) {
+      return false;
+    }
+    return ((ApiVersions) obj)._versions.equals(_versions);
+  }
+
+  @Override
+  public int hashCode() {
+    return _versions.hashCode();
+  }
+}

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/VersionCompatibilityFilter.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/VersionCompatibilityFilter.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
+import org.batfish.common.CoordConsts;
 
 /** This filter verifies that the client supplied a version. */
 @PreMatching
@@ -18,6 +19,11 @@ public class VersionCompatibilityFilter implements ContainerRequestFilter {
 
   @Override
   public void filter(ContainerRequestContext requestContext) {
+    if (requestContext.getUriInfo().getPath().startsWith(WHITELISTED_PATH_PREFIX)) {
+      // Seems dumb to require a declared version to fetch supported API versions
+      // TODO: Should we just delete this class? We don't use the header value.
+      return;
+    }
     String clientVersion = requestContext.getHeaderString(HTTP_HEADER_BATFISH_VERSION);
     if (Strings.isNullOrEmpty(clientVersion)) {
       requestContext.abortWith(
@@ -30,4 +36,7 @@ public class VersionCompatibilityFilter implements ContainerRequestFilter {
               .build());
     }
   }
+
+  private static final String WHITELISTED_PATH_PREFIX =
+      CoordConsts.SVC_CFG_API_VERSION.substring(1);
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
@@ -40,7 +40,7 @@ public class Settings extends BaseSettings {
   public static final String ARG_SERVICE_NAME = "servicename";
   public static final String ARG_SERVICE_POOL_PORT = "poolport";
   public static final String ARG_SERVICE_WORK_PORT = "workport";
-  public static final String ARG_SERVICE_WORK_V2_PORT = "workv2port";
+  public static final String ARG_SERVICE_PORT = "workv2port"; // TODO: migrate to "serviceport"
   private static final String ARG_SSL_POOL_DISABLE = "sslpooldisable";
 
   private static final String ARG_SSL_POOL_KEYSTORE_FILE = "sslpoolkeystorefile";
@@ -48,19 +48,19 @@ public class Settings extends BaseSettings {
   private static final String ARG_SSL_POOL_TRUST_ALL_CERTS = "sslpooltrustallcerts";
   private static final String ARG_SSL_POOL_TRUSTSTORE_FILE = "sslpooltruststorefile";
   private static final String ARG_SSL_POOL_TRUSTSTORE_PASSWORD = "sslpooltruststorepassword";
-  private static final String ARG_SSL_WORK_DISABLE = "sslworkdisable";
-  private static final String ARG_SSL_WORK_KEYSTORE_FILE = "sslworkkeystorefile";
+  private static final String ARG_SSL_SERVICE_DISABLE = "sslworkdisable";
+  private static final String ARG_SSL_SERVICE_KEYSTORE_FILE = "sslworkkeystorefile";
 
-  private static final String ARG_SSL_WORK_KEYSTORE_PASSWORD = "sslworkkeystorepassword";
-  private static final String ARG_SSL_WORK_TRUST_ALL_CERTS = "sslworktrustallcerts";
-  private static final String ARG_SSL_WORK_TRUSTSTORE_FILE = "sslworktruststorefile";
-  private static final String ARG_SSL_WORK_TRUSTSTORE_PASSWORD = "sslworktruststorepassword";
+  private static final String ARG_SSL_SERVICE_KEYSTORE_PASSWORD = "sslworkkeystorepassword";
+  private static final String ARG_SSL_SERVICE_TRUST_ALL_CERTS = "sslworktrustallcerts";
+  private static final String ARG_SSL_SERVICE_TRUSTSTORE_FILE = "sslworktruststorefile";
+  private static final String ARG_SSL_SERVICE_TRUSTSTORE_PASSWORD = "sslworktruststorepassword";
 
   private static final String ARG_TRACING_AGENT_HOST = "tracingagenthost";
   private static final String ARG_TRACING_AGENT_PORT = "tracingagentport";
   public static final String ARG_TRACING_ENABLE = "tracingenable";
 
-  private static final String ARG_WORK_BIND_HOST = "workbindhost";
+  private static final String ARG_SERVICE_BIND_HOST = "workbindhost";
 
   private static final String ARGNAME_PATHS = "path..";
 
@@ -87,26 +87,26 @@ public class Settings extends BaseSettings {
   private String _serviceName;
   private int _servicePoolPort;
   private int _serviceWorkPort;
-  private int _serviceWorkV2Port;
+  private int _servicePort;
   private boolean _sslPoolDisable;
   private Path _sslPoolKeystoreFile;
   private String _sslPoolKeystorePassword;
   private boolean _sslPoolTrustAllCerts;
   private Path _sslPoolTruststoreFile;
   private String _sslPoolTruststorePassword;
-  private boolean _sslWorkDisable;
-  private Path _sslWorkKeystoreFile;
-  private String _sslWorkKeystorePassword;
-  private boolean _sslWorkTrustAllCerts;
-  private Path _sslWorkTruststoreFile;
-  private String _sslWorkTruststorePassword;
+  private boolean _sslServiceDisable;
+  private Path _sslServiceKeystoreFile;
+  private String _sslServiceKeystorePassword;
+  private boolean _sslServiceTrustAllCerts;
+  private Path _sslServiceTruststoreFile;
+  private String _sslServiceTruststorePassword;
   private String _storageAccountKey;
   private String _storageAccountName;
   private String _storageProtocol;
   private String _tracingAgentHost;
   private Integer _tracingAgentPort;
   private boolean _tracingEnable;
-  private String _workBindHost;
+  private String _serviceBindHost;
 
   public Settings(String[] args) {
     super(
@@ -200,8 +200,8 @@ public class Settings extends BaseSettings {
     return _serviceWorkPort;
   }
 
-  public int getServiceWorkV2Port() {
-    return _serviceWorkV2Port;
+  public int getServicePort() {
+    return _servicePort;
   }
 
   public boolean getSslPoolDisable() {
@@ -232,28 +232,28 @@ public class Settings extends BaseSettings {
     return _questionTemplateDirs;
   }
 
-  public boolean getSslWorkDisable() {
-    return _sslWorkDisable;
+  public boolean getSslServiceDisable() {
+    return _sslServiceDisable;
   }
 
-  public Path getSslWorkKeystoreFile() {
-    return _sslWorkKeystoreFile;
+  public Path getSslServiceKeystoreFile() {
+    return _sslServiceKeystoreFile;
   }
 
-  public String getSslWorkKeystorePassword() {
-    return _sslWorkKeystorePassword;
+  public String getSslServiceKeystorePassword() {
+    return _sslServiceKeystorePassword;
   }
 
-  public boolean getSslWorkTrustAllCerts() {
-    return _sslWorkTrustAllCerts;
+  public boolean getSslServiceTrustAllCerts() {
+    return _sslServiceTrustAllCerts;
   }
 
-  public Path getSslWorkTruststoreFile() {
-    return _sslWorkTruststoreFile;
+  public Path getSslServiceTruststoreFile() {
+    return _sslServiceTruststoreFile;
   }
 
-  public String getSslWorkTruststorePassword() {
-    return _sslWorkTruststorePassword;
+  public String getSslServiceTruststorePassword() {
+    return _sslServiceTruststorePassword;
   }
 
   public String getStorageAccountKey() {
@@ -280,8 +280,8 @@ public class Settings extends BaseSettings {
     return _tracingEnable;
   }
 
-  public String getWorkBindHost() {
-    return _workBindHost;
+  public String getServiceBindHost() {
+    return _serviceBindHost;
   }
 
   private void initConfigDefaults() {
@@ -309,22 +309,22 @@ public class Settings extends BaseSettings {
     setDefaultProperty(ARG_QUEUE_TYPE, WorkQueue.Type.memory.toString());
     setDefaultProperty(ARG_POOL_BIND_HOST, "localhost");
     setDefaultProperty(ARG_SERVICE_POOL_PORT, CoordConsts.SVC_CFG_POOL_PORT);
-    setDefaultProperty(ARG_WORK_BIND_HOST, Ip.ZERO.toString());
+    setDefaultProperty(ARG_SERVICE_BIND_HOST, Ip.ZERO.toString());
     setDefaultProperty(ARG_SERVICE_NAME, "coordinator-service");
     setDefaultProperty(ARG_SERVICE_WORK_PORT, CoordConsts.SVC_CFG_WORK_PORT);
-    setDefaultProperty(ARG_SERVICE_WORK_V2_PORT, CoordConsts.SVC_CFG_WORK_V2_PORT);
+    setDefaultProperty(ARG_SERVICE_PORT, CoordConsts.SVC_CFG_WORK_V2_PORT);
     setDefaultProperty(ARG_SSL_POOL_DISABLE, CoordConsts.SVC_CFG_POOL_SSL_DISABLE);
     setDefaultProperty(ARG_SSL_POOL_KEYSTORE_FILE, null);
     setDefaultProperty(ARG_SSL_POOL_KEYSTORE_PASSWORD, null);
     setDefaultProperty(ARG_SSL_POOL_TRUST_ALL_CERTS, false);
     setDefaultProperty(ARG_SSL_POOL_TRUSTSTORE_FILE, null);
     setDefaultProperty(ARG_SSL_POOL_TRUSTSTORE_PASSWORD, null);
-    setDefaultProperty(ARG_SSL_WORK_DISABLE, CoordConsts.SVC_CFG_WORK_SSL_DISABLE);
-    setDefaultProperty(ARG_SSL_WORK_KEYSTORE_FILE, null);
-    setDefaultProperty(ARG_SSL_WORK_KEYSTORE_PASSWORD, null);
-    setDefaultProperty(ARG_SSL_WORK_TRUST_ALL_CERTS, true);
-    setDefaultProperty(ARG_SSL_WORK_TRUSTSTORE_FILE, null);
-    setDefaultProperty(ARG_SSL_WORK_TRUSTSTORE_PASSWORD, null);
+    setDefaultProperty(ARG_SSL_SERVICE_DISABLE, CoordConsts.SVC_CFG_WORK_SSL_DISABLE);
+    setDefaultProperty(ARG_SSL_SERVICE_KEYSTORE_FILE, null);
+    setDefaultProperty(ARG_SSL_SERVICE_KEYSTORE_PASSWORD, null);
+    setDefaultProperty(ARG_SSL_SERVICE_TRUST_ALL_CERTS, true);
+    setDefaultProperty(ARG_SSL_SERVICE_TRUSTSTORE_FILE, null);
+    setDefaultProperty(ARG_SSL_SERVICE_TRUSTSTORE_PASSWORD, null);
     setDefaultProperty(ARG_TRACING_AGENT_HOST, "localhost");
     setDefaultProperty(ARG_TRACING_AGENT_PORT, 5775);
     setDefaultProperty(ARG_TRACING_ENABLE, false);
@@ -380,7 +380,7 @@ public class Settings extends BaseSettings {
         ARG_SERVICE_POOL_PORT, "port for pool management service", "port_number_pool_service");
 
     addOption(
-        ARG_WORK_BIND_HOST,
+        ARG_SERVICE_BIND_HOST,
         "hostname for work management service",
         "base url for work management service");
 
@@ -388,9 +388,7 @@ public class Settings extends BaseSettings {
         ARG_SERVICE_WORK_PORT, "port for work management service", "port_number_work_service");
 
     addOption(
-        ARG_SERVICE_WORK_V2_PORT,
-        "port for work management service v2",
-        "port_number_work_v2_service");
+        ARG_SERVICE_PORT, "port for work management service v2", "port_number_work_v2_service");
 
     addBooleanOption(ARG_SSL_POOL_DISABLE, "disable SSL on pool manager service");
 
@@ -398,10 +396,10 @@ public class Settings extends BaseSettings {
         ARG_SSL_POOL_TRUST_ALL_CERTS,
         "trust all SSL certs for outgoing connections from pool manager");
 
-    addBooleanOption(ARG_SSL_WORK_DISABLE, "disable SSL on work manager service");
+    addBooleanOption(ARG_SSL_SERVICE_DISABLE, "disable SSL on work manager service");
 
     addBooleanOption(
-        ARG_SSL_WORK_TRUST_ALL_CERTS,
+        ARG_SSL_SERVICE_TRUST_ALL_CERTS,
         "trust all SSL certs for outgoing connections from work manager");
 
     addOption(ARG_TRACING_AGENT_HOST, "jaeger agent host", "jaeger_agent_host");
@@ -433,21 +431,21 @@ public class Settings extends BaseSettings {
     _poolBindHost = getStringOptionValue(ARG_POOL_BIND_HOST);
     _serviceName = getStringOptionValue(ARG_SERVICE_NAME);
     _servicePoolPort = getIntegerOptionValue(ARG_SERVICE_POOL_PORT);
-    _workBindHost = getStringOptionValue(ARG_WORK_BIND_HOST);
+    _serviceBindHost = getStringOptionValue(ARG_SERVICE_BIND_HOST);
     _serviceWorkPort = getIntegerOptionValue(ARG_SERVICE_WORK_PORT);
-    _serviceWorkV2Port = getIntegerOptionValue(ARG_SERVICE_WORK_V2_PORT);
+    _servicePort = getIntegerOptionValue(ARG_SERVICE_PORT);
     _sslPoolDisable = getBooleanOptionValue(ARG_SSL_POOL_DISABLE);
     _sslPoolKeystoreFile = getPathOptionValue(ARG_SSL_POOL_KEYSTORE_FILE);
     _sslPoolKeystorePassword = getStringOptionValue(ARG_SSL_POOL_KEYSTORE_PASSWORD);
     _sslPoolTrustAllCerts = getBooleanOptionValue(ARG_SSL_POOL_TRUST_ALL_CERTS);
     _sslPoolTruststoreFile = getPathOptionValue(ARG_SSL_POOL_TRUSTSTORE_FILE);
     _sslPoolTruststorePassword = getStringOptionValue(ARG_SSL_POOL_TRUSTSTORE_PASSWORD);
-    _sslWorkDisable = getBooleanOptionValue(ARG_SSL_WORK_DISABLE);
-    _sslWorkKeystoreFile = getPathOptionValue(ARG_SSL_WORK_KEYSTORE_FILE);
-    _sslWorkKeystorePassword = getStringOptionValue(ARG_SSL_WORK_KEYSTORE_PASSWORD);
-    _sslWorkTrustAllCerts = getBooleanOptionValue(ARG_SSL_WORK_TRUST_ALL_CERTS);
-    _sslWorkTruststoreFile = getPathOptionValue(ARG_SSL_WORK_TRUSTSTORE_FILE);
-    _sslWorkTruststorePassword = getStringOptionValue(ARG_SSL_WORK_TRUSTSTORE_PASSWORD);
+    _sslServiceDisable = getBooleanOptionValue(ARG_SSL_SERVICE_DISABLE);
+    _sslServiceKeystoreFile = getPathOptionValue(ARG_SSL_SERVICE_KEYSTORE_FILE);
+    _sslServiceKeystorePassword = getStringOptionValue(ARG_SSL_SERVICE_KEYSTORE_PASSWORD);
+    _sslServiceTrustAllCerts = getBooleanOptionValue(ARG_SSL_SERVICE_TRUST_ALL_CERTS);
+    _sslServiceTruststoreFile = getPathOptionValue(ARG_SSL_SERVICE_TRUSTSTORE_FILE);
+    _sslServiceTruststorePassword = getStringOptionValue(ARG_SSL_SERVICE_TRUSTSTORE_PASSWORD);
     _tracingAgentHost = getStringOptionValue(ARG_TRACING_AGENT_HOST);
     _tracingAgentPort = getIntegerOptionValue(ARG_TRACING_AGENT_PORT);
     _tracingEnable = getBooleanOptionValue(ARG_TRACING_ENABLE);
@@ -491,27 +489,27 @@ public class Settings extends BaseSettings {
     _sslPoolTruststorePassword = sslPoolTruststorePassword;
   }
 
-  public void setSslWorkDisable(boolean sslWorkDisable) {
-    _sslWorkDisable = sslWorkDisable;
+  public void setSslServiceDisable(boolean sslServiceDisable) {
+    _sslServiceDisable = sslServiceDisable;
   }
 
-  public void setSslWorkKeystoreFile(Path sslWorkKeystoreFile) {
-    _sslWorkKeystoreFile = sslWorkKeystoreFile;
+  public void setSslServiceKeystoreFile(Path sslServiceKeystoreFile) {
+    _sslServiceKeystoreFile = sslServiceKeystoreFile;
   }
 
-  public void setSslWorkKeystorePassword(String sslWorkKeystorePassword) {
-    _sslWorkKeystorePassword = sslWorkKeystorePassword;
+  public void setSslServiceKeystorePassword(String sslServiceKeystorePassword) {
+    _sslServiceKeystorePassword = sslServiceKeystorePassword;
   }
 
-  public void setSslWorkTrustAllCerts(boolean sslWorkTrustAllCerts) {
-    _sslWorkTrustAllCerts = sslWorkTrustAllCerts;
+  public void setSslServiceTrustAllCerts(boolean sslServiceTrustAllCerts) {
+    _sslServiceTrustAllCerts = sslServiceTrustAllCerts;
   }
 
-  public void setSslWorkTruststoreFile(Path sslWorkTruststoreFile) {
-    _sslWorkTruststoreFile = sslWorkTruststoreFile;
+  public void setSslServiceTruststoreFile(Path sslServiceTruststoreFile) {
+    _sslServiceTruststoreFile = sslServiceTruststoreFile;
   }
 
-  public void setSslWorkTruststorePassword(String sslWorkTruststorePassword) {
-    _sslWorkTruststorePassword = sslWorkTruststorePassword;
+  public void setSslServiceTruststorePassword(String sslServiceTruststorePassword) {
+    _sslServiceTruststorePassword = sslServiceTruststorePassword;
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/ApiVersionServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/ApiVersionServiceTest.java
@@ -10,7 +10,6 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
-import org.batfish.version.BatfishVersion;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,8 +30,7 @@ public final class ApiVersionServiceTest extends MainServiceTestBase {
   private @Nonnull Builder getTarget() {
     return target(CoordConsts.SVC_CFG_API_VERSION)
         .request()
-        .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, CoordConsts.DEFAULT_API_KEY)
-        .header(CoordConstsV2.HTTP_HEADER_BATFISH_VERSION, BatfishVersion.getVersionStatic());
+        .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, CoordConsts.DEFAULT_API_KEY);
   }
 
   @Test

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/ApiVersionServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/ApiVersionServiceTest.java
@@ -1,0 +1,46 @@
+package org.batfish.coordinator;
+
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.Response;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.CoordConsts;
+import org.batfish.common.CoordConstsV2;
+import org.batfish.version.BatfishVersion;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Test of {@link ApiVersionService}. */
+public final class ApiVersionServiceTest extends MainServiceTestBase {
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  @Before
+  public void initTestEnvironment() {
+    BatfishLogger logger = new BatfishLogger("debug", false);
+    Main.mainInit(new String[] {"-containerslocation", _folder.getRoot().toString()});
+    Main.setLogger(logger);
+    Main.initAuthorizer();
+  }
+
+  private @Nonnull Builder getTarget() {
+    return target(CoordConsts.SVC_CFG_API_VERSION)
+        .request()
+        .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, CoordConsts.DEFAULT_API_KEY)
+        .header(CoordConstsV2.HTTP_HEADER_BATFISH_VERSION, BatfishVersion.getVersionStatic());
+  }
+
+  @Test
+  public void testGet() {
+    try (Response response = getTarget().get()) {
+      assertThat(response.getStatus(), equalTo(OK.getStatusCode()));
+      ApiVersions versions = response.readEntity(ApiVersions.class);
+      assertThat(versions, equalTo(ApiVersions.instance()));
+    }
+  }
+}

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/MainServiceTestBase.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/MainServiceTestBase.java
@@ -3,6 +3,7 @@ package org.batfish.coordinator;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.core.Application;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
@@ -13,7 +14,8 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;
 
-public class WorkMgrServiceV2TestBase extends JerseyTest {
+@ParametersAreNonnullByDefault
+public abstract class MainServiceTestBase extends JerseyTest {
 
   // Must be done statically to maintain references, or else 3rd-party code will not use our
   // settings. Do not move getLogger calls out of static initialization.
@@ -25,14 +27,14 @@ public class WorkMgrServiceV2TestBase extends JerseyTest {
         Logger.getLogger(NetworkListener.class.getName())
       };
 
-  public WorkMgrServiceV2TestBase() {
+  public MainServiceTestBase() {
     Arrays.stream(LOGGERS).forEach(logger -> logger.setLevel(Level.OFF));
   }
 
   @Override
   public Application configure() {
     forceSet(TestProperties.CONTAINER_PORT, "0");
-    return new ResourceConfig(WorkMgrServiceV2.class)
+    return new ResourceConfig(WorkMgrServiceV2.class, ApiVersionService.class)
         .register(ServiceObjectMapper.class)
         .register(ExceptionMapper.class)
         .register(JacksonFeature.class)

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
@@ -47,7 +47,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class WorkMgrServiceV2Test extends WorkMgrServiceV2TestBase {
+public class WorkMgrServiceV2Test extends MainServiceTestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Before

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/config/SettingsTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/config/SettingsTest.java
@@ -17,7 +17,7 @@ public class SettingsTest {
   public void testDefaultValue() {
     Settings settings = new Settings(new String[] {});
     assertThat(settings.getPoolBindHost(), equalTo("localhost"));
-    assertThat(settings.getWorkBindHost(), equalTo("0.0.0.0"));
+    assertThat(settings.getServiceBindHost(), equalTo("0.0.0.0"));
   }
 
   @Test
@@ -25,7 +25,7 @@ public class SettingsTest {
     String[] args = new String[] {"-poolbindhost=10.10.10.10", "-workbindhost=20.20.20.20"};
     Settings settings = new Settings(args);
     assertThat(settings.getPoolBindHost(), equalTo("10.10.10.10"));
-    assertThat(settings.getWorkBindHost(), equalTo("20.20.20.20"));
+    assertThat(settings.getServiceBindHost(), equalTo("20.20.20.20"));
   }
 
   /** Ensure {@link Path} objects are stored/returned properly (with default values) */

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AnswerResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AnswerResourceTest.java
@@ -24,7 +24,7 @@ import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.AnswerSummary;
@@ -43,7 +43,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 @ParametersAreNonnullByDefault
-public class AnswerResourceTest extends WorkMgrServiceV2TestBase {
+public class AnswerResourceTest extends MainServiceTestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   private Builder getAnswerTarget(String network, String question, @Nullable String snapshot) {

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AutocompleteResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AutocompleteResourceTest.java
@@ -23,7 +23,7 @@ import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.common.autocomplete.NodeCompletionMetadata;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.coordinator.id.IdManager;
 import org.batfish.datamodel.PrefixTrieMultiMap;
@@ -39,7 +39,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** Test of {@link AutocompleteResource}. */
-public final class AutocompleteResourceTest extends WorkMgrServiceV2TestBase {
+public final class AutocompleteResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRoleDimensionResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRoleDimensionResourceTest.java
@@ -14,7 +14,7 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class NetworkNodeRoleDimensionResourceTest extends WorkMgrServiceV2TestBase {
+public final class NetworkNodeRoleDimensionResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRolesResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRolesResourceTest.java
@@ -16,7 +16,7 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
@@ -28,7 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class NetworkNodeRolesResourceTest extends WorkMgrServiceV2TestBase {
+public final class NetworkNodeRolesResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkObjectsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkObjectsResourceTest.java
@@ -20,7 +20,7 @@ import org.apache.commons.io.IOUtils;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.version.BatfishVersion;
 import org.junit.Before;
@@ -28,7 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class NetworkObjectsResourceTest extends WorkMgrServiceV2TestBase {
+public final class NetworkObjectsResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkResourceTest.java
@@ -17,7 +17,7 @@ import org.batfish.common.Container;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.version.BatfishVersion;
 import org.junit.Before;
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 @ParametersAreNonnullByDefault
-public final class NetworkResourceTest extends WorkMgrServiceV2TestBase {
+public final class NetworkResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionBeanTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.RoleDimensionMapping;
@@ -13,7 +13,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class NodeRoleDimensionBeanTest extends WorkMgrServiceV2TestBase {
+public class NodeRoleDimensionBeanTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRolesDataBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRolesDataBeanTest.java
@@ -5,12 +5,12 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.role.NodeRolesData;
 import org.batfish.role.RoleMapping;
 import org.junit.Test;
 
-public class NodeRolesDataBeanTest extends WorkMgrServiceV2TestBase {
+public class NodeRolesDataBeanTest extends MainServiceTestBase {
 
   @Test
   public void testProperties() {

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/QuestionsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/QuestionsResourceTest.java
@@ -18,7 +18,7 @@ import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.datamodel.questions.TestQuestion;
 import org.batfish.version.BatfishVersion;
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 @ParametersAreNonnullByDefault
-public final class QuestionsResourceTest extends WorkMgrServiceV2TestBase {
+public final class QuestionsResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceBookResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceBookResourceTest.java
@@ -15,7 +15,7 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.referencelibrary.AddressGroup;
 import org.batfish.referencelibrary.ReferenceBook;
@@ -26,7 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class ReferenceBookResourceTest extends WorkMgrServiceV2TestBase {
+public class ReferenceBookResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceLibraryResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceLibraryResourceTest.java
@@ -14,7 +14,7 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.referencelibrary.ReferenceLibrary;
@@ -24,7 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class ReferenceLibraryResourceTest extends WorkMgrServiceV2TestBase {
+public class ReferenceLibraryResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotInputObjectsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotInputObjectsResourceTest.java
@@ -17,7 +17,7 @@ import org.batfish.common.BfConsts;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.storage.StoredObjectMetadata;
 import org.batfish.version.BatfishVersion;
@@ -26,7 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class SnapshotInputObjectsResourceTest extends WorkMgrServiceV2TestBase {
+public final class SnapshotInputObjectsResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotNodeRolesResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotNodeRolesResourceTest.java
@@ -13,7 +13,7 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.role.NodeRolesData;
 import org.batfish.version.BatfishVersion;
@@ -22,7 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class SnapshotNodeRolesResourceTest extends WorkMgrServiceV2TestBase {
+public final class SnapshotNodeRolesResourceTest extends MainServiceTestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   private Builder getNodeRolesTarget(String network, String snapshot, boolean inferred) {

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotObjectsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotObjectsResourceTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.io.IOUtils;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.storage.StoredObjectMetadata;
 import org.batfish.version.BatfishVersion;
@@ -33,7 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class SnapshotObjectsResourceTest extends WorkMgrServiceV2TestBase {
+public final class SnapshotObjectsResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
@@ -27,7 +27,7 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.coordinator.id.IdManager;
 import org.batfish.datamodel.SnapshotMetadata;
@@ -40,7 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class SnapshotResourceTest extends WorkMgrServiceV2TestBase {
+public final class SnapshotResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotsResourceTest.java
@@ -15,7 +15,7 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.coordinator.Main;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.datamodel.SnapshotMetadataEntry;
 import org.batfish.version.BatfishVersion;
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 @ParametersAreNonnullByDefault
-public final class SnapshotsResourceTest extends WorkMgrServiceV2TestBase {
+public final class SnapshotsResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/WorkResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/WorkResourceTest.java
@@ -30,8 +30,8 @@ import org.batfish.common.CoordConsts;
 import org.batfish.common.CoordConstsV2;
 import org.batfish.common.WorkItem;
 import org.batfish.coordinator.Main;
+import org.batfish.coordinator.MainServiceTestBase;
 import org.batfish.coordinator.WorkDetails.WorkType;
-import org.batfish.coordinator.WorkMgrServiceV2TestBase;
 import org.batfish.coordinator.WorkMgrTestUtils;
 import org.batfish.datamodel.pojo.WorkStatus;
 import org.batfish.version.BatfishVersion;
@@ -42,7 +42,7 @@ import org.junit.rules.TemporaryFolder;
 
 /** Test of {@link WorkResource}. */
 @ParametersAreNonnullByDefault
-public final class WorkResourceTest extends WorkMgrServiceV2TestBase {
+public final class WorkResourceTest extends MainServiceTestBase {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 


### PR DESCRIPTION
- Add new API version service resource
  - combine on same port as WorkMgrServiceV2
  - sole endpoint returns dict from major version number to semver
- rename Java identifiers for workmgrv2
- update test base to support both resources
- refactor and fix up service initialization
  - move ExceptionMapper to main resource list