### PR TITLE
Junos: add parsing for  `set interfaces damping suppress` command

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2634,6 +2634,8 @@ SUN_RPC: 'sun-rpc';
 
 SUNRPC: 'sunrpc';
 
+SUPPRESS: 'suppress';
+
 SWITCH_OPTIONS: 'switch-options';
 
 SWITCHOVER_ON_ROUTING_CRASH: 'switchover-on-routing-crash';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -635,8 +635,8 @@ int_named
    )
    (
       i_common
-      | i_flexible_vlan_tagging
       | i_damping
+      | i_flexible_vlan_tagging
       | i_link_mode
       | i_native_vlan_id
       | i_per_unit_scheduler

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -111,6 +111,7 @@ i_common
 i_common_physical
 :
     apply
+    | i_damping
     | i_description
     | i_disable
     | i_ether_options
@@ -122,6 +123,7 @@ i_common_physical
     | i_redundant_ether_options
     | i_speed
 ;
+
 i_damping
 :
    DAMPING
@@ -635,7 +637,6 @@ int_named
    )
    (
       i_common
-      | i_damping
       | i_flexible_vlan_tagging
       | i_link_mode
       | i_native_vlan_id

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -132,6 +132,12 @@ i_damping
    )
 ;
 
+id_suppress_null
+:
+  // range 1 through 20,000
+   SUPPRESS uint16
+;
+
 i_description
 :
    description
@@ -242,12 +248,6 @@ i_redundant_ether_options
 i_speed
 :
    SPEED dec speed_abbreviation
-;
-
-id_suppress_null
-:
-  // range 1 through 20,000
-   SUPPRESS uint16
 ;
 
 i_unit

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -126,7 +126,7 @@ i_damping
 :
    DAMPING
    (
-      i_suppress_null
+      id_suppress_null
    )
 ;
 
@@ -242,7 +242,7 @@ i_speed
    SPEED dec speed_abbreviation
 ;
 
-i_suppress_null
+id_suppress_null
 :
   // range 1 through 20,000
    SUPPRESS uint16
@@ -636,11 +636,11 @@ int_named
    (
       i_common
       | i_flexible_vlan_tagging
+      | i_damping
       | i_link_mode
       | i_native_vlan_id
       | i_per_unit_scheduler
       | i_unit
-      | i_damping
    )
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -122,6 +122,13 @@ i_common_physical
     | i_redundant_ether_options
     | i_speed
 ;
+i_damping
+:
+   DAMPING
+   (
+      i_suppress_null
+   )
+;
 
 i_description
 :
@@ -233,6 +240,12 @@ i_redundant_ether_options
 i_speed
 :
    SPEED dec speed_abbreviation
+;
+
+i_suppress_null
+:
+  // range 1 through 20,000
+   SUPPRESS uint16
 ;
 
 i_unit
@@ -627,6 +640,7 @@ int_named
       | i_native_vlan_id
       | i_per_unit_scheduler
       | i_unit
+      | i_damping
    )
 ;
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4536,6 +4536,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfaceDampingSuppress() {
+    parseConfig("juniper-set-interface-damping");
+    // don't crash.
+  }
+
+  @Test
   public void testJuniperPolicyStatementTermFromEvaluation() {
     // Configuration has policy statements
     Configuration c = parseConfig("juniper-policy-statement-term");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-set-interface-damping
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-set-interface-damping
@@ -1,0 +1,5 @@
+#
+set system host-name juniper-set-interface-damping
+#
+set interfaces ge-2/0/0 damping suppress 1000
+#


### PR DESCRIPTION

 The `suppress` command never needs to be extracted, so ignored silently