### PR TITLE
PAN: revisit permit/deny logic when Palo Alto's "App-ID" has to be used

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1740,16 +1740,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
         serviceDisjuncts.add(
             new AndMatchExpr(ImmutableList.of(applicationMatchNotDefault, serviceMatch)));
       } else if (serviceName.equals(ServiceBuiltIn.APPLICATION_DEFAULT.getName())) {
-        if (rule.getAction() == LineAction.PERMIT) {
-          // Since Batfish cannot currently match above L4, we follow Cisco-fragments-like logic:
-          // When permitting an application, optimistically permit all traffic where the L4 rule
-          // matches, assuming it is this application. But when blocking a specific application, do
-          // not block all matching L4 traffic, since we can't know it is this specific application.
-          serviceDisjuncts.add(
-              new OrMatchExpr(
-                  matchServicesForApplications(rule, vsys, appOverrideAcls, true),
-                  matchServiceApplicationDefaultTraceElement()));
-        }
+        serviceDisjuncts.add(
+            new OrMatchExpr(
+                matchServicesForApplications(rule, vsys, appOverrideAcls, true),
+                matchServiceApplicationDefaultTraceElement()));
       } else if (serviceName.equals(ServiceBuiltIn.SERVICE_HTTP.getName())) {
         AclLineMatchExpr serviceMatch = ServiceBuiltIn.SERVICE_HTTP.toAclLineMatchExpr();
 
@@ -1800,7 +1794,9 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                     .map(
                         a ->
                             aclLineMatchExprForApplication(
-                                a, appOverrideAclsMap, null, applicationDefaultService))
+                                a, appOverrideAclsMap, null, applicationDefaultService, rule, _w))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
                     .collect(ImmutableList.toImmutableList()),
                 matchApplicationGroupTraceElement(name, vsysName, _filename)));
       }
@@ -1808,12 +1804,15 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       Application a = containingVsys.getApplications().get(name);
       // If the reference is contained by a vsys, should match an application or group above
       assert a != null;
-      return ImmutableList.of(
+      Optional<AclLineMatchExpr> expr =
           aclLineMatchExprForApplication(
               a,
               appOverrideAclsMap,
               matchApplicationObjectTraceElement(name, vsysName, _filename),
-              applicationDefaultService));
+              applicationDefaultService,
+              rule,
+              _w);
+      return expr.isPresent() ? ImmutableList.of(expr.get()) : ImmutableList.of();
     }
 
     if (isBuiltInApp(name)) {
@@ -1824,7 +1823,11 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                       app,
                       appOverrideAclsMap,
                       matchBuiltInApplicationTraceElement(name),
-                      applicationDefaultService))
+                      applicationDefaultService,
+                      rule,
+                      _w))
+          .filter(Optional::isPresent)
+          .map(Optional::get)
           .collect(ImmutableList.toImmutableList());
     }
     // Did not find in the right hierarchy, so stop and warn.
@@ -1836,32 +1839,43 @@ public class PaloAltoConfiguration extends VendorConfiguration {
   }
 
   /** Create an {@link AclLineMatchExpr} matching any services in the specified application. */
-  private AclLineMatchExpr aclLineMatchExprForApplication(
+  @VisibleForTesting
+  public static Optional<AclLineMatchExpr> aclLineMatchExprForApplication(
       Application application,
       Map<String, AclLineMatchExpr> appOverrideAclsMap,
       @Nullable TraceElement traceElement,
-      boolean applicationDefaultService) {
+      boolean applicationDefaultService,
+      SecurityRule rule,
+      Warnings w) {
     String appName = application.getName();
 
     if (appOverrideAclsMap.containsKey(appName)) {
-      return appOverrideAclsMap.get(appName);
+      return Optional.of(appOverrideAclsMap.get(appName));
+    }
+
+    // Since Batfish cannot currently match above L4, we follow Cisco-fragments-like logic:
+    // When permitting an application, optimistically permit all traffic where the L4 rule
+    // matches, assuming it is this application. But when blocking a specific application, do
+    // not block all matching L4 traffic, since we can't know it is this specific application.
+    if (rule.getAction() == LineAction.DENY) {
+      return Optional.empty();
     }
 
     // If we're not using application-default services,
     // Assume application matches regardless of service-y signature
     if (!applicationDefaultService) {
-      return new TrueExpr(traceElement);
+      return Optional.of(new TrueExpr(traceElement));
     }
 
     AclLineMatchExpr appExpr =
         new OrMatchExpr(
             application.getServices().stream()
-                .map(s -> s.toMatchExpr(_w))
+                .map(s -> s.toMatchExpr(w))
                 .collect(ImmutableList.toImmutableList()),
             traceElement);
 
     if (appOverrideAclsMap.isEmpty()) {
-      return appExpr;
+      return Optional.of(appExpr);
     }
 
     // Match the application expr iff no app-override rules are matched
@@ -1869,7 +1883,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     ImmutableList.Builder<AclLineMatchExpr> conjunctions = ImmutableList.builder();
     appOverrideAclsMap.values().forEach(o -> conjunctions.add(new NotMatchExpr(o)));
     conjunctions.add(appExpr);
-    return new AndMatchExpr(conjunctions.build());
+    return Optional.of(new AndMatchExpr(conjunctions.build()));
   }
 
   private List<AclLineMatchExpr> matchServicesForApplications(

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1804,15 +1804,15 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       Application a = containingVsys.getApplications().get(name);
       // If the reference is contained by a vsys, should match an application or group above
       assert a != null;
-      Optional<AclLineMatchExpr> expr =
-          aclLineMatchExprForApplication(
+      return aclLineMatchExprForApplication(
               a,
               appOverrideAclsMap,
               matchApplicationObjectTraceElement(name, vsysName, _filename),
               applicationDefaultService,
               rule,
-              _w);
-      return expr.isPresent() ? ImmutableList.of(expr.get()) : ImmutableList.of();
+              _w)
+          .map(e -> ImmutableList.of(e))
+          .orElse(ImmutableList.of());
     }
 
     if (isBuiltInApp(name)) {
@@ -1849,6 +1849,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       Warnings w) {
     String appName = application.getName();
 
+    // an overridden application uses L4 definitions and skips app-id, so we can safely just match
+    // its L4 definition from this map.
     if (appOverrideAclsMap.containsKey(appName)) {
       return Optional.of(appOverrideAclsMap.get(appName));
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2057,7 +2057,10 @@ public final class PaloAltoGrammarTest {
     // tcp or udp will match application bittorrent
     Flow bitTorrentMatch = createFlow("1.1.2.2", "1.1.1.2", IpProtocol.TCP, 1, 999);
 
-    // Confirm flow matching bittorrent with Palo Alto's "App-ID" is not denied.
+    // Confirm flow matching bittorrent with Palo Alto's "App-ID" is not denied despite the deny
+    // rule
+    // in the config.
+    // it instead matches the implicit rule permitting intra-zone traffic
     assertThat(
         c,
         hasInterface(if1name, hasOutgoingOriginalFlowFilter(accepts(bitTorrentMatch, if1name, c))));

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2048,6 +2048,22 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testAppId() {
+    String hostname = "app-id";
+    Configuration c = parseConfig(hostname);
+
+    String if1name = "ethernet1/1";
+
+    // tcp or udp will match application bittorrent
+    Flow bitTorrentMatch = createFlow("1.1.2.2", "1.1.1.2", IpProtocol.TCP, 1, 999);
+
+    // Confirm flow matching bittorrent with Palo Alto's "App-ID" is not denied.
+    assertThat(
+        c,
+        hasInterface(if1name, hasOutgoingOriginalFlowFilter(accepts(bitTorrentMatch, if1name, c))));
+  }
+
+  @Test
   public void testSecurityRulesNotExplicitlyMatched() {
     /*
     Setup: Device has an interface in a zone with intrazone security rules. If flows leaving the

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2058,8 +2058,7 @@ public final class PaloAltoGrammarTest {
     Flow bitTorrentMatch = createFlow("1.1.2.2", "1.1.1.2", IpProtocol.TCP, 1, 999);
 
     // Confirm flow matching bittorrent with Palo Alto's "App-ID" is not denied despite the deny
-    // rule
-    // in the config.
+    // rule in the config.
     // it instead matches the implicit rule permitting intra-zone traffic
     assertThat(
         c,

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/app-id
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/app-id
@@ -1,0 +1,15 @@
+set deviceconfig system hostname app-id
+set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
+
+set zone z1 network layer3 ethernet1/1
+
+set rulebase security rules BLOCK-Apps to any
+set rulebase security rules BLOCK-Apps from any
+set rulebase security rules BLOCK-Apps source any
+set rulebase security rules BLOCK-Apps destination any
+set rulebase security rules BLOCK-Apps source-user any
+set rulebase security rules BLOCK-Apps category any
+set rulebase security rules BLOCK-Apps application bittorrent
+set rulebase security rules BLOCK-Apps service any
+set rulebase security rules BLOCK-Apps action deny
+


### PR DESCRIPTION
If Palo Alto's "App-ID" has to be used, it is possible there is a flow it will match, and it is possible there is a flow it will not match. So a permit rule should be permitted ("something is allowed") but a deny rule should not be denied ("something is not matched").

Previously we were only applying this logic for application-default - this PR does it for any service.