### PR TITLE
FileBasedStorage: don't throw if no blobs written yet

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -2016,7 +2016,11 @@ public class FileBasedStorage implements StorageProvider {
 
   /** Expunge blobs in a network older than the provided date. */
   private void expungeOldBlobs(NetworkId networkId, Instant blobExpungeBeforeDate) {
-    try (Stream<Path> blobs = Files.walk(getNetworkBlobsDir(networkId))) {
+    Path blobPath = getNetworkBlobsDir(networkId);
+    if (!Files.exists(blobPath)) {
+      return;
+    }
+    try (Stream<Path> blobs = Files.walk(blobPath)) {
       blobs.forEach(
           path -> {
             try {


### PR DESCRIPTION
Prevents

2022-12-06 07:11:43,019 ERROR storage.FileBasedStorage Failed to expunge blobs from networkId 'b5146401-c0a3-4419-9594-4103a92800da'
java.nio.file.NoSuchFileException: /data/containers/networks/b5146401-c0a3-4419-9594-4103a92800da/blobs
at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[?:?]
at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116) ~[?:?]
at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55) ~[?:?]
at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:149) ~[?:?]
at sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99) ~[?:?]
at java.nio.file.Files.readAttributes(Files.java:1764) ~[?:?]
at java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:219) ~[?:?]
at java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:276) ~[?:?]
at java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:322) ~[?:?]
at java.nio.file.FileTreeIterator.<init>(FileTreeIterator.java:71) ~[?:?]
at java.nio.file.Files.walk(Files.java:3825) ~[?:?]
at java.nio.file.Files.walk(Files.java:3879) ~[?:?]
at org.batfish.storage.FileBasedStorage.expungeOldBlobs(FileBasedStorage.java:2019) ~[allinone-bundle.jar:?]
at org.batfish.storage.FileBasedStorage.garbageCollectNetwork(FileBasedStorage.java:2013) ~[allinone-bundle.jar:?]
at org.batfish.storage.FileBasedStorage.runGarbageCollection(FileBasedStorage.java:2131) ~[allinone-bundle.jar:?]
at org.batfish.coordinator.WorkMgr.lambda$triggerGarbageCollection$1(WorkMgr.java:395) ~[allinone-bundle.jar:?]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
at java.lang.Thread.run(Thread.java:829) ~[?:?]