### PR TITLE
Add AdministrativeCost in BgpRoute, and in extension for SetAdministrativeCost in TRP.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRoute.java
@@ -29,6 +29,9 @@ import org.batfish.datamodel.bgp.community.Community;
 /** A user facing representation for IPv4 BGP route */
 @ParametersAreNonnullByDefault
 public final class BgpRoute {
+
+  public static final int DEFAULT_AD = 0;
+  public static final String PROP_ADMINISTRATIVE_DISTANCE = "adminDistance";
   public static final String PROP_AS_PATH = "asPath";
   public static final String PROP_CLUSTER_LIST = "clusterList";
   public static final String PROP_COMMUNITIES = "communities";
@@ -47,6 +50,7 @@ public final class BgpRoute {
   public static final String PROP_WEIGHT = "weight";
   public static final String PROP_CLASS = "class";
 
+  @Nullable private final Integer _adminDist;
   @Nonnull private final AsPath _asPath;
   @Nonnull private final Set<Long> _clusterList;
   @Nonnull private final SortedSet<Community> _communities;
@@ -65,6 +69,7 @@ public final class BgpRoute {
   private final int _weight;
 
   private BgpRoute(
+      @Nullable Integer adminDist,
       AsPath asPath,
       Set<Long> clusterList,
       SortedSet<Community> communities,
@@ -81,6 +86,7 @@ public final class BgpRoute {
       long tag,
       @Nullable TunnelEncapsulationAttribute tunnelEncapsulationAttribute,
       int weight) {
+    _adminDist = adminDist;
     _asPath = asPath;
     _clusterList = clusterList;
     _communities = communities;
@@ -101,6 +107,7 @@ public final class BgpRoute {
 
   @JsonCreator
   private static BgpRoute jsonCreator(
+      @Nullable @JsonProperty(PROP_ADMINISTRATIVE_DISTANCE) Integer adminDist,
       @Nullable @JsonProperty(PROP_AS_PATH) AsPath asPath,
       @Nullable @JsonProperty(PROP_CLUSTER_LIST) Set<Long> clusterList,
       @Nullable @JsonProperty(PROP_COMMUNITIES) SortedSet<Community> communities,
@@ -125,6 +132,7 @@ public final class BgpRoute {
     checkArgument(originType != null, "%s must be specified", PROP_ORIGIN_TYPE);
     checkArgument(protocol != null, "%s must be specified", PROP_PROTOCOL);
     return new BgpRoute(
+        firstNonNull(adminDist, DEFAULT_AD),
         firstNonNull(asPath, AsPath.empty()),
         firstNonNull(clusterList, ImmutableSet.of()),
         firstNonNull(communities, ImmutableSortedSet.of()),
@@ -141,6 +149,12 @@ public final class BgpRoute {
         tag,
         tunnelEncapsulationAttribute,
         weight);
+  }
+
+  @Nullable
+  @JsonProperty(PROP_ADMINISTRATIVE_DISTANCE)
+  public Integer getAdminDist() {
+    return _adminDist;
   }
 
   @Nonnull
@@ -261,6 +275,7 @@ public final class BgpRoute {
         && _metric == bgpRoute._metric
         && _tag == bgpRoute._tag
         && _weight == bgpRoute._weight
+        && Objects.equals(_adminDist, bgpRoute._adminDist)
         && Objects.equals(_asPath, bgpRoute._asPath)
         && Objects.equals(_clusterList, bgpRoute._clusterList)
         && Objects.equals(_communities, bgpRoute._communities)
@@ -278,6 +293,7 @@ public final class BgpRoute {
   @Override
   public int hashCode() {
     return Objects.hash(
+        _adminDist,
         _asPath,
         _clusterList,
         _communities,
@@ -302,6 +318,7 @@ public final class BgpRoute {
 
   public Builder toBuilder() {
     return builder()
+        .setAdminDist(_adminDist)
         .setAsPath(_asPath)
         .setClusterList(_clusterList)
         .setCommunities(_communities)
@@ -324,6 +341,7 @@ public final class BgpRoute {
   @ParametersAreNonnullByDefault
   public static final class Builder {
 
+    @Nullable private Integer _adminDist;
     @Nonnull private AsPath _asPath;
     @Nonnull private Set<Long> _clusterList;
     @Nonnull private SortedSet<Community> _communities;
@@ -355,6 +373,7 @@ public final class BgpRoute {
       checkArgument(_originType != null, "%s must be specified", PROP_ORIGIN_TYPE);
       checkArgument(_protocol != null, "%s must be specified", PROP_PROTOCOL);
       return new BgpRoute(
+          firstNonNull(_adminDist, DEFAULT_AD),
           _asPath,
           _clusterList,
           _communities,
@@ -371,6 +390,11 @@ public final class BgpRoute {
           _tag,
           _tunnelEncapsulationAttribute,
           _weight);
+    }
+
+    public Builder setAdminDist(@Nullable Integer adminDist) {
+      _adminDist = adminDist;
+      return this;
     }
 
     public Builder setAsPath(AsPath asPath) {
@@ -475,6 +499,7 @@ public final class BgpRoute {
         .add("tag", _tag)
         .add("tunnelEncapsulationAttribute", _tunnelEncapsulationAttribute)
         .add("weight", _weight)
+        .add("adminDist", _adminDist)
         .toString();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteDiff.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Ordering.natural;
 import static java.util.Comparator.comparing;
+import static org.batfish.datamodel.questions.BgpRoute.PROP_ADMINISTRATIVE_DISTANCE;
 import static org.batfish.datamodel.questions.BgpRoute.PROP_AS_PATH;
 import static org.batfish.datamodel.questions.BgpRoute.PROP_COMMUNITIES;
 import static org.batfish.datamodel.questions.BgpRoute.PROP_LOCAL_PREFERENCE;
@@ -41,6 +42,7 @@ public final class BgpRouteDiff implements Comparable<BgpRouteDiff> {
    */
   private static final Set<String> ROUTE_DIFF_FIELD_NAMES =
       ImmutableSet.of(
+          PROP_ADMINISTRATIVE_DISTANCE,
           PROP_AS_PATH,
           PROP_COMMUNITIES,
           PROP_LOCAL_PREFERENCE,
@@ -60,7 +62,7 @@ public final class BgpRouteDiff implements Comparable<BgpRouteDiff> {
     checkArgument(
         ROUTE_DIFF_FIELD_NAMES.contains(fieldName),
         "fieldName must be one of " + ROUTE_DIFF_FIELD_NAMES);
-    checkArgument(!oldValue.equals(newValue), "oldValue and newValule must be different");
+    checkArgument(!oldValue.equals(newValue), "oldValue and newValue must be different");
     _fieldName = fieldName;
     _oldValue = oldValue;
     _newValue = newValue;
@@ -125,6 +127,7 @@ public final class BgpRouteDiff implements Comparable<BgpRouteDiff> {
 
     checkArgument(
         route1.toBuilder()
+            .setAdminDist(route2.getAdminDist())
             .setAsPath(route2.getAsPath())
             .setCommunities(route2.getCommunities())
             .setLocalPreference(route2.getLocalPreference())
@@ -144,6 +147,7 @@ public final class BgpRouteDiff implements Comparable<BgpRouteDiff> {
 
     return new StructuredBgpRouteDiffs(
         Stream.of(
+                routeDiff(route1, route2, PROP_ADMINISTRATIVE_DISTANCE, BgpRoute::getAdminDist),
                 routeDiff(route1, route2, PROP_AS_PATH, BgpRoute::getAsPath),
                 routeDiff(route1, route2, PROP_LOCAL_PREFERENCE, BgpRoute::getLocalPreference),
                 routeDiff(route1, route2, PROP_METRIC, BgpRoute::getMetric),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteDiffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteDiffTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.BgpRoute.PROP_AS_PATH;
 import static org.batfish.datamodel.BgpRoute.PROP_COMMUNITIES;
 import static org.batfish.datamodel.BgpRoute.PROP_LOCAL_PREFERENCE;
 import static org.batfish.datamodel.OriginMechanism.LEARNED;
+import static org.batfish.datamodel.questions.BgpRoute.PROP_ADMINISTRATIVE_DISTANCE;
 import static org.batfish.datamodel.questions.BgpRoute.PROP_NEXT_HOP_IP;
 import static org.batfish.datamodel.questions.BgpRoute.PROP_ORIGINATOR_IP;
 import static org.batfish.datamodel.questions.BgpRoute.PROP_ORIGIN_TYPE;
@@ -100,9 +101,17 @@ public class BgpRouteDiffTest {
     assertThat(
         routeDiffs(route1, route2).getDiffs(), contains(new BgpRouteDiff(PROP_METRIC, "1", "2")));
 
+    // change administrative distance
+    route1 = builder().setAdminDist(1).build();
+    route2 = builder().setAdminDist(2).build();
+    assertThat(
+        routeDiffs(route1, route2).getDiffs(),
+        contains(new BgpRouteDiff(PROP_ADMINISTRATIVE_DISTANCE, "1", "2")));
+
     // change all properties
     route1 =
         builder()
+            .setAdminDist(1)
             .setAsPath(AsPath.ofSingletonAsSets(1L, 2L))
             .setCommunities(ImmutableSet.of(StandardCommunity.of(1L), StandardCommunity.of(2L)))
             .setLocalPreference(1)
@@ -115,6 +124,7 @@ public class BgpRouteDiffTest {
             .build();
     route2 =
         builder()
+            .setAdminDist(2)
             .setAsPath(AsPath.ofSingletonAsSets(2L, 3L))
             .setCommunities(ImmutableSet.of(StandardCommunity.of(2L), StandardCommunity.of(3L)))
             .setLocalPreference(2)
@@ -129,6 +139,7 @@ public class BgpRouteDiffTest {
     assertThat(
         routeDiffs(route1, route2).getDiffs(),
         containsInAnyOrder(
+            new BgpRouteDiff(PROP_ADMINISTRATIVE_DISTANCE, "1", "2"),
             new BgpRouteDiff(PROP_AS_PATH, "[1, 2]", "[2, 3]"),
             new BgpRouteDiff(PROP_COMMUNITIES, "[0:1, 0:2]", "[0:2, 0:3]"),
             new BgpRouteDiff(PROP_LOCAL_PREFERENCE, "1", "2"),

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
@@ -1,5 +1,6 @@
 package org.batfish.question.testroutepolicies;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.datamodel.LineAction.DENY;
 import static org.batfish.datamodel.LineAction.PERMIT;
 import static org.batfish.datamodel.answers.Schema.BGP_ROUTE;
@@ -36,6 +37,7 @@ import org.batfish.datamodel.Route;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.questions.BgpRoute;
 import org.batfish.datamodel.questions.BgpRouteDiffs;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -202,7 +204,15 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
     if (questionsBgpRoute == null) {
       return null;
     }
+
+    // We set the administrative distance to the default value chosen by BgpRoute. The more
+    // principled thing to do would be
+    // to use the value based on the vendor but since this is only used to convert the input route
+    // to
+    // the internal representation and AD is never matched as a field the default value does not
+    // really matter.
     return Bgpv4Route.builder()
+        .setAdmin(firstNonNull(questionsBgpRoute.getAdminDist(), BgpRoute.DEFAULT_AD))
         .setWeight(questionsBgpRoute.getWeight())
         .setNextHopIp(questionsBgpRoute.getNextHopIp())
         .setProtocol(questionsBgpRoute.getProtocol())
@@ -229,6 +239,7 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
       return null;
     }
     return org.batfish.datamodel.questions.BgpRoute.builder()
+        .setAdminDist(dataplaneBgpRoute.getAdministrativeCost())
         .setWeight(dataplaneBgpRoute.getWeight())
         // TODO: The next-hop IP AUTO/NONE (Ip.AUTO) is used to denote multiple different things;
         // we should distinguish these uses clearly from one another in the results returned by this

--- a/tests/questions/experimental/testRoutePolicies.ref
+++ b/tests/questions/experimental/testRoutePolicies.ref
@@ -3,6 +3,7 @@
   "direction" : "IN",
   "inputRoutes" : [
     {
+      "adminDistance" : 0,
       "localPreference" : 0,
       "metric" : 0,
       "network" : "0.0.0.0/0",


### PR DESCRIPTION
Adds `PROP_ADMINISTRATIVE_DISTANCE` to BgpRoute, to allow modeling the effect of `SetAdministrativeCost` in TRP/SRP.