### PR TITLE
Add support for IncrementMetric in TransferBDD.

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
@@ -81,4 +81,19 @@ public class MutableBDDIntegerTest {
     assertThat(xPlus1.getValuesSatisfying(x.value(3L), 100), contains(4L));
     assertThat(x.getValuesSatisfying(xPlus1.value(3L), 100), contains(2L));
   }
+
+  @Test
+  public void testAddClipping() {
+    BDDFactory factory = BDDUtils.bddFactory(10);
+    MutableBDDInteger x = MutableBDDInteger.makeFromIndex(factory, 5, 0, false);
+    MutableBDDInteger constant1 = MutableBDDInteger.makeFromValue(factory, 5, 1);
+    MutableBDDInteger constant16 = MutableBDDInteger.makeFromValue(factory, 5, 16);
+    BDDInteger xPlus1 = x.addClipping(constant1);
+    BDDInteger xPlus16 = x.addClipping(constant16);
+
+    assertTrue(x.value(0).equals(xPlus1.value(1))); // x == 0 <==> x+1 == 1
+    assertTrue(x.value(1).equals(xPlus1.value(2))); // x == 1 <==> x+1 == 2
+    assertTrue(x.geq(31).imp(xPlus1.value(31)).equals(factory.one())); // x >= 31 ==> x+1 == 31
+    assertTrue(x.geq(20).imp(xPlus16.value(31)).equals(factory.one())); // x >= 15 ==> x+16 == 31
+  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
@@ -93,7 +93,7 @@ public class MutableBDDIntegerTest {
 
     assertTrue(x.value(0).equals(xPlus1.value(1))); // x == 0 <==> x+1 == 1
     assertTrue(x.value(1).equals(xPlus1.value(2))); // x == 1 <==> x+1 == 2
-    assertTrue(x.geq(31).imp(xPlus1.value(31)).equals(factory.one())); // x >= 31 ==> x+1 == 31
-    assertTrue(x.geq(20).imp(xPlus16.value(31)).equals(factory.one())); // x >= 15 ==> x+16 == 31
+    assertTrue(x.geq(30).equals(xPlus1.value(31))); // x >= 31 ==> x+1 == 31
+    assertTrue(x.geq(15).equals(xPlus16.value(31))); // x >= 15 ==> x+16 == 31
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
@@ -76,6 +76,7 @@ import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.DiscardNextHop;
 import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
 import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.IncrementMetric;
 import org.batfish.datamodel.routing_policy.expr.IpNextHop;
 import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
@@ -89,6 +90,7 @@ import org.batfish.datamodel.routing_policy.statement.ExcludeAsPath;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
+import org.batfish.datamodel.routing_policy.statement.SetMetric;
 import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetWeight;
@@ -1689,6 +1691,127 @@ public class SearchRoutePoliciesAnswererTest {
 
     BgpRouteDiffs diff =
         new BgpRouteDiffs(ImmutableSet.of(new BgpRouteDiff(BgpRoute.PROP_WEIGHT, "0", "3")));
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(policy.getName()), Schema.STRING),
+                hasColumn(COL_ACTION, equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
+                hasColumn(COL_OUTPUT_ROUTE, equalTo(outputRoute), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
+  }
+
+  @Test
+  public void testSetMetricIncr() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(new SetMetric(new IncrementMetric(100)))
+            .addStatement(new StaticStatement(Statements.ExitAccept))
+            .build();
+
+    SearchRoutePoliciesQuestion question =
+        new SearchRoutePoliciesQuestion(
+            DEFAULT_DIRECTION,
+            EMPTY_CONSTRAINTS,
+            EMPTY_CONSTRAINTS,
+            HOSTNAME,
+            policy.getName(),
+            Action.PERMIT,
+            false);
+    SearchRoutePoliciesAnswerer answerer = new SearchRoutePoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer = (TableAnswerElement) answerer.answer(_batfish.getSnapshot());
+
+    BgpRoute inputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setMetric(0)
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .build();
+
+    BgpRoute outputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setMetric(100)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .build();
+
+    BgpRouteDiffs diff =
+        new BgpRouteDiffs(ImmutableSet.of(new BgpRouteDiff(BgpRoute.PROP_METRIC, "0", "100")));
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(policy.getName()), Schema.STRING),
+                hasColumn(COL_ACTION, equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
+                hasColumn(COL_OUTPUT_ROUTE, equalTo(outputRoute), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
+  }
+
+  @Test
+  public void testSetMetricIncrOverflow() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(new SetMetric(new IncrementMetric(100L)))
+            .addStatement(new StaticStatement(Statements.ExitAccept))
+            .build();
+
+    SearchRoutePoliciesQuestion question =
+        new SearchRoutePoliciesQuestion(
+            DEFAULT_DIRECTION,
+            BgpRouteConstraints.builder().setMed(LongSpace.of(0xFFFFFF9CL)).build(),
+            EMPTY_CONSTRAINTS,
+            HOSTNAME,
+            policy.getName(),
+            Action.PERMIT,
+            false);
+    SearchRoutePoliciesAnswerer answerer = new SearchRoutePoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer = (TableAnswerElement) answerer.answer(_batfish.getSnapshot());
+
+    BgpRoute inputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setMetric(0xFFFFFF9CL)
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .build();
+
+    BgpRoute outputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setMetric(0xFFFFFFFFL)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .build();
+
+    BgpRouteDiffs diff =
+        new BgpRouteDiffs(
+            ImmutableSet.of(new BgpRouteDiff(BgpRoute.PROP_METRIC, "4294967196", "4294967295")));
 
     assertThat(
         answer.getRows().getData(),


### PR DESCRIPTION
Enables support for `set metric +d` in stanzas.
If an overflow occurs, the value is set to the max value of the given field (in case of metric, 2^32-1).