### PR TITLE
Add StructureManager to improve performance and encapsulate logic

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/references/StructureManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/references/StructureManager.java
@@ -1,0 +1,363 @@
+package org.batfish.datamodel.references;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeMultiset;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings;
+import org.batfish.common.util.CollectionUtil;
+import org.batfish.datamodel.DefinedStructureInfo;
+import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+import org.batfish.vendor.StructureType;
+import org.batfish.vendor.StructureUsage;
+
+/** Manages information about structure definition, reference, and usage. */
+public final class StructureManager implements Serializable {
+
+  /**
+   * Delete the definition of and any references to the specified structure. Returns {@code false}
+   * and warns if the delete request is unsuccessful (e.g. no corresponding structure), otherwise
+   * returns {@code true}.
+   */
+  public boolean deleteStructure(String name, StructureType type, Warnings warnings) {
+    boolean succeeded = deleteDefinition(name, type, warnings);
+    if (succeeded) {
+      deleteReferences(name, type);
+    }
+    return succeeded;
+  }
+
+  /**
+   * Delete the definition for the specified structure. Returns {@code true} if the delete was
+   * successful, otherwise returns {@code false}.
+   */
+  private boolean deleteDefinition(String name, StructureType type, Warnings warnings) {
+    // TODO we're only deleting structures with self-refs currently and need to determine how to
+    // handle other references (e.g. are they undefined references now? do they disappear?)
+    DefinedStructureInfo info = _definitions.get(type.getDescription(), name);
+    if (info == null) {
+      warnings.redFlag(
+          String.format(
+              "Cannot delete structure %s (%s): %s is undefined.",
+              name, type.getDescription(), name));
+      return false;
+    }
+
+    _definitions.remove(type.getDescription(), name);
+    return true;
+  }
+
+  /** Delete any existing references to the specified structure. */
+  private void deleteReferences(String name, StructureType type) {
+    Map<String, Map<StructureUsage, Multiset<Integer>>> refsByName = _references.get(type);
+    if (refsByName != null) {
+      refsByName.remove(name);
+    }
+  }
+
+  /**
+   * Gets the {@link DefinedStructureInfo} for the specified structure {@code name} and {@code
+   * structureType}, initializing if necessary.
+   */
+  public @Nonnull DefinedStructureInfo getOrDefine(StructureType structureType, String name) {
+    DefinedStructureInfo info = _definitions.get(structureType.getDescription(), name);
+    if (info == null) {
+      info = new DefinedStructureInfo();
+      _definitions.put(structureType.getDescription(), name, info);
+    }
+    return info;
+  }
+
+  /**
+   * Gets the {@link DefinedStructureInfo} for the specified structure {@code name} and {@code
+   * structureType}, initializing if necessary.
+   */
+  public @Nonnull Optional<DefinedStructureInfo> getDefinition(
+      StructureType structureType, String name) {
+    return Optional.ofNullable(_definitions.get(structureType.getDescription(), name));
+  }
+
+  /** Returns a map of all structure references to the given type. */
+  public @Nonnull Map<String, Map<StructureUsage, Multiset<Integer>>> getStructureReferences(
+      StructureType type) {
+    return _references.getOrDefault(type, ImmutableMap.of());
+  }
+
+  /** Returns {@code true} iff there is a defined structure with the given type and name. */
+  public boolean hasDefinition(String type, String name) {
+    return _definitions.contains(type, name);
+  }
+
+  /**
+   * Mark all references to a structure of the given type.
+   *
+   * <p>Do not use if {@code type} is used as an abstract structure type; instead use {@link
+   * #markAbstractStructure(StructureType, StructureUsage, Collection)}.
+   */
+  public void markConcreteStructure(StructureType type) {
+    Map<String, Map<StructureUsage, Multiset<Integer>>> references =
+        _references.getOrDefault(type, Collections.emptyMap());
+    references.forEach(
+        (name, byUsage) -> {
+          DefinedStructureInfo def = _definitions.get(type.getDescription(), name);
+          if (def == null) {
+            byUsage.forEach(
+                (usage, lines) -> lines.forEach(line -> undefined(type, name, usage, line)));
+          } else {
+            int count = byUsage.values().stream().mapToInt(Multiset::size).sum();
+            def.setNumReferrers(def.getNumReferrers() + count);
+          }
+        });
+  }
+
+  /**
+   * Updates referrers and/or warns for undefined structures based on references to an abstract
+   * {@link StructureType}: a reference type that may refer to one of a number of defined structure
+   * types passed in {@code structureTypesToCheck}.
+   *
+   * <p>For example using Cisco devices, see {@code CiscoStructureType.ACCESS_LIST} and how it
+   * expands to a list containing many types of IPv4 and IPv6 access lists.
+   */
+  public void markAbstractStructure(
+      StructureType type,
+      StructureUsage usage,
+      Collection<? extends StructureType> structureTypesToCheck) {
+    Map<String, Map<StructureUsage, Multiset<Integer>>> references =
+        firstNonNull(_references.get(type), Collections.emptyMap());
+    references.forEach(
+        (name, byUsage) -> {
+          Multiset<Integer> lines = firstNonNull(byUsage.get(usage), ImmutableMultiset.of());
+          List<DefinedStructureInfo> matchingStructures =
+              structureTypesToCheck.stream()
+                  .map(t -> _definitions.get(t.getDescription(), name))
+                  .filter(Objects::nonNull)
+                  .collect(ImmutableList.toImmutableList());
+          if (matchingStructures.isEmpty()) {
+            for (int line : lines) {
+              undefined(type, name, usage, line);
+            }
+          } else {
+            matchingStructures.forEach(
+                info -> info.setNumReferrers(info.getNumReferrers() + lines.size()));
+          }
+        });
+  }
+
+  /**
+   * Updates referrers and/or warns for undefined structures based on references to an abstract
+   * {@link StructureType}: a reference type that may refer to one of a number of defined structure
+   * types passed in {@code structureTypesToCheck}.
+   */
+  public void markAbstractStructureAllUsages(
+      StructureType type, Collection<? extends StructureType> structureTypesToCheck) {
+    Map<String, Map<StructureUsage, Multiset<Integer>>> references =
+        firstNonNull(_references.get(type), Collections.emptyMap());
+    references.forEach(
+        (name, byUsage) ->
+            byUsage.forEach(
+                (usage, lines) -> {
+                  List<DefinedStructureInfo> matchingStructures =
+                      structureTypesToCheck.stream()
+                          .map(t -> _definitions.get(t.getDescription(), name))
+                          .filter(Objects::nonNull)
+                          .collect(ImmutableList.toImmutableList());
+                  if (matchingStructures.isEmpty()) {
+                    for (int line : lines) {
+                      undefined(type, name, usage, line);
+                    }
+                  } else {
+                    matchingStructures.forEach(
+                        info -> info.setNumReferrers(info.getNumReferrers() + lines.size()));
+                  }
+                }));
+  }
+
+  /** Record a reference on the given line. */
+  public void referenceStructure(
+      @Nonnull StructureType type, @Nonnull String name, @Nonnull StructureUsage usage, int line) {
+    _references
+        .computeIfAbsent(type, t -> new HashMap<>())
+        .computeIfAbsent(name, n -> new HashMap<>())
+        .computeIfAbsent(usage, u -> TreeMultiset.create())
+        .add(line);
+  }
+
+  /**
+   * Rename the specified structure in its definition as well as references. Returns {@code false}
+   * and warns if the rename request is unsuccessful (e.g. no corresponding structure or name
+   * conflict), otherwise returns {@code true}.
+   *
+   * <p>The specified {@link Collection} of {@link StructureType} should contain all structure types
+   * that share the same namespace (including the specified structure {@code type}); i.e. a rename
+   * will only succeed if the new name is not already in use by any structures of the specified
+   * types.
+   */
+  public boolean renameStructure(
+      String origName,
+      String newName,
+      StructureType type,
+      Collection<StructureType> sameNamespaceTypes,
+      Warnings warnings) {
+    assert sameNamespaceTypes.contains(type);
+    boolean succeeded =
+        renameStructureDefinition(origName, newName, type, sameNamespaceTypes, warnings);
+    if (succeeded) {
+      renameStructureReferences(origName, newName, type);
+    }
+    return succeeded;
+  }
+
+  /**
+   * Update the definition for the specified structure to use the new name. Returns {@code true} if
+   * the rename was successful, otherwise returns {@code false}.
+   *
+   * <p>Update is only successful if the specified structure is defined and the new name is not
+   * already taken. Checks for a name conflict with any of the specified structure types.
+   */
+  private boolean renameStructureDefinition(
+      String origName,
+      String newName,
+      StructureType type,
+      Collection<StructureType> sameNamespaceTypes,
+      Warnings warnings) {
+    if (!_definitions.contains(type.getDescription(), origName)) {
+      warnings.redFlag(
+          String.format(
+              "Cannot rename structure %s (%s) to %s: %s is undefined.",
+              origName, type.getDescription(), newName, origName));
+      return false;
+    }
+
+    for (StructureType otherType : sameNamespaceTypes) {
+      if (_definitions.contains(otherType.getDescription(), newName)) {
+        warnings.redFlag(
+            String.format(
+                "Cannot rename structure %s (%s) to %s: %s is already in use as %s.",
+                origName, type.getDescription(), newName, newName, otherType.getDescription()));
+        return false;
+      }
+    }
+
+    DefinedStructureInfo def = _definitions.remove(type.getDescription(), origName);
+    _definitions.put(type.getDescription(), newName, def);
+    return true;
+  }
+
+  /** If any references exist to the specified structure, update them to use the new name. */
+  private void renameStructureReferences(String origName, String newName, StructureType type) {
+    Map<String, Map<StructureUsage, Multiset<Integer>>> refsByName = _references.get(type);
+    if (refsByName != null && refsByName.containsKey(origName)) {
+      Map<StructureUsage, Multiset<Integer>> refs = refsByName.remove(origName);
+      refsByName.put(newName, refs);
+    }
+  }
+
+  public void undefined(StructureType structureType, String name, StructureUsage usage, int line) {
+    _undefinedReferences
+        .computeIfAbsent(structureType.getDescription(), t -> new HashMap<>())
+        .computeIfAbsent(name, n -> new HashMap<>())
+        .computeIfAbsent(usage.getDescription(), u -> new HashSet<>())
+        .add(line);
+  }
+
+  private void addReference(
+      Map<String, Map<String, Map<String, Set<Integer>>>> referenceMapByType,
+      StructureType structureType,
+      String name,
+      StructureUsage usage,
+      int line) {
+    referenceMapByType
+        .computeIfAbsent(structureType.getDescription(), t -> new HashMap<>())
+        .computeIfAbsent(name, n -> new HashMap<>())
+        .computeIfAbsent(usage.getDescription(), u -> new HashSet<>())
+        .add(line);
+  }
+
+  /** Returns a new, empty {@link StructureManager}. */
+  public static StructureManager create() {
+    return new StructureManager();
+  }
+
+  /**
+   * Saves the structure definition and reference information into the given {@link
+   * ConvertConfigurationAnswerElement}.
+   */
+  public void saveInto(ConvertConfigurationAnswerElement ccae, String filename) {
+    SortedMap<String, SortedMap<String, DefinedStructureInfo>> sortedDefs =
+        CollectionUtil.toImmutableSortedMap(
+            _definitions.rowMap(),
+            Entry::getKey,
+            typeEntry ->
+                CollectionUtil.toImmutableSortedMap(
+                    typeEntry.getValue(), Entry::getKey, Entry::getValue));
+    ccae.getDefinedStructures().put(filename, sortedDefs);
+
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> sortedRefs =
+        CollectionUtil.toImmutableSortedMap(
+            _references,
+            typeEntry -> typeEntry.getKey().getDescription(),
+            typeEntry ->
+                CollectionUtil.toImmutableSortedMap(
+                    typeEntry.getValue(),
+                    Entry::getKey,
+                    nameEntry ->
+                        CollectionUtil.toImmutableSortedMap(
+                            nameEntry.getValue(),
+                            usageEntry -> usageEntry.getKey().getDescription(),
+                            usageEntry -> ImmutableSortedSet.copyOf(usageEntry.getValue()))));
+    if (!sortedRefs.isEmpty()) {
+      ccae.getReferencedStructures().put(filename, sortedRefs);
+    }
+
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> sortedUndefined =
+        CollectionUtil.toImmutableSortedMap(
+            _undefinedReferences,
+            Entry::getKey,
+            typeEntry ->
+                CollectionUtil.toImmutableSortedMap(
+                    typeEntry.getValue(),
+                    Entry::getKey,
+                    nameEntry ->
+                        CollectionUtil.toImmutableSortedMap(
+                            nameEntry.getValue(),
+                            Entry::getKey,
+                            usageEntry -> ImmutableSortedSet.copyOf(usageEntry.getValue()))));
+    ccae.getUndefinedReferences().put(filename, sortedUndefined);
+  }
+
+  /** Type description -> Name -> DefinedStructureInfo */
+  private final @Nonnull Table<String, String, DefinedStructureInfo> _definitions;
+
+  /** StructureType -> Name -> StructureUsage */
+  private final @Nonnull Map<StructureType, Map<String, Map<StructureUsage, Multiset<Integer>>>>
+      _references;
+
+  /** structType -> structName -> usage -> lines */
+  private final @Nonnull Map<String, Map<String, Map<String, Set<Integer>>>> _undefinedReferences;
+
+  private StructureManager() {
+    _definitions = HashBasedTable.create();
+    _references = new HashMap<>();
+    _undefinedReferences = new HashMap<>();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/vendor/VendorConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/vendor/VendorConfigurationTest.java
@@ -87,7 +87,6 @@ public final class VendorConfigurationTest {
   private static VendorConfiguration buildVendorConfiguration() {
     VendorConfiguration c = new TestVendorConfiguration();
     c.setFilename(FILENAME);
-    c.setAnswerElement(new ConvertConfigurationAnswerElement());
     c.setWarnings(new Warnings(true, true, true));
     return c;
   }
@@ -110,7 +109,8 @@ public final class VendorConfigurationTest {
       assertFalse(c.deleteStructure(origName, _testStructureType1));
 
       // Need to call setAnswerElement to trigger population of CCAE / answerElement (for refs)
-      c.setAnswerElement(new ConvertConfigurationAnswerElement());
+      ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+      c.getStructureManager().saveInto(ccae, c.getFilename());
       // Should produce an appropriate warning and indicate the rename did not succeed
       assertThat(
           c.getWarnings(),
@@ -118,7 +118,7 @@ public final class VendorConfigurationTest {
 
       // Reference should be unaffected since the delete did not succeed
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasReferencedStructure(FILENAME, _testStructureType2, origName, _testStructureUsage));
     }
 
@@ -132,7 +132,8 @@ public final class VendorConfigurationTest {
       assertFalse(c.deleteStructure(origName, _testStructureType1));
 
       // Need to call setAnswerElement to trigger population of CCAE / answerElement (for refs)
-      c.setAnswerElement(new ConvertConfigurationAnswerElement());
+      ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+      c.getStructureManager().saveInto(ccae, c.getFilename());
       // Should produce an appropriate warning and indicate the rename did not succeed
       assertThat(
           c.getWarnings(),
@@ -140,7 +141,7 @@ public final class VendorConfigurationTest {
 
       // Reference should be unaffected since the delete did not succeed
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasReferencedStructure(FILENAME, _testStructureType1, otherName, _testStructureUsage));
     }
   }
@@ -164,23 +165,23 @@ public final class VendorConfigurationTest {
     assertTrue(c.deleteStructure(origName, _testStructureType1));
 
     // Need to call setAnswerElement to trigger population of CCAE / answerElement (for refs)
-    c.setAnswerElement(new ConvertConfigurationAnswerElement());
+    ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+    c.getStructureManager().saveInto(ccae, c.getFilename());
     // No warnings
     assertThat(c.getWarnings(), hasRedFlags(emptyIterable()));
     // Has no definition or reference for the old name
+    assertThat(ccae, not(hasDefinedStructure(FILENAME, _testStructureType1, origName)));
     assertThat(
-        c.getAnswerElement(), not(hasDefinedStructure(FILENAME, _testStructureType1, origName)));
-    assertThat(
-        c.getAnswerElement(),
+        ccae,
         not(hasReferencedStructure(FILENAME, _testStructureType1, origName, _testStructureUsage)));
 
     // Unaffected reference and definition should persist
     assertThat(
-        c.getAnswerElement(),
+        ccae,
         hasDefinedStructureWithDefinitionLines(
             FILENAME, _testStructureType1, unaffectedName, contains(otherLine)));
     assertThat(
-        c.getAnswerElement(),
+        ccae,
         hasReferencedStructure(FILENAME, _testStructureType1, unaffectedName, _testStructureUsage));
   }
 
@@ -226,7 +227,8 @@ public final class VendorConfigurationTest {
               ImmutableList.of(_testStructureType1, _testStructureType2));
 
       // Need to call setAnswerElement to trigger population of CCAE / answerElement (for refs)
-      c.setAnswerElement(new ConvertConfigurationAnswerElement());
+      ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+      c.getStructureManager().saveInto(ccae, c.getFilename());
 
       // Should produce an appropriate warning and indicate the rename did not succeed
       assertThat(
@@ -237,7 +239,7 @@ public final class VendorConfigurationTest {
       assertFalse(succeeded);
       // Reference should be unaffected since the rename did not succeed
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasReferencedStructure(FILENAME, _testStructureType2, origName, _testStructureUsage));
     }
   }
@@ -270,12 +272,14 @@ public final class VendorConfigurationTest {
       assertFalse(succeeded);
 
       // Both org and new structure defs persist
+      ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+      c.getStructureManager().saveInto(ccae, c.getFilename());
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasDefinedStructureWithDefinitionLines(
               FILENAME, _testStructureType1, origName, contains(origLine)));
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasDefinedStructureWithDefinitionLines(
               FILENAME, _testStructureType1, newName, contains(otherLine)));
     }
@@ -305,12 +309,14 @@ public final class VendorConfigurationTest {
       assertFalse(succeeded);
 
       // Both org and new structure defs persist
+      ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+      c.getStructureManager().saveInto(ccae, c.getFilename());
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasDefinedStructureWithDefinitionLines(
               FILENAME, _testStructureType2, origName, contains(origLine)));
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasDefinedStructureWithDefinitionLines(
               FILENAME, _testStructureType1, newName, contains(otherLine)));
     }
@@ -337,26 +343,27 @@ public final class VendorConfigurationTest {
           c.renameStructure(
               origName, newName, _testStructureType1, ImmutableList.of(_testStructureType1));
       // Need to call setAnswerElement to trigger population of CCAE / answerElement (for refs)
-      c.setAnswerElement(new ConvertConfigurationAnswerElement());
+      ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+      c.getStructureManager().saveInto(ccae, c.getFilename());
 
       // No warnings
       assertThat(c.getWarnings(), hasRedFlags(emptyIterable()));
       assertTrue(succeeded);
       // Has a definition and reference for the new structure name
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasDefinedStructureWithDefinitionLines(
               FILENAME, _testStructureType1, newName, contains(origLine)));
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasReferencedStructure(FILENAME, _testStructureType1, newName, _testStructureUsage));
       // Unaffected reference and definition should persist
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasDefinedStructureWithDefinitionLines(
               FILENAME, _testStructureType1, unaffectedName, contains(otherLine)));
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasReferencedStructure(
               FILENAME, _testStructureType1, unaffectedName, _testStructureUsage));
     }
@@ -373,26 +380,27 @@ public final class VendorConfigurationTest {
           c.renameStructure(
               origName, newName, _testStructureType1, ImmutableList.of(_testStructureType1));
       // Need to call setAnswerElement to trigger population of CCAE / answerElement (for refs)
-      c.setAnswerElement(new ConvertConfigurationAnswerElement());
+      ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+      c.getStructureManager().saveInto(ccae, c.getFilename());
 
       // No warnings
       assertThat(c.getWarnings(), hasRedFlags(emptyIterable()));
       assertTrue(succeeded);
       // Has a definition and reference for the new structure name
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasDefinedStructureWithDefinitionLines(
               FILENAME, _testStructureType1, newName, contains(origLine)));
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasReferencedStructure(FILENAME, _testStructureType1, newName, _testStructureUsage));
       // Unaffected reference and definition should persist
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasDefinedStructureWithDefinitionLines(
               FILENAME, _testStructureType2, newName, contains(otherLine)));
       assertThat(
-          c.getAnswerElement(),
+          ccae,
           hasReferencedStructure(FILENAME, _testStructureType2, newName, _testStructureUsage));
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -63,6 +63,7 @@ import com.google.common.primitives.Ints;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -2585,12 +2586,12 @@ public final class AristaConfiguration extends VendorConfiguration {
     // Define the Null0 interface if it has been referenced. Otherwise, these show as undefined
     // references.
     Optional<Integer> firstRefToNull0 =
-        _structureReferences
-            .getOrDefault(AristaStructureType.INTERFACE, ImmutableSortedMap.of())
-            .getOrDefault("Null0", ImmutableSortedMap.of())
-            .entrySet()
+        _structureManager
+            .getStructureReferences(AristaStructureType.INTERFACE)
+            .getOrDefault("Null0", ImmutableMap.of())
+            .values()
             .stream()
-            .flatMap(e -> e.getValue().stream())
+            .flatMap(Collection::stream)
             .min(Integer::compare);
     if (firstRefToNull0.isPresent()) {
       defineSingleLineStructure(AristaStructureType.INTERFACE, "Null0", firstRefToNull0.get());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2917,12 +2917,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
     // Define the Null0 interface if it has been referenced. Otherwise, these show as undefined
     // references.
     Optional<Integer> firstRefToNull0 =
-        _structureReferences
-            .getOrDefault(CiscoStructureType.INTERFACE, ImmutableSortedMap.of())
+        _structureManager
+            .getStructureReferences(CiscoStructureType.INTERFACE)
             .getOrDefault("Null0", ImmutableSortedMap.of())
-            .entrySet()
+            .values()
             .stream()
-            .flatMap(e -> e.getValue().stream())
+            .flatMap(Collection::stream)
             .min(Integer::compare);
     if (firstRefToNull0.isPresent()) {
       defineSingleLineStructure(CiscoStructureType.INTERFACE, "Null0", firstRefToNull0.get());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -62,6 +62,7 @@ import com.google.common.collect.Streams;
 import com.google.common.primitives.Ints;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -3154,12 +3155,12 @@ public final class AsaConfiguration extends VendorConfiguration {
     // Define the Null0 interface if it has been referenced. Otherwise, these show as undefined
     // references.
     Optional<Integer> firstRefToNull0 =
-        _structureReferences
-            .getOrDefault(AsaStructureType.INTERFACE, ImmutableSortedMap.of())
+        _structureManager
+            .getStructureReferences(AsaStructureType.INTERFACE)
             .getOrDefault("Null0", ImmutableSortedMap.of())
-            .entrySet()
+            .values()
             .stream()
-            .flatMap(e -> e.getValue().stream())
+            .flatMap(Collection::stream)
             .min(Integer::compare);
     if (firstRefToNull0.isPresent()) {
       defineSingleLineStructure(AsaStructureType.INTERFACE, "Null0", firstRefToNull0.get());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -60,6 +60,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.primitives.Ints;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -2201,12 +2202,12 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
     // Define the Null0 interface if it has been referenced. Otherwise, these show as undefined
     // references.
     Optional<Integer> firstRefToNull0 =
-        _structureReferences
-            .getOrDefault(CiscoXrStructureType.INTERFACE, ImmutableSortedMap.of())
+        _structureManager
+            .getStructureReferences(CiscoXrStructureType.INTERFACE)
             .getOrDefault("Null0", ImmutableSortedMap.of())
-            .entrySet()
+            .values()
             .stream()
-            .flatMap(e -> e.getValue().stream())
+            .flatMap(Collection::stream)
             .min(Integer::compare);
     if (firstRefToNull0.isPresent()) {
       defineSingleLineStructure(CiscoXrStructureType.INTERFACE, "Null0", firstRefToNull0.get());

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -14,6 +14,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -1063,11 +1064,11 @@ public class F5BigipConfiguration extends VendorConfiguration {
 
   private boolean isReferencedByRouteMap(String aclName) {
     // Return true iff the named acl is referenced via route-map match ip address
-    return Optional.ofNullable(_structureReferences.get(F5BigipStructureType.ACCESS_LIST))
-        .map(byStructureName -> byStructureName.get(aclName))
-        .map(byUsage -> byUsage.get(F5BigipStructureUsage.ROUTE_MAP_MATCH_IP_ADDRESS))
-        .map(lines -> !lines.isEmpty())
-        .orElse(false);
+    return !_structureManager
+        .getStructureReferences(F5BigipStructureType.ACCESS_LIST)
+        .getOrDefault(aclName, ImmutableMap.of())
+        .getOrDefault(F5BigipStructureUsage.ROUTE_MAP_MATCH_IP_ADDRESS, ImmutableMultiset.of())
+        .isEmpty();
   }
 
   private void markStructures() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3464,7 +3464,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   private @Nonnull JuniperConfiguration cloneConfiguration() {
     JuniperConfiguration clonedConfiguration = SerializationUtils.clone(this);
-    clonedConfiguration.setAnswerElement(getAnswerElement());
     clonedConfiguration.setUnrecognized(getUnrecognized());
     clonedConfiguration.setWarnings(_w);
     return clonedConfiguration;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -703,7 +703,7 @@ public final class CiscoGrammarTest {
   public void testIosBgpExtcommunityParsing() throws IOException {
     CiscoConfiguration c = parseCiscoConfig("ios-bgp-extcommunity", ConfigurationFormat.CISCO_IOS);
     ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
-    c.setAnswerElement(ccae);
+    c.getStructureManager().saveInto(ccae, c.getFilename());
     c.setWarnings(new Warnings(true, true, true));
     assertThat(
         ccae, hasDefinedStructure(c.getFilename(), EXTCOMMUNITY_LIST_STANDARD, "COM_WITH_RT"));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
@@ -2188,7 +2188,6 @@ public final class CiscoAsaGrammarTest {
 
     // Finishes extraction, necessary for object NATs
     config.setWarnings(new Warnings());
-    config.setAnswerElement(new ConvertConfigurationAnswerElement());
     config.toVendorIndependentConfigurations();
 
     List<AsaNat> nats = config.getCiscoAsaNats();

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import java.util.Set;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.Warnings;
@@ -24,7 +23,6 @@ import org.batfish.datamodel.DefinedStructureInfo;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MacAddress;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.grammar.BatfishParseTreeWalker;
 import org.batfish.grammar.GrammarSettings;
 import org.batfish.grammar.MockGrammarSettings;
@@ -46,41 +44,32 @@ public class CumulusInterfacesGrammarTest {
   private static final String FILENAME = "";
   private static CumulusConcatenatedConfiguration _config;
   private static CumulusInterfacesConfiguration _ic;
-  private static ConvertConfigurationAnswerElement _ccae;
   private static Warnings _warnings;
 
   @Before
   public void setup() {
     _config = new CumulusConcatenatedConfiguration();
     _ic = _config.getInterfacesConfiguration();
-    _ccae = new ConvertConfigurationAnswerElement();
     _warnings = new Warnings();
     _config.setFilename(FILENAME);
-    _config.setAnswerElement(_ccae);
     _config.setWarnings(_warnings);
   }
 
   private static DefinedStructureInfo getDefinedStructureInfo(
       CumulusStructureType type, String name) {
-    return _ccae
-        .getDefinedStructures()
-        .get(FILENAME)
-        .getOrDefault(type.getDescription(), ImmutableSortedMap.of())
-        .get(name);
+    return _config.getStructureManager().getDefinition(type, name).orElse(null);
   }
 
   private static Set<Integer> getStructureReferences(
       CumulusStructureType type, String name, CumulusStructureUsage usage) {
     // The config keeps reference data in a private variable, and only copies into the answer
     // element when you set it.
-    _config.setAnswerElement(new ConvertConfigurationAnswerElement());
     return _config
-        .getAnswerElement()
-        .getReferencedStructures()
-        .get(FILENAME)
-        .get(type.getDescription())
+        .getStructureManager()
+        .getStructureReferences(type)
         .get(name)
-        .get(usage.getDescription());
+        .get(usage)
+        .elementSet();
   }
 
   private static CumulusInterfacesConfiguration parse(String input) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/frr/FrrGrammarTest.java
@@ -185,7 +185,6 @@ public class FrrGrammarTest {
     _ccae = new ConvertConfigurationAnswerElement();
     _warnings = new Warnings(true, true, true);
     _config.setFilename(FILENAME);
-    _config.setAnswerElement(_ccae);
     _config.setWarnings(_warnings);
   }
 
@@ -199,11 +198,7 @@ public class FrrGrammarTest {
 
   private Set<Integer> getStructureReferences(
       FrrStructureType type, String name, FrrStructureUsage usage) {
-    // The config keeps reference data in a private variable, and only copies into the answer
-    // element when you set it.
-    _config.setAnswerElement(new ConvertConfigurationAnswerElement());
-    return _config
-        .getAnswerElement()
+    return _ccae
         .getReferencedStructures()
         .get(FILENAME)
         .get(type.getDescription())
@@ -222,6 +217,7 @@ public class FrrGrammarTest {
     settings.setThrowOnParserError(true);
 
     parseFromTextWithSettings(src, settings);
+    _config.getStructureManager().saveInto(_ccae, _config.getFilename());
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -334,11 +334,9 @@ public final class PaloAltoGrammarTest {
     extractor.processParseTree(DUMMY_SNAPSHOT_1, tree);
     PaloAltoConfiguration pac = (PaloAltoConfiguration) extractor.getVendorConfiguration();
     pac.setVendor(ConfigurationFormat.PALO_ALTO);
-    ConvertConfigurationAnswerElement answerElement = new ConvertConfigurationAnswerElement();
     pac.setFilename(TESTCONFIGS_PREFIX + hostname);
     // crash if not serializable
     pac = SerializationUtils.clone(pac);
-    pac.setAnswerElement(answerElement);
     pac.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     pac.setWarnings(parseWarnings);
     return pac;
@@ -362,9 +360,7 @@ public final class PaloAltoGrammarTest {
     extractor.processParseTree(DUMMY_SNAPSHOT_1, tree);
     PaloAltoConfiguration pac = (PaloAltoConfiguration) extractor.getVendorConfiguration();
     pac.setVendor(ConfigurationFormat.PALO_ALTO);
-    ConvertConfigurationAnswerElement answerElement = new ConvertConfigurationAnswerElement();
     pac.setFilename(TESTCONFIGS_PREFIX + hostname);
-    pac.setAnswerElement(answerElement);
     return pac;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
@@ -73,7 +73,6 @@ import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.OrMatchExpr;
 import org.batfish.datamodel.acl.TrueExpr;
-import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.trace.TraceTree;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
@@ -126,12 +125,10 @@ public class PaloAltoSecurityRuleTest {
     extractor.processParseTree(DUMMY_SNAPSHOT_1, tree);
     PaloAltoConfiguration pac = (PaloAltoConfiguration) extractor.getVendorConfiguration();
     pac.setVendor(ConfigurationFormat.PALO_ALTO);
-    ConvertConfigurationAnswerElement answerElement = new ConvertConfigurationAnswerElement();
     pac.setFilename(TESTCONFIGS_PREFIX + hostname);
     // crash if not serializable
     pac = SerializationUtils.clone(pac);
     pac.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
-    pac.setAnswerElement(answerElement);
     return pac;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/a10/grammar/A10GrammarTest.java
@@ -223,7 +223,6 @@ public class A10GrammarTest {
     vendorConfiguration.setFilename(TESTCONFIGS_PREFIX + hostname);
     // crash if not serializable
     A10Configuration vc = SerializationUtils.clone(vendorConfiguration);
-    vc.setAnswerElement(new ConvertConfigurationAnswerElement());
     vc.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     vc.setWarnings(parseWarnings);
     return vc;

--- a/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/check_point_gateway/grammar/CheckPointGatewayGrammarTest.java
@@ -189,7 +189,6 @@ public class CheckPointGatewayGrammarTest {
     vendorConfiguration.setFilename(TESTCONFIGS_PREFIX + hostname);
     // crash if not serializable
     CheckPointGatewayConfiguration vc = SerializationUtils.clone(vendorConfiguration);
-    vc.setAnswerElement(new ConvertConfigurationAnswerElement());
     vc.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     vc.setWarnings(parseWarnings);
     return vc;


### PR DESCRIPTION
We wanted sorted structures for deterministic and readable references, but this
hurts us during building/tracking.

Introduce a new class to encpsulate all the definition/reference/undefined
logic and layer in hash-based building phase with a save phase that produce
sorted objects.