### PR TITLE
PaloAlto: gracefully handle partially configured OSPF settings

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2850,6 +2850,11 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       long areaId,
       String processName,
       OspfInterface vsOspfIface) {
+    if (vsOspfIface.getEnable() == null) {
+      // Apparently the below assertions don't hold on at least some versions of Palo Alto
+      // See: https://github.com/batfish/batfish/issues/8876
+      return;
+    }
     // (enable = yes or no)  and (passive = yes or no should be explicitly configured
     assert vsOspfIface.getEnable() != null;
     assert vsOspfIface.getPassive() != null;

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1281,6 +1281,13 @@ public final class PaloAltoGrammarTest {
     assertThat(c.getLoggingServers(), contains("2.2.2.2"));
   }
 
+  /** See: https://github.com/batfish/batfish/issues/8876 */
+  @Test
+  public void testGh8876() throws IOException {
+    parseConfig("gh-8876");
+    // Don't crash
+  }
+
   @Test
   public void testGlobalProtectAppCryptoProfiles() {
     PaloAltoConfiguration c = parsePaloAltoConfig("global-protect-app-crypto-profiles");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/gh-8876
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/gh-8876
@@ -1,0 +1,7 @@
+set deviceconfig system hostname gh-8876
+# see: https://github.com/batfish/batfish/issues/8876
+set network interface ethernet ethernet1 layer3 units ethernet1.1 tag 1
+set network virtual-router VR protocol ospf enable yes
+set network virtual-router VR protocol ospf router-id 1.1.1.1
+set network virtual-router VR protocol ospf area 0.0.0.0 interface ethernet1.1 link-type broadcast
+set network virtual-router VR interface ethernet1.1


### PR DESCRIPTION
User @racsoce shared a lab config with incomplete OSPF configurations,
it appears that our assertions based on old Palo Alto are no longer true.
Given that interfaces can appear with absolutely no settings, error on the
side of ignoring their OSPF configuration so as not to crash.

Fix batfish/batfish#8876