### PR TITLE
Disable wadl to remove warning

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -5,6 +5,7 @@ import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.net.URI;
@@ -259,6 +260,7 @@ public class Main {
       int port,
       CompletableFuture<Integer> portFuture) {
     ResourceConfig rcWork = new ResourceConfig(serviceClass).register(ExceptionMapper.class);
+    rcWork.addProperties(ImmutableMap.of("jersey.config.server.wadl.disableWadl", "true"));
     for (Class<?> feature : features) {
       _logger.infof("Registering feature %s", feature.getSimpleName());
       rcWork.register(feature);


### PR DESCRIPTION
- disable unused jersey wadl feature to remove warnings like:
```
Aug 16, 2022 1:25:07 PM org.glassfish.jersey.server.wadl.WadlFeature configure
WARNING: JAXBContext implementation could not be found. WADL feature is disabled.
```