### PR TITLE
Junos: add parsing for  `fti` interface type

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3323,6 +3323,7 @@ F_InterfaceMediaType
    'et' |
    'fab' |
    'fe' |
+   'fti' |
    'fxp' |
    'ge' |
    'gr' |

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1619,6 +1619,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testDeleteUnsupportedProtocolsOnInterface() throws IOException {
+    parseConfig("juniper_delete_protocols_on_interface");
+    // don't crash.
+  }
+
+  @Test
   public void testPsFromCommunity() {
     Configuration c = parseConfig("community");
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1619,8 +1619,8 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testDeleteUnsupportedProtocolsOnInterface() throws IOException {
-    parseConfig("juniper_delete_protocols_on_interface");
+  public void testFtiInterfaceTypeSupport() {
+    parseConfig("juniper_fti_interface_type");
     // don't crash.
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_delete_protocols_on_interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_delete_protocols_on_interface
@@ -1,0 +1,6 @@
+#
+set system host-name juniper_delete_protocols_on_interface
+#
+delete protocols mpls interface fti0.0
+delete protocols rsvp interface fti0.0
+delete protocols isis interface fti0.0

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_delete_protocols_on_interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_delete_protocols_on_interface
@@ -1,6 +1,0 @@
-#
-set system host-name juniper_delete_protocols_on_interface
-#
-delete protocols mpls interface fti0.10
-delete protocols rsvp interface fti0.11
-delete protocols isis interface fti0.12

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_delete_protocols_on_interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_delete_protocols_on_interface
@@ -1,6 +1,6 @@
 #
 set system host-name juniper_delete_protocols_on_interface
 #
-delete protocols mpls interface fti0.0
-delete protocols rsvp interface fti0.0
-delete protocols isis interface fti0.0
+delete protocols mpls interface fti0.10
+delete protocols rsvp interface fti0.11
+delete protocols isis interface fti0.12

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_fti_interface_type
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_fti_interface_type
@@ -1,0 +1,7 @@
+#
+set system host-name juniper_fti_interface_type
+#
+set interfaces fti0.10 unit 0 tunnel encapsulation vxlan-gpe
+set interfaces fti0.10 unit 0 tunnel encapsulation vxlan-gpe source address 1.2.3.4
+delete protocols mpls interface fti0.10
+delete protocols rsvp interface fti0.10


### PR DESCRIPTION
Add support for  `fti` interface type.

Flexible tunnel interface (FTI) is a type of logical tunnel interface that uses static routing and BGP protocols to exchange routes over a tunnel that connects endpoints to routers.

JunOS documentation for [FTI interfaces](https://www.juniper.net/documentation/us/en/software/junos/interfaces-encryption/topics/topic-map/configuring-flexible-tunnel-interfaces.html)