### PR TITLE
Junos: cache GroupWildcard regex conversions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BUILD.bazel
@@ -12,6 +12,7 @@ java_library(
     deps = [
         "//projects/batfish-common-protocol:common",
         "//projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled",
+        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:org_apache_commons_commons_lang3",

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/GroupWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/GroupWildcard.java
@@ -1,9 +1,17 @@
 package org.batfish.representation.juniper;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
 /** Utility to convert a JunOS group wildcard into a Java regex. */
 public final class GroupWildcard {
+  private static final LoadingCache<String, String> CACHE =
+      Caffeine.newBuilder()
+          .maximumSize(1_000_000)
+          .build(org.batfish.representation.juniper.parboiled.GroupWildcard::toJavaRegex);
+
   public static String toJavaRegex(String wildcard) {
-    return org.batfish.representation.juniper.parboiled.GroupWildcard.toJavaRegex(wildcard);
+    return CACHE.get(wildcard);
   }
 
   private GroupWildcard() {} // prevent instantiation of utility class.


### PR DESCRIPTION
This is typically fast, but may appear thousands of times. Caching makes one
problematic file faster by minutes.