### PR TITLE
Junos: Move default address selection for BGP local IP to runtime rather than conversion time

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InferFromFib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InferFromFib.java
@@ -1,0 +1,79 @@
+package org.batfish.datamodel;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.visitors.FibActionVisitor;
+
+/**
+ * An implementation of {@link SourceIpInference} that infers source IP from FIB -- find LPM routes
+ * for the destination IP of the packet, and returns the IPs of those routes' forwarding interfaces.
+ * This is the default behavior in most cases.
+ */
+public final class InferFromFib extends SourceIpInference {
+  private static final InferFromFib INSTANCE = new InferFromFib();
+
+  /** Returns the singleton instance of {@link InferFromFib}. */
+  public static @Nonnull InferFromFib instance() {
+    return INSTANCE;
+  }
+
+  private InferFromFib() {}
+
+  /**
+   * Returns the potential source IPs of a packet with the given {@code dstIp} originating on the
+   * given {@link Configuration} in a VRF with the given {@link Fib}. Concretely, find LPM routes
+   * for {@code dstIp} and returns the IPs of those routes' forwarding interfaces.
+   */
+  @Override
+  public Set<Ip> getPotentialSourceIps(
+      @Nonnull Ip dstIp, @Nullable Fib fib, @Nonnull Configuration c) {
+    if (fib == null) {
+      return ImmutableSet.of();
+    }
+    return getSrcInterfaces(dstIp, fib, c).stream()
+        .map(Interface::getConcreteAddress)
+        .filter(Objects::nonNull)
+        .map(ConcreteInterfaceAddress::getIp)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  /**
+   * Returns the names of source interface(s) of a packet with the given {@code dstIp} originating
+   * on the given {@link Configuration} in a VRF with the given {@link Fib}. Concretely, finds LPM
+   * routes for {@code dstIp} and returns those routes' forwarding interfaces.
+   */
+  private static Set<Interface> getSrcInterfaces(
+      @Nonnull Ip dstIp, @Nonnull Fib fib, @Nonnull Configuration c) {
+    return fib.get(dstIp).stream()
+        .map(FibEntry::getAction)
+        // Find forwarding interface for this FIB entry, if any
+        .map(
+            action ->
+                action.accept(
+                    new FibActionVisitor<String>() {
+                      @Override
+                      public String visitFibForward(FibForward fibForward) {
+                        return fibForward.getInterfaceName();
+                      }
+
+                      @Override
+                      public String visitFibNextVrf(FibNextVrf fibNextVrf) {
+                        // TODO Can BGP peers initiate via interfaces in other VRFs? If
+                        //  so, need to return such interfaces here.
+                        return null;
+                      }
+
+                      @Override
+                      public String visitFibNullRoute(FibNullRoute fibNullRoute) {
+                        return null;
+                      }
+                    }))
+        .filter(Objects::nonNull)
+        .map(forwardingIfaceName -> c.getActiveInterfaces().get(forwardingIfaceName))
+        .filter(Objects::nonNull)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SourceIpInference.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SourceIpInference.java
@@ -1,0 +1,16 @@
+package org.batfish.datamodel;
+
+import java.io.Serializable;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Abstract class for source IP inference of locally generated IP packets. */
+public abstract class SourceIpInference implements Serializable {
+  /**
+   * Returns the potential source IPs of a packet with the given {@code dstIp} originating on the
+   * given {@link Configuration} in a VRF with the given {@link Fib}.
+   */
+  public abstract Set<Ip> getPotentialSourceIps(
+      @Nonnull Ip dstIp, @Nullable Fib fib, @Nonnull Configuration c);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UseConstantIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UseConstantIp.java
@@ -1,0 +1,52 @@
+package org.batfish.datamodel;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An implementation of {@link SourceIpInference} that uses a constant source IP regardless of
+ * destination IP and outgoing interface.
+ */
+public final class UseConstantIp extends SourceIpInference {
+  private final @Nonnull Ip _ip;
+
+  /** Return a singleton set of the given {@code ip}. */
+  @Override
+  public Set<Ip> getPotentialSourceIps(
+      @Nonnull Ip dstIp, @Nullable Fib fib, @Nonnull Configuration c) {
+    return ImmutableSet.of(_ip);
+  }
+
+  private UseConstantIp(@Nonnull Ip ip) {
+    _ip = ip;
+  }
+
+  /** Factory for creating a {@link UseConstantIp}. */
+  public static @Nonnull UseConstantIp create(@Nonnull Ip ip) {
+    return new UseConstantIp(ip);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UseConstantIp)) {
+      return false;
+    }
+    UseConstantIp useConstantIp = (UseConstantIp) o;
+    return _ip.equals(useConstantIp._ip);
+  }
+
+  @Override
+  public int hashCode() {
+    return _ip.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "UseConstantIp(" + _ip + ")";
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
@@ -126,6 +126,7 @@ public class Vrf extends ComparableStructure<String> {
   private Map<Integer, Layer2Vni> _layer2Vnis;
   private Map<Integer, Layer3Vni> _layer3Vnis;
   @Nullable private VrfLeakConfig _vrfLeakConfig;
+  private @Nonnull SourceIpInference _sourceIpInference;
 
   public Vrf(@Nonnull String name) {
     super(name);
@@ -137,6 +138,7 @@ public class Vrf extends ComparableStructure<String> {
     _staticRoutes = new TreeSet<>();
     _layer2Vnis = ImmutableMap.of();
     _layer3Vnis = ImmutableMap.of();
+    _sourceIpInference = InferFromFib.instance();
   }
 
   @JsonCreator
@@ -388,5 +390,14 @@ public class Vrf extends ComparableStructure<String> {
   @JsonProperty(PROP_STATIC_ROUTES)
   public void setStaticRoutes(SortedSet<StaticRoute> staticRoutes) {
     _staticRoutes = staticRoutes;
+  }
+
+  /** Source IP inference of locally generated IP packets, defaults to {@link InferFromFib}. */
+  public @Nonnull SourceIpInference getSourceIpInference() {
+    return _sourceIpInference;
+  }
+
+  public void setSourceIpInference(@Nonnull SourceIpInference sourceIpInference) {
+    _sourceIpInference = sourceIpInference;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -34,16 +34,10 @@ import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.BgpUnnumberedPeerConfig;
-import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Fib;
-import org.batfish.datamodel.FibEntry;
-import org.batfish.datamodel.FibForward;
-import org.batfish.datamodel.FibNextVrf;
-import org.batfish.datamodel.FibNullRoute;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.LongSpace;
@@ -55,7 +49,6 @@ import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
-import org.batfish.datamodel.visitors.FibActionVisitor;
 
 /** Utility functions for computing BGP topology */
 public final class BgpTopologyUtils {
@@ -198,9 +191,11 @@ public final class BgpTopologyUtils {
 
           if (config.getLocalIp() != null) {
             localIpsBuilder.put(neighborId, config.getLocalIp());
-          } else if (fib != null) {
+          } else {
             // No explicitly configured local IP. Check for dynamically resolvable local IPs.
-            localIpsBuilder.putAll(neighborId, getPotentialSrcIps(peerAddress, fib, node));
+            localIpsBuilder.putAll(
+                neighborId,
+                vrf.getSourceIpInference().getPotentialSourceIps(peerAddress, fib, node));
           }
         }
         // Dynamic peers: map of prefix to BgpPassivePeerConfig
@@ -521,55 +516,6 @@ public final class BgpTopologyUtils {
     BgpPeerConfig candidate = nc.getBgpPeerConfig(candidateId);
     return candidate instanceof BgpUnnumberedPeerConfig
         && bgpCandidateHasCompatibleAs(neighbor, candidate);
-  }
-
-  /**
-   * Returns the names of source interface(s) of a packet with the given {@code dstIp} originating
-   * on the given {@link Configuration} in a VRF with the given {@link Fib}. Concretely, finds LPM
-   * routes for {@code dstIp} and returns those routes' forwarding interfaces.
-   */
-  public static Set<Interface> getSrcInterfaces(Ip dstIp, Fib fib, Configuration c) {
-    return fib.get(dstIp).stream()
-        .map(FibEntry::getAction)
-        // Find forwarding interface for this FIB entry, if any
-        .map(
-            action ->
-                action.accept(
-                    new FibActionVisitor<String>() {
-                      @Override
-                      public String visitFibForward(FibForward fibForward) {
-                        return fibForward.getInterfaceName();
-                      }
-
-                      @Override
-                      public String visitFibNextVrf(FibNextVrf fibNextVrf) {
-                        // TODO Can BGP peers initiate via interfaces in other VRFs? If
-                        //  so, need to return such interfaces here.
-                        return null;
-                      }
-
-                      @Override
-                      public String visitFibNullRoute(FibNullRoute fibNullRoute) {
-                        return null;
-                      }
-                    }))
-        .filter(Objects::nonNull)
-        .map(forwardingIfaceName -> c.getActiveInterfaces().get(forwardingIfaceName))
-        .filter(Objects::nonNull)
-        .collect(ImmutableSet.toImmutableSet());
-  }
-
-  /**
-   * Returns the potential source IPs of a packet with the given {@code dstIp} originating on the
-   * given {@link Configuration} in a VRF with the given {@link Fib}. Concretely, finds LPM routes
-   * for {@code dstIp} and returns the IPs of those routes' forwarding interfaces.
-   */
-  public static Set<Ip> getPotentialSrcIps(Ip dstIp, Fib fib, Configuration c) {
-    return getSrcInterfaces(dstIp, fib, c).stream()
-        .map(Interface::getConcreteAddress)
-        .filter(Objects::nonNull)
-        .map(ConcreteInterfaceAddress::getIp)
-        .collect(ImmutableSet.toImmutableSet());
   }
 
   private static final class ReverseFlowAndFirewallSessions {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InferFromFibTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InferFromFibTest.java
@@ -1,0 +1,55 @@
+package org.batfish.datamodel;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class InferFromFibTest extends TestCase {
+  /**
+   * {@link InferFromFib#getPotentialSourceIps} should dynamically resolve source IP based on FIB
+   * and interface configurations.
+   */
+  @Test
+  public void testGetPotentialSourceIps() {
+    String iface1 = "iface1";
+
+    ImmutableList<AbstractRoute> resolutionSteps =
+        ImmutableList.of(new ConnectedRoute(Prefix.parse("2.2.2.2/31"), iface1));
+
+    FibEntry fibEntry = new FibEntry(FibForward.of(Ip.parse("1.1.1.1"), iface1), resolutionSteps);
+
+    Ip dstIp = Ip.parse("2.2.2.3");
+    Ip sourceIp = Ip.parse("2.2.2.2");
+
+    Fib fib =
+        MockFib.builder().setFibEntries(ImmutableMap.of(dstIp, ImmutableSet.of(fibEntry))).build();
+
+    Configuration c = Configuration.builder().setHostname("r1").build();
+    c.setInterfaces(
+        ImmutableSortedMap.of(
+            iface1,
+            Interface.builder()
+                .setName(iface1)
+                .setAddress(ConcreteInterfaceAddress.create(sourceIp, 31))
+                .build()));
+    assertEquals(
+        InferFromFib.instance().getPotentialSourceIps(dstIp, fib, c), ImmutableSet.of(sourceIp));
+  }
+
+  /**
+   * {@link InferFromFib#getPotentialSourceIps} should return an empty set if {@code fib} is null.
+   */
+  @Test
+  public void testGetPotentialSourceIps_nullFib() {
+    Configuration c = Configuration.builder().setHostname("r1").build();
+    assertEquals(
+        InferFromFib.instance().getPotentialSourceIps(Ip.parse("1.2.3.4"), null, c),
+        ImmutableSet.of());
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/UseConstantIpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/UseConstantIpTest.java
@@ -1,0 +1,41 @@
+package org.batfish.datamodel;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class UseConstantIpTest extends TestCase {
+  /**
+   * {@link UseConstantIp#getPotentialSourceIps} should return a singleton set of the given constant
+   * IP address.
+   */
+  @Test
+  public void testGetPotentialSourceIps() {
+    Ip constantIp = Ip.parse("1.2.3.4");
+    UseConstantIp useConstantIp = UseConstantIp.create(constantIp);
+    Fib dummyFib = MockFib.builder().build();
+    Configuration dummyConf = Configuration.builder().setHostname("r1").build();
+    assertEquals(
+        useConstantIp.getPotentialSourceIps(Ip.parse("5.6.7.8"), dummyFib, dummyConf),
+        ImmutableSet.of(constantIp));
+  }
+
+  @Test
+  public void testEquality() {
+    new EqualsTester()
+        .addEqualityGroup(
+            UseConstantIp.create(Ip.parse("1.1.1.1")), UseConstantIp.create(Ip.parse("1.1.1.1")))
+        .addEqualityGroup(UseConstantIp.create(Ip.parse("1.1.1.2")))
+        .addEqualityGroup(InferFromFib.instance())
+        .testEquals();
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals(UseConstantIp.create(Ip.parse("1.1.1.1")).toString(), "UseConstantIp(1.1.1.1)");
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -117,6 +117,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportEncapsulationType;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.UseConstantIp;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.VrfLeakConfig;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
@@ -817,18 +818,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       ipv4AfSettingsBuilder.setSendCommunity(true).setSendExtendedCommunity(true);
 
       // inherit update-source
-      Ip localIp = ig.getLocalAddress();
-
-      // When local IP is not explicitly set, the source address is dynamically picked based on the
-      // outgoing interface (done in VI land, so we don't need to do anything more here).
-      // The exception to this behavior occurs for iBGP and eBGP-multihop sessions when
-      // default-address-selection is set.
-      if (localIp == null
-          && _masterLogicalSystem.getDefaultAddressSelection()
-          && (ibgp || firstNonNull(ig.getEbgpMultihop(), false))) {
-        localIp = getDefaultSourceAddress(routingInstance, _c).orElse(null);
-      }
-      neighbor.setLocalIp(localIp);
+      neighbor.setLocalIp(ig.getLocalAddress());
       neighbor.setBgpProcess(proc);
       neighbor.setIpv4UnicastAddressFamily(
           ipv4AfBuilder.setAddressFamilyCapabilities(ipv4AfSettingsBuilder.build()).build());
@@ -3852,6 +3842,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (ri.getNamedBgpGroups().size() > 0 || ri.getIpBgpGroups().size() > 0) {
         BgpProcess proc = createBgpProcess(ri);
         vrf.setBgpProcess(proc);
+      }
+      if (_masterLogicalSystem.getDefaultAddressSelection()) {
+        // When local IP is not explicitly set, the source address is dynamically picked based on
+        // the outgoing interface (done in VI land, so we don't need to do anything more here).
+        // The exception to this behavior occurs for iBGP and eBGP-multihop sessions when
+        // default-address-selection is set.
+        getDefaultSourceAddress(ri, _c)
+            .ifPresent(ip -> vrf.setSourceIpInference(UseConstantIp.create(ip)));
       }
       convertResolution(ri);
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -321,6 +321,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.UseConstantIp;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
@@ -2983,6 +2984,20 @@ public final class FlatJuniperGrammarTest {
             .getCommunities()
             .getCommunities(),
         contains(StandardCommunity.of(65537L)));
+  }
+
+  /**
+   * When local-address of a BGP peer group is unconfigured and default-address-selection flag is
+   * on, BGP peer local IP is null and the VRF's source IP inference is set to use loopback IP.
+   */
+  @Test
+  public void testBgpDefaultAddressSelection() throws IOException {
+    Configuration config = parseConfig("bgp-default-address-selection");
+    Ip loopback = Ip.parse("1.1.1.1");
+    assertEquals(config.getDefaultVrf().getSourceIpInference(), UseConstantIp.create(loopback));
+    assertThat(
+        getOnlyElement(config.getDefaultVrf().getBgpProcess().getAllPeerConfigs()).getLocalIp(),
+        nullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-default-address-selection
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-default-address-selection
@@ -1,0 +1,9 @@
+#
+set system host-name bgp-default-address-selection
+set system default-address-selection
+#
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32 primary
+#
+set routing-options autonomous-system 1
+#
+set protocols bgp group G neighbor 2.2.2.2


### PR DESCRIPTION
Previously, when default-address-selection is enabled and BGP peer local-address is unconfigured, Junos picks the loopback IP (based on the [default-address-selection spec](https://www.juniper.net/documentation/us/en/software/junos/transport-ip/topics/ref/statement/default-address-selection-edit-system.html)) as the local IP of the outgoing BGP establishment.  Batfish modeled this behavior at _conversion_ time and used the loopback IP as the local IP of the BGP _peer config_ -- this means the _incoming_ BGP establishments would be rejected unless the remote IP is set to loopback IP, whereas in the real world the BGP establishment would be accepted because local-address is unconfigured.

This commit fixes the problem by not setting local IP in the BGP peer config, but instead applying the selected loopback IP address at BGP topology compute time.