### PR TITLE
fix_java_format.sh: fix missing command detection

### DIFF
--- a/tools/fix_java_format.sh
+++ b/tools/fix_java_format.sh
@@ -14,7 +14,7 @@ if [ ! -f ${JAR} ]; then
 fi
 
 # Some OS X users have installed GNU find as gfind.
-if [ "$(uname)" = "Darwin" ] && [ -x $(command -v gfind) ]; then
+if [ "$(uname)" = "Darwin" ] && [ -x "$(command -v gfind)" ]; then
   GNU_FIND=gfind
 else
   GNU_FIND=find


### PR DESCRIPTION
Without quotes, the if seems to return true even if the command does not exist