### PR TITLE
BGP: do not establish a session when mismatch with configured local IP

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -325,6 +325,7 @@ public final class BgpTopologyUtils {
                                     candidateId,
                                     neighbor,
                                     initiatorLocalIp,
+                                    candidate.getLocalIp(),
                                     tracerouteEngine))
                         .forEach(
                             srcIp -> addEdges(neighbor, neighborId, srcIp, candidateId, graph, nc));
@@ -628,6 +629,7 @@ public final class BgpTopologyUtils {
       @Nonnull BgpPeerConfigId listenerId,
       @Nonnull BgpActivePeerConfig initiator,
       @Nonnull Ip initiatorLocalIp,
+      @Nullable Ip listenerLocalIp,
       @Nonnull TracerouteEngine tracerouteEngine) {
     assert initiatorId.getType() == BgpPeerConfigType.ACTIVE;
     Flow flowFromSrc =
@@ -657,6 +659,11 @@ public final class BgpTopologyUtils {
             traceAndReverseFlow -> {
               Trace forwardTrace = traceAndReverseFlow.getTrace();
               return forwardTrace.getDisposition() == FlowDisposition.ACCEPTED
+                  && (listenerLocalIp == null
+                      // The src IP on the reverse flow is the actual destination IP (post any NAT)
+                      // used in the forward flow. Looking at IPs as seen by listener is most
+                      // accurate way to check this.
+                      || listenerLocalIp.equals(traceAndReverseFlow.getReverseFlow().getSrcIp()))
                   && (!bgpSingleHop || forwardTrace.getHops().size() <= 2);
             })
         .filter(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -770,9 +770,9 @@ public class IncrementalDataPlanePluginTest {
     DataPlane dp = result._dataPlane;
 
     BgpPeerConfigId initiator =
-        new BgpPeerConfigId("node1", "~Vrf_0~", Prefix.parse("1.0.0.0/32"), false);
+        new BgpPeerConfigId("node1", "~Vrf_0~", Prefix.parse("1.0.0.1/32"), false);
     BgpPeerConfigId listener =
-        new BgpPeerConfigId("node2", "~Vrf_1~", Prefix.parse("1.0.0.1/32"), false);
+        new BgpPeerConfigId("node2", "~Vrf_1~", Prefix.parse("1.0.0.0/32"), false);
 
     Ip initiatorLocalIp = Ip.parse("1.0.0.0");
     BgpActivePeerConfig source =
@@ -792,6 +792,18 @@ public class IncrementalDataPlanePluginTest {
             listener,
             source,
             initiatorLocalIp,
+            null,
+            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
+
+    // But if the listener has a local IP configured that does not match initiator's peer, will not
+    // be created
+    assertFalse(
+        BgpTopologyUtils.canEstablishBgpSession(
+            initiator,
+            listener,
+            source,
+            initiatorLocalIp,
+            Ip.parse("2.2.2.2"),
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
@@ -873,6 +885,7 @@ public class IncrementalDataPlanePluginTest {
             listener,
             source,
             initiatorLocalIp,
+            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
@@ -954,6 +967,7 @@ public class IncrementalDataPlanePluginTest {
             listener,
             source,
             initiatorLocalIp,
+            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
@@ -1039,6 +1053,7 @@ public class IncrementalDataPlanePluginTest {
             listener,
             source,
             initiatorLocalIp,
+            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
@@ -1124,6 +1139,7 @@ public class IncrementalDataPlanePluginTest {
             listener,
             source,
             initiatorLocalIp,
+            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 


### PR DESCRIPTION
If local IP is configured for a BGP peer, a listener should not create
a session to a different owned IP in the same VRF.