### PR TITLE
add support for nxos major 10

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco_nxos/NxosMajorVersion.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco_nxos/NxosMajorVersion.java
@@ -6,5 +6,6 @@ public enum NxosMajorVersion {
   NXOS6,
   NXOS7,
   NXOS9,
+  NXOS10,
   UNKNOWN
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
@@ -125,6 +125,8 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
         switch (version.charAt(1)) {
           case '0':
             return NxosMajorVersion.NXOS10;
+          default:
+            return null;
         }
       default:
         return null;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
@@ -122,7 +122,11 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
       case '9':
         return NxosMajorVersion.NXOS9;
       case '1':
-        return NxosMajorVersion.NXOS10;
+        if (version.length() >= 2 && version.charAt(1) == '0') {
+          return NxosMajorVersion.NXOS10;
+        } else {
+          return null;
+        }
       default:
         return null;
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
@@ -302,7 +302,7 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
             // https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus3600/sw/93x/interfaces/configuration/guide/b-cisco-nexus-3600-nx-os-interfaces-configuration-guide-93x/b-cisco-nexus-3600-nx-os-interfaces-configuration-guide-93x_chapter_011.html
             return true;
           case NXOS10:
-            // TODO: add link to doc
+            // https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/101x/configuration/interfaces/cisco-nexus-9000-nx-os-interfaces-configuration-guide-101x/b-cisco-nexus-9000-nx-os-interfaces-configuration-guide-93x_chapter_0101.html#:~:text=you%20would%20use.-,Default%20Settings,Admin%20state,-Shut
             return true;
           case NXOS4:
           case UNKNOWN:

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
@@ -74,9 +74,9 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
   private static final Pattern NEXUS_3K5K6K7K_IMAGE_MAJOR_VERSION_PATTERN =
       Pattern.compile(".*?[A-Za-z][0-9]\\.([0-9]).*");
   private static final Pattern NEXUS_9000_IMAGE_MAJOR_VERSION_PATTERN =
-      Pattern.compile(".*nxos\\.([0-9]|10).*");
+      Pattern.compile(".*nxos\\.(10|[0-9]).*");
   private static final Pattern KICKSTART_MAJOR_VERSION_PATTERN =
-      Pattern.compile(".*kickstart\\.([0-9]|10).*");
+      Pattern.compile(".*kickstart\\.(10|[0-9]).*");
 
   /**
    * Infers {@code NexusPlatform} of a configuration based on explicit version string or names of
@@ -122,10 +122,9 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
       case '9':
         return NxosMajorVersion.NXOS9;
       case '1':
-        if (version.length() >= 2 && version.charAt(1) == '0') {
-          return NxosMajorVersion.NXOS10;
-        } else {
-          return null;
+        switch (version.charAt(1)) {
+          case '0':
+            return NxosMajorVersion.NXOS10;
         }
       default:
         return null;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
@@ -74,9 +74,9 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
   private static final Pattern NEXUS_3K5K6K7K_IMAGE_MAJOR_VERSION_PATTERN =
       Pattern.compile(".*?[A-Za-z][0-9]\\.([0-9]).*");
   private static final Pattern NEXUS_9000_IMAGE_MAJOR_VERSION_PATTERN =
-      Pattern.compile(".*nxos\\.([0-9]).*");
+      Pattern.compile(".*nxos\\.([0-9]|10).*");
   private static final Pattern KICKSTART_MAJOR_VERSION_PATTERN =
-      Pattern.compile(".*kickstart\\.([0-9]).*");
+      Pattern.compile(".*kickstart\\.([0-9]|10).*");
 
   /**
    * Infers {@code NexusPlatform} of a configuration based on explicit version string or names of
@@ -121,6 +121,8 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
         return NxosMajorVersion.NXOS7;
       case '9':
         return NxosMajorVersion.NXOS9;
+      case '1':
+        return NxosMajorVersion.NXOS10;
       default:
         return null;
     }
@@ -182,7 +184,12 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
     // Assume that UNKNOWN means Nexus 3000/9000. Find likely default layer-3 shutdown behavior, and
     // infer platform accordingly
     if (majorVersion == NxosMajorVersion.NXOS9) {
-      // In this case, defaults are same for Nexus 3000 and Nexus 9000. So just arbitrarily chooose
+      // In this case, defaults are same for Nexus 3000 and Nexus 9000. So just arbitrarily choose
+      // Nexus 9000.
+      return NexusPlatform.NEXUS_9000;
+    }
+    if (majorVersion == NxosMajorVersion.NXOS10) {
+      // In this case, defaults are same for Nexus 3000 and Nexus 9000. So just arbitrarily choose
       // Nexus 9000.
       return NexusPlatform.NEXUS_9000;
     }
@@ -257,6 +264,7 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
 
           case NXOS7:
           case NXOS9:
+          case NXOS10:
           case UNKNOWN:
             // Assume NXOS7+ behavior arbitrarily when version is unknown.
             // Value depends on model, so just make an educated guess based on statistical analysis
@@ -288,6 +296,9 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
             return false;
           case NXOS9:
             // https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus3600/sw/93x/interfaces/configuration/guide/b-cisco-nexus-3600-nx-os-interfaces-configuration-guide-93x/b-cisco-nexus-3600-nx-os-interfaces-configuration-guide-93x_chapter_011.html
+            return true;
+          case NXOS10:
+            // TODO: add link to doc
             return true;
           case NXOS4:
           case UNKNOWN:

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessorTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform.NEXUS
 import static org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform.NEXUS_6000;
 import static org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform.NEXUS_7000;
 import static org.batfish.datamodel.vendor_family.cisco_nxos.NexusPlatform.NEXUS_9000;
+import static org.batfish.datamodel.vendor_family.cisco_nxos.NxosMajorVersion.NXOS10;
 import static org.batfish.datamodel.vendor_family.cisco_nxos.NxosMajorVersion.NXOS5;
 import static org.batfish.datamodel.vendor_family.cisco_nxos.NxosMajorVersion.NXOS6;
 import static org.batfish.datamodel.vendor_family.cisco_nxos.NxosMajorVersion.NXOS7;
@@ -162,6 +163,7 @@ public final class CiscoNxosPreprocessorTest {
     assertThat(inferMajorVersionFromImage("bootflash:/poap/nxos.7.0.3.I3.1.bin"), equalTo(NXOS7));
     assertThat(inferMajorVersionFromImage("bootflash:/nxos.9.2.1.bin"), equalTo(NXOS9));
     assertThat(inferMajorVersionFromImage("bootflash:/nxos.9.2.3.bin"), equalTo(NXOS9));
+    assertThat(inferMajorVersionFromImage("bootflash:/nxos.10.1.1.bin"), equalTo(NXOS10));
   }
 
   @Test
@@ -202,6 +204,7 @@ public final class CiscoNxosPreprocessorTest {
     assertThat(inferMajorVersionFromVersion("7.3(2)N1(1)"), equalTo(NXOS7));
     assertThat(inferMajorVersionFromVersion("9.2(1) Bios:version 05.31"), equalTo(NXOS9));
     assertThat(inferMajorVersionFromVersion("9.2(3) Bios:version"), equalTo(NXOS9));
+    assertThat(inferMajorVersionFromVersion("10.1(1) Bios:version 05.43"), equalTo(NXOS10));
   }
 
   @Test
@@ -222,6 +225,8 @@ public final class CiscoNxosPreprocessorTest {
     assertThat(inferMajorVersion(vc), equalTo(NXOS7));
     vc.setVersion("9.2.3 Bios:version");
     assertThat(inferMajorVersion(vc), equalTo(NXOS9));
+    vc.setVersion("10.1(1) Bios:version 05.43");
+    assertThat(inferMajorVersion(vc), equalTo(NXOS10));
   }
 
   @Test
@@ -375,6 +380,8 @@ public final class CiscoNxosPreprocessorTest {
         equalTo(NexusPlatform.UNKNOWN));
     assertThat(inferPlatformFromImage("bootflash:/nxos.9.2.1.bin"), equalTo(NexusPlatform.UNKNOWN));
     assertThat(inferPlatformFromImage("bootflash:/nxos.9.2.3.bin"), equalTo(NexusPlatform.UNKNOWN));
+    assertThat(
+        inferPlatformFromImage("bootflash:/nxos.10.1.1.bin"), equalTo(NexusPlatform.UNKNOWN));
   }
 
   @Test


### PR DESCRIPTION
hitting this error when I init with this config from a Cisco NX-OS device:
`java.lang.IllegalArgumentException: Unsupported major version: UNKNOWN`

It looks like this is the line the error is happening on?
```
!Command: show running-config
!Running configuration last done at: Wed Jun 28 10:02:27 2023
!Time: Wed Aug  9 18:25:19 2023

version 10.1(1) Bios:version 05.43 
```