### PR TITLE
DEFAULT_PACKET_LENGTH: move from PHC to HeaderSpace

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -2,7 +2,7 @@ package org.batfish.common.bdd;
 
 import static org.batfish.common.bdd.BDDFlowConstraintGenerator.RefineAll.refineAll;
 import static org.batfish.common.bdd.BDDFlowConstraintGenerator.RefineFirst.refineFirst;
-import static org.batfish.datamodel.PacketHeaderConstraintsUtil.DEFAULT_PACKET_LENGTH;
+import static org.batfish.datamodel.HeaderSpace.DEFAULT_PACKET_LENGTH;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -22,6 +22,9 @@ import javax.annotation.Nullable;
 
 public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
 
+  /** default packet length */
+  public static final int DEFAULT_PACKET_LENGTH = 512;
+
   private static <C extends Collection<?>> C nullIfEmpty(C collection) {
     return collection == null ? null : collection.isEmpty() ? null : collection;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
@@ -34,9 +34,6 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
 @ParametersAreNonnullByDefault
 public class PacketHeaderConstraintsUtil {
 
-  /** default packet length */
-  public static final int DEFAULT_PACKET_LENGTH = 512;
-
   /**
    * Convert {@link PacketHeaderConstraints} to an {@link AclLineMatchExpr}.
    *

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
@@ -1,6 +1,6 @@
 package org.batfish.common.bdd;
 
-import static org.batfish.datamodel.PacketHeaderConstraintsUtil.DEFAULT_PACKET_LENGTH;
+import static org.batfish.datamodel.HeaderSpace.DEFAULT_PACKET_LENGTH;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstPort;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIcmpCode;


### PR DESCRIPTION
HeaderSpace is much closer to being a 'core' datamodel class; it does not have
gross dependencies like on specifiers.

This makes some downstream work much easier.

commit-id:52cd4284

---

**Stack**:
- #8517
- #8515
- #8516 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*