### PR TITLE
Junos: parse set protocols isis ignore-attached-bit

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -909,6 +909,8 @@ IGMP_SNOOPING: 'igmp-snooping';
 
 IGNORE: 'ignore';
 
+IGNORE_ATTACHED_BIT: 'ignore-attached-bit';
+
 IGNORE_L3_INCOMPLETES: 'ignore-l3-incompletes';
 
 IGP: 'igp';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
@@ -17,6 +17,11 @@ is_export
   EXPORT expr = policy_expression
 ;
 
+is_ignore_attached_bit
+:
+  IGNORE_ATTACHED_BIT
+;
+
 is_interface
 :
   INTERFACE
@@ -255,6 +260,7 @@ p_isis
   (
     apply
     | is_export
+    | is_ignore_attached_bit
     | is_interface
     | is_level
     | is_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -386,6 +386,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ipsec_protocolContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ipv6_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ipv6_prefixContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_exportContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_ignore_attached_bitContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_levelContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_no_ipv4_routingContext;
@@ -5170,6 +5171,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
         .getIsisSettings()
         .getExportPolicies()
         .add(toComplexPolicyStatement(ctx.expr, ISIS_EXPORT_POLICY));
+  }
+
+  @Override
+  public void exitIs_ignore_attached_bit(Is_ignore_attached_bitContext ctx) {
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4272,6 +4272,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testIsisIgnoreAttachedBit() {
+    Configuration c = parseConfig("isis-ignore-attached-bit");
+    assertThat(c, hasDefaultVrf(hasIsisProcess(nullValue())));
+  }
+
+  @Test
   public void testIsisInterfaceAndLevelDisable() {
     Configuration c = parseConfig("isis-interface-and-level-disable");
     IsisProcess proc = c.getVrfs().get(DEFAULT_VRF_NAME).getIsisProcess();

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4273,8 +4273,8 @@ public final class FlatJuniperGrammarTest {
 
   @Test
   public void testIsisIgnoreAttachedBit() {
-    Configuration c = parseConfig("isis-ignore-attached-bit");
-    assertThat(c, hasDefaultVrf(hasIsisProcess(nullValue())));
+    parseConfig("isis-ignore-attached-bit");
+    // don't crash.
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-ignore-attached-bit
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-ignore-attached-bit
@@ -1,0 +1,5 @@
+#
+set system host-name isis-ignore-attached-bit
+#
+set protocols isis ignore-attached-bit
+#


### PR DESCRIPTION
Parse `set protocols isis ignore-attached-bit`

Relevant docs for this: https://www.juniper.net/documentation/us/en/software/junos/is-is/topics/ref/statement/ignore-attached-bit-edit-protocols-isis.html