### PR TITLE
SymbolicAsPathRegex: use long math, skip doubles

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicAsPathRegex.java
@@ -25,8 +25,7 @@ public class SymbolicAsPathRegex extends SymbolicRegex implements Comparable<Sym
   public static final SymbolicAsPathRegex ALL_AS_PATHS = new SymbolicAsPathRegex(".*");
 
   /** A regex representing integers in the range 0 to 2^32 - 1. */
-  @VisibleForTesting @Nonnull
-  static final String INT_32_REGEX = toRegex(0L, (long) Math.pow(2, 32) - 1);
+  @VisibleForTesting @Nonnull static final String INT_32_REGEX = toRegex(0L, (1L << 32) - 1);
 
   /**
    * A regex representing AS numbers. The first conjunct of the regex ensures there are no leading

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/SymbolicAsPathRegexTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/SymbolicAsPathRegexTest.java
@@ -95,7 +95,7 @@ public class SymbolicAsPathRegexTest {
     String r2 = SymbolicAsPathRegex.toRegex(500L, (long) Integer.MAX_VALUE + 20);
     String r3 =
         SymbolicAsPathRegex.toRegex((long) Integer.MAX_VALUE + 20, (long) Integer.MAX_VALUE + 500);
-    String r4 = SymbolicAsPathRegex.toRegex(0L, (long) Math.pow(2, 32) - 1);
+    String r4 = SymbolicAsPathRegex.toRegex(0L, (1L << 32) - 1);
 
     assertThat(r1, equalTo("<0-2147483647>"));
     assertThat(r2, equalTo("((<500-2147483647>)|(2<147483648-147483667>))"));
@@ -152,8 +152,7 @@ public class SymbolicAsPathRegexTest {
             .add(3999999999L)
             .build());
 
-    SymbolicAsPathRegex r4 =
-        singletonAsPathRegexForClosedInterval(400L, (long) Math.pow(2, 32) - 1);
+    SymbolicAsPathRegex r4 = singletonAsPathRegexForClosedInterval(400L, (1L << 32) - 1);
     testRegexBehavior(
         r4,
         ImmutableSet.<Long>builder()


### PR DESCRIPTION
**Stack**:
- #8799
- #8798 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*