### PR TITLE
Add option to return unique inputs for SRP

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -53,6 +54,7 @@ import org.batfish.minesweeper.bdd.ModelGeneration;
 import org.batfish.minesweeper.bdd.TransferBDD;
 import org.batfish.minesweeper.bdd.TransferReturn;
 import org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesQuestion.Action;
+import org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesQuestion.PathOption;
 import org.batfish.minesweeper.utils.Tuple;
 import org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer;
 import org.batfish.specifier.AllNodesNodeSpecifier;
@@ -72,10 +74,23 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
   @Nonnull private final RoutingPolicySpecifier _policySpecifier;
   @Nonnull private final Action _action;
 
-  private final boolean _perPath;
+  private final PathOption _pathOption;
 
   @Nonnull private final Set<String> _communityRegexes;
   @Nonnull private final Set<String> _asPathRegexes;
+
+  /**
+   * Helper class that contains both a row and and Bgpv4Route for a result
+   *
+   */
+  private static class RowAndRoute {
+      public Bgpv4Route _route;
+      public Row _row;
+      public RowAndRoute(Bgpv4Route route, Row row) {
+          this._route = route;
+          this._row = row;
+      }
+  }
 
   public SearchRoutePoliciesAnswerer(SearchRoutePoliciesQuestion question, IBatfish batfish) {
     super(question, batfish);
@@ -89,7 +104,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
         SpecifierFactories.getRoutingPolicySpecifierOrDefault(
             question.getPolicies(), ALL_ROUTING_POLICIES);
     _action = question.getAction();
-    _perPath = question.getPerPath();
+    _pathOption = question.getPathOption();
 
     // in the future, it may improve performance to combine all input community regexes
     // into a single regex representing their disjunction, and similarly for all output
@@ -122,7 +137,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
    * @return an optional answer, which includes a concrete input route and (if the desired action is
    *     PERMIT) concrete output route
    */
-  private Optional<Row> constraintsToResult(
+  private Optional<RowAndRoute> constraintsToResult(
       BDD constraints,
       RoutingPolicy policy,
       ConfigAtomicPredicates configAPs,
@@ -163,7 +178,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
       checkState(
           result.get(TestRoutePoliciesAnswerer.COL_ACTION, STRING).equals(_action.toString()),
           "SearchRoutePolicies and TestRoutePolicies disagree on the behavior of a route map");
-      return Optional.of(result);
+      return Optional.of(new RowAndRoute(inRoute, result));
     }
   }
 
@@ -391,6 +406,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     // for false positives as much as possible
     List<TransferReturn> relevantPaths = pathMap.get(false);
     relevantPaths.addAll(pathMap.get(true));
+    Set<PrefixSpace> blockedPrefixes = new HashSet<>();
     BDD inConstraints =
         routeConstraintsToBDD(
             _inputConstraints, new BDDRoute(tbdd.getFactory(), configAPs), false, configAPs);
@@ -399,6 +415,9 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
       BDD pathAnnouncements = path.getSecond();
       BDDRoute outputRoute = path.getFirst();
       BDD intersection = pathAnnouncements.and(inConstraints);
+      for (PrefixSpace blockedPrefix : blockedPrefixes) {
+          intersection = intersection.andWith(prefixSpaceToBDD(blockedPrefix, outputRoute, true));
+      }
       // make a copy of the config atomic predicates, since the process of creating the constraints
       // on the output route can modify them, in order to handle AS-path constraints in the presence
       // of AS prepending
@@ -409,14 +428,17 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             routeConstraintsToBDD(_outputConstraints, outputRoute, true, outConfigAPs);
         intersection = intersection.and(outConstraints);
       }
-
-      Optional<Row> result =
+      Optional<RowAndRoute> result =
           constraintsToResult(intersection, policy, outConfigAPs, outputRoute.getPrependedASes());
       if (result.isPresent()) {
-        builder.add(result.get());
-        if (!_perPath) {
+        builder.add(result.get()._row);
+        if (_pathOption == PathOption.SINGLE) {
           // return the first result we find
           break;
+        } else if (_pathOption == PathOption.NON_OVERLAP) {
+          // modify the input constraints to not include this route anymore
+          PrefixSpace prefixSpace = new PrefixSpace(PrefixRange.fromPrefix(result.get()._route.getNetwork()));
+          blockedPrefixes.add(prefixSpace);
         }
       }
     }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesQuestion.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesQuestion.java
@@ -24,13 +24,16 @@ public final class SearchRoutePoliciesQuestion extends Question {
   private static final String PROP_POLICIES = "policies";
   private static final String PROP_ACTION = "action";
 
-  private static final String PROP_PER_PATH = "perPath";
+  private static final String PROP_PER_PATH = "perOption";
+  private static final String PROP_PATH_OPTION = "pathOption";
 
   @VisibleForTesting
   static final BgpRouteConstraints DEFAULT_ROUTE_CONSTRAINTS =
       BgpRouteConstraints.builder().build();
 
   @VisibleForTesting static final Action DEFAULT_ACTION = Action.PERMIT;
+
+  @VisibleForTesting static final PathOption DEFAULT_PATH_OPTION = PathOption.SINGLE;
 
   @VisibleForTesting
   static final Environment.Direction DEFAULT_DIRECTION = Environment.Direction.IN;
@@ -43,11 +46,34 @@ public final class SearchRoutePoliciesQuestion extends Question {
   @Nonnull private final Action _action;
 
   // if set, the analysis is run separately on each execution path in the given route map
+  // this paramater is depricated in favor of PathOption
   private final boolean _perPath;
+
+  private final PathOption _pathOption;
 
   public enum Action {
     DENY,
     PERMIT
+  }
+
+  /**
+   * The PathOption enum represents various options for how results are presented based on how paths are explored.
+   */
+  public enum PathOption {
+    /**
+     * SINGLE means we return a single path that meets the input and ouput constraints.
+     */
+    SINGLE,
+
+    /**
+     * PER_PATH means we return a set of input and output routes that follow each execution path.
+     */
+    PER_PATH,
+
+    /**
+     * NON_OVERLAP means the same as PER_PATH except each input route we return does not conflict with any others.
+     */
+    NON_OVERLAP
   }
 
   public SearchRoutePoliciesQuestion() {
@@ -58,7 +84,8 @@ public final class SearchRoutePoliciesQuestion extends Question {
         null,
         null,
         DEFAULT_ACTION,
-        false);
+	false,
+	DEFAULT_PATH_OPTION);
   }
 
   public SearchRoutePoliciesQuestion(
@@ -68,7 +95,8 @@ public final class SearchRoutePoliciesQuestion extends Question {
       @Nullable String nodes,
       @Nullable String policies,
       Action action,
-      boolean perPath) {
+      boolean perPath,
+      PathOption pathOption) {
     checkArgument(
         action == Action.PERMIT || outputConstraints.equals(DEFAULT_ROUTE_CONSTRAINTS),
         "Output route constraints can only be provided when the action is 'permit'");
@@ -79,6 +107,11 @@ public final class SearchRoutePoliciesQuestion extends Question {
     _outputConstraints = outputConstraints;
     _action = action;
     _perPath = perPath;
+    if (perPath) {
+      _pathOption = PathOption.PER_PATH;
+    } else {
+      _pathOption = pathOption;
+    }
   }
 
   @JsonCreator
@@ -89,7 +122,8 @@ public final class SearchRoutePoliciesQuestion extends Question {
       @Nullable @JsonProperty(PROP_NODES) String nodes,
       @Nullable @JsonProperty(PROP_POLICIES) String policies,
       @Nullable @JsonProperty(PROP_ACTION) Action action,
-      @JsonProperty(PROP_PER_PATH) boolean perPath) {
+      @JsonProperty(PROP_PER_PATH) boolean perPath,
+      @Nullable @JsonProperty(PROP_PATH_OPTION) PathOption pathOption) {
     return new SearchRoutePoliciesQuestion(
         firstNonNull(direction, DEFAULT_DIRECTION),
         firstNonNull(inputConstraints, DEFAULT_ROUTE_CONSTRAINTS),
@@ -97,7 +131,8 @@ public final class SearchRoutePoliciesQuestion extends Question {
         nodes,
         policies,
         firstNonNull(action, DEFAULT_ACTION),
-        perPath);
+	perPath,
+	pathOption);
   }
 
   @JsonIgnore
@@ -149,8 +184,15 @@ public final class SearchRoutePoliciesQuestion extends Question {
     return _action;
   }
 
+  @JsonProperty(PROP_PATH_OPTION)
+  @Nonnull
+  public PathOption getPathOption() {
+    return _pathOption;
+  }
+
   @JsonProperty(PROP_PER_PATH)
   @Nonnull
+  @Deprecated
   public boolean getPerPath() {
     return _perPath;
   }

--- a/questions/experimental/searchRoutePolicies.json
+++ b/questions/experimental/searchRoutePolicies.json
@@ -7,6 +7,7 @@
     "action": "${action}",
     "outputConstraints": "${outputConstraints}",
     "perPath": "${perPath}",
+    "pathOption": "${pathOption}",
     "instance": {
         "description": "Finds route announcements for which a route policy has a particular behavior.",
         "instanceName": "searchRoutePolicies",
@@ -17,7 +18,8 @@
             "inputConstraints",
             "action",
             "outputConstraints",
-            "perPath"
+	    "perPath",
+            "pathOption"
         ],
         "tags": [
             "routing"
@@ -53,11 +55,17 @@
                 "optional": true,
                 "displayName": "Output Constraints"
             },
-            "perPath": {
+	    "perPath": {
                 "description": "Run the analysis separately for each execution path of a route map",
                 "type": "boolean",
                 "optional": true,
                 "displayName": "Per-Path"
+            },
+            "pathOption": {
+                "description": "If set to 'per_path' run the analysis separately for each execution path. If set to `non_overlap` run the analysis separately for each execution path but do not produce the same route for each path.",
+                "type": "string",
+                "optional": true,
+                "displayName": "Path Options"
             }
         }
     }


### PR DESCRIPTION
This change adds a new option for SRP to attempt to generate input advertisements that are unique by prefix. I'm using this functionality to attempt to create a set of advertisements that are non-overlapping that I can use for the purposes of test case generation.