### PR TITLE
Junos: add some missing todos for commands that only track references

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5976,6 +5976,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     String name = toString(ctx.name);
     _configuration.referenceStructure(
         POLICY_STATEMENT, name, ROUTING_INSTANCE_VRF_EXPORT, getLine(ctx.name.getStart()));
+    todo(ctx);
   }
 
   @Override
@@ -5983,6 +5984,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     String name = toString(ctx.name);
     _configuration.referenceStructure(
         POLICY_STATEMENT, name, ROUTING_INSTANCE_VRF_IMPORT, getLine(ctx.name.getStart()));
+    todo(ctx);
   }
 
   @Override
@@ -5990,6 +5992,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     String ifaceName = getInterfaceFullName(ctx.iface);
     _configuration.referenceStructure(
         INTERFACE, ifaceName, VTEP_SOURCE_INTERFACE, getLine(ctx.iface.getStart()));
+    todo(ctx);
   }
 
   @Override

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1115,6 +1115,20 @@
       },
       {
         "Filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
+        "Line" : 201,
+        "Text" : "vtep-source-interface lo0.0",
+        "Parser_Context" : "[ri_vtep_source_interface ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
+        "Line" : 203,
+        "Text" : "vrf-import fabric",
+        "Parser_Context" : "[ri_vrf_import ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
         "Line" : 211,
         "Text" : "vrf-target target:100:100",
         "Parser_Context" : "[evo_vrf_target e_vni_options p_evpn s_protocols ri_protocols ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
@@ -1345,6 +1359,13 @@
         "Comment" : "This feature is not currently supported"
       },
       {
+        "Filename" : "configs/juniper_misc",
+        "Line" : 9,
+        "Text" : "vtep-source-interface lo0.0",
+        "Parser_Context" : "[ri_vtep_source_interface ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
         "Filename" : "configs/juniper_ospf",
         "Line" : 15,
         "Text" : "area-range dead:beef::/56 override-metric 100",
@@ -1437,10 +1458,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 199 results",
+      "notes" : "Found 202 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 199
+      "numResults" : 202
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -70365,6 +70365,18 @@
             },
             {
               "Comment" : "This feature is not currently supported",
+              "Line" : 201,
+              "Parser_Context" : "[ri_vtep_source_interface ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "vtep-source-interface lo0.0"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 203,
+              "Parser_Context" : "[ri_vrf_import ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "vrf-import fabric"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
               "Line" : 211,
               "Parser_Context" : "[evo_vrf_target e_vni_options p_evpn s_protocols ri_protocols ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "vrf-target target:100:100"
@@ -70620,6 +70632,16 @@
               "Line" : 12,
               "Parser_Context" : "[isil_priority isi_level is_interface p_isis s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "priority 65"
+            }
+          ]
+        },
+        "configs/juniper_misc" : {
+          "Parse warnings" : [
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 9,
+              "Parser_Context" : "[ri_vtep_source_interface ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "vtep-source-interface lo0.0"
             }
           ]
         },


### PR DESCRIPTION
vrf-import
vrf-export
vtep-source-interface