### PR TITLE
Junos: handle quoted as-path-regex in hierarchical configs

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3703,7 +3703,7 @@ F_UnquotedAsPathRegexChar
 fragment
 F_QuotedAsPathRegex
 :
-  F_QuotedAsPathRegexChar+
+  '"' F_QuotedAsPathRegexChar+ '"'
 ;
 
 fragment
@@ -3727,13 +3727,8 @@ M_AsPathDefinitionRegex_NEWLINE: F_Newline -> type(NEWLINE), popMode;
 
 mode M_AsPathDefinitionRegex2;
 M_AsPathDefinitionRegex2_NEWLINE: F_Newline -> type(NEWLINE), popMode;
-M_AsPathDefinitionRegex2_DOUBLE_QUOTE: '"' -> channel(HIDDEN), mode(M_AsPathDefinitionRegexQuoted);
+M_AsPathDefinitionRegex2_QUOTED_AS_PATH_REGEX: F_QuotedAsPathRegex -> type(AS_PATH_REGEX), popMode;
 M_AsPathDefinitionRegex2_AS_PATH_REGEX: F_UnquotedAsPathRegex -> type(AS_PATH_REGEX), popMode;
-
-mode M_AsPathDefinitionRegexQuoted;
-M_AsPathDefinitionRegexQuoted_NEWLINE: F_Newline -> type(NEWLINE), popMode;
-M_AsPathDefinitionRegexQuoted_DOUBLE_QUOTE: '"' -> channel(HIDDEN), popMode;
-M_AsPathDefinitionRegexQuoted_AS_PATH_REGEX: F_QuotedAsPathRegex -> type(AS_PATH_REGEX);
 
 mode M_AsPathPrepend;
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5788,6 +5788,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testGH8744() {
+    parseConfig("gh-8744");
+    // don't crash.
+  }
+
+  @Test
   public void testImplicitInitInterface() {
     JuniperConfiguration juniperConfiguration = parseJuniperConfig("implicit-init-interface");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/gh-8744
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/gh-8744
@@ -1,0 +1,19 @@
+#RANCID-CONTENT-TYPE: juniper
+system {
+    host-name gh-8744;
+}
+groups {
+    POLICIES {
+        policy-options {
+            policy-statement TEST {
+                then reject;
+            }
+            as-path-group TEST-ASNS-GROUP {
+                as-path TEST-ASNS ".* [100-200] .*";
+            }
+        }
+    }
+}
+policy-options {
+    apply-groups POLICIES;
+}

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -49608,7 +49608,7 @@
             "                AS_PATH:'as-path'",
             "                name = (junos_name*",
             "                  NAME:'AS_PATH_REGEX_NAME2'  <== mode:M_AsPathDefinitionName)",
-            "                regex = AS_PATH_REGEX:'.* 654321 .*'  <== mode:M_AsPathDefinitionRegexQuoted))))))",
+            "                regex = AS_PATH_REGEX:'\".* 654321 .*\"'  <== mode:M_AsPathDefinitionRegex2))))))",
             "    NEWLINE:'\\n')",
             "  EOF:<EOF>)"
           ]
@@ -57292,7 +57292,7 @@
             "              AS_PATH:'as-path'",
             "              name = (junos_name*",
             "                NAME:'ORIGINATED_IN_65535'  <== mode:M_AsPathDefinitionName)",
-            "              regex = AS_PATH_REGEX:'.* 65535'  <== mode:M_AsPathDefinitionRegexQuoted)))))",
+            "              regex = AS_PATH_REGEX:'\".* 65535\"'  <== mode:M_AsPathDefinitionRegex2)))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",
             "    SET:'set'",
@@ -57305,7 +57305,7 @@
             "              AS_PATH:'as-path'",
             "              name = (junos_name*",
             "                NAME:'UNUSED_ORIGINATED_IN_65535'  <== mode:M_AsPathDefinitionName)",
-            "              regex = AS_PATH_REGEX:'.* 65535'  <== mode:M_AsPathDefinitionRegexQuoted)))))",
+            "              regex = AS_PATH_REGEX:'\".* 65535\"'  <== mode:M_AsPathDefinitionRegex2)))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",
             "    SET:'set'",
@@ -57322,7 +57322,7 @@
             "                AS_PATH:'as-path'",
             "                name = (junos_name*",
             "                  NAME:'ASN65534'  <== mode:M_AsPathDefinitionName)",
-            "                regex = AS_PATH_REGEX:'.* 65534$'  <== mode:M_AsPathDefinitionRegexQuoted))))))",
+            "                regex = AS_PATH_REGEX:'\".* 65534$\"'  <== mode:M_AsPathDefinitionRegex2))))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",
             "    SET:'set'",
@@ -57339,7 +57339,7 @@
             "                AS_PATH:'as-path'",
             "                name = (junos_name*",
             "                  NAME:'ASN65535'  <== mode:M_AsPathDefinitionName)",
-            "                regex = AS_PATH_REGEX:'.* 65535$'  <== mode:M_AsPathDefinitionRegexQuoted))))))",
+            "                regex = AS_PATH_REGEX:'\".* 65535$\"'  <== mode:M_AsPathDefinitionRegex2))))))",
             "    NEWLINE:'\\n')",
             "  EOF:<EOF>)"
           ]


### PR DESCRIPTION
Fix batfish/batfish#8744