### PR TITLE
Support iBGP across BGP confederations

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel.bgp;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -803,7 +802,6 @@ public final class BgpTopologyUtils {
   }
 
   @Nullable
-  @VisibleForTesting
   public static AsPair computeAsPair(
       @Nullable Long initiatorLocalAs,
       @Nullable Long initiatorConfed,
@@ -886,7 +884,6 @@ public final class BgpTopologyUtils {
     ACROSS_CONFED_BORDER
   }
 
-  @VisibleForTesting
   public static final class AsPair {
     private final long _localAs;
     private final long _remoteAs;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -804,7 +804,7 @@ public final class BgpTopologyUtils {
 
   @Nullable
   @VisibleForTesting
-  static AsPair computeAsPair(
+  public static AsPair computeAsPair(
       @Nullable Long initiatorLocalAs,
       @Nullable Long initiatorConfed,
       @Nonnull LongSpace initiatorRemoteAsns,
@@ -887,7 +887,7 @@ public final class BgpTopologyUtils {
   }
 
   @VisibleForTesting
-  static final class AsPair {
+  public static final class AsPair {
     private final long _localAs;
     private final long _remoteAs;
     private final ConfedSessionType _confedSessionType;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel;
 
 import static org.batfish.datamodel.BgpSessionProperties.getAddressFamilyIntersection;
+import static org.batfish.datamodel.BgpSessionProperties.getSessionType;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -17,6 +18,7 @@ import org.batfish.datamodel.BgpSessionProperties.RouteExchange;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.bgp.AddressFamily.Type;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
+import org.batfish.datamodel.bgp.BgpTopologyUtils.ConfedSessionType;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.junit.Test;
@@ -147,6 +149,79 @@ public class BgpSessionPropertiesTest {
               .setAddressFamilies(ImmutableList.of(addressFamily1.getType()))
               .setLocalAs(as)
               .setRemoteAs(as)
+              .setLocalIp(ip2)
+              .setRemoteIp(ip1)
+              .setSessionType(SessionType.IBGP)
+              .setRouteExchangeSettings(
+                  // Add paths false, advertise external false, advertise inactive true
+                  ImmutableMap.of(addressFamily1.getType(), new RouteExchange(false, false, false)))
+              .build();
+      assertThat(BgpSessionProperties.from(p1, p2, true), equalTo(reverseSession));
+    }
+  }
+
+  @Test
+  public void testSessionCreationIbgpAcrossConfederation() {
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+    long peeringAs = 1;
+    long subconfedAs = 2;
+    Ipv4UnicastAddressFamily addressFamily1 =
+        Ipv4UnicastAddressFamily.builder()
+            .setAddressFamilyCapabilities(
+                AddressFamilyCapabilities.builder()
+                    .setAdditionalPathsSelectAll(true)
+                    .setAdditionalPathsSend(true)
+                    .setAdvertiseExternal(true)
+                    .build())
+            .build();
+    Ipv4UnicastAddressFamily addressFamily2 =
+        Ipv4UnicastAddressFamily.builder()
+            .setAddressFamilyCapabilities(
+                AddressFamilyCapabilities.builder().setAdditionalPathsReceive(true).build())
+            .build();
+    BgpActivePeerConfig p1 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip1)
+            .setLocalAs(subconfedAs)
+            .setRemoteAs(peeringAs)
+            .setPeerAddress(ip2)
+            .setIpv4UnicastAddressFamily(addressFamily1)
+            .setConfederation(peeringAs)
+            .build();
+    assertThat(getSessionType(p1), equalTo(SessionType.IBGP));
+    BgpActivePeerConfig p2 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip2)
+            .setLocalAs(peeringAs)
+            .setRemoteAs(peeringAs)
+            .setPeerAddress(ip1)
+            .setIpv4UnicastAddressFamily(addressFamily2)
+            .build();
+    assertThat(getSessionType(p2), equalTo(SessionType.IBGP));
+    {
+      BgpSessionProperties forwardSession =
+          BgpSessionProperties.builder()
+              .setAddressFamilies(ImmutableList.of(addressFamily1.getType()))
+              .setConfedSessionType(ConfedSessionType.ACROSS_CONFED_BORDER)
+              .setLocalAs(peeringAs)
+              .setRemoteAs(peeringAs)
+              .setLocalIp(ip1)
+              .setRemoteIp(ip2)
+              .setSessionType(SessionType.IBGP)
+              .setRouteExchangeSettings(
+                  // Add paths false, advertise external false, advertise inactive true
+                  ImmutableMap.of(addressFamily1.getType(), new RouteExchange(true, true, false)))
+              .build();
+      assertThat(BgpSessionProperties.from(p1, p2, false), equalTo(forwardSession));
+    }
+    {
+      BgpSessionProperties reverseSession =
+          BgpSessionProperties.builder()
+              .setAddressFamilies(ImmutableList.of(addressFamily1.getType()))
+              .setConfedSessionType(ConfedSessionType.ACROSS_CONFED_BORDER)
+              .setLocalAs(peeringAs)
+              .setRemoteAs(peeringAs)
               .setLocalIp(ip2)
               .setRemoteIp(ip1)
               .setSessionType(SessionType.IBGP)

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -328,6 +328,7 @@ public class EdgesAnswererTest {
         BgpActivePeerConfig.builder()
             .setLocalIp(ip1)
             .setLocalAs(1L)
+            .setRemoteAs(2L)
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
     bgp1.getActiveNeighbors().put(ip2, activePeer1);
@@ -337,6 +338,7 @@ public class EdgesAnswererTest {
         BgpActivePeerConfig.builder()
             .setLocalIp(ip2)
             .setLocalAs(2L)
+            .setRemoteAs(1L)
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
     bgp2.getActiveNeighbors().put(ip1, activePeer2);
@@ -350,6 +352,7 @@ public class EdgesAnswererTest {
         BgpUnnumberedPeerConfig.builder()
             .setPeerInterface(iface1)
             .setLocalAs(1L)
+            .setRemoteAs(2L)
             .setLocalIp(Ip.parse("169.254.0.1"))
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
@@ -360,6 +363,7 @@ public class EdgesAnswererTest {
         BgpUnnumberedPeerConfig.builder()
             .setPeerInterface(iface2)
             .setLocalAs(2L)
+            .setRemoteAs(1L)
             .setLocalIp(Ip.parse("169.254.0.1"))
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();


### PR DESCRIPTION
* When a node is in a confederation and has a neighbor configuration with remote AS equal to the confederation AS, the session should be iBGP and considered to be across confederations.

Follow-on work:
* Determine and apply the correct AS-path modifying behavior when routes with subconfederation ASes are passed across confederation boundaries via iBGP