### PR TITLE
PrefixTrieMultiMap: reduce allocations in hotpath

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -152,8 +152,21 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
     return masked == _ip.asLong();
   }
 
+  /** Returns {@code true} if {@code this} contains every {@link Ip} in the given {@link Prefix}. */
   public boolean containsPrefix(Prefix prefix) {
     return _prefixLength <= prefix._prefixLength && containsIp(prefix._ip);
+  }
+
+  /**
+   * Returns {@code true} if {@code this} {@link Prefix} contains the prefix represented by the
+   * {@link Ip} and length are in separate parts. The given {@link Ip} does not need to be
+   * normalized as the lowest address in the prefix.
+   *
+   * <p>This is a zero-allocation alternative to calling {@link #containsPrefix(Prefix)} with the
+   * result of {@link Prefix#create(Ip, int)}.
+   */
+  public boolean containsPrefix(Ip ip, int prefixLength) {
+    return _prefixLength <= prefixLength && containsIp(ip);
   }
 
   @Override


### PR DESCRIPTION
PrefixTrieMultiMap#longestPrefixMatch(ip, int) is used on the hotpath during dataplane,
and it immediately converts its arguments into a Prefix. That involves allocation and
locking (interning prefixes), that is essentially unused later - the two components
of the Prefix are decoupled in trie traversal.

Change the relevant internal APIs to work on the component parts, saving allocations.

commit-id:6a7eec28