### PR TITLE
.bazelignore: remove unneeded maven state

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,13 +1,2 @@
-projects/allinone/target
-projects/coordinator/target
-projects/batfish/target
-projects/client/target
-projects/batfish-common-protocol/target
-projects/bdd/target
-projects/build-tools/target
-projects/minesweeper/target
-projects/question/target
-projects/symbolic/target
-projects/target
 containers
 .pytest_cache


### PR DESCRIPTION
**Stack**:
- #8584
- #8583 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*