### PR TITLE
Fix Juniper apply-groups processing order

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/main/PreprocessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/PreprocessTest.java
@@ -85,4 +85,11 @@ public final class PreprocessTest {
   public void testNop() throws IOException {
     assertValidPair(TESTCONFIGS_PREFIX, "nop-preprocess", "nop-preprocess");
   }
+
+  @Test
+  public void testApplyGroupsOrder() throws IOException {
+    assertValidPair(
+        "preprocess-flat-juniper-apply-groups-order-before",
+        "preprocess-flat-juniper-apply-groups-order-after");
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-after
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-after
@@ -1,10 +1,10 @@
 ####BATFISH PRE-PROCESSED JUNIPER CONFIG####
-set system host-name preprocess-flat
-set interfaces lo0 disable
-set interfaces lo0 unit 0 family inet address 192.0.2.1/24
+set interfaces et-0/0/4 disable
 set interfaces et-0/0/2 disable
 set interfaces et-0/0/2 unit 0 family iso
-set interfaces et-0/0/4 disable
+set interfaces lo0 disable
+set interfaces lo0 unit 0 family inet address 192.0.2.1/24
+set system host-name preprocess-flat
 set policy-options policy-statement p1 term t3 then accept
 set policy-options policy-statement p1 term t4 then accept
 set policy-options policy-statement p1 term t2 then accept

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-apply-groups-order-after
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-apply-groups-order-after
@@ -1,0 +1,8 @@
+####BATFISH PRE-PROCESSED JUNIPER CONFIG####
+set interfaces xe-0/0/0 ether-options 802.3ad ae3
+set interfaces xe-0/0/0 ether-options 802.3ad ae2
+set interfaces xe-0/0/0 ether-options 802.3ad ae1
+set interfaces lo0 unit 0 family inet address 1.2.3.4/32 primary
+set interfaces ae1 unit 0 family inet6 mtu 2000
+set interfaces ae2 mac 00:11:22:33:44:55
+set system host-name preprocess-flat-juniper-apply-groups-order

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-apply-groups-order-before
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-apply-groups-order-before
@@ -1,0 +1,10 @@
+set system host-name preprocess-flat-juniper-apply-groups-order
+set interfaces lo0 unit 0 family inet address 1.2.3.4/32 primary
+set apply-groups A
+set apply-groups B
+set interfaces ae1 unit 0 family inet6 mtu 2000
+set interfaces xe-0/0/0 ether-options 802.3ad ae1
+set interfaces ae2 mac 00:11:22:33:44:55
+delete groups A interfaces
+set groups A interfaces <xe-*> ether-options 802.3ad ae2
+set groups B interfaces <xe-*> ether-options 802.3ad ae3

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-apply-groups-order-before
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-juniper-apply-groups-order-before
@@ -5,6 +5,8 @@ set apply-groups B
 set interfaces ae1 unit 0 family inet6 mtu 2000
 set interfaces xe-0/0/0 ether-options 802.3ad ae1
 set interfaces ae2 mac 00:11:22:33:44:55
+# This delete is here to trigger the dirty bit in InsertDeleteApplicator,
+# which causes the hierarchy to be rebuilt from the resulting parse tree list
 delete groups A interfaces
 set groups A interfaces <xe-*> ether-options 802.3ad ae2
 set groups B interfaces <xe-*> ether-options 802.3ad ae3

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-hierarchical-after
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-hierarchical-after
@@ -1,11 +1,11 @@
 ####BATFISH PRE-PROCESSED JUNIPER CONFIG####
-set garbage line
-set system host-name preprocess-hierarchical
-set garbage line
 set interfaces lo0 disable
-set interfaces lo0 unit 0 family inet garbage line2
+set garbage line
 set interfaces lo0 unit 0 family inet address 192.0.2.1/24
 set garbage line3
 set interfaces lo0 unit 1 family inet address 192.0.3.1/24
 set garbage line4
 set garbage line5 garbage line6
+set system host-name preprocess-hierarchical
+set garbage line
+set interfaces lo0 unit 0 family inet garbage line2


### PR DESCRIPTION
* Insert inherited lines for each applied group at the top so that:
  * Non-inherited lines take precedence (appear later) over inherited lines
  * Groups earlier in the apply-groups list value take precedence over later ones
* See https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/ref/statement/apply-groups.html#apply-groups__d65612e42