### PR TITLE
Junos: add parsing for `set interfaces damping` commands

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -819,6 +819,8 @@ GROUP5: 'group5';
 
 GROUPS: 'groups' -> pushMode(M_Name);
 
+HALF_LIFE: 'half-life';
+
 HASH_KEY: 'hash-key';
 
 HELLO_AUTHENTICATION_KEY: 'hello-authentication-key' -> pushMode(M_SecretString);
@@ -1716,6 +1718,8 @@ MAX_SESSION_NUMBER: 'max-session-number';
 
 MAX_SESSIONS_PER_CONNECTION: 'max-sessions-per-connection';
 
+MAX_SUPPRESS: 'max-suppress';
+
 MAXIMUM: 'maximum';
 
 MAXIMUM_LABELS: 'maximum-labels';
@@ -2304,6 +2308,8 @@ RESTRICT: 'restrict';
 RESTRICTED_QUEUES: 'restricted-queues';
 
 RETAIN: 'retain';
+
+REUSE: 'reuse';
 
 REVERSE: 'reverse';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -128,8 +128,35 @@ i_damping
 :
    DAMPING
    (
-      id_suppress_null
+      id_enable_null
+      | id_half_life_null
+      | id_max_suppress_null
+      | id_reuse_null
+      | id_suppress_null
    )
+;
+
+id_enable_null
+:
+   ENABLE
+;
+
+id_half_life_null
+:
+  // range 1 through 30
+   HALF_LIFE uint8
+;
+
+id_max_suppress_null
+:
+  // range 1 through 20,000
+   MAX_SUPPRESS uint16
+;
+
+id_reuse_null
+:
+  // range 1 through 20,000
+   REUSE uint16
 ;
 
 id_suppress_null

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4536,7 +4536,7 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testInterfaceDampingSuppress() {
+  public void testInterfaceDamping() {
     parseConfig("juniper-set-interface-damping");
     // don't crash.
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-set-interface-damping
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-set-interface-damping
@@ -1,5 +1,9 @@
 #
 set system host-name juniper-set-interface-damping
 #
+set interfaces ge-2/0/0 damping enable
+set interfaces ge-2/0/0 damping half-life 15
+set interfaces ge-2/0/0 damping max-suppress 3000
 set interfaces ge-2/0/0 damping suppress 1000
+set interfaces ge-2/0/0 damping reuse 10
 #


### PR DESCRIPTION
The damping commands never needs to be extracted, so ignored silently