### PR TITLE
Move route reflection logic to a shared method

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/rr-rib-failure-client-non-client/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/rr-rib-failure-client-non-client/configs/r1
@@ -1,0 +1,30 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname r1
+!
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+interface GigabitEthernet0/1
+ ip address 10.12.0.1 255.255.255.0
+!
+router bgp 1
+ bgp router-id 1.1.1.1
+ neighbor 2.2.2.2 remote-as 1
+ neighbor 2.2.2.2 update-source Loopback0
+ !
+ address-family ipv4
+  redistribute static route-map rs
+  neighbor 2.2.2.2 activate
+ exit-address-family
+!
+ip route 2.2.2.2 255.255.255.255 10.12.0.2
+ip route 5.5.5.5 255.255.255.255 Null0
+!
+ip prefix-list five seq 5 permit 5.5.5.5/32
+!
+route-map rs permit 100
+ match ip address prefix-list five
+ set ip next-hop 10.23.0.3
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/rr-rib-failure-client-non-client/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/rr-rib-failure-client-non-client/configs/r2
@@ -1,0 +1,31 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname r2
+!
+interface Loopback0
+ ip address 2.2.2.2 255.255.255.255
+!
+interface GigabitEthernet0/1
+ ip address 10.12.0.2 255.255.255.0
+!
+interface GigabitEthernet0/2
+ ip address 10.23.0.2 255.255.255.0
+!
+router bgp 1
+ bgp router-id 2.2.2.2
+ neighbor 1.1.1.1 remote-as 1
+ neighbor 1.1.1.1 update-source Loopback0
+ neighbor 3.3.3.3 remote-as 1
+ neighbor 3.3.3.3 update-source Loopback0
+ !
+ address-family ipv4
+  neighbor 1.1.1.1 activate
+  neighbor 1.1.1.1 route-reflector-client
+  neighbor 3.3.3.3 activate
+ exit-address-family
+!
+ip route 1.1.1.1 255.255.255.255 10.12.0.1
+ip route 3.3.3.3 255.255.255.255 10.23.0.3
+ip route 5.5.5.5 255.255.255.255 Null0
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/rr-rib-failure-client-non-client/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/testrigs/rr-rib-failure-client-non-client/configs/r3
@@ -1,0 +1,22 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname r3
+!
+interface Loopback0
+ ip address 3.3.3.3 255.255.255.255
+!
+interface GigabitEthernet0/2
+ ip address 10.23.0.3 255.255.255.0
+!
+router bgp 1
+ bgp router-id 3.3.3.3
+ neighbor 2.2.2.2 remote-as 1
+ neighbor 2.2.2.2 update-source Loopback0
+ !
+ address-family ipv4
+  neighbor 2.2.2.2 activate
+ exit-address-family
+!
+ip route 2.2.2.2 255.255.255.255 10.23.0.2
+!
+end


### PR DESCRIPTION
Route reflection criteria was applied in two places, but one location was incomplete. Specifically, we have a check `isReflectable` that was used for advertising BGP routes that are not installed in the main RIB if they are a result of route reflection. Moved this logic into a shared method used for both the RIB failure spot and the BgpProtocolHelper spot. 

Functionally, this changes a single case: in the event of RIB failure, client-to-client and non-client-to-client cases were already covered, and this CR adds client-to-non-client.

Does not effect anything eBGP-related. 