### PR TITLE
Close WorkMgrV2 resource method `InputStream` parameters

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/NetworkObjectsResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/NetworkObjectsResource.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.nio.file.Paths;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.WillClose;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -59,12 +60,14 @@ public final class NetworkObjectsResource {
 
   @PUT
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-  public @Nonnull Response put(InputStream inputStream, @QueryParam(QP_KEY) String key)
-      throws IOException {
-    if (Main.getWorkMgr().putNetworkObject(inputStream, _network, key)) {
-      return Response.ok().build();
-    } else {
-      return Response.status(Status.NOT_FOUND).build();
+  public @Nonnull Response put(
+      @WillClose InputStream inputStreamArg, @QueryParam(QP_KEY) String key) throws IOException {
+    try (InputStream inputStream = inputStreamArg) {
+      if (Main.getWorkMgr().putNetworkObject(inputStream, _network, key)) {
+        return Response.ok().build();
+      } else {
+        return Response.status(Status.NOT_FOUND).build();
+      }
     }
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotObjectsResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotObjectsResource.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.WillClose;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -68,11 +69,14 @@ public final class SnapshotObjectsResource {
 
   @PUT
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-  public Response put(InputStream inputStream, @QueryParam(QP_KEY) String key) throws IOException {
-    if (Main.getWorkMgr().putSnapshotExtendedObject(inputStream, _network, _snapshot, key)) {
-      return Response.ok().build();
-    } else {
-      return Response.status(Status.NOT_FOUND).build();
+  public Response put(@WillClose InputStream inputStreamArg, @QueryParam(QP_KEY) String key)
+      throws IOException {
+    try (InputStream inputStream = inputStreamArg) {
+      if (Main.getWorkMgr().putSnapshotExtendedObject(inputStream, _network, _snapshot, key)) {
+        return Response.ok().build();
+      } else {
+        return Response.status(Status.NOT_FOUND).build();
+      }
     }
   }
 


### PR DESCRIPTION
- testing shows such parameters are not closed by framework at  conclusion of request processing
- close such `InputStream`s, and annotate the parameters with `@WillClose`