### PR TITLE
JunOS: parse and ignore snmp engine-id

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -613,8 +613,12 @@ ENCRYPTION_ALGORITHM: 'encryption-algorithm';
 
 ENFORCE_FIRST_AS: 'enforce-first-as';
 
+ENGINE_ID: 'engine-id';
+
 ENHANCED_HASH_KEY: 'enhanced-hash-key';
+
 EQUAL_COST_PATHS: 'equal-cost-paths';
+
 ESP: 'esp';
 
 ESP_HEADER: 'ESP-header';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_snmp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_snmp.g4
@@ -59,6 +59,7 @@ snmp_null
    (
       CONTACT
       | DESCRIPTION
+      | ENGINE_ID
       | FILTER_DUPLICATES
       | INTERFACE
       | LOCATION

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/snmp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/snmp
@@ -11,3 +11,4 @@ set snmp client-list SNMPCL 2.3.4.5
 set snmp client-list SNMPCL 20.0.0.0/8
 set snmp community COMM2 client-list-name SNMPCL
 #
+set snmp engine-id local engine_id_name


### PR DESCRIPTION
Parse and ignore snmp endinge-id

Received a `Parse warning` saying `This syntax is unrecognized` for the following valid syntax:

```
set snmp engine-id local NAME
```

Added the configuration to the existing SNMP configuration sample. The SNMP test that is in place at the moment now passes with this additional line of config. 

Let me know if it is more appropriate to add a new config sample together with a new test and I will add it.

For reference:
https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/ref/statement/engine-id-edit-snmp.html

