### PR TITLE
Junos: Add parsing support for bgp `family route-target` command

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -143,6 +143,7 @@ b_family
       | bf_inet
       | bf_inet6
       | bf_null
+      | bf_route_target
    ) bf_accepted_prefix_limit?
 ;
 
@@ -332,6 +333,12 @@ bf_null
       | L2VPN
    ) null_filler
 ;
+
+bf_route_target
+:
+   ROUTE_TARGET
+;
+
 
 bfi_any
 :

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -255,6 +255,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_typeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.BandwidthContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bd_routing_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bd_vlan_idContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bf_route_targetContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bfiu_add_pathContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bfiu_loopsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bfiu_rib_groupContext;
@@ -7249,6 +7250,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _configuration.referenceStructure(
         INTERFACE, iface, BRIDGE_DOMAINS_ROUTING_INTERFACE, getLine(ctx.getStart()));
     _currentBridgeDomain.setRoutingInterface(iface);
+  }
+
+  @Override
+  public void exitBf_route_target(Bf_route_targetContext ctx) {
+    warn(
+        ctx,
+        "family route-target statement used for filtering VPN routes is currently not supported");
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -7254,9 +7254,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitBf_route_target(Bf_route_targetContext ctx) {
-    warn(
-        ctx,
-        "family route-target statement used for filtering VPN routes is currently not supported");
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4562,6 +4562,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testBgpFamilyRouteTarget() {
+    parseConfig("juniper-bgp-family-route-target");
+    // don't crash.
+  }
+
+  @Test
   public void testJuniperPolicyStatementTermFromEvaluation() {
     // Configuration has policy statements
     Configuration c = parseConfig("juniper-policy-statement-term");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-bgp-family-route-target
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-bgp-family-route-target
@@ -1,0 +1,4 @@
+#RANCID-CONTENT-TYPE: juniper
+set system host-name juniper-bgp-family-route-target
+#
+set protocols bgp group XYZ-BGP neighbor 1.2.3.4 family route-target

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-bgp-family-route-target
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-bgp-family-route-target
@@ -1,4 +1,4 @@
 #RANCID-CONTENT-TYPE: juniper
 set system host-name juniper-bgp-family-route-target
 #
-set protocols bgp group XYZ-BGP neighbor 1.2.3.4 family route-target
+set protocols bgp group G1 neighbor 1.2.3.4 family route-target


### PR DESCRIPTION
Juniper docs on [family route-target](https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/topics/ref/statement/family-edit-protocols-bgp-route-target-vp.html) command. 

```
The family route-target statement is useful for filtering VPN routes before they are sent. Provider edge (PE) routers inform the route reflector (RR) which routes to send, using family route-target to provide the route-target-interest information. The RR then sends to the PE router only the advertisements containing the specified route target.
```

Add parsing support for the `route-target` command and `warn`. We still need to look into fully supporting this command in Batfish.