### PR TITLE
WORKSPACE: upgrade to https for buildifier-prebuilt

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,7 +118,7 @@ http_archive(
     sha256 = "95387c9dded7f8e3bdd4c598bc2ca4fbb6366cb214fa52e7d7b689eb2f421e01",
     strip_prefix = "buildifier-prebuilt-6.0.0",
     urls = [
-        "http://github.com/keith/buildifier-prebuilt/archive/6.0.0.tar.gz",
+        "https://github.com/keith/buildifier-prebuilt/archive/6.0.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
With sha256, I'm not worried but this feels better.

---

**Stack**:
- #8890
- #8889 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*