### PR TITLE
Junos: Create a /32 discard route for inactive interfaces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRouteMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRouteMetadata.java
@@ -15,6 +15,8 @@ import javax.annotation.Nullable;
 public final class ConnectedRouteMetadata implements Serializable {
   private static final String PROP_ADMIN = "admin";
   private static final String PROP_GENERATE_CONNECTED_ROUTE = "generateConnectedRoute";
+  private static final String PROP_GENERATE_LOCAL_NULL_ROUTE_IF_DOWN =
+      "generateLocalNullRouteIfDown";
   // plural for backwards compatibility, wrong.
   private static final String PROP_GENERATE_LOCAL_ROUTES = "generateLocalRoutes";
   private static final String PROP_TAG = "tag";
@@ -28,6 +30,10 @@ public final class ConnectedRouteMetadata implements Serializable {
   // If set, controls whether a local route is generated for this connected route. If unset, the
   // default behavior is to generate local routes for /31 networks or larger
   @Nullable private final Boolean _generateLocalRoute;
+
+  // If set, controls whether a local null route is generated for this connected route when the
+  // interface is down. If unset, these routes are not generated.
+  @Nullable private final Boolean _generateLocalNullRouteIfDown;
 
   @Nullable private final Long _tag;
 
@@ -49,6 +55,11 @@ public final class ConnectedRouteMetadata implements Serializable {
     return _generateLocalRoute;
   }
 
+  @JsonProperty(PROP_GENERATE_LOCAL_NULL_ROUTE_IF_DOWN)
+  public @Nullable Boolean getGenerateLocalNullRouteIfDown() {
+    return _generateLocalNullRouteIfDown;
+  }
+
   @Nullable
   @JsonProperty(PROP_TAG)
   public Long getTag() {
@@ -67,6 +78,7 @@ public final class ConnectedRouteMetadata implements Serializable {
     return Objects.equals(_admin, that._admin)
         && Objects.equals(_generateConnectedRoute, that._generateConnectedRoute)
         && Objects.equals(_generateLocalRoute, that._generateLocalRoute)
+        && Objects.equals(_generateLocalNullRouteIfDown, that._generateLocalNullRouteIfDown)
         && Objects.equals(_tag, that._tag);
   }
 
@@ -77,13 +89,15 @@ public final class ConnectedRouteMetadata implements Serializable {
         .add(PROP_ADMIN, _admin)
         .add(PROP_GENERATE_CONNECTED_ROUTE, _generateConnectedRoute)
         .add(PROP_GENERATE_LOCAL_ROUTES, _generateLocalRoute)
+        .add(PROP_GENERATE_LOCAL_NULL_ROUTE_IF_DOWN, _generateLocalNullRouteIfDown)
         .add(PROP_TAG, _tag)
         .toString();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_admin, _generateConnectedRoute, _generateLocalRoute, _tag);
+    return Objects.hash(
+        _admin, _generateConnectedRoute, _generateLocalRoute, _generateLocalNullRouteIfDown, _tag);
   }
 
   public static Builder builder() {
@@ -98,10 +112,12 @@ public final class ConnectedRouteMetadata implements Serializable {
       @Nullable Integer admin,
       @Nullable Boolean generateConnectedRoute,
       @Nullable Boolean generateLocalRoute,
+      @Nullable Boolean generateLocalNullRouteIfDown,
       @Nullable Long tag) {
     _admin = admin;
     _generateConnectedRoute = generateConnectedRoute;
     _generateLocalRoute = generateLocalRoute;
+    _generateLocalNullRouteIfDown = generateLocalNullRouteIfDown;
     _tag = tag;
   }
 
@@ -109,6 +125,7 @@ public final class ConnectedRouteMetadata implements Serializable {
     @Nullable private Integer _admin;
     @Nullable private Boolean _generateConnectedRoute;
     @Nullable private Boolean _generateLocalRoute;
+    @Nullable private Boolean _generateLocalNullRouteIfDown;
     @Nullable private Long _tag;
 
     private Builder() {}
@@ -144,6 +161,12 @@ public final class ConnectedRouteMetadata implements Serializable {
     }
 
     @Nonnull
+    public Builder setGenerateLocalNullRouteIfDown(@Nullable Boolean generateLocalNullRouteIfDown) {
+      _generateLocalNullRouteIfDown = generateLocalNullRouteIfDown;
+      return this;
+    }
+
+    @Nonnull
     public Builder setGenerateLocalRoute(boolean generateLocalRoute) {
       _generateLocalRoute = generateLocalRoute;
       return this;
@@ -163,7 +186,12 @@ public final class ConnectedRouteMetadata implements Serializable {
 
     @Nonnull
     public ConnectedRouteMetadata build() {
-      return new ConnectedRouteMetadata(_admin, _generateConnectedRoute, _generateLocalRoute, _tag);
+      return new ConnectedRouteMetadata(
+          _admin,
+          _generateConnectedRoute,
+          _generateLocalRoute,
+          _generateLocalNullRouteIfDown,
+          _tag);
     }
   }
 
@@ -172,7 +200,10 @@ public final class ConnectedRouteMetadata implements Serializable {
       @Nullable @JsonProperty(PROP_ADMIN) Integer admin,
       @Nullable @JsonProperty(PROP_GENERATE_CONNECTED_ROUTE) Boolean generateConnectedRoute,
       @Nullable @JsonProperty(PROP_GENERATE_LOCAL_ROUTES) Boolean generateLocalRoute,
+      @Nullable @JsonProperty(PROP_GENERATE_LOCAL_NULL_ROUTE_IF_DOWN)
+          Boolean generateLocalNullRouteIfDown,
       @Nullable @JsonProperty(PROP_TAG) Long tag) {
-    return new ConnectedRouteMetadata(admin, generateConnectedRoute, generateLocalRoute, tag);
+    return new ConnectedRouteMetadata(
+        admin, generateConnectedRoute, generateLocalRoute, generateLocalNullRouteIfDown, tag);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteMetadataTest.java
@@ -23,13 +23,20 @@ public class ConnectedRouteMetadataTest {
         .addEqualityGroup(builder.setTag(2).build())
         .addEqualityGroup(builder.setGenerateConnectedRoute(true).build())
         .addEqualityGroup(builder.setGenerateConnectedRoute(false).build())
+        .addEqualityGroup(builder.setGenerateLocalNullRouteIfDown(true).build())
+        .addEqualityGroup(builder.setGenerateLocalNullRouteIfDown(false).build())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
     ConnectedRouteMetadata crm =
-        ConnectedRouteMetadata.builder().setAdmin(2).setGenerateLocalRoute(true).setTag(1).build();
+        ConnectedRouteMetadata.builder()
+            .setAdmin(2)
+            .setGenerateLocalRoute(true)
+            .setGenerateLocalNullRouteIfDown(true)
+            .setTag(1)
+            .build();
     assertThat(SerializationUtils.clone(crm), equalTo(crm));
   }
 
@@ -40,6 +47,7 @@ public class ConnectedRouteMetadataTest {
             .setAdmin(2)
             .setGenerateConnectedRoute(false)
             .setGenerateLocalRoute(true)
+            .setGenerateLocalNullRouteIfDown(true)
             .setTag(1)
             .build();
     assertThat(BatfishObjectMapper.clone(crm, ConnectedRouteMetadata.class), equalTo(crm));

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.Range;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -73,6 +74,7 @@ import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.ConnectedRouteMetadata;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
@@ -215,6 +217,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   /** Juniper uses AD 170 for both EBGP and IBGP routes. */
   public static final int DEFAULT_BGP_ADMIN_DISTANCE = 170;
+
+  public static final ConnectedRouteMetadata JUNIPER_CONNECTED_ROUTE_METADATA =
+      ConnectedRouteMetadata.builder().setGenerateLocalNullRouteIfDown(true).build();
 
   public static @Nonnull String computeFirewallFilterTermName(
       @Nonnull String filterName, @Nonnull String termName) {
@@ -1969,23 +1974,15 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
     newIface.setOutgoingFilter(outAcl);
 
-    // Prefix primaryPrefix = iface.getPrimaryAddress();
-    // Set<Prefix> allPrefixes = iface.getAllAddresses();
-    // if (primaryPrefix != null) {
-    // newIface.setAddress(primaryPrefix);
-    // }
-    // else {
-    // if (!allPrefixes.isEmpty()) {
-    // Prefix firstOfAllPrefixes = allPrefixes.toArray(new Prefix[] {})[0];
-    // newIface.setAddress(firstOfAllPrefixes);
-    // }
-    // }
-    // newIface.getAllAddresses().addAll(allPrefixes);
-
     if (iface.getPrimaryAddress() != null) {
       newIface.setAddress(iface.getPrimaryAddress());
     }
     newIface.setAllAddresses(iface.getAllAddresses());
+    newIface.setAddressMetadata(
+        iface.getAllAddresses().stream()
+            .collect(
+                ImmutableSortedMap.toImmutableSortedMap(
+                    Ordering.natural(), a -> a, a -> JUNIPER_CONNECTED_ROUTE_METADATA)));
     if (!iface.getActive()) {
       newIface.adminDown();
     }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.bgp.BgpTopologyUtils.initBgpTopology;
 import static org.batfish.datamodel.eigrp.EigrpTopologyUtils.initEigrpTopology;
 import static org.batfish.datamodel.isis.IsisTopology.initIsisTopology;
 import static org.batfish.dataplane.ibdp.VirtualRouter.generateConnectedRoute;
+import static org.batfish.dataplane.ibdp.VirtualRouter.generateLocalNullRouteForDownInterface;
 import static org.batfish.dataplane.ibdp.VirtualRouter.generateLocalRoute;
 import static org.batfish.dataplane.ibdp.VirtualRouter.shouldGenerateConnectedRoute;
 import static org.batfish.dataplane.ibdp.VirtualRouter.shouldGenerateLocalRoute;
@@ -30,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedSet;
@@ -927,6 +929,38 @@ public class VirtualRouterTest {
     assertTrue(
         shouldGenerateLocalRoute(
             24, ConnectedRouteMetadata.builder().setGenerateLocalRoute(true).build()));
+  }
+
+  @Test
+  public void testShouldGenerateLocalNullRouteIfDown() {
+    ConcreteInterfaceAddress addr = ConcreteInterfaceAddress.parse("1.2.3.5/24");
+    LocalRoute lr =
+        LocalRoute.builder()
+            .setNetwork(Prefix.parse("1.2.3.5/32"))
+            .setNextHop(NextHopDiscard.instance())
+            .setSourcePrefixLength(24)
+            .build();
+
+    assertThat(generateLocalNullRouteForDownInterface(addr, null), equalTo(Optional.empty()));
+    assertThat(
+        generateLocalNullRouteForDownInterface(addr, ConnectedRouteMetadata.builder().build()),
+        equalTo(Optional.empty()));
+    assertThat(
+        generateLocalNullRouteForDownInterface(
+            addr, ConnectedRouteMetadata.builder().setGenerateLocalNullRouteIfDown(false).build()),
+        equalTo(Optional.empty()));
+    assertThat(
+        generateLocalNullRouteForDownInterface(
+            addr, ConnectedRouteMetadata.builder().setGenerateLocalNullRouteIfDown(true).build()),
+        equalTo(Optional.of(lr)));
+    assertThat(
+        generateLocalNullRouteForDownInterface(
+            addr,
+            ConnectedRouteMetadata.builder()
+                .setGenerateLocalNullRouteIfDown(true)
+                .setTag(5L)
+                .build()),
+        equalTo(Optional.of(lr.toBuilder().setTag(5L).build())));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -32,6 +32,7 @@ import static org.batfish.datamodel.flow.TransformationStep.TransformationType.S
 import static org.batfish.datamodel.flow.TransformationStep.TransformationType.STATIC_NAT;
 import static org.batfish.datamodel.matchers.AaaAuthenticationLoginListMatchers.hasMethods;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasAdministrativeCost;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHop;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasProtocol;
 import static org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchers.hasAllowLocalAsIn;
@@ -7728,6 +7729,19 @@ public final class FlatJuniperGrammarTest {
     String hostname = "juniper_nested_multiline_comments";
     // don't crash
     parseConfig(hostname);
+  }
+
+  @Test
+  public void testInactiveInterfaceRoutes() throws IOException {
+    Configuration c = parseConfig("inactive_interface_local_route");
+    Batfish batfish =
+        BatfishTestUtils.getBatfish(ImmutableSortedMap.of(c.getHostname(), c), _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+    assertThat(
+        dp.getRibs().get(c.getHostname(), c.getDefaultVrf().getName()).getRoutes(),
+        contains(
+            allOf(hasPrefix(Prefix.parse("1.1.1.1/32")), hasNextHop(NextHopDiscard.instance()))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/inactive_interface_local_route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/inactive_interface_local_route
@@ -1,0 +1,3 @@
+#RANCID-CONTENT-TYPE: juniper
+set system host-name inactive_interface_local_route
+set interfaces ae0 unit 0 family inet address 1.1.1.1/24


### PR DESCRIPTION
https://www.juniper.net/documentation/us/en/software/junos/interfaces-fundamentals/topics/topic-map/logical-interface-properties.html#id-disabling-a-logical-interface