### PR TITLE
andLiterals: always return a fresh BDD

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
@@ -339,7 +339,8 @@ public abstract class BDDFactory {
 
   /**
    * Returns the logical 'and' of zero or more BDD literals (constraints on exactly one variable --
-   * i.e. the variable must be true or must be false).
+   * i.e. the variable must be true or must be false). Does not consume any inputs, and returns a
+   * fresh BDD.
    *
    * <p>Precondition: The variables' levels must be strictly increasing.
    */

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -933,7 +933,7 @@ public class JFactory extends BDDFactory implements Serializable {
       return makeBDD(BDDONE);
     }
     if (literals.length == 1) {
-      return literals[0];
+      return literals[0].id();
     }
 
     int[] ids = new int[literals.length];

--- a/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -585,6 +586,20 @@ public class JFactoryTest {
 
     assertEquals(
         v0.and(v1.not()).and(v2).and(v3.not()), _factory.andLiterals(v0, v1.not(), v2, v3.not()));
+
+    // when given a single literal, returns a copy
+    {
+      BDD res = _factory.andLiterals(v0);
+      assertEquals(v0, res);
+      assertNotSame(v0, res);
+    }
+
+    {
+      BDD notV0 = v0.not();
+      BDD res = _factory.andLiterals(notV0);
+      assertEquals(notV0, res);
+      assertNotSame(notV0, res);
+    }
   }
 
   @Test


### PR DESCRIPTION
When called with a single literal, return a copy of it. Otherwise freeing the result is unsafe in general