### PR TITLE
Question for checking if an SNMP community supports clients

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsAnswerer.java
@@ -1,0 +1,151 @@
+package org.batfish.question.snmpcommunityclients;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import net.sf.javabdd.BDD;
+
+import org.batfish.common.Answerer;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.DeviceModel;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.SnmpCommunity;
+import org.batfish.datamodel.SnmpServer;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.datamodel.table.TableMetadata;
+import org.batfish.specifier.SpecifierContext;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.SortedMap;
+
+/** An answerer for {@link SnmpCommunityClientsQuestion}. */
+public class SnmpCommunityClientsAnswerer extends Answerer {
+  @VisibleForTesting static final String COL_NODE = "Node";
+  @VisibleForTesting static final String COL_COMMUNITY = "Community";
+  @VisibleForTesting static final String COL_REASON = "Reason";
+
+  public enum Reason {
+    NO_SUCH_COMMUNITY,
+    UNEXPECTED_CLIENTS,
+    UNSUPPORTED_DEVICE,
+  }
+
+  private final SnmpCommunityClientsQuestion _question;
+
+  public SnmpCommunityClientsAnswerer(SnmpCommunityClientsQuestion question, IBatfish batfish) {
+    super(question, batfish);
+    checkNotNull(question.getCommunity(), "SNMP community must be specified");
+    _question = question;
+  }
+
+  @Override
+  public TableAnswerElement answer(NetworkSnapshot snapshot) {
+    SpecifierContext ctxt = _batfish.specifierContext(snapshot);
+    SortedMap<String, Configuration> configurations = _batfish.loadConfigurations(snapshot);
+
+    String community = _question.getCommunity();
+    IpSpace expectedIps = _question.getClientsIpSpaceSpecifier().resolve(ctxt);
+    BDDPacket bddPacket = new BDDPacket();
+    BDD expectedBDD = bddPacket.getDstIpSpaceToBDD().visit(expectedIps);
+
+    TableMetadata tableMetadata = metadata();
+    Multiset<Row> rows =
+        _question.getNodeSpecifier().resolve(ctxt).stream()
+            .map(configurations::get)
+            .filter(SnmpCommunityClientsAnswerer::isConfigurationInScope)
+            .map(c -> getRow(expectedBDD, c, community, bddPacket))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(ImmutableMultiset.toImmutableMultiset());
+
+    TableAnswerElement answer = new TableAnswerElement(tableMetadata);
+    answer.postProcessAnswer(_question, rows);
+    return answer;
+  }
+
+  /** Return the result row for the configuration. The optional is empty if test passes. */
+  @VisibleForTesting
+  static Optional<Row> getRow(
+      BDD expectedBdd, Configuration c, String community, BDDPacket packet) {
+
+    Row.RowBuilder rowBuilder =
+        Row.builder(metadata().toColumnMap())
+            .put(COL_NODE, new Node(c.getHostname()))
+            .put(COL_COMMUNITY, community);
+
+    if (!isConfigurationSupported(c)) {
+      return Optional.of(rowBuilder.put(COL_REASON, Reason.UNSUPPORTED_DEVICE).build());
+    }
+
+    Optional<SnmpCommunity> maybeCommunity =
+        Optional.ofNullable(c.getDefaultVrf())
+            .map(Vrf::getSnmpServer)
+            .map(SnmpServer::getCommunities)
+            .map(comms -> comms.get(community));
+    if (!maybeCommunity.isPresent()) {
+      return Optional.of(rowBuilder.put(COL_REASON, Reason.NO_SUCH_COMMUNITY).build());
+    }
+
+    SnmpCommunity snmpCommunity = maybeCommunity.get();
+
+    IpSpace actualClientSpace = firstNonNull(snmpCommunity.getClientIps(), EmptyIpSpace.INSTANCE);
+    BDD actualBDD =
+        new IpSpaceToBDD(packet.getDstIpSpaceToBDD(), c.getIpSpaces()).visit(actualClientSpace);
+    if (!actualBDD.equals(expectedBdd)) {
+      return Optional.of(rowBuilder.put(COL_REASON, Reason.UNEXPECTED_CLIENTS).build());
+    }
+
+    return Optional.empty();
+  }
+
+  /** Create table metadata for the answer */
+  private static TableMetadata metadata() {
+    List<ColumnMetadata> columnMetadata =
+        ImmutableList.of(
+            new ColumnMetadata(COL_NODE, Schema.NODE, "Hostname.", true, false),
+            new ColumnMetadata(COL_COMMUNITY, Schema.STRING, "The community name.", false, true),
+            new ColumnMetadata(COL_REASON, Schema.STRING, "Result of the test.", false, true));
+    return new TableMetadata(columnMetadata);
+  }
+
+  /**
+   * Indicates whether this configuration is in scope for this question.
+   *
+   * <p>Auto-generated configs and AWS are out of scope.
+   */
+  private static boolean isConfigurationInScope(Configuration c) {
+    return c.getConfigurationFormat() != ConfigurationFormat.AWS
+        && c.getDeviceModel() != DeviceModel.BATFISH_INTERNET
+        && c.getDeviceModel() != DeviceModel.BATFISH_ISP;
+  }
+
+  /**
+   * Indicates whether this configuration is supported for this question.
+   *
+   * <p>For now, only Arista, Juniper, and SONiC are supported.
+   */
+  static boolean isConfigurationSupported(Configuration c) {
+    return c.getConfigurationFormat() == ConfigurationFormat.ARISTA
+        || c.getConfigurationFormat() == ConfigurationFormat.CISCO_NX
+        || c.getConfigurationFormat() == ConfigurationFormat.JUNIPER
+        || c.getConfigurationFormat() == ConfigurationFormat.JUNIPER_SWITCH
+        || c.getConfigurationFormat() == ConfigurationFormat.FLAT_JUNIPER
+        || c.getConfigurationFormat() == ConfigurationFormat.SONIC;
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsAnswerer.java
@@ -7,8 +7,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
+import java.util.List;
+import java.util.Optional;
+import java.util.SortedMap;
 import net.sf.javabdd.BDD;
-
 import org.batfish.common.Answerer;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.bdd.BDDPacket;
@@ -29,10 +31,6 @@ import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.table.TableMetadata;
 import org.batfish.specifier.SpecifierContext;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.SortedMap;
 
 /** An answerer for {@link SnmpCommunityClientsQuestion}. */
 public class SnmpCommunityClientsAnswerer extends Answerer {

--- a/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsPlugin.java
@@ -1,0 +1,25 @@
+package org.batfish.question.snmpcommunityclients;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.service.AutoService;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.Plugin;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.question.QuestionPlugin;
+
+/** Plugin for {@link SnmpCommunityClientsQuestion}. */
+@AutoService(Plugin.class)
+public final class SnmpCommunityClientsPlugin extends QuestionPlugin {
+  @Override
+  protected Answerer createAnswerer(Question question, IBatfish batfish) {
+    checkArgument(question instanceof SnmpCommunityClientsQuestion);
+    return new SnmpCommunityClientsAnswerer((SnmpCommunityClientsQuestion) question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new SnmpCommunityClientsQuestion();
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsQuestion.java
@@ -1,0 +1,98 @@
+package org.batfish.question.snmpcommunityclients;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.ConstantIpSpaceSpecifier;
+import org.batfish.specifier.IpSpaceSpecifier;
+import org.batfish.specifier.NodeSpecifier;
+import org.batfish.specifier.SpecifierFactories;
+
+/**
+ * A question to check if devices have an SNMP community that permits specified client IP space.
+ *
+ * <p>It does not support all device vendors. See {@link
+ * SnmpCommunityClientsAnswerer#isConfigurationSupported}
+ */
+@ParametersAreNonnullByDefault
+public final class SnmpCommunityClientsQuestion extends Question {
+  private static final String PROP_COMMUNITY = "community";
+  private static final String PROP_CLIENTS = "clients";
+  private static final String PROP_NODES = "nodes";
+
+  private static final IpSpaceSpecifier DEFAULT_CLIENTS_IPSPACE_SPECIFIER =
+      new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE);
+  private static final NodeSpecifier DEFAULT_NODE_SPECIFIER = AllNodesNodeSpecifier.INSTANCE;
+
+  @Nullable private final String _community;
+  @Nullable private final String _clients;
+  @Nullable private final String _nodes;
+
+  SnmpCommunityClientsQuestion() {
+    this(null, null, null);
+  }
+
+  SnmpCommunityClientsQuestion(
+      @Nullable String community, @Nullable String clients, @Nullable String nodes) {
+    _community = community;
+    _clients = clients;
+    _nodes = nodes;
+  }
+
+  @JsonCreator
+  private static SnmpCommunityClientsQuestion jsonCreator(
+      @JsonProperty(PROP_COMMUNITY) @Nullable String community,
+      @JsonProperty(PROP_CLIENTS) @Nullable String clients,
+      @JsonProperty(PROP_NODES) @Nullable String nodes) {
+    return new SnmpCommunityClientsQuestion(community, clients, nodes);
+  }
+
+  @Override
+  public boolean getDataPlane() {
+    return false;
+  }
+
+  @Override
+  public String getName() {
+    return "snmpCommunityClients";
+  }
+
+  @Nullable
+  @JsonProperty(PROP_COMMUNITY)
+  public String getCommunity() {
+    return _community;
+  }
+
+  @Nullable
+  @JsonProperty(PROP_CLIENTS)
+  public String getClients() {
+    return _clients;
+  }
+
+  @Nonnull
+  @JsonIgnore
+  IpSpaceSpecifier getClientsIpSpaceSpecifier() {
+    return SpecifierFactories.getIpSpaceSpecifierOrDefault(
+        _clients, DEFAULT_CLIENTS_IPSPACE_SPECIFIER);
+  }
+
+  @Nullable
+  @JsonProperty(PROP_NODES)
+  public String getNodes() {
+    return _nodes;
+  }
+
+  @Nonnull
+  @JsonIgnore
+  NodeSpecifier getNodeSpecifier() {
+    return SpecifierFactories.getNodeSpecifierOrDefault(_nodes, DEFAULT_NODE_SPECIFIER);
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsQuestion.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-
-import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.specifier.AllNodesNodeSpecifier;

--- a/projects/question/src/test/java/org/batfish/question/snmpcommunityclients/BUILD.bazel
+++ b/projects/question/src/test/java/org/batfish/question/snmpcommunityclients/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:private"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    resources = ["//projects/question/src/test/resources/org/batfish/question/snmpcommunityclients"],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ],
+    deps = [
+        "//projects/bdd",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol/src/test:common_testlib",
+        "//projects/question",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/question/src/test/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsAnswererTest.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.plugin.IBatfish;

--- a/projects/question/src/test/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/snmpcommunityclients/SnmpCommunityClientsAnswererTest.java
@@ -1,0 +1,112 @@
+package org.batfish.question.snmpcommunityclients;
+
+import static org.batfish.question.snmpcommunityclients.SnmpCommunityClientsAnswerer.COL_COMMUNITY;
+import static org.batfish.question.snmpcommunityclients.SnmpCommunityClientsAnswerer.COL_NODE;
+import static org.batfish.question.snmpcommunityclients.SnmpCommunityClientsAnswerer.COL_REASON;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.table.Row;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SnmpCommunityClientsAnswererTest {
+  private static final String TESTCONFIGS_DIR = "org/batfish/question/snmpcommunityclients";
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  public IBatfish getBatfish(List<String> filenames) throws IOException {
+    return BatfishTestUtils.getBatfishFromTestrigText(
+        TestrigText.builder().setConfigurationFiles(TESTCONFIGS_DIR, filenames).build(), _folder);
+  }
+
+  @Test
+  public void testPasses() throws IOException {
+    IpSpace expectedIps = Prefix.parse("1.2.3.4/32").toIpSpace();
+    BDDPacket bddPacket = new BDDPacket();
+    BDD expectedBDD = bddPacket.getDstIpSpaceToBDD().visit(expectedIps);
+    IBatfish batfish = getBatfish(ImmutableList.of("arista", "juniper", "nxos"));
+
+    for (Configuration c : batfish.loadConfigurations(batfish.getSnapshot()).values()) {
+      assertEquals(
+          Optional.empty(), SnmpCommunityClientsAnswerer.getRow(expectedBDD, c, "COMM", bddPacket));
+    }
+  }
+
+  @Test
+  public void testMissingCommunity() throws IOException {
+    IpSpace expectedIps = Prefix.parse("1.2.3.4/32").toIpSpace();
+    BDDPacket bddPacket = new BDDPacket();
+    BDD expectedBDD = bddPacket.getDstIpSpaceToBDD().visit(expectedIps);
+    IBatfish batfish = getBatfish(ImmutableList.of("arista"));
+
+    assertEquals(
+        Optional.of(
+            Row.builder()
+                .put(COL_NODE, new Node("arista"))
+                .put(COL_COMMUNITY, "COMM-Missing")
+                .put(COL_REASON, SnmpCommunityClientsAnswerer.Reason.NO_SUCH_COMMUNITY)
+                .build()),
+        SnmpCommunityClientsAnswerer.getRow(
+            expectedBDD,
+            batfish.loadConfigurations(batfish.getSnapshot()).get("arista"),
+            "COMM-Missing",
+            bddPacket));
+  }
+
+  @Test
+  public void testUnexpectedClients() throws IOException {
+    IpSpace expectedIps = Prefix.parse("10.20.30.40/32").toIpSpace();
+    BDDPacket bddPacket = new BDDPacket();
+    BDD expectedBDD = bddPacket.getDstIpSpaceToBDD().visit(expectedIps);
+    IBatfish batfish = getBatfish(ImmutableList.of("arista"));
+
+    assertEquals(
+        Optional.of(
+            Row.builder()
+                .put(COL_NODE, new Node("arista"))
+                .put(COL_COMMUNITY, "COMM")
+                .put(COL_REASON, SnmpCommunityClientsAnswerer.Reason.UNEXPECTED_CLIENTS)
+                .build()),
+        SnmpCommunityClientsAnswerer.getRow(
+            expectedBDD,
+            batfish.loadConfigurations(batfish.getSnapshot()).get("arista"),
+            "COMM",
+            bddPacket));
+  }
+
+  @Test
+  public void testUnsupportedDevice() throws IOException {
+    IpSpace expectedIps = Prefix.parse("10.20.30.40/32").toIpSpace();
+    BDDPacket bddPacket = new BDDPacket();
+    BDD expectedBDD = bddPacket.getDstIpSpaceToBDD().visit(expectedIps);
+    IBatfish batfish = getBatfish(ImmutableList.of("ios"));
+
+    assertEquals(
+        Optional.of(
+            Row.builder()
+                .put(COL_NODE, new Node("ios"))
+                .put(COL_COMMUNITY, "COMM")
+                .put(COL_REASON, SnmpCommunityClientsAnswerer.Reason.UNSUPPORTED_DEVICE)
+                .build()),
+        SnmpCommunityClientsAnswerer.getRow(
+            expectedBDD,
+            batfish.loadConfigurations(batfish.getSnapshot()).get("ios"),
+            "COMM",
+            bddPacket));
+  }
+}

--- a/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/BUILD.bazel
+++ b/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/BUILD.bazel
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "snmpcommunityclients",
+    srcs = glob(
+        ["**/*"],
+        exclude = ["BUILD.bazel"],
+    ),
+)

--- a/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/configs/arista
+++ b/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/configs/arista
@@ -1,0 +1,8 @@
+!RANCID-CONTENT-TYPE: arista
+hostname arista
+!
+ip access-list standard SNMP_ACCESS_LIST
+   10 permit 1.2.3.4/32
+!
+snmp-server community COMM ro SNMP_ACCESS_LIST
+!

--- a/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/configs/ios
+++ b/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/configs/ios
@@ -1,0 +1,8 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname ios
+!
+ip access-list SNMP_ACCESS_LIST
+  10 permit udp 1.2.3.4/32 any eq snmp
+!
+snmp-server community COMM use-acl SNMP_ACCESS_LIST
+!

--- a/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/configs/juniper
+++ b/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/configs/juniper
@@ -1,0 +1,8 @@
+#RANCID-CONTENT-TYPE: juniper
+#
+set system host-name juniper
+#
+set policy-options prefix-list SNMP_ACCESS_LIST 1.2.3.4/32
+#
+set snmp community COMM client-list-name SNMP_ACCESS_LIST
+#

--- a/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/configs/nxos
+++ b/projects/question/src/test/resources/org/batfish/question/snmpcommunityclients/configs/nxos
@@ -1,0 +1,8 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+hostname nxos
+!
+ip access-list SNMP_ACCESS_LIST
+  10 permit udp 1.2.3.4/32 any eq snmp
+!
+snmp-server community COMM use-acl SNMP_ACCESS_LIST
+!

--- a/questions/experimental/snmpCommunityClients.json
+++ b/questions/experimental/snmpCommunityClients.json
@@ -7,7 +7,7 @@
     "instance": {
         "description": "Checks if an SNMP community permits specified client IPs.",
         "instanceName": "snmpCommunityClients",
-        "longDescription": "This question checks if the specified SNMP community permits the specified client IPs on specified nodes. For each device, it reports if the community does not exist or the set of permitted IPs does not match those specified in the question. If the community exists and permits exactly the specified client IPs, the device is not included in the output. The question currently only supports Arista, Cisco-NXOS, and Juniper devices. For all others, it will report an UNSUPPORTED_DEVICE status in the output.",
+        "longDescription": "This question checks if the specified SNMP community permits the specified client IPs on specified devices. It reports if any device does not have the community or the set of permitted client IPs by the community does not match those specified in the question. If the community exists and permits exactly the specified client IPs, the device is not included in the output. The question currently only supports Arista, Cisco-NXOS, and Juniper devices. For all others, it will report an UNSUPPORTED_DEVICE status in the output.",
         "orderedVariableNames": [
             "community",
             "clients",

--- a/questions/experimental/snmpCommunityClients.json
+++ b/questions/experimental/snmpCommunityClients.json
@@ -1,0 +1,40 @@
+{
+    "class": "org.batfish.question.snmpcommunityclients.SnmpCommunityClientsQuestion",
+    "differential": false,
+    "nodes": "${nodes}",
+    "community": "${community}",
+    "clients": "${clients}",
+    "instance": {
+        "description": "Checks if an SNMP community permits specified client IPs.",
+        "instanceName": "snmpCommunityClients",
+        "longDescription": "This question checks if the specified SNMP community permits the specified client IPs on specified nodes. For each device, it reports if the community does not exist or the set of permitted IPs does not match those specified in the question. If the community exists and permits exactly the specified client IPs, the device is not included in the output. The question currently only supports Arista, Cisco-NXOS, and Juniper devices. For all others, it will report an UNSUPPORTED_DEVICE status in the output.",
+        "orderedVariableNames": [
+            "community",
+            "clients",
+            "nodes"
+        ],
+        "tags": [
+            "acl"
+        ],
+        "variables": {
+            "community": {
+                "description": "The SNMP community to consider",
+                "optional": false,
+                "type": "string",
+                "displayName": "Community"
+            },
+            "clients": {
+                "description": "Client IPs expected to be permitted",
+                "optional": true,
+                "type": "ipSpaceSpec",
+                "displayName": "Clients"
+            },
+            "nodes": {
+                "description": "Only evaluate nodes matching this specifier",
+                "optional": true,
+                "type": "nodeSpec",
+                "displayName": "Nodes"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The question checks if the specified SNMP community permits clients (specified as IpSpace). The check fails if the SNMP community does not exist or if the ipspace permitted for the community does not exactly match the specified client space. 

The question only supports Arista, Juniper, and SONiC devices at the moment, and if the check  It reports UNSUPPORTED_DEVICE status for others. 

This PR has Batifsh side changes. Pybatfish and docs changes will follow. 