### PR TITLE
checkstyle: one more nullity pattern to catch

### DIFF
--- a/projects/checkstyle.xml
+++ b/projects/checkstyle.xml
@@ -28,7 +28,7 @@
   </module>
 
   <module name="RegexpMultiline">
-    <property name="format" value="(@Nullable|@Nonnull)\s*\n\s*@"/>
+    <property name="format" value="(@Nullable|@Nonnull)\s*\n\s*(@|public|private|protected|static|final)"/>
     <property name="message" value="Nullity should annotate the type when possible"/>
     <property name="fileExtensions" value="java"/>
     <property name="matchAcrossLines" value="true"/>


### PR DESCRIPTION
The autoformatter will put @Nullable on its own line if it starts the line, but
we can require it to be moved if there's a modifier it will stay after.