### PR TITLE
Optimize initiateBgpSessions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -15,13 +15,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -54,8 +52,6 @@ import org.batfish.datamodel.flow.RouteInfo;
 import org.batfish.datamodel.flow.SessionScopeVisitor;
 import org.batfish.datamodel.flow.Step;
 import org.batfish.datamodel.flow.StepAction;
-import org.batfish.datamodel.flow.Trace;
-import org.batfish.datamodel.flow.TraceAndReverseFlow;
 import org.batfish.datamodel.flow.TransformationStep;
 import org.batfish.datamodel.flow.TransformationStep.TransformationStepDetail;
 import org.batfish.datamodel.flow.TransformationStep.TransformationType;
@@ -347,20 +343,5 @@ public final class TracerouteUtils {
     } else {
       return transformedFlow;
     }
-  }
-
-  static TraceAndReverseFlow toTraceAndReverseFlow(List<HopInfo> hopInfos) {
-    HopInfo lastHop = hopInfos.get(hopInfos.size() - 1);
-    FlowDisposition disposition = lastHop.getDisposition();
-    checkArgument(disposition != null, "Last hop of a complete trace must have a disposition");
-    List<Hop> hops =
-        hopInfos.stream().map(HopInfo::getHop).collect(ImmutableList.toImmutableList());
-    Set<FirewallSessionTraceInfo> newSessions =
-        hopInfos.stream()
-            .map(HopInfo::getFirewallSessionTraceInfo)
-            .filter(Objects::nonNull)
-            .collect(ImmutableSet.toImmutableSet());
-    return new TraceAndReverseFlow(
-        new Trace(disposition, hops), lastHop.getReturnFlow(), newSessions);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -15,11 +15,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -52,6 +54,8 @@ import org.batfish.datamodel.flow.RouteInfo;
 import org.batfish.datamodel.flow.SessionScopeVisitor;
 import org.batfish.datamodel.flow.Step;
 import org.batfish.datamodel.flow.StepAction;
+import org.batfish.datamodel.flow.Trace;
+import org.batfish.datamodel.flow.TraceAndReverseFlow;
 import org.batfish.datamodel.flow.TransformationStep;
 import org.batfish.datamodel.flow.TransformationStep.TransformationStepDetail;
 import org.batfish.datamodel.flow.TransformationStep.TransformationType;
@@ -343,5 +347,20 @@ public final class TracerouteUtils {
     } else {
       return transformedFlow;
     }
+  }
+
+  static TraceAndReverseFlow toTraceAndReverseFlow(List<HopInfo> hopInfos) {
+    HopInfo lastHop = hopInfos.get(hopInfos.size() - 1);
+    FlowDisposition disposition = lastHop.getDisposition();
+    checkArgument(disposition != null, "Last hop of a complete trace must have a disposition");
+    List<Hop> hops =
+        hopInfos.stream().map(HopInfo::getHop).collect(ImmutableList.toImmutableList());
+    Set<FirewallSessionTraceInfo> newSessions =
+        hopInfos.stream()
+            .map(HopInfo::getFirewallSessionTraceInfo)
+            .filter(Objects::nonNull)
+            .collect(ImmutableSet.toImmutableSet());
+    return new TraceAndReverseFlow(
+        new Trace(disposition, hops), lastHop.getReturnFlow(), newSessions);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -6,6 +6,9 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.ExprAclLine.REJECT_ALL;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasProtocol;
+import static org.batfish.datamodel.matchers.HopMatchers.hasNodeName;
+import static org.batfish.datamodel.matchers.TraceMatchers.hasDisposition;
+import static org.batfish.datamodel.matchers.TraceMatchers.hasHops;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -13,7 +16,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -79,6 +81,7 @@ import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.bgp.BgpTopologyUtils;
+import org.batfish.datamodel.bgp.BgpTopologyUtils.BgpSessionInitiationResult;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.isis.IsisInterfaceLevelSettings;
@@ -93,7 +96,6 @@ import org.batfish.dataplane.TracerouteEngineImpl;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -739,22 +741,22 @@ public class IncrementalDataPlanePluginTest {
             .build();
 
     // the neighbor should be reachable because it is only one hop away from the initiator
-    List<Ip> successfulInitiatorLocalIps =
+    List<BgpSessionInitiationResult> initiationResults =
         BgpTopologyUtils.initiateBgpSessions(
             initiator,
             listener,
             source,
             ImmutableSet.of(initiatorLocalIp),
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs));
-    Ip successfulInitiatorLocalIp = Iterables.getOnlyElement(successfulInitiatorLocalIps);
-    assertEquals(initiatorLocalIp, successfulInitiatorLocalIp);
-    //    assertTrue(bgpSessionInitiationResult.isSuccessful());
-    //    assertThat(
-    //        Iterables.getOnlyElement(bgpSessionInitiationResult.getForwardTraces()),
-    //        hasHops(contains(hasNodeName("node1"), hasNodeName("node2"))));
-    //    assertThat(
-    //        Iterables.getOnlyElement(bgpSessionInitiationResult.getReverseTraces()),
-    //        hasHops(contains(hasNodeName("node2"), hasNodeName("node1"))));
+    BgpSessionInitiationResult bgpSessionInitiationResult =
+        Iterables.getOnlyElement(initiationResults);
+    assertTrue(bgpSessionInitiationResult.isSuccessful());
+    assertThat(
+        Iterables.getOnlyElement(bgpSessionInitiationResult.getForwardTraces()),
+        hasHops(contains(hasNodeName("node1"), hasNodeName("node2"))));
+    assertThat(
+        Iterables.getOnlyElement(bgpSessionInitiationResult.getReverseTraces()),
+        hasHops(contains(hasNodeName("node2"), hasNodeName("node1"))));
   }
 
   @Test
@@ -784,14 +786,22 @@ public class IncrementalDataPlanePluginTest {
             .build();
 
     // the neighbor should be not be reachable because it is two hops away from the initiator
-    List<Ip> successfulInitiatorLocalIps =
+    List<BgpSessionInitiationResult> initiationResults =
         BgpTopologyUtils.initiateBgpSessions(
             initiator,
             listener,
             source,
             ImmutableSet.of(initiatorLocalIp),
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs));
-    assertThat(successfulInitiatorLocalIps, Matchers.empty());
+    BgpSessionInitiationResult bgpSessionInitiationResult =
+        Iterables.getOnlyElement(initiationResults);
+    assertFalse(bgpSessionInitiationResult.isSuccessful());
+    assertThat(
+        Iterables.getOnlyElement(bgpSessionInitiationResult.getForwardTraces()),
+        allOf(
+            hasDisposition(FlowDisposition.ACCEPTED),
+            hasHops(contains(hasNodeName("node1"), hasNodeName("node2"), hasNodeName("node3")))));
+    assertTrue(bgpSessionInitiationResult.getReverseTraces().isEmpty());
   }
 
   @Test
@@ -821,15 +831,22 @@ public class IncrementalDataPlanePluginTest {
             .build();
 
     // the neighbor should be reachable because multi-hops are allowed
-    List<Ip> successfulInitiatorLocalIps =
+    List<BgpSessionInitiationResult> initiationResults =
         BgpTopologyUtils.initiateBgpSessions(
             initiator,
             listener,
             source,
             ImmutableSet.of(initiatorLocalIp),
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs));
-    Ip successfulInitiatorLocalIp = Iterables.getOnlyElement(successfulInitiatorLocalIps);
-    assertEquals(initiatorLocalIp, successfulInitiatorLocalIp);
+    BgpSessionInitiationResult bgpSessionInitiationResult =
+        Iterables.getOnlyElement(initiationResults);
+    assertTrue(bgpSessionInitiationResult.isSuccessful());
+    assertThat(
+        Iterables.getOnlyElement(bgpSessionInitiationResult.getForwardTraces()),
+        hasHops(contains(hasNodeName("node1"), hasNodeName("node2"), hasNodeName("node3"))));
+    assertThat(
+        Iterables.getOnlyElement(bgpSessionInitiationResult.getReverseTraces()),
+        hasHops(contains(hasNodeName("node3"), hasNodeName("node2"), hasNodeName("node1"))));
   }
 
   @Test
@@ -861,14 +878,22 @@ public class IncrementalDataPlanePluginTest {
 
     // the neighbor should not be reachable even though multihops are allowed as traceroute would be
     // denied in on node 3
-    List<Ip> successfulInitiatorLocalIps =
+    List<BgpSessionInitiationResult> initiationResults =
         BgpTopologyUtils.initiateBgpSessions(
             initiator,
             listener,
             source,
             ImmutableSet.of(initiatorLocalIp),
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs));
-    assertThat(successfulInitiatorLocalIps, Matchers.empty());
+    BgpSessionInitiationResult bgpSessionInitiationResult =
+        Iterables.getOnlyElement(initiationResults);
+    assertFalse(bgpSessionInitiationResult.isSuccessful());
+    assertThat(
+        Iterables.getOnlyElement(bgpSessionInitiationResult.getForwardTraces()),
+        allOf(
+            hasDisposition(FlowDisposition.DENIED_IN),
+            hasHops(contains(hasNodeName("node1"), hasNodeName("node2"), hasNodeName("node3")))));
+    assertTrue(bgpSessionInitiationResult.getReverseTraces().isEmpty());
   }
 
   @Test
@@ -900,15 +925,22 @@ public class IncrementalDataPlanePluginTest {
 
     // neighbor should be reachable because ACL allows established connection back into node1 and
     // allows everything out
-    List<Ip> successfulInitiatorLocalIps =
+    List<BgpSessionInitiationResult> initiationResults =
         BgpTopologyUtils.initiateBgpSessions(
             initiator,
             listener,
             source,
             ImmutableSet.of(initiatorLocalIp),
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs));
-    Ip successfulInitiatorLocalIp = Iterables.getOnlyElement(successfulInitiatorLocalIps);
-    assertEquals(initiatorLocalIp, successfulInitiatorLocalIp);
+    BgpSessionInitiationResult bgpSessionInitiationResult =
+        Iterables.getOnlyElement(initiationResults);
+    assertTrue(bgpSessionInitiationResult.isSuccessful());
+    assertThat(
+        Iterables.getOnlyElement(bgpSessionInitiationResult.getForwardTraces()),
+        hasHops(contains(hasNodeName("node1"), hasNodeName("node2"), hasNodeName("node3"))));
+    assertThat(
+        Iterables.getOnlyElement(bgpSessionInitiationResult.getReverseTraces()),
+        hasHops(contains(hasNodeName("node3"), hasNodeName("node2"), hasNodeName("node1"))));
   }
 
   /**


### PR DESCRIPTION
1. Dedup reverse traceroutes. Previously, if there are multiple forward paths with the same traceroute parameters (return flow and established firewwall sessions), we would repeat the reverse traceroute for each forward trace.
2. Short-circuit. Stream traces directly from the TraceDag instead of first collecting them into a list, and stop as soon as we find one successful bidrectional trace.
3. Don't collect all the traces. Just return the successful initiator local IPs.

On one snapshot containing many BGP multihop sessions (with ECMP paths), this reduced BGP topology computation time from 90s to 25s (total over 4 computations while dataplaning).