### PR TITLE
Layer1Topology: reduce internal memory use and complexity

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/HybridL3Adjacencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/HybridL3Adjacencies.java
@@ -45,8 +45,8 @@ public final class HybridL3Adjacencies implements L3Adjacencies {
       Map<String, Configuration> configurations) {
     Set<String> nodesWithL1Topology =
         Stream.concat(
-                layer1Topologies.getUserProvidedL1().getGraph().edges().stream(),
-                layer1Topologies.getActiveLogicalL1().getGraph().edges().stream())
+                layer1Topologies.getUserProvidedL1().edgeStream(),
+                layer1Topologies.getActiveLogicalL1().edgeStream())
             .filter(
                 // Ignore border-to-ISP edges when computing the set of nodes for which users
                 // provided L1 topology. Batfish adds these edges during ISP modeling, and not

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Topologies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Topologies.java
@@ -1,9 +1,9 @@
 package org.batfish.common.topology;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Sets;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
@@ -97,7 +97,7 @@ public final class Layer1Topologies {
     _synthesizedL1 = synthesizedL1;
     _combinedL1 =
         new Layer1Topology(
-            Sets.union(_canonicalUserL1.getGraph().edges(), _synthesizedL1.getGraph().edges()));
+            Stream.concat(_canonicalUserL1.edgeStream(), _synthesizedL1.edgeStream()));
     _logicalL1 = logicalL1;
     _activeLogicalL1 = activeLogicalL1;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1TopologiesFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1TopologiesFactory.java
@@ -2,7 +2,6 @@ package org.batfish.common.topology;
 
 import static org.batfish.common.topology.Layer1Topologies.INVALID_INTERFACE;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -76,7 +75,7 @@ public final class Layer1TopologiesFactory {
       Layer1Topology topology, Map<String, Configuration> configurations) {
     Map<Layer1Node, Layer1Node> replacements = new HashMap<>();
     Set<String> missingDevices = new HashSet<>(); // dedupe warnings about missing devices
-    for (Layer1Node original : topology.getGraph().nodes()) {
+    for (Layer1Node original : topology.nodes()) {
       Layer1Node canonical = canonicalizeUserNode(original, configurations, missingDevices);
       if (!canonical.equals(original)) {
         replacements.put(original, canonical);
@@ -92,13 +91,13 @@ public final class Layer1TopologiesFactory {
       return topology;
     }
     return new Layer1Topology(
-        topology.getGraph().edges().stream()
+        topology
+            .edgeStream()
             .map(
                 edge ->
                     new Layer1Edge(
                         replacements.getOrDefault(edge.getNode1(), edge.getNode1()),
-                        replacements.getOrDefault(edge.getNode2(), edge.getNode2())))
-            .collect(ImmutableSet.toImmutableSet()));
+                        replacements.getOrDefault(edge.getNode2(), edge.getNode2()))));
   }
 
   /**
@@ -155,14 +154,12 @@ public final class Layer1TopologiesFactory {
     Set<Layer1Node> invalidInterfaces =
         new HashSet<>(); // dedupe warnings about missing or invalid interfaces.
     return new Layer1Topology(
-        Stream.concat(
-                userProvidedL1.getGraph().edges().stream(), syntheticL1.getGraph().edges().stream())
+        Stream.concat(userProvidedL1.edgeStream(), syntheticL1.edgeStream())
             .map(
                 edge ->
                     new Layer1Edge(
                         toLogicalNode(edge.getNode1(), configs, invalidInterfaces),
-                        toLogicalNode(edge.getNode2(), configs, invalidInterfaces)))
-            .collect(ImmutableSet.toImmutableSet()));
+                        toLogicalNode(edge.getNode2(), configs, invalidInterfaces))));
   }
 
   /**
@@ -173,11 +170,11 @@ public final class Layer1TopologiesFactory {
   private static @Nonnull Layer1Topology cleanLogicalTopology(
       Layer1Topology logicalTopology, Map<String, Configuration> configs) {
     return new Layer1Topology(
-        logicalTopology.getGraph().edges().stream()
+        logicalTopology
+            .edgeStream()
             .filter(
                 edge -> isActive(edge.getNode1(), configs) && isActive(edge.getNode2(), configs))
-            .flatMap(edge -> Stream.of(edge, edge.reverse()))
-            .collect(ImmutableSet.toImmutableSet()));
+            .flatMap(edge -> Stream.of(edge, edge.reverse())));
   }
 
   /** Returns true if the node corresponds to an existing, active interface. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Topology.java
@@ -3,13 +3,18 @@ package org.batfish.common.topology;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.graph.ImmutableNetwork;
-import com.google.common.graph.MutableNetwork;
-import com.google.common.graph.NetworkBuilder;
+import com.google.common.collect.Ordering;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.ImmutableGraph;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.SortedSet;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -26,29 +31,47 @@ public final class Layer1Topology {
     return new Layer1Topology(edges != null ? edges : ImmutableSortedSet.of());
   }
 
-  private final ImmutableNetwork<Layer1Node, Layer1Edge> _graph;
+  private final ImmutableGraph<Layer1Node> _graph;
 
+  @VisibleForTesting
   public Layer1Topology(@Nonnull Layer1Edge... edges) {
-    this(Arrays.asList(edges));
+    this(Arrays.stream(edges));
   }
 
   public Layer1Topology(@Nonnull Iterable<Layer1Edge> edges) {
-    MutableNetwork<Layer1Node, Layer1Edge> graph =
-        NetworkBuilder.directed().allowsParallelEdges(false).allowsSelfLoops(false).build();
+    this(StreamSupport.stream(edges.spliterator(), false));
+  }
+
+  public Layer1Topology(@Nonnull Stream<Layer1Edge> edges) {
+    ImmutableGraph.Builder<Layer1Node> graph =
+        GraphBuilder.directed().allowsSelfLoops(false).immutable();
     edges.forEach(
         edge -> {
-          if (edge.getNode1().equals(edge.getNode2()) || graph.edges().contains(edge)) {
-            // Ignore self-loops and parallel edges
+          if (edge.getNode1().equals(edge.getNode2())) {
+            // Ignore self-loops
             return;
           }
-          graph.addEdge(edge.getNode1(), edge.getNode2(), edge);
+          graph.putEdge(edge.getNode1(), edge.getNode2());
         });
-    _graph = ImmutableNetwork.copyOf(graph);
+    _graph = graph.build();
   }
 
   @JsonIgnore
-  public @Nonnull ImmutableNetwork<Layer1Node, Layer1Edge> getGraph() {
-    return _graph;
+  public @Nonnull Stream<Layer1Edge> edgeStream() {
+    return _graph.edges().stream().map(ep -> new Layer1Edge(ep.nodeU(), ep.nodeV()));
+  }
+
+  @JsonIgnore
+  public @Nonnull Set<Layer1Node> adjacentNodes(Layer1Node node) {
+    if (!_graph.nodes().contains(node)) {
+      return ImmutableSet.of();
+    }
+    return _graph.adjacentNodes(node);
+  }
+
+  @JsonIgnore
+  public @Nonnull Set<Layer1Node> nodes() {
+    return _graph.nodes();
   }
 
   /** Returns true if this {@link Layer1Topology} has no edges (it may have nodes). */
@@ -59,7 +82,7 @@ public final class Layer1Topology {
 
   @JsonProperty(PROP_EDGES)
   private SortedSet<Layer1Edge> getJsonEdges() {
-    return ImmutableSortedSet.copyOf(_graph.edges());
+    return edgeStream().collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural()));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/PointToPointComputer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/PointToPointComputer.java
@@ -55,12 +55,12 @@ public final class PointToPointComputer {
   @VisibleForTesting
   static Map<NodeInterfacePair, NodeInterfacePair> pointToPointInterfaces(Layer1Topology topology) {
     Map<NodeInterfacePair, NodeInterfacePair> pointToPoint = new HashMap<>();
-    for (Layer1Node n : topology.getGraph().nodes()) {
+    for (Layer1Node n : topology.nodes()) {
       if (n.equals(Layer1Topologies.INVALID_INTERFACE)) {
         // Not valid point-to-point interface.
         continue;
       }
-      Set<Layer1Node> neighbors = topology.getGraph().adjacentNodes(n);
+      Set<Layer1Node> neighbors = topology.adjacentNodes(n);
       if (neighbors.size() != 1) {
         // Not unique, so no point-to-point link.
         continue;
@@ -70,7 +70,7 @@ public final class PointToPointComputer {
         // Not valid point-to-point interface.
         continue;
       }
-      Set<Layer1Node> neighborNeighbors = topology.getGraph().adjacentNodes(neighbor);
+      Set<Layer1Node> neighborNeighbors = topology.adjacentNodes(neighbor);
       if (!neighborNeighbors.isEmpty() && !neighborNeighbors.equals(ImmutableSet.of(n))) {
         // Neighbor has either too many neighbors or the wrong neighbor; empty is okay though.
         // (Keep in mind: topology is directed, and may be asymmetric.)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -361,8 +361,7 @@ public final class TopologyUtil {
 
     // Pre-compute nodes that have L1 or VXLAN edges, and only compute L2 edges for those.
     Set<String> nodesWithL1Edge =
-        layer1LogicalTopology.getGraph().edges().stream()
-            .flatMap(edge -> Stream.of(edge.getNode1(), edge.getNode2()))
+        layer1LogicalTopology.nodes().stream()
             .map(Layer1Node::getHostname)
             .collect(ImmutableSet.toImmutableSet());
     Set<String> nodesWithVxlan =
@@ -392,8 +391,7 @@ public final class TopologyUtil {
 
     // Add layer2 edges for physical links.
     layer1LogicalTopology
-        .getGraph()
-        .edges()
+        .edgeStream()
         .forEach(
             layer1Edge ->
                 computeLayer2EdgesForLayer1Edge(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.batfish.common.topology.Layer1Node;
 import org.batfish.common.topology.Layer1Topologies;
-import org.batfish.common.topology.Layer1Topology;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.Interface;
@@ -233,11 +232,11 @@ public class InterfaceDependencies {
     Layer1Node layer1Node = new Layer1Node(iface.getOwner().getHostname(), iface.getName());
     switch (iface.getInterfaceType()) {
       case PHYSICAL:
-        return adjacentNodes(_layer1Topologies.getCombinedL1(), layer1Node);
+        return _layer1Topologies.getCombinedL1().adjacentNodes(layer1Node);
       case AGGREGATED:
       case REDUNDANT:
         // the logical L1 contains physical nodes and AGGREGATED/REDUNDANT nodes. filter them out.
-        return adjacentNodes(_layer1Topologies.getLogicalL1(), layer1Node).stream()
+        return _layer1Topologies.getLogicalL1().adjacentNodes(layer1Node).stream()
             .filter(
                 node ->
                     getInterfaceType(node)
@@ -262,13 +261,6 @@ public class InterfaceDependencies {
       return Optional.empty();
     }
     return Optional.of(iface.getInterfaceType());
-  }
-
-  private static Set<Layer1Node> adjacentNodes(Layer1Topology topology, Layer1Node node) {
-    if (!topology.getGraph().nodes().contains(node)) {
-      return ImmutableSet.of();
-    }
-    return topology.getGraph().adjacentNodes(node);
   }
 
   private @Nullable NodeInterfacePair getL1Neighbor(Interface iface) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1TopologyTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 /** Tests of {@link Layer1Topology} */
@@ -14,7 +15,7 @@ public class Layer1TopologyTest {
     // Two equivalent edges. Resulting topology should contain only one copy of the edge.
     Layer1Edge e1 = new Layer1Edge("c1", "i1", "c2", "i2");
     Layer1Edge e2 = new Layer1Edge("c1", "i1", "c2", "i2");
-    assertThat(new Layer1Topology(e1, e2).getGraph().edges(), contains(e1));
+    assertThat(new Layer1Topology(e1, e2).edgeStream().collect(Collectors.toList()), contains(e1));
   }
 
   @Test
@@ -28,6 +29,6 @@ public class Layer1TopologyTest {
   public void testConstructorDoesNotIgnoreEdgeBetweenInterfacesOnSameNode() {
     // Edge between two different interfaces on the same node should not be ignored.
     Layer1Edge e = new Layer1Edge("c1", "i1", "c1", "i2");
-    assertThat(new Layer1Topology(e).getGraph().edges(), contains(e));
+    assertThat(new Layer1Topology(e).edgeStream().collect(Collectors.toList()), contains(e));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1039,7 +1039,7 @@ public final class FlatJuniperGrammarTest {
 
     // check layer-1 logical adjacencies
     assertThat(
-        layer1LogicalTopology.getGraph().edges(),
+        layer1LogicalTopology.edgeStream().collect(Collectors.toList()),
         hasItem(new Layer1Edge("r1", "ae0", "r2", "ae0")));
 
     // check layer-2 adjacencies

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -390,13 +390,12 @@ public class BatfishTest {
     Layer1Node c1i3 = new Layer1Node("c1", "i3");
     Layer1Node c2i4 = new Layer1Node("c2", "i4");
     assertThat(
-        layer1Topology.getGraph().edges(),
-        equalTo(
-            ImmutableSet.of(
-                new Layer1Edge(c1i1, c2i2),
-                new Layer1Edge(c2i2, c1i1),
-                new Layer1Edge(c1i3, c2i4),
-                new Layer1Edge(c2i4, c1i3))));
+        layer1Topology.edgeStream().collect(Collectors.toList()),
+        containsInAnyOrder(
+            new Layer1Edge(c1i1, c2i2),
+            new Layer1Edge(c2i2, c1i1),
+            new Layer1Edge(c1i3, c2i4),
+            new Layer1Edge(c2i4, c1i3)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -2224,7 +2225,7 @@ public class CheckPointGatewayGrammarTest {
         batfish.getTopologyProvider().getLayer1Topologies(batfish.getSnapshot()).getSynthesizedL1();
 
     assertThat(
-        generatedTopology.getGraph().edges(),
+        generatedTopology.edgeStream().collect(Collectors.toList()),
         containsInAnyOrder(
             new Layer1Edge(hostname1, SYNC_INTERFACE_NAME, hostname2, SYNC_INTERFACE_NAME),
             new Layer1Edge(hostname2, SYNC_INTERFACE_NAME, hostname1, SYNC_INTERFACE_NAME)));

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -190,7 +190,8 @@ public class EdgesAnswerer extends Answerer {
             .map(
                 userProvidedLayer1Topology ->
                     (Multiset<Row>)
-                        userProvidedLayer1Topology.getGraph().edges().stream()
+                        userProvidedLayer1Topology
+                            .edgeStream()
                             .map(EdgesAnswerer::layer1EdgeToRow)
                             .collect(Collectors.toCollection(HashMultiset::create)))
             .orElse(ImmutableMultiset.of());
@@ -287,7 +288,8 @@ public class EdgesAnswerer extends Answerer {
     if (layer1Topology == null) {
       return ImmutableList.of();
     }
-    return layer1Topology.getGraph().edges().stream()
+    return layer1Topology
+        .edgeStream()
         .filter(
             layer1Edge ->
                 includeNodes.contains(layer1Edge.getNode1().getHostname())


### PR DESCRIPTION
Guava Network has data-typed edges, where as Graph just has node pairs. We only
need the latter.

To improve maintainability, stop exposing internal implementation details and
create only-Batfish-typed accessors.

commit-id:c2478701