### PR TITLE
Extend BgpRouteCommunityDiff and StructuredBgpRouteDiffs public interface.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteCommunityDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteCommunityDiff.java
@@ -44,6 +44,14 @@ public class BgpRouteCommunityDiff {
     return _removed;
   }
 
+  public SortedSet<Community> getOldValue() {
+    return _oldValue;
+  }
+
+  public SortedSet<Community> getNewValue() {
+    return _newValue;
+  }
+
   /**
    * The hash (and resp. the equality function) of this object only considers the _added and
    * _removed fields, ignoring the _oldValue and _newValue. This facilitates distinguishing

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffs.java
@@ -47,6 +47,13 @@ public class StructuredBgpRouteDiffs {
             .collect(ImmutableSortedSet.toImmutableSortedSet(natural())));
   }
 
+  /**
+   * @return true if there are some route field differences represented by this object.
+   */
+  public boolean hasDifferences() {
+    return !_diffs.isEmpty() || _communityDiff.isPresent();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteCommunityDiffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteCommunityDiffTest.java
@@ -27,6 +27,8 @@ public class BgpRouteCommunityDiffTest {
     BgpRouteCommunityDiff comms1 = new BgpRouteCommunityDiff(oldComms1, newComms1);
     assertEquals(comms1.getAdded(), Set.of(StandardCommunity.of(2, 2)));
     assertEquals(comms1.getRemoved(), Set.of(StandardCommunity.of(0, 0)));
+    assertEquals(comms1.getOldValue(), oldComms1);
+    assertEquals(comms1.getNewValue(), newComms1);
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffsTest.java
@@ -44,4 +44,31 @@ public class StructuredBgpRouteDiffsTest {
             new StructuredBgpRouteDiffs(ImmutableSortedSet.of(), Optional.of(comms2)))
         .testEquals();
   }
+
+  @Test
+  public void testHasDifferences() {
+
+    StructuredBgpRouteDiffs d1 = new StructuredBgpRouteDiffs();
+    assert (!d1.hasDifferences());
+
+    SortedSet<Community> oldComms1 = new TreeSet<>();
+    SortedSet<Community> newComms1 = new TreeSet<>();
+
+    oldComms1.add(StandardCommunity.of(0, 0));
+    oldComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(2, 2));
+    BgpRouteCommunityDiff comms1 = new BgpRouteCommunityDiff(oldComms1, newComms1);
+
+    StructuredBgpRouteDiffs d2 =
+        new StructuredBgpRouteDiffs(ImmutableSortedSet.of(), Optional.of(comms1));
+    assert (d2.hasDifferences());
+
+    StructuredBgpRouteDiffs d3 =
+        new StructuredBgpRouteDiffs(
+            ImmutableSortedSet.of(new BgpRouteDiff(BgpRoute.PROP_AS_PATH, "B", "C")),
+            Optional.empty());
+
+    assert (d3.hasDifferences());
+  }
 }


### PR DESCRIPTION
Adds a getter for 2 fields in `BgpRouteCommunityDiff` and a `hasDifference` method in `StructuredBgpRouteDiffs`.