### PR TITLE
Juniper support flat 'activate' and hierarchical 'active:' tag

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -53,7 +53,7 @@ ACCESS_INTERNAL: 'access-internal';
 ACCESS_PROFILE: 'access-profile' -> pushMode(M_Name);
 
 ACCOUNTING: 'accounting';
-
+ACTIVATE: 'activate';
 ACTIVE: 'active';
 
 ACTIVE_SERVER_GROUP: 'active-server-group' -> pushMode(M_Name);

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -9,6 +9,11 @@ options {
    tokenVocab = FlatJuniperLexer;
 }
 
+activate_line
+:
+   ACTIVATE activate_line_tail NEWLINE
+;
+
 deactivate_line
 :
    DEACTIVATE deactivate_line_tail NEWLINE
@@ -19,6 +24,11 @@ hierarchy_element:
   | ~NEWLINE
 ;
 
+
+activate_line_tail
+:
+   hierarchy_element*
+;
 
 deactivate_line_tail
 :
@@ -64,7 +74,8 @@ insert_dst
 flat_juniper_configuration
 :
    (
-      deactivate_line
+      activate_line
+      | deactivate_line
       | delete_line
       | insert_line
       | protect_line

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
@@ -4,6 +4,8 @@ options {
    superClass = 'org.batfish.grammar.juniper.parsing.JuniperBaseLexer';
 }
 
+ACTIVE: 'active:';
+
 REPLACE
 :
   'replace:'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperParser.g4
@@ -36,10 +36,7 @@ flat_statement
 hierarchical_statement
 :
   descriptive_comment += MULTILINE_COMMENT*
-  (
-    INACTIVE
-    | REPLACE
-  )? words += word+
+  tag* words += word+
   (
     braced_clause MULTILINE_COMMENT* close = CLOSE_BRACE
     | bracketed_clause close = CLOSE_BRACKET terminator
@@ -55,4 +52,11 @@ terminator
 word
 :
   WORD
+;
+
+tag
+:
+  ACTIVE
+  | INACTIVE
+  | REPLACE
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ActivationLinePruner.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ActivationLinePruner.java
@@ -3,10 +3,11 @@ package org.batfish.grammar.flatjuniper;
 import java.util.ArrayList;
 import java.util.List;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Activate_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Deactivate_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Flat_juniper_configurationContext;
 
-public class DeactivateLinePruner extends FlatJuniperParserBaseListener {
+public class ActivationLinePruner extends FlatJuniperParserBaseListener {
 
   private Flat_juniper_configurationContext _configurationContext;
 
@@ -20,6 +21,11 @@ public class DeactivateLinePruner extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitDeactivate_line(Deactivate_lineContext ctx) {
+    _newConfigurationLines.remove(ctx);
+  }
+
+  @Override
+  public void exitActivate_line(Activate_lineContext ctx) {
     _newConfigurationLines.remove(ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivateTreeBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/DeactivateTreeBuilder.java
@@ -1,6 +1,8 @@
 package org.batfish.grammar.flatjuniper;
 
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Activate_lineContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Activate_line_tailContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Deactivate_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Deactivate_line_tailContext;
 import org.batfish.grammar.flatjuniper.Hierarchy.HierarchyTree.HierarchyPath;
@@ -40,6 +42,30 @@ public class DeactivateTreeBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitDeactivate_line_tail(Deactivate_line_tailContext ctx) {
+    _enablePathRecording = false;
+  }
+
+  @Override
+  public void enterActivate_line(Activate_lineContext ctx) {
+    _addLine = true;
+  }
+
+  @Override
+  public void enterActivate_line_tail(Activate_line_tailContext ctx) {
+    _enablePathRecording = true;
+    _currentPath = new HierarchyPath();
+  }
+
+  @Override
+  public void exitActivate_line(Activate_lineContext ctx) {
+    if (_addLine) {
+      _hierarchy.removeDeactivatePath(_currentPath, ctx);
+      _currentPath = null;
+    }
+  }
+
+  @Override
+  public void exitActivate_line_tail(Activate_line_tailContext ctx) {
     _enablePathRecording = false;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/InsertDeleteApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/InsertDeleteApplicator.java
@@ -13,6 +13,8 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.common.Warnings;
 import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.BatfishListener;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Activate_lineContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Activate_line_tailContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Deactivate_lineContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Deactivate_line_tailContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Delete_lineContext;
@@ -37,26 +39,26 @@ public class InsertDeleteApplicator extends FlatJuniperParserBaseListener
    * Implementation overview:
    *
    * Iterate through each child parse-tree of the configuration. Each corresponds to a set,
-   * deactivate, or delete line.
+   * activate, deactivate, or delete line.
    *
    * Each time a 'set' parse-tree is encountered:
    * - record the words following 'set'
    * - build out the set StatementTree, using each word as a key.
    * - add the parse-tree to the set of parse-trees stored at the node corresponding to the last word
    *
-   * Each time a 'deactivate' parse-tree is encountered:
-   * - record the words following 'deactivate'
+   * Each time an 'activate' or 'deactivate' parse-tree is encountered:
+   * - record the words following 'activate'/'deactivate'
    * - find the StatementTree node corresponding to the recorded words
    * - add the parse-tree to the set of parse-trees stored at the node corresponding to the last word
    *
-   * Each time an 'insert' parse-tree is encounted:
+   * Each time an 'insert' parse-tree is encountered:
    * - reorder subtree at common parent by moving the named child before/after target child
    *
    * Each time a 'delete' parse-tree is encountered:
    * - record the words following 'delete'
    * - find the node corresponding to the last word
    * - remove the node (and therefore its subtrees) from the tree
-   *   - note that this removes both 'set' and 'deactivate' lines
+   *   - note that this removes 'set', 'activate', and 'deactivate' lines
    *
    * Each of these statements takes affect when it is reached, rather than after a pass. That way you don't
    * (e.g.) delete set lines that occur later in the text.
@@ -103,6 +105,22 @@ public class InsertDeleteApplicator extends FlatJuniperParserBaseListener
 
   @Override
   public void exitDeactivate_line(Deactivate_lineContext ctx) {
+    addStatementToTree(_statementTree, ctx);
+  }
+
+  @Override
+  public void enterActivate_line_tail(Activate_line_tailContext ctx) {
+    _enablePathRecording = true;
+    _words = new LinkedList<>();
+  }
+
+  @Override
+  public void exitActivate_line_tail(Activate_line_tailContext ctx) {
+    _enablePathRecording = false;
+  }
+
+  @Override
+  public void exitActivate_line(Activate_lineContext ctx) {
     addStatementToTree(_statementTree, ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/PreprocessJuniperExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/PreprocessJuniperExtractor.java
@@ -55,16 +55,16 @@ public final class PreprocessJuniperExtractor implements PreprocessExtractor {
     ParseTreeWalker walker = new BatfishParseTreeWalker(parser);
 
     // Implements insert and delete respecting order of configuration lines.
-    // Properly handles set and deactivate lines.
+    // Properly handles set, activate, and deactivate lines.
     InsertDeleteApplicator d = new InsertDeleteApplicator(parser, w);
     walker.walk(d, tree);
 
     // Delete all deactivated lines:
-    // 1. Mark parts of the hierarchy as deleted
+    // 1. Mark parts of the hierarchy as deactivated
     DeactivateTreeBuilder dtb = new DeactivateTreeBuilder(hierarchy);
     walker.walk(dtb, tree);
-    // 2. Remove 'deactivate <tree>' lines
-    DeactivateLinePruner dp = new DeactivateLinePruner();
+    // 2. Remove 'activate <tree>' and 'deactivate <tree>' lines
+    ActivationLinePruner dp = new ActivationLinePruner();
     walker.walk(dp, tree);
     // 3. Remove 'set' lines that are deactivated
     DeactivatedLinePruner dlp = new DeactivatedLinePruner(hierarchy);

--- a/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
@@ -103,7 +103,6 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
     _extraLines.add(extraLinesBuilder.build());
     _currentStatement = new ArrayList<>();
     _stack.add(_currentStatement);
-    // TODO: handle 'active:'
     for (TagContext tagCtx : ctx.tag()) {
       constructTagCommand(tagCtx, ctx.words);
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.batfish.grammar.flattener.Flattener;
 import org.batfish.grammar.flattener.FlattenerLineMap;
@@ -14,6 +15,7 @@ import org.batfish.grammar.juniper.JuniperParser.Bracketed_clauseContext;
 import org.batfish.grammar.juniper.JuniperParser.Flat_statementContext;
 import org.batfish.grammar.juniper.JuniperParser.Hierarchical_statementContext;
 import org.batfish.grammar.juniper.JuniperParser.Juniper_configurationContext;
+import org.batfish.grammar.juniper.JuniperParser.TagContext;
 import org.batfish.grammar.juniper.JuniperParser.TerminatorContext;
 import org.batfish.grammar.juniper.JuniperParser.WordContext;
 
@@ -102,12 +104,8 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
     _currentStatement = new ArrayList<>();
     _stack.add(_currentStatement);
     // TODO: handle 'active:'
-    if (ctx.INACTIVE() != null) {
-      // Deactivate tree from this depth
-      constructDeactivateLine(ctx.words);
-    } else if (ctx.REPLACE() != null) {
-      // Delete everything at current depth before deeper set lines are added
-      constructDeleteLine(ctx.words);
+    for (TagContext tagCtx : ctx.tag()) {
+      constructTagCommand(tagCtx, ctx.words);
     }
   }
 
@@ -160,12 +158,19 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
     constructFlatLine("set", ImmutableList.of());
   }
 
-  private void constructDeactivateLine(List<WordContext> suffixWords) {
-    constructFlatLine("deactivate", suffixWords);
+  private void constructTagCommand(TagContext tagCtx, List<WordContext> suffixWords) {
+    constructFlatLine(toCommandString(tagCtx), suffixWords);
   }
 
-  private void constructDeleteLine(List<WordContext> suffixWords) {
-    constructFlatLine("delete", suffixWords);
+  private static @Nonnull String toCommandString(TagContext ctx) {
+    if (ctx.ACTIVE() != null) {
+      return "activate";
+    } else if (ctx.INACTIVE() != null) {
+      return "deactivate";
+    } else {
+      assert ctx.REPLACE() != null;
+      return "delete";
+    }
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/main/FlattenTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/FlattenTest.java
@@ -66,4 +66,14 @@ public final class FlattenTest {
   public void testReplaceFilter() throws IOException {
     assertInputOutputPair("replace_filter", "replace_filter_flattened");
   }
+
+  @Test
+  public void testActiveOnly() throws IOException {
+    assertInputOutputPair("active_only", "active_only_flattened");
+  }
+
+  @Test
+  public void testMultipleTags() throws IOException {
+    assertInputOutputPair("multiple_tags", "multiple_tags_flattened");
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/main/PreprocessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/PreprocessTest.java
@@ -70,6 +70,12 @@ public final class PreprocessTest {
   }
 
   @Test
+  public void testFlatJuniperActivation() throws IOException {
+    assertValidPair(
+        "preprocess-flat-juniper-activation-before", "preprocess-flat-juniper-activation-after");
+  }
+
+  @Test
   public void testMainBadArgs() throws IOException {
     _thrown.expect(IllegalArgumentException.class);
     main(new String[] {});

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/active_only
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/active_only
@@ -1,0 +1,6 @@
+#RANCID-CONTENT-TYPE: juniper
+system {
+  active:
+  host-name active_only;
+}
+

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/active_only_flattened
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/active_only_flattened
@@ -1,0 +1,3 @@
+####BATFISH FLATTENED JUNIPER CONFIG####
+activate system host-name active_only
+set system host-name active_only

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/multiple_tags
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/multiple_tags
@@ -1,0 +1,7 @@
+#RANCID-CONTENT-TYPE: juniper
+system {
+  replace:
+  active:
+  host-name multiple_tags;
+}
+

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/multiple_tags_flattened
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/multiple_tags_flattened
@@ -1,0 +1,4 @@
+####BATFISH FLATTENED JUNIPER CONFIG####
+delete system host-name multiple_tags
+activate system host-name multiple_tags
+set system host-name multiple_tags

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-activation-after
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-activation-after
@@ -1,0 +1,3 @@
+####BATFISH PRE-PROCESSED JUNIPER CONFIG####
+set system host-name preprocess-flat-juniper-activation
+set interfaces xe-0/0/2 unit 0 family inet address 10.0.0.2/32

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-activation-before
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-activation-before
@@ -1,0 +1,23 @@
+#
+set system host-name preprocess-flat-juniper-activation
+#
+
+# deactivate hierarchy not yet declared
+deactivate interfaces xe-0/0/0
+
+set interfaces xe-0/0/0 unit 0 family inet address 10.0.0.0/32
+set interfaces xe-0/0/1 unit 0 family inet address 10.0.0.1/32
+set interfaces xe-0/0/2 unit 0 family inet address 10.0.0.2/32
+
+# deactivate a line that does not exist
+deactivate interfaces xe-0/0/3
+
+# activate a line that does not exist
+activate interfaces xe-0/0/4
+
+# deactivate hierarchy previously declared
+deactivate interfaces xe-0/0/1
+deactivate interfaces xe-0/0/2
+
+# reactivate deactivated hierarchy
+activate interfaces xe-0/0/2


### PR DESCRIPTION
* Support 'active:' tag in hierarchical Juniper syntax
  * Implement by inserting 'activate' line before deeper 'set' elements
* Support multiple tags in hierarchical Juniper syntax
  * e.g. both 'replace:' and 'active:' at the same hierarchy level
* Support 'activate' command in flat Juniper syntax
  * Undoes 'deactivate'
* Fix Juniper deactivate semantics
  * Allow deactivating/reactivating  multiple subpaths of a path independently