### PR TITLE
TransferBDD: Model "at-most-one" route attributes using BDDDomain

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -20,7 +20,7 @@ public class BDDDomain<T> {
   private MutableBDDInteger _integer;
 
   public BDDDomain(BDDFactory factory, List<T> values, int index) {
-    int bits = numBits(values);
+    int bits = numBits(values.size());
     _factory = factory;
     _values = values;
     _integer = MutableBDDInteger.makeFromIndex(_factory, bits, index, false);
@@ -42,8 +42,13 @@ public class BDDDomain<T> {
     _integer = other.getInteger().and(pred);
   }
 
-  private int numBits(List<T> values) {
-    int size = values.size();
+  /**
+   * Returns the number of bits used to represent a domain of the given size.
+   *
+   * @param size the number of elements in the domain
+   * @return the number of bits required
+   */
+  public static int numBits(int size) {
     double log = Math.log((double) size);
     double base = Math.log((double) 2);
     if (size == 0) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -1,5 +1,7 @@
 package org.batfish.minesweeper.bdd;
 
+import com.google.common.math.IntMath;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Objects;
 import net.sf.javabdd.BDD;
@@ -49,13 +51,10 @@ public class BDDDomain<T> {
    * @return the number of bits required
    */
   public static int numBits(int size) {
-    double log = Math.log((double) size);
-    double base = Math.log((double) 2);
     if (size == 0) {
       return 0;
-    } else {
-      return (int) Math.ceil(log / base);
     }
+    return IntMath.log2(size, RoundingMode.CEILING);
   }
 
   public BDD value(T value) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -278,6 +278,8 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     addBitNames("as-path atomic predicates", len, idx, false);
     idx += len;
 
+    // we track one extra value for the next-hop interfaces and source VRFs, to represent
+    // "none", since these are optional parts of a route
     _nextHopInterfaces =
         new BDDDomain<>(
             factory,
@@ -286,7 +288,6 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     len = _nextHopInterfaces.getInteger().size();
     addBitNames("next-hop interfaces", len, idx, false);
     idx += len;
-
     _sourceVrfs =
         new BDDDomain<>(
             factory,

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -130,16 +130,16 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
   private final BDDDomain<RoutingProtocol> _protocolHistory;
 
   /**
-   * Contains a BDD variable for each next-hop interface name that may be encountered along the
-   * path. See {@link org.batfish.datamodel.routing_policy.expr.MatchInterface}.
+   * Represents the route's optional next-hop interface name. See {@link
+   * org.batfish.datamodel.routing_policy.expr.MatchInterface}.
    */
-  private final BDD[] _nextHopInterfaces;
+  private final BDDDomain<Integer> _nextHopInterfaces;
 
   /**
-   * Contains a BDD variable for each source VRF that may be encountered along the path. See {@link
+   * Represents the optional source VRF from which the route was sent. See {@link
    * org.batfish.datamodel.routing_policy.expr.MatchSourceVrf}.
    */
-  private final BDD[] _sourceVrfs;
+  private final BDDDomain<Integer> _sourceVrfs;
 
   private MutableBDDInteger _tag;
 
@@ -193,7 +193,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
       int numTracks) {
     _factory = factory;
 
-    int bitsToRepresentAdmin = IntMath.log2(AbstractRoute.MAX_ADMIN_DISTANCE, RoundingMode.CEILING);
+    int bitsToRepresentAdmin = numBits(AbstractRoute.MAX_ADMIN_DISTANCE);
     // or else we need to do tricks in the BDDInteger.
     assert LongMath.isPowerOfTwo(1L + AbstractRoute.MAX_ADMIN_DISTANCE);
     int numVars = factory.varNum();
@@ -203,13 +203,15 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
             + bitsToRepresentAdmin
             + 6
             + numCommAtomicPredicates
-            + numAsPathRegexAtomicPredicates
-            + numNextHopInterfaces
-            + numSourceVrfs
+            + numBits(numAsPathRegexAtomicPredicates)
+            // we track one extra value for the next-hop interfaces and source VRFs, to represent
+            // "none", since these are optional parts of a route
+            + numBits(numNextHopInterfaces + 1)
+            + numBits(numSourceVrfs + 1)
             + numTracks
-            + IntMath.log2(OriginType.values().length, RoundingMode.CEILING)
-            + IntMath.log2(RoutingProtocol.values().length, RoundingMode.CEILING)
-            + IntMath.log2(allMetricTypes.size(), RoundingMode.CEILING);
+            + numBits(OriginType.values().length)
+            + numBits(RoutingProtocol.values().length)
+            + numBits(allMetricTypes.size());
     if (numVars < numNeeded) {
       factory.setVarNum(numNeeded);
     }
@@ -264,10 +266,9 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
       _bitNames.put(idx, "community atomic predicate " + i);
       idx++;
     }
-    // Initialize one BDD per AS-path regex atomic predicate, each of which has a corresponding
-    // BDD variable
+
     _asPathRegexAtomicPredicates =
-        new BDDDomain<Integer>(
+        new BDDDomain<>(
             factory,
             IntStream.range(0, numAsPathRegexAtomicPredicates).boxed().collect(Collectors.toList()),
             idx);
@@ -275,21 +276,24 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     addBitNames("as-path atomic predicates", len, idx, false);
     idx += len;
 
-    // Initialize one BDD per next-hop interface name, each of which has a corresponding BDD
-    // variable
-    _nextHopInterfaces = new BDD[numNextHopInterfaces];
-    for (int i = 0; i < numNextHopInterfaces; i++) {
-      _nextHopInterfaces[i] = factory.ithVar(idx);
-      _bitNames.put(idx, "next-hop interface " + i);
-      idx++;
-    }
-    // Initialize one BDD per source VRF, each of which has a corresponding BDD variable
-    _sourceVrfs = new BDD[numSourceVrfs];
-    for (int i = 0; i < numSourceVrfs; i++) {
-      _sourceVrfs[i] = factory.ithVar(idx);
-      _bitNames.put(idx, "source VRF " + i);
-      idx++;
-    }
+    _nextHopInterfaces =
+        new BDDDomain<>(
+            factory,
+            IntStream.range(0, numNextHopInterfaces + 1).boxed().collect(Collectors.toList()),
+            idx);
+    len = _nextHopInterfaces.getInteger().size();
+    addBitNames("next-hop interfaces", len, idx, false);
+    idx += len;
+
+    _sourceVrfs =
+        new BDDDomain<>(
+            factory,
+            IntStream.range(0, numSourceVrfs + 1).boxed().collect(Collectors.toList()),
+            idx);
+    len = _sourceVrfs.getInteger().size();
+    addBitNames("source VRFs", len, idx, false);
+    idx += len;
+
     // Initialize one BDD per tracked name, each of which has a corresponding BDD variable
     _tracks = new BDD[numTracks];
     for (int i = 0; i < numTracks; i++) {
@@ -331,8 +335,8 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     _ospfMetric = new BDDDomain<>(other._ospfMetric);
     _bitNames = other._bitNames;
     _prependedASes = new ArrayList<>(other._prependedASes);
-    _nextHopInterfaces = other._nextHopInterfaces.clone();
-    _sourceVrfs = other._sourceVrfs.clone();
+    _nextHopInterfaces = new BDDDomain<>(other._nextHopInterfaces);
+    _sourceVrfs = new BDDDomain<>(other._sourceVrfs);
     _tracks = other._tracks.clone();
     _unsupported = other._unsupported;
   }
@@ -372,9 +376,17 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     _nextHopType = route.getNextHopType();
     _unsupported = route.getUnsupported();
     _prependedASes = new ArrayList<>(route.getPrependedASes());
-    _nextHopInterfaces = route.getNextHopInterfaces();
-    _sourceVrfs = route.getSourceVrfs();
+    _nextHopInterfaces = new BDDDomain<>(pred, route._nextHopInterfaces);
+    _sourceVrfs = new BDDDomain<>(pred, route._sourceVrfs);
     _tracks = route.getTracks();
+  }
+
+  // Compute the number of bits needed to represent the given number in binary.
+  private static int numBits(int numValues) {
+    if (numValues == 0) {
+      return 0;
+    }
+    return IntMath.log2(numValues, RoundingMode.CEILING);
   }
 
   /*
@@ -411,17 +423,6 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     return _factory.orAll(elements.stream().map(bddDomain::value).collect(Collectors.toList()));
   }
 
-  /** Produce a constraint that at most one of the given array of BDDs is true. */
-  private BDD atMostOneOf(BDD[] bdds) {
-    BDD atMostOne = _factory.one();
-    for (int i = 0; i < bdds.length; i++) {
-      for (int j = i + 1; j < bdds.length; j++) {
-        atMostOne.andWith(bdds[i].nand(bdds[j]));
-      }
-    }
-    return atMostOne;
-  }
-
   /**
    * Not all assignments to the BDD variables that make up a BDDRoute represent valid BGP routes.
    * This method produces constraints that well-formed BGP routes must satisfy, represented as a
@@ -444,19 +445,10 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     BDD protocolConstraint = anyElementOf(ALL_BGP_PROTOCOLS, this.getProtocolHistory());
     // the prefix length should be 32 or less
     BDD prefLenConstraint = _prefixLength.leq(32);
-    // at most one source VRF should be in the environment
-    BDD sourceVrfConstraint = atMostOneOf(_sourceVrfs);
     // the next hop should be neither the min nor the max possible IP
     // this constraint is enforced by NextHopIp's constructor
     BDD nextHopConstraint = _nextHop.range(Ip.ZERO.asLong() + 1, Ip.MAX.asLong() - 1);
-    // at most one next-hop interface name should be selected
-    BDD nextHopInterfaceConstraint = atMostOneOf(_nextHopInterfaces);
-
-    return protocolConstraint
-        .andWith(prefLenConstraint)
-        .andWith(sourceVrfConstraint)
-        .andWith(nextHopConstraint)
-        .andWith(nextHopInterfaceConstraint);
+    return protocolConstraint.andWith(prefLenConstraint).andWith(nextHopConstraint);
   }
 
   /*
@@ -626,11 +618,11 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     _tag = tag;
   }
 
-  public BDD[] getNextHopInterfaces() {
+  public BDDDomain<Integer> getNextHopInterfaces() {
     return _nextHopInterfaces;
   }
 
-  public BDD[] getSourceVrfs() {
+  public BDDDomain<Integer> getSourceVrfs() {
     return _sourceVrfs;
   }
 
@@ -679,8 +671,8 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
         && Arrays.equals(_communityAtomicPredicates, other._communityAtomicPredicates)
         && Objects.equals(_asPathRegexAtomicPredicates, other._asPathRegexAtomicPredicates)
         && Objects.equals(_prependedASes, other._prependedASes)
-        && Arrays.equals(_nextHopInterfaces, other._nextHopInterfaces)
-        && Arrays.equals(_sourceVrfs, other._sourceVrfs)
+        && Objects.equals(_nextHopInterfaces, other._nextHopInterfaces)
+        && Objects.equals(_sourceVrfs, other._sourceVrfs)
         && Arrays.equals(_tracks, other._tracks)
         && Objects.equals(_unsupported, other._unsupported);
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -1,5 +1,7 @@
 package org.batfish.minesweeper.bdd;
 
+import static org.batfish.minesweeper.bdd.BDDDomain.numBits;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -193,7 +195,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
       int numTracks) {
     _factory = factory;
 
-    int bitsToRepresentAdmin = numBits(AbstractRoute.MAX_ADMIN_DISTANCE);
+    int bitsToRepresentAdmin = IntMath.log2(AbstractRoute.MAX_ADMIN_DISTANCE, RoundingMode.CEILING);
     // or else we need to do tricks in the BDDInteger.
     assert LongMath.isPowerOfTwo(1L + AbstractRoute.MAX_ADMIN_DISTANCE);
     int numVars = factory.varNum();
@@ -379,14 +381,6 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     _nextHopInterfaces = new BDDDomain<>(pred, route._nextHopInterfaces);
     _sourceVrfs = new BDDDomain<>(pred, route._sourceVrfs);
     _tracks = route.getTracks();
-  }
-
-  // Compute the number of bits needed to represent the given number in binary.
-  private static int numBits(int numValues) {
-    if (numValues == 0) {
-      return 0;
-    }
-    return IntMath.log2(numValues, RoundingMode.CEILING);
   }
 
   /*

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
@@ -183,15 +183,12 @@ public class ModelGeneration {
     Ip ip = Ip.create(r.getNextHop().satAssignmentToLong(model));
     // if we matched on a next-hop interface then include the interface name in the produced
     // next-hop
-    List<String> nextHopInterfaces =
-        allSatisfyingItems(configAPs.getNextHopInterfaces(), r.getNextHopInterfaces(), model);
-    checkState(
-        nextHopInterfaces.size() <= 1,
-        "Error in symbolic route analysis: at most one next-hop interface can be set");
-    if (nextHopInterfaces.isEmpty()) {
+    String nextHopInterface =
+        optionalItem(configAPs.getNextHopInterfaces(), r.getNextHopInterfaces(), model);
+    if (nextHopInterface == null) {
       return NextHopIp.of(ip);
     } else {
-      return NextHopInterface.of(nextHopInterfaces.get(0), ip);
+      return NextHopInterface.of(nextHopInterface, ip);
     }
   }
 
@@ -353,14 +350,10 @@ public class ModelGeneration {
 
     List<String> successfulTracks = allSatisfyingItems(configAPs.getTracks(), r.getTracks(), model);
 
-    // see if the route should have a source VRF, and if so then add it
-    List<String> sourceVrfs =
-        allSatisfyingItems(configAPs.getSourceVrfs(), r.getSourceVrfs(), model);
-    checkState(
-        sourceVrfs.size() <= 1,
-        "Error in symbolic route analysis: at most one source VRF can be in the environment");
+    // get the optional (and hence possibly null) source VRF
+    String sourceVrf = optionalItem(configAPs.getSourceVrfs(), r.getSourceVrfs(), model);
 
-    return new Tuple<>(successfulTracks::contains, sourceVrfs.isEmpty() ? null : sourceVrfs.get(0));
+    return new Tuple<>(successfulTracks::contains, sourceVrf);
   }
 
   // Return a list of all items whose corresponding BDD is consistent with the given variable
@@ -370,6 +363,15 @@ public class ModelGeneration {
         .filter(i -> mustBeTrueInModel(itemBDDs[i], model))
         .mapToObj(items::get)
         .collect(ImmutableList.toImmutableList());
+  }
+
+  private static String optionalItem(List<String> items, BDDDomain<Integer> itemsBDD, BDD model) {
+    int index = itemsBDD.satAssignmentToValue(model) - 1;
+    if (index == -1) {
+      return null;
+    } else {
+      return items.get(index);
+    }
   }
 
   /**

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -593,6 +593,7 @@ public class TransferBDD {
 
     } else if (expr instanceof MatchSourceVrf) {
       MatchSourceVrf msv = (MatchSourceVrf) expr;
+      // we add 1 to the index since 0 in the BDDDomain is used to represent the absence of a value
       int index = _configAtomicPredicates.getSourceVrfs().indexOf(msv.getSourceVrf()) + 1;
       BDD sourceVrfPred = p.getData().getSourceVrfs().value(index);
       finalResults.add(result.setReturnValueBDD(sourceVrfPred).setReturnValueAccepted(true));
@@ -615,6 +616,8 @@ public class TransferBDD {
           mi.getInterfaces().stream()
               .map(
                   nhi -> {
+                    // we add 1 to the index since 0 in the BDDDomain is used to represent the
+                    // absence of a value
                     int index = _configAtomicPredicates.getNextHopInterfaces().indexOf(nhi) + 1;
                     return p.getData().getNextHopInterfaces().value(index);
                   })

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -593,11 +593,8 @@ public class TransferBDD {
 
     } else if (expr instanceof MatchSourceVrf) {
       MatchSourceVrf msv = (MatchSourceVrf) expr;
-      BDD sourceVrfPred =
-          itemToBDD(
-              msv.getSourceVrf(),
-              _configAtomicPredicates.getSourceVrfs(),
-              p.getData().getSourceVrfs());
+      int index = _configAtomicPredicates.getSourceVrfs().indexOf(msv.getSourceVrf()) + 1;
+      BDD sourceVrfPred = p.getData().getSourceVrfs().value(index);
       finalResults.add(result.setReturnValueBDD(sourceVrfPred).setReturnValueAccepted(true));
 
     } else if (expr instanceof TrackSucceeded) {
@@ -614,13 +611,13 @@ public class TransferBDD {
         // upon, so we check for that situation here
         throw new UnsupportedOperationException(expr.toString());
       }
-      BDD[] nextHopInterfaces = p.getData().getNextHopInterfaces();
       BDD miPred =
           mi.getInterfaces().stream()
               .map(
-                  nhi ->
-                      itemToBDD(
-                          nhi, _configAtomicPredicates.getNextHopInterfaces(), nextHopInterfaces))
+                  nhi -> {
+                    int index = _configAtomicPredicates.getNextHopInterfaces().indexOf(nhi) + 1;
+                    return p.getData().getNextHopInterfaces().value(index);
+                  })
               .reduce(_factory.zero(), BDD::or);
       finalResults.add(result.setReturnValueBDD(miPred).setReturnValueAccepted(true));
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -1385,7 +1385,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
 
     BDDRoute any = new BDDRoute(tbdd.getFactory(), _configAPs);
-    BDD sourcePred = any.getSourceVrfs()[0];
+    BDD sourcePred = any.getSourceVrfs().value(1);
 
     assertTrue(
         equalsForTesting(
@@ -1410,7 +1410,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
 
     BDDRoute any = new BDDRoute(tbdd.getFactory(), _configAPs);
-    BDD intPred = any.getNextHopInterfaces()[0].or(any.getNextHopInterfaces()[1]);
+    BDD intPred = any.getNextHopInterfaces().value(1).or(any.getNextHopInterfaces().value(2));
 
     assertTrue(
         equalsForTesting(


### PR DESCRIPTION
Updates the symbolic route analysis to represent "at-most-one" route attributes, namely the next-hop interface name and the source VRF, using a BDDDomain.  This has the effect of requiring only a logarithmic number of BDD variables in the number of options, whereas before we were using a linear number of BDD variables. It also simplifies some of the code since the "at-most-one" constraint is now enforced implicitly through the representation.