### PR TITLE
Add VI support for replacing all AS-path elements with local AS

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
@@ -39,7 +39,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
       @JsonProperty(PROP_REMOTE_ASNS) @Nullable LongSpace remoteAsns,
       @JsonProperty(PROP_IPV4_UNICAST_ADDRESS_FAMILY) @Nullable
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
-      @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily) {
+      @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
+      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport) {
     return new BgpActivePeerConfig(
         appliedRibGroup,
         authenticationSettings,
@@ -56,7 +57,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
         peerAddress,
         firstNonNull(remoteAsns, LongSpace.EMPTY),
         ipv4UnicastAddressFamily,
-        evpnAddressFamily);
+        evpnAddressFamily,
+        replaceNonLocalAsesOnExport);
   }
 
   private BgpActivePeerConfig(
@@ -75,7 +77,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
       @Nullable Ip peerAddress,
       @Nullable LongSpace remoteAsns,
       Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
-      @Nullable EvpnAddressFamily evpnAddressFamily) {
+      @Nullable EvpnAddressFamily evpnAddressFamily,
+      boolean replaceNonLocalAsesOnExport) {
     super(
         appliedRibGroup,
         authenticationSettings,
@@ -91,7 +94,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
         localIp,
         remoteAsns,
         ipv4UnicastAddressFamily,
-        evpnAddressFamily);
+        evpnAddressFamily,
+        replaceNonLocalAsesOnExport);
     _peerAddress = peerAddress;
   }
 
@@ -161,7 +165,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
               _peerAddress,
               _remoteAsns,
               _ipv4UnicastAddressFamily,
-              _evpnAddressFamily);
+              _evpnAddressFamily,
+              _replaceNonLocalAsesOnExport);
       if (_bgpProcess != null && _peerAddress != null) {
         _bgpProcess.getActiveNeighbors().put(_peerAddress, bgpPeerConfig);
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
@@ -41,7 +41,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
       @JsonProperty(PROP_REMOTE_ASNS) @Nullable LongSpace remoteAsns,
       @JsonProperty(PROP_IPV4_UNICAST_ADDRESS_FAMILY) @Nullable
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
-      @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily) {
+      @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
+      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport) {
     return new BgpPassivePeerConfig(
         appliedRibGroup,
         authenticationSettings,
@@ -58,7 +59,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
         peerPrefix,
         firstNonNull(remoteAsns, LongSpace.EMPTY),
         ipv4UnicastAddressFamily,
-        evpnAddressFamily);
+        evpnAddressFamily,
+        replaceNonLocalAsesOnExport);
   }
 
   private BgpPassivePeerConfig(
@@ -77,7 +79,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
       @Nullable Prefix peerPrefix,
       @Nullable LongSpace remoteAsns,
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
-      @Nullable EvpnAddressFamily evpnAddressFamily) {
+      @Nullable EvpnAddressFamily evpnAddressFamily,
+      boolean replaceNonLocalAsesOnExport) {
     super(
         appliedRibGroup,
         authenticationSettings,
@@ -93,7 +96,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
         localIp,
         remoteAsns,
         ipv4UnicastAddressFamily,
-        evpnAddressFamily);
+        evpnAddressFamily,
+        replaceNonLocalAsesOnExport);
     _peerPrefix = peerPrefix;
   }
 
@@ -153,7 +157,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
               _peerPrefix,
               _remoteAsns,
               _ipv4UnicastAddressFamily,
-              _evpnAddressFamily);
+              _evpnAddressFamily,
+              _replaceNonLocalAsesOnExport);
       if (_bgpProcess != null) {
         _bgpProcess.getPassiveNeighbors().put(_peerPrefix, bgpPeerConfig);
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -43,6 +43,8 @@ public abstract class BgpPeerConfig implements Serializable {
   static final String PROP_IPV4_UNICAST_ADDRESS_FAMILY = "ipv4UnicastAddressFamily";
   static final String PROP_EVPN_ADDRESS_FAMILY = "evpnAddressFamily";
 
+  static final String PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT = "replaceNonLocalAsesOnExport";
+
   @Nullable private final RibGroup _appliedRibGroup;
   @Nullable private final BgpAuthenticationSettings _authenticationSettings;
   /** The cluster id associated with this peer to be used in route reflection */
@@ -78,6 +80,8 @@ public abstract class BgpPeerConfig implements Serializable {
   @Nullable private Ipv4UnicastAddressFamily _ipv4UnicastAddressFamily;
   @Nullable private EvpnAddressFamily _evpnAddressFamily;
 
+  private final boolean _replaceNonLocalAsesOnExport;
+
   protected BgpPeerConfig(
       @Nullable RibGroup appliedRibGroup,
       @Nullable BgpAuthenticationSettings authenticationSettings,
@@ -93,7 +97,8 @@ public abstract class BgpPeerConfig implements Serializable {
       @Nullable Ip localIp,
       @Nullable LongSpace remoteAsns,
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
-      @Nullable EvpnAddressFamily evpnAddressFamily) {
+      @Nullable EvpnAddressFamily evpnAddressFamily,
+      boolean replaceNonLocalAsesOnExport) {
     _appliedRibGroup = appliedRibGroup;
     _authenticationSettings = authenticationSettings;
     _clusterId = clusterId;
@@ -109,6 +114,7 @@ public abstract class BgpPeerConfig implements Serializable {
     _remoteAsns = firstNonNull(remoteAsns, ALL_AS_NUMBERS);
     _ipv4UnicastAddressFamily = ipv4UnicastAddressFamily;
     _evpnAddressFamily = evpnAddressFamily;
+    _replaceNonLocalAsesOnExport = replaceNonLocalAsesOnExport;
   }
 
   /** Return the {@link RibGroup} applied to this config */
@@ -253,6 +259,15 @@ public abstract class BgpPeerConfig implements Serializable {
     }
   }
 
+  /**
+   * When true, replace every AS-path element with the singleton element of the local AS as the last
+   * step post-export. Only applicable to eBGP sessions.
+   */
+  @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT)
+  public boolean getReplaceNonLocalAsesOnExport() {
+    return _replaceNonLocalAsesOnExport;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -276,7 +291,8 @@ public abstract class BgpPeerConfig implements Serializable {
         && Objects.equals(_localIp, that._localIp)
         && _remoteAsns.equals(that._remoteAsns)
         && Objects.equals(_ipv4UnicastAddressFamily, that._ipv4UnicastAddressFamily)
-        && Objects.equals(_evpnAddressFamily, that._evpnAddressFamily);
+        && Objects.equals(_evpnAddressFamily, that._evpnAddressFamily)
+        && _replaceNonLocalAsesOnExport == that._replaceNonLocalAsesOnExport;
   }
 
   @Override
@@ -296,7 +312,8 @@ public abstract class BgpPeerConfig implements Serializable {
         _localIp,
         _remoteAsns,
         _ipv4UnicastAddressFamily,
-        _evpnAddressFamily);
+        _evpnAddressFamily,
+        _replaceNonLocalAsesOnExport);
   }
 
   @Override
@@ -317,6 +334,7 @@ public abstract class BgpPeerConfig implements Serializable {
         .add("_remoteAsns", _remoteAsns)
         .add("_ipv4UnicastAddressFamily", _ipv4UnicastAddressFamily)
         .add("_evpnAddressFamily", _evpnAddressFamily)
+        .add("_replaceNonLocalAsesOnExport", _replaceNonLocalAsesOnExport)
         .toString();
   }
 
@@ -340,6 +358,8 @@ public abstract class BgpPeerConfig implements Serializable {
 
     // Identifying fields
     @Nullable protected String _hostname;
+
+    protected boolean _replaceNonLocalAsesOnExport;
 
     protected Builder() {
       _remoteAsns = LongSpace.EMPTY;
@@ -439,6 +459,11 @@ public abstract class BgpPeerConfig implements Serializable {
 
     public S setEvpnAddressFamily(@Nullable EvpnAddressFamily evpnAddressFamily) {
       _evpnAddressFamily = evpnAddressFamily;
+      return getThis();
+    }
+
+    public S setReplaceNonLocalAsesOnExport(boolean replaceNonLocalAsesOnExport) {
+      _replaceNonLocalAsesOnExport = replaceNonLocalAsesOnExport;
       return getThis();
     }
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpUnnumberedPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpUnnumberedPeerConfig.java
@@ -47,7 +47,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
               _peerInterface,
               _remoteAsns,
               _ipv4UnicastAddressFamily,
-              _evpnAddressFamily);
+              _evpnAddressFamily,
+              _replaceNonLocalAsesOnExport);
       if (_bgpProcess != null) {
         _bgpProcess.getInterfaceNeighbors().put(_peerInterface, bgpPeerConfig);
       }
@@ -90,7 +91,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
       @JsonProperty(PROP_REMOTE_ASNS) @Nullable LongSpace remoteAsns,
       @JsonProperty(PROP_IPV4_UNICAST_ADDRESS_FAMILY) @Nullable
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
-      @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily) {
+      @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
+      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport) {
     checkArgument(peerInterface != null, "Missing %s", PROP_PEER_INTERFACE);
     return new BgpUnnumberedPeerConfig(
         appliedRibGroup,
@@ -108,7 +110,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
         peerInterface,
         firstNonNull(remoteAsns, LongSpace.EMPTY),
         ipv4UnicastAddressFamily,
-        evpnAddressFamily);
+        evpnAddressFamily,
+        replaceNonLocalAsesOnExport);
   }
 
   @Nonnull private final String _peerInterface;
@@ -129,7 +132,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
       @Nonnull String peerInterface,
       @Nullable LongSpace remoteAsns,
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
-      @Nullable EvpnAddressFamily evpnAddressFamily) {
+      @Nullable EvpnAddressFamily evpnAddressFamily,
+      boolean replaceNonLocalAsesOnExport) {
     super(
         appliedRibGroup,
         authenticationSettings,
@@ -145,7 +149,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
         localIp,
         remoteAsns,
         ipv4UnicastAddressFamily,
-        evpnAddressFamily);
+        evpnAddressFamily,
+        replaceNonLocalAsesOnExport);
     _peerInterface = peerInterface;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
@@ -46,6 +46,7 @@ public class BgpSessionPropertiesTest {
             .setRemoteAs(as2)
             .setPeerAddress(ip2)
             .setIpv4UnicastAddressFamily(addressFamily1)
+            .setReplaceNonLocalAsesOnExport(true)
             .build();
     BgpActivePeerConfig p2 =
         BgpActivePeerConfig.builder()
@@ -54,6 +55,7 @@ public class BgpSessionPropertiesTest {
             .setRemoteAs(as1)
             .setPeerAddress(ip1)
             .setIpv4UnicastAddressFamily(addressFamily2)
+            .setReplaceNonLocalAsesOnExport(false)
             .build();
     {
       BgpSessionProperties forwardSession =
@@ -67,6 +69,7 @@ public class BgpSessionPropertiesTest {
               .setRouteExchangeSettings(
                   // Add paths false, advertise external false, advertise inactive true
                   ImmutableMap.of(addressFamily1.getType(), new RouteExchange(false, false, true)))
+              .setReplaceNonLocalAsesOnExport(true)
               .build();
       assertThat(BgpSessionProperties.from(p1, p2, false), equalTo(forwardSession));
     }
@@ -82,6 +85,7 @@ public class BgpSessionPropertiesTest {
               .setRouteExchangeSettings(
                   // Add paths false, advertise external false, advertise inactive true
                   ImmutableMap.of(addressFamily1.getType(), new RouteExchange(false, false, false)))
+              .setReplaceNonLocalAsesOnExport(false)
               .build();
       assertThat(BgpSessionProperties.from(p1, p2, true), equalTo(reverseSession));
     }
@@ -181,7 +185,8 @@ public class BgpSessionPropertiesTest {
         // note the head/tail swap
         .addEqualityGroup(builder.setRemoteIp(tailIp).build())
         .addEqualityGroup(builder.setLocalIp(headIp).build())
-        .addEqualityGroup(builder.setSessionType(SessionType.EBGP_SINGLEHOP))
+        .addEqualityGroup(builder.setSessionType(SessionType.EBGP_SINGLEHOP).build())
+        .addEqualityGroup(builder.setReplaceNonLocalAsesOnExport(true).build())
         .addEqualityGroup(new Object())
         .testEquals();
   }
@@ -200,6 +205,7 @@ public class BgpSessionPropertiesTest {
             .setLocalIp(tailIp)
             .setRemoteIp(headIp)
             .setSessionType(SessionType.EBGP_MULTIHOP)
+            .setReplaceNonLocalAsesOnExport(true)
             .build();
     assertThat(BatfishObjectMapper.clone(bsp, BgpSessionProperties.class), equalTo(bsp));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpUnnumberedPeerConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpUnnumberedPeerConfigTest.java
@@ -89,6 +89,7 @@ public final class BgpUnnumberedPeerConfigTest {
         .addEqualityGroup(
             builder.setEvpnAddressFamily(
                 EvpnAddressFamily.builder().setPropagateUnmatched(true).build()))
+        .addEqualityGroup(builder.setReplaceNonLocalAsesOnExport(true).build())
         .testEquals();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -198,12 +198,21 @@ public class BgpProtocolHelperTest {
   public void testTransformPostExportClearTag() {
     Builder builder = _baseBgpRouteBuilder.setTag(MAX_TAG);
     transformBgpRoutePostExport(
-        builder, true, false, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null);
+        builder, true, false, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
     assertThat("Tag is cleared", builder.getTag(), equalTo(UNSET_ROUTE_TAG));
 
     builder.setTag(MAX_TAG);
     transformBgpRoutePostExport(
-        builder, false, false, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null);
+        builder,
+        false,
+        false,
+        false,
+        ConfedSessionType.NO_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
     assertThat("Tag is cleared", builder.getTag(), equalTo(UNSET_ROUTE_TAG));
   }
 
@@ -215,13 +224,13 @@ public class BgpProtocolHelperTest {
     // Nothing sent
     Builder builder = _baseBgpRouteBuilder.setCommunities(mixedComms).build().toBuilder();
     transformBgpRoutePostExport(
-        builder, true, false, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null);
+        builder, true, false, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
     assertThat("Communities cleared", builder.getCommunities(), equalTo(CommunitySet.empty()));
 
     // only standard sent
     builder = _baseBgpRouteBuilder.setCommunities(mixedComms).build().toBuilder();
     transformBgpRoutePostExport(
-        builder, true, true, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null);
+        builder, true, true, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
     assertThat(
         "Only standard communities",
         builder.getCommunities().getCommunities(),
@@ -230,7 +239,7 @@ public class BgpProtocolHelperTest {
     // only extended sent
     builder = _baseBgpRouteBuilder.setCommunities(mixedComms).build().toBuilder();
     transformBgpRoutePostExport(
-        builder, true, false, true, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null);
+        builder, true, false, true, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
     assertThat(
         "Only extended communities",
         builder.getCommunities().getCommunities(),
@@ -239,7 +248,7 @@ public class BgpProtocolHelperTest {
     // both sent
     builder = _baseBgpRouteBuilder.setCommunities(mixedComms).build().toBuilder();
     transformBgpRoutePostExport(
-        builder, true, true, true, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null);
+        builder, true, true, true, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
     assertThat("All communities", builder.getCommunities(), equalTo(mixedComms));
   }
 
@@ -257,7 +266,8 @@ public class BgpProtocolHelperTest {
         1,
         DEST_IP,
         Ip.ZERO,
-        null);
+        null,
+        false);
     assertThat(
         _baseBgpRouteBuilder.getAsPath(),
         equalTo(
@@ -279,7 +289,8 @@ public class BgpProtocolHelperTest {
         2,
         DEST_IP,
         Ip.ZERO,
-        null);
+        null,
+        false);
     assertThat(
         _baseBgpRouteBuilder.getAsPath(),
         equalTo(
@@ -297,7 +308,8 @@ public class BgpProtocolHelperTest {
         4,
         DEST_IP,
         Ip.ZERO,
-        null);
+        null,
+        false);
     assertThat(
         _baseBgpRouteBuilder.getAsPath(),
         equalTo(
@@ -319,7 +331,8 @@ public class BgpProtocolHelperTest {
         5,
         DEST_IP,
         Ip.ZERO,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getAsPath(), equalTo(baseAsPath));
 
     // Do not prepend for IBGP within confed
@@ -334,7 +347,8 @@ public class BgpProtocolHelperTest {
         6,
         DEST_IP,
         Ip.ZERO,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getAsPath(), equalTo(baseAsPath));
   }
 
@@ -353,7 +367,8 @@ public class BgpProtocolHelperTest {
         1,
         nextHopIp,
         DEST_IP,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(nextHopIp));
 
     // eBGP across confederation border
@@ -367,7 +382,8 @@ public class BgpProtocolHelperTest {
         1,
         nextHopIp,
         DEST_IP,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(nextHopIp));
 
     // eBGP within confederation -- change
@@ -381,7 +397,8 @@ public class BgpProtocolHelperTest {
         1,
         nextHopIp,
         DEST_IP,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(nextHopIp));
 
     // iBGP no confederation -- no change
@@ -395,7 +412,8 @@ public class BgpProtocolHelperTest {
         1,
         nextHopIp,
         DEST_IP,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(DEST_IP));
 
     // iBGP within confederation -- no change
@@ -409,7 +427,8 @@ public class BgpProtocolHelperTest {
         1,
         nextHopIp,
         DEST_IP,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(DEST_IP));
 
     // eBGP within confederation, unset original IP -- overwrite
@@ -423,7 +442,8 @@ public class BgpProtocolHelperTest {
         1,
         nextHopIp,
         UNSET_ROUTE_NEXT_HOP_IP,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(nextHopIp));
 
     // iBGP no confederation, unset original IP -- overwrite
@@ -437,7 +457,8 @@ public class BgpProtocolHelperTest {
         1,
         nextHopIp,
         UNSET_ROUTE_NEXT_HOP_IP,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(nextHopIp));
 
     // iBGP within confederation, unset original IP -- overwrite
@@ -451,7 +472,8 @@ public class BgpProtocolHelperTest {
         1,
         nextHopIp,
         UNSET_ROUTE_NEXT_HOP_IP,
-        null);
+        null,
+        false);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(nextHopIp));
   }
 

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -4226,7 +4226,8 @@
                   "localAs" : 65534,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "backbone",
-                  "remoteAsns" : "16509"
+                  "remoteAsns" : "16509",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "multipathEbgp" : false,
@@ -36566,7 +36567,8 @@
                   "localAs" : 65534,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "backbone",
-                  "remoteAsns" : "16509"
+                  "remoteAsns" : "16509",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "multipathEbgp" : false,
@@ -36759,7 +36761,8 @@
                   "localAs" : 65534,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "backbone",
-                  "remoteAsns" : "16509"
+                  "remoteAsns" : "16509",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "multipathEbgp" : false,
@@ -36951,7 +36954,8 @@
                   "localAs" : 65534,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "backbone",
-                  "remoteAsns" : "16509"
+                  "remoteAsns" : "16509",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "multipathEbgp" : false,
@@ -37115,7 +37119,8 @@
                   "localAs" : 65537,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "To-isp_16509",
-                  "remoteAsns" : "16509"
+                  "remoteAsns" : "16509",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "multipathEbgp" : true,
@@ -42077,7 +42082,8 @@
                   "localAs" : 16509,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "To-Internet",
-                  "remoteAsns" : "65537"
+                  "remoteAsns" : "65537",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "To-__aws-services-gateway__-backbone" : {
                   "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
@@ -42102,7 +42108,8 @@
                   "localAs" : 16509,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "To-__aws-services-gateway__-backbone",
-                  "remoteAsns" : "65534"
+                  "remoteAsns" : "65534",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "To-igw-068fee63-backbone" : {
                   "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
@@ -42127,7 +42134,8 @@
                   "localAs" : 16509,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "To-igw-068fee63-backbone",
-                  "remoteAsns" : "65534"
+                  "remoteAsns" : "65534",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "To-igw-9b93ddfc-backbone" : {
                   "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
@@ -42152,7 +42160,8 @@
                   "localAs" : 16509,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "To-igw-9b93ddfc-backbone",
-                  "remoteAsns" : "65534"
+                  "remoteAsns" : "65534",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "To-igw-fac5839d-backbone" : {
                   "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
@@ -42177,7 +42186,8 @@
                   "localAs" : 16509,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "To-igw-fac5839d-backbone",
-                  "remoteAsns" : "65534"
+                  "remoteAsns" : "65534",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "To-vgw-81fd279f-backbone" : {
                   "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
@@ -42202,7 +42212,8 @@
                   "localAs" : 16509,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "To-vgw-81fd279f-backbone",
-                  "remoteAsns" : "65534"
+                  "remoteAsns" : "65534",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "multipathEbgp" : true,
@@ -82444,7 +82455,8 @@
                   "localAs" : 65301,
                   "localIp" : "10.10.10.38",
                   "peerAddress" : "10.10.10.37",
-                  "remoteAsns" : "65201"
+                  "remoteAsns" : "65201",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.10.10.45" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -82471,7 +82483,8 @@
                   "localAs" : 65301,
                   "localIp" : "10.10.10.46",
                   "peerAddress" : "10.10.10.45",
-                  "remoteAsns" : "65202"
+                  "remoteAsns" : "65202",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.10.30.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -82501,7 +82514,8 @@
                   "localAs" : 65301,
                   "localIp" : "10.10.30.1",
                   "peerAddress" : "10.10.30.2",
-                  "remoteAsns" : "65331"
+                  "remoteAsns" : "65331",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.10.255.7" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -82527,7 +82541,8 @@
                   "localAs" : 65301,
                   "localIp" : "10.10.255.8",
                   "peerAddress" : "10.10.255.7",
-                  "remoteAsns" : "65301"
+                  "remoteAsns" : "65301",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "169.254.13.237" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -82572,7 +82587,8 @@
                   "localAs" : 65301,
                   "localIp" : "169.254.13.238",
                   "peerAddress" : "169.254.13.237",
-                  "remoteAsns" : "65401"
+                  "remoteAsns" : "65401",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "169.254.15.193" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -82617,7 +82633,8 @@
                   "localAs" : 65301,
                   "localIp" : "169.254.15.194",
                   "peerAddress" : "169.254.15.193",
-                  "remoteAsns" : "65401"
+                  "remoteAsns" : "65401",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ROUTER_ID"
@@ -85906,7 +85923,8 @@
                   "localAs" : 65401,
                   "localIp" : "169.254.13.237",
                   "peerAddress" : "169.254.13.238",
-                  "remoteAsns" : "65301"
+                  "remoteAsns" : "65301",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "169.254.15.194" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -85932,7 +85950,8 @@
                   "localAs" : 65401,
                   "localIp" : "169.254.15.193",
                   "peerAddress" : "169.254.15.194",
-                  "remoteAsns" : "65301"
+                  "remoteAsns" : "65301",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -85984,7 +86003,8 @@
                   "localAs" : 65534,
                   "localIp" : "169.254.0.1",
                   "peerInterface" : "backbone",
-                  "remoteAsns" : "16509"
+                  "remoteAsns" : "16509",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "multipathEbgp" : false,

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -3592,7 +3592,8 @@
                 "localAs" : 1,
                 "localIp" : "1.1.1.1",
                 "peerAddress" : "1.10.1.1",
-                "remoteAsns" : "1"
+                "remoteAsns" : "1",
+                "replaceNonLocalAsesOnExport" : false
               },
               "3.2.2.2" : {
                 "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -3618,7 +3619,8 @@
                 },
                 "localAs" : 1,
                 "peerAddress" : "3.2.2.2",
-                "remoteAsns" : "666"
+                "remoteAsns" : "666",
+                "replaceNonLocalAsesOnExport" : false
               },
               "5.6.7.8" : {
                 "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -3644,7 +3646,8 @@
                 },
                 "localAs" : 1,
                 "peerAddress" : "5.6.7.8",
-                "remoteAsns" : "555"
+                "remoteAsns" : "555",
+                "replaceNonLocalAsesOnExport" : false
               },
               "10.12.11.2" : {
                 "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -3678,7 +3681,8 @@
                 "localAs" : 1,
                 "localIp" : "10.12.11.1",
                 "peerAddress" : "10.12.11.2",
-                "remoteAsns" : "2"
+                "remoteAsns" : "2",
+                "replaceNonLocalAsesOnExport" : false
               }
             },
             "tieBreaker" : "ARRIVAL_ORDER"

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -1529,7 +1529,8 @@
                   "localAs" : 1,
                   "localIp" : "1.1.1.1",
                   "peerAddress" : "1.10.1.1",
-                  "remoteAsns" : "1"
+                  "remoteAsns" : "1",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "3.2.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -1555,7 +1556,8 @@
                   },
                   "localAs" : 1,
                   "peerAddress" : "3.2.2.2",
-                  "remoteAsns" : "666"
+                  "remoteAsns" : "666",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "5.6.7.8" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -1581,7 +1583,8 @@
                   },
                   "localAs" : 1,
                   "peerAddress" : "5.6.7.8",
-                  "remoteAsns" : "555"
+                  "remoteAsns" : "555",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.12.11.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -1615,7 +1618,8 @@
                   "localAs" : 1,
                   "localIp" : "10.12.11.1",
                   "peerAddress" : "10.12.11.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -3213,7 +3217,8 @@
                   "localAs" : 1,
                   "localIp" : "1.2.2.2",
                   "peerAddress" : "1.10.1.1",
-                  "remoteAsns" : "1"
+                  "remoteAsns" : "1",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.13.22.3" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -3247,7 +3252,8 @@
                   "localAs" : 1,
                   "localIp" : "10.13.22.1",
                   "peerAddress" : "10.13.22.3",
-                  "remoteAsns" : "3"
+                  "remoteAsns" : "3",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.14.22.4" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -3281,7 +3287,8 @@
                   "localAs" : 1,
                   "localIp" : "10.14.22.1",
                   "peerAddress" : "10.14.22.4",
-                  "remoteAsns" : "4"
+                  "remoteAsns" : "4",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -3743,7 +3750,8 @@
                   "localAs" : 1,
                   "localIp" : "1.10.1.1",
                   "peerAddress" : "1.1.1.1",
-                  "remoteAsns" : "1"
+                  "remoteAsns" : "1",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "1.2.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -3770,7 +3778,8 @@
                   "localAs" : 1,
                   "localIp" : "1.10.1.1",
                   "peerAddress" : "1.2.2.2",
-                  "remoteAsns" : "1"
+                  "remoteAsns" : "1",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -5447,7 +5456,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.1.1",
                   "peerAddress" : "2.1.2.1",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -5474,7 +5484,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.1.1",
                   "peerAddress" : "2.1.2.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.12.11.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -5508,7 +5519,8 @@
                   "localAs" : 2,
                   "localIp" : "10.12.11.2",
                   "peerAddress" : "10.12.11.1",
-                  "remoteAsns" : "1"
+                  "remoteAsns" : "1",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -7105,7 +7117,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.1.2",
                   "peerAddress" : "2.1.2.1",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -7132,7 +7145,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.1.2",
                   "peerAddress" : "2.1.2.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.23.21.3" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -7166,7 +7180,8 @@
                   "localAs" : 2,
                   "localIp" : "10.23.21.2",
                   "peerAddress" : "10.23.21.3",
-                  "remoteAsns" : "3"
+                  "remoteAsns" : "3",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -7863,7 +7878,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.1",
                   "peerAddress" : "2.1.1.1",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.1.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -7890,7 +7906,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.1",
                   "peerAddress" : "2.1.1.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.3.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -7917,7 +7934,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.1",
                   "peerAddress" : "2.1.3.1",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.3.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -7944,7 +7962,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.1",
                   "peerAddress" : "2.1.3.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -8542,7 +8561,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.2",
                   "peerAddress" : "2.1.1.1",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.1.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -8569,7 +8589,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.2",
                   "peerAddress" : "2.1.1.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.3.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -8596,7 +8617,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.2",
                   "peerAddress" : "2.1.3.1",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.3.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -8623,7 +8645,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.2.2",
                   "peerAddress" : "2.1.3.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -9891,7 +9914,8 @@
                   "localAs" : 65001,
                   "localIp" : "2.34.101.4",
                   "peerAddress" : "2.34.101.3",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.34.201.3" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -9925,7 +9949,8 @@
                   "localAs" : 65001,
                   "localIp" : "2.34.201.4",
                   "peerAddress" : "2.34.201.3",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -10901,7 +10926,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.3.1",
                   "peerAddress" : "2.1.2.1",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -10928,7 +10954,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.3.1",
                   "peerAddress" : "2.1.2.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.34.101.4" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -10962,7 +10989,8 @@
                   "localAs" : 2,
                   "localIp" : "2.34.101.3",
                   "peerAddress" : "2.34.101.4",
-                  "remoteAsns" : "65001"
+                  "remoteAsns" : "65001",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -11938,7 +11966,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.3.2",
                   "peerAddress" : "2.1.2.1",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.1.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -11965,7 +11994,8 @@
                   "localAs" : 2,
                   "localIp" : "2.1.3.2",
                   "peerAddress" : "2.1.2.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "2.34.201.4" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -11999,7 +12029,8 @@
                   "localAs" : 2,
                   "localIp" : "2.34.201.3",
                   "peerAddress" : "2.34.201.4",
-                  "remoteAsns" : "65001"
+                  "remoteAsns" : "65001",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -13499,7 +13530,8 @@
                   "localAs" : 3,
                   "localIp" : "3.1.1.1",
                   "peerAddress" : "3.10.1.1",
-                  "remoteAsns" : "3"
+                  "remoteAsns" : "3",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.23.21.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -13533,7 +13565,8 @@
                   "localAs" : 3,
                   "localIp" : "10.23.21.3",
                   "peerAddress" : "10.23.21.2",
-                  "remoteAsns" : "2"
+                  "remoteAsns" : "2",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -14950,7 +14983,8 @@
                   "localAs" : 3,
                   "localIp" : "3.2.2.2",
                   "peerAddress" : "3.10.1.1",
-                  "remoteAsns" : "3"
+                  "remoteAsns" : "3",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "10.13.22.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -14984,7 +15018,8 @@
                   "localAs" : 3,
                   "localIp" : "10.13.22.3",
                   "peerAddress" : "10.13.22.1",
-                  "remoteAsns" : "1"
+                  "remoteAsns" : "1",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -15598,7 +15633,8 @@
                   "localAs" : 3,
                   "localIp" : "3.10.1.1",
                   "peerAddress" : "3.1.1.1",
-                  "remoteAsns" : "3"
+                  "remoteAsns" : "3",
+                  "replaceNonLocalAsesOnExport" : false
                 },
                 "3.2.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
@@ -15625,7 +15661,8 @@
                   "localAs" : 3,
                   "localIp" : "3.10.1.1",
                   "peerAddress" : "3.2.2.2",
-                  "remoteAsns" : "3"
+                  "remoteAsns" : "3",
+                  "replaceNonLocalAsesOnExport" : false
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"


### PR DESCRIPTION
* Add BgpPeerConfig/BgpSessionProperties field `replaceNonLocalAsesOnExport`
* When true, and session is eBGP, the final step in transformation of a BGP route post export is to replace every element of the AS path with the singleton as-set of the local AS