### PR TITLE
JunOS: allow colon in names

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3476,6 +3476,7 @@ F_NameChar
   | '-'
   | '/'
   | '.'
+  | ':'
 ;
 
 // Any number of newlines, allowing whitespace in between

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5156,12 +5156,12 @@ public final class FlatJuniperGrammarTest {
     JuniperConfiguration c = parseJuniperConfig("name");
     assertThat(c.getMasterLogicalSystem().getPolicyStatements(), hasKeys("XX"));
     PolicyStatement ps = c.getMasterLogicalSystem().getPolicyStatements().get("XX");
-    assertThat(ps.getTerms(), hasKeys("10/8", "Dot.Name"));
+    assertThat(ps.getTerms(), hasKeys("10/8", "Colon:Name", "Dot.Name"));
 
     assertThat(
         ((ConcreteFirewallFilter) c.getMasterLogicalSystem().getFirewallFilters().get("filterName"))
             .getTerms(),
-        hasKeys("Dot.Name", "Slash/Name"));
+        hasKeys("Colon:Name", "Dot.Name", "Slash/Name"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/name
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/name
@@ -12,3 +12,6 @@ set firewall family inet filter filterName term Slash/Name then accept
 # '.' is allowed in names
 set policy-options policy-statement XX term Dot.Name from protocol bgp
 set firewall family inet filter filterName term Dot.Name then accept
+# ':' is allowed in names
+set policy-options policy-statement XX term Colon:Name from protocol bgp
+set firewall family inet filter filterName term Colon:Name then accept


### PR DESCRIPTION
E.g., policy-statements with IPv6 addresses in the name.