### PR TITLE
SemDiff question.

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/AsPathNameAsPathMatchExprCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/AsPathNameAsPathMatchExprCollector.java
@@ -1,0 +1,48 @@
+package org.batfish.minesweeper.collectors;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchAny;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchExpr;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchExprReference;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchExprVisitor;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchRegex;
+import org.batfish.datamodel.routing_policy.as_path.AsSetsMatchingRanges;
+import org.batfish.datamodel.routing_policy.as_path.HasAsPathLength;
+
+/** Collect all AS-path list names in a {@link AsPathMatchExpr}. */
+@ParametersAreNonnullByDefault
+public class AsPathNameAsPathMatchExprCollector
+    implements AsPathMatchExprVisitor<Set<String>, Configuration> {
+
+  @Override
+  public Set<String> visitAsPathMatchAny(AsPathMatchAny asPathMatchAny, Configuration arg) {
+    return asPathMatchAny.getDisjuncts().stream()
+        .flatMap(expr -> expr.accept(this, arg).stream())
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Override
+  public Set<String> visitAsPathMatchExprReference(
+      AsPathMatchExprReference asPathMatchExprReference, Configuration arg) {
+    return ImmutableSet.of(asPathMatchExprReference.getName());
+  }
+
+  @Override
+  public Set<String> visitAsPathMatchRegex(AsPathMatchRegex asPathMatchRegex, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitAsSetsMatchingRanges(
+      AsSetsMatchingRanges asSetsMatchingRanges, Configuration arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitHasAsPathLength(HasAsPathLength hasAsPathLength, Configuration arg) {
+    return ImmutableSet.of();
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/AsPathNameBooleanExprCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/AsPathNameBooleanExprCollector.java
@@ -1,0 +1,36 @@
+package org.batfish.minesweeper.collectors;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchExpr;
+import org.batfish.datamodel.routing_policy.as_path.MatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.AsPathSetExpr;
+import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
+import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.NamedAsPathSet;
+import org.batfish.minesweeper.aspath.BooleanExprMatchCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/** Collect all AS-path list names in a {@link BooleanExpr}. */
+@ParametersAreNonnullByDefault
+public class AsPathNameBooleanExprCollector extends BooleanExprMatchCollector<String> {
+
+  @Override
+  public Set<String> visitMatchAsPath(
+      MatchAsPath matchAsPath, Tuple<Set<String>, Configuration> arg) {
+    AsPathMatchExpr matchExpr = matchAsPath.getAsPathMatchExpr();
+    return matchExpr.accept(new AsPathNameAsPathMatchExprCollector(), arg.getSecond());
+  }
+
+  @Override
+  public Set<String> visitMatchLegacyAsPath(
+      LegacyMatchAsPath legacyMatchAsPath, Tuple<Set<String>, Configuration> arg) {
+    AsPathSetExpr expr = legacyMatchAsPath.getExpr();
+    if (expr instanceof NamedAsPathSet) {
+      return ImmutableSet.of(((NamedAsPathSet) expr).getName());
+    }
+    return ImmutableSet.of();
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/CommunityBooleanExprCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/CommunityBooleanExprCollector.java
@@ -1,0 +1,64 @@
+package org.batfish.minesweeper.collectors;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
+import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
+import org.batfish.datamodel.routing_policy.expr.CallExpr;
+import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
+import org.batfish.minesweeper.aspath.BooleanExprMatchCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/** Collect all community-list names in a {@link BooleanExpr}. */
+@ParametersAreNonnullByDefault
+public class CommunityBooleanExprCollector extends BooleanExprMatchCollector<String> {
+
+  @Override
+  public Set<String> visitMatchCommunities(
+      MatchCommunities matchCommunities, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.<String>builder()
+        .addAll(matchCommunities.getCommunitySetExpr().accept(new CommunitySetExprCollector(), arg))
+        .addAll(
+            matchCommunities
+                .getCommunitySetMatchExpr()
+                .accept(new CommunitySetMatchExprCollector(), arg))
+        .build();
+  }
+
+  @Override
+  public Set<String> visitCallExpr(CallExpr callExpr, Tuple<Set<String>, Configuration> arg) {
+    if (arg.getFirst().contains(callExpr.getCalledPolicyName())) {
+      // If we have already visited this policy then don't visit again
+      return ImmutableSet.of();
+    }
+    // Otherwise update the set of seen policies and recurse.
+    arg.getFirst().add(callExpr.getCalledPolicyName());
+
+    return new RoutingPolicyStatementCommunityCollector()
+        .visitAll(
+            arg.getSecond()
+                .getRoutingPolicies()
+                .get(callExpr.getCalledPolicyName())
+                .getStatements(),
+            arg);
+  }
+
+  @Override
+  public Set<String> visitWithEnvironmentExpr(
+      WithEnvironmentExpr withEnvironmentExpr, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.<String>builder()
+        .addAll(withEnvironmentExpr.getExpr().accept(this, arg))
+        .addAll(
+            new RoutingPolicyStatementCommunityCollector()
+                .visitAll(withEnvironmentExpr.getPreStatements(), arg))
+        .addAll(
+            new RoutingPolicyStatementCommunityCollector()
+                .visitAll(withEnvironmentExpr.getPostStatements(), arg))
+        .addAll(
+            new RoutingPolicyStatementCommunityCollector()
+                .visitAll(withEnvironmentExpr.getPostTrueStatements(), arg))
+        .build();
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/CommunityMatchExprCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/CommunityMatchExprCollector.java
@@ -1,0 +1,214 @@
+package org.batfish.minesweeper.collectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.batfish.common.BatfishException;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.communities.AllExtendedCommunities;
+import org.batfish.datamodel.routing_policy.communities.AllLargeCommunities;
+import org.batfish.datamodel.routing_policy.communities.AllStandardCommunities;
+import org.batfish.datamodel.routing_policy.communities.CommunityAcl;
+import org.batfish.datamodel.routing_policy.communities.CommunityAclLine;
+import org.batfish.datamodel.routing_policy.communities.CommunityIn;
+import org.batfish.datamodel.routing_policy.communities.CommunityIs;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchAll;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchAny;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprVisitor;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.CommunityNot;
+import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorHighMatch;
+import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorLowMatch;
+import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorMatch;
+import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityLocalAdministratorMatch;
+import org.batfish.datamodel.routing_policy.communities.OpaqueExtendedCommunities;
+import org.batfish.datamodel.routing_policy.communities.RouteTargetExtendedCommunities;
+import org.batfish.datamodel.routing_policy.communities.SiteOfOriginExtendedCommunities;
+import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighMatch;
+import org.batfish.datamodel.routing_policy.communities.StandardCommunityLowMatch;
+import org.batfish.datamodel.routing_policy.communities.VpnDistinguisherExtendedCommunities;
+import org.batfish.minesweeper.utils.Tuple;
+
+/**
+ * Collect all community-list names in a {@link CommunityMatchExpr}. The visitor takes as argument a
+ * set of seen community names (used to break out of potential infinite loops in a malformed
+ * snapshot) and a Batfish {@link Configuration} used to dereference some community expressions.
+ */
+@ParametersAreNonnullByDefault
+public class CommunityMatchExprCollector
+    implements CommunityMatchExprVisitor<Set<String>, Tuple<Set<String>, Configuration>> {
+
+  private static final Logger LOGGER = LogManager.getLogger(CommunityMatchExprCollector.class);
+
+  @Override
+  public Set<String> visitAllExtendedCommunities(
+      AllExtendedCommunities allExtendedCommunities, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitAllLargeCommunities(
+      AllLargeCommunities allLargeCommunities, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitAllStandardCommunities(
+      AllStandardCommunities allStandardCommunities, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitCommunityAcl(
+      CommunityAcl communityAcl, Tuple<Set<String>, Configuration> arg) {
+    return visitAll(
+        communityAcl.getLines().stream()
+            .map(CommunityAclLine::getCommunityMatchExpr)
+            .collect(ImmutableList.toImmutableList()),
+        arg);
+  }
+
+  @Override
+  public Set<String> visitCommunityIn(
+      CommunityIn communityIn, Tuple<Set<String>, Configuration> arg) {
+    return communityIn.getCommunitySetExpr().accept(new CommunitySetExprCollector(), arg);
+  }
+
+  @Override
+  public Set<String> visitCommunityIs(
+      CommunityIs communityIs, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitCommunityMatchAll(
+      CommunityMatchAll communityMatchAll, Tuple<Set<String>, Configuration> arg) {
+    return visitAll(communityMatchAll.getExprs(), arg);
+  }
+
+  @Override
+  public Set<String> visitCommunityMatchAny(
+      CommunityMatchAny communityMatchAny, Tuple<Set<String>, Configuration> arg) {
+    return visitAll(communityMatchAny.getExprs(), arg);
+  }
+
+  @Override
+  public Set<String> visitCommunityMatchExprReference(
+      CommunityMatchExprReference communityMatchExprReference,
+      Tuple<Set<String>, Configuration> arg) {
+    String name = communityMatchExprReference.getName();
+    // In case we have already dereferenced this community in this visit, issue a warning and return
+    // an empty set.
+    if (arg.getFirst().contains(name)) {
+      LOGGER.warn("Cycle detected in communities - this denotes a malformed snapshot.");
+      return ImmutableSet.of();
+    }
+
+    CommunityMatchExpr matchExpr = arg.getSecond().getCommunityMatchExprs().get(name);
+    if (matchExpr == null) {
+      throw new BatfishException("Cannot find community match expression: " + name);
+    }
+
+    // Add this name to set of seen references.
+    Set<String> newSeen = new HashSet<>(arg.getFirst());
+    newSeen.add(name);
+    return ImmutableSet.<String>builder()
+        .add(name)
+        .addAll(matchExpr.accept(this, new Tuple<>(newSeen, arg.getSecond())))
+        .build();
+  }
+
+  @Override
+  public Set<String> visitCommunityMatchRegex(
+      CommunityMatchRegex communityMatchRegex, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitCommunityNot(
+      CommunityNot communityNot, Tuple<Set<String>, Configuration> arg) {
+    return communityNot.getExpr().accept(this, arg);
+  }
+
+  @Override
+  public Set<String> visitExtendedCommunityGlobalAdministratorHighMatch(
+      ExtendedCommunityGlobalAdministratorHighMatch extendedCommunityGlobalAdministratorHighMatch,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitExtendedCommunityGlobalAdministratorLowMatch(
+      ExtendedCommunityGlobalAdministratorLowMatch extendedCommunityGlobalAdministratorLowMatch,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitExtendedCommunityGlobalAdministratorMatch(
+      ExtendedCommunityGlobalAdministratorMatch extendedCommunityGlobalAdministratorMatch,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitExtendedCommunityLocalAdministratorMatch(
+      ExtendedCommunityLocalAdministratorMatch extendedCommunityLocalAdministratorMatch,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitOpaqueExtendedCommunities(
+      OpaqueExtendedCommunities opaqueExtendedCommunities, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitRouteTargetExtendedCommunities(
+      RouteTargetExtendedCommunities routeTargetExtendedCommunities,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitSiteOfOriginExtendedCommunities(
+      SiteOfOriginExtendedCommunities siteOfOriginExtendedCommunities,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitStandardCommunityHighMatch(
+      StandardCommunityHighMatch standardCommunityHighMatch,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitStandardCommunityLowMatch(
+      StandardCommunityLowMatch standardCommunityLowMatch, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitVpnDistinguisherExtendedCommunities(
+      VpnDistinguisherExtendedCommunities vpnDistinguisherExtendedCommunities,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  private Set<String> visitAll(
+      Collection<CommunityMatchExpr> exprs, Tuple<Set<String>, Configuration> arg) {
+    return exprs.stream()
+        .flatMap(expr -> expr.accept(this, arg).stream())
+        .collect(ImmutableSet.toImmutableSet());
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/CommunitySetExprCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/CommunitySetExprCollector.java
@@ -1,0 +1,96 @@
+package org.batfish.minesweeper.collectors;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.batfish.common.BatfishException;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.communities.CommunityExprsSet;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExprVisitor;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetUnion;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
+import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
+import org.batfish.minesweeper.utils.Tuple;
+
+/** Collect all community-lists referenced in a {@link CommunitySetExpr}. */
+@ParametersAreNonnullByDefault
+public class CommunitySetExprCollector
+    implements CommunitySetExprVisitor<Set<String>, Tuple<Set<String>, Configuration>> {
+
+  private static final Logger LOGGER = LogManager.getLogger(CommunitySetExprCollector.class);
+
+  @Override
+  public Set<String> visitCommunityExprsSet(
+      CommunityExprsSet communityExprsSet, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitCommunitySetDifference(
+      CommunitySetDifference communitySetDifference, Tuple<Set<String>, Configuration> arg) {
+    Set<String> s1 = communitySetDifference.getInitial().accept(this, arg);
+    Set<String> s2 =
+        communitySetDifference.getRemovalCriterion().accept(new CommunityMatchExprCollector(), arg);
+    return ImmutableSet.<String>builder().addAll(s1).addAll(s2).build();
+  }
+
+  @Override
+  public Set<String> visitCommunitySetExprReference(
+      CommunitySetExprReference communitySetExprReference, Tuple<Set<String>, Configuration> arg) {
+    String name = communitySetExprReference.getName();
+    // In case we have already dereferenced this community in this visit, issue a warning and return
+    // an empty set.
+    if (arg.getFirst().contains(name)) {
+      LOGGER.warn("Cycle detected in communities - this denotes a malformed snapshot.");
+      return ImmutableSet.of();
+    }
+
+    CommunitySetExpr setExpr = arg.getSecond().getCommunitySetExprs().get(name);
+    if (setExpr == null) {
+      throw new BatfishException("Cannot find community set expression: " + name);
+    }
+
+    // Add this name to set of seen references.
+    Set<String> newSeen = new HashSet<>(arg.getFirst());
+    newSeen.add(name);
+
+    return ImmutableSet.<String>builder()
+        .add(name)
+        .addAll(setExpr.accept(this, new Tuple<>(newSeen, arg.getSecond())))
+        .build();
+  }
+
+  @Override
+  public Set<String> visitCommunitySetReference(
+      CommunitySetReference communitySetReference, Tuple<Set<String>, Configuration> arg) {
+    String name = communitySetReference.getName();
+    return ImmutableSet.of(name);
+  }
+
+  @Override
+  public Set<String> visitCommunitySetUnion(
+      CommunitySetUnion communitySetUnion, Tuple<Set<String>, Configuration> arg) {
+    return communitySetUnion.getExprs().stream()
+        .flatMap(e -> e.accept(this, arg).stream())
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Override
+  public Set<String> visitInputCommunities(
+      InputCommunities inputCommunities, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitLiteralCommunitySet(
+      LiteralCommunitySet literalCommunitySet, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/CommunitySetMatchExprCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/CommunitySetMatchExprCollector.java
@@ -1,0 +1,109 @@
+package org.batfish.minesweeper.collectors;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetAcl;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetAclLine;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAll;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAny;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprVisitor;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetNot;
+import org.batfish.datamodel.routing_policy.communities.HasCommunity;
+import org.batfish.datamodel.routing_policy.communities.HasSize;
+import org.batfish.minesweeper.utils.Tuple;
+
+/** Collect all community-list names in a {@link CommunitySetMatchExpr}. */
+@ParametersAreNonnullByDefault
+public class CommunitySetMatchExprCollector
+    implements CommunitySetMatchExprVisitor<Set<String>, Tuple<Set<String>, Configuration>> {
+  private static final Logger LOGGER = LogManager.getLogger(CommunitySetMatchExprCollector.class);
+
+  @Override
+  public Set<String> visitCommunitySetAcl(
+      CommunitySetAcl communitySetAcl, Tuple<Set<String>, Configuration> arg) {
+    return visitAll(
+        communitySetAcl.getLines().stream()
+            .map(CommunitySetAclLine::getCommunitySetMatchExpr)
+            .collect(ImmutableList.toImmutableList()),
+        arg);
+  }
+
+  @Override
+  public Set<String> visitCommunitySetMatchAll(
+      CommunitySetMatchAll communitySetMatchAll, Tuple<Set<String>, Configuration> arg) {
+    return visitAll(communitySetMatchAll.getExprs(), arg);
+  }
+
+  @Override
+  public Set<String> visitCommunitySetMatchAny(
+      CommunitySetMatchAny communitySetMatchAny, Tuple<Set<String>, Configuration> arg) {
+    return visitAll(communitySetMatchAny.getExprs(), arg);
+  }
+
+  @Override
+  public Set<String> visitCommunitySetMatchExprReference(
+      CommunitySetMatchExprReference communitySetMatchExprReference,
+      Tuple<Set<String>, Configuration> arg) {
+    String name = communitySetMatchExprReference.getName();
+    // In case we have already dereferenced this community in this visit, issue a warning and return
+    // an empty set.
+    if (arg.getFirst().contains(name)) {
+      LOGGER.warn("Cycle detected in communities - this denotes a malformed snapshot.");
+      return ImmutableSet.of();
+    }
+    CommunitySetMatchExpr expr = arg.getSecond().getCommunitySetMatchExprs().get(name);
+    // Expr should exist, enforced during conversion by CommunityStructuresVerifier.
+    checkState(expr != null, "Undefined reference in community exprs should not be possible");
+
+    // Add this name to set of seen references.
+    Set<String> newSeen = new HashSet<>(arg.getFirst());
+    newSeen.add(name);
+
+    return ImmutableSet.<String>builder()
+        .add(name)
+        .addAll(expr.accept(this, new Tuple<>(newSeen, arg.getSecond())))
+        .build();
+  }
+
+  @Override
+  public Set<String> visitCommunitySetMatchRegex(
+      CommunitySetMatchRegex communitySetMatchRegex, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitCommunitySetNot(
+      CommunitySetNot communitySetNot, Tuple<Set<String>, Configuration> arg) {
+    return communitySetNot.getExpr().accept(this, arg);
+  }
+
+  @Override
+  public Set<String> visitHasCommunity(
+      HasCommunity hasCommunity, Tuple<Set<String>, Configuration> arg) {
+    return hasCommunity.getExpr().accept(new CommunityMatchExprCollector(), arg);
+  }
+
+  @Override
+  public Set<String> visitHasSize(HasSize hasSize, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  private Set<String> visitAll(
+      Collection<CommunitySetMatchExpr> exprs, Tuple<Set<String>, Configuration> arg) {
+    return exprs.stream()
+        .flatMap(expr -> expr.accept(this, arg).stream())
+        .collect(ImmutableSet.toImmutableSet());
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RouteFilterBooleanExprCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RouteFilterBooleanExprCollector.java
@@ -1,0 +1,34 @@
+package org.batfish.minesweeper.collectors;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
+import org.batfish.datamodel.routing_policy.expr.HasRoute;
+import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
+import org.batfish.minesweeper.aspath.BooleanExprMatchCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/** Collect all prefix-list names in a {@link BooleanExpr}. */
+@ParametersAreNonnullByDefault
+public class RouteFilterBooleanExprCollector extends BooleanExprMatchCollector<String> {
+
+  @Override
+  public Set<String> visitHasRoute(HasRoute hasRoute, Tuple<Set<String>, Configuration> arg) {
+    if (hasRoute.getExpr() instanceof NamedPrefixSet) {
+      return ImmutableSet.of(((NamedPrefixSet) hasRoute.getExpr()).getName());
+    }
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> visitMatchPrefixSet(
+      MatchPrefixSet matchPrefixSet, Tuple<Set<String>, Configuration> arg) {
+    if (matchPrefixSet.getPrefixSet() instanceof NamedPrefixSet) {
+      return ImmutableSet.of(((NamedPrefixSet) matchPrefixSet.getPrefixSet()).getName());
+    }
+    return ImmutableSet.of();
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RoutePolicyBooleanExprCallCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RoutePolicyBooleanExprCallCollector.java
@@ -1,0 +1,39 @@
+package org.batfish.minesweeper.collectors;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.expr.CallExpr;
+import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
+import org.batfish.minesweeper.aspath.BooleanExprMatchCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/**
+ * Collects the names of all policies *directly* called in a {@link
+ * org.batfish.datamodel.routing_policy.expr.BooleanExpr}. By this, we mean it only returns the
+ * calls made by the original policy, excluding any other policy calls made by the callees.
+ */
+public final class RoutePolicyBooleanExprCallCollector extends BooleanExprMatchCollector<String> {
+
+  @Override
+  public Set<String> visitCallExpr(CallExpr callExpr, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of(callExpr.getCalledPolicyName());
+  }
+
+  @Override
+  public Set<String> visitWithEnvironmentExpr(
+      WithEnvironmentExpr withEnvironmentExpr, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.<String>builder()
+        .addAll(withEnvironmentExpr.getExpr().accept(this, arg))
+        .addAll(
+            new RoutePolicyStatementCallCollector()
+                .visitAll(withEnvironmentExpr.getPreStatements(), arg))
+        .addAll(
+            new RoutePolicyStatementCallCollector()
+                .visitAll(withEnvironmentExpr.getPostStatements(), arg))
+        .addAll(
+            new RoutePolicyStatementCallCollector()
+                .visitAll(withEnvironmentExpr.getPostTrueStatements(), arg))
+        .build();
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RoutePolicyStatementCallCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RoutePolicyStatementCallCollector.java
@@ -1,0 +1,28 @@
+package org.batfish.minesweeper.collectors;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.statement.CallStatement;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.minesweeper.aspath.RoutePolicyStatementMatchCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/**
+ * Collects the names of all policies *directly* called in a {@link Statement}. By this, we mean it
+ * only returns the calls made by the original policy, excluding any other policy calls made by the
+ * callees.
+ */
+public final class RoutePolicyStatementCallCollector
+    extends RoutePolicyStatementMatchCollector<String> {
+
+  public RoutePolicyStatementCallCollector() {
+    super(new RoutePolicyBooleanExprCallCollector());
+  }
+
+  @Override
+  public Set<String> visitCallStatement(
+      CallStatement callStatement, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of(callStatement.getCalledPolicyName());
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RoutingPolicyStatementCommunityCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RoutingPolicyStatementCommunityCollector.java
@@ -1,0 +1,24 @@
+package org.batfish.minesweeper.collectors;
+
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.communities.SetCommunities;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.minesweeper.aspath.RoutePolicyStatementMatchCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/** Collect all community-list names in a route-policy {@link Statement}. */
+@ParametersAreNonnullByDefault
+public class RoutingPolicyStatementCommunityCollector
+    extends RoutePolicyStatementMatchCollector<String> {
+  public RoutingPolicyStatementCommunityCollector() {
+    super(new CommunityBooleanExprCollector());
+  }
+
+  @Override
+  public Set<String> visitSetCommunities(
+      SetCommunities setCommunities, Tuple<Set<String>, Configuration> arg) {
+    return setCommunities.getCommunitySetExpr().accept(new CommunitySetExprCollector(), arg);
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RoutingPolicyStatementRouteFilterCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/collectors/RoutingPolicyStatementRouteFilterCollector.java
@@ -1,0 +1,14 @@
+package org.batfish.minesweeper.collectors;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.minesweeper.aspath.RoutePolicyStatementMatchCollector;
+
+/** Collect all prefix-list names in a route-policy {@link Statement}. */
+@ParametersAreNonnullByDefault
+public class RoutingPolicyStatementRouteFilterCollector
+    extends RoutePolicyStatementMatchCollector<String> {
+  public RoutingPolicyStatementRouteFilterCollector() {
+    super(new RouteFilterBooleanExprCollector());
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswerer.java
@@ -1,0 +1,37 @@
+package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.batfish.common.Answerer;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.datamodel.table.Row;
+import org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesAnswerer;
+import org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer;
+
+public class ComparePeerGroupPoliciesAnswerer extends Answerer {
+
+  public ComparePeerGroupPoliciesAnswerer(Question question, IBatfish batfish) {
+    super(question, batfish);
+  }
+
+  /** This question is only working in Differential mode. */
+  @Override
+  public AnswerElement answer(NetworkSnapshot snapshot) {
+
+    throw new UnsupportedOperationException(
+        "SemDiff is only meant to be used in differential mode.");
+  }
+
+  @Override
+  public AnswerElement answerDiff(NetworkSnapshot snapshot, NetworkSnapshot reference) {
+    List<Row> answers =
+        ComparePeerGroupPoliciesUtils.getDifferencesStream(_batfish, snapshot, reference)
+            .map(t -> TestRoutePoliciesAnswerer.toCompareRow(t.getFirst(), t.getSecond()))
+            .collect(ImmutableList.toImmutableList());
+
+    return CompareRoutePoliciesAnswerer.toTableAnswer(_question, answers);
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesPlugin.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesPlugin.java
@@ -1,0 +1,21 @@
+package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import com.google.auto.service.AutoService;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.Plugin;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.question.QuestionPlugin;
+
+@AutoService(Plugin.class)
+public class ComparePeerGroupPoliciesPlugin extends QuestionPlugin {
+  @Override
+  protected Answerer createAnswerer(Question question, IBatfish batfish) {
+    return new ComparePeerGroupPoliciesAnswerer(question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new ComparePeerGroupPoliciesQuestion();
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesQuestion.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesQuestion.java
@@ -1,0 +1,18 @@
+package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import org.batfish.datamodel.questions.Question;
+
+public class ComparePeerGroupPoliciesQuestion extends Question {
+
+  public ComparePeerGroupPoliciesQuestion() {}
+
+  @Override
+  public boolean getDataPlane() {
+    return false;
+  }
+
+  @Override
+  public String getName() {
+    return "SemDiff";
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
@@ -1,0 +1,179 @@
+package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.BgpPeerConfig;
+import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.questions.BgpRoute;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesAnswerer;
+import org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesQuestion;
+import org.batfish.minesweeper.utils.Tuple;
+import org.batfish.question.testroutepolicies.Result;
+
+public final class ComparePeerGroupPoliciesUtils {
+
+  /**
+   * @param batfish the batfish object
+   * @param snapshot the current snapshot
+   * @param reference the reference snapshot
+   * @return a stream of all the BGP policy semantic differences between the two snapshots. For
+   *     every node in both snapshots, and for every peer group that appears in both snapshots we
+   *     use CRP to compare their policies across the snapshots and add to the stream any pair of
+   *     policies that are different. See {@link CompareRoutePoliciesAnswerer} for more details on
+   *     the comparison of two policies.
+   */
+  public static Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> getDifferencesStream(
+      IBatfish batfish, NetworkSnapshot snapshot, NetworkSnapshot reference) {
+    // Find the candidate differences based on a syntactic check.
+    Map<SyntacticDifference, SortedSet<String>> candidates =
+        findDifferenceCandidates(batfish, snapshot, reference);
+
+    Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> answers =
+        Stream.<Tuple<Result<BgpRoute>, Result<BgpRoute>>>builder().build();
+
+    for (Map.Entry<SyntacticDifference, SortedSet<String>> entry : candidates.entrySet()) {
+      SyntacticDifference candidate = entry.getKey();
+      String representativeDevice = entry.getValue().first();
+      // For each potential difference running CompareRoutePolicies
+      CompareRoutePoliciesQuestion crpQ =
+          new CompareRoutePoliciesQuestion(
+              Environment.Direction.IN,
+              candidate.getCurrentPolicy().getName(),
+              candidate.getReferencePolicy().getName(),
+              representativeDevice);
+
+      CompareRoutePoliciesAnswerer crpAnswerer = new CompareRoutePoliciesAnswerer(crpQ, batfish);
+      answers =
+          Stream.concat(answers, crpAnswerer.getUtils().getDifferencesStream(snapshot, reference));
+    }
+
+    return answers;
+  }
+
+  /**
+   * @param router The router for which we are comparing routing policies
+   * @param currentPolicy the name policy of the new snapshot
+   * @param referencePolicy the name policy of the reference snapshot
+   * @param syntacticCompare A syntactic comparator.
+   * @param differences A map tracking the syntactic differences. The keys of the map represent
+   *     syntactic differences and the values are the sets of devices they appear on.
+   */
+  private static void trackDifference(
+      String router,
+      String currentPolicy,
+      String referencePolicy,
+      SyntacticCompare syntacticCompare,
+      Map<SyntacticDifference, SortedSet<String>> differences) {
+    if (!syntacticCompare.areEqual(currentPolicy, referencePolicy)) {
+      SyntacticDifference d =
+          new SyntacticDifference(
+              syntacticCompare.getCurrentConfig().getRoutingPolicies().get(currentPolicy),
+              syntacticCompare.getReferenceConfig().getRoutingPolicies().get(referencePolicy),
+              syntacticCompare.getContextDiff());
+      SortedSet<String> routers = differences.computeIfAbsent(d, k -> new TreeSet<>());
+      routers.add(router);
+    }
+  }
+
+  /**
+   * @param batfish the batfish object
+   * @param snapshot The current snapshot
+   * @param reference The reference snapshot
+   * @return A map from potential differences to the devices they appear on.
+   */
+  private static SortedMap<SyntacticDifference, SortedSet<String>> findDifferenceCandidates(
+      IBatfish batfish, NetworkSnapshot snapshot, NetworkSnapshot reference) {
+    SortedMap<String, Configuration> currentConfigs =
+        batfish.getProcessedConfigurations(snapshot).orElse(batfish.loadConfigurations(snapshot));
+    SortedMap<String, Configuration> referenceConfigs =
+        batfish.getProcessedConfigurations(reference).orElse(batfish.loadConfigurations(reference));
+
+    // Routing policies that are potentially different. Maps them to the devices they live on.
+    SortedMap<SyntacticDifference, SortedSet<String>> candidates = new TreeMap<>();
+
+    // Go through every device in the current snapshot
+    for (Map.Entry<String, Configuration> current : currentConfigs.entrySet()) {
+      String router = current.getKey();
+      Configuration currentConfig = current.getValue();
+      Configuration refConfig = referenceConfigs.get(current.getKey());
+      // If the device is also present in the reference snapshot
+      if (refConfig != null) {
+        // Find out what changed in the route-maps of this device.
+
+        SyntacticCompare syntacticCompare = new SyntacticCompare(currentConfig, refConfig);
+        for (Vrf vrf : currentConfig.getVrfs().values()) {
+          // Each peerGroup has multiple peers that have uniform policy. We keep this set of
+          // peerGroup's seen to
+          // ignore tracking a difference for the same peerGroup twice.
+          Set<String> peerGroupsSeen = new HashSet<>();
+          Vrf refVrf = refConfig.getVrfs().get(vrf.getName());
+          if (refVrf != null) {
+            // Compare the BGP peering policies on this VRF.
+            BgpProcess bgp = vrf.getBgpProcess();
+            if (bgp != null) {
+              // If there is a BGP process on the device in the current snapshot.
+              for (BgpPeerConfig peer : bgp.getAllPeerConfigs()) {
+                // If we have already covered this peerGroup then we do not to compare policies
+                // again.
+                if (!peerGroupsSeen.contains(peer.getGroup())) {
+                  // Find the config for the same peer in the reference snapshot.
+                  Optional<BgpPeerConfig> refPeer =
+                      refVrf
+                          .getBgpProcess()
+                          .allPeerConfigsStream()
+                          .filter(
+                              p -> {
+                                assert p.getGroup() != null;
+                                return p.getGroup().equals(peer.getGroup());
+                              })
+                          .findFirst();
+
+                  if (refPeer.isPresent()) {
+                    // The peer is in both snapshots. Check if the export policy used in both
+                    // snapshots is syntactically
+                    // the same.
+                    if ((peer.getIpv4UnicastAddressFamily().getExportPolicy() != null)
+                        && (refPeer.get().getIpv4UnicastAddressFamily().getExportPolicy()
+                            != null)) {
+                      trackDifference(
+                          router,
+                          peer.getIpv4UnicastAddressFamily().getExportPolicy(),
+                          refPeer.get().getIpv4UnicastAddressFamily().getExportPolicy(),
+                          syntacticCompare,
+                          candidates);
+                    }
+                    // Likewise for the import policy.
+                    if ((peer.getIpv4UnicastAddressFamily().getImportPolicy() != null)
+                        && (refPeer.get().getIpv4UnicastAddressFamily().getImportPolicy()
+                            != null)) {
+                      trackDifference(
+                          router,
+                          peer.getIpv4UnicastAddressFamily().getImportPolicy(),
+                          refPeer.get().getIpv4UnicastAddressFamily().getImportPolicy(),
+                          syntacticCompare,
+                          candidates);
+                    }
+                    peerGroupsSeen.add(peer.getGroup());
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return candidates;
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/RoutingPolicyContextDiff.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/RoutingPolicyContextDiff.java
@@ -1,0 +1,134 @@
+package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.minesweeper.aspath.RoutePolicyStatementMatchCollector;
+import org.batfish.minesweeper.collectors.AsPathNameBooleanExprCollector;
+import org.batfish.minesweeper.collectors.RoutingPolicyStatementCommunityCollector;
+import org.batfish.minesweeper.collectors.RoutingPolicyStatementRouteFilterCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/**
+ * This class describes the diff of the context (prefix-lists, community-lists, as-path lists)
+ * between two configurations. This is a purely syntactic diff.
+ *
+ * <p>It is meant to be used via the method {@link RoutingPolicyContextDiff#differ(RoutingPolicy)}
+ * which "projects" the context difference on a given routing-policy: If there are no differences in
+ * the definitions used by policy {@link RoutingPolicyContextDiff#differ(RoutingPolicy)} returns
+ * false, even if there are differences in other definitions that do not appear in policy.
+ *
+ * <p>Note: {@link RoutingPolicyContextDiff#differ(RoutingPolicy)} does not perform a recursive
+ * exploration of policy calls. If you want a full syntactic difference, including the context and
+ * statements of a routing policy, you should use {@link SyntacticCompare}.
+ */
+public final class RoutingPolicyContextDiff {
+  private final Configuration _currentConfig;
+
+  /** The set of community lists that differ between the two configurations. */
+  private final Set<String> _communityListsDiff;
+
+  /** The set of as-path access lists that differ between the two configurations. */
+  private final Set<String> _asPathAccessListsDiff;
+
+  /** The set of prefix lists that differ between the two configurations. */
+  private final Set<String> _routeFilterListsDiff;
+
+  public RoutingPolicyContextDiff(Configuration currentConfig, Configuration referenceConfig) {
+    this._currentConfig = currentConfig;
+    this._communityListsDiff =
+        mapDiffKeys(
+            currentConfig.getCommunitySetMatchExprs(), referenceConfig.getCommunitySetMatchExprs());
+    this._communityListsDiff.addAll(
+        mapDiffKeys(currentConfig.getCommunitySetExprs(), referenceConfig.getCommunitySetExprs()));
+    this._communityListsDiff.addAll(
+        mapDiffKeys(
+            currentConfig.getCommunityMatchExprs(), referenceConfig.getCommunityMatchExprs()));
+    this._asPathAccessListsDiff =
+        mapDiffKeys(currentConfig.getAsPathAccessLists(), referenceConfig.getAsPathAccessLists());
+    this._routeFilterListsDiff =
+        mapDiffKeys(currentConfig.getRouteFilterLists(), referenceConfig.getRouteFilterLists());
+  }
+
+  /**
+   * @param first a map from K to V
+   * @param second another map from K to V
+   * @return the set of keys for which the value V differs between the two maps (including keys
+   *     missing from one map).
+   */
+  private <K, V> Set<K> mapDiffKeys(Map<K, V> first, Map<K, V> second) {
+    Set<K> diff = new HashSet<>();
+    Set<K> keys = new HashSet<>(first.keySet());
+    keys.addAll(second.keySet());
+    for (K key : keys) {
+      V fv = first.get(key);
+      V sv = second.get(key);
+      if (!Objects.equals(fv, sv)) {
+        diff.add(key);
+      }
+    }
+    return diff;
+  }
+
+  /**
+   * This method only looks through the names used by the currentConfig (and the currentPolicy).
+   * This is because it assumes that the referencePolicy and currentPolicy are syntactically equal,
+   * hence there is no point in also looking for references used through the referencePolicy. Note
+   * that if the given policy calls other routing policies, the contexts of these won't be
+   * automatically recursively checked for equality by this method. One may separately check them by
+   * another call to this method; class {@link SyntacticCompare} implements this logic.
+   *
+   * @param currentPolicy a routing policy
+   * @return for the given routing policy, find if the context differs based on the references used
+   *     in the routing policy.
+   */
+  public boolean differ(RoutingPolicy currentPolicy) {
+    // Find all the references/names used by the routing policy
+    Set<String> communityNames =
+        new RoutingPolicyStatementCommunityCollector()
+            .visitAll(
+                currentPolicy.getStatements(),
+                new Tuple<>(
+                    new HashSet<>(Collections.singleton(currentPolicy.getName())),
+                    this._currentConfig));
+    Set<String> routeFilterNames =
+        new RoutingPolicyStatementRouteFilterCollector()
+            .visitAll(
+                currentPolicy.getStatements(),
+                new Tuple<>(
+                    new HashSet<>(Collections.singleton(currentPolicy.getName())),
+                    this._currentConfig));
+    Set<String> asPathNames =
+        new RoutePolicyStatementMatchCollector<>(new AsPathNameBooleanExprCollector())
+            .visitAll(
+                currentPolicy.getStatements(),
+                new Tuple<>(
+                    new HashSet<>(Collections.singleton(currentPolicy.getName())),
+                    this._currentConfig));
+
+    // Return true if any of the names referenced in the routing policy are in the set of diffs.
+    return communityNames.stream().anyMatch(_communityListsDiff::contains)
+        || routeFilterNames.stream().anyMatch(_routeFilterListsDiff::contains)
+        || asPathNames.stream().anyMatch(_asPathAccessListsDiff::contains);
+  }
+
+  @VisibleForTesting
+  public Set<String> getCommunityListsDiff() {
+    return _communityListsDiff;
+  }
+
+  @VisibleForTesting
+  public Set<String> getAsPathAccessListsDiff() {
+    return _asPathAccessListsDiff;
+  }
+
+  @VisibleForTesting
+  public Set<String> getRouteFilterListsDiff() {
+    return _routeFilterListsDiff;
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticCompare.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticCompare.java
@@ -1,0 +1,117 @@
+package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.batfish.common.BatfishException;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.minesweeper.collectors.RoutePolicyStatementCallCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/**
+ * A class that performs a syntactic comparison of two routing policies by comparing their
+ * statements and the list-definitions they use. This class will recursively compare any routing
+ * policy called.
+ */
+public final class SyntacticCompare {
+  /** The configuration of a device in the current snapshot. */
+  private final Configuration _currentConfig;
+
+  /** The configuration of the same device in the reference snapshot. */
+  private final Configuration _referenceConfig;
+
+  /**
+   * A cache mapping tuples of (current policy, reference policy) to a boolean indicating whether
+   * they are syntactically equal
+   */
+  private final Map<Tuple<String, String>, Boolean> _resultsCache;
+
+  /** A cache mapping policies in the current config to the set of policies that they calL. */
+  private final Map<String, Set<String>> _callees;
+
+  /**
+   * A class comparing the context (community-lists, prefix-lists, aspath-lists) for two given
+   * routing policies.
+   */
+  private final RoutingPolicyContextDiff _contextDiff;
+
+  public SyntacticCompare(
+      @Nonnull Configuration currentConfig, @Nonnull Configuration referenceConfig) {
+    _currentConfig = currentConfig;
+    _referenceConfig = referenceConfig;
+    _resultsCache = new HashMap<>();
+    _callees = new HashMap<>();
+    _contextDiff = new RoutingPolicyContextDiff(currentConfig, referenceConfig);
+  }
+
+  public boolean areEqual(String currentPolicy, String referencePolicy) {
+    Boolean result = _resultsCache.get(new Tuple<>(currentPolicy, referencePolicy));
+    if (result != null) {
+      return result;
+    }
+    RoutingPolicy cpol = _currentConfig.getRoutingPolicies().get(currentPolicy);
+    RoutingPolicy rpol = _referenceConfig.getRoutingPolicies().get(referencePolicy);
+    if (cpol == null) {
+      throw new BatfishException("Did not find policy " + currentPolicy + " in current snapshot.");
+    }
+    if (rpol == null) {
+      throw new BatfishException(
+          "Did not find policy " + referencePolicy + " in reference snapshot.");
+    }
+
+    // First compare the list of statements of the two policies syntactically,
+    // then compare their contexts, and finally recursively compare the policies they call.
+    // The recursive call will compare the statements of the callees as well as their contexts.
+
+    return cpol.getStatements().equals(rpol.getStatements())
+        && !_contextDiff.differ(cpol)
+        && comparePoliciesSet(getCallees(currentPolicy, _currentConfig, _callees));
+  }
+
+  /**
+   * @param currentPolicies a set of routing policies
+   * @return true if they are all syntactically equal in the current and reference snapshot
+   */
+  private boolean comparePoliciesSet(Set<String> currentPolicies) {
+    for (String callee : currentPolicies) {
+      if (!areEqual(callee, callee)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * @param policy a policy name
+   * @param config the config of the device
+   * @param cache a cache mapping policies to the set of policies that they call
+   * @return the set of policies that the given policy calls. Also updates the given cache.
+   */
+  private Set<String> getCallees(
+      String policy, Configuration config, Map<String, Set<String>> cache) {
+    Set<String> callees = cache.get(policy);
+    if (callees == null) {
+      RoutingPolicy pol = config.getRoutingPolicies().get(policy);
+      callees =
+          new RoutePolicyStatementCallCollector()
+              .visitAll(pol.getStatements(), new Tuple<>(new HashSet<>(), config));
+      cache.put(policy, callees);
+    }
+    return callees;
+  }
+
+  public Configuration getCurrentConfig() {
+    return _currentConfig;
+  }
+
+  public Configuration getReferenceConfig() {
+    return _referenceConfig;
+  }
+
+  public RoutingPolicyContextDiff getContextDiff() {
+    return _contextDiff;
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticDifference.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticDifference.java
@@ -1,0 +1,48 @@
+package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import java.util.Comparator;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+
+/**
+ * Captures pairs of current/reference routing policies that *may* differ, based on syntactic
+ * equality and differences in community/as-path/prefix lists.
+ */
+public class SyntacticDifference implements Comparable<SyntacticDifference> {
+
+  /** The policy for the current snapshot */
+  private final RoutingPolicy _currentPolicy;
+
+  /** The policy for the reference snapshot */
+  private final RoutingPolicy _referencePolicy;
+
+  /** The (potential) context-diff under which the two policies differ */
+  private final RoutingPolicyContextDiff _context;
+
+  public SyntacticDifference(
+      RoutingPolicy currentPolicy,
+      RoutingPolicy referencePolicy,
+      RoutingPolicyContextDiff context) {
+    this._currentPolicy = currentPolicy;
+    this._referencePolicy = referencePolicy;
+    this._context = context;
+  }
+
+  public RoutingPolicy getCurrentPolicy() {
+    return _currentPolicy;
+  }
+
+  public RoutingPolicy getReferencePolicy() {
+    return _referencePolicy;
+  }
+
+  public RoutingPolicyContextDiff getContext() {
+    return _context;
+  }
+
+  @Override
+  public int compareTo(SyntacticDifference o) {
+    Comparator<RoutingPolicy> policyName = Comparator.comparing(RoutingPolicy::getName);
+    Comparator<RoutingPolicy> ownerName = Comparator.comparing(r -> r.getOwner().getHostname());
+    return policyName.thenComparing(ownerName).compare(this._currentPolicy, o._currentPolicy);
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesAnswerer.java
@@ -1,499 +1,42 @@
 package org.batfish.minesweeper.question.compareroutepolicies;
 
-import static org.batfish.minesweeper.bdd.BDDRouteDiff.computeDifferences;
-import static org.batfish.minesweeper.bdd.ModelGeneration.constraintsToModel;
-import static org.batfish.minesweeper.bdd.ModelGeneration.satAssignmentToEnvironment;
-import static org.batfish.minesweeper.bdd.ModelGeneration.satAssignmentToInputRoute;
-import static org.batfish.specifier.NameRegexRoutingPolicySpecifier.ALL_ROUTING_POLICIES;
-
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import net.sf.javabdd.BDD;
-import net.sf.javabdd.BDDFactory;
-import net.sf.javabdd.JFactory;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.datamodel.Bgpv4Route;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.answers.AnswerElement;
-import org.batfish.datamodel.questions.BgpRoute;
 import org.batfish.datamodel.questions.Question;
-import org.batfish.datamodel.routing_policy.Environment;
-import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
-import org.batfish.minesweeper.AsPathRegexAtomicPredicates;
-import org.batfish.minesweeper.CommunityVar;
-import org.batfish.minesweeper.ConfigAtomicPredicates;
-import org.batfish.minesweeper.bdd.BDDRoute;
-import org.batfish.minesweeper.bdd.BDDRouteDiff;
-import org.batfish.minesweeper.bdd.ModelGeneration;
-import org.batfish.minesweeper.bdd.TransferBDD;
-import org.batfish.minesweeper.bdd.TransferReturn;
-import org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer;
-import org.batfish.minesweeper.utils.Tuple;
-import org.batfish.question.testroutepolicies.Result;
 import org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer;
-import org.batfish.specifier.AllNodesNodeSpecifier;
-import org.batfish.specifier.NodeSpecifier;
-import org.batfish.specifier.RoutingPolicySpecifier;
-import org.batfish.specifier.SpecifierContext;
-import org.batfish.specifier.SpecifierFactories;
 
 /** An answerer for {@link CompareRoutePoliciesQuestion}. */
-@SuppressWarnings("DuplicatedCode")
 @ParametersAreNonnullByDefault
 public final class CompareRoutePoliciesAnswerer extends Answerer {
 
-  private final @Nonnull Environment.Direction _direction;
-
-  private final @Nonnull String _policySpecifierString;
-  private final @Nullable String _referencePolicySpecifierString;
-  private final @Nonnull RoutingPolicySpecifier _policySpecifier;
-  private final @Nullable RoutingPolicySpecifier _referencePolicySpecifier;
-
-  private final @Nonnull NodeSpecifier _nodeSpecifier;
-
-  private final @Nonnull Set<String> _communityRegexes;
-  private final @Nonnull Set<String> _asPathRegexes;
+  private final @Nonnull CompareRoutePoliciesUtils _utils;
 
   public CompareRoutePoliciesAnswerer(
       org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesQuestion question,
       IBatfish batfish) {
     super(question, batfish);
-    _nodeSpecifier =
-        SpecifierFactories.getNodeSpecifierOrDefault(
-            question.getNodes(), AllNodesNodeSpecifier.INSTANCE);
-    _direction = question.getDirection();
-
-    _policySpecifierString = question.getPolicy();
-    _policySpecifier =
-        SpecifierFactories.getRoutingPolicySpecifierOrDefault(
-            _policySpecifierString, ALL_ROUTING_POLICIES);
-
-    // If the referencePolicySpecifier is null then we compare using the route-maps in
-    // policySpecifier
-    _referencePolicySpecifierString = question.getReferencePolicy();
-    _referencePolicySpecifier =
-        SpecifierFactories.getRoutingPolicySpecifierOrDefault(
-            _referencePolicySpecifierString, _policySpecifier);
-
-    // in the future, it may improve performance to combine all input community regexes
-    // into a single regex representing their disjunction, and similarly for all output
-    // community regexes, in order to minimize the number of atomic predicates that are
-    // created and tracked by the analysis
-    _communityRegexes = ImmutableSet.<String>builder().build();
-    _asPathRegexes = ImmutableSet.<String>builder().build();
-  }
-
-  /**
-   * @param constraints Logical constraints that describe a set of routes.
-   * @param configAPs the atomic predicates used for communities/as-paths.
-   * @return An input route, a predicate on tracks, and a (possibly null) source VRF that conform to
-   *     the given constraints.
-   */
-  private Tuple<Bgpv4Route, Tuple<Predicate<String>, String>> constraintsToInputs(
-      BDD constraints, ConfigAtomicPredicates configAPs) {
-    assert (!constraints.isZero());
-    BDD model = constraintsToModel(constraints, configAPs);
-    return new Tuple<>(
-        satAssignmentToInputRoute(model, configAPs), satAssignmentToEnvironment(model, configAPs));
-  }
-
-  /**
-   * @param tbdd the transfer function to symbolically evaluate
-   * @return the set of paths generated by symbolic execution
-   */
-  private List<TransferReturn> computePaths(TransferBDD tbdd) {
-    try {
-      return tbdd.computePaths(ImmutableSet.of());
-    } catch (Exception e) {
-      throw new BatfishException(
-          "Unexpected error analyzing policy "
-              + tbdd.getPolicy().getName()
-              + " in node "
-              + tbdd.getPolicy().getOwner().getHostname(),
-          e);
-    }
-  }
-
-  /**
-   * @param factory the BDD factory used for this analysis
-   * @param diffs A list of differences found between two output routes.
-   * @param r1 the first of the two output routes that were compared
-   * @param r2 the second of the two output routes that were compared
-   * @return A BDD that denotes at least one of the differences in the given diffs list. Only
-   *     capturing differences in communities for now; the rest are not necessary because they do
-   *     not have additive semantics, like "set community additive". Note that AS-path prepends are
-   *     recorded concretely rather than symbolically in {@link BDDRoute}s, so their differences are
-   *     also ignored here. (actually, I think you might be able to plus on the local-pref value,
-   *     TODO: check)
-   */
-  private BDD counterExampleOutputConstraints(
-      BDDFactory factory, List<BDDRouteDiff.DifferenceType> diffs, BDDRoute r1, BDDRoute r2) {
-    BDD acc = factory.zero();
-    for (BDDRouteDiff.DifferenceType d : diffs) {
-      switch (d) {
-        case AS_PATH:
-        case OSPF_METRIC:
-        case LOCAL_PREF:
-        case MED:
-        case NEXTHOP:
-        case NEXTHOP_TYPE:
-        case NEXTHOP_SET:
-        case TAG:
-        case ADMIN_DIST:
-        case WEIGHT:
-        case UNSUPPORTED:
-          break;
-        case COMMUNITIES:
-          BDD[] communityAtomicPredicates = r1.getCommunityAtomicPredicates();
-          BDD[] otherCommunityAtomicPredicates = r2.getCommunityAtomicPredicates();
-          for (int i = 0; i < communityAtomicPredicates.length; i++) {
-            BDD outConstraint = communityAtomicPredicates[i].xor(otherCommunityAtomicPredicates[i]);
-            // If there is a scenario where the two outputs differ at this community then ensure
-            // this scenario
-            // manifests during model generation.
-            acc = acc.or(outConstraint);
-          }
-          break;
-        default:
-          throw new UnsupportedOperationException(d.name());
-      }
-    }
-    if (!acc.isZero()) {
-      // If we have accumulated some constraints from the output routes then return these
-      return acc;
-    } else {
-      // otherwise return true.
-      return factory.one();
-    }
-  }
-
-  /**
-   * Check that the results of symbolic analysis are consistent with the given concrete result from
-   * route simulation.
-   *
-   * @param fullModel a satisfying assignment to the constraints from symbolic route analysis along
-   *     a given path
-   * @param configAPs the {@link ConfigAtomicPredicates} object, which enables proper interpretation
-   *     of atomic predicates
-   * @param path the symbolic representation of that path
-   * @param result the expected input-output behavior
-   * @return a boolean indicating whether the check succeeded
-   */
-  private boolean validateModel(
-      BDD fullModel,
-      ConfigAtomicPredicates configAPs,
-      TransferReturn path,
-      Result<BgpRoute> result) {
-    // update the atomic predicates to include any prepended ASes on this path
-    ConfigAtomicPredicates configAPsCopy = new ConfigAtomicPredicates(configAPs);
-    AsPathRegexAtomicPredicates aps = configAPsCopy.getAsPathRegexAtomicPredicates();
-    aps.prependAPs(path.getFirst().getPrependedASes());
-
-    return ModelGeneration.validateModel(
-        fullModel,
-        path.getFirst(),
-        configAPsCopy,
-        path.getAccepted() ? LineAction.PERMIT : LineAction.DENY,
-        _direction,
-        result);
-  }
-
-  /**
-   * Check that the example of a behavioral difference between the two route maps the symbolic
-   * analysis finds is consistent with the results from the concrete route simulation.
-   *
-   * @param constraints representation of the set of input routes that should exhibit a difference
-   * @param configAPs the {@link ConfigAtomicPredicates} object, which enables proper interpretation
-   *     of atomic predicates
-   * @param path the symbolic representation of the path through the original route map
-   * @param otherPath the symbolic representation of the path through the other route map
-   * @param result the expected behavior of the original route map on an input that should exhibit a
-   *     difference
-   * @param otherResult the expected behavior of the other route map on the same input
-   * @return a boolean indicating whether the check succeeded
-   */
-  private boolean validateDifference(
-      BDD constraints,
-      ConfigAtomicPredicates configAPs,
-      TransferReturn path,
-      TransferReturn otherPath,
-      Result<BgpRoute> result,
-      Result<BgpRoute> otherResult) {
-    BDD fullModel = ModelGeneration.constraintsToModel(constraints, configAPs);
-    return validateModel(fullModel, configAPs, path, result)
-        && validateModel(fullModel, configAPs, otherPath, otherResult);
-  }
-
-  /**
-   * Compare two route policies for behavioral differences.
-   *
-   * @param referencePolicy the routing policy of the reference snapshot
-   * @param policy the routing policy of the current snapshot
-   * @param configAPs an object providing the atomic predicates for the policy's owner configuration
-   * @return a set of differences
-   */
-  private Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> comparePolicies(
-      RoutingPolicy referencePolicy, RoutingPolicy policy, ConfigAtomicPredicates configAPs) {
-    // The set of differences if any.
-    List<Tuple<Result<BgpRoute>, Result<BgpRoute>>> differences = new ArrayList<>();
-
-    BDDFactory factory = JFactory.init(100000, 10000);
-    TransferBDD tBDD = new TransferBDD(factory, configAPs, referencePolicy);
-    TransferBDD otherTBDD = new TransferBDD(factory, configAPs, policy);
-
-    // Generate well-formedness constraints
-    BDD wf = new BDDRoute(tBDD.getFactory(), configAPs).bgpWellFormednessConstraints();
-
-    // The set of paths for the current policy
-    List<TransferReturn> paths = computePaths(tBDD);
-    // The set of paths for the proposed policy
-    List<TransferReturn> otherPaths = computePaths(otherTBDD);
-
-    // Potential optimization: if a set of input routes between the two paths is the same then we
-    // only need to validate
-    // the outputs between this pair; the intersection with all others is going to be empty.
-    // This will probably be more efficient when we expect the two route-maps to be (almost)
-    // equivalent.
-    for (TransferReturn path : paths) {
-      for (TransferReturn otherPath : otherPaths) {
-        BDD inputRoutes = path.getSecond();
-        BDD inputRoutesOther = otherPath.getSecond();
-        BDD intersection = inputRoutesOther.and(inputRoutes).and(wf);
-
-        // If the sets of input routes between the two paths intersect, then these paths describe
-        // some common input routes and their behavior should match.
-        if (!intersection.isZero()) {
-          // a flag that is set if we find a behavioral difference between the two paths
-          boolean behaviorDiff = false;
-          BDD finalConstraints = null;
-          // Naive check to see if both policies accepted/rejected the route(s).
-          if (path.getAccepted() != otherPath.getAccepted()) {
-            behaviorDiff = true;
-            finalConstraints = intersection;
-          } else {
-            // If both policies perform the same action, then check that their outputs match.
-            // We compute the outputs of interest, by restricting the sets of output routes to the
-            // intersection of the input routes and then comparing them.
-            // We only need to compare the outputs if the routes were permitted.
-            if (path.getAccepted()) {
-              BDDRoute outputRoutes = new BDDRoute(intersection, path.getFirst());
-              BDDRoute outputRoutesOther = new BDDRoute(intersection, otherPath.getFirst());
-              List<BDDRouteDiff.DifferenceType> diff =
-                  computeDifferences(outputRoutes, outputRoutesOther);
-              // Compute any constraints on the output routes.
-              BDD outputConstraints =
-                  counterExampleOutputConstraints(factory, diff, outputRoutes, outputRoutesOther);
-              if (!diff.isEmpty()) {
-                behaviorDiff = true;
-                finalConstraints = intersection.and(outputConstraints);
-              }
-            }
-          }
-
-          // we have found a difference, so let's get a concrete example of the difference
-          if (behaviorDiff) {
-            Tuple<Bgpv4Route, Tuple<Predicate<String>, String>> t =
-                constraintsToInputs(finalConstraints, configAPs);
-            Result<BgpRoute> otherResult =
-                SearchRoutePoliciesAnswerer.simulatePolicy(
-                    policy, t.getFirst(), _direction, t.getSecond(), otherPath.getFirst());
-            Result<BgpRoute> refResult =
-                SearchRoutePoliciesAnswerer.simulatePolicy(
-                    referencePolicy, t.getFirst(), _direction, t.getSecond(), path.getFirst());
-            differences.add(new Tuple<>(otherResult, refResult));
-
-            // As a sanity check, compare the simulated results above with what the symbolic route
-            // analysis predicts will happen.
-            assert validateDifference(
-                finalConstraints, configAPs, path, otherPath, refResult, otherResult);
-          }
-        }
-      }
-    }
-    return differences.stream()
-        .sorted(Comparator.comparing(t -> t.getFirst().getInputRoute().getNetwork()));
-  }
-
-  //      return differences.stream()
-  //              .sorted(Comparator.comparing(t -> t.getFirst().getInputRoute().getNetwork()))
-  //          .map(t -> TestRoutePoliciesAnswerer.toCompareRow(t.getFirst(), t.getSecond()))
-  //          .collect(Collectors.toList());
-
-  /**
-   * Search all of the route policies of a particular node for behaviors of interest.
-   *
-   * @param node the node - for now assuming a single config, might lift that assumption later.
-   * @param policies all route policies in the given node for the new snapshot
-   * @param referencePolicies all route policies in the given node for the reference snapshot.
-   * @param crossPolicies if true then policies and referencePolicies are all compared with each
-   *     other. Otherwise we use a one-to-one mapping where names must match in order to compare.
-   * @param snapshot the snapshot of the proposed change
-   * @param reference the reference snapshot
-   * @return all results from analyzing those route policies
-   */
-  private Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> comparePoliciesForNode(
-      String node,
-      Stream<RoutingPolicy> policies,
-      Stream<RoutingPolicy> referencePolicies,
-      boolean crossPolicies,
-      NetworkSnapshot snapshot,
-      NetworkSnapshot reference) {
-    List<RoutingPolicy> referencePoliciesList = referencePolicies.collect(Collectors.toList());
-    List<RoutingPolicy> currentPoliciesList = policies.collect(Collectors.toList());
-
-    if (referencePoliciesList.isEmpty()) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Could not find policy matching %s in reference snapshot",
-              _referencePolicySpecifier));
-    }
-    if (currentPoliciesList.isEmpty()) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Could not find policy matching %s in current snapshot", _policySpecifierString));
-    }
-
-    if (!crossPolicies) {
-      // In this case we are comparing all route-maps with the same name.
-      Set<String> referencePoliciesNames =
-          referencePoliciesList.stream().map(RoutingPolicy::getName).collect(Collectors.toSet());
-      Set<String> policiesNames =
-          currentPoliciesList.stream().map(RoutingPolicy::getName).collect(Collectors.toSet());
-      Set<String> intersection =
-          referencePoliciesNames.stream()
-              .filter(policiesNames::contains)
-              .collect(Collectors.toSet());
-      if (intersection.isEmpty()) {
-        throw new IllegalArgumentException(
-            String.format(
-                "No common policies described by %s in %s", _policySpecifierString, node));
-      }
-      // Filter down the lists such that they include policies with the same name only
-      referencePoliciesList.removeIf(p -> !intersection.contains(p.getName()));
-      currentPoliciesList.removeIf(p -> !intersection.contains(p.getName()));
-    }
-
-    ConfigAtomicPredicates configAPs =
-        new ConfigAtomicPredicates(
-            _batfish,
-            snapshot,
-            reference,
-            node,
-            _communityRegexes.stream()
-                .map(CommunityVar::from)
-                .collect(ImmutableSet.toImmutableSet()),
-            _asPathRegexes,
-            currentPoliciesList,
-            referencePoliciesList);
-
-    if (crossPolicies) {
-      // In this case we cross-compare all routing policies in the two sets regardless of their
-      // names.
-      return referencePoliciesList.stream()
-          .flatMap(
-              referencePolicy ->
-                  currentPoliciesList.stream()
-                      .flatMap(
-                          currentPolicy ->
-                              comparePolicies(referencePolicy, currentPolicy, configAPs)));
-    } else {
-      // In this case we only compare policies with the same name.
-      // Create a stream of policy tuples (referencePolicy, currentPolicy) for policies with the
-      // same name.
-      currentPoliciesList.sort(Comparator.comparing(RoutingPolicy::getName));
-      referencePoliciesList.sort(Comparator.comparing(RoutingPolicy::getName));
-
-      // Since the two lists have been filtered to include only elements in their intersection they
-      // should have the same
-      // length.
-      assert (currentPoliciesList.size() == referencePoliciesList.size());
-
-      // Since they have been sorted by name the policies at each index should have the same name.
-      return IntStream.range(0, currentPoliciesList.size())
-          .mapToObj(
-              i -> {
-                assert (referencePoliciesList
-                    .get(i)
-                    .getName()
-                    .equals(currentPoliciesList.get(i).getName()));
-                return new Tuple<>(referencePoliciesList.get(i), currentPoliciesList.get(i));
-              })
-          .flatMap(
-              policyTuple ->
-                  comparePolicies(policyTuple.getFirst(), policyTuple.getSecond(), configAPs));
-    }
+    _utils =
+        new CompareRoutePoliciesUtils(
+            question.getDirection(),
+            question.getPolicy(),
+            question.getReferencePolicy(),
+            question.getNodes(),
+            _batfish);
   }
 
   @Override
   public AnswerElement answer(NetworkSnapshot snapshot) {
     throw new BatfishException(
         String.format("%s can only be run in differential mode.", _question.getName()));
-  }
-
-  /**
-   * Compares the policies in policySpecifier with the policies in proposedPolicySpecifier (all of
-   * them, their names don't have to match up). If, however, the proposedPolicySpecifier is empty it
-   * will do a 1-1 comparison with the policies found in policySpecifier. Note, this only compares
-   * across the same hostnames between the two snapshots, i.e., it will compare route-maps in r1
-   * with route-maps in r1 of the new snapshot.
-   *
-   * <p>This method returns a structured representation suitable for use by other questions, rather
-   * than a TableAnswer.
-   */
-  public Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> answerDiffHelper(
-      NetworkSnapshot snapshot, NetworkSnapshot reference) {
-
-    SpecifierContext currentContext = _batfish.specifierContext(snapshot);
-    SpecifierContext referenceContext = _batfish.specifierContext(reference);
-    Set<String> currentNodes = _nodeSpecifier.resolve(currentContext);
-    Set<String> referenceNodes = _nodeSpecifier.resolve(referenceContext);
-    // Only compare nodes that are in both snapshots.
-    Stream<String> nodes = currentNodes.stream().filter(referenceNodes::contains);
-
-    // Using stream.sorted() to ensure consistent order.
-    return nodes
-        .sorted()
-        .flatMap(
-            node -> {
-              // If the referencePolicySpecifier is null then use the policies from
-              // policySpecifier and do a 1-1 comparison based on policy name equality.
-              if (_referencePolicySpecifier == null) {
-                return comparePoliciesForNode(
-                    node,
-                    _policySpecifier.resolve(node, currentContext).stream().sorted(),
-                    _policySpecifier.resolve(node, referenceContext).stream().sorted(),
-                    false,
-                    snapshot,
-                    reference);
-              } else {
-                // Otherwise cross-compare all policies in each set (policySpecifier and
-                // referencePolicySpecifier)
-                return comparePoliciesForNode(
-                    node,
-                    _policySpecifier.resolve(node, currentContext).stream().sorted(),
-                    _referencePolicySpecifier.resolve(node, referenceContext).stream().sorted(),
-                    true,
-                    snapshot,
-                    reference);
-              }
-            });
   }
 
   public static TableAnswerElement toTableAnswer(Question question, List<Row> rows) {
@@ -506,27 +49,14 @@ public final class CompareRoutePoliciesAnswerer extends Answerer {
   @Override
   public AnswerElement answerDiff(NetworkSnapshot snapshot, NetworkSnapshot reference) {
     List<Row> rows =
-        answerDiffHelper(snapshot, reference)
+        _utils
+            .getDifferencesStream(snapshot, reference)
             .map(t -> TestRoutePoliciesAnswerer.toCompareRow(t.getFirst(), t.getSecond()))
             .collect(ImmutableList.toImmutableList());
     return toTableAnswer(_question, rows);
   }
 
-  @VisibleForTesting
-  @Nonnull
-  NodeSpecifier getNodeSpecifier() {
-    return _nodeSpecifier;
-  }
-
-  @VisibleForTesting
-  @Nonnull
-  RoutingPolicySpecifier getPolicySpecifier() {
-    return _policySpecifier;
-  }
-
-  @VisibleForTesting
-  @Nullable
-  RoutingPolicySpecifier getReferencePolicySpecifier() {
-    return _referencePolicySpecifier;
+  public @Nonnull CompareRoutePoliciesUtils getUtils() {
+    return _utils;
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -1,0 +1,484 @@
+package org.batfish.minesweeper.question.compareroutepolicies;
+
+import static org.batfish.minesweeper.bdd.BDDRouteDiff.computeDifferences;
+import static org.batfish.minesweeper.bdd.ModelGeneration.constraintsToModel;
+import static org.batfish.minesweeper.bdd.ModelGeneration.satAssignmentToEnvironment;
+import static org.batfish.minesweeper.bdd.ModelGeneration.satAssignmentToInputRoute;
+import static org.batfish.specifier.NameRegexRoutingPolicySpecifier.ALL_ROUTING_POLICIES;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import net.sf.javabdd.JFactory;
+import org.batfish.common.BatfishException;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.questions.BgpRoute;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.minesweeper.CommunityVar;
+import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.batfish.minesweeper.bdd.BDDRoute;
+import org.batfish.minesweeper.bdd.BDDRouteDiff;
+import org.batfish.minesweeper.bdd.TransferBDD;
+import org.batfish.minesweeper.bdd.TransferReturn;
+import org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer;
+import org.batfish.minesweeper.utils.Tuple;
+import org.batfish.question.testroutepolicies.Result;
+import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.NodeSpecifier;
+import org.batfish.specifier.RoutingPolicySpecifier;
+import org.batfish.specifier.SpecifierContext;
+import org.batfish.specifier.SpecifierFactories;
+
+public final class CompareRoutePoliciesUtils {
+
+  private final @Nonnull Environment.Direction _direction;
+
+  private final @Nonnull String _policySpecifierString;
+  private final @Nullable String _referencePolicySpecifierString;
+  private final @Nonnull RoutingPolicySpecifier _policySpecifier;
+  private final @Nullable RoutingPolicySpecifier _referencePolicySpecifier;
+
+  private final @Nonnull NodeSpecifier _nodeSpecifier;
+
+  private final @Nonnull Set<String> _communityRegexes;
+  private final @Nonnull Set<String> _asPathRegexes;
+
+  private final @Nonnull IBatfish _batfish;
+
+  public CompareRoutePoliciesUtils(
+      @Nonnull Environment.Direction direction,
+      @Nonnull String policySpecifierString,
+      @Nullable String referencePolicySpecifierString,
+      String nodes,
+      IBatfish batfish) {
+    _nodeSpecifier =
+        SpecifierFactories.getNodeSpecifierOrDefault(nodes, AllNodesNodeSpecifier.INSTANCE);
+    _direction = direction;
+
+    _policySpecifierString = policySpecifierString;
+    _policySpecifier =
+        SpecifierFactories.getRoutingPolicySpecifierOrDefault(
+            _policySpecifierString, ALL_ROUTING_POLICIES);
+
+    // If the referencePolicySpecifier is null then we compare using the route-maps in
+    // policySpecifier
+    _referencePolicySpecifierString = referencePolicySpecifierString;
+    _referencePolicySpecifier =
+        SpecifierFactories.getRoutingPolicySpecifierOrDefault(
+            _referencePolicySpecifierString, _policySpecifier);
+
+    // in the future, it may improve performance to combine all input community regexes
+    // into a single regex representing their disjunction, and similarly for all output
+    // community regexes, in order to minimize the number of atomic predicates that are
+    // created and tracked by the analysis
+    _communityRegexes = ImmutableSet.<String>builder().build();
+    _asPathRegexes = ImmutableSet.<String>builder().build();
+    this._batfish = batfish;
+  }
+
+  /**
+   * Compares the policies in policySpecifier with the policies in proposedPolicySpecifier (all of
+   * them, their names don't have to match up). If, however, the proposedPolicySpecifier is empty it
+   * will do a 1-1 comparison with the policies found in policySpecifier. Note, this only compares
+   * across the same hostnames between the two snapshots, i.e., it will compare route-maps in r1
+   * with route-maps in r1 of the new snapshot.
+   *
+   * <p>This method returns a structured representation suitable for use by other questions, rather
+   * than a TableAnswer. In particular, it returns a stream of "differences", represented as a tuple
+   * where the first element corresponds to the behavior in the current snapshot, and the second
+   * element corresponds to the behavior in the reference snapshot. The two elements contain the
+   * corresponding node and routing policies, as well, as the input route that triggers the
+   * difference (should be the same across both tuple components) and the action+output route+trace
+   * in each case (will be different).
+   */
+  public Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> getDifferencesStream(
+      NetworkSnapshot snapshot, NetworkSnapshot reference) {
+
+    SpecifierContext currentContext = _batfish.specifierContext(snapshot);
+    SpecifierContext referenceContext = _batfish.specifierContext(reference);
+    Set<String> currentNodes = _nodeSpecifier.resolve(currentContext);
+    Set<String> referenceNodes = _nodeSpecifier.resolve(referenceContext);
+    // Only compare nodes that are in both snapshots.
+    Stream<String> nodes = currentNodes.stream().filter(referenceNodes::contains);
+
+    // Using stream.sorted() to ensure consistent order.
+    return nodes
+        .sorted()
+        .flatMap(
+            node -> {
+              // If the referencePolicySpecifier is null then use the policies from
+              // policySpecifier and do a 1-1 comparison based on policy name equality.
+              if (_referencePolicySpecifier == null) {
+                return comparePoliciesForNode(
+                    node,
+                    _policySpecifier.resolve(node, currentContext).stream().sorted(),
+                    _policySpecifier.resolve(node, referenceContext).stream().sorted(),
+                    false,
+                    snapshot,
+                    reference);
+              } else {
+                // Otherwise cross-compare all policies in each set (policySpecifier and
+                // referencePolicySpecifier)
+                return comparePoliciesForNode(
+                    node,
+                    _policySpecifier.resolve(node, currentContext).stream().sorted(),
+                    _referencePolicySpecifier.resolve(node, referenceContext).stream().sorted(),
+                    true,
+                    snapshot,
+                    reference);
+              }
+            });
+  }
+
+  /**
+   * Search all of the route policies of a particular node for behaviors of interest.
+   *
+   * @param node the node - for now assuming a single config, might lift that assumption later.
+   * @param policies all route policies in the given node for the new snapshot
+   * @param referencePolicies all route policies in the given node for the reference snapshot.
+   * @param crossPolicies if true then policies and referencePolicies are all compared with each
+   *     other. Otherwise we use a one-to-one mapping where names must match in order to compare.
+   * @param snapshot the snapshot of the proposed change
+   * @param reference the reference snapshot
+   * @return all results from analyzing those route policies
+   */
+  private Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> comparePoliciesForNode(
+      String node,
+      Stream<RoutingPolicy> policies,
+      Stream<RoutingPolicy> referencePolicies,
+      boolean crossPolicies,
+      NetworkSnapshot snapshot,
+      NetworkSnapshot reference) {
+    List<RoutingPolicy> referencePoliciesList = referencePolicies.collect(Collectors.toList());
+    List<RoutingPolicy> currentPoliciesList = policies.collect(Collectors.toList());
+
+    if (referencePoliciesList.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Could not find policy matching %s in reference snapshot",
+              _referencePolicySpecifierString));
+    }
+    if (currentPoliciesList.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Could not find policy matching %s in current snapshot", _policySpecifierString));
+    }
+
+    if (!crossPolicies) {
+      // In this case we are comparing all route-maps with the same name.
+      Set<String> referencePoliciesNames =
+          referencePoliciesList.stream().map(RoutingPolicy::getName).collect(Collectors.toSet());
+      Set<String> policiesNames =
+          currentPoliciesList.stream().map(RoutingPolicy::getName).collect(Collectors.toSet());
+      Set<String> intersection =
+          referencePoliciesNames.stream()
+              .filter(policiesNames::contains)
+              .collect(Collectors.toSet());
+      if (intersection.isEmpty()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "No common policies described by %s in %s", _policySpecifierString, node));
+      }
+      // Filter down the lists such that they include policies with the same name only
+      referencePoliciesList.removeIf(p -> !intersection.contains(p.getName()));
+      currentPoliciesList.removeIf(p -> !intersection.contains(p.getName()));
+    }
+
+    ConfigAtomicPredicates configAPs =
+        new ConfigAtomicPredicates(
+            _batfish,
+            snapshot,
+            reference,
+            node,
+            _communityRegexes.stream()
+                .map(CommunityVar::from)
+                .collect(ImmutableSet.toImmutableSet()),
+            _asPathRegexes,
+            currentPoliciesList,
+            referencePoliciesList);
+
+    if (crossPolicies) {
+      // In this case we cross-compare all routing policies in the two sets regardless of their
+      // names.
+      return referencePoliciesList.stream()
+          .flatMap(
+              referencePolicy ->
+                  currentPoliciesList.stream()
+                      .flatMap(
+                          currentPolicy ->
+                              comparePolicies(referencePolicy, currentPolicy, configAPs)));
+    } else {
+      // In this case we only compare policies with the same name.
+      // Create a stream of policy tuples (referencePolicy, currentPolicy) for policies with the
+      // same name.
+      currentPoliciesList.sort(Comparator.comparing(RoutingPolicy::getName));
+      referencePoliciesList.sort(Comparator.comparing(RoutingPolicy::getName));
+
+      // Since the two lists have been filtered to include only elements in their intersection they
+      // should have the same
+      // length.
+      assert (currentPoliciesList.size() == referencePoliciesList.size());
+
+      // Since they have been sorted by name the policies at each index should have the same name.
+      return IntStream.range(0, currentPoliciesList.size())
+          .mapToObj(
+              i -> {
+                assert (referencePoliciesList
+                    .get(i)
+                    .getName()
+                    .equals(currentPoliciesList.get(i).getName()));
+                return new Tuple<>(referencePoliciesList.get(i), currentPoliciesList.get(i));
+              })
+          .flatMap(
+              policyTuple ->
+                  comparePolicies(policyTuple.getFirst(), policyTuple.getSecond(), configAPs));
+    }
+  }
+
+  /**
+   * @param constraints Logical constraints that describe a set of routes.
+   * @param configAPs the atomic predicates used for communities/as-paths.
+   * @return An input route, a predicate on tracks, and a (possibly null) source VRF that conform to
+   *     the given constraints.
+   */
+  private Tuple<Bgpv4Route, Tuple<Predicate<String>, String>> constraintsToInputs(
+      BDD constraints, ConfigAtomicPredicates configAPs) {
+    assert (!constraints.isZero());
+    BDD model = constraintsToModel(constraints, configAPs);
+    return new Tuple<>(
+        satAssignmentToInputRoute(model, configAPs), satAssignmentToEnvironment(model, configAPs));
+  }
+
+  /**
+   * @param tbdd the transfer function to symbolically evaluate
+   * @return a list of paths generated by symbolic execution
+   */
+  private List<TransferReturn> computePaths(TransferBDD tbdd) {
+    try {
+      return tbdd.computePaths(ImmutableSet.of());
+    } catch (Exception e) {
+      throw new BatfishException(
+          "Unexpected error analyzing policy "
+              + tbdd.getPolicy().getName()
+              + " in node "
+              + tbdd.getPolicy().getOwner().getHostname(),
+          e);
+    }
+  }
+
+  /**
+   * @param factory the BDD factory used for this analysis
+   * @param diffs A list of differences found between two output routes.
+   * @param r1 the first of the two output routes that were compared
+   * @param r2 the second of the two output routes that were compared
+   * @return A BDD that denotes at least one of the differences in the given diffs list. Only
+   *     capturing differences in communities for now; the rest are not necessary because they do
+   *     not have additive semantics, like "set community additive". Note that AS-path prepends are
+   *     recorded concretely rather than symbolically in {@link BDDRoute}s, so their differences are
+   *     also ignored here. I think you might be able to plus on the local-pref value (TODO: check)
+   *     so we might have to account for this case too.
+   */
+  private BDD counterExampleOutputConstraints(
+      BDDFactory factory, List<BDDRouteDiff.DifferenceType> diffs, BDDRoute r1, BDDRoute r2) {
+    BDD acc = factory.zero();
+    for (BDDRouteDiff.DifferenceType d : diffs) {
+      switch (d) {
+        case AS_PATH:
+        case OSPF_METRIC:
+        case LOCAL_PREF:
+        case MED:
+        case NEXTHOP:
+        case NEXTHOP_TYPE:
+        case NEXTHOP_SET:
+        case TAG:
+        case ADMIN_DIST:
+        case WEIGHT:
+        case UNSUPPORTED:
+          break;
+        case COMMUNITIES:
+          BDD[] communityAtomicPredicates = r1.getCommunityAtomicPredicates();
+          BDD[] otherCommunityAtomicPredicates = r2.getCommunityAtomicPredicates();
+          for (int i = 0; i < communityAtomicPredicates.length; i++) {
+            BDD outConstraint = communityAtomicPredicates[i].xor(otherCommunityAtomicPredicates[i]);
+            // If there is a scenario where the two outputs differ at this community then ensure
+            // this scenario
+            // manifests during model generation.
+            acc = acc.or(outConstraint);
+          }
+          break;
+        default:
+          throw new UnsupportedOperationException(d.name());
+      }
+    }
+    if (!acc.isZero()) {
+      // If we have accumulated some constraints from the output routes then return these
+      return acc;
+    } else {
+      // otherwise return true.
+      return factory.one();
+    }
+  }
+
+  /**
+   * Check that the results of symbolic analysis are consistent with the given concrete result from
+   * route simulation.
+   *
+   * @param fullModel a satisfying assignment to the constraints from symbolic route analysis along
+   *     a given path
+   * @param configAPs the {@link ConfigAtomicPredicates} object, which enables proper interpretation
+   *     of atomic predicates
+   * @param path the symbolic representation of that path
+   * @param result the expected input-output behavior
+   * @return a boolean indicating whether the check succeeded
+   */
+  private boolean validateModel(
+      BDD fullModel,
+      ConfigAtomicPredicates configAPs,
+      TransferReturn path,
+      Result<BgpRoute> result) {
+    // update the atomic predicates to include any prepended ASes on this path
+    ConfigAtomicPredicates configAPsCopy = new ConfigAtomicPredicates(configAPs);
+    org.batfish.minesweeper.AsPathRegexAtomicPredicates aps =
+        configAPsCopy.getAsPathRegexAtomicPredicates();
+    aps.prependAPs(path.getFirst().getPrependedASes());
+
+    return org.batfish.minesweeper.bdd.ModelGeneration.validateModel(
+        fullModel,
+        path.getFirst(),
+        configAPsCopy,
+        path.getAccepted() ? LineAction.PERMIT : LineAction.DENY,
+        _direction,
+        result);
+  }
+
+  /**
+   * Check that the example of a behavioral difference between the two route maps the symbolic
+   * analysis finds is consistent with the results from the concrete route simulation.
+   *
+   * @param constraints representation of the set of input routes that should exhibit a difference
+   * @param configAPs the {@link ConfigAtomicPredicates} object, which enables proper interpretation
+   *     of atomic predicates
+   * @param path the symbolic representation of the path through the original route map
+   * @param otherPath the symbolic representation of the path through the other route map
+   * @param result the expected behavior of the original route map on an input that should exhibit a
+   *     difference
+   * @param otherResult the expected behavior of the other route map on the same input
+   * @return a boolean indicating whether the check succeeded
+   */
+  private boolean validateDifference(
+      BDD constraints,
+      ConfigAtomicPredicates configAPs,
+      TransferReturn path,
+      TransferReturn otherPath,
+      Result<BgpRoute> result,
+      Result<BgpRoute> otherResult) {
+    BDD fullModel =
+        org.batfish.minesweeper.bdd.ModelGeneration.constraintsToModel(constraints, configAPs);
+    return validateModel(fullModel, configAPs, path, result)
+        && validateModel(fullModel, configAPs, otherPath, otherResult);
+  }
+
+  /**
+   * Compare two route policies for behavioral differences.
+   *
+   * @param referencePolicy the routing policy of the reference snapshot
+   * @param policy the routing policy of the current snapshot
+   * @param configAPs an object providing the atomic predicates for the policy's owner configuration
+   * @return a set of differences
+   */
+  private Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> comparePolicies(
+      RoutingPolicy referencePolicy, RoutingPolicy policy, ConfigAtomicPredicates configAPs) {
+    // The set of differences if any.
+    List<Tuple<Result<BgpRoute>, Result<BgpRoute>>> differences = new ArrayList<>();
+
+    BDDFactory factory = JFactory.init(100000, 10000);
+    TransferBDD tBDD = new TransferBDD(factory, configAPs, referencePolicy);
+    TransferBDD otherTBDD = new TransferBDD(factory, configAPs, policy);
+
+    // Generate well-formedness constraints
+    BDD wf = new BDDRoute(tBDD.getFactory(), configAPs).bgpWellFormednessConstraints();
+
+    // The set of paths for the current policy
+    List<TransferReturn> paths = computePaths(tBDD);
+    // The set of paths for the proposed policy
+    List<TransferReturn> otherPaths = computePaths(otherTBDD);
+
+    // Potential optimization: if a set of input routes between the two paths is the same then we
+    // only need to validate
+    // the outputs between this pair; the intersection with all others is going to be empty.
+    // This will probably be more efficient when we expect the two route-maps to be (almost)
+    // equivalent.
+    for (TransferReturn path : paths) {
+      for (TransferReturn otherPath : otherPaths) {
+        BDD inputRoutes = path.getSecond();
+        BDD inputRoutesOther = otherPath.getSecond();
+        BDD intersection = inputRoutesOther.and(inputRoutes).and(wf);
+
+        // If the sets of input routes between the two paths intersect, then these paths describe
+        // some common input routes and their behavior should match.
+        if (!intersection.isZero()) {
+          // a flag that is set if we find a behavioral difference between the two paths
+          boolean behaviorDiff = false;
+          BDD finalConstraints = null;
+          // Naive check to see if both policies accepted/rejected the route(s).
+          if (path.getAccepted() != otherPath.getAccepted()) {
+            behaviorDiff = true;
+            finalConstraints = intersection;
+          } else {
+            // If both policies perform the same action, then check that their outputs match.
+            // We compute the outputs of interest, by restricting the sets of output routes to the
+            // intersection of the input routes and then comparing them.
+            // We only need to compare the outputs if the routes were permitted.
+            if (path.getAccepted()) {
+              BDDRoute outputRoutes = new BDDRoute(intersection, path.getFirst());
+              BDDRoute outputRoutesOther = new BDDRoute(intersection, otherPath.getFirst());
+              List<BDDRouteDiff.DifferenceType> diff =
+                  computeDifferences(outputRoutes, outputRoutesOther);
+              // Compute any constraints on the output routes.
+              BDD outputConstraints =
+                  counterExampleOutputConstraints(factory, diff, outputRoutes, outputRoutesOther);
+              if (!diff.isEmpty()) {
+                behaviorDiff = true;
+                finalConstraints = intersection.and(outputConstraints);
+              }
+            }
+          }
+
+          // we have found a difference, so let's get a concrete example of the difference
+          if (behaviorDiff) {
+            Tuple<Bgpv4Route, Tuple<Predicate<String>, String>> t =
+                constraintsToInputs(finalConstraints, configAPs);
+            Result<BgpRoute> otherResult =
+                SearchRoutePoliciesAnswerer.simulatePolicy(
+                    policy, t.getFirst(), _direction, t.getSecond(), otherPath.getFirst());
+            Result<BgpRoute> refResult =
+                SearchRoutePoliciesAnswerer.simulatePolicy(
+                    referencePolicy, t.getFirst(), _direction, t.getSecond(), path.getFirst());
+            differences.add(new Tuple<>(otherResult, refResult));
+
+            // As a sanity check, compare the simulated results above with what the symbolic route
+            // analysis predicts will happen.
+            assert validateDifference(
+                finalConstraints, configAPs, path, otherPath, refResult, otherResult);
+          }
+        }
+      }
+    }
+    return differences.stream()
+        .sorted(Comparator.comparing(t -> t.getFirst().getInputRoute().getNetwork()));
+  }
+}

--- a/projects/minesweeper/src/test/java/BUILD.bazel
+++ b/projects/minesweeper/src/test/java/BUILD.bazel
@@ -13,6 +13,8 @@ junit_tests(
         "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
     deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol/src/test:common_testlib",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/AsPathNameAsPathMatchExprCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/AsPathNameAsPathMatchExprCollectorTest.java
@@ -1,0 +1,66 @@
+package org.batfish.minesweeper.collectors;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchAny;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchExprReference;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchRegex;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link org.batfish.minesweeper.collectors.AsPathNameAsPathMatchExprCollector}. */
+public class AsPathNameAsPathMatchExprCollectorTest {
+
+  private static final String HOSTNAME = "hostname";
+  private Configuration _baseConfig;
+  private AsPathNameAsPathMatchExprCollector _collector;
+
+  private static final String ASPATH_LST_1 = "lst1";
+  private static final String ASPATH_LST_2 = "lst2";
+
+  @Before
+  public void setup() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _baseConfig = cb.build();
+    _baseConfig.setAsPathMatchExprs(
+        ImmutableMap.of(
+            ASPATH_LST_1, AsPathMatchRegex.of(" 40$"), ASPATH_LST_2, AsPathMatchRegex.of(" 30$")));
+    nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+
+    _collector = new AsPathNameAsPathMatchExprCollector();
+  }
+
+  @Test
+  public void testVisitAsPathMatchAny() {
+    assertEquals(
+        ImmutableSet.of(ASPATH_LST_1, ASPATH_LST_2),
+        AsPathMatchAny.of(
+                ImmutableList.of(
+                    AsPathMatchExprReference.of(ASPATH_LST_1),
+                    AsPathMatchExprReference.of(ASPATH_LST_2)))
+            .accept(_collector, _baseConfig));
+  }
+
+  @Test
+  public void testAsPathMatchExprReference() {
+
+    AsPathMatchExprReference reference = AsPathMatchExprReference.of(ASPATH_LST_1);
+
+    assertEquals(ImmutableSet.of(ASPATH_LST_1), reference.accept(_collector, _baseConfig));
+  }
+
+  @Test
+  public void testAsPathMatchRegex() {
+    assertEquals(ImmutableSet.of(), AsPathMatchRegex.of(" 40$").accept(_collector, _baseConfig));
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/AsPathNameBooleanExprCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/AsPathNameBooleanExprCollectorTest.java
@@ -1,0 +1,195 @@
+package org.batfish.minesweeper.collectors;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.Set;
+import org.batfish.datamodel.AsPathAccessList;
+import org.batfish.datamodel.AsPathAccessListLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchAny;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchExprReference;
+import org.batfish.datamodel.routing_policy.as_path.AsPathMatchRegex;
+import org.batfish.datamodel.routing_policy.as_path.InputAsPath;
+import org.batfish.datamodel.routing_policy.as_path.MatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.Conjunction;
+import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
+import org.batfish.datamodel.routing_policy.expr.Disjunction;
+import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
+import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.NamedAsPathSet;
+import org.batfish.datamodel.routing_policy.expr.Not;
+import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.minesweeper.utils.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link AsPathNameBooleanExprCollector}. */
+public class AsPathNameBooleanExprCollectorTest {
+
+  private static final String HOSTNAME = "hostname";
+  private Configuration _baseConfig;
+  private AsPathNameBooleanExprCollector _collector;
+
+  private static final String ASPATH_LST_1 = "lst1";
+  private static final String ASPATH_LST_2 = "lst2";
+  private static final String ASPATH_LST_3 = "lst3";
+  private static final String ASPATH_LST_4 = "lst4";
+
+  @Before
+  public void setup() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _baseConfig = cb.build();
+    _baseConfig.setAsPathMatchExprs(
+        ImmutableMap.of(
+            ASPATH_LST_1,
+            AsPathMatchRegex.of(" 10$"),
+            ASPATH_LST_2,
+            AsPathMatchRegex.of(" 20$"),
+            ASPATH_LST_3,
+            AsPathMatchRegex.of(" 30$"),
+            ASPATH_LST_4,
+            AsPathMatchRegex.of(" 40$")));
+    nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+
+    _collector = new AsPathNameBooleanExprCollector();
+  }
+
+  @Test
+  public void testVisitConjunction() {
+    Conjunction c =
+        new Conjunction(
+            ImmutableList.of(
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_1)),
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_2))));
+
+    Set<String> result = _collector.visitConjunction(c, new Tuple<>(new HashSet<>(), _baseConfig));
+    assertEquals(ImmutableSet.of(ASPATH_LST_1, ASPATH_LST_2), result);
+  }
+
+  @Test
+  public void testVisitConjunctionChain() {
+    ConjunctionChain cc =
+        new ConjunctionChain(
+            ImmutableList.of(
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_1)),
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_2))));
+
+    Set<String> result =
+        _collector.visitConjunctionChain(cc, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(ASPATH_LST_1, ASPATH_LST_2), result);
+  }
+
+  @Test
+  public void testVisitDisjunction() {
+    Disjunction d =
+        new Disjunction(
+            ImmutableList.of(
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_1)),
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_2))));
+
+    Set<String> result = _collector.visitDisjunction(d, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(ASPATH_LST_1, ASPATH_LST_2), result);
+  }
+
+  @Test
+  public void testVisitFirstMatchChain() {
+    FirstMatchChain fmc =
+        new FirstMatchChain(
+            ImmutableList.of(
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_1)),
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_2))));
+
+    Set<String> result =
+        _collector.visitFirstMatchChain(fmc, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(ASPATH_LST_1, ASPATH_LST_2), result);
+  }
+
+  @Test
+  public void testVisitMatchAsPath() {
+    MatchAsPath matchAsPath =
+        MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_1));
+
+    Set<String> result =
+        _collector.visitMatchAsPath(matchAsPath, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(ASPATH_LST_1), result);
+  }
+
+  @Test
+  public void testVisitMatchLegacyAsPathNamed() {
+    String asPathName = "name";
+
+    _baseConfig.setAsPathAccessLists(
+        ImmutableMap.of(
+            asPathName,
+            new AsPathAccessList(
+                asPathName,
+                ImmutableList.of(
+                    new AsPathAccessListLine(LineAction.PERMIT, "40"),
+                    new AsPathAccessListLine(LineAction.DENY, "30")))));
+
+    LegacyMatchAsPath matchAsPath = new LegacyMatchAsPath(new NamedAsPathSet(asPathName));
+
+    Set<String> result =
+        _collector.visitMatchLegacyAsPath(matchAsPath, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(asPathName), result);
+  }
+
+  @Test
+  public void testVisitNot() {
+    Not n =
+        new Not(
+            MatchAsPath.of(
+                InputAsPath.instance(),
+                AsPathMatchAny.of(
+                    ImmutableList.of(
+                        AsPathMatchExprReference.of(ASPATH_LST_1),
+                        AsPathMatchExprReference.of(ASPATH_LST_2)))));
+
+    Set<String> result = _collector.visitNot(n, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(ASPATH_LST_1, ASPATH_LST_2), result);
+  }
+
+  @Test
+  public void testVisitWithEnvironmentExpr() {
+    WithEnvironmentExpr wee = new WithEnvironmentExpr();
+    wee.setExpr(MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_1)));
+    wee.setPreStatements(
+        ImmutableList.of(
+            new If(
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_2)),
+                ImmutableList.of())));
+    wee.setPostStatements(
+        ImmutableList.of(
+            new If(
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_3)),
+                ImmutableList.of())));
+    wee.setPostTrueStatements(
+        ImmutableList.of(
+            new If(
+                MatchAsPath.of(InputAsPath.instance(), AsPathMatchExprReference.of(ASPATH_LST_4)),
+                ImmutableList.of())));
+
+    Set<String> result =
+        _collector.visitWithEnvironmentExpr(wee, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(ASPATH_LST_1, ASPATH_LST_2, ASPATH_LST_3, ASPATH_LST_4), result);
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunityBooleanExprCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunityBooleanExprCollectorTest.java
@@ -1,0 +1,202 @@
+package org.batfish.minesweeper.collectors;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAny;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetUnion;
+import org.batfish.datamodel.routing_policy.communities.HasCommunity;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
+import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
+import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
+import org.batfish.datamodel.routing_policy.communities.SetCommunities;
+import org.batfish.datamodel.routing_policy.expr.Conjunction;
+import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
+import org.batfish.datamodel.routing_policy.expr.Disjunction;
+import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
+import org.batfish.datamodel.routing_policy.expr.Not;
+import org.batfish.datamodel.routing_policy.expr.TrackSucceeded;
+import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
+import org.batfish.minesweeper.utils.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link CommunityBooleanExprCollector}. */
+public class CommunityBooleanExprCollectorTest {
+
+  private static final String HOSTNAME = "hostname";
+  private static final String COMM_LST_1 = "comm1";
+  private static final String COMM_LST_2 = "comm2";
+  private static final String COMM_LST_3 = "comm3";
+  private static final String COMM_LST_4 = "comm4";
+
+  private CommunityBooleanExprCollector _collector;
+
+  private Configuration _config;
+
+  @Before
+  public void setup() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    _config = cb.build();
+
+    CommunitySetMatchExpr cyclic =
+        new CommunitySetMatchAny(
+            ImmutableSet.of(
+                new CommunitySetMatchExprReference(COMM_LST_2),
+                new HasCommunity(
+                    new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:"))));
+    _config.setCommunitySetMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1,
+            new HasCommunity(new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^10:")),
+            COMM_LST_2,
+            cyclic));
+
+    CommunitySetExpr cyclicSet =
+        CommunitySetUnion.of(
+            ImmutableSet.of(
+                new CommunitySetReference(COMM_LST_2),
+                new LiteralCommunitySet(CommunitySet.of(StandardCommunity.parse("20:30")))));
+    _config.setCommunitySetExprs(
+        ImmutableMap.of(
+            COMM_LST_1,
+            new LiteralCommunitySet(CommunitySet.of(StandardCommunity.parse("20:30"))),
+            COMM_LST_2,
+            cyclicSet,
+            COMM_LST_3,
+            new LiteralCommunitySet(CommunitySet.of(StandardCommunity.parse("30:30"))),
+            COMM_LST_4,
+            new LiteralCommunitySet(CommunitySet.of(StandardCommunity.parse("40:30")))));
+    _collector = new CommunityBooleanExprCollector();
+  }
+
+  @Test
+  public void testVisitConjunction() {
+
+    Conjunction c =
+        new Conjunction(
+            ImmutableList.of(
+                new MatchCommunities(
+                    InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_1)),
+                new MatchCommunities(
+                    InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_2))));
+
+    Set<String> result = _collector.visitConjunction(c, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitConjunctionChain() {
+
+    ConjunctionChain cc =
+        new ConjunctionChain(
+            ImmutableList.of(
+                new MatchCommunities(
+                    InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_1)),
+                new MatchCommunities(
+                    InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_2))));
+
+    Set<String> result =
+        _collector.visitConjunctionChain(cc, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitDisjunction() {
+
+    Disjunction d =
+        new Disjunction(
+            ImmutableList.of(
+                new MatchCommunities(
+                    InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_1)),
+                new MatchCommunities(
+                    InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_2))));
+
+    Set<String> result = _collector.visitDisjunction(d, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitFirstMatchChain() {
+
+    FirstMatchChain fmc =
+        new FirstMatchChain(
+            ImmutableList.of(
+                new MatchCommunities(
+                    InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_1)),
+                new MatchCommunities(
+                    InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_2))));
+
+    Set<String> result =
+        _collector.visitFirstMatchChain(fmc, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitTrackSucceeded() {
+    assertThat(
+        _collector.visitTrackSucceeded(
+            new TrackSucceeded("foo"), new Tuple<>(new HashSet<>(), _config)),
+        empty());
+  }
+
+  @Test
+  public void testVisitNot() {
+
+    Not n =
+        new Not(
+            new MatchCommunities(
+                InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_1)));
+
+    Set<String> result = _collector.visitNot(n, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1), result);
+  }
+
+  @Test
+  public void testVisitWithEnvironmentExpr() {
+
+    WithEnvironmentExpr wee = new WithEnvironmentExpr();
+    wee.setExpr(
+        new MatchCommunities(
+            InputCommunities.instance(), new CommunitySetMatchExprReference(COMM_LST_1)));
+    wee.setPreStatements(
+        ImmutableList.of(new SetCommunities(new CommunitySetExprReference(COMM_LST_2))));
+    wee.setPostStatements(
+        ImmutableList.of(new SetCommunities(new CommunitySetExprReference(COMM_LST_3))));
+    wee.setPostTrueStatements(
+        ImmutableList.of(new SetCommunities(new CommunitySetExprReference(COMM_LST_4))));
+
+    Set<String> result =
+        _collector.visitWithEnvironmentExpr(wee, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2, COMM_LST_3, COMM_LST_4), result);
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunityMatchExprCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunityMatchExprCollectorTest.java
@@ -1,0 +1,289 @@
+package org.batfish.minesweeper.collectors;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
+import org.batfish.datamodel.routing_policy.communities.CommunityAcl;
+import org.batfish.datamodel.routing_policy.communities.CommunityAclLine;
+import org.batfish.datamodel.routing_policy.communities.CommunityIn;
+import org.batfish.datamodel.routing_policy.communities.CommunityIs;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchAll;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchAny;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.CommunityNot;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorHighMatch;
+import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorLowMatch;
+import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorMatch;
+import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityLocalAdministratorMatch;
+import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
+import org.batfish.datamodel.routing_policy.communities.RouteTargetExtendedCommunities;
+import org.batfish.datamodel.routing_policy.communities.SiteOfOriginExtendedCommunities;
+import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighMatch;
+import org.batfish.datamodel.routing_policy.communities.StandardCommunityLowMatch;
+import org.batfish.datamodel.routing_policy.communities.VpnDistinguisherExtendedCommunities;
+import org.batfish.datamodel.routing_policy.expr.IntComparator;
+import org.batfish.datamodel.routing_policy.expr.IntComparison;
+import org.batfish.datamodel.routing_policy.expr.LiteralInt;
+import org.batfish.datamodel.routing_policy.expr.LiteralLong;
+import org.batfish.datamodel.routing_policy.expr.LongComparison;
+import org.batfish.minesweeper.utils.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link CommunityMatchExprCollector}. */
+public class CommunityMatchExprCollectorTest {
+
+  private static final String HOSTNAME = "hostname";
+  private static final String COMM_LST_1 = "comm1";
+  private static final String COMM_LST_2 = "comm2";
+
+  private static final Community COMM1 = StandardCommunity.parse("20:30");
+  private static final Community COMM2 = StandardCommunity.parse("21:30");
+
+  private CommunityMatchExprCollector _collector;
+
+  private Configuration _config;
+
+  @Before
+  public void setup() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    _config = cb.build();
+
+    CommunityMatchExpr cyclic =
+        new CommunityMatchAny(
+            ImmutableSet.of(
+                new CommunityMatchExprReference(COMM_LST_2),
+                new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^30:")));
+    _config.setCommunityMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1,
+            new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:"),
+            COMM_LST_2,
+            cyclic));
+    _collector = new CommunityMatchExprCollector();
+  }
+
+  @Test
+  public void testVisitCommunityAcl() {
+    CommunityAcl cacl =
+        new CommunityAcl(
+            ImmutableList.of(
+                new CommunityAclLine(
+                    LineAction.PERMIT, new CommunityMatchExprReference(COMM_LST_1)),
+                new CommunityAclLine(
+                    LineAction.DENY, new CommunityMatchExprReference(COMM_LST_2))));
+
+    Set<String> result = _collector.visitCommunityAcl(cacl, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunityIn() {
+    CommunityIn ci = new CommunityIn(new LiteralCommunitySet(CommunitySet.of(COMM1, COMM2)));
+
+    Set<String> result = _collector.visitCommunityIn(ci, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitCommunityIs() {
+    CommunityIs ci = new CommunityIs(COMM1);
+
+    Set<String> result = _collector.visitCommunityIs(ci, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitCommunityMatchAll() {
+    CommunityMatchAll cma =
+        new CommunityMatchAll(
+            ImmutableList.of(
+                new CommunityIs(COMM1),
+                new CommunityMatchExprReference(COMM_LST_1),
+                new CommunityMatchExprReference(COMM_LST_2)));
+
+    Set<String> result =
+        _collector.visitCommunityMatchAll(cma, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunityMatchAny() {
+    CommunityMatchAny cma =
+        new CommunityMatchAny(
+            ImmutableList.of(
+                new CommunityIs(COMM1),
+                new CommunityMatchExprReference(COMM_LST_1),
+                new CommunityMatchExprReference(COMM_LST_2)));
+
+    Set<String> result =
+        _collector.visitCommunityMatchAny(cma, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunityMatchExprReference() {
+    CommunityMatchExprReference cmer = new CommunityMatchExprReference(COMM_LST_1);
+
+    Set<String> result =
+        _collector.visitCommunityMatchExprReference(cmer, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1), result);
+  }
+
+  @Test
+  public void testVisitCommunityMatchRegex() {
+    CommunityMatchRegex cmr = new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:");
+
+    Set<String> result =
+        _collector.visitCommunityMatchRegex(cmr, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitCommunityNot() {
+    CommunityNot cn = new CommunityNot(new CommunityMatchExprReference(COMM_LST_2));
+
+    Set<String> result = _collector.visitCommunityNot(cn, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitExtendedCommunityGlobalAdministratorHighMatch() {
+    ExtendedCommunityGlobalAdministratorHighMatch ec =
+        new ExtendedCommunityGlobalAdministratorHighMatch(
+            new IntComparison(IntComparator.EQ, new LiteralInt(3)));
+    Set<String> result =
+        _collector.visitExtendedCommunityGlobalAdministratorHighMatch(
+            ec, new Tuple<>(new HashSet<>(), _config));
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitExtendedCommunityGlobalAdministratorLowMatch() {
+    ExtendedCommunityGlobalAdministratorLowMatch ec =
+        new ExtendedCommunityGlobalAdministratorLowMatch(
+            new IntComparison(IntComparator.EQ, new LiteralInt(3)));
+    Set<String> result =
+        _collector.visitExtendedCommunityGlobalAdministratorLowMatch(
+            ec, new Tuple<>(new HashSet<>(), _config));
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitExtendedCommunityGlobalAdministratorMatch() {
+    ExtendedCommunityGlobalAdministratorMatch ec =
+        new ExtendedCommunityGlobalAdministratorMatch(
+            new LongComparison(IntComparator.EQ, new LiteralLong(3L)));
+    Set<String> result =
+        _collector.visitExtendedCommunityGlobalAdministratorMatch(
+            ec, new Tuple<>(new HashSet<>(), _config));
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitExtendedCommunityLocalAdministratorMatch() {
+    ExtendedCommunityLocalAdministratorMatch ec =
+        new ExtendedCommunityLocalAdministratorMatch(
+            new IntComparison(IntComparator.EQ, new LiteralInt(3)));
+    Set<String> result =
+        _collector.visitExtendedCommunityLocalAdministratorMatch(
+            ec, new Tuple<>(new HashSet<>(), _config));
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitRouteTargetExtendedCommunities() {
+    RouteTargetExtendedCommunities ec = RouteTargetExtendedCommunities.instance();
+    Set<String> result =
+        _collector.visitRouteTargetExtendedCommunities(ec, new Tuple<>(new HashSet<>(), _config));
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitSiteOfOriginExtendedCommunities() {
+    SiteOfOriginExtendedCommunities ec = SiteOfOriginExtendedCommunities.instance();
+    Set<String> result =
+        _collector.visitSiteOfOriginExtendedCommunities(ec, new Tuple<>(new HashSet<>(), _config));
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitStandardCommunityHighMatch() {
+    StandardCommunityHighMatch schm =
+        new StandardCommunityHighMatch(new IntComparison(IntComparator.EQ, new LiteralInt(20)));
+
+    Set<String> result =
+        _collector.visitStandardCommunityHighMatch(schm, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitStandardCommunityHighMatchUnsupported() {
+    StandardCommunityHighMatch schm =
+        new StandardCommunityHighMatch(new IntComparison(IntComparator.LT, new LiteralInt(20)));
+
+    Set<String> result =
+        _collector.visitStandardCommunityHighMatch(schm, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitStandardCommunityLowMatch() {
+    StandardCommunityLowMatch sclm =
+        new StandardCommunityLowMatch(new IntComparison(IntComparator.EQ, new LiteralInt(30)));
+
+    Set<String> result =
+        _collector.visitStandardCommunityLowMatch(sclm, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitStandardCommunityLowMatchUnsupported() {
+    StandardCommunityLowMatch sclm =
+        new StandardCommunityLowMatch(new IntComparison(IntComparator.LT, new LiteralInt(30)));
+
+    Set<String> result =
+        _collector.visitStandardCommunityLowMatch(sclm, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitVpnDistinguisherExtendedCommunities() {
+    VpnDistinguisherExtendedCommunities ec = VpnDistinguisherExtendedCommunities.instance();
+    Set<String> result =
+        _collector.visitVpnDistinguisherExtendedCommunities(
+            ec, new Tuple<>(new HashSet<>(), _config));
+    assertEquals(ImmutableSet.of(), result);
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunitySetExprCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunitySetExprCollectorTest.java
@@ -1,0 +1,129 @@
+package org.batfish.minesweeper.collectors;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
+import org.batfish.datamodel.routing_policy.communities.CommunityExprsSet;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetUnion;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
+import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
+import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighLowExprs;
+import org.batfish.datamodel.routing_policy.expr.LiteralInt;
+import org.batfish.minesweeper.utils.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link CommunitySetExprCollector}. */
+public class CommunitySetExprCollectorTest {
+  private static final String HOSTNAME = "hostname";
+  private static final String COMM_LST_1 = "comm1";
+  private static final String COMM_LST_2 = "comm2";
+
+  private CommunitySetExprCollector _collector;
+
+  private Configuration _config;
+
+  @Before
+  public void setup() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    _config = cb.build();
+
+    CommunitySetExpr cyclic =
+        CommunitySetUnion.of(
+            ImmutableSet.of(
+                new CommunitySetReference(COMM_LST_2),
+                new LiteralCommunitySet(CommunitySet.of(StandardCommunity.parse("20:30")))));
+    _config.setCommunitySetExprs(
+        ImmutableMap.of(
+            COMM_LST_1,
+            new LiteralCommunitySet(CommunitySet.of(StandardCommunity.parse("20:30"))),
+            COMM_LST_2,
+            cyclic));
+    _collector = new CommunitySetExprCollector();
+  }
+
+  @Test
+  public void testVisitCommunityExprsSet() {
+    CommunityExprsSet ces =
+        CommunityExprsSet.of(
+            new StandardCommunityHighLowExprs(new LiteralInt(20), new LiteralInt(30)),
+            new StandardCommunityHighLowExprs(new LiteralInt(21), new LiteralInt(30)));
+
+    Set<String> result =
+        _collector.visitCommunityExprsSet(ces, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetDifference() {
+    CommunitySetDifference csd =
+        new CommunitySetDifference(
+            new CommunitySetExprReference(COMM_LST_2),
+            new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:"));
+
+    Set<String> result =
+        _collector.visitCommunitySetDifference(csd, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetExprReference() {
+    Set<String> result =
+        _collector.visitCommunitySetExprReference(
+            new CommunitySetExprReference(COMM_LST_2), new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetReference() {
+    Set<String> result =
+        _collector.visitCommunitySetReference(
+            new CommunitySetReference(COMM_LST_2), new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetUnion() {
+    CommunitySetUnion csu =
+        CommunitySetUnion.of(
+            new CommunitySetExprReference(COMM_LST_1), new CommunitySetExprReference(COMM_LST_2));
+
+    Set<String> result =
+        _collector.visitCommunitySetUnion(csu, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitInputCommunities() {
+
+    Set<String> result =
+        _collector.visitInputCommunities(
+            new InputCommunities(), new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunitySetMatchExprCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunitySetMatchExprCollectorTest.java
@@ -1,0 +1,153 @@
+package org.batfish.minesweeper.collectors;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
+import org.batfish.datamodel.routing_policy.communities.CommunityIs;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetAcl;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetAclLine;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAll;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAny;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetNot;
+import org.batfish.datamodel.routing_policy.communities.HasCommunity;
+import org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated;
+import org.batfish.minesweeper.utils.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link CommunitySetMatchExprCollector}. */
+public class CommunitySetMatchExprCollectorTest {
+  private static final String HOSTNAME = "hostname";
+  private static final String COMM_LST_1 = "comm1";
+  private static final String COMM_LST_2 = "comm2";
+
+  private static final Community COMM1 = StandardCommunity.parse("20:30");
+  private static final Community COMM2 = StandardCommunity.parse("21:30");
+
+  private CommunitySetMatchExprCollector _collector;
+
+  private Configuration _config;
+
+  @Before
+  public void setup() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    _config = cb.build();
+
+    CommunitySetMatchExpr cyclic =
+        new CommunitySetMatchAny(
+            ImmutableSet.of(
+                new CommunitySetMatchExprReference(COMM_LST_2),
+                new HasCommunity(
+                    new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:"))));
+    _config.setCommunitySetMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1,
+            new HasCommunity(new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^10:")),
+            COMM_LST_2,
+            cyclic));
+    _collector = new CommunitySetMatchExprCollector();
+  }
+
+  @Test
+  public void testVisitCommunitySetAcl() {
+    CommunitySetAcl csacl =
+        new CommunitySetAcl(
+            ImmutableList.of(
+                new CommunitySetAclLine(LineAction.DENY, new HasCommunity(new CommunityIs(COMM1))),
+                new CommunitySetAclLine(
+                    LineAction.PERMIT, new HasCommunity(new CommunityIs(COMM2)))));
+
+    Set<String> result =
+        _collector.visitCommunitySetAcl(csacl, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetMatchAll() {
+    CommunitySetMatchAll csma =
+        new CommunitySetMatchAll(
+            ImmutableList.of(
+                new CommunitySetMatchExprReference(COMM_LST_1),
+                new CommunitySetMatchExprReference(COMM_LST_2)));
+
+    Set<String> result =
+        _collector.visitCommunitySetMatchAll(csma, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetMatchAny() {
+    CommunitySetMatchAny csma =
+        new CommunitySetMatchAny(
+            ImmutableList.of(
+                new CommunitySetMatchExprReference(COMM_LST_1),
+                new CommunitySetMatchExprReference(COMM_LST_2)));
+
+    Set<String> result =
+        _collector.visitCommunitySetMatchAny(csma, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1, COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetMatchExprReference() {
+    CommunitySetMatchExprReference csmer = new CommunitySetMatchExprReference(COMM_LST_2);
+
+    Set<String> result =
+        _collector.visitCommunitySetMatchExprReference(
+            csmer, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_2), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetMatchRegex() {
+    CommunitySetMatchRegex cmsr =
+        new CommunitySetMatchRegex(
+            new TypesFirstAscendingSpaceSeparated(ColonSeparatedRendering.instance()),
+            "^65000:123 65011:12[3]$");
+    Set<String> result = cmsr.accept(_collector, new Tuple<>(new HashSet<>(), _config));
+    assertEquals(ImmutableSet.of(), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetNot() {
+    CommunitySetNot csn = new CommunitySetNot(new CommunitySetMatchExprReference(COMM_LST_1));
+
+    Set<String> result =
+        _collector.visitCommunitySetNot(csn, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(COMM_LST_1), result);
+  }
+
+  @Test
+  public void testVisitHasCommunity() {
+    HasCommunity hc = new HasCommunity(new CommunityIs(COMM1));
+
+    Set<String> result = _collector.visitHasCommunity(hc, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(), result);
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/RoutePolicyBooleanExprCallCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/RoutePolicyBooleanExprCallCollectorTest.java
@@ -1,0 +1,152 @@
+package org.batfish.minesweeper.collectors;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.expr.CallExpr;
+import org.batfish.datamodel.routing_policy.expr.Conjunction;
+import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
+import org.batfish.datamodel.routing_policy.expr.Disjunction;
+import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
+import org.batfish.datamodel.routing_policy.expr.Not;
+import org.batfish.datamodel.routing_policy.expr.TrackSucceeded;
+import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
+import org.batfish.datamodel.routing_policy.statement.CallStatement;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.batfish.minesweeper.utils.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RoutePolicyBooleanExprCallCollectorTest {
+  private static final String HOSTNAME = "hostname";
+  private static final String RM1 = "RM1";
+  private static final String RM2 = "RM2";
+  private static final String RM3 = "RM3";
+  private static final String RM4 = "RM4";
+  private RoutePolicyBooleanExprCallCollector _collector;
+  private NetworkFactory _nf;
+  private Configuration _config;
+
+  @Before
+  public void setup() throws IOException {
+    _nf = new NetworkFactory();
+    Configuration.Builder cb =
+        _nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    _config = cb.build();
+
+    _collector = new RoutePolicyBooleanExprCallCollector();
+  }
+
+  @Test
+  public void testVisitConjunction() {
+
+    Conjunction c = new Conjunction(ImmutableList.of(new CallExpr(RM2), new CallExpr(RM3)));
+
+    Set<String> result = _collector.visitConjunction(c, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(RM2, RM3), result);
+  }
+
+  @Test
+  public void testVisitConjunctionChain() {
+
+    ConjunctionChain cc =
+        new ConjunctionChain(ImmutableList.of(new CallExpr(RM2), new CallExpr(RM3)));
+
+    Set<String> result =
+        _collector.visitConjunctionChain(cc, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(RM2, RM3), result);
+  }
+
+  @Test
+  public void testVisitDisjunction() {
+
+    Disjunction d = new Disjunction(ImmutableList.of(new CallExpr(RM2), new CallExpr(RM3)));
+
+    Set<String> result = _collector.visitDisjunction(d, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(RM2, RM3), result);
+  }
+
+  @Test
+  public void testVisitFirstMatchChain() {
+
+    FirstMatchChain fmc =
+        new FirstMatchChain(ImmutableList.of(new CallExpr(RM2), new CallExpr(RM3)));
+
+    Set<String> result =
+        _collector.visitFirstMatchChain(fmc, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(RM2, RM3), result);
+  }
+
+  @Test
+  public void testVisitTrackSucceeded() {
+    assertThat(
+        _collector.visitTrackSucceeded(
+            new TrackSucceeded("foo"), new Tuple<>(new HashSet<>(), _config)),
+        empty());
+  }
+
+  @Test
+  public void testVisitNot() {
+
+    Not n = new Not(new CallExpr(RM1));
+
+    Set<String> result = _collector.visitNot(n, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(RM1), result);
+  }
+
+  @Test
+  public void testVisitWithEnvironmentExpr() {
+
+    WithEnvironmentExpr wee = new WithEnvironmentExpr();
+    wee.setExpr(new CallExpr(RM1));
+    wee.setPreStatements(ImmutableList.of(new CallStatement(RM2)));
+    wee.setPostStatements(ImmutableList.of(new CallStatement(RM3)));
+    wee.setPostTrueStatements(ImmutableList.of(new CallStatement(RM4)));
+
+    Set<String> result =
+        _collector.visitWithEnvironmentExpr(wee, new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(RM1, RM2, RM3, RM4), result);
+  }
+
+  @Test
+  public void testCallExprNested() {
+    Map<String, RoutingPolicy> routingPolicies = new HashMap<>();
+    _config.setRoutingPolicies(routingPolicies);
+    RoutingPolicy rm1 =
+        _nf.routingPolicyBuilder()
+            .setOwner(_config)
+            .setName("RM1")
+            .addStatement(
+                new If(
+                    new CallExpr(RM2),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+    routingPolicies.put(RM1, rm1);
+
+    Set<String> result =
+        _collector.visitCallExpr(new CallExpr(RM1), new Tuple<>(new HashSet<>(), _config));
+
+    assertEquals(ImmutableSet.of(RM1), result);
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/RoutePolicyStatementCallCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/RoutePolicyStatementCallCollectorTest.java
@@ -1,0 +1,98 @@
+package org.batfish.minesweeper.collectors;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.expr.CallExpr;
+import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
+import org.batfish.datamodel.routing_policy.statement.CallStatement;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
+import org.batfish.minesweeper.utils.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link RoutePolicyStatementCallCollector}. */
+public class RoutePolicyStatementCallCollectorTest {
+  private static final String HOSTNAME = "hostname";
+  private static final String RM1 = "RM1";
+  private static final String RM2 = "RM2";
+  private Configuration _baseConfig;
+  private NetworkFactory _nf;
+  private RoutePolicyStatementCallCollector _collector;
+
+  @Before
+  public void setup() {
+    _nf = new NetworkFactory();
+    Configuration.Builder cb =
+        _nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _baseConfig = cb.build();
+    _nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+
+    _collector = new RoutePolicyStatementCallCollector();
+  }
+
+  @Test
+  public void testVisitBufferedStatement() {
+    BufferedStatement bs =
+        new BufferedStatement(
+            new If(new CallExpr(RM1), ImmutableList.of(Statements.ExitAccept.toStaticStatement())));
+
+    Set<String> result =
+        _collector.visitBufferedStatement(bs, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(RM1), result);
+  }
+
+  @Test
+  public void testVisitIf() {
+    If ifstmt = new If(new CallExpr(RM2), ImmutableList.of(new CallStatement(RM1)));
+    Set<String> result = _collector.visitIf(ifstmt, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    assertEquals(ImmutableSet.of(RM1, RM2), result);
+  }
+
+  @Test
+  public void testVisitTraceableStatement() {
+    TraceableStatement traceableStatement =
+        new TraceableStatement(
+            TraceElement.of("statement"), ImmutableList.of(new CallStatement(RM2)));
+
+    Set<String> result =
+        _collector.visitTraceableStatement(
+            traceableStatement, new Tuple<>(new HashSet<>(), _baseConfig));
+    assertEquals(ImmutableSet.of(RM2), result);
+  }
+
+  @Test
+  public void testVisitCallStatement() {
+
+    RoutingPolicy rm2 =
+        _nf.routingPolicyBuilder()
+            .setName(RM2)
+            .setOwner(_baseConfig)
+            .addStatement(new CallStatement("ignored"))
+            .build();
+
+    RoutingPolicy rm1 =
+        _nf.routingPolicyBuilder().setName(RM1).addStatement(new CallStatement(RM2)).build();
+
+    _baseConfig.setRoutingPolicies(ImmutableMap.of(RM2, rm2, RM1, rm1));
+
+    assertEquals(
+        ImmutableSet.of(RM2),
+        _collector.visitAll(rm1.getStatements(), new Tuple<>(new HashSet<>(), _baseConfig)));
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
@@ -1,0 +1,699 @@
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import static org.batfish.datamodel.LineAction.DENY;
+import static org.batfish.datamodel.LineAction.PERMIT;
+import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
+import static org.batfish.datamodel.table.TableDiff.baseColumnName;
+import static org.batfish.datamodel.table.TableDiff.deltaColumnName;
+import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.COL_ACTION;
+import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.COL_DIFF;
+import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.COL_INPUT_ROUTE;
+import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.COL_NODE;
+import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.COL_OUTPUT_ROUTE;
+import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.COL_POLICY_NAME;
+import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.COL_REFERENCE_POLICY_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import java.io.IOException;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.AsPathAccessList;
+import org.batfish.datamodel.AsPathAccessListLine;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.OriginMechanism;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.PrefixSpace;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker;
+import org.batfish.datamodel.bgp.NextHopIpTieBreaker;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.questions.BgpRoute;
+import org.batfish.datamodel.questions.BgpRouteDiff;
+import org.batfish.datamodel.questions.BgpRouteDiffs;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.HasCommunity;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
+import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
+import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
+import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.LiteralLong;
+import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.NamedAsPathSet;
+import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.ComparePeerGroupPoliciesAnswerer;
+import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.ComparePeerGroupPoliciesQuestion;
+
+public class ComparePeerGroupPoliciesAnswererTest {
+  @Rule public TemporaryFolder _tempFolder = new TemporaryFolder();
+
+  Batfish _batfish;
+
+  private static final String HOSTNAME = "hostname";
+  private static final String POLICY_NAME = "RM1";
+  private static final String AS_PATH_1 = "asPath1";
+  private static final String AS_PATH_2 = "asPath2";
+  private static final String PFX_LST_1 = "pfx1";
+  private static final String PFX_LST_2 = "pfx2";
+  private static final String COMM_LST_1 = "comm1";
+
+  private RoutingPolicy.Builder _policyBuilderDelta;
+  private RoutingPolicy.Builder _policyBuilderBase;
+
+  @Before
+  public void setup() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    Configuration baseConfig = cb.build();
+
+    Configuration.Builder db =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    Configuration deltaConfig = db.build();
+
+    // AsPathAccessList only properly initializes its state upon deserialization
+    AsPathAccessList asPath1 =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_1, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^40$"))));
+    AsPathAccessList asPath2 =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_2, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^50$"))));
+
+    AsPathAccessList asPath1Delta =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_1, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^30$"))));
+    baseConfig.setAsPathAccessLists(ImmutableMap.of(AS_PATH_1, asPath1, AS_PATH_2, asPath2));
+    deltaConfig.setAsPathAccessLists(ImmutableMap.of(AS_PATH_1, asPath1Delta, AS_PATH_2, asPath2));
+
+    RouteFilterList f1 =
+        new RouteFilterList(
+            PFX_LST_1,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.1/32")))));
+    RouteFilterList f2 =
+        new RouteFilterList(
+            PFX_LST_2,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/31")))));
+    RouteFilterList f1Delta =
+        new RouteFilterList(
+            PFX_LST_1,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.1/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.2/32")))));
+
+    baseConfig.setRouteFilterLists(ImmutableMap.of(PFX_LST_1, f1, PFX_LST_2, f2));
+    deltaConfig.setRouteFilterLists(ImmutableMap.of(PFX_LST_1, f1Delta, PFX_LST_2, f2));
+
+    baseConfig.setCommunityMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:")));
+    deltaConfig.setCommunityMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^10:")));
+
+    Vrf baseVrf =
+        nf.vrfBuilder().setOwner(baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+    Vrf deltaVrf =
+        nf.vrfBuilder().setOwner(deltaConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+
+    BgpProcess baseBgp =
+        nf.bgpProcessBuilder()
+            .setRouterId(Ip.FIRST_CLASS_A_PRIVATE_IP)
+            .setEbgpAdminCost(0)
+            .setIbgpAdminCost(0)
+            .setLocalAdminCost(0)
+            .setLocalOriginationTypeTieBreaker(LocalOriginationTypeTieBreaker.NO_PREFERENCE)
+            .setNetworkNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
+            .setRedistributeNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
+            .setVrf(baseVrf)
+            .build();
+
+    BgpActivePeerConfig baseBgpPeer =
+        BgpActivePeerConfig.builder()
+            .setGroup("testGroup")
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder().setExportPolicy(POLICY_NAME).build())
+            .build();
+    baseBgp.setNeighbors(ImmutableSortedMap.of(Ip.FIRST_CLASS_A_PRIVATE_IP, baseBgpPeer));
+
+    baseVrf.setBgpProcess(baseBgp);
+
+    BgpProcess deltaBgp =
+        nf.bgpProcessBuilder()
+            .setRouterId(Ip.FIRST_CLASS_A_PRIVATE_IP)
+            .setEbgpAdminCost(0)
+            .setIbgpAdminCost(0)
+            .setLocalAdminCost(0)
+            .setLocalOriginationTypeTieBreaker(LocalOriginationTypeTieBreaker.NO_PREFERENCE)
+            .setNetworkNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
+            .setRedistributeNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
+            .setVrf(deltaVrf)
+            .build();
+
+    BgpActivePeerConfig deltaBgpPeer =
+        BgpActivePeerConfig.builder()
+            .setGroup("testGroup")
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder().setExportPolicy(POLICY_NAME).build())
+            .build();
+    deltaBgp.setNeighbors(ImmutableSortedMap.of(Ip.FIRST_CLASS_A_PRIVATE_IP, deltaBgpPeer));
+
+    deltaVrf.setBgpProcess(deltaBgp);
+
+    _policyBuilderBase = nf.routingPolicyBuilder().setOwner(baseConfig).setName(POLICY_NAME);
+    _policyBuilderDelta = nf.routingPolicyBuilder().setOwner(deltaConfig).setName(POLICY_NAME);
+
+    _batfish =
+        BatfishTestUtils.getBatfish(
+            ImmutableSortedMap.of(HOSTNAME, baseConfig),
+            ImmutableSortedMap.of(HOSTNAME, deltaConfig),
+            _tempFolder);
+  }
+
+  @Test
+  public void testNoDifference() {
+    _policyBuilderDelta.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+    _policyBuilderBase.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    assertThat("the two are equivalent", answer.getRows().getData().isEmpty());
+  }
+
+  /** Tests route-map diff when the action differs. */
+  @Test
+  public void testActionDifference() {
+    _policyBuilderDelta.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+    _policyBuilderBase.addStatement(new Statements.StaticStatement(Statements.ExitReject)).build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    BgpRouteDiffs diff = new BgpRouteDiffs(ImmutableSet.of());
+
+    BgpRoute inputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of())
+            .setAsPath(AsPath.ofSingletonAsSets())
+            .build();
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
+  }
+
+  private MatchPrefixSet matchPrefixSet(List<PrefixRange> prList) {
+    return new MatchPrefixSet(
+        DestinationNetwork.instance(), new ExplicitPrefixSet(new PrefixSpace(prList)));
+  }
+
+  /** Tests route-map diff when the output routes differ. */
+  @Test
+  public void testRouteMapDiff() {
+    _policyBuilderDelta
+        .addStatement(
+            new If(
+                matchPrefixSet(
+                    ImmutableList.of(
+                        new PrefixRange(Prefix.parse("10.0.0.0/24"), new SubRange(32, 32)))),
+                ImmutableList.of(
+                    new SetLocalPreference(new LiteralLong(150)),
+                    new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+    _policyBuilderDelta.addStatement(new Statements.StaticStatement(Statements.ExitReject)).build();
+    _policyBuilderBase.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    BgpRouteDiffs diff =
+        new BgpRouteDiffs(
+            ImmutableSet.of(new BgpRouteDiff(BgpRoute.PROP_LOCAL_PREFERENCE, "150", "100")));
+
+    BgpRoute inputRoute_1 =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of())
+            .setAsPath(AsPath.ofSingletonAsSets())
+            .build();
+
+    BgpRoute inputRoute_2 =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/32"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of())
+            .setAsPath(AsPath.ofSingletonAsSets())
+            .build();
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute_1), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(deltaColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, new BgpRouteDiffs(ImmutableSet.of()), Schema.BGP_ROUTE_DIFFS)),
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute_2), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
+  }
+
+  /** Tests route-map diff when an AS-Path list definition differs. */
+  @Test
+  public void testMatchNamedAsPathDiff() {
+    _policyBuilderBase
+        .addStatement(
+            new If(
+                new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+    _policyBuilderDelta
+        .addStatement(
+            new If(
+                new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    BgpRouteDiffs diff = new BgpRouteDiffs(ImmutableSet.of());
+
+    BgpRoute inputRoute_1 =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of())
+            .setAsPath(AsPath.ofSingletonAsSets(30L))
+            .build();
+
+    BgpRoute inputRoute_2 =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of())
+            .setAsPath(AsPath.ofSingletonAsSets(40L))
+            .build();
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute_1), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(deltaColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS)),
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute_2), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
+  }
+
+  /** Tests route-map diff when the policies are the same but a named prefix-list differs. */
+  @Test
+  public void testMatchNamedPrefix() {
+    _policyBuilderBase
+        .addStatement(
+            new If(
+                new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_1)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+    _policyBuilderDelta
+        .addStatement(
+            new If(
+                new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_1)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    BgpRouteDiffs diff = new BgpRouteDiffs(ImmutableSet.of());
+
+    BgpRoute inputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.2/32"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of())
+            .setAsPath(AsPath.ofSingletonAsSets())
+            .build();
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
+  }
+
+  /** Tests route-map diffs when a named-prefix list is the same. Should be no difference. */
+  @Test
+  public void testMatchNamedPrefixSame() {
+    _policyBuilderBase
+        .addStatement(
+            new If(
+                new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_2)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+    _policyBuilderDelta
+        .addStatement(
+            new If(
+                new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_2)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    assertThat("the two are equivalent", answer.getRows().getData().isEmpty());
+  }
+
+  /** Tests route-maps when their community-lists differ. */
+  @Test
+  public void testMatchCommunityReference() {
+    _policyBuilderBase
+        .addStatement(
+            new If(
+                new MatchCommunities(
+                    InputCommunities.instance(),
+                    new HasCommunity(new CommunityMatchExprReference(COMM_LST_1))),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+    _policyBuilderDelta
+        .addStatement(
+            new If(
+                new MatchCommunities(
+                    InputCommunities.instance(),
+                    new HasCommunity(new CommunityMatchExprReference(COMM_LST_1))),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    BgpRouteDiffs diff = new BgpRouteDiffs(ImmutableSet.of());
+
+    BgpRoute inputRoute_1 =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of(StandardCommunity.of(10, 0)))
+            .setAsPath(AsPath.ofSingletonAsSets())
+            .build();
+
+    BgpRoute inputRoute_2 =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.0/8"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of(StandardCommunity.of(20, 0)))
+            .setAsPath(AsPath.ofSingletonAsSets())
+            .build();
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute_1), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(deltaColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS)),
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute_2), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
+  }
+
+  /** Tests that table stitching works correctly. */
+  @Test
+  public void testTableStitching() throws IOException {
+    _policyBuilderBase
+        .addStatement(
+            new If(
+                new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_1)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+    _policyBuilderDelta
+        .addStatement(
+            new If(
+                new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_1)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+
+    // Add another peer group
+    Configuration currentConfig =
+        _batfish.getProcessedConfigurations(_batfish.getSnapshot()).get().get(HOSTNAME);
+    Configuration referenceConfig =
+        _batfish.getProcessedConfigurations(_batfish.getReferenceSnapshot()).get().get(HOSTNAME);
+
+    SortedMap<Ip, BgpActivePeerConfig> baseBgpPeers =
+        new TreeMap<>(currentConfig.getDefaultVrf().getBgpProcess().getActiveNeighbors());
+    BgpActivePeerConfig secondBgpPeer =
+        BgpActivePeerConfig.builder()
+            .setGroup("secondTestGroup")
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder().setExportPolicy("RM2").build())
+            .build();
+    baseBgpPeers.put(Ip.FIRST_CLASS_B_PRIVATE_IP, secondBgpPeer);
+    currentConfig.getDefaultVrf().getBgpProcess().setNeighbors(baseBgpPeers);
+
+    SortedMap<Ip, BgpActivePeerConfig> deltaBgpPeers =
+        new TreeMap<>(referenceConfig.getDefaultVrf().getBgpProcess().getActiveNeighbors());
+    deltaBgpPeers.put(Ip.FIRST_CLASS_B_PRIVATE_IP, secondBgpPeer);
+    referenceConfig.getDefaultVrf().getBgpProcess().setNeighbors(deltaBgpPeers);
+
+    // Add policy to second peer group
+    _policyBuilderBase
+        .setName("RM2")
+        .addStatement(
+            new If(
+                new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_1)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+    _policyBuilderDelta
+        .setName("RM2")
+        .addStatement(
+            new If(
+                new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_1)),
+                ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+        .build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    BgpRouteDiffs diff = new BgpRouteDiffs(ImmutableSet.of());
+
+    BgpRoute inputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("10.0.0.2/32"))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.EGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(Ip.parse("0.0.0.1"))
+            .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)
+            .setCommunities(ImmutableSet.of())
+            .setAsPath(AsPath.ofSingletonAsSets())
+            .build();
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS)),
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo("RM2"), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo("RM2"), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(baseColumnName(COL_OUTPUT_ROUTE), anything(), Schema.BGP_ROUTE),
+                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/RoutingPolicyContextDiffTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/RoutingPolicyContextDiffTest.java
@@ -1,0 +1,202 @@
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import static org.batfish.datamodel.LineAction.PERMIT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.datamodel.AsPathAccessList;
+import org.batfish.datamodel.AsPathAccessListLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
+import org.batfish.datamodel.routing_policy.communities.HasCommunity;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
+import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
+import org.batfish.datamodel.routing_policy.expr.Conjunction;
+import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
+import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.NamedAsPathSet;
+import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.junit.Before;
+import org.junit.Test;
+import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.RoutingPolicyContextDiff;
+
+public class RoutingPolicyContextDiffTest {
+  private static final String HOSTNAME = "hostname";
+  private static final String AS_PATH_1 = "asPath1";
+  private static final String AS_PATH_2 = "asPath2";
+  private static final String PFX_LST_1 = "pfx1";
+  private static final String PFX_LST_2 = "pfx2";
+  private static final String COMM_LST_1 = "comm1";
+  private static final String COMM_LST_2 = "comm2";
+  private RoutingPolicyContextDiff _contextDiff;
+  private RoutingPolicy.Builder _policyBuilder;
+
+  @Before
+  public void setup() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    Configuration baseConfig = cb.build();
+
+    Configuration.Builder db =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    Configuration deltaConfig = db.build();
+
+    // AsPathAccessList only properly initializes its state upon deserialization
+    AsPathAccessList asPath1 =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_1, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^40$"))));
+    AsPathAccessList asPath2 =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_2, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^50$"))));
+
+    AsPathAccessList asPath1Delta =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_1, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^30$"))));
+    baseConfig.setAsPathAccessLists(ImmutableMap.of(AS_PATH_1, asPath1, AS_PATH_2, asPath2));
+    deltaConfig.setAsPathAccessLists(ImmutableMap.of(AS_PATH_1, asPath1Delta, AS_PATH_2, asPath2));
+
+    RouteFilterList f1 =
+        new RouteFilterList(
+            PFX_LST_1,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.1/32")))));
+    RouteFilterList f2 =
+        new RouteFilterList(
+            PFX_LST_2,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/31")))));
+    RouteFilterList f1Delta =
+        new RouteFilterList(
+            PFX_LST_1,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.1/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.2/32")))));
+
+    baseConfig.setRouteFilterLists(ImmutableMap.of(PFX_LST_1, f1, PFX_LST_2, f2));
+
+    // Note: we do not add PFX_LST_2 to the delta config.
+    deltaConfig.setRouteFilterLists(ImmutableMap.of(PFX_LST_1, f1Delta));
+
+    baseConfig.setCommunityMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:"),
+            COMM_LST_2, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^0:0$")));
+    deltaConfig.setCommunityMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^10:"),
+            COMM_LST_2, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^0:0$")));
+    _contextDiff = new RoutingPolicyContextDiff(baseConfig, deltaConfig);
+    _policyBuilder = nf.routingPolicyBuilder().setOwner(baseConfig).setName("RM1");
+  }
+
+  @Test
+  public void testAsPathDiff() {
+    assertEquals(ImmutableSet.of(AS_PATH_1), _contextDiff.getAsPathAccessListsDiff());
+  }
+
+  @Test
+  public void testRouteFilterListDiff() {
+    assertEquals(ImmutableSet.of(PFX_LST_1, PFX_LST_2), _contextDiff.getRouteFilterListsDiff());
+  }
+
+  @Test
+  public void testCommunityMatchExprDiff() {
+    assertEquals(ImmutableSet.of(COMM_LST_1), _contextDiff.getCommunityListsDiff());
+  }
+
+  /**
+   * Test that the difference due to the as-path is found if the AS-Path list that differs is used.
+   */
+  @Test
+  public void testDifferOnAsPath() {
+    RoutingPolicy p =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+    assertTrue(_contextDiff.differ(p));
+  }
+
+  /**
+   * Test that the difference due to the community list is found if the community list that differs
+   * is used.
+   */
+  @Test
+  public void testDifferOnCommunity() {
+    RoutingPolicy p =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    new MatchCommunities(
+                        InputCommunities.instance(),
+                        new HasCommunity(new CommunityMatchExprReference(COMM_LST_1))),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+    assertTrue(_contextDiff.differ(p));
+  }
+
+  /**
+   * Test that the difference due to the route-filter is found if the route-filter list that differs
+   * is used.
+   */
+  @Test
+  public void testDifferOnPrefixList() {
+    RoutingPolicy p =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    new MatchPrefixSet(
+                        DestinationNetwork.instance(), new NamedPrefixSet(PFX_LST_1)),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+    assertTrue(_contextDiff.differ(p));
+  }
+
+  /** Test that differences are ignored if they are not used in the given routing policy */
+  @Test
+  public void testDifferencesIgnored() {
+    RoutingPolicy p =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    new Conjunction(
+                        ImmutableList.of(
+                            new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_2)),
+                            new MatchCommunities(
+                                InputCommunities.instance(),
+                                new HasCommunity(new CommunityMatchExprReference(COMM_LST_2))))),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+    assertFalse(_contextDiff.differ(p));
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticCompareTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticCompareTest.java
@@ -1,0 +1,255 @@
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
+
+import static org.batfish.datamodel.LineAction.PERMIT;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.datamodel.AsPathAccessList;
+import org.batfish.datamodel.AsPathAccessListLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
+import org.batfish.datamodel.routing_policy.expr.LegacyMatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.NamedAsPathSet;
+import org.batfish.datamodel.routing_policy.statement.CallStatement;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.junit.Before;
+import org.junit.Test;
+import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.SyntacticCompare;
+
+public class SyntacticCompareTest {
+  private static final String HOSTNAME = "hostname";
+  private static final String AS_PATH_1 = "asPath1";
+  private static final String AS_PATH_2 = "asPath2";
+  private static final String PFX_LST_1 = "pfx1";
+  private static final String PFX_LST_2 = "pfx2";
+  private static final String COMM_LST_1 = "comm1";
+  private static final String COMM_LST_2 = "comm2";
+
+  private RoutingPolicy.Builder _policyBuilderBase;
+  private RoutingPolicy.Builder _policyBuilderDelta;
+  private SyntacticCompare _syntacticCompare;
+  private Configuration _baseConfig;
+  private Configuration _deltaConfig;
+
+  @Before
+  public void setup() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    _baseConfig = cb.build();
+
+    Configuration.Builder db =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    _deltaConfig = db.build();
+
+    // AsPathAccessList only properly initializes its state upon deserialization
+    AsPathAccessList asPath1 =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_1, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^40$"))));
+    AsPathAccessList asPath2 =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_2, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^50$"))));
+
+    AsPathAccessList asPath1Delta =
+        SerializationUtils.clone(
+            new AsPathAccessList(
+                AS_PATH_1, ImmutableList.of(new AsPathAccessListLine(PERMIT, "^30$"))));
+    _baseConfig.setAsPathAccessLists(ImmutableMap.of(AS_PATH_1, asPath1, AS_PATH_2, asPath2));
+    _deltaConfig.setAsPathAccessLists(ImmutableMap.of(AS_PATH_1, asPath1Delta, AS_PATH_2, asPath2));
+
+    RouteFilterList f1 =
+        new RouteFilterList(
+            PFX_LST_1,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.1/32")))));
+    RouteFilterList f2 =
+        new RouteFilterList(
+            PFX_LST_2,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/31")))));
+    RouteFilterList f1Delta =
+        new RouteFilterList(
+            PFX_LST_1,
+            ImmutableList.of(
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.0/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.1/32"))),
+                new RouteFilterLine(PERMIT, PrefixRange.fromPrefix(Prefix.parse("10.0.0.2/32")))));
+
+    _baseConfig.setRouteFilterLists(ImmutableMap.of(PFX_LST_1, f1, PFX_LST_2, f2));
+
+    // Note: we do not add PFX_LST_2 to the delta config.
+    _deltaConfig.setRouteFilterLists(ImmutableMap.of(PFX_LST_1, f1Delta));
+
+    _baseConfig.setCommunityMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:"),
+            COMM_LST_2, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^0:0$")));
+    _deltaConfig.setCommunityMatchExprs(
+        ImmutableMap.of(
+            COMM_LST_1, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^10:"),
+            COMM_LST_2, new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^0:0$")));
+    _policyBuilderBase = nf.routingPolicyBuilder().setOwner(_baseConfig).setName("RM1");
+    _policyBuilderDelta = nf.routingPolicyBuilder().setOwner(_baseConfig).setName("RM1");
+    _syntacticCompare = new SyntacticCompare(_baseConfig, _deltaConfig);
+    Map<String, RoutingPolicy> routingPolicies = new HashMap<>();
+    Map<String, RoutingPolicy> deltaRoutingPolicies = new HashMap<>();
+    _baseConfig.setRoutingPolicies(routingPolicies);
+    _deltaConfig.setRoutingPolicies(deltaRoutingPolicies);
+  }
+
+  @Test
+  public void testNoDifference() {
+    RoutingPolicy base =
+        _policyBuilderBase
+            .addStatement(new Statements.StaticStatement(Statements.ExitAccept))
+            .build();
+    RoutingPolicy delta =
+        _policyBuilderDelta
+            .addStatement(new Statements.StaticStatement(Statements.ExitAccept))
+            .build();
+    _baseConfig.getRoutingPolicies().put("RM1", base);
+    _deltaConfig.getRoutingPolicies().put("RM1", delta);
+    assertTrue(_syntacticCompare.areEqual(base.getName(), delta.getName()));
+  }
+
+  @Test
+  public void testSyntacticDifference() {
+    RoutingPolicy base =
+        _policyBuilderBase
+            .addStatement(new Statements.StaticStatement(Statements.ExitAccept))
+            .build();
+    RoutingPolicy delta =
+        _policyBuilderDelta
+            .addStatement(new Statements.StaticStatement(Statements.ExitReject))
+            .build();
+    _baseConfig.getRoutingPolicies().put("RM1", base);
+    _deltaConfig.getRoutingPolicies().put("RM1", delta);
+    assertFalse(_syntacticCompare.areEqual(base.getName(), delta.getName()));
+  }
+
+  @Test
+  public void testContextDifference() {
+    RoutingPolicy base =
+        _policyBuilderBase
+            .addStatement(
+                new If(
+                    new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+    RoutingPolicy delta =
+        _policyBuilderDelta
+            .addStatement(
+                new If(
+                    new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+    _baseConfig.getRoutingPolicies().put("RM1", base);
+    _deltaConfig.getRoutingPolicies().put("RM1", delta);
+    assertFalse(_syntacticCompare.areEqual(base.getName(), delta.getName()));
+  }
+
+  /** Tests that difference in called policies result in differences in the callers */
+  @Test
+  public void testCalleeDifference() {
+    RoutingPolicy calledPolicyBase =
+        _policyBuilderBase
+            .setName("RM2")
+            .setOwner(_baseConfig)
+            .addStatement(
+                new If(
+                    new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+
+    RoutingPolicy calledPolicyDelta =
+        _policyBuilderBase
+            .setName("RM2")
+            .setOwner(_deltaConfig)
+            .addStatement(
+                new If(
+                    new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+
+    RoutingPolicy base = _policyBuilderBase.addStatement(new CallStatement("RM2")).build();
+    RoutingPolicy delta = _policyBuilderDelta.addStatement(new CallStatement("RM2")).build();
+    _baseConfig.getRoutingPolicies().put("RM1", base);
+    _baseConfig.getRoutingPolicies().put("RM2", calledPolicyBase);
+    _deltaConfig.getRoutingPolicies().put("RM1", delta);
+    _baseConfig.getRoutingPolicies().put("RM2", calledPolicyDelta);
+    assertFalse(_syntacticCompare.areEqual(base.getName(), delta.getName()));
+  }
+
+  /**
+   * Tests that difference in called policies result in differences in the callers even if there are
+   * multiple levels of nesting
+   */
+  @Test
+  public void testNestedCalleeDifference() {
+    RoutingPolicy calledPolicyBase1 =
+        _policyBuilderBase
+            .setName("RM2")
+            .setOwner(_baseConfig)
+            .addStatement(new CallStatement("RM3"))
+            .build();
+
+    RoutingPolicy calledPolicyDelta1 =
+        _policyBuilderDelta
+            .setName("RM2")
+            .setOwner(_deltaConfig)
+            .addStatement(new CallStatement("RM3"))
+            .build();
+
+    RoutingPolicy calledPolicyBase2 =
+        _policyBuilderBase
+            .setName("RM3")
+            .setOwner(_baseConfig)
+            .addStatement(
+                new If(
+                    new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+
+    RoutingPolicy calledPolicyDelta2 =
+        _policyBuilderDelta
+            .setName("RM3")
+            .setOwner(_deltaConfig)
+            .addStatement(
+                new If(
+                    new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_1)),
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept))))
+            .build();
+
+    RoutingPolicy base = _policyBuilderBase.addStatement(new CallStatement("RM2")).build();
+    RoutingPolicy delta = _policyBuilderDelta.addStatement(new CallStatement("RM2")).build();
+    _baseConfig.getRoutingPolicies().put("RM1", base);
+    _baseConfig.getRoutingPolicies().put("RM2", calledPolicyBase1);
+    _baseConfig.getRoutingPolicies().put("RM3", calledPolicyBase2);
+    _deltaConfig.getRoutingPolicies().put("RM1", delta);
+    _baseConfig.getRoutingPolicies().put("RM2", calledPolicyDelta1);
+    _baseConfig.getRoutingPolicies().put("RM2", calledPolicyDelta2);
+    assertFalse(_syntacticCompare.areEqual(base.getName(), delta.getName()));
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/RoutingPolicyId.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/RoutingPolicyId.java
@@ -7,7 +7,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** Global identifier of a routing policy (node name, policy name). */
 @ParametersAreNonnullByDefault
-final class RoutingPolicyId implements Comparable<RoutingPolicyId> {
+public final class RoutingPolicyId implements Comparable<RoutingPolicyId> {
   private static final Comparator<RoutingPolicyId> COMPARATOR =
       Comparator.comparing(RoutingPolicyId::getNode).thenComparing(RoutingPolicyId::getPolicy);
 

--- a/questions/experimental/comparePeerGroupPolicies.json
+++ b/questions/experimental/comparePeerGroupPolicies.json
@@ -1,0 +1,15 @@
+{
+  "class": "org.batfish.minesweeper.question.comparepeergrouppolicies.ComparePeerGroupPoliciesQuestion",
+  "differential": true,
+  "instance": {
+    "description": "Compares the behavior of routing policies across a network change.",
+    "instanceName": "comparePeerGroupPolicies",
+    "longDescription": "This is a differential question that compares the behavior of routing policies across a network change.  For each peer group, the associated routing policy is semantically compared before and after the change using CRP.",
+    "orderedVariableNames": [],
+    "tags": [
+      "routing"
+    ],
+    "variables": {
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new differential question which uses CompareRoutePolicies to semantically compare routing policies that were changed. The key idea is for each peer group, do a lightweight syntactic comparison between the old and new snapshot, and if the result says they differ then check the exact differences using CRP.