### PR TITLE
Junos: predefine 'master' routing instance and translate during VI conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -17,6 +17,7 @@ import static org.batfish.datamodel.routing_policy.statement.Statements.ReturnFa
 import static org.batfish.representation.juniper.EthernetSwitching.DEFAULT_VLAN_MEMBER;
 import static org.batfish.representation.juniper.JuniperStructureType.ADDRESS_BOOK;
 import static org.batfish.representation.juniper.JuniperStructureType.POLICY_STATEMENT_TERM;
+import static org.batfish.representation.juniper.JuniperStructureType.ROUTING_INSTANCE;
 import static org.batfish.representation.juniper.NatPacketLocation.interfaceLocation;
 import static org.batfish.representation.juniper.NatPacketLocation.routingInstanceLocation;
 import static org.batfish.representation.juniper.NatPacketLocation.zoneLocation;
@@ -220,6 +221,19 @@ public final class JuniperConfiguration extends VendorConfiguration {
   /** Juniper uses AD 170 for both EBGP and IBGP routes. */
   public static final int DEFAULT_BGP_ADMIN_DISTANCE = 170;
 
+  /** Juniper's default routing instance is called "master". */
+  public static final @Nonnull String DEFAULT_ROUTING_INSTANCE_NAME = "master";
+
+  /** Normalize to VI VRF name. */
+  public static @Nonnull String toVrfName(String routingInstanceName) {
+    if (routingInstanceName.equals(DEFAULT_ROUTING_INSTANCE_NAME)) {
+      // TODO: preserve Junos name, which is tricky. There's too much in Batfish that relies on
+      // default vrf being this default.
+      return Configuration.DEFAULT_VRF_NAME;
+    }
+    return routingInstanceName;
+  }
+
   private static final ConnectedRouteMetadata JUNIPER_CONNECTED_ROUTE_METADATA =
       ConnectedRouteMetadata.builder().setGenerateLocalNullRouteIfDown(true).build();
 
@@ -405,6 +419,13 @@ public final class JuniperConfiguration extends VendorConfiguration {
     _masterLogicalSystem = new LogicalSystem("");
     _nodeDevices = new TreeMap<>();
     _indirectAccessPorts = new HashMap<>();
+    // Create and then self-reference the default routing instance.
+    defineSingleLineStructure(ROUTING_INSTANCE, DEFAULT_ROUTING_INSTANCE_NAME, 0);
+    referenceStructure(
+        ROUTING_INSTANCE,
+        DEFAULT_ROUTING_INSTANCE_NAME,
+        JuniperStructureUsage.ROUTING_INSTANCE_SELF_REFERENCE,
+        0);
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromInstance.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.representation.juniper.JuniperConfiguration.toVrfName;
+
 import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
@@ -9,7 +11,7 @@ import org.batfish.datamodel.routing_policy.expr.MatchSourceVrf;
 /** Represents a "from instance" line in a {@link PsTerm} */
 public class PsFromInstance extends PsFrom {
 
-  private String _routingInstanceName;
+  private final @Nonnull String _routingInstanceName;
 
   public PsFromInstance(@Nonnull String routingInstanceName) {
     _routingInstanceName = routingInstanceName;
@@ -21,6 +23,6 @@ public class PsFromInstance extends PsFrom {
 
   @Override
   public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
-    return new MatchSourceVrf(_routingInstanceName);
+    return new MatchSourceVrf(toVrfName(_routingInstanceName));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatement.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatement.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.representation.juniper.JuniperConfiguration.toVrfName;
+
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
@@ -66,7 +68,8 @@ public final class TermFwThenToPacketPolicyStatement implements FwThenVisitor<St
   public Statement visitThenRoutingInstance(FwThenRoutingInstance routingInstance) {
     return _skipRest
         ? null
-        : new Return(new FibLookup(new LiteralVrfName(routingInstance.getInstanceName())));
+        : new Return(
+            new FibLookup(new LiteralVrfName(toVrfName(routingInstance.getInstanceName()))));
   }
 
   /** Convert all "then" statements in the {@code term} to a list of packet policy statements */

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/BUILD.bazel
@@ -13,6 +13,7 @@ java_library(
     ],
     deps = [
         "//projects/batfish-common-protocol:common",
+        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:org_parboiled_parboiled_core",

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromInstanceTest.java
@@ -1,0 +1,31 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.routing_policy.expr.MatchSourceVrf;
+import org.junit.Test;
+
+public class PsFromInstanceTest {
+  @Test
+  public void testConversion() {
+    JuniperConfiguration jc = new JuniperConfiguration();
+    Configuration c =
+        Configuration.builder()
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .setHostname("c")
+            .build();
+    Warnings w = new Warnings();
+
+    assertThat(
+        new PsFromInstance("master").toBooleanExpr(jc, c, w),
+        equalTo(new MatchSourceVrf("default")));
+
+    assertThat(
+        new PsFromInstance("MY_VRF").toBooleanExpr(jc, c, w),
+        equalTo(new MatchSourceVrf("MY_VRF")));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatementTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatementTest.java
@@ -82,6 +82,14 @@ public class TermFwThenToPacketPolicyStatementTest {
   }
 
   @Test
+  public void testVisitMasterRoutingInstance() {
+    _fwTerm.getThens().add(new FwThenRoutingInstance("master"));
+    assertThat(
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
+        equalTo(ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("default"))))));
+  }
+
+  @Test
   public void testVisitRoutingInstanceAfterSkip() {
     _fwTerm
         .getThens()

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -11406,6 +11406,12 @@
               "definitionLines" : "47-48",
               "numReferrers" : 3
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/as1border2.cfg" : {
@@ -11561,6 +11567,12 @@
             "original_prefixes" : {
               "definitionLines" : "54-55",
               "numReferrers" : 3
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
@@ -12936,6 +12948,13 @@
                 45
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/as1border2.cfg" : {
@@ -13153,6 +13172,13 @@
                 30,
                 32,
                 43
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -6337,6 +6337,12 @@
               "numReferrers" : 2
             }
           },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          },
           "security policy" : {
             "zone~junos-host~to~zone~untrust" : {
               "definitionLines" : "68-75",
@@ -6543,6 +6549,12 @@
               "numReferrers" : 2
             }
           },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          },
           "security policy" : {
             "zone~trust~to~zone~trust" : {
               "definitionLines" : "48-51",
@@ -6703,6 +6715,12 @@
             "bgp_export 1" : {
               "definitionLines" : "92-93",
               "numReferrers" : 2
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           },
           "security policy" : {
@@ -6939,6 +6957,13 @@
               "policy-statement term" : [
                 115,
                 116
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           },
@@ -7272,6 +7297,13 @@
               ]
             }
           },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          },
           "security policy" : {
             "zone~trust~to~zone~trust" : {
               "security policy" : [
@@ -7498,6 +7530,13 @@
               "policy-statement term" : [
                 92,
                 93
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -73412,6 +73412,10 @@
               "definitionLines" : "200-237",
               "numReferrers" : 17
             },
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            },
             "vr" : {
               "definitionLines" : "196-199",
               "numReferrers" : 2
@@ -74042,6 +74046,12 @@
               "definitionLines" : "5,15",
               "numReferrers" : 3
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper-tcpflags" : {
@@ -74056,6 +74066,12 @@
               "definitionLines" : "4",
               "numReferrers" : 1
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_application" : {
@@ -74068,9 +74084,22 @@
               "definitionLines" : "6-7",
               "numReferrers" : 0
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
-        "configs/juniper_apply_macro" : { },
+        "configs/juniper_apply_macro" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/juniper_as_path_group" : {
           "as-path-group" : {
             "AS_PATH_GROUP1" : {
@@ -74085,6 +74114,12 @@
             },
             "AS_PATH_REGEX_NAME2" : {
               "definitionLines" : "6",
+              "numReferrers" : 1
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -74129,12 +74164,24 @@
               "definitionLines" : "25",
               "numReferrers" : 1
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_bgp_allow" : {
           "bgp group" : {
             "GROUP" : {
               "definitionLines" : "6-8",
+              "numReferrers" : 1
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -74165,6 +74212,12 @@
               "definitionLines" : "22",
               "numReferrers" : 1
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_bgp_disable" : {
@@ -74172,6 +74225,12 @@
             "GROUP" : {
               "definitionLines" : "4",
               "numReferrers" : 0
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
@@ -74187,6 +74246,12 @@
               "definitionLines" : "7",
               "numReferrers" : 1
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_bgp_remove_private_as" : {
@@ -74198,6 +74263,12 @@
             "someipv6bgpgroup" : {
               "definitionLines" : "7,13-16",
               "numReferrers" : 0
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
@@ -74214,6 +74285,12 @@
             "COMM_REGEX" : {
               "definitionLines" : "7",
               "numReferrers" : 0
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
@@ -74277,6 +74354,12 @@
               "definitionLines" : "48-55",
               "numReferrers" : 8
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_forwarding_options" : {
@@ -74288,6 +74371,12 @@
             "test2" : {
               "definitionLines" : "26",
               "numReferrers" : 2
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
@@ -74390,6 +74479,10 @@
             "SOME_INSTANCE" : {
               "definitionLines" : "24",
               "numReferrers" : 1
+            },
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           },
           "vlan" : {
@@ -74409,13 +74502,30 @@
               "definitionLines" : "6",
               "numReferrers" : 8
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
-        "configs/juniper_l2_learning" : { },
+        "configs/juniper_l2_learning" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/juniper_misc" : {
           "routing-instance" : {
             "ROUTING_INSTANCE" : {
               "definitionLines" : "9",
+              "numReferrers" : 1
+            },
+            "master" : {
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -74464,6 +74574,12 @@
               "definitionLines" : "8-9,11-15,17-18,20-21",
               "numReferrers" : 0
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_ntp" : {
@@ -74471,10 +74587,21 @@
             "MGMT" : {
               "definitionLines" : "6",
               "numReferrers" : 2
+            },
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
-        "configs/juniper_ospf" : { },
+        "configs/juniper_ospf" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/juniper_ospf_disable" : {
           "interface" : {
             "ge-0/0/0" : {
@@ -74485,10 +74612,30 @@
               "definitionLines" : "4",
               "numReferrers" : 2
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
-        "configs/juniper_ospf_stub_areas" : { },
-        "configs/juniper_passwords" : { },
+        "configs/juniper_ospf_stub_areas" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
+        "configs/juniper_passwords" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/juniper_policy_statement" : {
           "as-path" : {
             "ORIGINATED_IN_65535" : {
@@ -74531,6 +74678,12 @@
               "definitionLines" : "4-39",
               "numReferrers" : 36
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/juniper_relay" : {
@@ -74538,6 +74691,12 @@
             "site-dhcp" : {
               "definitionLines" : "4",
               "numReferrers" : 2
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
@@ -74565,6 +74724,12 @@
             },
             "reth0.3" : {
               "definitionLines" : "8",
+              "numReferrers" : 1
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -74606,6 +74771,10 @@
             "ROUTING_INSTANCE_NAME" : {
               "definitionLines" : "20-25",
               "numReferrers" : 6
+            },
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
@@ -74629,9 +74798,22 @@
               "definitionLines" : "11-16",
               "numReferrers" : 6
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
           }
         },
-        "configs/juniper_routing_options" : { },
+        "configs/juniper_routing_options" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/juniper_routing_policy" : {
           "interface" : {
             "ge-0/0/0" : {
@@ -74657,6 +74839,12 @@
             "POLICY-NAME TERM2" : {
               "definitionLines" : "9-10",
               "numReferrers" : 2
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           }
         },
@@ -74701,6 +74889,12 @@
               "numReferrers" : 2
             }
           },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          },
           "security policy" : {
             "zone~A~to~zone~B" : {
               "definitionLines" : "19-22",
@@ -74730,9 +74924,29 @@
             }
           }
         },
-        "configs/juniper_snmp" : { },
-        "configs/juniper_syslog" : { },
+        "configs/juniper_snmp" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
+        "configs/juniper_syslog" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/juniper_system" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          },
           "security-profile" : {
             "ls1" : {
               "definitionLines" : "16-21",
@@ -74740,8 +74954,22 @@
             }
           }
         },
-        "configs/juniper_tacplus" : { },
-        "configs/juniper_trailing_space" : { },
+        "configs/juniper_tacplus" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
+        "configs/juniper_trailing_space" : {
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/juniper_vlan" : {
           "interface" : {
             "xe-0/0/0" : {
@@ -74751,6 +74979,12 @@
             "xe-0/0/0.0" : {
               "definitionLines" : "10-14",
               "numReferrers" : 5
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "definitionLines" : "0",
+              "numReferrers" : 1
             }
           },
           "vlan" : {
@@ -80078,6 +80312,11 @@
                 200
               ]
             },
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            },
             "vr" : {
               "routing-instance" : [
                 196
@@ -81010,6 +81249,13 @@
                 17
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/juniper-tcpflags" : {
@@ -81017,6 +81263,31 @@
             "foo bar" : {
               "firewall filter term" : [
                 4
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_application" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_apply_macro" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81031,6 +81302,13 @@
             "AS_PATH_REGEX_NAME2" : {
               "as-path-group as-path" : [
                 6
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81107,6 +81385,13 @@
                 39
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/juniper_bgp_allow" : {
@@ -81114,6 +81399,13 @@
             "GROUP" : {
               "bgp group allow" : [
                 8
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81154,6 +81446,22 @@
                 22
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_bgp_disable" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/juniper_bgp_enforce_fist_as" : {
@@ -81168,6 +81476,31 @@
             "1.1.1.1 (VRF default)" : {
               "bgp neighbor self ref" : [
                 7
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_bgp_remove_private_as" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_extended_community" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81259,6 +81592,11 @@
               "firewall filter then routing-instance" : [
                 38
               ]
+            },
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
             }
           }
         },
@@ -81291,6 +81629,13 @@
             "xe-1/0/0.0" : {
               "fowarding-options dhcp-relay group interface" : [
                 10
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81431,6 +81776,11 @@
               "routing-instance" : [
                 24
               ]
+            },
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
             }
           },
           "vlan" : {
@@ -81462,6 +81812,22 @@
                 14
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_l2_learning" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/juniper_misc" : {
@@ -81476,6 +81842,11 @@
             "ROUTING_INSTANCE" : {
               "routing-instance" : [
                 9
+              ]
+            },
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81511,6 +81882,13 @@
                 21
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/juniper_ntp" : {
@@ -81521,6 +81899,11 @@
               ],
               "routing-instance" : [
                 6
+              ]
+            },
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81555,6 +81938,13 @@
                 8
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/juniper_ospf_disable" : {
@@ -81570,6 +81960,31 @@
               ],
               "ospf area interface" : [
                 6
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_ospf_stub_areas" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_passwords" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81654,6 +82069,11 @@
               "policy-statement from instance" : [
                 17
               ]
+            },
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
             }
           }
         },
@@ -81675,6 +82095,13 @@
             "irb.20" : {
               "fowarding-options dhcp-relay group interface" : [
                 8
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81711,6 +82138,13 @@
             "reth0.3" : {
               "interface" : [
                 8
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81786,6 +82220,11 @@
                 24,
                 25
               ]
+            },
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
             }
           }
         },
@@ -81811,6 +82250,13 @@
                 16
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/juniper_routing_options" : {
@@ -81818,6 +82264,13 @@
             "AGGREGATE_ROUTE_POLICY" : {
               "aggregate route policy" : [
                 9
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81856,6 +82309,13 @@
               "policy-statement term" : [
                 9,
                 10
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81900,6 +82360,13 @@
               ],
               "security zones security-zone interfaces" : [
                 30
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           },
@@ -81953,6 +82420,22 @@
                 5
               ]
             }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_syslog" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
           }
         },
         "configs/juniper_system" : {
@@ -81960,6 +82443,31 @@
             "ls905" : {
               "security-profile logical-system" : [
                 21
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_tacplus" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
+              ]
+            }
+          }
+        },
+        "configs/juniper_trailing_space" : {
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           }
@@ -81992,6 +82500,13 @@
                 12,
                 13,
                 14
+              ]
+            }
+          },
+          "routing-instance" : {
+            "master" : {
+              "routing-instance" : [
+                0
               ]
             }
           },


### PR DESCRIPTION
**Stack**:
- #8756
- #8755
- #8754 ⬅
- #8753


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*