### PR TITLE
SearchRoutePolicies - only build AtomicPredicates for relevant policies.

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/ConfigAtomicPredicates.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/ConfigAtomicPredicates.java
@@ -1,8 +1,11 @@
 package org.batfish.minesweeper;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -15,6 +18,7 @@ import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.minesweeper.aspath.RoutePolicyStatementAsPathCollector;
 import org.batfish.minesweeper.communities.RoutePolicyStatementVarCollector;
+import org.batfish.minesweeper.utils.Tuple;
 
 /**
  * This class computes the community-regex and AS-path-regex atomic predicates for a single router
@@ -58,16 +62,20 @@ public class ConfigAtomicPredicates {
    * @param router the name of the router whose configuration is being analyzed
    * @param communities additional community regexes to track, from user-defined constraints
    * @param asPathRegexes additional as-path regexes to track, from user-defined constraints
+   * @param policies the set of policies to create AtomicPredicates for
    */
   public ConfigAtomicPredicates(
       IBatfish batfish,
       NetworkSnapshot snapshot,
       String router,
       @Nullable Set<CommunityVar> communities,
-      @Nullable Set<String> asPathRegexes) {
+      @Nullable Set<String> asPathRegexes,
+      @Nullable Collection<RoutingPolicy> policies) {
     _configuration = batfish.loadConfigurations(snapshot).get(router);
+    Collection<RoutingPolicy> usedPolicies =
+        policies == null ? _configuration.getRoutingPolicies().values() : policies;
 
-    Set<CommunityVar> allCommunities = findAllCommunities(communities);
+    Set<CommunityVar> allCommunities = findAllCommunities(communities, usedPolicies);
 
     // currently we only support regex matching for standard communities
     Predicate<CommunityVar> isStandardCommunity =
@@ -90,19 +98,37 @@ public class ConfigAtomicPredicates {
     for (int i = 0; i < nonStandardCommunityVars.length; i++) {
       _nonStandardCommunityLiterals.put(i + numAPs, nonStandardCommunityVars[i]);
     }
-
     _asPathRegexAtomicPredicates =
         new RegexAtomicPredicates<>(
-            findAllAsPathRegexes(asPathRegexes), SymbolicAsPathRegex.ALL_AS_PATHS);
+            findAllAsPathRegexes(asPathRegexes, usedPolicies), SymbolicAsPathRegex.ALL_AS_PATHS);
   }
 
   /**
-   * Identifies all of the community literals and regexes in the given configurations. An optional
+   * Compute atomic predicates for the given router's configuration.
+   *
+   * @param batfish the batfish object
+   * @param snapshot the current snapshot
+   * @param router the name of the router whose configuration is being analyzed
+   * @param communities additional community regexes to track, from user-defined constraints
+   * @param asPathRegexes additional as-path regexes to track, from user-defined constraints
+   */
+  public ConfigAtomicPredicates(
+      IBatfish batfish,
+      NetworkSnapshot snapshot,
+      String router,
+      @Nullable Set<CommunityVar> communities,
+      @Nullable Set<String> asPathRegexes) {
+    this(batfish, snapshot, router, communities, asPathRegexes, null);
+  }
+
+  /**
+   * Identifies all of the community literals and regexes in the given routing policies. An optional
    * set of additional community literals and regexes is also included, which is used to support
    * user-specified community constraints for symbolic analysis.
    */
-  private Set<CommunityVar> findAllCommunities(@Nullable Set<CommunityVar> communities) {
-    Set<CommunityVar> allCommunities = findAllCommunities();
+  private Set<CommunityVar> findAllCommunities(
+      @Nullable Set<CommunityVar> communities, Collection<RoutingPolicy> policies) {
+    Set<CommunityVar> allCommunities = findAllCommunities(policies);
     if (communities != null) {
       allCommunities.addAll(communities);
     }
@@ -110,31 +136,47 @@ public class ConfigAtomicPredicates {
   }
 
   /**
-   * Finds all community literals and regexes in the configuration by walking over all of its route
-   * policies
+   * Collect all community vars that appear in the given policy
+   *
+   * @param policy the policy to collect community vars from
+   * @return a set of community vars
    */
-  private Set<CommunityVar> findAllCommunities() {
+  private Set<CommunityVar> findAllCommunities(RoutingPolicy policy) {
     Set<CommunityVar> comms = new HashSet<>();
-    Configuration conf = _configuration;
-
-    // walk through every statement of every route policy
-    for (RoutingPolicy pol : conf.getRoutingPolicies().values()) {
-      for (Statement stmt : pol.getStatements()) {
-        comms.addAll(stmt.accept(new RoutePolicyStatementVarCollector(), conf));
-      }
-    }
+    List<Statement> stmts = policy.getStatements();
+    stmts.forEach(
+        stmt ->
+            comms.addAll(
+                stmt.accept(
+                    new RoutePolicyStatementVarCollector(),
+                    new Tuple<>(
+                        new HashSet<>(Collections.singleton(policy.getName())), _configuration))));
     return comms;
   }
 
   /**
-   * Identifies all of the AS-path regexes in the given configuration. An optional set of additional
-   * AS-path regexes is also included, which is used to support user-specified AS-path constraints
-   * for symbolic analysis.
+   * Finds all community literals and regexes in the given routing policies by walking over them
+   *
+   * @param policies the routing policies to retrieve the community literals/regexes from.
    */
-  private Set<SymbolicAsPathRegex> findAllAsPathRegexes(@Nullable Set<String> asPathRegexes) {
+  private Set<CommunityVar> findAllCommunities(Collection<RoutingPolicy> policies) {
+    Set<CommunityVar> comms = new HashSet<>();
+
+    // walk through every statement of every route policy
+    policies.forEach(pol -> comms.addAll(findAllCommunities(pol)));
+    return comms;
+  }
+
+  /**
+   * Identifies all of the AS-path regexes in the given routing policies. An optional set of
+   * additional AS-path regexes is also included, which is used to support user-specified AS-path
+   * constraints for symbolic analysis.
+   */
+  private Set<SymbolicAsPathRegex> findAllAsPathRegexes(
+      @Nullable Set<String> asPathRegexes, Collection<RoutingPolicy> policies) {
     ImmutableSet.Builder<SymbolicAsPathRegex> builder = ImmutableSet.builder();
 
-    builder.addAll(findAsPathRegexes());
+    builder.addAll(findAsPathRegexes(policies));
     if (asPathRegexes != null) {
       builder.addAll(
           asPathRegexes.stream()
@@ -145,19 +187,36 @@ public class ConfigAtomicPredicates {
   }
 
   /**
-   * Collect up all AS-path regexes that appear in the given router's configuration.
+   * Collect all AS-path regexes that appear in the given policy
    *
+   * @param policy the policy to collect AS-path regexes from
+   * @return a set of symbolic AS path regexes.
+   */
+  private Set<SymbolicAsPathRegex> findAsPathRegexes(RoutingPolicy policy) {
+    Set<SymbolicAsPathRegex> asPathRegexes = new HashSet<>();
+    List<Statement> stmts = policy.getStatements();
+    stmts.forEach(
+        stmt ->
+            asPathRegexes.addAll(
+                stmt.accept(
+                    new RoutePolicyStatementAsPathCollector(),
+                    new Tuple<>(
+                        new HashSet<>(Collections.singleton(policy.getName())), _configuration))));
+    return asPathRegexes;
+  }
+
+  /**
+   * Collect up all AS-path regexes that appear in the given policies.
+   *
+   * @param policies the set of policies to collect AS-path regexes from.
    * @return a set of all AS-path regexes that appear
    */
-  private Set<SymbolicAsPathRegex> findAsPathRegexes() {
+  private Set<SymbolicAsPathRegex> findAsPathRegexes(Collection<RoutingPolicy> policies) {
     Set<SymbolicAsPathRegex> asPathRegexes = new HashSet<>();
-    Configuration conf = _configuration;
+
     // walk through every statement of every route policy
-    for (RoutingPolicy pol : conf.getRoutingPolicies().values()) {
-      for (Statement stmt : pol.getStatements()) {
-        asPathRegexes.addAll(stmt.accept(new RoutePolicyStatementAsPathCollector(), conf));
-      }
-    }
+    policies.forEach(pol -> asPathRegexes.addAll(findAsPathRegexes(pol)));
+
     return asPathRegexes;
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/Graph.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/Graph.java
@@ -51,6 +51,7 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.minesweeper.aspath.RoutePolicyStatementAsPathCollector;
 import org.batfish.minesweeper.collections.Table2;
 import org.batfish.minesweeper.communities.RoutePolicyStatementVarCollector;
+import org.batfish.minesweeper.utils.Tuple;
 
 /**
  * A graph object representing the structure of the network. The graph is built potentially by
@@ -860,7 +861,9 @@ public class Graph {
     // walk through every statement of every route policy
     for (RoutingPolicy pol : conf.getRoutingPolicies().values()) {
       for (Statement stmt : pol.getStatements()) {
-        comms.addAll(stmt.accept(new RoutePolicyStatementVarCollector(), conf));
+        comms.addAll(
+            stmt.accept(
+                new RoutePolicyStatementVarCollector(), new Tuple<>(new HashSet<>(), conf)));
       }
     }
     return comms;
@@ -878,7 +881,9 @@ public class Graph {
     // walk through every statement of every route policy
     for (RoutingPolicy pol : conf.getRoutingPolicies().values()) {
       for (Statement stmt : pol.getStatements()) {
-        asPathRegexes.addAll(stmt.accept(new RoutePolicyStatementAsPathCollector(), conf));
+        asPathRegexes.addAll(
+            stmt.accept(
+                new RoutePolicyStatementAsPathCollector(), new Tuple<>(new HashSet<>(), conf)));
       }
     }
     return asPathRegexes;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollector.java
@@ -42,83 +42,100 @@ import org.batfish.datamodel.routing_policy.expr.RibIntersectsPrefixSpace;
 import org.batfish.datamodel.routing_policy.expr.RouteIsClassful;
 import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
+import org.batfish.minesweeper.utils.Tuple;
 
 /** Collect all AS-path regexes in a {@link BooleanExpr}. */
 @ParametersAreNonnullByDefault
 public class BooleanExprAsPathCollector
-    implements BooleanExprVisitor<Set<SymbolicAsPathRegex>, Configuration> {
+    implements BooleanExprVisitor<Set<SymbolicAsPathRegex>, Tuple<Set<String>, Configuration>> {
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchClusterListLength(
-      MatchClusterListLength matchClusterListLength, Configuration arg) {
+      MatchClusterListLength matchClusterListLength, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitBooleanExprs(
-      StaticBooleanExpr staticBooleanExpr, Configuration arg) {
+      StaticBooleanExpr staticBooleanExpr, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitCallExpr(CallExpr callExpr, Configuration arg) {
-    /* we already visit all route policies in a configuration (see Graph::findAsPathRegexes), so no
-    need to recurse to the callee policy */
-    return ImmutableSet.of();
+  public Set<SymbolicAsPathRegex> visitCallExpr(
+      CallExpr callExpr, Tuple<Set<String>, Configuration> arg) {
+    if (arg.getFirst().contains(callExpr.getCalledPolicyName())) {
+      // If we have already visited this policy then don't visit again
+      return ImmutableSet.of();
+    }
+    // Otherwise update the set of seen policies and recurse.
+    arg.getFirst().add(callExpr.getCalledPolicyName());
+
+    return new RoutePolicyStatementAsPathCollector()
+        .visitAll(
+            arg.getSecond()
+                .getRoutingPolicies()
+                .get(callExpr.getCalledPolicyName())
+                .getStatements(),
+            arg);
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitConjunction(Conjunction conjunction, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitConjunction(
+      Conjunction conjunction, Tuple<Set<String>, Configuration> arg) {
     return visitAll(conjunction.getConjuncts(), arg);
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitConjunctionChain(
-      ConjunctionChain conjunctionChain, Configuration arg) {
+      ConjunctionChain conjunctionChain, Tuple<Set<String>, Configuration> arg) {
     return visitAll(conjunctionChain.getSubroutines(), arg);
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitDisjunction(Disjunction disjunction, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitDisjunction(
+      Disjunction disjunction, Tuple<Set<String>, Configuration> arg) {
     return visitAll(disjunction.getDisjuncts(), arg);
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitFirstMatchChain(
-      FirstMatchChain firstMatchChain, Configuration arg) {
+      FirstMatchChain firstMatchChain, Tuple<Set<String>, Configuration> arg) {
     return visitAll(firstMatchChain.getSubroutines(), arg);
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitRibIntersectsPrefixSpace(
-      RibIntersectsPrefixSpace ribIntersectsPrefixSpace, Configuration arg) {
+      RibIntersectsPrefixSpace ribIntersectsPrefixSpace, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitHasRoute(HasRoute hasRoute, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitHasRoute(
+      HasRoute hasRoute, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitMatchAsPath(MatchAsPath matchAsPath, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitMatchAsPath(
+      MatchAsPath matchAsPath, Tuple<Set<String>, Configuration> arg) {
     AsPathMatchExpr matchExpr = matchAsPath.getAsPathMatchExpr();
-    return matchExpr.accept(new AsPathMatchExprAsPathCollector(), arg);
+    return matchExpr.accept(new AsPathMatchExprAsPathCollector(), arg.getSecond());
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchBgpSessionType(
-      MatchBgpSessionType matchBgpSessionType, Configuration arg) {
+      MatchBgpSessionType matchBgpSessionType, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchLegacyAsPath(
-      LegacyMatchAsPath legacyMatchAsPath, Configuration arg) {
+      LegacyMatchAsPath legacyMatchAsPath, Tuple<Set<String>, Configuration> arg) {
     AsPathSetExpr expr = legacyMatchAsPath.getExpr();
     if (expr instanceof NamedAsPathSet) {
       NamedAsPathSet namedSet = (NamedAsPathSet) expr;
-      AsPathAccessList list = arg.getAsPathAccessLists().get(namedSet.getName());
+      AsPathAccessList list = arg.getSecond().getAsPathAccessLists().get(namedSet.getName());
       // conversion to VI should guarantee list is not null
       assert list != null;
       return list.getLines().stream()
@@ -131,99 +148,104 @@ public class BooleanExprAsPathCollector
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitMatchColor(MatchColor matchColor, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitMatchColor(
+      MatchColor matchColor, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchCommunities(
-      MatchCommunities matchCommunities, Configuration arg) {
+      MatchCommunities matchCommunities, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchInterface(
-      MatchInterface matchInterface, Configuration arg) {
+      MatchInterface matchInterface, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitMatchIpv4(MatchIpv4 matchIpv4, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitMatchIpv4(
+      MatchIpv4 matchIpv4, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchLocalPreference(
-      MatchLocalPreference matchLocalPreference, Configuration arg) {
+      MatchLocalPreference matchLocalPreference, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchLocalRouteSourcePrefixLength(
-      MatchLocalRouteSourcePrefixLength matchLocalRouteSourcePrefixLength, Configuration arg) {
+      MatchLocalRouteSourcePrefixLength matchLocalRouteSourcePrefixLength,
+      Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitMatchMetric(MatchMetric matchMetric, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitMatchMetric(
+      MatchMetric matchMetric, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchPrefixSet(
-      MatchPrefixSet matchPrefixSet, Configuration arg) {
+      MatchPrefixSet matchPrefixSet, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchProcessAsn(
-      MatchProcessAsn matchProcessAsn, Configuration arg) {
+      MatchProcessAsn matchProcessAsn, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchProtocol(
-      MatchProtocol matchProtocol, Configuration arg) {
+      MatchProtocol matchProtocol, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchRouteType(
-      MatchRouteType matchRouteType, Configuration arg) {
+      MatchRouteType matchRouteType, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchSourceProtocol(
-      MatchSourceProtocol matchSourceProtocol, Configuration arg) {
+      MatchSourceProtocol matchSourceProtocol, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitMatchSourceVrf(
-      MatchSourceVrf matchSourceVrf, Configuration arg) {
+      MatchSourceVrf matchSourceVrf, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitMatchTag(MatchTag matchTag, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitMatchTag(
+      MatchTag matchTag, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitNot(Not not, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitNot(Not not, Tuple<Set<String>, Configuration> arg) {
     return not.getExpr().accept(this, arg);
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitRouteIsClassful(
-      RouteIsClassful routeIsClassful, Configuration arg) {
+      RouteIsClassful routeIsClassful, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitWithEnvironmentExpr(
-      WithEnvironmentExpr withEnvironmentExpr, Configuration arg) {
+      WithEnvironmentExpr withEnvironmentExpr, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.<SymbolicAsPathRegex>builder()
         .addAll(withEnvironmentExpr.getExpr().accept(this, arg))
         .addAll(
@@ -238,7 +260,8 @@ public class BooleanExprAsPathCollector
         .build();
   }
 
-  private Set<SymbolicAsPathRegex> visitAll(List<BooleanExpr> exprs, Configuration arg) {
+  private Set<SymbolicAsPathRegex> visitAll(
+      List<BooleanExpr> exprs, Tuple<Set<String>, Configuration> arg) {
     return exprs.stream()
         .flatMap(expr -> expr.accept(this, arg).stream())
         .collect(ImmutableSet.toImmutableSet());

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollector.java
@@ -34,32 +34,44 @@ import org.batfish.datamodel.routing_policy.statement.StatementVisitor;
 import org.batfish.datamodel.routing_policy.statement.Statements.StaticStatement;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
+import org.batfish.minesweeper.utils.Tuple;
 
 /** Collect all AS-path regexes in a route-policy {@link Statement}. */
 @ParametersAreNonnullByDefault
 public class RoutePolicyStatementAsPathCollector
-    implements StatementVisitor<Set<SymbolicAsPathRegex>, Configuration> {
+    implements StatementVisitor<Set<SymbolicAsPathRegex>, Tuple<Set<String>, Configuration>> {
   @Override
   public Set<SymbolicAsPathRegex> visitBufferedStatement(
-      BufferedStatement bufferedStatement, Configuration arg) {
+      BufferedStatement bufferedStatement, Tuple<Set<String>, Configuration> arg) {
     return bufferedStatement.getStatement().accept(this, arg);
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitCallStatement(
-      CallStatement callStatement, Configuration arg) {
-    // no need to check the callee here because we already execute this visitor on every statement
-    // of every route policy (see Graph::findAsPathRegexes)
+      CallStatement callStatement, Tuple<Set<String>, Configuration> arg) {
+    if (arg.getFirst().contains(callStatement.getCalledPolicyName())) {
+      // If we have already visited this policy then don't visit again
+      return ImmutableSet.of();
+    }
+    // Otherwise update the set of seen policies and recurse.
+    arg.getFirst().add(callStatement.getCalledPolicyName());
+
+    return visitAll(
+        arg.getSecond()
+            .getRoutingPolicies()
+            .get(callStatement.getCalledPolicyName())
+            .getStatements(),
+        arg);
+  }
+
+  @Override
+  public Set<SymbolicAsPathRegex> visitComment(
+      Comment comment, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitComment(Comment comment, Configuration arg) {
-    return ImmutableSet.of();
-  }
-
-  @Override
-  public Set<SymbolicAsPathRegex> visitIf(If if1, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitIf(If if1, Tuple<Set<String>, Configuration> arg) {
     ImmutableSet.Builder<SymbolicAsPathRegex> builder = ImmutableSet.builder();
     return builder
         .addAll(if1.getGuard().accept(new BooleanExprAsPathCollector(), arg))
@@ -70,7 +82,7 @@ public class RoutePolicyStatementAsPathCollector
 
   @Override
   public Set<SymbolicAsPathRegex> visitPrependAsPath(
-      PrependAsPath prependAsPath, Configuration arg) {
+      PrependAsPath prependAsPath, Tuple<Set<String>, Configuration> arg) {
     // if/when we update TransferBDD to support AS-path prepending, we will need to update this as
     // well
     return ImmutableSet.of();
@@ -86,120 +98,128 @@ public class RoutePolicyStatementAsPathCollector
 
   @Override
   public Set<SymbolicAsPathRegex> visitExcludeAsPath(
-      ExcludeAsPath excludeAsPath, Configuration arg) {
+      ExcludeAsPath excludeAsPath, Tuple<Set<String>, Configuration> arg) {
     // if/when TransferBDD gets updated to support AS-path excluding, this will have to be updated
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitRemoveTunnelEncapsulationAttribute(
-      RemoveTunnelEncapsulationAttribute removeTunnelAttribute, Configuration arg) {
+      RemoveTunnelEncapsulationAttribute removeTunnelAttribute,
+      Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetAdministrativeCost(
-      SetAdministrativeCost setAdministrativeCost, Configuration arg) {
+      SetAdministrativeCost setAdministrativeCost, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetCommunities(
-      SetCommunities setCommunities, Configuration arg) {
+      SetCommunities setCommunities, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetDefaultPolicy(
-      SetDefaultPolicy setDefaultPolicy, Configuration arg) {
+      SetDefaultPolicy setDefaultPolicy, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetEigrpMetric(
-      SetEigrpMetric setEigrpMetric, Configuration arg) {
+      SetEigrpMetric setEigrpMetric, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitSetIsisLevel(SetIsisLevel setIsisLevel, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitSetIsisLevel(
+      SetIsisLevel setIsisLevel, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetIsisMetricType(
-      SetIsisMetricType setIsisMetricType, Configuration arg) {
+      SetIsisMetricType setIsisMetricType, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetLocalPreference(
-      SetLocalPreference setLocalPreference, Configuration arg) {
+      SetLocalPreference setLocalPreference, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitSetMetric(SetMetric setMetric, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitSetMetric(
+      SetMetric setMetric, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitSetNextHop(SetNextHop setNextHop, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitSetNextHop(
+      SetNextHop setNextHop, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitSetOrigin(SetOrigin setOrigin, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitSetOrigin(
+      SetOrigin setOrigin, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetOspfMetricType(
-      SetOspfMetricType setOspfMetricType, Configuration arg) {
+      SetOspfMetricType setOspfMetricType, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitSetTag(SetTag setTag, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitSetTag(
+      SetTag setTag, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetDefaultTag(
-      SetDefaultTag setDefaultTag, Configuration arg) {
+      SetDefaultTag setDefaultTag, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetTunnelEncapsulationAttribute(
-      SetTunnelEncapsulationAttribute setTunnelAttribute, Configuration arg) {
+      SetTunnelEncapsulationAttribute setTunnelAttribute, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitSetVarMetricType(
-      SetVarMetricType setVarMetricType, Configuration arg) {
+      SetVarMetricType setVarMetricType, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<SymbolicAsPathRegex> visitSetWeight(SetWeight setWeight, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitSetWeight(
+      SetWeight setWeight, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitStaticStatement(
-      StaticStatement staticStatement, Configuration arg) {
+      StaticStatement staticStatement, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<SymbolicAsPathRegex> visitTraceableStatement(
-      TraceableStatement traceableStatement, Configuration arg) {
+      TraceableStatement traceableStatement, Tuple<Set<String>, Configuration> arg) {
     return visitAll(traceableStatement.getInnerStatements(), arg);
   }
 
-  public Set<SymbolicAsPathRegex> visitAll(List<Statement> statements, Configuration arg) {
+  public Set<SymbolicAsPathRegex> visitAll(
+      List<Statement> statements, Tuple<Set<String>, Configuration> arg) {
     return statements.stream()
         .flatMap(stmt -> stmt.accept(this, arg).stream())
         .collect(ImmutableSet.toImmutableSet());

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
@@ -37,177 +37,205 @@ import org.batfish.datamodel.routing_policy.expr.RibIntersectsPrefixSpace;
 import org.batfish.datamodel.routing_policy.expr.RouteIsClassful;
 import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.minesweeper.CommunityVar;
+import org.batfish.minesweeper.utils.Tuple;
 
 /** Collect all community literals and regexes in a {@link BooleanExpr}. */
 @ParametersAreNonnullByDefault
 public class BooleanExprVarCollector
-    implements BooleanExprVisitor<Set<CommunityVar>, Configuration> {
+    implements BooleanExprVisitor<Set<CommunityVar>, Tuple<Set<String>, Configuration>> {
 
   @Override
   public Set<CommunityVar> visitMatchClusterListLength(
-      MatchClusterListLength matchClusterListLength, Configuration arg) {
+      MatchClusterListLength matchClusterListLength, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitBooleanExprs(
-      StaticBooleanExpr staticBooleanExpr, Configuration arg) {
+      StaticBooleanExpr staticBooleanExpr, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitCallExpr(CallExpr callExpr, Configuration arg) {
-    /* we already visit all route policies in a configuration (see Graph::findAllCommunities), so no
-    need to recurse to the callee policy */
-    return ImmutableSet.of();
+  public Set<CommunityVar> visitCallExpr(CallExpr callExpr, Tuple<Set<String>, Configuration> arg) {
+    if (arg.getFirst().contains(callExpr.getCalledPolicyName())) {
+      // If we have already visited this policy then don't visit again
+      return ImmutableSet.of();
+    }
+    // Otherwise update the set of seen policies and recurse.
+    arg.getFirst().add(callExpr.getCalledPolicyName());
+
+    return new RoutePolicyStatementVarCollector()
+        .visitAll(
+            arg.getSecond()
+                .getRoutingPolicies()
+                .get(callExpr.getCalledPolicyName())
+                .getStatements(),
+            arg);
   }
 
   @Override
-  public Set<CommunityVar> visitConjunction(Conjunction conjunction, Configuration arg) {
+  public Set<CommunityVar> visitConjunction(
+      Conjunction conjunction, Tuple<Set<String>, Configuration> arg) {
     return visitAll(conjunction.getConjuncts(), arg);
   }
 
   @Override
   public Set<CommunityVar> visitConjunctionChain(
-      ConjunctionChain conjunctionChain, Configuration arg) {
+      ConjunctionChain conjunctionChain, Tuple<Set<String>, Configuration> arg) {
     return visitAll(conjunctionChain.getSubroutines(), arg);
   }
 
   @Override
-  public Set<CommunityVar> visitDisjunction(Disjunction disjunction, Configuration arg) {
+  public Set<CommunityVar> visitDisjunction(
+      Disjunction disjunction, Tuple<Set<String>, Configuration> arg) {
     return visitAll(disjunction.getDisjuncts(), arg);
   }
 
   @Override
   public Set<CommunityVar> visitFirstMatchChain(
-      FirstMatchChain firstMatchChain, Configuration arg) {
+      FirstMatchChain firstMatchChain, Tuple<Set<String>, Configuration> arg) {
     return visitAll(firstMatchChain.getSubroutines(), arg);
   }
 
   @Override
   public Set<CommunityVar> visitRibIntersectsPrefixSpace(
-      RibIntersectsPrefixSpace ribIntersectsPrefixSpace, Configuration arg) {
-    return ribIntersectsPrefixSpace.getRibExpr().accept(RibExprVarCollector.instance(), arg);
+      RibIntersectsPrefixSpace ribIntersectsPrefixSpace, Tuple<Set<String>, Configuration> arg) {
+    return ribIntersectsPrefixSpace
+        .getRibExpr()
+        .accept(RibExprVarCollector.instance(), arg.getSecond());
   }
 
   @Override
-  public Set<CommunityVar> visitHasRoute(HasRoute hasRoute, Configuration arg) {
+  public Set<CommunityVar> visitHasRoute(HasRoute hasRoute, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchAsPath(MatchAsPath matchAsPath, Configuration arg) {
+  public Set<CommunityVar> visitMatchAsPath(
+      MatchAsPath matchAsPath, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitMatchLegacyAsPath(
-      LegacyMatchAsPath legacyMatchAsPath, Configuration arg) {
+      LegacyMatchAsPath legacyMatchAsPath, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitMatchBgpSessionType(
-      MatchBgpSessionType matchBgpSessionType, Configuration arg) {
+      MatchBgpSessionType matchBgpSessionType, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchColor(MatchColor matchColor, Configuration arg) {
+  public Set<CommunityVar> visitMatchColor(
+      MatchColor matchColor, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitMatchCommunities(
-      MatchCommunities matchCommunities, Configuration arg) {
+      MatchCommunities matchCommunities, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.<CommunityVar>builder()
         .addAll(
-            matchCommunities.getCommunitySetExpr().accept(new CommunitySetExprVarCollector(), arg))
+            matchCommunities
+                .getCommunitySetExpr()
+                .accept(new CommunitySetExprVarCollector(), arg.getSecond()))
         .addAll(
             matchCommunities
                 .getCommunitySetMatchExpr()
-                .accept(new CommunitySetMatchExprVarCollector(), arg))
+                .accept(new CommunitySetMatchExprVarCollector(), arg.getSecond()))
         .build();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchInterface(MatchInterface matchInterface, Configuration arg) {
+  public Set<CommunityVar> visitMatchInterface(
+      MatchInterface matchInterface, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchIpv4(MatchIpv4 matchIpv4, Configuration arg) {
+  public Set<CommunityVar> visitMatchIpv4(
+      MatchIpv4 matchIpv4, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitMatchLocalPreference(
-      MatchLocalPreference matchLocalPreference, Configuration arg) {
+      MatchLocalPreference matchLocalPreference, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitMatchLocalRouteSourcePrefixLength(
-      MatchLocalRouteSourcePrefixLength matchLocalRouteSourcePrefixLength, Configuration arg) {
+      MatchLocalRouteSourcePrefixLength matchLocalRouteSourcePrefixLength,
+      Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchMetric(MatchMetric matchMetric, Configuration arg) {
+  public Set<CommunityVar> visitMatchMetric(
+      MatchMetric matchMetric, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchPrefixSet(MatchPrefixSet matchPrefixSet, Configuration arg) {
+  public Set<CommunityVar> visitMatchPrefixSet(
+      MatchPrefixSet matchPrefixSet, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitMatchProcessAsn(
-      MatchProcessAsn matchProcessAsn, Configuration arg) {
+      MatchProcessAsn matchProcessAsn, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchProtocol(MatchProtocol matchProtocol, Configuration arg) {
+  public Set<CommunityVar> visitMatchProtocol(
+      MatchProtocol matchProtocol, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchRouteType(MatchRouteType matchRouteType, Configuration arg) {
+  public Set<CommunityVar> visitMatchRouteType(
+      MatchRouteType matchRouteType, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitMatchSourceProtocol(
-      MatchSourceProtocol matchSourceProtocol, Configuration arg) {
+      MatchSourceProtocol matchSourceProtocol, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchSourceVrf(MatchSourceVrf matchSourceVrf, Configuration arg) {
+  public Set<CommunityVar> visitMatchSourceVrf(
+      MatchSourceVrf matchSourceVrf, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitMatchTag(MatchTag matchTag, Configuration arg) {
+  public Set<CommunityVar> visitMatchTag(MatchTag matchTag, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
-  public Set<CommunityVar> visitNot(Not not, Configuration arg) {
+  public Set<CommunityVar> visitNot(Not not, Tuple<Set<String>, Configuration> arg) {
     return not.getExpr().accept(this, arg);
   }
 
   @Override
   public Set<CommunityVar> visitRouteIsClassful(
-      RouteIsClassful routeIsClassful, Configuration arg) {
+      RouteIsClassful routeIsClassful, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();
   }
 
   @Override
   public Set<CommunityVar> visitWithEnvironmentExpr(
-      WithEnvironmentExpr withEnvironmentExpr, Configuration arg) {
+      WithEnvironmentExpr withEnvironmentExpr, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.<CommunityVar>builder()
         .addAll(withEnvironmentExpr.getExpr().accept(this, arg))
         .addAll(
@@ -222,7 +250,8 @@ public class BooleanExprVarCollector
         .build();
   }
 
-  private Set<CommunityVar> visitAll(List<BooleanExpr> exprs, Configuration arg) {
+  private Set<CommunityVar> visitAll(
+      List<BooleanExpr> exprs, Tuple<Set<String>, Configuration> arg) {
     return exprs.stream()
         .flatMap(expr -> expr.accept(this, arg).stream())
         .collect(ImmutableSet.toImmutableSet());

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareRoutePolicies/CompareRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareRoutePolicies/CompareRoutePoliciesAnswerer.java
@@ -266,6 +266,13 @@ public final class CompareRoutePoliciesAnswerer extends Answerer {
       Stream<RoutingPolicy> policies,
       Stream<RoutingPolicy> proposedPolicies,
       NetworkSnapshot snapshot) {
+    List<RoutingPolicy> policiesList = policies.collect(Collectors.toList());
+    List<RoutingPolicy> proposedPoliciesList = proposedPolicies.collect(Collectors.toList());
+
+    // Compute AtomicPredicates for both policies and proposedPolicies.
+    List<RoutingPolicy> allPolicies = new ArrayList<>(policiesList);
+    allPolicies.addAll(proposedPoliciesList);
+
     ConfigAtomicPredicates configAPs =
         new ConfigAtomicPredicates(
             _batfish,
@@ -274,12 +281,16 @@ public final class CompareRoutePoliciesAnswerer extends Answerer {
             _communityRegexes.stream()
                 .map(CommunityVar::from)
                 .collect(ImmutableSet.toImmutableSet()),
-            _asPathRegexes);
+            _asPathRegexes,
+            allPolicies);
 
-    return policies.flatMap(
-        policy ->
-            proposedPolicies.flatMap(
-                proposedPolicy -> comparePolicies(policy, proposedPolicy, configAPs).stream()));
+    return policiesList.stream()
+        .flatMap(
+            policy ->
+                proposedPoliciesList.stream()
+                    .flatMap(
+                        proposedPolicy ->
+                            comparePolicies(policy, proposedPolicy, configAPs).stream()));
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -359,7 +359,8 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             _communityRegexes.stream()
                 .map(CommunityVar::from)
                 .collect(ImmutableSet.toImmutableSet()),
-            _asPathRegexes);
+            _asPathRegexes,
+            policies);
 
     return policies.stream().flatMap(policy -> searchPolicy(policy, configAPs).stream());
   }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/ConfigAtomicPredicatesTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/ConfigAtomicPredicatesTest.java
@@ -19,6 +19,14 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetUnion;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
+import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
+import org.batfish.datamodel.routing_policy.communities.SetCommunities;
+import org.batfish.datamodel.routing_policy.statement.CallStatement;
+import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.specifier.Location;
 import org.batfish.specifier.LocationInfo;
 import org.junit.Before;
@@ -29,6 +37,8 @@ public class ConfigAtomicPredicatesTest {
   private static final String HOSTNAME = "hostname";
   private IBatfish _batfish;
   private Configuration _baseConfig;
+
+  private NetworkFactory _nf;
 
   static final class MockBatfish extends IBatfishTestAdapter {
     private final SortedMap<String, Configuration> _baseConfigs;
@@ -63,13 +73,13 @@ public class ConfigAtomicPredicatesTest {
 
   @Before
   public void setup() {
-    NetworkFactory nf = new NetworkFactory();
+    _nf = new NetworkFactory();
     Configuration.Builder cb =
-        nf.configurationBuilder()
+        _nf.configurationBuilder()
             .setHostname(HOSTNAME)
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     _baseConfig = cb.build();
-    nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+    _nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
 
     _batfish = new MockBatfish(ImmutableSortedMap.of(HOSTNAME, _baseConfig));
   }
@@ -167,5 +177,42 @@ public class ConfigAtomicPredicatesTest {
     assertThat(
         asAPs.getAtomicPredicateAutomata().values(),
         hasItem(new SymbolicAsPathRegex("^$").toAutomaton()));
+  }
+
+  @Test
+  public void testCallStatement() {
+
+    RoutingPolicy firstPolicy =
+        _nf.routingPolicyBuilder()
+            .setName("firstPolicy")
+            .setOwner(_baseConfig)
+            .addStatement(new CallStatement("secondPolicy"))
+            .addStatement(
+                new SetCommunities(
+                    CommunitySetUnion.of(
+                        InputCommunities.instance(),
+                        new LiteralCommunitySet(CommunitySet.of(StandardCommunity.parse("1:1"))))))
+            .addStatement(new Statements.StaticStatement(Statements.ExitAccept))
+            .build();
+
+    RoutingPolicy secondPolicy =
+        _nf.routingPolicyBuilder()
+            .setName("secondPolicy")
+            .setOwner(_baseConfig)
+            .addStatement(new CallStatement("firstPolicy"))
+            .addStatement(
+                new SetCommunities(
+                    CommunitySetUnion.of(
+                        InputCommunities.instance(),
+                        new LiteralCommunitySet(CommunitySet.of(StandardCommunity.parse("2:2"))))))
+            .addStatement(new Statements.StaticStatement(Statements.ExitAccept))
+            .build();
+
+    _baseConfig.setRoutingPolicies(
+        ImmutableMap.of("firstPolicy", firstPolicy, "secondPolicy", secondPolicy));
+    ConfigAtomicPredicates cap =
+        new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+
+    assertEquals(3, cap.getStandardCommunityAtomicPredicates().getNumAtomicPredicates());
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/BooleanExprAsPathCollectorTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
 import java.util.Set;
 import org.batfish.datamodel.AsPathAccessList;
 import org.batfish.datamodel.AsPathAccessListLine;
@@ -26,6 +27,7 @@ import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
+import org.batfish.minesweeper.utils.Tuple;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,7 +63,8 @@ public class BooleanExprAsPathCollectorTest {
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH1)),
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH2))));
 
-    Set<SymbolicAsPathRegex> result = _collector.visitConjunction(c, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _collector.visitConjunction(c, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<SymbolicAsPathRegex> expected =
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2));
@@ -78,7 +81,8 @@ public class BooleanExprAsPathCollectorTest {
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH1)),
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH2))));
 
-    Set<SymbolicAsPathRegex> result = _collector.visitConjunctionChain(cc, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _collector.visitConjunctionChain(cc, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<SymbolicAsPathRegex> expected =
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2));
@@ -95,7 +99,8 @@ public class BooleanExprAsPathCollectorTest {
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH1)),
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH2))));
 
-    Set<SymbolicAsPathRegex> result = _collector.visitDisjunction(d, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _collector.visitDisjunction(d, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<SymbolicAsPathRegex> expected =
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2));
@@ -112,7 +117,8 @@ public class BooleanExprAsPathCollectorTest {
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH1)),
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH2))));
 
-    Set<SymbolicAsPathRegex> result = _collector.visitFirstMatchChain(fmc, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _collector.visitFirstMatchChain(fmc, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<SymbolicAsPathRegex> expected =
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2));
@@ -125,7 +131,8 @@ public class BooleanExprAsPathCollectorTest {
 
     MatchAsPath matchAsPath = MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(ASPATH1));
 
-    Set<SymbolicAsPathRegex> result = _collector.visitMatchAsPath(matchAsPath, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _collector.visitMatchAsPath(matchAsPath, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<SymbolicAsPathRegex> expected = ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1));
 
@@ -148,7 +155,8 @@ public class BooleanExprAsPathCollectorTest {
 
     LegacyMatchAsPath matchAsPath = new LegacyMatchAsPath(new NamedAsPathSet(asPathName));
 
-    Set<SymbolicAsPathRegex> result = _collector.visitMatchLegacyAsPath(matchAsPath, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _collector.visitMatchLegacyAsPath(matchAsPath, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<SymbolicAsPathRegex> expected =
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2));
@@ -166,7 +174,8 @@ public class BooleanExprAsPathCollectorTest {
                 AsPathMatchAny.of(
                     ImmutableList.of(AsPathMatchRegex.of(ASPATH1), AsPathMatchRegex.of(ASPATH2)))));
 
-    Set<SymbolicAsPathRegex> result = _collector.visitNot(n, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _collector.visitNot(n, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<SymbolicAsPathRegex> expected =
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2));
@@ -198,7 +207,8 @@ public class BooleanExprAsPathCollectorTest {
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of(asPath4)),
                 ImmutableList.of())));
 
-    Set<SymbolicAsPathRegex> result = _collector.visitWithEnvironmentExpr(wee, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _collector.visitWithEnvironmentExpr(wee, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<SymbolicAsPathRegex> expected =
         ImmutableSet.of(ASPATH1, ASPATH2, asPath3, asPath4).stream()

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/RoutePolicyStatementAsPathCollectorTest.java
@@ -3,7 +3,9 @@ package org.batfish.minesweeper.aspath;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -11,6 +13,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.as_path.AsPathMatchAny;
 import org.batfish.datamodel.routing_policy.as_path.AsPathMatchRegex;
 import org.batfish.datamodel.routing_policy.as_path.InputAsPath;
@@ -19,11 +22,13 @@ import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
 import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
+import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
+import org.batfish.minesweeper.utils.Tuple;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,6 +36,7 @@ import org.junit.Test;
 public class RoutePolicyStatementAsPathCollectorTest {
   private static final String HOSTNAME = "hostname";
   private Configuration _baseConfig;
+  private NetworkFactory _nf;
   private RoutePolicyStatementAsPathCollector _asPathCollector;
 
   private static final String ASPATH1 = " 40$";
@@ -45,13 +51,13 @@ public class RoutePolicyStatementAsPathCollectorTest {
 
   @Before
   public void setup() {
-    NetworkFactory nf = new NetworkFactory();
+    _nf = new NetworkFactory();
     Configuration.Builder cb =
-        nf.configurationBuilder()
+        _nf.configurationBuilder()
             .setHostname(HOSTNAME)
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     _baseConfig = cb.build();
-    nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+    _nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
 
     _asPathCollector = new RoutePolicyStatementAsPathCollector();
   }
@@ -64,7 +70,8 @@ public class RoutePolicyStatementAsPathCollectorTest {
                 makeMatchAsPath(ImmutableList.of(ASPATH1, ASPATH2)),
                 ImmutableList.of(Statements.ExitAccept.toStaticStatement())));
 
-    Set<SymbolicAsPathRegex> result = _asPathCollector.visitBufferedStatement(bs, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _asPathCollector.visitBufferedStatement(bs, new Tuple<>(new HashSet<>(), _baseConfig));
 
     assertEquals(
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2)),
@@ -80,7 +87,8 @@ public class RoutePolicyStatementAsPathCollectorTest {
                 new If(makeMatchAsPath(ImmutableList.of(ASPATH2)), ImmutableList.of())),
             ImmutableList.of(
                 new If(makeMatchAsPath(ImmutableList.of(ASPATH3)), ImmutableList.of())));
-    Set<SymbolicAsPathRegex> result = _asPathCollector.visitIf(ifstmt, _baseConfig);
+    Set<SymbolicAsPathRegex> result =
+        _asPathCollector.visitIf(ifstmt, new Tuple<>(new HashSet<>(), _baseConfig));
 
     assertEquals(
         ImmutableSet.of(
@@ -100,7 +108,8 @@ public class RoutePolicyStatementAsPathCollectorTest {
                 new If(makeMatchAsPath(ImmutableList.of(ASPATH2)), ImmutableList.of())));
 
     Set<SymbolicAsPathRegex> result =
-        _asPathCollector.visitTraceableStatement(traceableStatement, _baseConfig);
+        _asPathCollector.visitTraceableStatement(
+            traceableStatement, new Tuple<>(new HashSet<>(), _baseConfig));
     assertEquals(
         ImmutableSet.of(new SymbolicAsPathRegex(ASPATH1), new SymbolicAsPathRegex(ASPATH2)),
         result);
@@ -112,6 +121,43 @@ public class RoutePolicyStatementAsPathCollectorTest {
         new ExcludeAsPath(new LiteralAsList(ImmutableList.of(new ExplicitAs(1L))));
 
     assertEquals(
-        ImmutableSet.of(), _asPathCollector.visitExcludeAsPath(excludeAsPath, _baseConfig));
+        ImmutableSet.of(),
+        _asPathCollector.visitExcludeAsPath(
+            excludeAsPath, new Tuple<>(new HashSet<>(), _baseConfig)));
+  }
+
+  @Test
+  public void testVisitCallStatement() {
+    String calledPolicyName = "calledPolicy";
+
+    BufferedStatement bs =
+        new BufferedStatement(
+            new If(
+                makeMatchAsPath(ImmutableList.of(ASPATH1, ASPATH2)),
+                ImmutableList.of(Statements.ExitAccept.toStaticStatement())));
+
+    RoutingPolicy calledPolicy =
+        _nf.routingPolicyBuilder()
+            .setName(calledPolicyName)
+            .setOwner(_baseConfig)
+            .addStatement(bs)
+            .build();
+
+    RoutingPolicy policy =
+        _nf.routingPolicyBuilder()
+            .setName("BASE_POLICY")
+            .addStatement(new CallStatement(calledPolicyName))
+            .addStatement(new Statements.StaticStatement(Statements.ExitAccept))
+            .build();
+
+    _baseConfig.setRoutingPolicies(
+        ImmutableMap.of(calledPolicyName, calledPolicy, "BASE_POLICY", policy));
+
+    Set<SymbolicAsPathRegex> bufferedStmtResult =
+        _asPathCollector.visitBufferedStatement(bs, new Tuple<>(new HashSet<>(), _baseConfig));
+    Set<SymbolicAsPathRegex> callStmtResult =
+        _asPathCollector.visitAll(
+            policy.getStatements(), new Tuple<>(new HashSet<>(), _baseConfig));
+    assertEquals(bufferedStmtResult, callStmtResult);
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/BooleanExprVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/BooleanExprVarCollectorTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
 import java.util.Set;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -30,6 +31,7 @@ import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.expr.RibIntersectsPrefixSpace;
 import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.minesweeper.CommunityVar;
+import org.batfish.minesweeper.utils.Tuple;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -67,7 +69,8 @@ public class BooleanExprVarCollectorTest {
                 new MatchCommunities(
                     InputCommunities.instance(), new HasCommunity(new CommunityIs(COMM2)))));
 
-    Set<CommunityVar> result = _varCollector.visitConjunction(c, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitConjunction(c, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<CommunityVar> expected =
         ImmutableSet.of(CommunityVar.from(COMM1), CommunityVar.from(COMM2));
@@ -86,7 +89,8 @@ public class BooleanExprVarCollectorTest {
                 new MatchCommunities(
                     InputCommunities.instance(), new HasCommunity(new CommunityIs(COMM2)))));
 
-    Set<CommunityVar> result = _varCollector.visitConjunctionChain(cc, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitConjunctionChain(cc, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<CommunityVar> expected =
         ImmutableSet.of(CommunityVar.from(COMM1), CommunityVar.from(COMM2));
@@ -105,7 +109,8 @@ public class BooleanExprVarCollectorTest {
                 new MatchCommunities(
                     InputCommunities.instance(), new HasCommunity(new CommunityIs(COMM2)))));
 
-    Set<CommunityVar> result = _varCollector.visitDisjunction(d, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitDisjunction(d, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<CommunityVar> expected =
         ImmutableSet.of(CommunityVar.from(COMM1), CommunityVar.from(COMM2));
@@ -124,7 +129,8 @@ public class BooleanExprVarCollectorTest {
                 new MatchCommunities(
                     InputCommunities.instance(), new HasCommunity(new CommunityIs(COMM2)))));
 
-    Set<CommunityVar> result = _varCollector.visitFirstMatchChain(fmc, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitFirstMatchChain(fmc, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<CommunityVar> expected =
         ImmutableSet.of(CommunityVar.from(COMM1), CommunityVar.from(COMM2));
@@ -138,7 +144,10 @@ public class BooleanExprVarCollectorTest {
         new RibIntersectsPrefixSpace(
             MainRib.instance(), new ExplicitPrefixSet(new PrefixSpace(ImmutableList.of())));
 
-    assertThat(_varCollector.visitRibIntersectsPrefixSpace(expr, _baseConfig), empty());
+    assertThat(
+        _varCollector.visitRibIntersectsPrefixSpace(
+            expr, new Tuple<>(new HashSet<>(), _baseConfig)),
+        empty());
   }
 
   @Test
@@ -149,7 +158,8 @@ public class BooleanExprVarCollectorTest {
             new LiteralCommunitySet(CommunitySet.of(COMM1)),
             new HasCommunity(new CommunityIs(COMM2)));
 
-    Set<CommunityVar> result = _varCollector.visitMatchCommunities(mc, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitMatchCommunities(mc, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<CommunityVar> expected =
         ImmutableSet.of(CommunityVar.from(COMM1), CommunityVar.from(COMM2));
@@ -165,7 +175,7 @@ public class BooleanExprVarCollectorTest {
             new MatchCommunities(
                 InputCommunities.instance(), new HasCommunity(new CommunityIs(COMM1))));
 
-    Set<CommunityVar> result = _varCollector.visitNot(n, _baseConfig);
+    Set<CommunityVar> result = _varCollector.visitNot(n, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<CommunityVar> expected = ImmutableSet.of(CommunityVar.from(COMM1));
 
@@ -189,7 +199,8 @@ public class BooleanExprVarCollectorTest {
     wee.setPostTrueStatements(
         ImmutableList.of(new SetCommunities(new LiteralCommunitySet(CommunitySet.of(comm4)))));
 
-    Set<CommunityVar> result = _varCollector.visitWithEnvironmentExpr(wee, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitWithEnvironmentExpr(wee, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<CommunityVar> expected =
         ImmutableSet.of(COMM1, COMM2, comm3, comm4).stream()

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/RoutePolicyStatementVarCollectorTest.java
@@ -3,7 +3,9 @@ package org.batfish.minesweeper.communities;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
 import java.util.Set;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -11,6 +13,7 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
@@ -22,10 +25,13 @@ import org.batfish.datamodel.routing_policy.communities.SetCommunities;
 import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
 import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
+import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
 import org.batfish.minesweeper.CommunityVar;
+import org.batfish.minesweeper.utils.Tuple;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,18 +41,20 @@ public class RoutePolicyStatementVarCollectorTest {
   private Configuration _baseConfig;
   private RoutePolicyStatementVarCollector _varCollector;
 
+  private NetworkFactory _nf;
+
   private static final Community COMM1 = StandardCommunity.parse("20:30");
   private static final Community COMM2 = StandardCommunity.parse("21:30");
 
   @Before
   public void setup() {
-    NetworkFactory nf = new NetworkFactory();
+    _nf = new NetworkFactory();
     Configuration.Builder cb =
-        nf.configurationBuilder()
+        _nf.configurationBuilder()
             .setHostname(HOSTNAME)
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     _baseConfig = cb.build();
-    nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+    _nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
 
     _varCollector = new RoutePolicyStatementVarCollector();
   }
@@ -56,7 +64,8 @@ public class RoutePolicyStatementVarCollectorTest {
     BufferedStatement bs =
         new BufferedStatement(new SetCommunities(new LiteralCommunitySet(CommunitySet.of(COMM1))));
 
-    Set<CommunityVar> result = _varCollector.visitBufferedStatement(bs, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitBufferedStatement(bs, new Tuple<>(new HashSet<>(), _baseConfig));
 
     assertEquals(ImmutableSet.of(CommunityVar.from(COMM1)), result);
   }
@@ -72,7 +81,8 @@ public class RoutePolicyStatementVarCollectorTest {
             ImmutableList.of(new SetCommunities(new LiteralCommunitySet(CommunitySet.of(COMM1)))),
             ImmutableList.of(new SetCommunities(new LiteralCommunitySet(CommunitySet.of(COMM2)))));
 
-    Set<CommunityVar> result = _varCollector.visitIf(ifStmt, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitIf(ifStmt, new Tuple<>(new HashSet<>(), _baseConfig));
 
     Set<CommunityVar> expected =
         ImmutableSet.of(
@@ -85,7 +95,8 @@ public class RoutePolicyStatementVarCollectorTest {
   public void testVisitSetCommunities() {
     SetCommunities sc = new SetCommunities(new LiteralCommunitySet(CommunitySet.of(COMM1)));
 
-    Set<CommunityVar> result = _varCollector.visitSetCommunities(sc, _baseConfig);
+    Set<CommunityVar> result =
+        _varCollector.visitSetCommunities(sc, new Tuple<>(new HashSet<>(), _baseConfig));
 
     assertEquals(ImmutableSet.of(CommunityVar.from(COMM1)), result);
   }
@@ -98,8 +109,40 @@ public class RoutePolicyStatementVarCollectorTest {
             ImmutableList.of(new SetCommunities(new LiteralCommunitySet(CommunitySet.of(COMM1)))));
 
     assertEquals(
-        _varCollector.visitTraceableStatement(traceableStatement, _baseConfig),
+        _varCollector.visitTraceableStatement(
+            traceableStatement, new Tuple<>(new HashSet<>(), _baseConfig)),
         ImmutableSet.of(CommunityVar.from(COMM1)));
+  }
+
+  @Test
+  public void testVisitCallStatement() {
+    String calledPolicyName = "calledPolicy";
+
+    BufferedStatement bs =
+        new BufferedStatement(new SetCommunities(new LiteralCommunitySet(CommunitySet.of(COMM1))));
+
+    RoutingPolicy calledPolicy =
+        _nf.routingPolicyBuilder()
+            .setName(calledPolicyName)
+            .setOwner(_baseConfig)
+            .addStatement(bs)
+            .build();
+
+    RoutingPolicy policy =
+        _nf.routingPolicyBuilder()
+            .setName("BASE_POLICY")
+            .addStatement(new CallStatement(calledPolicyName))
+            .addStatement(new Statements.StaticStatement(Statements.ExitAccept))
+            .build();
+
+    _baseConfig.setRoutingPolicies(
+        ImmutableMap.of(calledPolicyName, calledPolicy, "BASE_POLICY", policy));
+
+    Set<CommunityVar> bufferedStmtResult =
+        _varCollector.visitBufferedStatement(bs, new Tuple<>(new HashSet<>(), _baseConfig));
+    Set<CommunityVar> callStmtResult =
+        _varCollector.visitAll(policy.getStatements(), new Tuple<>(new HashSet<>(), _baseConfig));
+    assertEquals(bufferedStmtResult, callStmtResult);
   }
 
   @Test
@@ -107,6 +150,8 @@ public class RoutePolicyStatementVarCollectorTest {
     ExcludeAsPath excludeAsPath =
         new ExcludeAsPath(new LiteralAsList(ImmutableList.of(new ExplicitAs(1L))));
 
-    assertEquals(ImmutableSet.of(), _varCollector.visitExcludeAsPath(excludeAsPath, _baseConfig));
+    assertEquals(
+        ImmutableSet.of(),
+        _varCollector.visitExcludeAsPath(excludeAsPath, new Tuple<>(new HashSet<>(), _baseConfig)));
   }
 }


### PR DESCRIPTION
Updates the SearchRoutePolicies/CompareRoutePolicies questions to only compute the AtomicPredicates for the set of policies that are used in the question instead of the whole file. This is done for performance reasons; computing APs in configs with multiple regex based AS-path/community definitions can be very expensive.

Updates community/AS visitors to recursively visit called policies. This assumes routing policies do not include mutual recursion (a valid assumption AFAIK), otherwise the visitors would loop forever.