### PR TITLE
bazel_run.sh: remove warning about bazelisk

### DIFF
--- a/tools/bazel_run.sh
+++ b/tools/bazel_run.sh
@@ -2,11 +2,8 @@
 
 set -euo pipefail
 
-CMD="bazelisk"
-if ! type "${CMD}" &> /dev/null; then
-  echo "This script works better with bazelisk. Use 'go get github.com/bazelbuild/bazelisk' to get it.'"
-  echo
-  CMD="bazel"
+if [[ $(bazel version) != *azelisk* ]]; then
+  echo "The recommended way to use bazel is to install bazelisk as the bazel command."
 fi
 
 if [ "${1-}" = "-d" ]
@@ -17,7 +14,7 @@ else
 fi
 
 
-${CMD} build //projects/allinone:allinone_main
+bazel build //projects/allinone:allinone_main
 ./bazel-bin/projects/allinone/allinone_main \
     --jvm_flag=-Xmx12g \
     --jvm_flag=-Dlog4j2.configurationFile=tools/log4j2.yaml \


### PR DESCRIPTION
The modern recommendation (and what happens by default usually) is to have bazel
just be an alias for bazelisk.