### PR TITLE
google-java-format: upgrade to new release

### DIFF
--- a/tools/fix_java_format.sh
+++ b/tools/fix_java_format.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Find the jar, and download it if needed.
-GJF_VERSION=1.15.0
+GJF_VERSION=1.16.0
 JAR_NAME="google-java-format-${GJF_VERSION}-all-deps.jar"
 JAR_URL="https://github.com/google/google-java-format/releases/download/v${GJF_VERSION}/${JAR_NAME}"
 JAR_DIR="${HOME}/.cache/google-java-format"


### PR DESCRIPTION
It's now the default for the IDEs

commit-id:e9dbb3c4