### PR TITLE
Add option to return unique inputs for SRP

### DIFF
--- a/questions/experimental/searchRoutePolicies.json
+++ b/questions/experimental/searchRoutePolicies.json
@@ -6,7 +6,7 @@
     "inputConstraints": "${inputConstraints}",
     "action": "${action}",
     "outputConstraints": "${outputConstraints}",
-    "perPath": "${perPath}",
+    "pathOption": "${pathOption}",
     "instance": {
         "description": "Finds route announcements for which a route policy has a particular behavior.",
         "instanceName": "searchRoutePolicies",
@@ -17,7 +17,7 @@
             "inputConstraints",
             "action",
             "outputConstraints",
-            "perPath"
+            "pathOption"
         ],
         "tags": [
             "routing"
@@ -53,11 +53,11 @@
                 "optional": true,
                 "displayName": "Output Constraints"
             },
-            "perPath": {
-                "description": "Run the analysis separately for each execution path of a route map",
-                "type": "boolean",
+            "pathOption": {
+                "description": "If set to 'per_path' run the analysis separately for each execution path. If set to `non_overlap` run the analysis separately for each execution path but do not produce the same route for each path.",
+                "type": "string",
                 "optional": true,
-                "displayName": "Per-Path"
+                "displayName": "Path Options"
             }
         }
     }


### PR DESCRIPTION
This change creates a new option for SRP to create unique prefixes for each new Input route it suggests to cover a new term of a route map.