### PR TITLE
Add routing policy expr for matching BGP cluster list length

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -33,6 +33,7 @@ import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>>
     extends AbstractRoute
     implements HasReadableAsPath,
+        HasReadableClusterList,
         HasReadableCommunities,
         HasReadableLocalPreference,
         HasReadableOriginType,
@@ -225,6 +226,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
   public abstract static class Builder<B extends Builder<B, R>, R extends BgpRoute<B, R>>
       extends AbstractRouteBuilder<B, R>
       implements HasWritableAsPath<B, R>,
+          HasWritableClusterList<B, R>,
           HasWritableCommunities<B, R>,
           HasWritableLocalPreference<B, R>,
           HasWritableOriginType<B, R>,
@@ -278,8 +280,8 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
       return _asPath;
     }
 
-    @Nonnull
-    public Set<Long> getClusterList() {
+    @Override
+    public @Nonnull Set<Long> getClusterList() {
       return _clusterList instanceof ImmutableSet
           ? _clusterList
           : Collections.unmodifiableSet(_clusterList);
@@ -344,6 +346,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
     }
 
     /** Overwrite the clusterList attribute */
+    @Override
     public B setClusterList(Set<Long> clusterList) {
       _clusterList = clusterList instanceof ImmutableSet ? clusterList : new HashSet<>(clusterList);
       return getThis();
@@ -519,6 +522,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
     return _attributes._asPath;
   }
 
+  @Override
   public @Nonnull Set<Long> getClusterList() {
     return _attributes._clusterList;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HasReadableClusterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HasReadableClusterList.java
@@ -1,0 +1,11 @@
+package org.batfish.datamodel;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/** A route or route builder with readable BGP cluster-list. */
+public interface HasReadableClusterList {
+
+  @Nonnull
+  Set<Long> getClusterList();
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HasWritableClusterList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HasWritableClusterList.java
@@ -1,0 +1,16 @@
+package org.batfish.datamodel;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/**
+ * A generic route builder of type {@code B} for routes of type {@code R} with a BGP cluster list
+ * that may be written.
+ */
+public interface HasWritableClusterList<
+        B extends AbstractRouteBuilder<B, R>, R extends AbstractRoute>
+    extends HasReadableClusterList {
+
+  @Nonnull
+  B setClusterList(Set<Long> clusterList);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
@@ -66,6 +66,7 @@ import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MainRib;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
+import org.batfish.datamodel.routing_policy.expr.MatchClusterListLength;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -135,9 +136,16 @@ public final class CommunityStructuresVerifier {
 
   private static final class CommunityStructuresBooleanExprVerifier
       implements BooleanExprVisitor<Void, CommunityStructuresVerifierContext> {
+
     @Override
     public Void visitBooleanExprs(
         StaticBooleanExpr staticBooleanExpr, CommunityStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchClusterListLength(
+        MatchClusterListLength matchClusterListLength, CommunityStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
@@ -21,6 +21,7 @@ import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
+import org.batfish.datamodel.routing_policy.expr.MatchClusterListLength;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -92,6 +93,12 @@ public final class AsPathStructuresVerifier {
     @Override
     public Void visitBooleanExprs(
         StaticBooleanExpr staticBooleanExpr, AsPathStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchClusterListLength(
+        MatchClusterListLength matchClusterListLength, AsPathStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprVisitor.java
@@ -7,6 +7,8 @@ import org.batfish.datamodel.routing_policy.expr.BooleanExprs.StaticBooleanExpr;
 /** A visitor of {@link BooleanExpr} that takes 1 generic argument and returns a generic value. */
 public interface BooleanExprVisitor<T, U> {
 
+  T visitMatchClusterListLength(MatchClusterListLength matchClusterListLength, U arg);
+
   T visitBooleanExprs(StaticBooleanExpr staticBooleanExpr, U arg);
 
   T visitCallExpr(CallExpr callExpr, U arg);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchClusterListLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchClusterListLength.java
@@ -1,0 +1,95 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.HasReadableClusterList;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+
+/**
+ * Boolean expression that returns {@code true} iff the {@link Environment}'s route's BGP Cluster
+ * List Length matches a provided {@link IntExpr} using a provided {@link IntComparator}.
+ *
+ * <p>Assumes a length of 0 is source route does not have a cluster list.
+ */
+@ParametersAreNonnullByDefault
+public final class MatchClusterListLength extends BooleanExpr {
+  @Override
+  public <T, U> T accept(BooleanExprVisitor<T, U> visitor, U arg) {
+    return visitor.visitMatchClusterListLength(this, arg);
+  }
+
+  @Override
+  public Result evaluate(Environment environment) {
+    // Treat as 0 if undefined
+    int effectiveClusterListLength;
+    if (environment.getUseOutputAttributes()
+        && environment.getOutputRoute() instanceof HasReadableClusterList) {
+      effectiveClusterListLength =
+          ((HasReadableClusterList) environment.getOutputRoute()).getClusterList().size();
+    } else if (environment.getOriginalRoute() instanceof HasReadableClusterList) {
+      effectiveClusterListLength =
+          ((HasReadableClusterList) environment.getOriginalRoute()).getClusterList().size();
+    } else {
+      effectiveClusterListLength = 0;
+    }
+    int rhs = _rhs.evaluate(environment);
+    return _comparator.apply(effectiveClusterListLength, rhs);
+  }
+
+  @JsonProperty(PROP_COMPARATOR)
+  public @Nonnull IntComparator getCmp() {
+    return _comparator;
+  }
+
+  @JsonProperty(PROP_RHS)
+  public @Nonnull IntExpr getRhs() {
+    return _rhs;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof MatchClusterListLength)) {
+      return false;
+    }
+    MatchClusterListLength other = (MatchClusterListLength) obj;
+    return _comparator == other._comparator && Objects.equals(_rhs, other._rhs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_comparator.ordinal(), _rhs);
+  }
+
+  public static @Nonnull MatchClusterListLength of(IntComparator comparator, IntExpr rhs) {
+    return new MatchClusterListLength(comparator, rhs);
+  }
+
+  @JsonCreator
+  private static MatchClusterListLength create(
+      @Nullable @JsonProperty(PROP_COMPARATOR) IntComparator comparator,
+      @Nullable @JsonProperty(PROP_RHS) IntExpr rhs) {
+    checkArgument(comparator != null, "%s must be provided", PROP_COMPARATOR);
+    checkArgument(rhs != null, "%s must be provided", PROP_RHS);
+    return new MatchClusterListLength(comparator, rhs);
+  }
+
+  private MatchClusterListLength(IntComparator comparator, IntExpr rhs) {
+    _comparator = comparator;
+    _rhs = rhs;
+  }
+
+  private static final String PROP_COMPARATOR = "comparator";
+  private static final String PROP_RHS = "rhs";
+
+  private final @Nonnull IntComparator _comparator;
+  private final @Nonnull IntExpr _rhs;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchClusterListLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchClusterListLength.java
@@ -44,7 +44,7 @@ public final class MatchClusterListLength extends BooleanExpr {
   }
 
   @JsonProperty(PROP_COMPARATOR)
-  public @Nonnull IntComparator getCmp() {
+  public @Nonnull IntComparator getComparator() {
     return _comparator;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchClusterListLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchClusterListLength.java
@@ -16,7 +16,7 @@ import org.batfish.datamodel.routing_policy.Result;
  * Boolean expression that returns {@code true} iff the {@link Environment}'s route's BGP Cluster
  * List Length matches a provided {@link IntExpr} using a provided {@link IntComparator}.
  *
- * <p>Assumes a length of 0 is source route does not have a cluster list.
+ * <p>Assumes a length of 0 if source route does not have a cluster list.
  */
 @ParametersAreNonnullByDefault
 public final class MatchClusterListLength extends BooleanExpr {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchClusterListLengthTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchClusterListLengthTest.java
@@ -1,0 +1,92 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OriginMechanism;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ReceivedFromIp;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.junit.Test;
+
+/** Tests of {@link MatchClusterListLength} */
+public final class MatchClusterListLengthTest {
+
+  @Test
+  public void testJacksonSerialization() {
+    BooleanExpr obj = MatchClusterListLength.of(IntComparator.EQ, new LiteralInt(1));
+    assertThat(BatfishObjectMapper.clone(obj, BooleanExpr.class), equalTo(obj));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    BooleanExpr obj = MatchClusterListLength.of(IntComparator.EQ, new LiteralInt(1));
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    MatchClusterListLength obj = MatchClusterListLength.of(IntComparator.EQ, new LiteralInt(1));
+    new EqualsTester()
+        .addEqualityGroup(obj, MatchClusterListLength.of(IntComparator.EQ, new LiteralInt(1)))
+        .addEqualityGroup(MatchClusterListLength.of(IntComparator.GE, new LiteralInt(1)))
+        .addEqualityGroup(MatchClusterListLength.of(IntComparator.EQ, new LiteralInt(0)))
+        .testEquals();
+  }
+
+  @Test
+  public void testEvaluate() {
+    BooleanExpr matchClusterListLength_0 =
+        MatchClusterListLength.of(IntComparator.EQ, new LiteralInt(0));
+    BooleanExpr matchClusterListLength_1 =
+        MatchClusterListLength.of(IntComparator.EQ, new LiteralInt(1));
+    Configuration c =
+        Configuration.builder()
+            .setHostname("h")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    Bgpv4Route baseBgpRoute =
+        Bgpv4Route.builder()
+            .setNetwork(Prefix.ZERO)
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.IBGP)
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("192.0.2.1")))
+            .setNextHop(NextHopDiscard.instance())
+            .build();
+    {
+      Bgpv4Route route = baseBgpRoute.toBuilder().setClusterList(ImmutableSet.of(10L)).build();
+      Environment e = Environment.builder(c).setOriginalRoute(route).build();
+      assertFalse(matchClusterListLength_0.evaluate(e).getBooleanValue());
+      assertTrue(matchClusterListLength_1.evaluate(e).getBooleanValue());
+    }
+    {
+      Bgpv4Route route = baseBgpRoute;
+      Environment e = Environment.builder(c).setOriginalRoute(route).build();
+      assertTrue(matchClusterListLength_0.evaluate(e).getBooleanValue());
+      assertFalse(matchClusterListLength_1.evaluate(e).getBooleanValue());
+    }
+    {
+      // route without cluster list is treated as having cluster list length 0
+      ConnectedRoute route = new ConnectedRoute(Prefix.ZERO, "foo");
+      Environment e = Environment.builder(c).setOriginalRoute(route).build();
+      assertTrue(matchClusterListLength_0.evaluate(e).getBooleanValue());
+      assertFalse(matchClusterListLength_1.evaluate(e).getBooleanValue());
+    }
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollector.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
+import org.batfish.datamodel.routing_policy.expr.MatchClusterListLength;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -46,6 +47,13 @@ import org.batfish.minesweeper.SymbolicAsPathRegex;
 @ParametersAreNonnullByDefault
 public class BooleanExprAsPathCollector
     implements BooleanExprVisitor<Set<SymbolicAsPathRegex>, Configuration> {
+
+  @Override
+  public Set<SymbolicAsPathRegex> visitMatchClusterListLength(
+      MatchClusterListLength matchClusterListLength, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
   @Override
   public Set<SymbolicAsPathRegex> visitBooleanExprs(
       StaticBooleanExpr staticBooleanExpr, Configuration arg) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
@@ -18,6 +18,7 @@ import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
 import org.batfish.datamodel.routing_policy.expr.HasRoute;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
+import org.batfish.datamodel.routing_policy.expr.MatchClusterListLength;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
@@ -41,6 +42,13 @@ import org.batfish.minesweeper.CommunityVar;
 @ParametersAreNonnullByDefault
 public class BooleanExprVarCollector
     implements BooleanExprVisitor<Set<CommunityVar>, Configuration> {
+
+  @Override
+  public Set<CommunityVar> visitMatchClusterListLength(
+      MatchClusterListLength matchClusterListLength, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
   @Override
   public Set<CommunityVar> visitBooleanExprs(
       StaticBooleanExpr staticBooleanExpr, Configuration arg) {


### PR DESCRIPTION
- match via IntComparator against rhs IntExpr
- treat routes/builders without cluster list as having list of length 0