### PR TITLE
black: upgrade to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         require_serial: true
         pass_filenames: false  # this is a global check, only run it once
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-isort


### PR DESCRIPTION
Work around a Python 3.9 issue with click. For more info, see
https://github.com/psf/black/issues/2964

commit-id:f2ffb26c