### PR TITLE
BgpConfederation: swap members to a LongSpace

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifier.java
@@ -117,7 +117,7 @@ public class BgpProcessPropertySpecifier extends PropertySpecifier {
                       bgpProcess.getConfederation() != null
                           ? bgpProcess.getConfederation().getMembers()
                           : null,
-                  Schema.set(Schema.LONG),
+                  Schema.STRING,
                   "Set of autonomous system numbers visible only within this BGP confederation"))
           .build();
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -848,8 +848,7 @@ public final class AristaConfiguration extends VendorConfiguration {
               bgpVrf.getConfederationPeers(),
               LongSpace.of(firstNonNull(bgpVrf.getLocalAs(), bgpGlobal.getAsn())));
       newBgpProcess.setConfederation(
-          // Assuming peers is a small space/set in most configs, so safe to enumerate
-          new BgpConfederation(bgpVrf.getConfederationIdentifier(), peers.enumerate()));
+          new BgpConfederation(bgpVrf.getConfederationIdentifier(), peers));
     }
 
     // Process vrf-level address family configuration, such as export policy.

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -3665,14 +3665,14 @@ public class AristaGrammarTest {
     {
       BgpConfederation confederation = c.getDefaultVrf().getBgpProcess().getConfederation();
       assertThat(confederation.getId(), equalTo(1111L));
-      assertThat(confederation.getMembers(), equalTo(ImmutableSet.of(3L, 4L, 5L, 6L)));
+      assertThat(confederation.getMembers().enumerate(), equalTo(ImmutableSet.of(3L, 4L, 5L, 6L)));
     }
     {
       BgpConfederation confederation = c.getVrfs().get("vrf2").getBgpProcess().getConfederation();
 
       assertThat(confederation.getId(), equalTo((22L << 16) + 22));
       assertThat(
-          confederation.getMembers(),
+          confederation.getMembers().enumerate(),
           containsInAnyOrder((1L << 16) + 1, (1L << 16) + 2, (3L << 16) + 3, 44L));
     }
   }

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpProcessConfigurationAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpProcessConfigurationAnswererTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
+import com.google.common.collect.Range;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpProcess;
@@ -89,7 +90,7 @@ public class BgpProcessConfigurationAnswererTest {
             .put(BgpProcessConfigurationAnswerer.COL_VRF, "vrf")
             .put(BgpProcessConfigurationAnswerer.COL_ROUTER_ID, Ip.ZERO)
             .put(CONFEDERATION_ID, 1L)
-            .put(CONFEDERATION_MEMBERS, ImmutableSet.of(2L, 3L))
+            .put(CONFEDERATION_MEMBERS, LongSpace.of(Range.closed(2L, 3L)))
             .put(BgpProcessPropertySpecifier.MULTIPATH_EQUIVALENT_AS_PATH_MATCH_MODE, null)
             .put(BgpProcessPropertySpecifier.MULTIPATH_EBGP, false)
             .put(BgpProcessPropertySpecifier.MULTIPATH_IBGP, false)


### PR DESCRIPTION
Several vendors allow a range of peers which makes enumerating them all
prohibitively expensive.