### PR TITLE
BDDLoopDetectionAnalysis: fix self-loop bug

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDLoopDetectionAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDLoopDetectionAnalysis.java
@@ -5,6 +5,7 @@ import static org.batfish.bddreachability.BDDReachabilityUtils.getIngressStateEx
 import static org.batfish.bddreachability.BDDReachabilityUtils.toIngressLocation;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Table;
 import java.util.Collection;
@@ -118,7 +119,8 @@ public class BDDLoopDetectionAnalysis {
    * Run BFS from one step past the initial state. Each round, check if the initial state has been
    * reached yet.
    */
-  private boolean confirmLoop(StateExpr stateExpr, BDD bdd) {
+  @VisibleForTesting
+  boolean confirmLoop(StateExpr stateExpr, BDD bdd) {
     Map<StateExpr, BDD> reachable = propagate(ImmutableMap.of(stateExpr, bdd));
     Set<StateExpr> dirty = new HashSet<>(reachable.keySet());
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDLoopDetectionAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDLoopDetectionAnalysis.java
@@ -128,38 +128,31 @@ public class BDDLoopDetectionAnalysis {
     while (!dirty.isEmpty()) {
       Set<StateExpr> newDirty = new HashSet<>();
 
-      dirty.forEach(
-          preState -> {
-            Map<StateExpr, Transition> preStateOutEdges = _forwardEdgeTable.row(preState);
-            if (preStateOutEdges == null) {
-              // preState has no out-edges
-              return;
-            }
+      for (StateExpr preState : dirty) {
+        BDD preStateBDD = reachable.get(preState);
+        for (Entry<StateExpr, Transition> entry : _forwardEdgeTable.row(preState).entrySet()) {
+          StateExpr postState = entry.getKey();
+          Transition transition = entry.getValue();
+          BDD result = transition.transitForward(preStateBDD);
+          if (result.isZero()) {
+            continue;
+          }
 
-            BDD preStateBDD = reachable.get(preState);
-            preStateOutEdges.forEach(
-                (postState, transition) -> {
-                  BDD result = transition.transitForward(preStateBDD);
-                  if (result.isZero()) {
-                    return;
-                  }
+          if (postState.equals(stateExpr) && result.andSat(bdd)) {
+            return true;
+          }
 
-                  // update postState BDD reverse-reachable from leaf
-                  BDD oldReach = reachable.getOrDefault(postState, zero);
-                  BDD newReach = oldReach == null ? result : oldReach.or(result);
-                  if (oldReach == null || !oldReach.equals(newReach)) {
-                    reachable.put(postState, newReach);
-                    newDirty.add(postState);
-                  }
-                });
-          });
-
-      dirty = newDirty;
-      if (dirty.contains(stateExpr)) {
-        if (reachable.get(stateExpr).andSat(bdd)) {
-          return true;
+          // update postState BDD reverse-reachable from leaf
+          BDD oldReach = reachable.getOrDefault(postState, zero);
+          BDD newReach = oldReach == null ? result : oldReach.or(result);
+          if (oldReach == null || !oldReach.equals(newReach)) {
+            reachable.put(postState, newReach);
+            newDirty.add(postState);
+          }
         }
       }
+
+      dirty = newDirty;
     }
     return false;
   }


### PR DESCRIPTION
Previously, confirmLoop would fail to confirm a self-loop on the input start state.