### PR TITLE
Evict existing related BGP routes when  merging UPDATE-like route

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -188,7 +188,6 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
     // Evict older non-trackable-local routes for same prefix, receivedFrom, and path-id.
     // Note that trackable local routes are managed elsewhere,
     // e.g. in Bgpv4Rib.{add,remove}LocalRoute
-    Prefix prefix = route.getNetwork();
     RibDelta<R> evictionDelta =
         route.isTrackableLocalRoute() ? RibDelta.empty() : evictSamePrefixReceivedFromPathId(route);
     Map<NextHop, SortedSet<R>> routesByNh = null;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.GenericRibReadOnly;
@@ -112,6 +113,12 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
               });
     }
 
+    /**
+     * Evict any distinct existing route with the same values as {@code route} for {@link
+     * BgpRoute#getNetwork()}, {@link BgpRoute#getReceivedFrom()}, and {@link BgpRoute#getPathId()}.
+     *
+     * <p>See also the same-named function in {@link BgpRib}.
+     */
     void evictSamePrefixReceivedFromPathId(Bgpv4Route route) {
       Bgpv4Route oldRoute =
           getRouteSamePrefixReceivedFromPathId(route, getBgpRoutes(route.getNetwork()));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -495,7 +495,11 @@ public class AbstractRibTest {
             .setOriginatorIp(originator2)
             .setReceivedFrom(ReceivedFromIp.of(originator2))
             .build();
-    Bgpv4Route route3 = routeBuilder.setLocalPreference(1).build();
+    Bgpv4Route route3 =
+        routeBuilder
+            .setLocalPreference(1)
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("3.3.3.3")))
+            .build();
 
     bestPathRib.mergeRoute(route1);
     bestPathRib.mergeRoute(route2);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
@@ -406,9 +406,15 @@ public class Bgpv4RibTest {
 
     Bgpv4Route base = _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     Bgpv4Route candidate1 =
-        _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).setNextHopIp(Ip.parse("5.5.5.5")).build();
+        _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L))
+            .setNextHopIp(Ip.parse("5.5.5.5"))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("5.5.5.5")))
+            .build();
     Bgpv4Route candidate2 =
-        _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 3L)).setNextHopIp(Ip.parse("5.5.5.6")).build();
+        _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 3L))
+            .setNextHopIp(Ip.parse("5.5.5.6"))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("5.5.5.6")))
+            .build();
 
     rib.mergeRoute(base);
     assertTrue("Exact AS path match, allow merge", rib.mergeRoute(candidate1));
@@ -432,9 +438,15 @@ public class Bgpv4RibTest {
 
     Bgpv4Route base = _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     Bgpv4Route candidate1 =
-        _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 3L)).setNextHopIp(Ip.parse("5.5.5.5")).build();
+        _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 3L))
+            .setNextHopIp(Ip.parse("5.5.5.5"))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("5.5.5.5")))
+            .build();
     Bgpv4Route candidate2 =
-        _rb.setAsPath(AsPath.ofSingletonAsSets(2L, 3L)).setNextHopIp(Ip.parse("5.5.5.6")).build();
+        _rb.setAsPath(AsPath.ofSingletonAsSets(2L, 3L))
+            .setNextHopIp(Ip.parse("5.5.5.6"))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("5.5.5.6")))
+            .build();
 
     rib.mergeRoute(base);
     assertTrue("Exact AS path match, allow merge", rib.mergeRoute(candidate1));
@@ -449,10 +461,12 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(
         _rb.setOriginatorIp(Ip.parse("2.2.2.2"))
             .setNextHop(NextHopIp.of(Ip.parse("2.2.2.2")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.2")))
             .build());
     _multiPathRib.mergeRoute(
         _rb.setOriginatorIp(Ip.parse("2.2.2.3"))
             .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3")))
             .build());
     _multiPathRib.mergeRoute(bestPath);
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
@@ -475,11 +489,13 @@ public class Bgpv4RibTest {
     Bgpv4Route earliest =
         _rb.setOriginatorIp(Ip.parse("2.2.2.2"))
             .setNextHop(NextHopIp.of(Ip.parse("2.2.2.2")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.2")))
             .build();
     _multiPathRib.mergeRoute(earliest);
     _multiPathRib.mergeRoute(
         _rb.setOriginatorIp(Ip.parse("2.2.2.3"))
             .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3")))
             .build());
     _multiPathRib.mergeRoute(best);
 
@@ -495,10 +511,12 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(
         _rb.setClusterList(ImmutableSortedSet.of(11L))
             .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3")))
             .build());
     _multiPathRib.mergeRoute(
         _rb.setClusterList(ImmutableSortedSet.of(22L, 33L))
             .setNextHop(NextHopIp.of(Ip.parse("2.2.2.4")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.4")))
             .build());
 
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
@@ -591,6 +609,7 @@ public class Bgpv4RibTest {
         _rb.setNetwork(Prefix.parse("10.1.1.0/24"))
             .setOriginatorIp(Ip.parse("22.22.22.22"))
             .setNextHop(NextHopIp.of(Ip.parse("22.22.22.22")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("22.22.22.22")))
             .build());
     assertThat(_multiPathRib.getRoutes(), hasSize(4));
     assertThat(_multiPathRib.getBestPathRoutes(), hasSize(3));
@@ -639,8 +658,12 @@ public class Bgpv4RibTest {
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
     Bgpv4Route bestPath = _rb.build();
     _bestPathRib.mergeRoute(bestPath);
-    // Oldest route should win despite newer having lower in Originator IP
-    _bestPathRib.mergeRoute(_rb.setOriginatorIp(Ip.parse("1.1.0.1")).build());
+    // Oldest route should win despite newer having lower Originator IP
+    _bestPathRib.mergeRoute(
+        _rb.setOriginatorIp(Ip.parse("1.1.0.1"))
+            .setNextHop(NextHopIp.of(Ip.parse("1.1.0.1")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("1.1.0.1")))
+            .build());
 
     assertThat(_bestPathRib.getRoutes(), contains(bestPath));
   }
@@ -1025,13 +1048,15 @@ public class Bgpv4RibTest {
     Bgpv4Route.Builder b1 =
         Bgpv4Route.testBuilder()
             .setNextHop(NextHopIp.of(Ip.parse("3.3.3.3")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("3.3.3.3")))
             .setOriginType(OriginType.INCOMPLETE)
             .setOriginatorIp(Ip.ZERO)
             .setProtocol(RoutingProtocol.BGP)
-            .setReceivedFrom(ReceivedFromSelf.instance());
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("3.3.3.3")));
     Bgpv4Route.Builder b2 =
         Bgpv4Route.testBuilder()
             .setNextHop(NextHopIp.of(Ip.parse("3.3.3.4")))
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("3.3.3.4")))
             .setOriginType(OriginType.INCOMPLETE)
             .setOriginatorIp(Ip.MAX)
             .setProtocol(RoutingProtocol.BGP)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/EvpnMasterRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/EvpnMasterRibTest.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginMechanism;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ReceivedFromIp;
 import org.batfish.datamodel.ReceivedFromSelf;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
@@ -33,14 +34,17 @@ public final class EvpnMasterRibTest {
             .setOriginMechanism(OriginMechanism.LEARNED)
             .setOriginType(OriginType.IGP)
             .setOriginatorIp(Ip.ZERO)
-            .setReceivedFrom(ReceivedFromSelf.instance())
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("10.0.0.1")))
             .setVni(1);
     EvpnType5Route route1 =
         rb.setRouteDistinguisher(RouteDistinguisher.from(1, 1L)).setLocalPreference(10).build();
     EvpnType5Route route21 =
         rb.setRouteDistinguisher(RouteDistinguisher.from(2, 2L)).setLocalPreference(20).build();
     EvpnType5Route route22 =
-        rb.setRouteDistinguisher(RouteDistinguisher.from(2, 2L)).setLocalPreference(15).build();
+        rb.setRouteDistinguisher(RouteDistinguisher.from(2, 2L))
+            .setLocalPreference(15)
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("10.0.0.2")))
+            .build();
 
     // route1 and route21 should be best. route22 should be backup
     assertThat(rib.mergeRouteGetDelta(route1), equalTo(RibDelta.adding(route1)));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
@@ -186,7 +186,8 @@ public class RibDeltaTest {
     Bgpv4Route route = routeBuilder.build();
     // Better preference, kicks out route
     routeBuilder.setLocalPreference(route.getLocalPreference() + 1);
-    Bgpv4Route betterRoute = routeBuilder.build();
+    Bgpv4Route betterRoute =
+        routeBuilder.setReceivedFrom(ReceivedFromIp.of(Ip.parse("7.7.7.8"))).build();
 
     // Rib is empty beforehand, merges route, and then replaces it with betterRoute.
     List<RouteAdvertisement<Bgpv4Route>> firstRound =
@@ -200,7 +201,10 @@ public class RibDeltaTest {
     assertThat(firstRound, contains(equalTo(new RouteAdvertisement<>(betterRoute))));
 
     Bgpv4Route bestRoute =
-        routeBuilder.setLocalPreference(betterRoute.getLocalPreference() + 1).build();
+        routeBuilder
+            .setLocalPreference(betterRoute.getLocalPreference() + 1)
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("7.7.7.9")))
+            .build();
     List<RouteAdvertisement<Bgpv4Route>> secondRound =
         RibDelta.<Bgpv4Route>builder()
             .from(rib.mergeRouteGetDelta(bestRoute))


### PR DESCRIPTION
* evict existing distinct routes with same prefix, receivedFrom, and pathId
* skip tracked local routes, for which there is existing intricate logic for this purpose