### PR TITLE
Junos: cache regex conversions if referenced more than once

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/BUILD.bazel
@@ -13,6 +13,7 @@ java_library(
     ],
     deps = [
         "//projects/batfish-common-protocol:common",
+        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:org_parboiled_parboiled_core",


### PR DESCRIPTION
**Stack**:
- #8756
- #8755
- #8754
- #8753 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*