### PR TITLE
Use https instead of git (ssh) protocol to fetch autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v4.3.21
     hooks:
         -   id: isort
--   repo: git@github.com:humitos/mirrors-autoflake.git
+-   repo: https://github.com/humitos/mirrors-autoflake.git
     rev: v1.3
     hooks:
         - id: autoflake


### PR DESCRIPTION
- removes need for github-known SSH key to run pre-commit