### PR TITLE
Fix 'forwarding-options dhcp-security' parse warning for Juniper

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -543,6 +543,8 @@ DHCP_LOCAL_SERVER: 'dhcp-local-server';
 
 DHCP_RELAY: 'dhcp-relay';
 
+DHCP_SECURITY: 'dhcp-security';
+
 DIRECT: 'direct';
 
 DISABLE: 'disable';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -180,22 +180,6 @@ s_vlans
    )
 ;
 
-vlt_forwarding_options
-:
-   FORWARDING_OPTIONS
-   (
-      apply
-      | vlt_fo_null
-   )
-;
-
-vlt_fo_null
-:
-   (
-      DHCP_SECURITY
-   ) null_filler
-;
-
 s_vlans_named
 :
   name = junos_name
@@ -203,7 +187,7 @@ s_vlans_named
     apply
     | vlt_description
     | vlt_filter
-    | vlt_forwarding_options    
+    | vlt_forwarding_options
     | vlt_interface
     | vlt_l3_interface
     | vlt_vlan_id
@@ -236,6 +220,22 @@ vlt_filter
       INPUT
       | OUTPUT
    ) name = filter_name
+;
+
+vlt_forwarding_options
+:
+   FORWARDING_OPTIONS
+   (
+      apply
+      | vltfo_null
+   )
+;
+
+vltfo_null
+:
+   (
+      DHCP_SECURITY
+   ) null_filler
 ;
 
 vlt_interface

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -161,6 +161,7 @@ s_null
          | MULTI_CHASSIS
          | POE
          | VIRTUAL_CHASSIS
+         | FORWARDING_OPTIONS DHCP_SECURITY
       ) null_filler
    )
    | ri_null
@@ -180,6 +181,13 @@ s_vlans
    )
 ;
 
+sl_vlans_null
+:
+   (
+      FORWARDING_OPTIONS DHCP_SECURITY
+   ) null_filler
+;
+
 s_vlans_named
 :
   name = junos_name
@@ -192,6 +200,7 @@ s_vlans_named
     | vlt_vlan_id
     | vlt_vlan_id_list
     | vlt_vni_id
+    | sl_vlans_null
   )
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -181,10 +181,19 @@ s_vlans
    )
 ;
 
-sl_vlans_null
+vlt_forwarding_options
+:
+   FORWARDING_OPTIONS
+   (
+      apply
+      | vltfo_null
+   )
+;
+
+vltfo_null
 :
    (
-      FORWARDING_OPTIONS DHCP_SECURITY
+      DHCP_SECURITY
    ) null_filler
 ;
 
@@ -195,12 +204,12 @@ s_vlans_named
     apply
     | vlt_description
     | vlt_filter
+    | vlt_forwarding_options    
     | vlt_interface
     | vlt_l3_interface
     | vlt_vlan_id
     | vlt_vlan_id_list
     | vlt_vni_id
-    | sl_vlans_null
   )
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -185,11 +185,11 @@ vlt_forwarding_options
    FORWARDING_OPTIONS
    (
       apply
-      | vltfo_null
+      | vlt_fo_null
    )
 ;
 
-vltfo_null
+vlt_fo_null
 :
    (
       DHCP_SECURITY

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -161,7 +161,6 @@ s_null
          | MULTI_CHASSIS
          | POE
          | VIRTUAL_CHASSIS
-         | FORWARDING_OPTIONS DHCP_SECURITY
       ) null_filler
    )
    | ri_null

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -7953,9 +7953,8 @@ public final class FlatJuniperGrammarTest {
 
   @Test
   public void testVlanForwardingOptionsDhcpSecurity() {
-     // doesn't crash.
-     parseJuniperConfig("vlan-forwarding-options");
- 
+    // doesn't crash.
+    parseJuniperConfig("vlan-forwarding-options");
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -7952,6 +7952,13 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testVlanForwardingOptionsDhcpSecurity() {
+     // doesn't crash.
+     parseJuniperConfig("vlan-forwarding-options");
+ 
+  }
+
+  @Test
   public void testApplyPathMixedIpAndNotIpOrPrefixExtraction() {
     String hostname = "apply-path-mixed-ip-and-not-ip-or-prefix";
     JuniperConfiguration vc = parseJuniperConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/vlan-forwarding-options
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/vlan-forwarding-options
@@ -1,0 +1,5 @@
+#
+set system host-name vlan-forwarding-options
+#
+set vlans VLAN_10 vlan-id 10
+set vlans VLAN_10 forwarding-options dhcp-security


### PR DESCRIPTION
A 'Parse warning' is being triggered by the following configuration:
```
set vlans <name> forwarding-options dhcp-security
```
The `dhcp-security` configuration is valid only under the ‘forwarding-options’ inside the vlans stanza.

This PR addresses the parse warning by extending the lexer/parser.

The configuration statement is documented [here](https://www.juniper.net/documentation/us/en/software/junos/security-services/topics/ref/statement/dhcp-security-edit-vlans.html)
