### PR TITLE
Implement network statement advertisement to bgp rib

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,6 +60,7 @@ public class BgpProcess implements Serializable {
     @Nullable private Ip _routerId;
     @Nullable private Vrf _vrf;
     @Nullable private String _networkPolicy;
+    @Nullable private String _mainRibIndependentNetworkPolicy;
     @Nullable private String _redistributionPolicy;
     @Nullable private LocalOriginationTypeTieBreaker _localOriginationTypeTieBreaker;
     @Nullable private NextHopIpTieBreaker _networkNextHopIpTieBreaker;
@@ -92,6 +94,7 @@ public class BgpProcess implements Serializable {
               _localAdminCost,
               _confederation,
               _networkPolicy,
+              _mainRibIndependentNetworkPolicy,
               _redistributionPolicy,
               _localOriginationTypeTieBreaker,
               _networkNextHopIpTieBreaker,
@@ -143,6 +146,12 @@ public class BgpProcess implements Serializable {
 
     public @Nonnull Builder setNetworkPolicy(@Nullable String networkPolicy) {
       _networkPolicy = networkPolicy;
+      return this;
+    }
+
+    public @Nonnull Builder setMainRibIndependentNetworkPolicy(
+        @Nullable String mainRibIndependentNetworkPolicy) {
+      _mainRibIndependentNetworkPolicy = mainRibIndependentNetworkPolicy;
       return this;
     }
 
@@ -198,6 +207,8 @@ public class BgpProcess implements Serializable {
   private static final String PROP_CLUSTER_LIST_AS_IBGP_COST = "clusterListAsIbgpCost";
   private static final String PROP_CLUSTER_LIST_AS_IGP_COST_DEPRECATED = "clusterListAsIgpCost";
   private static final String PROP_INDEPENDENT_NETWORK_POLICY = "independentNetworkPolicy";
+  private static final String PROP_MAIN_RIB_INDEPENDENT_NETWORK_POLICY =
+      "mainRibIndependentNetworkPolicy";
   private static final String PROP_REDISTRIBUTION_POLICY = "redistributionPolicy";
   private static final String PROP_LOCAL_ORIGINATION_TYPE_TIE_BREAKER =
       "localOriginationTypeTieBreaker";
@@ -239,11 +250,19 @@ public class BgpProcess implements Serializable {
 
   @Nullable private String _independentNetworkPolicy;
 
+  @Nullable private String _mainRibIndependentNetworkPolicy;
+
   @Nullable private String _redistributionPolicy;
 
   private final @Nonnull LocalOriginationTypeTieBreaker _localOriginationTypeTieBreaker;
   private final @Nonnull NextHopIpTieBreaker _networkNextHopIpTieBreaker;
   private final @Nonnull NextHopIpTieBreaker _redistributeNextHopIpTieBreaker;
+
+  /**
+   * a list of prefixes from bgp network statements that will be unconditionally advertised if
+   * _mainRibIndependentNetworkPolicy is set
+   */
+  private List<Prefix> _unconditionalNetworkStatements;
 
   private BgpProcess(
       @Nonnull Ip routerId,
@@ -252,6 +271,7 @@ public class BgpProcess implements Serializable {
       int localAdminCost,
       @Nullable BgpConfederation confederation,
       @Nullable String independentNetworkPolicy,
+      @Nullable String mainRibIndependentNetworkPolicy,
       @Nullable String redistributionPolicy,
       @Nonnull LocalOriginationTypeTieBreaker localOriginationTypeTieBreaker,
       @Nonnull NextHopIpTieBreaker networkNextHopIpTieBreaker,
@@ -270,10 +290,12 @@ public class BgpProcess implements Serializable {
     _routerId = routerId;
     _clusterListAsIbgpCost = false;
     _independentNetworkPolicy = independentNetworkPolicy;
+    _mainRibIndependentNetworkPolicy = mainRibIndependentNetworkPolicy;
     _redistributionPolicy = redistributionPolicy;
     _localOriginationTypeTieBreaker = localOriginationTypeTieBreaker;
     _networkNextHopIpTieBreaker = networkNextHopIpTieBreaker;
     _redistributeNextHopIpTieBreaker = redistributeNextHopIpTieBreaker;
+    _unconditionalNetworkStatements = new ArrayList<>();
   }
 
   @JsonCreator
@@ -284,6 +306,8 @@ public class BgpProcess implements Serializable {
       @Nullable @JsonProperty(PROP_IBGP_ADMIN_COST) Integer ibgpAdminCost,
       @Nullable @JsonProperty(PROP_LOCAL_ADMIN_COST) Integer localAdminCost,
       @Nullable @JsonProperty(PROP_INDEPENDENT_NETWORK_POLICY) String networkPolicy,
+      @Nullable @JsonProperty(PROP_MAIN_RIB_INDEPENDENT_NETWORK_POLICY)
+          String mainRibIndependentNetworkPolicy,
       @Nullable @JsonProperty(PROP_REDISTRIBUTION_POLICY) String redistributionPolicy,
       @Nullable @JsonProperty(PROP_LOCAL_ORIGINATION_TYPE_TIE_BREAKER)
           LocalOriginationTypeTieBreaker localOriginationTypeTieBreaker,
@@ -313,6 +337,7 @@ public class BgpProcess implements Serializable {
         localAdminCost,
         confederation,
         networkPolicy,
+        mainRibIndependentNetworkPolicy,
         redistributionPolicy,
         localOriginationTypeTieBreaker,
         networkNextHopIpTieBreaker,
@@ -357,6 +382,11 @@ public class BgpProcess implements Serializable {
    */
   public void addToOriginationSpace(Prefix prefix) {
     _originationSpace.addPrefix(prefix);
+  }
+
+  /** Add a prefix announced in a network statement unconditionally (without consulting main RIB) */
+  public void addUnconditionalNetworkStatements(Prefix prefix) {
+    _unconditionalNetworkStatements.add(prefix);
   }
 
   /**
@@ -468,6 +498,11 @@ public class BgpProcess implements Serializable {
   @JsonIgnore
   public PrefixSpace getOriginationSpace() {
     return _originationSpace;
+  }
+
+  @JsonIgnore
+  public List<Prefix> getUnconditionalNetworkStatements() {
+    return _unconditionalNetworkStatements;
   }
 
   /**
@@ -584,6 +619,26 @@ public class BgpProcess implements Serializable {
 
   public void setIndependentNetworkPolicy(@Nullable String independentNetworkPolicy) {
     _independentNetworkPolicy = independentNetworkPolicy;
+  }
+
+  /**
+   * Name of the main RIB independent network policy for this process. Set for vendors like FRR that
+   * may announce networks via {@code network} statements regardless of if the route is present in
+   * the main RIB.
+   *
+   * <p>If non-null, these networks will unquestionably be announced to BGP neighbors
+   *
+   * <p>If {@code null}, indicates that networks must be in the main RIB to be announced to BGP
+   * neighbors.
+   */
+  @JsonProperty(PROP_MAIN_RIB_INDEPENDENT_NETWORK_POLICY)
+  @Nullable
+  public String getMainRibIndependentNetworkPolicy() {
+    return _mainRibIndependentNetworkPolicy;
+  }
+
+  public void setMainRibIndependentNetworkPolicy(@Nullable String mainRibIndependentNetworkPolicy) {
+    _mainRibIndependentNetworkPolicy = mainRibIndependentNetworkPolicy;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -75,6 +75,7 @@ import org.batfish.datamodel.EvpnType5Route;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.GenericRibReadOnly;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.KernelRoute;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.OriginMechanism;
@@ -266,6 +267,13 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   /** Keep track of EVPN type 3 routes initialized from our own VNI settings */
   @Nonnull private RibDelta<EvpnType3Route> _evpnInitializationDelta;
 
+  /**
+   * Delta builder for vendors that announce networks to all neighbors regardless of whether they
+   * have that network in their main RIB
+   */
+  @Nonnull
+  private RibDelta<AnnotatedRoute<AbstractRoute>> _mainRibIndependentNetworkInitializationDelta;
+
   /** Delta builder for routes that must be propagated to the main RIB */
   @Nonnull private RibDelta.Builder<BgpRoute<?, ?>> _toMainRib = RibDelta.builder();
 
@@ -406,6 +414,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             clusterListAsIbgpCost,
             _process.getLocalOriginationTypeTieBreaker());
     _evpnInitializationDelta = RibDelta.empty();
+    _mainRibIndependentNetworkInitializationDelta = RibDelta.empty();
     _ribExprEvaluator = new RibExprEvaluator(_mainRib);
     _aggregates = new PrefixTrieMultiMap<>();
     _process.getAggregates().forEach(_aggregates::put);
@@ -421,6 +430,25 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   public void initialize(Node n) {
     _initialized = true;
     initLocalEvpnRoutes();
+    initMainRibIndependentNetworkRoutes();
+  }
+
+  /** Initialize routes that will be announced to BGP neighbors regardless of main RIB */
+  public void initMainRibIndependentNetworkRoutes() {
+    if (_process.getMainRibIndependentNetworkPolicy() == null) {
+      return;
+    }
+
+    Builder<AnnotatedRoute<AbstractRoute>> initializationBuilder = RibDelta.builder();
+    _process
+        .getUnconditionalNetworkStatements()
+        .forEach(
+            network -> {
+              AnnotatedRoute<AbstractRoute> route =
+                  annotateRoute(KernelRoute.builder().setNetwork(network).build());
+              initializationBuilder.add(route);
+            });
+    _mainRibIndependentNetworkInitializationDelta = initializationBuilder.build();
   }
 
   /** Returns true if this process has been initialized */
@@ -559,6 +587,19 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       _evpnInitializationDelta = RibDelta.empty();
     }
 
+    if (!_mainRibIndependentNetworkInitializationDelta.isEmpty()
+        && _process.getMainRibIndependentNetworkPolicy() != null) {
+      _mainRibIndependentNetworkInitializationDelta
+          .getActions()
+          .forEach(
+              a ->
+                  redistributeRouteToBgpRib(
+                      a,
+                      _policies.get(_process.getMainRibIndependentNetworkPolicy()).get(),
+                      NETWORK));
+      _mainRibIndependentNetworkInitializationDelta = RibDelta.empty();
+    }
+
     /*
      If we have any new edges, send out our RIB state to them.
      EVPN only
@@ -648,8 +689,8 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   }
 
   /**
-   * Convert the advertised main RIB route to a BGP route and run it through the provided policy. If
-   * it passes, apply the advertisement to the BGP RIB (i.e. merge or withdraw the route) and update
+   * Convert the advertised route to a BGP route and run it through the provided policy. If it
+   * passes, apply the advertisement to the BGP RIB (i.e. merge or withdraw the route) and update
    * BGP delta builders.
    */
   private void redistributeRouteToBgpRib(


### PR DESCRIPTION
Fix #8623

Update `BgpProcess` and `BgpRoutingProcess` to support announcing prefixes from network statements to neighbors regardless of if they have that neighbor in their main RIB. 

This is implemented by adding a list of networks into BgpProcess as well as a new policy, mainRibIndependentNetworkPolicy. On initialization in BgpRoutingProcess, a RibDelta is populated, which is then used in the next iteration to redistribute these routes to BGP.