### PR TITLE
Compute added/removed set for communities in BgpRouteDiff.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteCommunityDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteCommunityDiff.java
@@ -1,0 +1,78 @@
+package org.batfish.datamodel.questions;
+
+import static com.google.common.collect.Ordering.natural;
+
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.SortedSet;
+import org.batfish.datamodel.bgp.community.Community;
+
+public class BgpRouteCommunityDiff {
+
+  private final SortedSet<Community> _added;
+  private final SortedSet<Community> _removed;
+
+  private final SortedSet<Community> _oldValue;
+
+  private final SortedSet<Community> _newValue;
+
+  public BgpRouteCommunityDiff(SortedSet<Community> oldValue, SortedSet<Community> newValue) {
+    _oldValue = ImmutableSortedSet.copyOf(oldValue);
+    _newValue = ImmutableSortedSet.copyOf(newValue);
+    _added =
+        newValue.stream()
+            .filter(c -> !oldValue.contains(c))
+            .collect(ImmutableSortedSet.toImmutableSortedSet(natural()));
+    _removed =
+        oldValue.stream()
+            .filter(c -> !newValue.contains(c))
+            .collect(ImmutableSortedSet.toImmutableSortedSet(natural()));
+  }
+
+  /**
+   * @return projects this community difference to a {@link BgpRouteDiff} that describes the old and
+   *     the new value for the community field.
+   */
+  public BgpRouteDiff toRouteDiff() {
+    return new BgpRouteDiff(BgpRoute.PROP_COMMUNITIES, _oldValue.toString(), _newValue.toString());
+  }
+
+  public SortedSet<Community> getAdded() {
+    return _added;
+  }
+
+  public SortedSet<Community> getRemoved() {
+    return _removed;
+  }
+
+  /**
+   * The hash (and resp. the equality function) of this object only considers the _added and
+   * _removed fields, ignoring the _oldValue and _newValue. This facilitates distinguishing
+   * community differences when they add or remove a different community, hence allows us to
+   * deduplicate two differences where the same community was added/removed even though the set of
+   * communities in each case is not the same.
+   */
+  @Override
+  public int hashCode() {
+    int result = 1;
+    result = 31 * result + _added.hashCode();
+    result = 31 * result + _removed.hashCode();
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BgpRouteCommunityDiff that = (BgpRouteCommunityDiff) o;
+
+    if (!_added.equals(that._added)) {
+      return false;
+    }
+    return _removed.equals(that._removed);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffs.java
@@ -1,0 +1,73 @@
+package org.batfish.datamodel.questions;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Ordering.natural;
+
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.stream.Stream;
+
+/**
+ * A class for structured BGP Route differences. This class might keep more information than just
+ * the old/new value for a field. Currently, only community sets have a richer representation that
+ * includes a delta between old/new value but in the future we might do the same for as-paths.
+ */
+public class StructuredBgpRouteDiffs {
+
+  private final SortedSet<BgpRouteDiff> _diffs;
+  private final Optional<BgpRouteCommunityDiff> _communityDiff;
+
+  public StructuredBgpRouteDiffs(
+      SortedSet<BgpRouteDiff> diffs, Optional<BgpRouteCommunityDiff> communityDiff) {
+    _diffs = diffs;
+    _communityDiff = communityDiff;
+    checkArgument(
+        diffs.stream().noneMatch(d -> d.getFieldName().equals(BgpRoute.PROP_COMMUNITIES)),
+        "Unexpected use of unstructured community differences");
+  }
+
+  public SortedSet<BgpRouteDiff> get_diffs() {
+    return _diffs;
+  }
+
+  public Optional<BgpRouteCommunityDiff> get_communityDiff() {
+    return _communityDiff;
+  }
+
+  public StructuredBgpRouteDiffs() {
+    _diffs = ImmutableSortedSet.of();
+    _communityDiff = Optional.empty();
+  }
+
+  public BgpRouteDiffs toBgpRouteDiffs() {
+    return new BgpRouteDiffs(
+        Stream.concat(
+                _diffs.stream(), _communityDiff.map(BgpRouteCommunityDiff::toRouteDiff).stream())
+            .collect(ImmutableSortedSet.toImmutableSortedSet(natural())));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    StructuredBgpRouteDiffs that = (StructuredBgpRouteDiffs) o;
+
+    if (!_diffs.equals(that._diffs)) {
+      return false;
+    }
+    return _communityDiff.equals(that._communityDiff);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = _diffs.hashCode();
+    result = 31 * result + _communityDiff.hashCode();
+    return result;
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteCommunityDiffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteCommunityDiffTest.java
@@ -1,0 +1,66 @@
+package org.batfish.datamodel.questions;
+
+import static org.batfish.datamodel.BgpRoute.PROP_COMMUNITIES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.junit.Test;
+
+/** Tests of {@link BgpRouteCommunityDiff}. */
+public class BgpRouteCommunityDiffTest {
+
+  /** Test that the added/removed sets are computed correctly. */
+  @Test
+  public void testSetsConstruction() {
+    // [0:0, 1:1] -> [1:1, 2:2]
+    SortedSet<Community> oldComms1 = new TreeSet<>();
+    SortedSet<Community> newComms1 = new TreeSet<>();
+    oldComms1.add(StandardCommunity.of(0, 0));
+    oldComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(2, 2));
+    BgpRouteCommunityDiff comms1 = new BgpRouteCommunityDiff(oldComms1, newComms1);
+    assertEquals(comms1.getAdded(), Set.of(StandardCommunity.of(2, 2)));
+    assertEquals(comms1.getRemoved(), Set.of(StandardCommunity.of(0, 0)));
+  }
+
+  @Test
+  public void testProjection() {
+    SortedSet<Community> oldComms = new TreeSet<>();
+    SortedSet<Community> newComms = new TreeSet<>();
+    oldComms.add(StandardCommunity.of(0, 0));
+    newComms.add(StandardCommunity.of(1, 1));
+    assertEquals(
+        new BgpRouteDiff(PROP_COMMUNITIES, "[0:0]", "[1:1]"),
+        new BgpRouteCommunityDiff(oldComms, newComms).toRouteDiff());
+  }
+
+  @Test
+  public void testDeltaEquals() {
+    // [0:0, 1:1] -> [1:1, 2:2]
+    SortedSet<Community> oldComms1 = new TreeSet<>();
+    SortedSet<Community> newComms1 = new TreeSet<>();
+    oldComms1.add(StandardCommunity.of(0, 0));
+    oldComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(2, 2));
+    BgpRouteCommunityDiff comms1 = new BgpRouteCommunityDiff(oldComms1, newComms1);
+
+    // [0:0] -> [2:2]
+    SortedSet<Community> oldComms2 = new TreeSet<>();
+    SortedSet<Community> newComms2 = new TreeSet<>();
+    oldComms2.add(StandardCommunity.of(0, 0));
+    newComms2.add(StandardCommunity.of(2, 2));
+    BgpRouteCommunityDiff comms2 = new BgpRouteCommunityDiff(oldComms2, newComms2);
+
+    // These community diffs are delta equal
+    assert (comms1.equals(comms2));
+    // but not equal according to BgpRouteDiff
+    assertNotEquals(comms1.toRouteDiff(), comms2.toRouteDiff());
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteDiffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteDiffTest.java
@@ -71,7 +71,8 @@ public class BgpRouteDiffTest {
     route1 = builder().setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     route2 = builder().setAsPath(AsPath.ofSingletonAsSets(2L, 3L)).build();
     assertThat(
-        routeDiffs(route1, route2), contains(new BgpRouteDiff(PROP_AS_PATH, "[1, 2]", "[2, 3]")));
+        routeDiffs(route1, route2).getDiffs(),
+        contains(new BgpRouteDiff(PROP_AS_PATH, "[1, 2]", "[2, 3]")));
 
     // change communities
     route1 =
@@ -83,19 +84,21 @@ public class BgpRouteDiffTest {
             .setCommunities(ImmutableSet.of(StandardCommunity.of(2L), StandardCommunity.of(3L)))
             .build();
     assertThat(
-        routeDiffs(route1, route2),
+        routeDiffs(route1, route2).getDiffs(),
         contains(new BgpRouteDiff(PROP_COMMUNITIES, "[0:1, 0:2]", "[0:2, 0:3]")));
 
     // change local preference
     route1 = builder().setLocalPreference(1).build();
     route2 = builder().setLocalPreference(2).build();
     assertThat(
-        routeDiffs(route1, route2), contains(new BgpRouteDiff(PROP_LOCAL_PREFERENCE, "1", "2")));
+        routeDiffs(route1, route2).getDiffs(),
+        contains(new BgpRouteDiff(PROP_LOCAL_PREFERENCE, "1", "2")));
 
     // change metric
     route1 = builder().setMetric(1).build();
     route2 = builder().setMetric(2).build();
-    assertThat(routeDiffs(route1, route2), contains(new BgpRouteDiff(PROP_METRIC, "1", "2")));
+    assertThat(
+        routeDiffs(route1, route2).getDiffs(), contains(new BgpRouteDiff(PROP_METRIC, "1", "2")));
 
     // change all properties
     route1 =
@@ -124,7 +127,7 @@ public class BgpRouteDiffTest {
             .setWeight(2)
             .build();
     assertThat(
-        routeDiffs(route1, route2),
+        routeDiffs(route1, route2).getDiffs(),
         containsInAnyOrder(
             new BgpRouteDiff(PROP_AS_PATH, "[1, 2]", "[2, 3]"),
             new BgpRouteDiff(PROP_COMMUNITIES, "[0:1, 0:2]", "[0:2, 0:3]"),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffsTest.java
@@ -1,0 +1,47 @@
+package org.batfish.datamodel.questions;
+
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.testing.EqualsTester;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.junit.Test;
+
+/** Tests for {@link StructuredBgpRouteDiffs} */
+public class StructuredBgpRouteDiffsTest {
+  @Test
+  public void testEquals() {
+    // [0:0, 1:1] -> [1:1, 2:2]
+    SortedSet<Community> oldComms1 = new TreeSet<>();
+    SortedSet<Community> newComms1 = new TreeSet<>();
+    oldComms1.add(StandardCommunity.of(0, 0));
+    oldComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(2, 2));
+    BgpRouteCommunityDiff comms1 = new BgpRouteCommunityDiff(oldComms1, newComms1);
+
+    // [0:0] -> [2:2]
+    SortedSet<Community> oldComms2 = new TreeSet<>();
+    SortedSet<Community> newComms2 = new TreeSet<>();
+    oldComms2.add(StandardCommunity.of(0, 0));
+    newComms2.add(StandardCommunity.of(2, 2));
+    BgpRouteCommunityDiff comms2 = new BgpRouteCommunityDiff(oldComms2, newComms2);
+
+    // comms1 and comms2 should be equal.
+    new EqualsTester()
+        .addEqualityGroup(new StructuredBgpRouteDiffs(), new StructuredBgpRouteDiffs())
+        .addEqualityGroup(
+            new StructuredBgpRouteDiffs(
+                ImmutableSortedSet.of(new BgpRouteDiff(BgpRoute.PROP_AS_PATH, "B", "C")),
+                Optional.of(comms1)),
+            new StructuredBgpRouteDiffs(
+                ImmutableSortedSet.of(new BgpRouteDiff(BgpRoute.PROP_AS_PATH, "B", "C")),
+                Optional.of(comms2)))
+        .addEqualityGroup(
+            new StructuredBgpRouteDiffs(ImmutableSortedSet.of(), Optional.of(comms1)),
+            new StructuredBgpRouteDiffs(ImmutableSortedSet.of(), Optional.of(comms2)))
+        .testEquals();
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
@@ -428,7 +428,7 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
         .put(COL_INPUT_ROUTE, inputRoute)
         .put(COL_ACTION, action)
         .put(COL_OUTPUT_ROUTE, permit ? outputRoute : null)
-        .put(COL_DIFF, permit ? new BgpRouteDiffs(routeDiffs(inputRoute, outputRoute)) : null)
+        .put(COL_DIFF, permit ? routeDiffs(inputRoute, outputRoute) : null)
         .put(COL_TRACE, result.getTrace())
         .build();
   }
@@ -460,8 +460,7 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
       return null;
     }
 
-    BgpRouteDiffs routeDiffs =
-        new BgpRouteDiffs(routeDiffs(referenceOutputRoute, snapshotOutputRoute));
+    BgpRouteDiffs routeDiffs = routeDiffs(referenceOutputRoute, snapshotOutputRoute);
 
     RoutingPolicyId policyId = snapshotResult.getPolicyId();
     Bgpv4Route inputRoute = snapshotResult.getInputRoute();
@@ -497,8 +496,7 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
     boolean equalOutputRoutes = Objects.equals(referenceOutputRoute, snapshotOutputRoute);
     assert !(equalAction && equalOutputRoutes);
 
-    BgpRouteDiffs routeDiffs =
-        new BgpRouteDiffs(routeDiffs(referenceOutputRoute, snapshotOutputRoute));
+    BgpRouteDiffs routeDiffs = routeDiffs(referenceOutputRoute, snapshotOutputRoute);
 
     RoutingPolicyId referencePolicyId = referenceResult.getPolicyId();
     RoutingPolicyId policyId = snapshotResult.getPolicyId();


### PR DESCRIPTION
Computes the set of added/removed communities in BgpRouteDiff.
Should not change the behavior of BgpRouteDiff at all.