### PR TITLE
TransferBDD: Precise Number Regexes

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
@@ -43,6 +43,11 @@ public final class CommunityVar extends SymbolicRegex implements Comparable<Comm
   @Nonnull private final Type _type;
   @Nullable private final Community _literalValue;
 
+  /**
+   * A regex representing numbers that can be part of communities. The first conjunct of the regex
+   * ensures there are no leading zeros. The second conjunct of the regex ensures that the number is
+   * at most 16 bits, using the numeric interval syntax of the automaton library.
+   */
   @Nonnull private static final String NUM_REGEX = "((0|[1-9][0-9]*)&<0-65535>)";
 
   // a regex that represents the syntax of standard community literals supported by Batfish

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
@@ -43,7 +43,7 @@ public final class CommunityVar extends SymbolicRegex implements Comparable<Comm
   @Nonnull private final Type _type;
   @Nullable private final Community _literalValue;
 
-  @Nonnull private static final String NUM_REGEX = "(0|[1-9][0-9]*)";
+  @Nonnull private static final String NUM_REGEX = "((0|[1-9][0-9]*)&<0-65535>)";
 
   // a regex that represents the syntax of standard community literals supported by Batfish
   // see StandardCommunity::matchString()

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
@@ -3,6 +3,7 @@ package org.batfish.minesweeper;
 import static org.batfish.minesweeper.CommunityVar.Type.EXACT;
 import static org.batfish.minesweeper.CommunityVar.Type.REGEX;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import dk.brics.automaton.Automaton;
 import dk.brics.automaton.RegExp;
@@ -48,15 +49,18 @@ public final class CommunityVar extends SymbolicRegex implements Comparable<Comm
    * ensures there are no leading zeros. The second conjunct of the regex ensures that the number is
    * at most 16 bits, using the numeric interval syntax of the automaton library.
    */
-  @Nonnull private static final String NUM_REGEX = "((0|[1-9][0-9]*)&<0-65535>)";
+  @VisibleForTesting @Nonnull
+  static final String COMMUNITY_NUM_REGEX = "((0|[1-9][0-9]*)&<0-65535>)";
 
-  // a regex that represents the syntax of standard community literals supported by Batfish
-  // see StandardCommunity::matchString()
+  /**
+   * A regex that represents the syntax of standard community literals supported by Batfish (see
+   * StandardCommunity::matchString())
+   */
   @Nonnull
   private static final String COMMUNITY_REGEX =
       // start-of-string character
       "^"
-          + String.join(":", NUM_REGEX, NUM_REGEX)
+          + String.join(":", COMMUNITY_NUM_REGEX, COMMUNITY_NUM_REGEX)
           // end-of-string character
           + "$";
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/RegexAtomicPredicates.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/RegexAtomicPredicates.java
@@ -102,6 +102,7 @@ public class RegexAtomicPredicates<T extends SymbolicRegex> {
       }
       mmap = newMMap;
     }
+
     // assign a unique integer to each automaton.
     // create a mapping from each integer to its corresponding automaton
     // and a mapping from each regex to its corresponding set of integers.

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/RegexAtomicPredicates.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/RegexAtomicPredicates.java
@@ -102,7 +102,6 @@ public class RegexAtomicPredicates<T extends SymbolicRegex> {
       }
       mmap = newMMap;
     }
-
     // assign a unique integer to each automaton.
     // create a mapping from each integer to its corresponding automaton
     // and a mapping from each regex to its corresponding set of integers.

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
@@ -41,8 +41,8 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
    * <p>Note: in general an AS path is a list of *sets* of AS numbers. but the format of regexes
    * over sets is apparently vendor-dependent. for now we do not support them.
    */
-  @Nonnull
-  private static final String AS_PATH_REGEX =
+  @VisibleForTesting @Nonnull
+  static final String AS_PATH_REGEX =
       // the empty AS-path
       "^^$"
           + "|"

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
@@ -48,7 +48,7 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
    * over sets is apparently vendor-dependent. for now we do not support them.
    */
   @Nonnull
-  static final String AS_PATH_REGEX =
+  private static final String AS_PATH_REGEX =
       // the empty AS-path
       "^^$"
           + "|"

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
@@ -24,6 +24,12 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
 
   public static final SymbolicAsPathRegex ALL_AS_PATHS = new SymbolicAsPathRegex(".*");
 
+  /**
+   * A regex representing AS numbers. The first conjunct of the regex ensures there are no leading
+   * zeros. The second conjunct of the regex ensures that the number is at most 32 bits, using the
+   * numeric interval syntax of the automaton library. It's a bit complicated because that syntax
+   * only supports numbers in the Java int range.
+   */
   @VisibleForTesting @Nonnull
   static final String AS_NUM_REGEX =
       "((0|[1-9][0-9]*)&(<0-2147483647>|2<147483648-999999999>|3<000000000-999999999>|4<000000000-294967295>))";
@@ -41,7 +47,7 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
    * <p>Note: in general an AS path is a list of *sets* of AS numbers. but the format of regexes
    * over sets is apparently vendor-dependent. for now we do not support them.
    */
-  @VisibleForTesting @Nonnull
+  @Nonnull
   static final String AS_PATH_REGEX =
       // the empty AS-path
       "^^$"
@@ -161,7 +167,7 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
   }
 
   /**
-   * Produce an numeric interval expression for the Automaton library. See {@link RegExp#INTERVAL}.
+   * Produce a numeric interval expression for the Automaton library. See {@link RegExp#INTERVAL}.
    *
    * @param lower the lower bound of the interval
    * @param upper the upper bound of the interval

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
@@ -24,6 +24,10 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
 
   public static final SymbolicAsPathRegex ALL_AS_PATHS = new SymbolicAsPathRegex(".*");
 
+  /** A regex representing integers in the range 0 to 2^32 - 1. */
+  @VisibleForTesting @Nonnull
+  static final String INT_32_REGEX = toRegex(0L, (long) Math.pow(2, 32) - 1);
+
   /**
    * A regex representing AS numbers. The first conjunct of the regex ensures there are no leading
    * zeros. The second conjunct of the regex ensures that the number is at most 32 bits, using the
@@ -31,8 +35,7 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
    * only supports numbers in the Java int range.
    */
   @VisibleForTesting @Nonnull
-  static final String AS_NUM_REGEX =
-      "((0|[1-9][0-9]*)&(<0-2147483647>|2<147483648-999999999>|3<000000000-999999999>|4<000000000-294967295>))";
+  static final String AS_NUM_REGEX = "((0|[1-9][0-9]*)" + "&" + INT_32_REGEX + ")";
 
   /**
    * A regex that represents the language of AS paths: a space-separated list of AS numbers,

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
@@ -24,7 +24,9 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
 
   public static final SymbolicAsPathRegex ALL_AS_PATHS = new SymbolicAsPathRegex(".*");
 
-  @Nonnull private static final String AS_NUM_REGEX = "(0|[1-9][0-9]*)";
+  @Nonnull
+  private static final String AS_NUM_REGEX =
+      "((0|[1-9][0-9]*)&(<0-2147483647>|2<147483648-999999999>|3<000000000-999999999>|4<000000000-294967295>))";
 
   /**
    * A regex that represents the language of AS paths: a space-separated list of AS numbers,
@@ -201,7 +203,7 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
      * these as ordinary characters.
      */
     String regex = ".*" + "(" + _regex + ")" + ".*";
-    return new RegExp(regex, RegExp.INTERVAL).toAutomaton().intersection(AS_PATH_FSM);
+    return new RegExp(regex).toAutomaton().intersection(AS_PATH_FSM);
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
@@ -24,8 +24,8 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
 
   public static final SymbolicAsPathRegex ALL_AS_PATHS = new SymbolicAsPathRegex(".*");
 
-  @Nonnull
-  private static final String AS_NUM_REGEX =
+  @VisibleForTesting @Nonnull
+  static final String AS_NUM_REGEX =
       "((0|[1-9][0-9]*)&(<0-2147483647>|2<147483648-999999999>|3<000000000-999999999>|4<000000000-294967295>))";
 
   /**

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/AsPathRegexAtomicPredicatesTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/AsPathRegexAtomicPredicatesTest.java
@@ -1,6 +1,7 @@
 package org.batfish.minesweeper;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -10,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import org.batfish.minesweeper.question.searchroutepolicies.RegexConstraint;
 import org.batfish.minesweeper.question.searchroutepolicies.RegexConstraints;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /** Tests for the {@link AsPathRegexAtomicPredicates} class. */
@@ -77,12 +79,15 @@ public class AsPathRegexAtomicPredicatesTest {
     copy2.prependAPs(ImmutableList.of(10L, 20L));
     Map<Integer, Automaton> copy2AutomataMap = copy2.getAtomicPredicateAutomata();
     assertEquals(copy2AutomataMap.keySet().size(), 2);
-    assertEquals(
-        copy2AutomataMap.get(0),
-        new RegExp("^^10 20 .*")
-            .toAutomaton()
-            .intersection(SymbolicAsPathRegex.ALL_AS_PATHS.toAutomaton()));
-    assertEquals(copy2AutomataMap.get(1), new RegExp("^^10 20$").toAutomaton());
+    assertThat(
+        copy2AutomataMap,
+        Matchers.allOf(
+            Matchers.hasValue(Matchers.equalTo(new RegExp("^^10 20$").toAutomaton())),
+            Matchers.hasValue(
+                Matchers.equalTo(
+                    new RegExp("^^10 20 .*")
+                        .toAutomaton()
+                        .intersection(SymbolicAsPathRegex.ALL_AS_PATHS.toAutomaton())))));
   }
 
   @Test
@@ -101,12 +106,15 @@ public class AsPathRegexAtomicPredicatesTest {
                 new RegexConstraint("^40 ", false), new RegexConstraint("^50 ", false))));
     Map<Integer, Automaton> copy2AutomataMap = copy2.getAtomicPredicateAutomata();
     assertEquals(copy2AutomataMap.keySet().size(), 2);
-    assertEquals(
-        copy2AutomataMap.get(0),
-        new RegExp("^^(40|50) .*")
-            .toAutomaton()
-            .intersection(SymbolicAsPathRegex.ALL_AS_PATHS.toAutomaton()));
-    assertEquals(copy2AutomataMap.get(1), Automaton.makeEmpty());
+    assertThat(
+        copy2AutomataMap,
+        Matchers.allOf(
+            Matchers.hasValue(Matchers.equalTo(Automaton.makeEmpty())),
+            Matchers.hasValue(
+                Matchers.equalTo(
+                    new RegExp("^^(40|50) .*")
+                        .toAutomaton()
+                        .intersection(SymbolicAsPathRegex.ALL_AS_PATHS.toAutomaton())))));
 
     AsPathRegexAtomicPredicates copy3 = new AsPathRegexAtomicPredicates(twoAPs);
     copy3.constrainAPs(
@@ -115,12 +123,15 @@ public class AsPathRegexAtomicPredicatesTest {
                 new RegexConstraint("^40 ", true), new RegexConstraint("^50 ", true))));
     Map<Integer, Automaton> copy3AutomataMap = copy3.getAtomicPredicateAutomata();
     assertEquals(copy3AutomataMap.keySet().size(), 2);
-    assertEquals(
-        copy3AutomataMap.get(0),
-        new RegExp("^^.+$")
-            .toAutomaton()
-            .intersection(new RegExp("^^(40|50) .*").toAutomaton().complement())
-            .intersection(SymbolicAsPathRegex.ALL_AS_PATHS.toAutomaton()));
-    assertEquals(copy3AutomataMap.get(1), new RegExp("^^$").toAutomaton());
+    assertThat(
+        copy3AutomataMap,
+        Matchers.allOf(
+            Matchers.hasValue(Matchers.equalTo(new RegExp("^^$").toAutomaton())),
+            Matchers.hasValue(
+                Matchers.equalTo(
+                    new RegExp("^^.+$")
+                        .toAutomaton()
+                        .intersection(new RegExp("^^(40|50) .*").toAutomaton().complement())
+                        .intersection(SymbolicAsPathRegex.ALL_AS_PATHS.toAutomaton())))));
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
@@ -1,6 +1,7 @@
 package org.batfish.minesweeper;
 
 import static org.batfish.datamodel.routing_policy.Common.DEFAULT_UNDERSCORE_REPLACEMENT;
+import static org.batfish.minesweeper.CommunityVar.COMMUNITY_NUM_REGEX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -40,7 +41,7 @@ public class CommunityVarTest {
 
     assertThat(cv3.toAutomaton(), equalTo(CommunityVar.COMMUNITY_FSM));
     assertThat(
-        cv4.toAutomaton(), equalTo(new RegExp("^40:((0|[1-9][0-9]*)&<0-65535>)$").toAutomaton()));
+        cv4.toAutomaton(), equalTo(new RegExp("^40:" + COMMUNITY_NUM_REGEX + "$").toAutomaton()));
     assertThat(cv5.toAutomaton(), equalTo(new RegExp("^40:50$").toAutomaton()));
 
     assertThat(cv6.toAutomaton(), equalTo(new RegExp("^0:[1-9]0$").toAutomaton()));

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
@@ -39,7 +39,8 @@ public class CommunityVarTest {
     assertThat(cv2.toAutomaton(), equalTo(new RegExp("^large:10:20:30$").toAutomaton()));
 
     assertThat(cv3.toAutomaton(), equalTo(CommunityVar.COMMUNITY_FSM));
-    assertThat(cv4.toAutomaton(), equalTo(new RegExp("^40:(0|[1-9][0-9]*)$").toAutomaton()));
+    assertThat(
+        cv4.toAutomaton(), equalTo(new RegExp("^40:((0|[1-9][0-9]*)&<0-65535>)$").toAutomaton()));
     assertThat(cv5.toAutomaton(), equalTo(new RegExp("^40:50$").toAutomaton()));
 
     assertThat(cv6.toAutomaton(), equalTo(new RegExp("^0:[1-9]0$").toAutomaton()));

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/RegexAtomicPredicatesTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/RegexAtomicPredicatesTest.java
@@ -90,6 +90,9 @@ public class RegexAtomicPredicatesTest {
         hasEntry(equalTo(CommunityVar.from("12345:67$")), iterableWithSize(1)));
     assertThat(
         commAPs.getRegexAtomicPredicates(),
+        hasEntry(equalTo(CommunityVar.from("^12345:67$")), iterableWithSize(1)));
+    assertThat(
+        commAPs.getRegexAtomicPredicates(),
         hasEntry(equalTo(CommunityVar.from(".*")), iterableWithSize(2)));
   }
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/SymbolicAsPathRegexTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/SymbolicAsPathRegexTest.java
@@ -1,6 +1,7 @@
 package org.batfish.minesweeper;
 
 import static org.batfish.datamodel.routing_policy.Common.DEFAULT_UNDERSCORE_REPLACEMENT;
+import static org.batfish.minesweeper.SymbolicAsPathRegex.AS_NUM_REGEX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
@@ -42,23 +43,14 @@ public class SymbolicAsPathRegexTest {
     assertThat(r2.toAutomaton(), equalTo(new RegExp("^^$").toAutomaton()));
     assertThat(
         r3.toAutomaton(),
-        equalTo(
-            new RegExp("^^" + "(" + SymbolicAsPathRegex.AS_NUM_REGEX + " )*" + "40$")
-                .toAutomaton()));
+        equalTo(new RegExp("^^" + "(" + AS_NUM_REGEX + " )*" + "40$").toAutomaton()));
 
     assertThat(
-        r4.toAutomaton(),
-        equalTo(new RegExp("^^40( " + SymbolicAsPathRegex.AS_NUM_REGEX + ")*$").toAutomaton()));
+        r4.toAutomaton(), equalTo(new RegExp("^^40( " + AS_NUM_REGEX + ")*$").toAutomaton()));
     assertThat(
         r5.toAutomaton(),
         equalTo(
-            new RegExp(
-                    "^^("
-                        + SymbolicAsPathRegex.AS_NUM_REGEX
-                        + " )*40 50( "
-                        + SymbolicAsPathRegex.AS_NUM_REGEX
-                        + ")*$")
-                .toAutomaton()));
+            new RegExp("^^(" + AS_NUM_REGEX + " )*40 50( " + AS_NUM_REGEX + ")*$").toAutomaton()));
   }
 
   @Test
@@ -74,11 +66,9 @@ public class SymbolicAsPathRegexTest {
     assertThat(r1.toAutomaton(), equalTo(new RegExp("^^40$").toAutomaton()));
     assertThat(r2.toAutomaton(), equalTo(new RegExp("^^$").toAutomaton()));
     assertThat(
-        r3.toAutomaton(),
-        equalTo(new RegExp("^^(" + SymbolicAsPathRegex.AS_NUM_REGEX + " )*40$").toAutomaton()));
+        r3.toAutomaton(), equalTo(new RegExp("^^(" + AS_NUM_REGEX + " )*40$").toAutomaton()));
     assertThat(
-        r4.toAutomaton(),
-        equalTo(new RegExp("^^40( " + SymbolicAsPathRegex.AS_NUM_REGEX + ")*$").toAutomaton()));
+        r4.toAutomaton(), equalTo(new RegExp("^^40( " + AS_NUM_REGEX + ")*$").toAutomaton()));
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/SymbolicAsPathRegexTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/SymbolicAsPathRegexTest.java
@@ -40,11 +40,25 @@ public class SymbolicAsPathRegexTest {
 
     assertThat(r1.toAutomaton(), equalTo(new RegExp("^^40$").toAutomaton()));
     assertThat(r2.toAutomaton(), equalTo(new RegExp("^^$").toAutomaton()));
-    assertThat(r3.toAutomaton(), equalTo(new RegExp("^^((0|[1-9][0-9]*) )*40$").toAutomaton()));
-    assertThat(r4.toAutomaton(), equalTo(new RegExp("^^40( (0|[1-9][0-9]*))*$").toAutomaton()));
+    assertThat(
+        r3.toAutomaton(),
+        equalTo(
+            new RegExp("^^" + "(" + SymbolicAsPathRegex.AS_NUM_REGEX + " )*" + "40$")
+                .toAutomaton()));
+
+    assertThat(
+        r4.toAutomaton(),
+        equalTo(new RegExp("^^40( " + SymbolicAsPathRegex.AS_NUM_REGEX + ")*$").toAutomaton()));
     assertThat(
         r5.toAutomaton(),
-        equalTo(new RegExp("^^((0|[1-9][0-9]*) )*40 50( (0|[1-9][0-9]*))*$").toAutomaton()));
+        equalTo(
+            new RegExp(
+                    "^^("
+                        + SymbolicAsPathRegex.AS_NUM_REGEX
+                        + " )*40 50( "
+                        + SymbolicAsPathRegex.AS_NUM_REGEX
+                        + ")*$")
+                .toAutomaton()));
   }
 
   @Test
@@ -59,8 +73,12 @@ public class SymbolicAsPathRegexTest {
 
     assertThat(r1.toAutomaton(), equalTo(new RegExp("^^40$").toAutomaton()));
     assertThat(r2.toAutomaton(), equalTo(new RegExp("^^$").toAutomaton()));
-    assertThat(r3.toAutomaton(), equalTo(new RegExp("^^((0|[1-9][0-9]*) )*40$").toAutomaton()));
-    assertThat(r4.toAutomaton(), equalTo(new RegExp("^^40( (0|[1-9][0-9]*))*$").toAutomaton()));
+    assertThat(
+        r3.toAutomaton(),
+        equalTo(new RegExp("^^(" + SymbolicAsPathRegex.AS_NUM_REGEX + " )*40$").toAutomaton()));
+    assertThat(
+        r4.toAutomaton(),
+        equalTo(new RegExp("^^40( " + SymbolicAsPathRegex.AS_NUM_REGEX + ")*$").toAutomaton()));
   }
 
   @Test


### PR DESCRIPTION
This PR updates the symbolic route analysis to properly account for the ranges of numbers that can appear in communities and in AS-paths.  Otherwise the analysis can provide spurious results, for example a community that is ill-formed because one half is a number that is out of range.