### PR TITLE
Fix BGP route resolution tracker losing routes

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
@@ -1337,6 +1337,13 @@ public class Bgpv4RibTest {
           bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
           equalTo(RibDelta.of(RouteAdvertisement.withdrawing(dependentRoute))));
       assertThat(bgpRib.getTypedRoutes(), empty());
+
+      // Re-add resolving route from main RIB and update BGP. Dependent route should be reactivated
+      mainRibDelta = mainRib.mergeRouteGetDelta(resolvingRoute);
+      assertThat(
+          bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
+          equalTo(RibDelta.of(RouteAdvertisement.adding(dependentRoute))));
+      assertThat(bgpRib.getTypedRoutes(), contains(dependentRoute));
     }
   }
 


### PR DESCRIPTION
* Fix bug where a dependent route is removed from the resolution tracker if it is determined not to be resolvable during updateActiveRoutes
* With fix, such a dependent route can now be (re-)activated when a suitable main RIB route is added in the delta supplied o a subsequent call to updateActiveRoutes