### PR TITLE
BgpPeerConfig: _localIp should be valid or null

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -194,7 +194,13 @@ public abstract class BgpPeerConfig implements Serializable {
     return _localAs;
   }
 
-  /** The local (source) IPV4 address of this peering */
+  /**
+   * Get the IP that this peer will originate BGP sessions from and/or listen for incoming
+   * connections on.
+   *
+   * <p>If {@code null}, the IP address will be chosen dynamically among valid IPs in the vrf,
+   * perhaps by vendor's logic (e.g., lo0) or by the dest IP of an incoming BGP connection.
+   */
   @JsonProperty(PROP_LOCAL_IP)
   @Nullable
   public Ip getLocalIp() {
@@ -433,8 +439,20 @@ public abstract class BgpPeerConfig implements Serializable {
       return getThis();
     }
 
+    /**
+     * Set the IP that this peer will originate BGP sessions from and/or listen for incoming
+     * connections on.
+     *
+     * <p>If {@code null}, the IP address will be chosen dynamically among valid IPs in the vrf,
+     * perhaps by vendor's logic (e.g., lo0) or by the dest IP of an incoming BGP connection.
+     */
     public S setLocalIp(@Nullable Ip localIp) {
-      _localIp = localIp;
+      assert localIp == null || localIp.valid();
+      if (localIp != null && !localIp.valid()) {
+        _localIp = null;
+      } else {
+        _localIp = localIp;
+      }
       return getThis();
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -429,7 +429,6 @@ public final class BgpTopologyUtils {
 
     Ip localIp = config.getLocalIp();
     return localIp == null
-        || localIp.equals(Ip.AUTO) // dynamic
         || (ipOwners.containsKey(localIp)
             && ipOwners.get(localIp).getOrDefault(hostname, ImmutableSet.of()).contains(vrfName));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
@@ -341,7 +341,6 @@ public class BgpSessionPropertiesTest {
     BgpPassivePeerConfig p2 =
         BgpPassivePeerConfig.builder()
             .setPeerPrefix(Prefix.create(ip1, 24))
-            .setLocalIp(Ip.AUTO)
             .setLocalAs(as2)
             .setRemoteAs(as1)
             .setIpv4UnicastAddressFamily(addressFamily)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
@@ -119,7 +119,6 @@ public class BgpTopologyUtilsTest {
     Prefix peer2PeerPrefix = Prefix.create(ip1, 24);
     BgpPassivePeerConfig peer2 =
         BgpPassivePeerConfig.builder()
-            .setLocalIp(Ip.AUTO)
             .setLocalAs(2L)
             .setRemoteAs(1L)
             .setPeerPrefix(peer2PeerPrefix)
@@ -197,7 +196,6 @@ public class BgpTopologyUtilsTest {
     Prefix prefixForPeer1 = Prefix.create(ip1, 24);
     BgpPassivePeerConfig.Builder passivePeerBuilder =
         BgpPassivePeerConfig.builder()
-            .setLocalIp(Ip.AUTO)
             .setLocalAs(2L)
             .setRemoteAs(1L)
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -334,7 +334,7 @@ final class AristaConversions {
       }
       return address.getIp();
     } else if (dynamic) {
-      return Ip.AUTO;
+      return null;
     }
     Optional<Ip> firstMatchingInterfaceAddress =
         vrfInterfaces.values().stream()

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -827,7 +827,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       }
     } else {
       if (lpg instanceof DynamicIpBgpPeerGroup) {
-        updateSource = Ip.AUTO;
+        updateSource = null;
       } else {
         Ip neighborAddress = lpg.getNeighborPrefix().getStartIp();
         for (org.batfish.datamodel.Interface iface : c.getAllInterfaces(vrfName).values()) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -903,7 +903,7 @@ public final class AsaConfiguration extends VendorConfiguration {
       }
     } else {
       if (lpg instanceof DynamicIpBgpPeerGroup) {
-        updateSource = Ip.AUTO;
+        updateSource = null;
       } else {
         Ip neighborAddress = lpg.getNeighborPrefix().getStartIp();
         for (org.batfish.datamodel.Interface iface : c.getAllInterfaces(vrfName).values()) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -363,7 +363,7 @@ public final class Conversions {
       }
       return address.getIp();
     } else if (dynamic) {
-      return Ip.AUTO;
+      return null;
     }
     Optional<Ip> firstMatchingInterfaceAddress =
         vrfInterfaces.values().stream()

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -695,7 +695,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
       }
     } else {
       if (lpg instanceof DynamicIpBgpPeerGroup) {
-        updateSource = Ip.AUTO;
+        updateSource = null;
       } else {
         Ip neighborAddress = lpg.getNeighborPrefix().getStartIp();
         for (org.batfish.datamodel.Interface iface : c.getAllInterfaces(vrfName).values()) {

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
@@ -1,5 +1,6 @@
 package org.batfish.question.bgpsessionstatus;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.datamodel.BgpSessionProperties.getSessionType;
 import static org.batfish.datamodel.questions.ConfiguredSessionStatus.DYNAMIC_MATCH;
 import static org.batfish.datamodel.questions.ConfiguredSessionStatus.NO_MATCH_FOUND;
@@ -225,10 +226,11 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
     // - remote IP
     // - session type
     // Local and remote interface will not be filled in (reserved for unnumbered peers).
+    // Local IP is set to Ip.AUTO if null, for presentation backwards compatibility.
     Row.TypedRowBuilder rb =
         Row.builder(METADATA_MAP)
             .put(COL_LOCAL_AS, passivePeer.getLocalAs())
-            .put(COL_LOCAL_IP, passivePeer.getLocalIp())
+            .put(COL_LOCAL_IP, firstNonNull(passivePeer.getLocalIp(), Ip.AUTO))
             .put(COL_NODE, new Node(passiveId.getHostname()))
             .put(COL_REMOTE_AS, passivePeer.getRemoteAsns().toString())
             .put(

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -1,5 +1,6 @@
 package org.batfish.question.bgpsessionstatus;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.datamodel.BgpSessionProperties.getSessionType;
 import static org.batfish.datamodel.questions.BgpSessionStatus.ESTABLISHED;
 import static org.batfish.datamodel.questions.BgpSessionStatus.NOT_COMPATIBLE;
@@ -290,11 +291,12 @@ public class BgpSessionStatusAnswerer extends Answerer {
     // - remote IP
     // - session type
     // Local and remote interface will not be filled in (reserved for unnumbered peers).
+    // Local IP is set to Ip.AUTO if null, for presentation backwards compatibility.
     Row.TypedRowBuilder rb =
         Row.builder(METADATA_MAP)
             .put(COL_ADDRESS_FAMILIES, ImmutableSet.of())
             .put(COL_LOCAL_AS, passivePeer.getLocalAs())
-            .put(COL_LOCAL_IP, passivePeer.getLocalIp())
+            .put(COL_LOCAL_IP, firstNonNull(passivePeer.getLocalIp(), Ip.AUTO))
             .put(COL_NODE, new Node(passiveId.getHostname()))
             .put(COL_REMOTE_AS, passivePeer.getRemoteAsns().toString())
             .put(

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
@@ -195,7 +195,6 @@ public class BgpSessionCompatibilityAnswererTest {
     BgpPeerConfigId peerId = new BgpPeerConfigId("c1", "vrf1", remotePrefix, true);
     BgpPassivePeerConfig peer =
         BgpPassivePeerConfig.builder()
-            .setLocalIp(Ip.AUTO)
             .setPeerPrefix(remotePrefix)
             .setLocalAs(1L)
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
@@ -229,7 +228,6 @@ public class BgpSessionCompatibilityAnswererTest {
     BgpPeerConfigId peerId = new BgpPeerConfigId("c1", "vrf1", remotePrefix, true);
     BgpPassivePeerConfig peer =
         BgpPassivePeerConfig.builder()
-            .setLocalIp(Ip.AUTO)
             .setPeerPrefix(remotePrefix)
             .setLocalAs(1L)
             .setRemoteAsns(remoteAsns)
@@ -270,7 +268,6 @@ public class BgpSessionCompatibilityAnswererTest {
     BgpPeerConfigId peerId = new BgpPeerConfigId("c1", "vrf1", remotePrefix, true);
     BgpPassivePeerConfig peer =
         BgpPassivePeerConfig.builder()
-            .setLocalIp(Ip.AUTO)
             .setPeerPrefix(remotePrefix)
             .setLocalAs(1L)
             .setRemoteAsns(remoteAsns)

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswererTest.java
@@ -210,7 +210,6 @@ public class BgpSessionStatusAnswererTest {
     BgpPeerConfigId peerId = new BgpPeerConfigId("c1", "vrf1", remotePrefix, true);
     BgpPassivePeerConfig peer =
         BgpPassivePeerConfig.builder()
-            .setLocalIp(Ip.AUTO)
             .setPeerPrefix(remotePrefix)
             .setLocalAs(1L)
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
@@ -244,7 +243,6 @@ public class BgpSessionStatusAnswererTest {
     BgpPeerConfigId peerId = new BgpPeerConfigId("c1", "vrf1", remotePrefix, true);
     BgpPassivePeerConfig peer =
         BgpPassivePeerConfig.builder()
-            .setLocalIp(Ip.AUTO)
             .setPeerPrefix(remotePrefix)
             .setLocalAs(1L)
             .setRemoteAsns(remoteAsns)
@@ -370,7 +368,6 @@ public class BgpSessionStatusAnswererTest {
     BgpPeerConfigId peerId = new BgpPeerConfigId("c1", "vrf1", remotePrefix, true);
     BgpPassivePeerConfig peer =
         BgpPassivePeerConfig.builder()
-            .setLocalIp(Ip.AUTO)
             .setPeerPrefix(remotePrefix)
             .setLocalAs(1L)
             .setRemoteAsns(remoteAsns)


### PR DESCRIPTION
Some vendors use Ip.AUTO to indicate that the local IP is chosen dynamically,
but this usage is inconsistent and makes it hard to consume this code downstream.
Instead, ensure that the value of _localIp is null for dynamic IP selection,
update callers, and update presentation code that wants to use Ip.AUTO to
explain to users.

---

**Stack**:
- #8781
- #8780 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*