### PR TITLE
NXOS: Add structure usage for service-policy under vlan configuration

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vlan.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vlan.g4
@@ -20,12 +20,12 @@ vlan_configuration
 :
   CONFIGURATION range = vlan_id_range NEWLINE
     (
-      vc_service_policy
+      vlanc_service_policy
       | vlanc_null
-    )
+    )*
 ;
 
-vc_service_policy
+vlanc_service_policy
 :
   SERVICE_POLICY vcsp_type
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vlan.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vlan.g4
@@ -18,7 +18,29 @@ s_vlan
 
 vlan_configuration
 :
-  CONFIGURATION range = vlan_id_range NEWLINE vlanc_null*
+  CONFIGURATION range = vlan_id_range NEWLINE
+    (
+      vc_service_policy
+      | vlanc_null
+    )
+;
+
+vc_service_policy
+:
+  SERVICE_POLICY vcsp_type
+;
+
+vcsp_type
+:
+  TYPE
+  (
+    vcspt_qos
+  )
+;
+
+vcspt_qos
+:
+  QOS (INPUT | OUTPUT) name = policy_map_qos_name NEWLINE
 ;
 
 vlanc_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -196,6 +196,7 @@ import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.SYSQ
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.TACACS_SOURCE_INTERFACE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.TRACK_INTERFACE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.TRACK_IP_ROUTE_VRF;
+import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.VLAN_CONFIGURATION_QOS;
 import static org.batfish.representation.cisco_nxos.Interface.VLAN_RANGE;
 import static org.batfish.representation.cisco_nxos.Interface.newNonVlanInterface;
 import static org.batfish.representation.cisco_nxos.Interface.newVlanInterface;
@@ -736,6 +737,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vc_shutdownContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vc_vniContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vcaf4u_route_targetContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vcaf6u_route_targetContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vcspt_qosContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vdc_idContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vlan_idContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vlan_id_rangeContext;
@@ -6941,6 +6943,16 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     }
     Integer vni = vniOrError.get();
     _currentVrf.setVni(vni);
+  }
+
+  @Override
+  public void exitVcspt_qos(Vcspt_qosContext ctx) {
+    Optional<String> name = toString(ctx, ctx.name);
+    if (!name.isPresent()) {
+      return;
+    }
+    _c.referenceStructure(
+        POLICY_MAP_QOS, name.get(), VLAN_CONFIGURATION_QOS, ctx.getStart().getLine());
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
@@ -162,7 +162,8 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   SYSQOS_QUEUING("system qos service-policy type queuing"),
   TACACS_SOURCE_INTERFACE("ip tacacs source-interface"),
   TRACK_INTERFACE("track interface"),
-  TRACK_IP_ROUTE_VRF("track ip route vrf");
+  TRACK_IP_ROUTE_VRF("track ip route vrf"),
+  VLAN_CONFIGURATION_QOS("vlan configuration service-policy type qos");
 
   private final @Nonnull String _description;
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -9934,4 +9934,10 @@ public final class CiscoNxosGrammarTest {
     Configuration c = batfish.loadConfigurations(batfish.getSnapshot()).get(hostname);
     assertThat(c, hasIpAccessList("foo", hasLines(empty())));
   }
+
+  @Test
+  public void testVlanServicePolicyExtraction() {
+    parseVendorConfig("nxos_vlan_service_policy");
+  }
+
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -9940,4 +9940,20 @@ public final class CiscoNxosGrammarTest {
     parseVendorConfig("nxos_vlan_service_policy");
   }
 
+  @Test
+  public void testVlanServicePolicyExtractionPolicy() throws IOException {
+    String hostname = "nxos_vlan_service_policy";
+    String filename = String.format("configs/%s", hostname);
+    Batfish bf = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ans =
+        bf.loadConvertConfigurationAnswerElementOrReparse(bf.getSnapshot());
+
+    assertThat(
+        ans,
+        hasNumReferrers(filename, CiscoNxosStructureType.POLICY_MAP_QOS, "qos-classify-used", 1));
+
+    assertThat(
+        ans,
+        hasNumReferrers(filename, CiscoNxosStructureType.POLICY_MAP_QOS, "qos-classify-unused", 0));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vlan_service_policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vlan_service_policy
@@ -5,9 +5,12 @@ hostname nxos_vlan_service_policy
 interface loopback0
  ip address 1.1.1.1/32
 !
-policy-map type qos qos-classify-lan
+policy-map type qos qos-classify-used
+ class class-default
+!
+policy-map type qos qos-classify-unused
  class class-default
 !
 vlan configuration 100
- service-policy type qos input qos-classify-lan
+ service-policy type qos input qos-classify-used
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vlan_service_policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vlan_service_policy
@@ -1,0 +1,13 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_vlan_service_policy
+!
+interface loopback0
+ ip address 1.1.1.1/32
+!
+policy-map type qos qos-classify-lan
+ class class-default
+!
+vlan configuration 100
+ service-policy type qos input qos-classify-lan
+!


### PR DESCRIPTION
Fixes #8760 
Believe the necessary test were added to validate this, didn't see any `hasUnusedStructure` type methods that could validate one is used vs unused for a new structure usage.