### PR TITLE
Junos: parse standalone set protocols

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_protocols.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_protocols.g4
@@ -11,7 +11,8 @@ s_protocols
 :
    PROTOCOLS
    (
-      p_bgp
+      // empty protocol is valid
+      | p_bgp
       | p_connections
       | p_evpn
       | p_isis

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8059,5 +8059,11 @@ public final class FlatJuniperGrammarTest {
     parseConfig("firewall-next-header-ipv6");
   }
 
+  @Test
+  public void testSetPartial() {
+    // Should not crash.
+    parseConfig("set-partial");
+  }
+
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/set-partial
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/set-partial
@@ -1,0 +1,4 @@
+#
+set system host-name set-partial
+#
+set protocols


### PR DESCRIPTION
support a standalone `set protocols`. Note that my commit message is missing `set protocols`; somehow it got removed because of backticks