### PR TITLE
SONiC: trim YAML file before parsing

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sonic/grammar/SonicControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sonic/grammar/SonicControlPlaneExtractor.java
@@ -86,7 +86,9 @@ public class SonicControlPlaneExtractor implements ControlPlaneExtractor {
     if (snmpYmlFilename != null) {
       ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
       try {
-        SnmpYml snmpYml = mapper.readValue(_fileTexts.get(snmpYmlFilename), SnmpYml.class);
+        // Trim YAML before deserializing since Jackson doesn't ignore, e.g., a trailing tab,
+        // but SONiC doesn't mind.
+        SnmpYml snmpYml = mapper.readValue(_fileTexts.get(snmpYmlFilename).trim(), SnmpYml.class);
         _configuration.setSnmpYml(snmpYml);
       } catch (JsonProcessingException exception) {
         ErrorDetails errorDetails =

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sonic/grammar/snapshots/snmp_yml/sonic_configs/device/snmp.yml
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sonic/grammar/snapshots/snmp_yml/sonic_configs/device/snmp.yml
@@ -1,3 +1,5 @@
 snmp_rocommunity: public
 snmp_rocommunity6: public6
 snmp_location: dc
+#note: special character on the next line is deliberate; do not remove.
+


### PR DESCRIPTION
Special characters mess up Jackson, but are allowed
on-device.