### PR TITLE
fix batfish crash due to junOS interface filter direction and name missing in config command 

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -4968,6 +4968,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitIfe_filter(Ife_filterContext ctx) {
     FilterContext filter = ctx.filter();
+    if (filter.direction() == null) {
+      return;
+    }
     String name = toString(filter.name);
     int line = getLine(filter.name.getStart());
     _configuration.referenceStructure(FIREWALL_FILTER, name, INTERFACE_FILTER, line);
@@ -5028,6 +5031,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitIfi_filter(Ifi_filterContext ctx) {
     FilterContext filter = ctx.filter();
+    if (filter.direction() == null) {
+      return;
+    }
     String name = toString(filter.name);
     JuniperStructureUsage usage = INTERFACE_FILTER;
     if (filter.direction() != null) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4530,6 +4530,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfaceFilter() {
+    parseConfig("juniper-set-interface-filter-crash");
+    // don't crash.
+  }
+
+  @Test
   public void testJuniperPolicyStatementTermFromEvaluation() {
     // Configuration has policy statements
     Configuration c = parseConfig("juniper-policy-statement-term");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-set-interface-filter-crash
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-set-interface-filter-crash
@@ -1,0 +1,7 @@
+#
+set system host-name juniper-set-interface-filter-crash
+#
+# don't crash if there is no direction provided
+set interfaces reth0 unit 10 family inet filter
+set interfaces reth0 unit 10 family ethernet-switching filter
+#


### PR DESCRIPTION
Update exit functions to handle missing filter direction and name. These are optional in the junOS grammer. 