### PR TITLE
Garbage collect network blobs older than oldest snapshot

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -2027,15 +2027,13 @@ public class FileBasedStorage implements StorageProvider {
             } catch (IOException e) {
               LOGGER.error(
                   String.format(
-                      "Failed to expunge blob '%s' of networkId '%s': %s",
-                      path.getFileName(), networkId, Throwables.getStackTraceAsString(e)));
+                      "Failed to expunge blob '%s' of networkId '%s'",
+                      path.getFileName(), networkId),
+                  e);
             }
           });
     } catch (IOException e) {
-      LOGGER.error(
-          String.format(
-              "Failed to expunge blobs from networkId '%s': %s",
-              networkId, Throwables.getStackTraceAsString(e)));
+      LOGGER.error(String.format("Failed to expunge blobs from networkId '%s'", networkId), e);
     }
   }
 
@@ -2055,8 +2053,9 @@ public class FileBasedStorage implements StorageProvider {
                 } catch (IOException e) {
                   LOGGER.error(
                       String.format(
-                          "Error loading snapshot metadata for networkId '%s' snapshotId '%s': %s",
-                          networkId, snapshotId, Throwables.getStackTraceAsString(e)));
+                          "Error loading snapshot metadata for networkId '%s' snapshotId '%s'",
+                          networkId, snapshotId),
+                      e);
                   // Just skip this snapshot
                   return Optional.<SnapshotMetadata>empty();
                 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -884,7 +884,7 @@ public final class FileBasedStorageTest {
   }
 
   @Test
-  public void testGetOldestExtantSnapshotFileLastModifiedDate() throws IOException {
+  public void testGetOldestSnapshotCreationTime() throws IOException {
     NetworkId networkId = new NetworkId("network-id");
     SnapshotId extantSnapshotId = new SnapshotId("snapshot-id");
     SnapshotId orphanedSnapshotId = new SnapshotId("orphaned-snapshot-id");


### PR DESCRIPTION
- fixes batfish/batfish#8546
- during network GC, fetch oldest last modified time of all extant snapshot files
- delete network blobs older than that time, or now minus GC skew allowance if earlier