### PR TITLE
Introduce Bazel Steward - a tool for keeping dependencies up to date in Bazel

### DIFF
--- a/.github/workflows/bazel-steward.yaml
+++ b/.github/workflows/bazel-steward.yaml
@@ -1,0 +1,15 @@
+name: Bazel Steward
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  bazel-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: VirtusLab/bazel-steward@latest

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 /bazel-*
-
+!bazel-steward.yaml
 # Ignore python cache files
 __pycache__
 .pytest_cache/

--- a/bazel-steward.yaml
+++ b/bazel-steward.yaml
@@ -1,0 +1,31 @@
+pull-requests:
+  - dependencies: "com.fasterxml.jackson*:*"
+    group-id: jackson
+  - dependencies: "com.google.auto.service:*"
+    group-id: google-auto-service
+  - dependencies: "org.apache.logging.log4j:*"
+    group-id: log4j
+  - dependencies: "org.glassfish.jersey*:*"
+    group-id: jersey
+  - dependencies: "org.glassfish.grizzly:*"
+    group-id: grizzly
+  - dependencies: "org.mockito:*"
+    group-id: mockito
+  - dependencies: "org.parboiled:*"
+    group-id: parboiled
+  - limits:
+      max-open: 10
+
+post-update-hooks:
+  - kinds: maven
+    commands:
+      - "REPIN=1 bazel run @unpinned_maven//:pin"
+    files-to-commit:
+      - "maven_install.json"
+    run-for: commit
+  - dependencies: rules_jvm_external
+    commands:
+      - "REPIN=1 bazel run @unpinned_maven//:pin"
+    files-to-commit:
+      - "maven_install.json"
+    run-for: commit


### PR DESCRIPTION
Hello! 
I am creating this PR again (https://github.com/batfish/batfish/pull/8716) after accidentally closing the previous one by accidentally removing a branch from my fork 😅. Latest version of Bazel Steward supports grouping of PRs, I also configured it to repin dependencies after rules_jvm_external update. Please, refer to the original PR for more details. 