### PR TITLE
common: separate specifier/parboiled code out

### DIFF
--- a/projects/batfish-common-protocol/BUILD
+++ b/projects/batfish-common-protocol/BUILD
@@ -4,46 +4,51 @@ load("@batfish//skylark:pmd_test.bzl", "pmd_test")
 
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
-    name = "parser_files",
-    srcs = [
-        "src/main/java/org/batfish/common/BatfishException.java",
-        "src/main/java/org/batfish/common/DebugBatfishException.java",
-        "src/main/java/org/batfish/common/ErrorDetails.java",
-        "src/main/java/org/batfish/common/ParseTreeSentences.java",
-        "src/main/java/org/batfish/common/WillNotCommitException.java",
-        "src/main/java/org/batfish/common/util/BatfishObjectMapper.java",
-        "src/main/java/org/batfish/common/util/serialization/BatfishThirdPartyDeserializers.java",
-        "src/main/java/org/batfish/common/util/serialization/BatfishThirdPartySerializationModule.java",
-        "src/main/java/org/batfish/common/util/serialization/BatfishThirdPartySerializers.java",
-        "src/main/java/org/batfish/common/util/serialization/guava/RangeSetDeserializer.java",
-        "src/main/java/org/batfish/common/util/serialization/guava/RangeSetDeserializerConverter.java",
-        "src/main/java/org/batfish/common/util/serialization/guava/RangeSetSerializer.java",
-        "src/main/java/org/batfish/common/util/serialization/guava/RangeSetSerializerConverter.java",
-        "src/main/java/org/batfish/datamodel/answers/AnswerElement.java",
-        "src/main/java/org/batfish/datamodel/answers/AnswerSummary.java",
-        "src/main/java/org/batfish/grammar/BatfishANTLRErrorStrategy.java",
-        "src/main/java/org/batfish/grammar/BatfishCombinedParser.java",
-        "src/main/java/org/batfish/grammar/BatfishGrammarErrorListener.java",
-        "src/main/java/org/batfish/grammar/BatfishLexer.java",
-        "src/main/java/org/batfish/grammar/BatfishLexerErrorListener.java",
-        "src/main/java/org/batfish/grammar/BatfishLexerRecoveryStrategy.java",
-        "src/main/java/org/batfish/grammar/BatfishParseException.java",
-        "src/main/java/org/batfish/grammar/BatfishParseTreeWalker.java",
-        "src/main/java/org/batfish/grammar/BatfishParser.java",
-        "src/main/java/org/batfish/grammar/BatfishParserATNSimulator.java",
-        "src/main/java/org/batfish/grammar/BatfishParserErrorListener.java",
-        "src/main/java/org/batfish/grammar/GrammarSettings.java",
-        "src/main/java/org/batfish/grammar/ImplementedRules.java",
-        "src/main/java/org/batfish/grammar/ParseTreePrettyPrinter.java",
-        "src/main/java/org/batfish/grammar/UnrecognizedLineToken.java",
-        "src/main/java/org/batfish/grammar/flattener/FlattenerLineMap.java",
-    ],
-)
+###################################################################
+### parser_common_files are files that antlr4-generated
+### java code is allowed to depend on. We keep this set small
+### and explicit to minimize the number of times we have to
+### recompile parsers when we change unrelated things in common.
+###
+### TODO: actually have a sensible directory structure and modules
+###################################################################
+parser_common_srcs = [
+    "src/main/java/org/batfish/common/BatfishException.java",
+    "src/main/java/org/batfish/common/DebugBatfishException.java",
+    "src/main/java/org/batfish/common/ErrorDetails.java",
+    "src/main/java/org/batfish/common/ParseTreeSentences.java",
+    "src/main/java/org/batfish/common/WillNotCommitException.java",
+    "src/main/java/org/batfish/common/util/BatfishObjectMapper.java",
+    "src/main/java/org/batfish/common/util/serialization/BatfishThirdPartyDeserializers.java",
+    "src/main/java/org/batfish/common/util/serialization/BatfishThirdPartySerializationModule.java",
+    "src/main/java/org/batfish/common/util/serialization/BatfishThirdPartySerializers.java",
+    "src/main/java/org/batfish/common/util/serialization/guava/RangeSetDeserializer.java",
+    "src/main/java/org/batfish/common/util/serialization/guava/RangeSetDeserializerConverter.java",
+    "src/main/java/org/batfish/common/util/serialization/guava/RangeSetSerializer.java",
+    "src/main/java/org/batfish/common/util/serialization/guava/RangeSetSerializerConverter.java",
+    "src/main/java/org/batfish/datamodel/answers/AnswerElement.java",
+    "src/main/java/org/batfish/datamodel/answers/AnswerSummary.java",
+    "src/main/java/org/batfish/grammar/BatfishANTLRErrorStrategy.java",
+    "src/main/java/org/batfish/grammar/BatfishCombinedParser.java",
+    "src/main/java/org/batfish/grammar/BatfishGrammarErrorListener.java",
+    "src/main/java/org/batfish/grammar/BatfishLexer.java",
+    "src/main/java/org/batfish/grammar/BatfishLexerErrorListener.java",
+    "src/main/java/org/batfish/grammar/BatfishLexerRecoveryStrategy.java",
+    "src/main/java/org/batfish/grammar/BatfishParseException.java",
+    "src/main/java/org/batfish/grammar/BatfishParseTreeWalker.java",
+    "src/main/java/org/batfish/grammar/BatfishParser.java",
+    "src/main/java/org/batfish/grammar/BatfishParserATNSimulator.java",
+    "src/main/java/org/batfish/grammar/BatfishParserErrorListener.java",
+    "src/main/java/org/batfish/grammar/GrammarSettings.java",
+    "src/main/java/org/batfish/grammar/ImplementedRules.java",
+    "src/main/java/org/batfish/grammar/ParseTreePrettyPrinter.java",
+    "src/main/java/org/batfish/grammar/UnrecognizedLineToken.java",
+    "src/main/java/org/batfish/grammar/flattener/FlattenerLineMap.java",
+]
 
 java_library(
     name = "parser_common",
-    srcs = [":parser_files"],
+    srcs = parser_common_srcs,
     deps = [
         "@maven//:com_fasterxml_jackson_core_jackson_annotations",
         "@maven//:com_fasterxml_jackson_core_jackson_core",
@@ -57,11 +62,88 @@ java_library(
     ],
 )
 
+pmd_test(
+    name = "parser_common_pmd",
+    lib = ":parser_common",
+)
+
+###################################################################
+### specifier_common_srcs are files that must be compiled with the
+### generated Parboiled parsers used in specifier resolution.
+### We must exclude the Parboiled parsers from code coverage, so
+### keeping this library small means we get coverage for as much
+### of the project as possible.
+###
+### TODO: actually have a sensible directory structure and modules
+### TODO: figure out why bazel coverage + parboiled = crash and fix
+###################################################################
+specifier_common_srcs = [
+    "src/main/java/org/batfish/common/util/CompletionMetadataUtils.java",
+    "src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java",
+    "src/main/java/org/batfish/datamodel/answers/InputValidationUtils.java",
+    "src/main/java/org/batfish/datamodel/PacketHeaderConstraints.java",
+    "src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java",
+    "src/main/java/org/batfish/datamodel/phc_to_flow/DstIpExtractorDefault.java",
+    "src/main/java/org/batfish/datamodel/phc_to_flow/DstIpExtractorPhcOnly.java",
+    "src/main/java/org/batfish/datamodel/phc_to_flow/FieldExtractor.java",
+    "src/main/java/org/batfish/datamodel/phc_to_flow/IpFieldExtractorContext.java",
+    "src/main/java/org/batfish/datamodel/phc_to_flow/IpProtocolExtractorDefaultTcp.java",
+    "src/main/java/org/batfish/datamodel/phc_to_flow/SrcIpExtractorDefault.java",
+    "src/main/java/org/batfish/datamodel/phc_to_flow/SrcIpExtractorLocation.java",
+    "src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java",
+    "src/main/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifier.java",
+    "src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java",
+    "src/main/java/org/batfish/datamodel/questions/NamedStructurePropertySpecifier.java",
+    "src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java",
+    "src/main/java/org/batfish/datamodel/questions/OspfInterfacePropertySpecifier.java",
+    "src/main/java/org/batfish/datamodel/questions/OspfProcessPropertySpecifier.java",
+    "src/main/java/org/batfish/datamodel/questions/VxlanVniPropertySpecifier.java",
+    "src/main/java/org/batfish/specifier/DispositionSpecifier.java",
+    "src/main/java/org/batfish/specifier/Grammar.java",
+    "src/main/java/org/batfish/specifier/ReferenceFilterGroupFilterSpecifier.java",
+    "src/main/java/org/batfish/specifier/RoutingProtocolSpecifier.java",
+    "src/main/java/org/batfish/specifier/SpecifierFactories.java",
+] + glob(["src/main/java/org/batfish/specifier/parboiled/*.java"])
+
 java_library(
-    name = "common",
-    srcs = glob([
-        "src/main/**/*.java",
-    ]),
+    name = "specifier_common",
+    srcs = specifier_common_srcs,
+    deps = [
+        ":common_lib",
+        ":parser_common",
+        "//projects/bdd",
+        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
+        "@maven//:com_fasterxml_jackson_core_jackson_databind",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_re2j_re2j",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_apache_commons_commons_text",
+        "@maven//:org_parboiled_parboiled_core",
+        "@maven//:org_parboiled_parboiled_java",
+    ],
+)
+
+pmd_test(
+    name = "specifier_common_pmd",
+    lib = ":specifier_common",
+)
+
+###################################################################
+### common_lib is the bulk of the batfish-common-protocol common code.
+### It is so cyclicly dependent that it must be compiled as one unit
+### rather than using efficient, modular, incremental compilation.
+###
+### TODO: actually have a sensible directory structure and modules
+###################################################################
+java_library(
+    name = "common_lib",
+    srcs = glob(
+        [
+            "src/main/**/*.java",
+        ],
+        exclude = specifier_common_srcs + parser_common_srcs,
+    ),
     plugins = [
         "//:auto_service_plugin",
     ],
@@ -75,6 +157,7 @@ java_library(
         "@maven//:org_glassfish_jersey_inject_jersey_hk2",
     ],
     deps = [
+        ":parser_common",
         "//projects/bdd",
         "@maven//:com_fasterxml_jackson_core_jackson_annotations",
         "@maven//:com_fasterxml_jackson_core_jackson_core",
@@ -110,6 +193,25 @@ java_library(
     ],
 )
 
+pmd_test(
+    name = "common_lib_pmd",
+    lib = ":common_lib",
+)
+
+###################################################################
+### common is a virtual dependency aggregating and exporting the
+### submodules in this directory so that downstream code does not
+### need to change when the internal module structure changes.
+###################################################################
+java_library(
+    name = "common",
+    exports = [
+        ":common_lib",
+        ":parser_common",
+        ":specifier_common",
+    ],
+)
+
 java_library(
     name = "common_testlib",
     testonly = True,
@@ -132,6 +234,11 @@ java_library(
         "@maven//:org_parboiled_parboiled_core",
         "@maven//:org_parboiled_parboiled_java",
     ],
+)
+
+pmd_test(
+    name = "common_testlib_pmd",
+    lib = ":common_testlib",
 )
 
 junit_tests(
@@ -298,9 +405,4 @@ genrule(
 BATFISH_VERSION="$$(grep -1 batfish-parent $(location //projects:pom.xml) | grep version | sed 's/[<>]/|/g' | cut -f3 -d\\|)"
 sed s/\\$${project.version}/$${BATFISH_VERSION}/ $(location src/main/resources/org/batfish/common/common.properties) > "$@"
 """,
-)
-
-pmd_test(
-    name = "pmd",
-    lib = ":common",
 )


### PR DESCRIPTION
Since the parboiled parser does not play nice with Bazel code coverage,
pull it into its own library. Much like parser_common, I had a huge
challenge with modularity as the existing code doesn't really have
any.

Related work: removing the parser_common files from being compiled
twice, adding the missing dependency, adding missing pmd_test,
and making a "virtual :common" target to ensure that no existing
code has to be changed (even downstream).

commit-id:d4ccf516

---

**Stack**:
- #8518
- #8517
- #8515 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*