### PR TITLE
checkstyle: small optimizations

### DIFF
--- a/projects/checkstyle.xml
+++ b/projects/checkstyle.xml
@@ -54,32 +54,27 @@
     </module>
 
     <module name="RegexpSinglelineJava">
-      <property name="format" value="import com.google.common.base.Preconditions;"/>
+      <property name="format" value="import com\.google\.common\.base\.Preconditions;"/>
       <property name="message" value="Static import from Guava utility classes"/>
     </module>
 
     <module name="RegexpSinglelineJava">
-      <property name="format" value="import org.parboiled.common.Immutable.*"/>
+      <property name="format" value="import org\.parboiled\.common\.Immutable"/>
       <property name="message" value="Import Guava from Guava"/>
     </module>
 
     <module name="RegexpSinglelineJava">
-      <property name="format" value="org.hamcrest.collection.(IsCollectionWithSize|IsEmptyCollection|IsIterableContaining|IsMapContaining|IsMapWithSize)"/>
+      <property name="format" value="org\.hamcrest\.(collection\.(IsCollectionWithSize|IsEmptyCollection|IsIterableContaining|IsMapContaining|IsMapWithSize)|core\.(AllOf|Is))"/>
       <property name="message" value="Static import from org.hamcrest.Matchers"/>
     </module>
 
     <module name="RegexpSinglelineJava">
-      <property name="format" value="org.hamcrest.core.(AllOf|Is)"/>
-      <property name="message" value="Static import from org.hamcrest.Matchers"/>
-    </module>
-
-    <module name="RegexpSinglelineJava">
-      <property name="format" value="import org.junit.Assert;"/>
+      <property name="format" value="import org\.junit\.Assert;"/>
       <property name="message" value="Static import JUnit assertion helpers"/>
     </module>
 
     <module name="RegexpSinglelineJava">
-      <property name="format" value=".*MoreObjects\.firstNonNull\(.*"/>
+      <property name="format" value="MoreObjects\.firstNonNull\("/>
       <property name="message" value="Static import from Guava utility classes"/>
     </module>
 


### PR DESCRIPTION
1. Escape '.' in regex.
2. Remove unnecessary leading/trailing '.*'
3. Combine rules that are easy to combine.

Saves about 10%-15% runtime.