### PR TITLE
Add VI support for BGP resolving route conditions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -220,6 +220,9 @@ public class BgpProcess implements Serializable {
       "redistributeNextHopIpTieBreaker";
   private static final String PROP_TRACKS = "tracks";
 
+  private static final String PROP_NEXT_HOP_IP_RESOLVER_RESTRICTION_POLICY =
+      "nextHopIpResolverRestrictionPolicy";
+
   private boolean _clientToClientReflection;
   private @Nullable BgpConfederation _confederation;
   private final int _ebgpAdminCost;
@@ -264,6 +267,7 @@ public class BgpProcess implements Serializable {
   private final @Nonnull NextHopIpTieBreaker _redistributeNextHopIpTieBreaker;
 
   private @Nonnull Set<String> _tracks;
+  private @Nullable String _nextHopIpResolverRestrictionPolicy;
 
   /**
    * a list of prefixes from bgp network statements that will be unconditionally advertised if
@@ -701,5 +705,16 @@ public class BgpProcess implements Serializable {
   @JsonProperty(PROP_TRACKS)
   public void setTracks(@Nonnull Set<String> tracks) {
     _tracks = tracks;
+  }
+
+  @JsonProperty(PROP_NEXT_HOP_IP_RESOLVER_RESTRICTION_POLICY)
+  public @Nullable String getNextHopIpResolverRestrictionPolicy() {
+    return _nextHopIpResolverRestrictionPolicy;
+  }
+
+  @JsonProperty(PROP_NEXT_HOP_IP_RESOLVER_RESTRICTION_POLICY)
+  public void setNextHopIpResolverRestrictionPolicy(
+      @Nullable String nextHopIpResolverRestrictionPolicy) {
+    _nextHopIpResolverRestrictionPolicy = nextHopIpResolverRestrictionPolicy;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -85,6 +85,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixTrieMultiMap;
 import org.batfish.datamodel.ReceivedFromIp;
 import org.batfish.datamodel.ReceivedFromSelf;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.AddressFamily;
@@ -401,6 +402,15 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     MultipathEquivalentAsPathMatchMode multiPathMatchMode =
         firstNonNull(_process.getMultipathEquivalentAsPathMatchMode(), EXACT_PATH);
     boolean clusterListAsIbgpCost = _process.getClusterListAsIbgpCost();
+    ResolutionRestriction<AnnotatedRoute<AbstractRoute>> nextHopIpResolverRestriction;
+    String nextHopIpResolverRestrictionPolicyName = process.getNextHopIpResolverRestrictionPolicy();
+    if (nextHopIpResolverRestrictionPolicyName == null) {
+      nextHopIpResolverRestriction = ResolutionRestriction.alwaysTrue();
+    } else {
+      nextHopIpResolverRestriction =
+          configuration.getRoutingPolicies().get(nextHopIpResolverRestrictionPolicyName)
+              ::processReadOnly;
+    }
     _ebgpv4Rib =
         new Bgpv4Rib(
             _mainRib,
@@ -410,7 +420,8 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             clusterListAsIbgpCost,
             _process.getLocalOriginationTypeTieBreaker(),
             _process.getNetworkNextHopIpTieBreaker(),
-            _process.getRedistributeNextHopIpTieBreaker());
+            _process.getRedistributeNextHopIpTieBreaker(),
+            nextHopIpResolverRestriction);
     _ibgpv4Rib =
         new Bgpv4Rib(
             _mainRib,
@@ -420,7 +431,8 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             clusterListAsIbgpCost,
             _process.getLocalOriginationTypeTieBreaker(),
             _process.getNetworkNextHopIpTieBreaker(),
-            _process.getRedistributeNextHopIpTieBreaker());
+            _process.getRedistributeNextHopIpTieBreaker(),
+            nextHopIpResolverRestriction);
     _bgpv4Rib =
         new Bgpv4Rib(
             _mainRib,
@@ -430,7 +442,8 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             clusterListAsIbgpCost,
             _process.getLocalOriginationTypeTieBreaker(),
             _process.getNetworkNextHopIpTieBreaker(),
-            _process.getRedistributeNextHopIpTieBreaker());
+            _process.getRedistributeNextHopIpTieBreaker(),
+            nextHopIpResolverRestriction);
 
     _mainRibDelta = RibDelta.empty();
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -337,8 +337,12 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
    */
   private boolean isResolvable(Ip nhip) {
     assert _mainRib != null;
-    return _mainRib.longestPrefixMatch(nhip, alwaysTrue()).stream()
-        .anyMatch(_nextHopIpResolverRestriction);
+    for (AnnotatedRoute<AbstractRoute> route : _mainRib.longestPrefixMatch(nhip, alwaysTrue())) {
+      if (_nextHopIpResolverRestriction.test(route)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -30,6 +30,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.OriginMechanism;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker;
 import org.batfish.datamodel.bgp.NextHopIpTieBreaker;
@@ -128,7 +129,30 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
   private final @Nonnull ResolvabilityEnforcer _resolvabilityEnforcer;
   private final @Nonnull Map<OriginMechanism, SortedSetMultimap<Prefix, Bgpv4Route>> _localRoutes;
   private final @Nonnull Map<OriginMechanism, Comparator<Bgpv4Route>> _localRouteComparators;
+  private final @Nonnull ResolutionRestriction<AnnotatedRoute<AbstractRoute>>
+      _nextHopIpResolverRestriction;
 
+  /**
+   * Construct a Bgpv4Rib
+   *
+   * @param mainRib If non-null, the main RIB used to check resolvability of routes merged into this
+   *     RIB.
+   * @param tieBreaker The tie-breaker used to compare routes merged into this RIB.
+   * @param maxPaths The maximum number of paths to install in this RIB for the same prefix.
+   * @param multipathEquivalentAsPathMatchMode How to determine whether two routes merged into this
+   *     RIB are multipath-equivalent with respect to their AS paths.
+   * @param clusterListAsIgpCost Whether to use cluster list length as IGP cost when comparing IGP
+   *     cost to next hop for different routes for the same prefix merged into this RIB.
+   * @param localOriginationTypeTieBreaker How to tie-break two local routes merged into this RIB
+   *     based on their {@link OriginMechanism}.
+   * @param networkNextHopIpTieBreaker How to tie-break two local routes merged into this RIB
+   *     orignated via {@link OriginMechanism#NETWORK}.
+   * @param redistributeNextHopIpTieBreaker How to tie-break two local routes merged into this RIB
+   *     orignated via {@link OriginMechanism#REDISTRIBUTE}.
+   * @param nextHopIpResolverRestriction A predicate on a next-hop IP's direct LPM routes in the
+   *     main RIB. If no direct LPM routes for a next-hop IP are matched by this predicate, routes
+   *     with that next hop IP are considered unresolvable.
+   */
   public Bgpv4Rib(
       @Nullable GenericRibReadOnly<AnnotatedRoute<AbstractRoute>> mainRib,
       BgpTieBreaker tieBreaker,
@@ -137,7 +161,8 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
       boolean clusterListAsIgpCost,
       LocalOriginationTypeTieBreaker localOriginationTypeTieBreaker,
       NextHopIpTieBreaker networkNextHopIpTieBreaker,
-      NextHopIpTieBreaker redistributeNextHopIpTieBreaker) {
+      NextHopIpTieBreaker redistributeNextHopIpTieBreaker,
+      ResolutionRestriction<AnnotatedRoute<AbstractRoute>> nextHopIpResolverRestriction) {
     super(
         mainRib,
         tieBreaker,
@@ -150,6 +175,7 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
     _localRouteComparators =
         initLocalRouteComparators(networkNextHopIpTieBreaker, redistributeNextHopIpTieBreaker);
     _localRoutes = new EnumMap<>(OriginMechanism.class);
+    _nextHopIpResolverRestriction = nextHopIpResolverRestriction;
   }
 
   private static @Nonnull Map<OriginMechanism, Comparator<Bgpv4Route>> initLocalRouteComparators(
@@ -311,8 +337,8 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
    */
   private boolean isResolvable(Ip nhip) {
     assert _mainRib != null;
-    // TODO: implement resolution restriction
-    return !_mainRib.longestPrefixMatch(nhip, alwaysTrue()).isEmpty();
+    return _mainRib.longestPrefixMatch(nhip, alwaysTrue()).stream()
+        .anyMatch(_nextHopIpResolverRestriction);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -56,13 +56,13 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
                   route, computeResolutionRestriction(resolutionRestriction)::test);
     }
 
-    /** Wrap resolution restriction with some whitelisting if needed. */
+    /** Wrap resolution restriction with some allow-listing if needed. */
     private @Nonnull ResolutionRestriction<AnnotatedRoute<AbstractRoute>>
         computeResolutionRestriction(
             ResolutionRestriction<AnnotatedRoute<AbstractRoute>> baseResolutionRestriction) {
       if (baseResolutionRestriction
           == ResolutionRestriction.<AnnotatedRoute<AbstractRoute>>alwaysTrue()) {
-        // no need to whitelist anything, so stop here.
+        // no need to allow-list anything, so stop here.
         return baseResolutionRestriction;
       }
       return route -> {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpResolutionConditionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpResolutionConditionTest.java
@@ -1,0 +1,286 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.RoutingProtocol.IBGP;
+import static org.batfish.datamodel.RoutingProtocol.STATIC;
+import static org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker.NO_PREFERENCE;
+import static org.batfish.datamodel.bgp.NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP;
+import static org.batfish.dataplane.ibdp.TestUtils.assertNoRoute;
+import static org.batfish.dataplane.ibdp.TestUtils.assertRoute;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.io.IOException;
+import java.util.Set;
+import java.util.SortedMap;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.PrefixSpace;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
+import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
+import org.batfish.datamodel.routing_policy.expr.UnchangedNextHop;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.SetNextHop;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Test of BGP resolution condition on main RIB LPM routes for BGPv4 route next hop IP. */
+public final class BgpResolutionConditionTest {
+
+  private static final long AS = 1L;
+
+  private static final String R1 = "r1";
+  private static final String R2 = "r2";
+  private static final Ip R1_ROUTER_ID = Ip.parse("1.1.1.1");
+  private static final Ip R2_ROUTER_ID = Ip.parse("2.2.2.2");
+
+  private static final Prefix DEPENDENT_ROUTE1_NETWORK = Prefix.parse("10.0.0.1/32");
+  private static final Prefix DEPENDENT_ROUTE2_NETWORK = Prefix.parse("10.0.0.2/32");
+  private static final ConcreteInterfaceAddress R1_RESOLVER_INTERFACE1_ADDRESS =
+      ConcreteInterfaceAddress.parse("10.0.1.1/24");
+  private static final ConcreteInterfaceAddress R1_RESOLVER_INTERFACE2_ADDRESS =
+      ConcreteInterfaceAddress.parse("10.0.2.1/24");
+  private static final ConcreteInterfaceAddress R2_RESOLVER_INTERFACE1_ADDRESS =
+      ConcreteInterfaceAddress.parse("10.0.1.2/24");
+  private static final ConcreteInterfaceAddress R2_RESOLVER_INTERFACE2_ADDRESS =
+      ConcreteInterfaceAddress.parse("10.0.2.2/24");
+  private static final Ip DEPENDENT_ROUTE1_NEXT_HOP_IP = Ip.parse("10.0.1.254");
+  private static final Ip DEPENDENT_ROUTE2_NEXT_HOP_IP = Ip.parse("10.0.2.254");
+  private static final ConcreteInterfaceAddress R1_PEERING_ADDR =
+      ConcreteInterfaceAddress.parse("2.2.2.2/24");
+  private static final ConcreteInterfaceAddress R2_PEERING_ADDR =
+      ConcreteInterfaceAddress.parse("2.2.2.3/24");
+
+  /** A default BGP process to start with */
+  private static @Nonnull BgpProcess.Builder bgpProcessBuilder() {
+    return BgpProcess.builder()
+        .setEbgpAdminCost(1)
+        .setIbgpAdminCost(1)
+        .setLocalAdminCost(1)
+        .setLocalOriginationTypeTieBreaker(NO_PREFERENCE)
+        .setNetworkNextHopIpTieBreaker(HIGHEST_NEXT_HOP_IP)
+        .setRedistributeNextHopIpTieBreaker(HIGHEST_NEXT_HOP_IP);
+  }
+
+  /**
+   * Returns a two node network where first node (r1) advertises two static routes and the second
+   * node installs only the received route whose resolver is matched by r2's BGP process's
+   * resolution restriction.
+   */
+  //
+  // +--------------+             +---------------+
+  // |              |             |               |
+  // |     r1       |r1_r2        |     r2        |
+  // |              +-------------+               +
+  // |              |        r2_r1|               |
+  // |              |             |               |
+  // +--------------+             +---------------+
+  //
+  private @Nonnull SortedMap<String, Configuration> network(
+      boolean r2ResolutionRestrictionToNetwork1) {
+    // r1
+    Configuration r1 =
+        Configuration.builder()
+            .setHostname(R1)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    r1.setExportBgpFromBgpRib(true);
+    Vrf r1Vrf = Vrf.builder().setName(DEFAULT_VRF_NAME).setOwner(r1).build();
+    Interface.builder()
+        .setName("r1_r2")
+        .setAddress(R1_PEERING_ADDR)
+        .setVrf(r1Vrf)
+        .setOwner(r1)
+        .build();
+    // needed to activate static route
+    String r1StaticRoute1ResolverInterfaceName = "r1sr1";
+    Interface.builder()
+        .setName(r1StaticRoute1ResolverInterfaceName)
+        .setOwner(r1)
+        .setVrf(r1Vrf)
+        .setAddress(R1_RESOLVER_INTERFACE1_ADDRESS)
+        .build();
+    String r1StaticRoute2ResolverInterfaceName = "r1sr2";
+    Interface.builder()
+        .setName(r1StaticRoute2ResolverInterfaceName)
+        .setOwner(r1)
+        .setVrf(r1Vrf)
+        .setAddress(R1_RESOLVER_INTERFACE2_ADDRESS)
+        .build();
+    StaticRoute.Builder staticRouteBuilder = StaticRoute.builder().setAdministrativeCost(1);
+    r1Vrf.setStaticRoutes(
+        ImmutableSortedSet.of(
+            staticRouteBuilder
+                .setNetwork(DEPENDENT_ROUTE1_NETWORK)
+                .setNextHop(NextHopIp.of(DEPENDENT_ROUTE1_NEXT_HOP_IP))
+                .build(),
+            staticRouteBuilder
+                .setNetwork(DEPENDENT_ROUTE2_NETWORK)
+                .setNextHop(NextHopIp.of(DEPENDENT_ROUTE2_NEXT_HOP_IP))
+                .build()));
+    String r1RedistributionPolicyName = "r1Redistribute";
+    RoutingPolicy.builder()
+        .setName(r1RedistributionPolicyName)
+        .setStatements(
+            ImmutableList.of(
+                new If(
+                    new MatchProtocol(STATIC),
+                    ImmutableList.of(
+                        new SetNextHop(UnchangedNextHop.getInstance()),
+                        Statements.ExitAccept.toStaticStatement()))))
+        .setOwner(r1)
+        .build();
+    String r1ExportPolicyName = "r1export";
+    RoutingPolicy.builder()
+        .setName(r1ExportPolicyName)
+        .setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()))
+        .setOwner(r1)
+        .build();
+    BgpProcess r1BgpProcess =
+        bgpProcessBuilder()
+            .setRouterId(R1_ROUTER_ID)
+            .setVrf(r1Vrf)
+            .setRedistributionPolicy(r1RedistributionPolicyName)
+            .build();
+    BgpActivePeerConfig.builder()
+        .setPeerAddress(R2_PEERING_ADDR.getIp())
+        .setLocalAs(AS)
+        .setLocalIp(R1_PEERING_ADDR.getIp())
+        .setRemoteAs(AS)
+        .setBgpProcess(r1BgpProcess)
+        .setIpv4UnicastAddressFamily(
+            Ipv4UnicastAddressFamily.builder().setExportPolicy(r1ExportPolicyName).build())
+        .build();
+
+    // r2
+    Configuration r2 =
+        Configuration.builder()
+            .setHostname(R2)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    r2.setExportBgpFromBgpRib(true);
+    Vrf r2Vrf = Vrf.builder().setName(DEFAULT_VRF_NAME).setOwner(r2).build();
+    Interface.builder()
+        .setName("r2_r1")
+        .setAddress(R2_PEERING_ADDR)
+        .setVrf(r2Vrf)
+        .setOwner(r2)
+        .build();
+    // interface whose routes resolve the received BGP routes
+    String r2ResolverInterface1Name = "r2resolver1";
+    Interface.builder()
+        .setName(r2ResolverInterface1Name)
+        .setOwner(r2)
+        .setVrf(r2Vrf)
+        .setAddress(R2_RESOLVER_INTERFACE1_ADDRESS)
+        .build();
+    String r2ResolverInterface2Name = "r2resolver2";
+    Interface.builder()
+        .setName(r2ResolverInterface2Name)
+        .setOwner(r2)
+        .setVrf(r2Vrf)
+        .setAddress(R2_RESOLVER_INTERFACE2_ADDRESS)
+        .build();
+    String r2BgpNextHopResolverPolicyName = "r2Restriction";
+    RoutingPolicy.builder()
+        .setName(r2BgpNextHopResolverPolicyName)
+        .setStatements(
+            ImmutableList.of(
+                new If(
+                    new MatchPrefixSet(
+                        DestinationNetwork.instance(),
+                        new ExplicitPrefixSet(
+                            new PrefixSpace(
+                                PrefixRange.fromPrefix(
+                                    R2_RESOLVER_INTERFACE1_ADDRESS.getPrefix())))),
+                    ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
+                    ImmutableList.of(Statements.ExitReject.toStaticStatement()))))
+        .setOwner(r2)
+        .build();
+    String r2ExportPolicyName = "denyAll";
+    RoutingPolicy.builder()
+        .setName(r2ExportPolicyName)
+        .setStatements(ImmutableList.of(Statements.ExitReject.toStaticStatement()))
+        .setOwner(r2)
+        .build();
+    BgpProcess r2BgpProcess =
+        bgpProcessBuilder()
+            .setRouterId(R2_ROUTER_ID)
+            .setVrf(r2Vrf)
+            .setRedistributionPolicy(r2ExportPolicyName)
+            .build();
+    if (r2ResolutionRestrictionToNetwork1) {
+      r2BgpProcess.setNextHopIpResolverRestrictionPolicy(r2BgpNextHopResolverPolicyName);
+    }
+    BgpActivePeerConfig.builder()
+        .setPeerAddress(R1_PEERING_ADDR.getIp())
+        .setLocalAs(AS)
+        .setLocalIp(R2_PEERING_ADDR.getIp())
+        .setRemoteAs(AS)
+        .setBgpProcess(r2BgpProcess)
+        .setIpv4UnicastAddressFamily(
+            Ipv4UnicastAddressFamily.builder().setExportPolicy(r2ExportPolicyName).build())
+        .build();
+
+    return ImmutableSortedMap.of(r1.getHostname(), r1, r2.getHostname(), r2);
+  }
+
+  @Test
+  public void testResolutionRestriction() throws IOException {
+    Batfish batfish = BatfishTestUtils.getBatfish(network(true), _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dataplane =
+        (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+    SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routes =
+        IncrementalBdpEngine.getRoutes(dataplane);
+
+    // r1 has routes to be sent
+    assertRoute(routes, STATIC, R1, DEPENDENT_ROUTE1_NETWORK, 0, DEPENDENT_ROUTE1_NEXT_HOP_IP);
+    assertRoute(routes, STATIC, R1, DEPENDENT_ROUTE2_NETWORK, 0, DEPENDENT_ROUTE2_NEXT_HOP_IP);
+
+    // r2 only installs the first route, as the second does not match the resolution restriction
+    assertRoute(routes, IBGP, R2, DEPENDENT_ROUTE1_NETWORK, 0, DEPENDENT_ROUTE1_NEXT_HOP_IP);
+    assertNoRoute(routes, R2, DEPENDENT_ROUTE2_NETWORK);
+  }
+
+  @Test
+  public void testNoResolutionRestriction() throws IOException {
+    Batfish batfish = BatfishTestUtils.getBatfish(network(false), _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dataplane =
+        (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+    SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routes =
+        IncrementalBdpEngine.getRoutes(dataplane);
+
+    // r1 has routes to be sent
+    assertRoute(routes, STATIC, R1, DEPENDENT_ROUTE1_NETWORK, 0, DEPENDENT_ROUTE1_NEXT_HOP_IP);
+    assertRoute(routes, STATIC, R1, DEPENDENT_ROUTE2_NETWORK, 0, DEPENDENT_ROUTE2_NEXT_HOP_IP);
+
+    // r2 only installs the first route, as the second does not match the resolution restriction
+    assertRoute(routes, IBGP, R2, DEPENDENT_ROUTE1_NETWORK, 0, DEPENDENT_ROUTE1_NEXT_HOP_IP);
+    assertRoute(routes, IBGP, R2, DEPENDENT_ROUTE2_NETWORK, 0, DEPENDENT_ROUTE2_NEXT_HOP_IP);
+  }
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpResolutionConditionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpResolutionConditionTest.java
@@ -277,7 +277,7 @@ public final class BgpResolutionConditionTest {
     assertRoute(routes, STATIC, R1, DEPENDENT_ROUTE1_NETWORK, 0, DEPENDENT_ROUTE1_NEXT_HOP_IP);
     assertRoute(routes, STATIC, R1, DEPENDENT_ROUTE2_NETWORK, 0, DEPENDENT_ROUTE2_NEXT_HOP_IP);
 
-    // r2 only installs the first route, as the second does not match the resolution restriction
+    // r2 installs both routes, as there is no resolution restriction
     assertRoute(routes, IBGP, R2, DEPENDENT_ROUTE1_NETWORK, 0, DEPENDENT_ROUTE1_NEXT_HOP_IP);
     assertRoute(routes, IBGP, R2, DEPENDENT_ROUTE2_NETWORK, 0, DEPENDENT_ROUTE2_NEXT_HOP_IP);
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -476,7 +476,8 @@ public class AbstractRibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Ip originator1 = Ip.parse("1.1.1.1");
     Ip originator2 = Ip.parse("2.2.2.2");
     Bgpv4Route.Builder routeBuilder =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
@@ -24,6 +24,7 @@ import org.batfish.datamodel.ReceivedFrom;
 import org.batfish.datamodel.ReceivedFromInterface;
 import org.batfish.datamodel.ReceivedFromIp;
 import org.batfish.datamodel.ReceivedFromSelf;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker;
 import org.batfish.datamodel.bgp.NextHopIpTieBreaker;
@@ -48,7 +49,8 @@ public class BgpRibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder rb =
         Bgpv4Route.builder()
             .setNetwork(Prefix.strict("10.0.0.1/32"))
@@ -87,7 +89,8 @@ public class BgpRibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder rb = Bgpv4Route.testBuilder().setNetwork(Prefix.ZERO);
 
     Bgpv4Route good =
@@ -160,7 +163,8 @@ public class BgpRibTest {
                 false,
                 LocalOriginationTypeTieBreaker.NO_PREFERENCE,
                 NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-                NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+                NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+                ResolutionRestriction.alwaysTrue());
 
     Bgpv4Route nh1 =
         rb.setNextHop(NextHopIp.of(Ip.parse("1.1.1.1")))
@@ -264,7 +268,8 @@ public class BgpRibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder rb = Bgpv4Route.testBuilder().setNetwork(Prefix.ZERO);
 
     Bgpv4Route good =
@@ -347,7 +352,8 @@ public class BgpRibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder rb =
         Bgpv4Route.testBuilder()
             .setNetwork(Prefix.ZERO)
@@ -430,7 +436,8 @@ public class BgpRibTest {
             true,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder rb =
         Bgpv4Route.testBuilder()
             .setNetwork(Prefix.ZERO)
@@ -478,7 +485,8 @@ public class BgpRibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder rb =
         Bgpv4Route.testBuilder()
             .setNetwork(Prefix.ZERO)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
@@ -45,12 +45,14 @@ import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.ReceivedFromIp;
 import org.batfish.datamodel.ReceivedFromSelf;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker;
 import org.batfish.datamodel.bgp.NextHopIpTieBreaker;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
@@ -96,7 +98,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     _bestPathRib =
         new Bgpv4Rib(
             null,
@@ -106,7 +109,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
   }
 
   @Test
@@ -125,7 +129,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder rb =
         Bgpv4Route.builder()
             .setNetwork(Prefix.strict("10.0.0.1/32"))
@@ -188,7 +193,8 @@ public class Bgpv4RibTest {
         false,
         LocalOriginationTypeTieBreaker.NO_PREFERENCE,
         NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-        NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+        NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+        ResolutionRestriction.alwaysTrue());
   }
 
   @Test
@@ -203,7 +209,8 @@ public class Bgpv4RibTest {
         false,
         LocalOriginationTypeTieBreaker.NO_PREFERENCE,
         NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-        NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+        NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+        ResolutionRestriction.alwaysTrue());
   }
 
   @Test
@@ -218,7 +225,8 @@ public class Bgpv4RibTest {
         false,
         LocalOriginationTypeTieBreaker.NO_PREFERENCE,
         NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-        NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+        NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+        ResolutionRestriction.alwaysTrue());
   }
 
   @Test
@@ -232,7 +240,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     assertTrue("MaxPaths=1, not multipath", !rib.isMultipath());
     rib =
         new Bgpv4Rib(
@@ -243,7 +252,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     assertTrue("Maxpaths=2 -> multipath", rib.isMultipath());
     rib =
         new Bgpv4Rib(
@@ -254,7 +264,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     assertTrue("Maxpaths=null -> multipath", rib.isMultipath());
   }
 
@@ -365,7 +376,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
 
     Bgpv4Route worse = _rb.setNextHopIp(Ip.parse("5.5.5.6")).build();
     // Lower IGP cost to next hop is better
@@ -403,7 +415,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
 
     // Discard next hop is worse despite lower IGP cost
     Bgpv4Route worse = _rb.setNextHopIp(Ip.parse("5.5.5.6")).build();
@@ -447,7 +460,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
 
     Bgpv4Route worse =
         _rb.setNetwork(Prefix.strict("6.0.0.0/24")).setNextHopIp(Ip.parse("4.4.4.6")).build();
@@ -472,7 +486,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
 
     Bgpv4Route base = _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     Bgpv4Route candidate1 =
@@ -504,7 +519,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
 
     Bgpv4Route base = _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     Bgpv4Route candidate1 =
@@ -554,7 +570,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route best = _rb.setNextHop(NextHopIp.of(Ip.parse("2.2.2.1"))).build();
     Bgpv4Route earliest =
         _rb.setOriginatorIp(Ip.parse("2.2.2.2"))
@@ -656,7 +673,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route bestPath = _rb.build();
     bestPathRib.mergeRoute(_rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.2"))).build());
     bestPathRib.mergeRoute(_rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3"))).build());
@@ -725,7 +743,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route bestPath = _rb.build();
     _bestPathRib.mergeRoute(bestPath);
     // Oldest route should win despite newer having lower Originator IP
@@ -749,7 +768,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route bestPath =
         _rb.setProtocol(RoutingProtocol.IBGP).setClusterList(ImmutableSet.of()).build();
     Bgpv4Route earliestPath =
@@ -772,7 +792,8 @@ public class Bgpv4RibTest {
             true,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route bestPath =
         _rb.setProtocol(RoutingProtocol.IBGP)
             .setClusterList(ImmutableSet.of())
@@ -800,7 +821,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route bestPath =
         _rb.setProtocol(RoutingProtocol.IBGP)
             .setClusterList(ImmutableSet.of())
@@ -830,7 +852,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route route =
         _rb.setProtocol(RoutingProtocol.IBGP)
             .setClusterList(ImmutableSet.of())
@@ -861,7 +884,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route route =
         _rb.setProtocol(RoutingProtocol.IBGP)
             .setClusterList(ImmutableSet.of())
@@ -966,7 +990,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
 
     /*
      * Add routes to multipath RIB.
@@ -1033,7 +1058,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Rib bmr =
         new Bgpv4Rib(
             null,
@@ -1043,7 +1069,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
 
     Prefix p = Prefix.ZERO;
     Bgpv4Route.Builder b = Bgpv4Route.testBuilder().setNetwork(p).setProtocol(RoutingProtocol.IBGP);
@@ -1102,7 +1129,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Rib bmr =
         new Bgpv4Rib(
             null,
@@ -1112,7 +1140,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Ip ip1 = Ip.parse("1.0.0.0");
     Ip ip2 = Ip.parse("2.2.0.0");
     Bgpv4Route.Builder b1 =
@@ -1187,7 +1216,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     // ebgp
     Bgpv4Rib ebgpBpr =
         new Bgpv4Rib(
@@ -1198,7 +1228,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder ebgpBuilder =
         Bgpv4Route.testBuilder()
             .setNetwork(Prefix.ZERO)
@@ -1230,7 +1261,8 @@ public class Bgpv4RibTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder ibgpBuilder =
         Bgpv4Route.testBuilder()
             .setNetwork(Prefix.ZERO)
@@ -1296,7 +1328,8 @@ public class Bgpv4RibTest {
               false,
               LocalOriginationTypeTieBreaker.NO_PREFERENCE,
               NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+              ResolutionRestriction.alwaysTrue());
 
       // Add dependent route. It should not be activated since it isn't resolvable in the main RIB
       assertThat(bgpRib.mergeRouteGetDelta(dependentRoute), equalTo(RibDelta.empty()));
@@ -1323,7 +1356,8 @@ public class Bgpv4RibTest {
               false,
               LocalOriginationTypeTieBreaker.NO_PREFERENCE,
               NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+              ResolutionRestriction.alwaysTrue());
 
       // Add dependent route. It should be activated because it is resolvable in the main RIB
       assertThat(
@@ -1340,6 +1374,46 @@ public class Bgpv4RibTest {
 
       // Re-add resolving route from main RIB and update BGP. Dependent route should be reactivated
       mainRibDelta = mainRib.mergeRouteGetDelta(resolvingRoute);
+      assertThat(
+          bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
+          equalTo(RibDelta.of(RouteAdvertisement.adding(dependentRoute))));
+      assertThat(bgpRib.getTypedRoutes(), contains(dependentRoute));
+    }
+    {
+      // Test of next hop IP LPM resolver restriction
+      AnnotatedRoute<AbstractRoute> resolvingRoute1 =
+          new AnnotatedRoute<>(new ConnectedRoute(nhip.toPrefix(), "foo"), "default");
+      AnnotatedRoute<AbstractRoute> resolvingRoute2 =
+          new AnnotatedRoute<>(new ConnectedRoute(nhip.toPrefix(), "bar"), "default");
+
+      Rib mainRib = new Rib();
+      Bgpv4Rib bgpRib =
+          new Bgpv4Rib(
+              mainRib,
+              BgpTieBreaker.ARRIVAL_ORDER,
+              1,
+              null,
+              false,
+              LocalOriginationTypeTieBreaker.NO_PREFERENCE,
+              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+              r -> r.getAbstractRoute().getNextHop().equals(NextHopInterface.of("bar")));
+
+      // Add dependent route. It should be inactive because there is no resolver in the main RIB
+      assertThat(bgpRib.mergeRouteGetDelta(dependentRoute), equalTo(RibDelta.empty()));
+      assertThat(bgpRib.getTypedRoutes(), empty());
+
+      // Add resolving route that DOES NOT pass restriction to main RIB and update BGP. No change
+      // should occur to BGP RIB.
+      RibDelta<AnnotatedRoute<AbstractRoute>> mainRibDelta =
+          mainRib.mergeRouteGetDelta(resolvingRoute1);
+      assertThat(
+          bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(), equalTo(RibDelta.empty()));
+      assertThat(bgpRib.getTypedRoutes(), empty());
+
+      // Add resolving route that DOES pass restriction to main RIB and update BGP. BGP RIB should
+      // gain dependent route.
+      mainRibDelta = mainRib.mergeRouteGetDelta(resolvingRoute2);
       assertThat(
           bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
           equalTo(RibDelta.of(RouteAdvertisement.adding(dependentRoute))));
@@ -1378,7 +1452,8 @@ public class Bgpv4RibTest {
               false,
               NO_PREFERENCE,
               HIGHEST_NEXT_HOP_IP,
-              LOWEST_NEXT_HOP_IP);
+              LOWEST_NEXT_HOP_IP,
+              ResolutionRestriction.alwaysTrue());
 
       // Add less preferred NHIP route
       assertThat(
@@ -1435,7 +1510,8 @@ public class Bgpv4RibTest {
               false,
               NO_PREFERENCE,
               LOWEST_NEXT_HOP_IP, // different on purpose
-              HIGHEST_NEXT_HOP_IP);
+              HIGHEST_NEXT_HOP_IP,
+              ResolutionRestriction.alwaysTrue());
 
       // Add less preferred NHIP route
       assertThat(
@@ -1492,7 +1568,8 @@ public class Bgpv4RibTest {
               false,
               NO_PREFERENCE,
               LOWEST_NEXT_HOP_IP,
-              HIGHEST_NEXT_HOP_IP /* different on purpose */);
+              HIGHEST_NEXT_HOP_IP, /* different on purpose */
+              ResolutionRestriction.alwaysTrue());
 
       // Add less preferred NHIP route
       assertThat(
@@ -1549,7 +1626,8 @@ public class Bgpv4RibTest {
               false,
               NO_PREFERENCE,
               HIGHEST_NEXT_HOP_IP,
-              LOWEST_NEXT_HOP_IP /* different on purpose */);
+              LOWEST_NEXT_HOP_IP, /* different on purpose */
+              ResolutionRestriction.alwaysTrue());
 
       // Add less preferred NHIP route
       assertThat(
@@ -1606,7 +1684,8 @@ public class Bgpv4RibTest {
               false,
               NO_PREFERENCE,
               HIGHEST_NEXT_HOP_IP /* same on purpose */,
-              HIGHEST_NEXT_HOP_IP /* same on purpose */);
+              HIGHEST_NEXT_HOP_IP, /* same on purpose */
+              ResolutionRestriction.alwaysTrue());
 
       bgpRib.mergeRouteGetDelta(networkRoute);
       bgpRib.mergeRouteGetDelta(redistributeRoute);
@@ -1640,7 +1719,8 @@ public class Bgpv4RibTest {
               false,
               PREFER_NETWORK,
               HIGHEST_NEXT_HOP_IP /* same on purpose */,
-              HIGHEST_NEXT_HOP_IP /* same on purpose */);
+              HIGHEST_NEXT_HOP_IP, /* same on purpose */
+              ResolutionRestriction.alwaysTrue());
 
       bgpRib.mergeRouteGetDelta(networkRoute);
       bgpRib.mergeRouteGetDelta(redistributeRoute);
@@ -1677,7 +1757,8 @@ public class Bgpv4RibTest {
               false,
               PREFER_REDISTRIBUTE,
               HIGHEST_NEXT_HOP_IP /* same on purpose */,
-              HIGHEST_NEXT_HOP_IP /* same on purpose */);
+              HIGHEST_NEXT_HOP_IP, /* same on purpose */
+              ResolutionRestriction.alwaysTrue());
 
       bgpRib.mergeRouteGetDelta(networkRoute);
       bgpRib.mergeRouteGetDelta(redistributeRoute);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
@@ -15,6 +15,7 @@ import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.ReceivedFromIp;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker;
@@ -174,7 +175,8 @@ public class RibDeltaTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route.Builder routeBuilder = Bgpv4Route.testBuilder();
     routeBuilder
         .setNetwork(Ip.parse("1.1.1.1").toPrefix())
@@ -232,7 +234,8 @@ public class RibDeltaTest {
             false,
             LocalOriginationTypeTieBreaker.NO_PREFERENCE,
             NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
-            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
     Bgpv4Route r1 =
         Bgpv4Route.testBuilder()
             .setNetwork(Ip.parse("1.1.1.1").toPrefix())

--- a/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
@@ -831,9 +831,7 @@ public final class ConvertConfigurationJobTest {
             .setDefaultCrossZoneAction(LineAction.PERMIT)
             .setDefaultInboundAction(LineAction.PERMIT)
             .build();
-
-    Vrf vWithUndefined = Vrf.builder().setOwner(c).setName("vWithUndefined").build();
-    BgpProcess procWithUndefined =
+    BgpProcess.Builder bgpProcessBuilder =
         BgpProcess.builder()
             .setRouterId(Ip.ZERO)
             .setEbgpAdminCost(1)
@@ -841,37 +839,18 @@ public final class ConvertConfigurationJobTest {
             .setLocalAdminCost(1)
             .setLocalOriginationTypeTieBreaker(LocalOriginationTypeTieBreaker.NO_PREFERENCE)
             .setNetworkNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
-            .setRedistributeNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
-            .setVrf(vWithUndefined)
-            .build();
+            .setRedistributeNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP);
+
+    Vrf vWithUndefined = Vrf.builder().setOwner(c).setName("vWithUndefined").build();
+    BgpProcess procWithUndefined = bgpProcessBuilder.setVrf(vWithUndefined).build();
     procWithUndefined.setNextHopIpResolverRestrictionPolicy("absent");
 
     Vrf vWithDefined = Vrf.builder().setOwner(c).setName("vWithDefined").build();
-    BgpProcess procWithDefined =
-        BgpProcess.builder()
-            .setRouterId(Ip.ZERO)
-            .setEbgpAdminCost(1)
-            .setIbgpAdminCost(1)
-            .setLocalAdminCost(1)
-            .setLocalOriginationTypeTieBreaker(LocalOriginationTypeTieBreaker.NO_PREFERENCE)
-            .setNetworkNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
-            .setRedistributeNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
-            .setVrf(vWithDefined)
-            .build();
+    BgpProcess procWithDefined = bgpProcessBuilder.setVrf(vWithDefined).build();
     procWithDefined.setNextHopIpResolverRestrictionPolicy("present");
 
     Vrf vWithNone = Vrf.builder().setOwner(c).setName("vWithNone").build();
-    BgpProcess procWithNone =
-        BgpProcess.builder()
-            .setRouterId(Ip.ZERO)
-            .setEbgpAdminCost(1)
-            .setIbgpAdminCost(1)
-            .setLocalAdminCost(1)
-            .setLocalOriginationTypeTieBreaker(LocalOriginationTypeTieBreaker.NO_PREFERENCE)
-            .setNetworkNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
-            .setRedistributeNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
-            .setVrf(vWithNone)
-            .build();
+    BgpProcess procWithNone = bgpProcessBuilder.setVrf(vWithNone).build();
 
     RoutingPolicy.builder().setName("present").setOwner(c).build();
 


### PR DESCRIPTION
* add BGPv4 RIB support for conditioning resolvability not just on the presence of one or more resolving routes, but also predicates on such resolving routes
  * unlike main RIB resolvability conditions, more general routes are not checked if the LPM routes are not matched by the predicate
* add ability to specify a routing policy for a BgpProcess used to check resolving routes from the main RIB