### PR TITLE
Junos: fix name-server

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -1819,7 +1819,7 @@ NAME_LITERALLY: 'name' -> pushMode(M_Name);
 
 NAME_RESOLUTION: 'name-resolution';
 
-NAME_SERVER: 'name-server' -> pushMode(M_Name);
+NAME_SERVER: 'name-server';
 
 NAT: 'nat';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_system.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_system.g4
@@ -61,8 +61,7 @@ sy_host_name
 
 sy_name_server
 :
-  // TODO: do better
-  NAME_SERVER hostname = junos_name SOURCE_ADDRESS ip_address
+  NAME_SERVER server = ip_address
 ;
 
 sy_ntp

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -7025,7 +7025,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitSy_name_server(Sy_name_serverContext ctx) {
     Set<String> dnsServers = _currentLogicalSystem.getDnsServers();
-    String hostname = toString(ctx.hostname);
+    String hostname = toIp(ctx.server).toString();
     dnsServers.add(hostname);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2722,6 +2722,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testNameServer() {
+    Configuration config = parseConfig("name-server");
+    assertThat(config.getDnsServers(), contains("1.2.3.4"));
+  }
+
+  @Test
   public void testAggregateDefaults() {
     Configuration config = parseConfig("aggregate-defaults");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/name-server
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/name-server
@@ -1,0 +1,5 @@
+# RANCID-CONTENT-TYPE: juniper
+set system host-name name-server
+#
+set system name-server 1.2.3.4
+#


### PR DESCRIPTION
Parsing Junos config `set system name-server <ip>` fails. This allows it.