### PR TITLE
Extended Communities: Add a CommunityMatchExpr for opaque extended communities

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
@@ -49,6 +49,7 @@ import org.batfish.datamodel.routing_policy.communities.HasCommunity;
 import org.batfish.datamodel.routing_policy.communities.InputCommunities;
 import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
+import org.batfish.datamodel.routing_policy.communities.OpaqueExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.RouteTargetExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.SetCommunities;
 import org.batfish.datamodel.routing_policy.communities.SiteOfOriginExtendedCommunities;
@@ -442,6 +443,13 @@ public final class CommunityStructuresVerifier {
         ExtendedCommunityLocalAdministratorMatch extendedCommunityLocalAdministratorMatch,
         CommunityStructuresVerifierContext arg) {
       // nothing that can be checked statically
+      return null;
+    }
+
+    @Override
+    public Void visitOpaqueExtendedCommunities(
+        OpaqueExtendedCommunities opaqueExtendedCommunities,
+        CommunityStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -228,6 +228,12 @@ public final class ExtendedCommunity extends Community {
     return (_type == 0x00 || _type == 0x01) && _subType == 0x10;
   }
 
+  /** Check whether this community is opaque */
+  public boolean isOpaque() {
+    // https://tools.ietf.org/html/rfc4360
+    return _type == 0x03 || _type == 0x43;
+  }
+
   /**
    * Returns the global administrator value, if applicable to this type of extended community. May
    * be either 2 or 4 bytes depending on type/subtype.
@@ -256,6 +262,24 @@ public final class ExtendedCommunity extends Community {
           String.format("Extended community does not have a local administrator: %s", this));
     }
     return _value & (VALUE_MAX >> globalAdministratorBits());
+  }
+
+  /** Return true if the value field contains a subtype */
+  private boolean hasSubtype() {
+    return true;
+  }
+
+  /**
+   * Returns the subtype value, if applicable to this type of extended community.
+   *
+   * @throws UnsupportedOperationException if this extended community does not have a subtype.
+   */
+  public int getSubtype() {
+    if (!hasSubtype()) {
+      throw new UnsupportedOperationException(
+          String.format("Extended community does not have a subtype: %s", this));
+    }
+    return _subType;
   }
 
   /** Return the 6 byte value */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluator.java
@@ -167,6 +167,17 @@ public final class CommunityMatchExprEvaluator
   }
 
   @Override
+  public Boolean visitOpaqueExtendedCommunities(
+      OpaqueExtendedCommunities opaqueExtendedCommunities, Community arg) {
+    if (!(arg instanceof ExtendedCommunity)) {
+      return false;
+    }
+    return ((ExtendedCommunity) arg).isOpaque()
+        && opaqueExtendedCommunities.getIsTransitive() == arg.isTransitive()
+        && opaqueExtendedCommunities.getSubtype() == ((ExtendedCommunity) arg).getSubtype();
+  }
+
+  @Override
   public @Nonnull Boolean visitRouteTargetExtendedCommunities(
       RouteTargetExtendedCommunities routeTargetExtendedCommunities, Community arg) {
     if (!(arg instanceof ExtendedCommunity)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprVisitor.java
@@ -43,6 +43,8 @@ public interface CommunityMatchExprVisitor<T, U> {
   T visitExtendedCommunityLocalAdministratorMatch(
       ExtendedCommunityLocalAdministratorMatch extendedCommunityLocalAdministratorMatch, U arg);
 
+  T visitOpaqueExtendedCommunities(OpaqueExtendedCommunities opaqueExtendedCommunities, U arg);
+
   T visitRouteTargetExtendedCommunities(
       RouteTargetExtendedCommunities routeTargetExtendedCommunities, U arg);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/OpaqueExtendedCommunities.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/OpaqueExtendedCommunities.java
@@ -1,0 +1,57 @@
+package org.batfish.datamodel.routing_policy.communities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * Matches a {@link org.batfish.datamodel.bgp.community.Community} iff it is an opaque extended
+ * community of the given type specifications.
+ */
+public final class OpaqueExtendedCommunities extends CommunityMatchExpr {
+  private final boolean _isTransitive;
+  private final int _subType;
+
+  private OpaqueExtendedCommunities(boolean isTransitive, int subType) {
+    _isTransitive = isTransitive;
+    _subType = subType;
+  }
+
+  public static OpaqueExtendedCommunities of(boolean isTransitive, int subType) {
+    return new OpaqueExtendedCommunities(isTransitive, subType);
+  }
+
+  @Override
+  public <T, U> T accept(CommunityMatchExprVisitor<T, U> visitor, U arg) {
+    return visitor.visitOpaqueExtendedCommunities(this, arg);
+  }
+
+  @JsonProperty(PROP_TRANSITIVE)
+  public boolean getIsTransitive() {
+    return _isTransitive;
+  }
+
+  @JsonProperty(PROP_SUBTYPE)
+  public int getSubtype() {
+    return _subType;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof OpaqueExtendedCommunities)) {
+      return false;
+    }
+    OpaqueExtendedCommunities that = (OpaqueExtendedCommunities) obj;
+    return _isTransitive == that._isTransitive && _subType == that._subType;
+  }
+
+  private static final String PROP_TRANSITIVE = "transitive";
+  private static final String PROP_SUBTYPE = "subType";
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_isTransitive, _subType);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
@@ -239,6 +239,14 @@ public final class ExtendedCommunityTest {
   }
 
   @Test
+  public void testIsOpaque() {
+    assertFalse(ExtendedCommunity.of(0x0010, 1, 1).isOpaque());
+    assertFalse(ExtendedCommunity.of(0x0110, 1, 1).isOpaque());
+    assertTrue(ExtendedCommunity.of(0x0300, 1, 1).isOpaque());
+    assertTrue(ExtendedCommunity.opaque(false, 1, 1).isOpaque());
+  }
+
+  @Test
   public void testGetGlobalAdmin() {
     assertThat(ExtendedCommunity.of(1, 2, 3).getGlobalAdministrator(), equalTo(2L));
     assertThat(
@@ -259,5 +267,12 @@ public final class ExtendedCommunityTest {
         ExtendedCommunity.of(0x01 << 8 | 1, 4294967295L, 1).getLocalAdministrator(), equalTo(1L));
     assertThat(
         ExtendedCommunity.of(0x01 << 8 | 1, 1, 42995L).getLocalAdministrator(), equalTo(42995L));
+  }
+
+  @Test
+  public void testGetSubType() {
+    assertThat(ExtendedCommunity.of(0x0201, 2, 3).getSubtype(), equalTo(0x01));
+    assertThat(ExtendedCommunity.opaque(true, 0x04, 3).getSubtype(), equalTo(0x04));
+    assertThat(ExtendedCommunity.target(1, 3).getSubtype(), equalTo(0x02));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluatorTest.java
@@ -197,6 +197,26 @@ public final class CommunityMatchExprEvaluatorTest {
   }
 
   @Test
+  public void testVisitOpaqueExtendedCommunities() {
+    assertTrue(
+        OpaqueExtendedCommunities.of(false, 0x00)
+            .accept(EVAL, ExtendedCommunity.opaque(false, 0x00, 1L)));
+    assertTrue(
+        OpaqueExtendedCommunities.of(true, 0x02)
+            .accept(EVAL, ExtendedCommunity.opaque(true, 0x02, 1L)));
+    assertFalse(OpaqueExtendedCommunities.of(true, 0x00).accept(EVAL, StandardCommunity.of(1L)));
+    assertFalse(
+        OpaqueExtendedCommunities.of(true, 0x00)
+            .accept(EVAL, ExtendedCommunity.of(0x0000, 1L, 1L)));
+    assertFalse(
+        OpaqueExtendedCommunities.of(true, 0x00)
+            .accept(EVAL, ExtendedCommunity.opaque(false, 0x00, 1L)));
+    assertFalse(
+        OpaqueExtendedCommunities.of(false, 0x03)
+            .accept(EVAL, ExtendedCommunity.opaque(false, 0x00, 1L)));
+  }
+
+  @Test
   public void testVisitRouteTargetExtendedCommunities() {
     assertTrue(
         RouteTargetExtendedCommunities.instance()

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDD.java
@@ -35,6 +35,7 @@ import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalA
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorLowMatch;
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorMatch;
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityLocalAdministratorMatch;
+import org.batfish.datamodel.routing_policy.communities.OpaqueExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.RouteTargetExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.SiteOfOriginExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighMatch;
@@ -181,6 +182,13 @@ public class CommunityMatchExprToBDD implements CommunityMatchExprVisitor<BDD, A
       ExtendedCommunityLocalAdministratorMatch extendedCommunityLocalAdministratorMatch, Arg arg) {
     throw new UnsupportedOperationException(
         "Currently not supporting matches on extended communities");
+  }
+
+  @Override
+  public BDD visitOpaqueExtendedCommunities(
+      OpaqueExtendedCommunities opaqueExtendedCommunities, Arg arg) {
+    throw new UnsupportedOperationException(
+        "Currently not supporting matches on opaque extended communities");
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollector.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalA
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorLowMatch;
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorMatch;
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityLocalAdministratorMatch;
+import org.batfish.datamodel.routing_policy.communities.OpaqueExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.RouteTargetExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.SiteOfOriginExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighMatch;
@@ -147,6 +148,12 @@ public class CommunityMatchExprVarCollector
       Configuration arg) {
     // This is not supported, but rather than throw we do nothing. If we end up needing to model
     // this structure, the later code will crash instead.
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<CommunityVar> visitOpaqueExtendedCommunities(
+      OpaqueExtendedCommunities opaqueExtendedCommunities, Configuration arg) {
     return ImmutableSet.of();
   }
 


### PR DESCRIPTION
Parametrized to allow it to match on more specific types of opaque ECs as needed. 

hasSubtype() trivially returns true right now as none of the supported ECs lack a subtype (see ExtendedCommunity's VALID_TYPES).