### PR TITLE
Docs: Add config states to parser documentation

### DIFF
--- a/docs/example_code/new_vendor/src/main/antlr4/org/batfish/grammar/cool_nos/CoolNosLexer.g4
+++ b/docs/example_code/new_vendor/src/main/antlr4/org/batfish/grammar/cool_nos/CoolNosLexer.g4
@@ -19,6 +19,7 @@ ETHERNET: 'ethernet';
 GATEWAY: 'gateway';
 HOST_NAME: 'host-name' -> pushMode(M_String);
 INTERFACE: 'interface';
+LINE: 'line';
 LOG: 'log';
 LOGIN_BANNER: 'login-banner';
 MODIFY: 'modify';
@@ -26,6 +27,7 @@ STATIC_ROUTES: 'static-routes';
 SYSLOG: 'syslog';
 SYSTEM: 'system';
 VLAN: 'vlan';
+VTY: 'vty';
 
 // END keywords
 

--- a/docs/example_code/new_vendor/src/main/antlr4/org/batfish/grammar/cool_nos/CoolNosParser.g4
+++ b/docs/example_code/new_vendor/src/main/antlr4/org/batfish/grammar/cool_nos/CoolNosParser.g4
@@ -18,9 +18,15 @@ cool_nos_configuration
 
 statement
 :
-  s_log_null
+  s_line
+  | s_log_null
   | s_static_routes
   | s_system
+;
+
+s_line
+:
+  LINE VTY NEWLINE
 ;
 
 s_log_null

--- a/docs/example_code/new_vendor/src/main/java/org/batfish/grammar/cool_nos/CoolNosConfigurationBuilder.java
+++ b/docs/example_code/new_vendor/src/main/java/org/batfish/grammar/cool_nos/CoolNosConfigurationBuilder.java
@@ -22,6 +22,7 @@ import org.batfish.grammar.cool_nos.CoolNosParser.Host_nameContext;
 import org.batfish.grammar.cool_nos.CoolNosParser.Interface_nameContext;
 import org.batfish.grammar.cool_nos.CoolNosParser.Ipv4_addressContext;
 import org.batfish.grammar.cool_nos.CoolNosParser.Ipv4_prefixContext;
+import org.batfish.grammar.cool_nos.CoolNosParser.S_lineContext;
 import org.batfish.grammar.cool_nos.CoolNosParser.Ss_addContext;
 import org.batfish.grammar.cool_nos.CoolNosParser.Ss_deleteContext;
 import org.batfish.grammar.cool_nos.CoolNosParser.Ss_disableContext;
@@ -144,6 +145,11 @@ public final class CoolNosConfigurationBuilder extends CoolNosParserBaseListener
   @Override
   public void exitSs_disable(Ss_disableContext ctx) {
     _currentStaticRoute.setEnable(false);
+  }
+
+  @Override
+  public void exitS_line(S_lineContext ctx) {
+    todo(ctx);
   }
 
   private @Nonnull Optional<String> toString(

--- a/docs/extraction/README.md
+++ b/docs/extraction/README.md
@@ -291,3 +291,25 @@ parse tree nodes (subclasses of `ParserRuleContext`). This has multiple benefits
 * If the type of a child node (or alias of a child node) changes, the converter-calling code will no
   longer compile. You will immediately see where changes need to be made, rather than having to wait
   for a test to fail, or worse - something to fail in production.
+
+### Unimplemented warnings in extraction
+Sometimes there are cases where a line has been added to the grammar, but it still needs further implementation. 
+In these cases, we still want to leave a warning for this line. 
+
+A generic `todo` in extraction automatically adds an unimplemented warning:
+
+```
+  @Override
+  public void exitS_line(S_lineContext ctx) {
+    todo(ctx);
+  }
+```
+
+or alternatively, add a custom warning, to give further details:
+
+```
+...
+warn(ctx, "This line is unimplemented for reasons");
+...
+```
+

--- a/docs/parsing/README.md
+++ b/docs/parsing/README.md
@@ -22,6 +22,17 @@ have a good foundation and be better prepared to:
 * understand build errors and test failures you encounter while making changes
 * respond and react competently to review comments on your pull requests
 
+## States of config support and accompanying warnings:
+Based on how far implementation goes, a config line should be in one of the following states:
+
+1. Not parsed (in the grammar) at all: unrecognized.
+2. In the grammar, but never needs to be extracted: silently ignored, but we add [_null suffix](#ending-rules-in-_null) to indicate it.
+3. In the grammar, not implemented yet, but known to be wrong if used. In this case, we warn, with things like [todo(...)](../extraction/README.md#Unimplemented-warnings-in-extraction)  or [warn(...)](../extraction/README.md#Validating-and-converting-parse-tree-nodes-with-variable-text) at extraction time. See `todo` and `warn` functions in [BatfishListener.java](https://github.com/batfish/batfish/blob/master/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishListener.java)
+4. In the grammar and extracted, but depending on how it's used may not be supported correctly. In that case, we warn during conversion (Warnings#redFlag typically) if we can tell that it's not supported. If we can't tell, we warn unconditionally (and try to come up with a better system).
+5. Fully implemented. No warnings.
+
+It is important to identify which state a line should be in before parsing, so that all unimplemented constructs have appropriate indicators. 
+
 ## Batfish DSL parsing
 
 Within the Batfish repository, Batfish DSL parsers are divided into several components. For the


### PR DESCRIPTION
The fourth state could use some more context, but this can be added when we circle back to flesh out the Conversion documentation. 