### PR TITLE
Junos: test JuniperListPaths and fix unrecognized lines

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
@@ -63,7 +63,7 @@ ff_term
    (
       fft_from
       | fft_then
-   )
+   )?
 ;
 
 fft_from

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -253,7 +253,7 @@ rs_rule
       rsr_description
       | rsr_match
       | rsr_then
-   )
+   )?
 ;
 
 rs_zone

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/JuniperListPaths.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/JuniperListPaths.java
@@ -12,6 +12,7 @@ public final class JuniperListPaths {
     return JUNIPER_LIST_PATHS;
   }
 
+  // These should be tested, in "FlatJuniperGrammarTest#testApplyGroupsLists"
   private static final String[] JUNIPER_LIST_PATHS =
       new String[] {
         // The last space-separated word of each item corresponds to a Juniper list node, i.e.

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -7994,6 +7994,20 @@ public final class FlatJuniperGrammarTest {
   }
 
   /**
+   * Tests of {@link JuniperListPaths}.
+   *
+   * <p>The code underlying this is somewhat complicated, and in an early version we found that it
+   * crashed when the entire structure is defined in a group (because of generated code lines
+   * created to ensure the relevant node in the syntax tree is present). This test is dedicated to
+   * exercising this case for all paths in there.
+   */
+  @Test
+  public void testApplyGroupsLists() {
+    // Simply tests that all the lines parse without errors
+    parseConfig("apply-groups-lists");
+  }
+
+  /**
    * TODO: Fix and un-xfail. To fix, should backtrack and try alternate (shallow, wildcard) paths
    * when inheriting groups lines and no match is found. See {@link GroupInheritor}.
    */

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-groups-lists
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-groups-lists
@@ -1,0 +1,17 @@
+set system host-name apply-groups-lists
+#
+set groups G firewall family inet filter F term T then accept
+set groups G firewall filter F2 term T2 then accept
+set groups G interfaces xe-0/0/0 unit 0 family inet filter input-list F
+set groups G interfaces xe-0/0/0 unit 0 family inet filter output-list F
+set groups G policy-options policy-statement PS term T then accept
+set groups G protocols bgp group G export P
+set groups G protocols bgp group G import P
+set groups G security nat destination rule-set RS rule R then destination-nat off
+set groups G security nat destination rule-set RS rule R match source-address-name A
+set groups G security nat source rule-set RS rule R then source-nat off
+set groups G security nat source rule-set RS rule R match source-address-name A
+set groups G security policies from-zone Z to-zone Z policy P then permit
+set groups G system domain-search foo.net
+set apply-groups G
+#


### PR DESCRIPTION
When the 'empty list' variant is not recognized, the parser crashes when
creating new syntax.

commit-id:476d1827