### PR TITLE
Bugfix: Consider using the output/intermediate route when matching on the metric

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchMetric.java
@@ -41,8 +41,15 @@ public final class MatchMetric extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    return _comparator.apply(
-        Math.toIntExact(environment.getOriginalRoute().getMetric()), _metric.evaluate(environment));
+    long metric;
+    if (environment.getUseOutputAttributes()) {
+      metric = environment.getOutputRoute().getMetric();
+    } else if (environment.getReadFromIntermediateBgpAttributes()) {
+      metric = environment.getIntermediateBgpAttributes().getMetric();
+    } else {
+      metric = environment.getOriginalRoute().getMetric();
+    }
+    return _comparator.apply(Math.toIntExact(metric), _metric.evaluate(environment));
   }
 
   @JsonProperty(PROP_COMPARATOR)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchTag.java
@@ -45,10 +45,10 @@ public final class MatchTag extends BooleanExpr {
   @Override
   public Result evaluate(Environment environment) {
     long lhs;
-    if (environment.getReadFromIntermediateBgpAttributes()) {
-      lhs = environment.getIntermediateBgpAttributes().getTag();
-    } else if (environment.getUseOutputAttributes()) {
+    if (environment.getUseOutputAttributes()) {
       lhs = environment.getOutputRoute().getTag();
+    } else if (environment.getReadFromIntermediateBgpAttributes()) {
+      lhs = environment.getIntermediateBgpAttributes().getTag();
     } else {
       lhs = environment.getOriginalRoute().getTag();
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4763,7 +4763,7 @@ public final class FlatJuniperGrammarTest {
   }
 
   private static Environment envWithRoute(Configuration c, AbstractRoute route) {
-    return Environment.builder(c).setOriginalRoute(route).build();
+    return Environment.builder(c).setOriginalRoute(route).setOutputRoute(route.toBuilder()).build();
   }
 
   @Test


### PR DESCRIPTION
Check for usage of output/intermediate route attributes when matching on the metric, similar to how matching is done for other attributes; reorder the existing checks when matching on the tag to be consistent with how it's done elsewhere.