### PR TITLE
BgpTopologyUtils: allow for vendors that don't check local IP on connection

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
@@ -25,6 +25,7 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
       @JsonProperty(PROP_APPLIED_RIB_GROUP) @Nullable RibGroup appliedRibGroup,
       @JsonProperty(PROP_AUTHENTICATION_SETTINGS) @Nullable
           BgpAuthenticationSettings authenticationSettings,
+      @JsonProperty(PROP_CHECK_LOCAL_IP_ON_ACCEPT) @Nullable Boolean checkLocalIpOnAccept,
       @JsonProperty(PROP_CLUSTER_ID) @Nullable Long clusterId,
       @JsonProperty(PROP_CONFEDERATION_AS) @Nullable Long confederation,
       @JsonProperty(PROP_DEFAULT_METRIC) int defaultMetric,
@@ -44,6 +45,7 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
     return new BgpActivePeerConfig(
         appliedRibGroup,
         authenticationSettings,
+        checkLocalIpOnAccept,
         clusterId,
         confederation,
         defaultMetric,
@@ -64,6 +66,7 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
   private BgpActivePeerConfig(
       @Nullable RibGroup appliedRibGroup,
       @Nullable BgpAuthenticationSettings authenticationSettings,
+      @Nullable Boolean checkLocalIpOnAccept,
       @Nullable Long clusterId,
       @Nullable Long confederation,
       int defaultMetric,
@@ -82,6 +85,7 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
     super(
         appliedRibGroup,
         authenticationSettings,
+        checkLocalIpOnAccept,
         clusterId,
         confederation,
         defaultMetric,
@@ -152,6 +156,7 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
           new BgpActivePeerConfig(
               _appliedRibGroup,
               _authenticationSettings,
+              _checkLocalIpOnAccept,
               _clusterId,
               _confederation,
               _defaultMetric,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
@@ -27,8 +27,9 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
       @JsonProperty(PROP_APPLIED_RIB_GROUP) @Nullable RibGroup appliedRibGroup,
       @JsonProperty(PROP_AUTHENTICATION_SETTINGS) @Nullable
           BgpAuthenticationSettings authenticationSettings,
+      @JsonProperty(PROP_CHECK_LOCAL_IP_ON_ACCEPT) @Nullable Boolean checkLocalIpOnAccept,
       @JsonProperty(PROP_CLUSTER_ID) @Nullable Long clusterId,
-      @Nullable @JsonProperty(PROP_CONFEDERATION_AS) Long confederation,
+      @JsonProperty(PROP_CONFEDERATION_AS) @Nullable Long confederation,
       @JsonProperty(PROP_DEFAULT_METRIC) int defaultMetric,
       @JsonProperty(PROP_DESCRIPTION) @Nullable String description,
       @JsonProperty(PROP_EBGP_MULTIHOP) boolean ebgpMultihop,
@@ -46,6 +47,7 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
     return new BgpPassivePeerConfig(
         appliedRibGroup,
         authenticationSettings,
+        checkLocalIpOnAccept,
         clusterId,
         confederation,
         defaultMetric,
@@ -66,6 +68,7 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
   private BgpPassivePeerConfig(
       @Nullable RibGroup appliedRibGroup,
       @Nullable BgpAuthenticationSettings authenticationSettings,
+      @Nullable Boolean checkLocalIpOnAccept,
       @Nullable Long clusterId,
       @Nullable Long confederation,
       int defaultMetric,
@@ -84,6 +87,7 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
     super(
         appliedRibGroup,
         authenticationSettings,
+        checkLocalIpOnAccept,
         clusterId,
         confederation,
         defaultMetric,
@@ -144,6 +148,7 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
           new BgpPassivePeerConfig(
               _appliedRibGroup,
               _authenticationSettings,
+              _checkLocalIpOnAccept,
               _clusterId,
               _confederation,
               _defaultMetric,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpUnnumberedPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpUnnumberedPeerConfig.java
@@ -4,6 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.Set;
@@ -17,6 +18,7 @@ import org.batfish.datamodel.dataplane.rib.RibGroup;
  * Represents a BGP unnumbered config, which allows peering over a layer-3-capable interface without
  * IP configuration.
  */
+@JsonIgnoreProperties(BgpPeerConfig.PROP_CHECK_LOCAL_IP_ON_ACCEPT) // not relevant
 public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
 
   public static class Builder extends BgpPeerConfig.Builder<Builder, BgpUnnumberedPeerConfig> {
@@ -30,6 +32,7 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
     @Nonnull
     public BgpUnnumberedPeerConfig build() {
       checkArgument(_peerInterface != null, "Missing %s", PROP_PEER_INTERFACE);
+      checkArgument(_checkLocalIpOnAccept == null, "Unsupported %s", PROP_CHECK_LOCAL_IP_ON_ACCEPT);
       BgpUnnumberedPeerConfig bgpPeerConfig =
           new BgpUnnumberedPeerConfig(
               _appliedRibGroup,
@@ -137,6 +140,7 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
     super(
         appliedRibGroup,
         authenticationSettings,
+        false,
         clusterId,
         confederation,
         defaultMetric,

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
@@ -618,6 +618,8 @@ public final class FrrConversions {
       assert localAddress instanceof ConcreteInterfaceAddress;
       peerConfigBuilder =
           BgpActivePeerConfig.builder()
+              // https://github.com/FRRouting/frr/commit/8ed9dca7fb2b06834d7effeba94676ad928b1ce9
+              .setCheckLocalIpOnAccept(false)
               .setLocalIp(((ConcreteInterfaceAddress) localAddress).getIp())
               .setPeerAddress(inferredIp.get());
     } else {
@@ -729,6 +731,8 @@ public final class FrrConversions {
       Warnings w) {
     BgpActivePeerConfig.Builder peerConfigBuilder =
         BgpActivePeerConfig.builder()
+            // https://github.com/FRRouting/frr/commit/8ed9dca7fb2b06834d7effeba94676ad928b1ce9
+            .setCheckLocalIpOnAccept(false)
             .setLocalIp(
                 Optional.ofNullable(
                         resolveLocalIpFromUpdateSource(neighbor.getBgpNeighborSource(), c, w))
@@ -750,6 +754,8 @@ public final class FrrConversions {
       Warnings w) {
     BgpPassivePeerConfig.Builder peerConfigBuilder =
         BgpPassivePeerConfig.builder()
+            // https://github.com/FRRouting/frr/commit/8ed9dca7fb2b06834d7effeba94676ad928b1ce9
+            .setCheckLocalIpOnAccept(false)
             .setLocalIp(resolveLocalIpFromUpdateSource(neighbor.getBgpNeighborSource(), c, w))
             .setPeerPrefix(neighbor.getListenRange());
     generateBgpCommonPeerConfig(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -784,6 +784,13 @@ public class IncrementalDataPlanePluginTest {
             .setRemoteAs(2L)
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
+    BgpActivePeerConfig.Builder destB =
+        BgpActivePeerConfig.builder()
+            .setPeerAddress(listener.getRemotePeerPrefix().getStartIp())
+            .setEbgpMultihop(false)
+            .setLocalAs(2L)
+            .setRemoteAs(1L)
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build());
 
     // the neighbor should be reachable because it is only one hop away from the initiator
     assertTrue(
@@ -791,19 +798,31 @@ public class IncrementalDataPlanePluginTest {
             initiator,
             listener,
             source,
+            destB.build(),
             initiatorLocalIp,
-            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
 
     // But if the listener has a local IP configured that does not match initiator's peer, will not
     // be created
+    destB.setLocalIp(Ip.parse("2.2.2.2")).setCheckLocalIpOnAccept(true);
     assertFalse(
         BgpTopologyUtils.canEstablishBgpSession(
             initiator,
             listener,
             source,
+            destB.build(),
             initiatorLocalIp,
-            Ip.parse("2.2.2.2"),
+            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
+
+    // But if the listener is on a weird vendor that doesn't check local IP, it will be accepted.
+    destB.setLocalIp(Ip.parse("2.2.2.2")).setCheckLocalIpOnAccept(false);
+    assertTrue(
+        BgpTopologyUtils.canEstablishBgpSession(
+            initiator,
+            listener,
+            source,
+            destB.build(),
+            initiatorLocalIp,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
@@ -878,14 +897,23 @@ public class IncrementalDataPlanePluginTest {
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
 
+    BgpActivePeerConfig dest =
+        BgpActivePeerConfig.builder()
+            .setPeerAddress(listener.getRemotePeerPrefix().getStartIp())
+            .setEbgpMultihop(false)
+            .setLocalAs(2L)
+            .setRemoteAs(1L)
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
+            .build();
+
     // the neighbor should be not be reachable because it is two hops away from the initiator
     assertFalse(
         BgpTopologyUtils.canEstablishBgpSession(
             initiator,
             listener,
             source,
+            dest,
             initiatorLocalIp,
-            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
@@ -960,14 +988,23 @@ public class IncrementalDataPlanePluginTest {
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
 
+    BgpActivePeerConfig dest =
+        BgpActivePeerConfig.builder()
+            .setPeerAddress(listener.getRemotePeerPrefix().getStartIp())
+            .setEbgpMultihop(true)
+            .setLocalAs(2L)
+            .setRemoteAs(1L)
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
+            .build();
+
     // the neighbor should be reachable because multi-hops are allowed
     assertTrue(
         BgpTopologyUtils.canEstablishBgpSession(
             initiator,
             listener,
             source,
+            dest,
             initiatorLocalIp,
-            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
@@ -1045,6 +1082,15 @@ public class IncrementalDataPlanePluginTest {
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
 
+    BgpActivePeerConfig dest =
+        BgpActivePeerConfig.builder()
+            .setPeerAddress(listener.getRemotePeerPrefix().getStartIp())
+            .setEbgpMultihop(true)
+            .setLocalAs(2L)
+            .setRemoteAs(1L)
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
+            .build();
+
     // the neighbor should not be reachable even though multihops are allowed as traceroute would be
     // denied in on node 3
     assertFalse(
@@ -1052,8 +1098,8 @@ public class IncrementalDataPlanePluginTest {
             initiator,
             listener,
             source,
+            dest,
             initiatorLocalIp,
-            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
@@ -1131,6 +1177,15 @@ public class IncrementalDataPlanePluginTest {
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
 
+    BgpActivePeerConfig dest =
+        BgpActivePeerConfig.builder()
+            .setPeerAddress(listener.getRemotePeerPrefix().getStartIp())
+            .setEbgpMultihop(true)
+            .setLocalAs(2L)
+            .setRemoteAs(1L)
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
+            .build();
+
     // neighbor should be reachable because ACL allows established connection back into node1 and
     // allows everything out
     assertTrue(
@@ -1138,8 +1193,8 @@ public class IncrementalDataPlanePluginTest {
             initiator,
             listener,
             source,
+            dest,
             initiatorLocalIp,
-            null,
             new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -82435,6 +82435,7 @@
               "neighbors" : {
                 "10.10.10.37" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 168492808,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -82467,6 +82468,7 @@
                 },
                 "10.10.10.45" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 168492808,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -82495,6 +82497,7 @@
                 },
                 "10.10.30.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 168492808,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -82526,6 +82529,7 @@
                 },
                 "10.10.255.7" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 168492808,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -82553,6 +82557,7 @@
                 },
                 "169.254.13.237" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 168492808,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -82599,6 +82604,7 @@
                 },
                 "169.254.15.193" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 168492808,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -85909,6 +85915,7 @@
               "neighbors" : {
                 "169.254.13.238" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
                   "enforceFirstAs" : false,
@@ -85936,6 +85943,7 @@
                 },
                 "169.254.15.194" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
                   "enforceFirstAs" : false,

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -3570,6 +3570,7 @@
             "neighbors" : {
               "1.10.1.1" : {
                 "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                "checkLocalIpOnAccept" : true,
                 "clusterId" : 16843009,
                 "defaultMetric" : 0,
                 "ebgpMultihop" : false,
@@ -3598,6 +3599,7 @@
               },
               "3.2.2.2" : {
                 "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                "checkLocalIpOnAccept" : true,
                 "clusterId" : 16843009,
                 "defaultMetric" : 0,
                 "ebgpMultihop" : false,
@@ -3625,6 +3627,7 @@
               },
               "5.6.7.8" : {
                 "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                "checkLocalIpOnAccept" : true,
                 "clusterId" : 16843009,
                 "defaultMetric" : 0,
                 "ebgpMultihop" : false,
@@ -3652,6 +3655,7 @@
               },
               "10.12.11.2" : {
                 "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                "checkLocalIpOnAccept" : true,
                 "clusterId" : 16843009,
                 "defaultMetric" : 0,
                 "ebgpMultihop" : false,

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -1507,6 +1507,7 @@
               "neighbors" : {
                 "1.10.1.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 16843009,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -1535,6 +1536,7 @@
                 },
                 "3.2.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 16843009,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -1562,6 +1564,7 @@
                 },
                 "5.6.7.8" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 16843009,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -1589,6 +1592,7 @@
                 },
                 "10.12.11.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 16843009,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -3196,6 +3200,7 @@
               "neighbors" : {
                 "1.10.1.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 16908802,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -3224,6 +3229,7 @@
                 },
                 "10.13.22.3" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 16908802,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -3259,6 +3265,7 @@
                 },
                 "10.14.22.4" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 16908802,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -3730,6 +3737,7 @@
               "neighbors" : {
                 "1.1.1.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 17432833,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -3758,6 +3766,7 @@
                 },
                 "1.2.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 17432833,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -5437,6 +5446,7 @@
               "neighbors" : {
                 "2.1.2.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620225,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -5465,6 +5475,7 @@
                 },
                 "2.1.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620225,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -5493,6 +5504,7 @@
                 },
                 "10.12.11.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620225,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -7099,6 +7111,7 @@
               "neighbors" : {
                 "2.1.2.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620226,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -7127,6 +7140,7 @@
                 },
                 "2.1.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620226,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -7155,6 +7169,7 @@
                 },
                 "10.23.21.3" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620226,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -7861,6 +7876,7 @@
               "neighbors" : {
                 "2.1.1.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620481,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -7889,6 +7905,7 @@
                 },
                 "2.1.1.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620481,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -7917,6 +7934,7 @@
                 },
                 "2.1.3.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620481,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -7945,6 +7963,7 @@
                 },
                 "2.1.3.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620481,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -8545,6 +8564,7 @@
               "neighbors" : {
                 "2.1.1.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620482,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -8573,6 +8593,7 @@
                 },
                 "2.1.1.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620482,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -8601,6 +8622,7 @@
                 },
                 "2.1.3.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620482,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -8629,6 +8651,7 @@
                 },
                 "2.1.3.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620482,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -9892,6 +9915,7 @@
               "neighbors" : {
                 "2.34.101.3" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620993,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -9927,6 +9951,7 @@
                 },
                 "2.34.201.3" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620993,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -10912,6 +10937,7 @@
               "neighbors" : {
                 "2.1.2.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620737,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -10940,6 +10966,7 @@
                 },
                 "2.1.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620737,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -10968,6 +10995,7 @@
                 },
                 "2.34.101.4" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620737,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -11953,6 +11981,7 @@
               "neighbors" : {
                 "2.1.2.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620738,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -11981,6 +12010,7 @@
                 },
                 "2.1.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620738,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -12009,6 +12039,7 @@
                 },
                 "2.34.201.4" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 33620738,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -13518,6 +13549,7 @@
               "neighbors" : {
                 "3.10.1.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 50397441,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -13546,6 +13578,7 @@
                 },
                 "10.23.21.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 50397441,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -14972,6 +15005,7 @@
               "neighbors" : {
                 "3.10.1.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 50463234,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -15000,6 +15034,7 @@
                 },
                 "10.13.22.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 50463234,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -15623,6 +15658,7 @@
               "neighbors" : {
                 "3.1.1.1" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 50987265,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
@@ -15651,6 +15687,7 @@
                 },
                 "3.2.2.2" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "checkLocalIpOnAccept" : true,
                   "clusterId" : 50987265,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,


### PR DESCRIPTION
In https://github.com/batfish/batfish/pull/8781 I made BGP listeners reject incoming
connections that aren't to a configured local IP (update source, in Cisco terms).

Turns out not all vendors do this, in particular FRR does not seem to have this check.
Extend BGP config to handle that, and set for FRR.