### PR TITLE
Fix receivedFromRouteReflectorClient not set for main rib exports

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
@@ -30,6 +30,7 @@ import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasWeight;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.IsBgpv4RouteThat;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.IsEvpnType3RouteThat;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.IsEvpnType5RouteThat;
+import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.IsReceivedFromRouteReflectorClient;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 import org.hamcrest.Matcher;
 
@@ -96,6 +97,14 @@ public final class BgpRouteMatchers {
   public static @Nonnull Matcher<BgpRoute<?, ?>> hasReceivedFrom(
       Matcher<? super ReceivedFrom> subMatcher) {
     return new HasReceivedFrom(subMatcher);
+  }
+
+  public static @Nonnull Matcher<BgpRoute<?, ?>> isReceivedFromRouteReflectorClient() {
+    return isReceivedFromRouteReflectorClient(true);
+  }
+
+  public static @Nonnull Matcher<BgpRoute<?, ?>> isReceivedFromRouteReflectorClient(boolean b) {
+    return new IsReceivedFromRouteReflectorClient(equalTo(b));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
@@ -99,6 +99,22 @@ final class BgpRouteMatchersImpl {
     }
   }
 
+  static final class IsReceivedFromRouteReflectorClient
+      extends FeatureMatcher<BgpRoute<?, ?>, Boolean> {
+
+    IsReceivedFromRouteReflectorClient(Matcher<? super Boolean> subMatcher) {
+      super(
+          subMatcher,
+          "A BgpRoute with receivedFromRouteReflectorClient",
+          "receivedFromRouteReflectorClient");
+    }
+
+    @Override
+    protected Boolean featureValueOf(BgpRoute<?, ?> actual) {
+      return actual.getReceivedFromRouteReflectorClient();
+    }
+  }
+
   static final class HasWeight extends FeatureMatcher<HasReadableWeight, Integer> {
     HasWeight(@Nonnull Matcher<? super Integer> subMatcher) {
       super(subMatcher, "A HasReadableWeight with weight:", "weight");

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -973,6 +973,13 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         continue;
       }
 
+      // Note whether new route is received from route reflector client
+      AddressFamily ourAfSettingsForPeer = ourBgpConfig.getIpv4UnicastAddressFamily();
+      assert ourAfSettingsForPeer
+          != null; // invariant of proper queue setup and route exchange for this AF type
+      transformedIncomingRouteBuilder.setReceivedFromRouteReflectorClient(
+          !ourSessionProperties.isEbgp() && ourAfSettingsForPeer.getRouteReflectorClient());
+
       // Process route through import policy, if one exists
       String importPolicyName = ourBgpConfig.getIpv4UnicastAddressFamily().getImportPolicy();
       boolean acceptIncoming = true;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -101,16 +101,9 @@ public final class BgpProtocolHelper {
 
     // Set originatorIP
     if (localSessionProperties.isEbgp() || !routeProtocol.equals(RoutingProtocol.IBGP)) {
-      // eBGP session and not iBGP route: override the originator
+      // eBGP session or not iBGP route: override the originator
       builder.setOriginatorIp(localBgpProcess.getRouterId());
     }
-
-    // note whether new route is received from route reflector client
-    AddressFamily toNeighborAf = remoteNeighbor.getAddressFamily(afType);
-    assert toNeighborAf
-        != null; // invariant of proper queue setup and route exchange for this AF type
-    builder.setReceivedFromRouteReflectorClient(
-        !localSessionProperties.isEbgp() && toNeighborAf.getRouteReflectorClient());
 
     AddressFamily af = localNeighbor.getAddressFamily(afType);
     assert af != null;
@@ -461,6 +454,7 @@ public final class BgpProtocolHelper {
                   pathIdGenerators.compute(
                       originalRoute.getNetwork(), (p, lastId) -> lastId == null ? 1 : lastId + 1));
     }
+
     transformBgpRoutePostExport(
         routeBuilder,
         ourSessionProperties.isEbgp(),

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -454,7 +454,6 @@ public final class BgpProtocolHelper {
                   pathIdGenerators.compute(
                       originalRoute.getNetwork(), (p, lastId) -> lastId == null ? 1 : lastId + 1));
     }
-
     transformBgpRoutePostExport(
         routeBuilder,
         ourSessionProperties.isEbgp(),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/ReceivedFromRouteReflectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/ReceivedFromRouteReflectorTest.java
@@ -26,6 +26,14 @@ import org.junit.rules.TemporaryFolder;
 public final class ReceivedFromRouteReflectorTest {
 
   /*
+  rrcm: Route-Reflector-Client that exports from the Main RIB
+  nrrcm: Non-Route-Reflector-Client that exports from the Main RIB
+  rrcb: Route-Reflector-Client that exports from the BGP RIB
+  nrrcb: Non-Route-Reflector-Client that exports from the BGP RIB
+  rr: Route-Reflector
+  AS2: AS of all the devices above
+  AS1: source of external eBGP advertisements
+
                      AS2       AS2
    Topology: AS1 <=> rrcm  <=> rr
                  <=> nrrcm <=>
@@ -54,8 +62,7 @@ public final class ReceivedFromRouteReflectorTest {
                 .setExternalBgpAnnouncements(snapshotPath)
                 .build(),
             _folder);
-    // TODO: parse neighbor xxx additional-paths send receive
-    batfish.getSettings().setDisableUnrecognized(false);
+    batfish.getSettings().setDisableUnrecognized(true);
     batfish.computeDataPlane(batfish.getSnapshot());
     _dp = batfish.loadDataPlane(batfish.getSnapshot());
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/ReceivedFromRouteReflectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/ReceivedFromRouteReflectorTest.java
@@ -1,0 +1,115 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.isReceivedFromRouteReflectorClient;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Table;
+import java.io.IOException;
+import java.util.Set;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Prefix;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** End-to-end tests of the setting of the receivedFromRouteReflectorClient BGP route bit. */
+public final class ReceivedFromRouteReflectorTest {
+
+  /*
+                     AS2       AS2
+   Topology: AS1 <=> rrcm  <=> rr
+                 <=> nrrcm <=>
+                 <=> rrcb  <=>
+                 <=> nrrcb <=>
+   - rr has iBGP peerings with each of rrcm, nrrcm, rrcb, nrrcb
+   - rr considers rrcm and rrcb to be route-reflector-clients
+   - rr does not consider nrrcm nor nrrcb to be route-reflector-clients
+   - rrcm and nrrcm export from the main RIB (Juniper)
+   - rrcb and nrrcb export from the BGP RIB (Cisco IOS)
+   - rrcm, nrrcm, rrcb, and nrrcb each originate a distinct /32 subnet of distinct /31 supernets
+   - rrcm, nrrcm, rrcb, and nrrcb each originate an aggregate /31 supernet of their respective /32 above
+   - rrcm, nrrcm, rrcb, and nrrcb each receive a distinct eBGP /32 from AS1 via external BGP announcements
+   - all routes rr receives from rrcm and rrcb should have the receivedFromRouteReflectorClient bit
+     set in rr's main/BGP RIBs
+   - all routes rr receives from nrrcm and nrrcb should have the receivedFromRouteReflectorClient
+     bit unset in rr's main/BGP RIBs
+  */
+  @Before
+  public void setup() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/route-reflection/rrrc";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(snapshotPath, "rrcm", "nrrcm", "rrcb", "nrrcb", "rr")
+                .setExternalBgpAnnouncements(snapshotPath)
+                .build(),
+            _folder);
+    // TODO: parse neighbor xxx additional-paths send receive
+    batfish.getSettings().setDisableUnrecognized(false);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    _dp = batfish.loadDataPlane(batfish.getSnapshot());
+  }
+
+  private static final Prefix NRRCB_STATIC = Prefix.strict("2.0.0.0/32");
+  private static final Prefix NRRCB_AGGREGATE = Prefix.strict("2.0.0.0/31");
+  private static final Prefix NRRCB_EBGP = Prefix.strict("1.0.0.2/32");
+  private static final Prefix NRRCM_STATIC = Prefix.strict("3.0.0.0/32");
+  private static final Prefix NRRCM_AGGREGATE = Prefix.strict("3.0.0.0/31");
+  private static final Prefix NRRCM_EBGP = Prefix.strict("1.0.0.3/32");
+  private static final Prefix RRCB_STATIC = Prefix.strict("4.0.0.0/32");
+  private static final Prefix RRCB_AGGREGATE = Prefix.strict("4.0.0.0/31");
+  private static final Prefix RRCB_EBGP = Prefix.strict("1.0.0.4/32");
+  private static final Prefix RRCM_STATIC = Prefix.strict("5.0.0.0/32");
+  private static final Prefix RRCM_AGGREGATE = Prefix.strict("5.0.0.0/31");
+  private static final Prefix RRCM_EBGP = Prefix.strict("1.0.0.5/32");
+
+  @Test
+  public void testBgpRib() {
+    Table<String, String, Set<Bgpv4Route>> bgpRoutes = _dp.getBgpRoutes();
+    Set<Bgpv4Route> rrRoutes = bgpRoutes.get("rr", DEFAULT_VRF_NAME);
+    assertNotReceivedFromRouteReflectorClient(rrRoutes, NRRCB_STATIC);
+    assertNotReceivedFromRouteReflectorClient(rrRoutes, NRRCB_AGGREGATE);
+    assertNotReceivedFromRouteReflectorClient(rrRoutes, NRRCB_EBGP);
+    assertNotReceivedFromRouteReflectorClient(rrRoutes, NRRCM_STATIC);
+    assertNotReceivedFromRouteReflectorClient(rrRoutes, NRRCM_AGGREGATE);
+    assertNotReceivedFromRouteReflectorClient(rrRoutes, NRRCM_EBGP);
+    assertReceivedFromRouteReflectorClient(rrRoutes, RRCB_STATIC);
+    assertReceivedFromRouteReflectorClient(rrRoutes, RRCB_AGGREGATE);
+    assertReceivedFromRouteReflectorClient(rrRoutes, RRCB_EBGP);
+    assertReceivedFromRouteReflectorClient(rrRoutes, RRCM_STATIC);
+    assertReceivedFromRouteReflectorClient(rrRoutes, RRCM_AGGREGATE);
+    assertReceivedFromRouteReflectorClient(rrRoutes, RRCM_EBGP);
+    assertThat(rrRoutes, hasSize(12));
+  }
+
+  /**
+   * Assert that the route with given {@code prefix} exists in {@code routes}, and that its
+   * receivedFromRouteReflectorClient bit is set.
+   */
+  private static void assertReceivedFromRouteReflectorClient(
+      Set<Bgpv4Route> routes, Prefix prefix) {
+    assertThat(routes, hasItem(allOf(hasPrefix(prefix), isReceivedFromRouteReflectorClient())));
+  }
+  /**
+   * Assert that the route with given {@code prefix} exists in {@code routes}, and that its
+   * receivedFromRouteReflectorClient bit is unset.
+   */
+  private static void assertNotReceivedFromRouteReflectorClient(
+      Set<Bgpv4Route> routes, Prefix prefix) {
+    assertThat(
+        routes, hasItem(allOf(hasPrefix(prefix), isReceivedFromRouteReflectorClient(false))));
+  }
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+  private DataPlane _dp;
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/ReceivedFromRouteReflectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/ReceivedFromRouteReflectorTest.java
@@ -100,6 +100,7 @@ public final class ReceivedFromRouteReflectorTest {
       Set<Bgpv4Route> routes, Prefix prefix) {
     assertThat(routes, hasItem(allOf(hasPrefix(prefix), isReceivedFromRouteReflectorClient())));
   }
+
   /**
    * Assert that the route with given {@code prefix} exists in {@code routes}, and that its
    * receivedFromRouteReflectorClient bit is unset.

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/nrrcb
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/nrrcb
@@ -1,0 +1,45 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname nrrcb
+!
+interface GigabitEthernet0/0
+ description to AS1
+ ip address 10.0.12.1 255.255.255.254
+!
+interface GigabitEthernet0/1
+ description to rr
+ ip address 10.0.26.0 255.255.255.254
+!
+!
+ip route 2.0.0.0 255.255.255.255 Null0
+!
+route-map rm-to-as1 deny 100
+!
+route-map rm-from-as1 permit 100
+!
+route-map rm-to-rr permit 100
+!
+route-map rm-from-rr deny 100
+!
+
+router bgp 2
+  bgp router-id 2.2.2.2
+  neighbor 10.0.12.0 remote-as 1
+  !
+  neighbor 10.0.26.1 remote-as 2
+  neighbor 10.0.26.1 update-source GigabitEthernet0/1
+  !
+  address-family ipv4 unicast
+    !
+    redistribute static
+    !
+    aggregate-address 2.0.0.0 255.255.255.254
+    !
+    neighbor 10.0.12.0 activate
+    neighbor 10.0.12.0 route-map rm-to-as1 out
+    neighbor 10.0.12.0 route-map rm-from-as1 in
+    !
+    neighbor 10.0.26.1 activate
+    neighbor 10.0.26.1 route-map rm-to-rr out
+    neighbor 10.0.26.1 route-map rm-from-rr in
+  !
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/nrrcm
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/nrrcm
@@ -1,0 +1,39 @@
+#RANCID-CONTENT-TYPE: juniper
+#
+set system host-name nrrcm
+#
+set interfaces xe-0/0/0 description "to AS1"
+set interfaces xe-0/0/0 unit 0 family inet address 10.0.13.1/31
+#
+set interfaces xe-0/0/1 description "to rr"
+set interfaces xe-0/0/1 unit 0 family inet address 10.0.36.0/31
+#
+set routing-options autonomous-system 2
+set routing-options router-id 3.3.3.3
+#
+set routing-options static route 3.0.0.0/32 discard
+set routing-options aggregate route 3.0.0.0/31
+#
+set policy-options policy-statement ps-to-as1 then reject
+#
+set policy-options policy-statement ps-from-as1 then accept
+#
+set policy-options policy-statement ps-to-rr from protocol static
+set policy-options policy-statement ps-to-rr from protocol aggregate
+set policy-options policy-statement ps-to-rr from protocol bgp
+set policy-options policy-statement ps-to-rr then accept
+#
+set policy-options policy-statement ps-from-rr then reject
+#
+set protocols bgp group e peer-as 1
+set protocols bgp group e type external
+set protocols bgp group e export ps-to-as1
+set protocols bgp group e import ps-from-as1
+set protocols bgp group e neighbor 10.0.13.0 local-address 10.0.13.1
+#
+set protocols bgp group i peer-as 2
+set protocols bgp group i type internal
+set protocols bgp group i export ps-to-rr
+set protocols bgp group i import ps-from-rr
+set protocols bgp group i neighbor 10.0.36.1 local-address 10.0.36.0
+#

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/rr
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/rr
@@ -1,0 +1,68 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname rr
+!
+interface GigabitEthernet0/0
+ description to nrrcb
+ ip address 10.0.26.1 255.255.255.254
+!
+ip route 10.0.12.0 255.255.255.254 10.0.26.0
+!
+interface GigabitEthernet0/1
+ description to nrrcm
+ ip address 10.0.36.1 255.255.255.254
+!
+ip route 10.0.13.0 255.255.255.254 10.0.36.0
+!
+interface GigabitEthernet0/2
+ description to rrcb
+ ip address 10.0.46.1 255.255.255.254
+!
+ip route 10.0.14.0 255.255.255.254 10.0.46.0
+!
+interface GigabitEthernet0/3
+ description to rrcm
+ ip address 10.0.56.1 255.255.255.254
+!
+ip route 10.0.15.0 255.255.255.254 10.0.56.0
+!
+route-map rm-to-peers deny 100
+!
+route-map rm-from-peers permit 100
+!
+router bgp 2
+  bgp router-id 6.6.6.6
+  !
+  neighbor rrc peer-group
+  neighbor rrc remote-as 2
+  neighbor rrc route-reflector-client
+  !
+  neighbor nrrc peer-group
+  neighbor nrrc remote-as 2
+  !
+  neighbor 10.0.26.0 peer-group nrrc
+  neighbor 10.0.26.0 update-source GigabitEthernet0/0
+  !
+  neighbor 10.0.36.0 peer-group nrrc
+  neighbor 10.0.36.0 update-source GigabitEthernet0/1
+  !
+  neighbor 10.0.46.0 peer-group rrc
+  neighbor 10.0.46.0 update-source GigabitEthernet0/2
+  !
+  neighbor 10.0.56.0 peer-group rrc
+  neighbor 10.0.56.0 update-source GigabitEthernet0/3
+  !
+  address-family ipv4 unicast
+    !
+    neighbor rrc route-map rm-to-peers out
+    neighbor rrc route-map rm-from-peers in
+    !
+    neighbor nrrc route-map rm-to-peers out
+    neighbor nrrc route-map rm-from-peers in
+    !
+    neighbor 10.0.26.0 activate
+    neighbor 10.0.36.0 activate
+    neighbor 10.0.46.0 activate
+    neighbor 10.0.56.0 activate
+    !
+  !
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/rrcb
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/rrcb
@@ -1,0 +1,45 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname rrcb
+!
+interface GigabitEthernet0/0
+ description to AS1
+ ip address 10.0.14.1 255.255.255.254
+!
+interface GigabitEthernet0/1
+ description to rr
+ ip address 10.0.46.0 255.255.255.254
+!
+!
+ip route 4.0.0.0 255.255.255.255 Null0
+!
+route-map rm-to-as1 deny 100
+!
+route-map rm-from-as1 permit 100
+!
+route-map rm-to-rr permit 100
+!
+route-map rm-from-rr deny 100
+!
+
+router bgp 2
+  bgp router-id 4.4.4.4
+  neighbor 10.0.14.0 remote-as 1
+  !
+  neighbor 10.0.46.1 remote-as 2
+  neighbor 10.0.46.1 update-source GigabitEthernet0/1
+  !
+  address-family ipv4 unicast
+    !
+    redistribute static
+    !
+    aggregate-address 4.0.0.0 255.255.255.254
+    !
+    neighbor 10.0.14.0 activate
+    neighbor 10.0.14.0 route-map rm-to-as1 out
+    neighbor 10.0.14.0 route-map rm-from-as1 in
+    !
+    neighbor 10.0.46.1 activate
+    neighbor 10.0.46.1 route-map rm-to-rr out
+    neighbor 10.0.46.1 route-map rm-from-rr in
+  !
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/rrcm
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/configs/rrcm
@@ -1,0 +1,39 @@
+#RANCID-CONTENT-TYPE: juniper
+#
+set system host-name rrcm
+#
+set interfaces xe-0/0/0 description "to AS1"
+set interfaces xe-0/0/0 unit 0 family inet address 10.0.15.1/31
+#
+set interfaces xe-0/0/1 description "to rr"
+set interfaces xe-0/0/1 unit 0 family inet address 10.0.56.0/31
+#
+set routing-options autonomous-system 2
+set routing-options router-id 5.5.5.5
+#
+set routing-options static route 5.0.0.0/32 discard
+set routing-options aggregate route 5.0.0.0/31
+#
+set policy-options policy-statement ps-to-as1 then reject
+#
+set policy-options policy-statement ps-from-as1 then accept
+#
+set policy-options policy-statement ps-to-rr from protocol static
+set policy-options policy-statement ps-to-rr from protocol aggregate
+set policy-options policy-statement ps-to-rr from protocol bgp
+set policy-options policy-statement ps-to-rr then accept
+#
+set policy-options policy-statement ps-from-rr then reject
+#
+set protocols bgp group e peer-as 1
+set protocols bgp group e type external
+set protocols bgp group e export ps-to-as1
+set protocols bgp group e import ps-from-as1
+set protocols bgp group e neighbor 10.0.15.0 local-address 10.0.15.1
+#
+set protocols bgp group i peer-as 2
+set protocols bgp group i type internal
+set protocols bgp group i export ps-to-rr
+set protocols bgp group i import ps-from-rr
+set protocols bgp group i neighbor 10.0.56.1 local-address 10.0.56.0
+#

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/external_bgp_announcements.json
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/route-reflection/rrrc/external_bgp_announcements.json
@@ -1,0 +1,88 @@
+{
+  "Announcements": [
+    {
+      "type": "ebgp_sent",
+      "network": "1.0.0.2/32",
+      "nextHopIp": "10.0.12.0",
+      "srcIp": "10.0.12.0",
+      "dstNode": "nrrcb",
+      "dstIp": "10.0.12.1",
+      "srcProtocol": "AGGREGATE",
+      "originType": "igp",
+      "localPreference": 0,
+      "med": 20,
+      "originatorIp": "0.0.0.0",
+      "asPath": [
+        [
+          1
+        ]
+      ],
+      "communities": [],
+      "dstVrf": "default",
+      "clusterList": []
+    },
+    {
+      "type": "ebgp_sent",
+      "network": "1.0.0.3/32",
+      "nextHopIp": "10.0.13.0",
+      "srcIp": "10.0.13.0",
+      "dstNode": "nrrcm",
+      "dstIp": "10.0.13.1",
+      "srcProtocol": "AGGREGATE",
+      "originType": "igp",
+      "localPreference": 0,
+      "med": 20,
+      "originatorIp": "0.0.0.0",
+      "asPath": [
+        [
+          1
+        ]
+      ],
+      "communities": [],
+      "dstVrf": "default",
+      "clusterList": []
+    },
+    {
+      "type": "ebgp_sent",
+      "network": "1.0.0.4/32",
+      "nextHopIp": "10.0.14.0",
+      "srcIp": "10.0.14.0",
+      "dstNode": "rrcb",
+      "dstIp": "10.0.14.1",
+      "srcProtocol": "AGGREGATE",
+      "originType": "igp",
+      "localPreference": 0,
+      "med": 20,
+      "originatorIp": "0.0.0.0",
+      "asPath": [
+        [
+          1
+        ]
+      ],
+      "communities": [],
+      "dstVrf": "default",
+      "clusterList": []
+    },
+    {
+      "type": "ebgp_sent",
+      "network": "1.0.0.5/32",
+      "nextHopIp": "10.0.15.0",
+      "srcIp": "10.0.15.0",
+      "dstNode": "rrcm",
+      "dstIp": "10.0.15.1",
+      "srcProtocol": "AGGREGATE",
+      "originType": "igp",
+      "localPreference": 0,
+      "med": 20,
+      "originatorIp": "0.0.0.0",
+      "asPath": [
+        [
+          1
+        ]
+      ],
+      "communities": [],
+      "dstVrf": "default",
+      "clusterList": []
+    }
+  ]
+}


### PR DESCRIPTION
* receivedFromRouteReflectorCllent bit was not being set in multiple cases  for routes being originated into BGP RIB
* move bit setting from postExport to preImport transformation, which makes better sense semantically and covers all gaps