### PR TITLE
Community: make memoized strings transient, fix style

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -23,7 +23,7 @@ import org.batfish.datamodel.Ip;
 @ParametersAreNonnullByDefault
 public final class ExtendedCommunity extends Community {
 
-  private static final Set<Byte> _validTypes =
+  private static final Set<Byte> VALID_TYPES =
       ImmutableSet.of(
           (byte) 0x00,
           (byte) 0x01,
@@ -39,8 +39,8 @@ public final class ExtendedCommunity extends Community {
   private final long _localAdministrator;
 
   // Cached string representations
-  @Nullable private String _str;
-  @Nullable private String _regexStr;
+  @Nullable private transient String _str;
+  @Nullable private transient String _regexStr;
 
   private ExtendedCommunity(
       byte type, byte subType, long globalAdministrator, long localAdministrator) {
@@ -155,7 +155,7 @@ public final class ExtendedCommunity extends Community {
         type);
     byte typeByte = (byte) (type >> 8);
     checkArgument(
-        _validTypes.contains(typeByte), "Not a valid BGP extended community type: %s", type);
+        VALID_TYPES.contains(typeByte), "Not a valid BGP extended community type: %s", type);
     checkArgument(
         globalAdministrator >= 0 && localAdministrator >= 0,
         "Administrator values must be positive");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/StandardCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/StandardCommunity.java
@@ -50,7 +50,7 @@ public final class StandardCommunity extends Community {
   private final long _value;
 
   // Cached string representation
-  @Nullable private String _str;
+  @Nullable private transient String _str;
 
   private StandardCommunity(long value) {
     checkArgument(


### PR DESCRIPTION
There's no need to include memoized string representations in serialized
output. Also fix the CASE_FORMAT of a private static final variable.

commit-id:3623fb62