### PR TITLE
Cisco IOS: Parse and ignore cts substanzas under interface

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -2969,6 +2969,8 @@ LAST_MEMBER_QUERY_INTERVAL: 'last-member-query-interval';
 
 LAST_MEMBER_QUERY_RESPONSE_TIME: 'last-member-query-response-time';
 
+LAYER3: 'layer3';
+
 LCD_MENU: 'lcd-menu';
 
 LDAP: 'ldap';
@@ -3286,6 +3288,8 @@ MANAGEMENT_PLANE: 'management-plane';
 MANAGEMENT_PROFILE: 'management-profile';
 
 MANAGER: 'manager';
+
+MANUAL: 'manual';
 
 MAP: 'map';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -94,6 +94,16 @@ if_crypto_map
    CRYPTO MAP name = variable NEWLINE
 ;
 
+if_cts
+:
+   CTS
+   (
+      ifcts_dot1x
+      | ifcts_layer3_null
+      | ifcts_manual
+   )
+;
+
 if_default_gw
 :
    DEFAULT_GW IP_ADDRESS NEWLINE
@@ -1538,6 +1548,33 @@ if_zone_member
    ZONE_MEMBER SECURITY? name = variable_permissive NEWLINE
 ;
 
+ifcts_dot1x
+:
+   DOT1X NEWLINE
+   ifctsdot1x_null*
+;
+
+ifctsdot1x_null
+:
+    (DEFAULT | TIMER) null_rest_of_line
+;
+
+ifcts_manual
+:
+   MANUAL NEWLINE
+   ifctsmanual_null*
+;
+
+ifctsmanual_null
+:
+   (POLICY | SAP) null_rest_of_line
+;
+
+ifcts_layer3_null
+:
+   LAYER3 (IPV4 | IPV6) null_rest_of_line
+;
+
 ifipdhcp_null
 :
    (
@@ -1783,6 +1820,7 @@ if_inner
    | if_bfd
    | if_channel_group
    | if_crypto_map
+   | if_cts
    | if_default_gw
    | if_delay
    | if_description

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -7178,4 +7178,9 @@ public final class CiscoGrammarTest {
     assertThat(c.getAllInterfaces().get("Vlan100").getActive(), equalTo(false));
     assertThat(c.getAllInterfaces().get("Vlan3000").getActive(), equalTo(false));
   }
+
+  @Test
+  public void testIosInterfaceCts() {
+    parseCiscoConfig("ios-interface-cts", ConfigurationFormat.CISCO_IOS);
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-cts
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-cts
@@ -1,0 +1,19 @@
+!
+hostname ios-interface-cts
+!
+! grammar based on https://www.cisco.com/c/en/us/td/docs/switches/lan/trustsec/configuration/guide/trustsec/command_sum.html
+! focusing on things that can appear under the interface stanza
+!
+interface TenGigabitEthernet1/1/21
+ cts dot1x
+   default timer reauthentication
+   timer reauthentication 44
+!
+ cts layer3 ipv4 trustsec forwarding
+ cts layer3 ipv6 policy
+ cts layer3 ipv4 trustsec
+!
+ cts manual
+  policy static sgt 2 trusted
+  sap pmk 1234abcdef mode-list gcm null no-encap
+!

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -20558,7 +20558,7 @@
             "      (null_rest_of_line*",
             "        VFI:'vfi'",
             "        VARIABLE:'foobar'",
-            "        VARIABLE:'manual'",
+            "        MANUAL:'manual'",
             "        NEWLINE:'\\n')",
             "      (l2_null*",
             "        BRIDGE_DOMAIN:'bridge-domain'",


### PR DESCRIPTION
Fixes #8700 