### PR TITLE
Junos: parse and warn on `isis import` and `tag2`

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2692,6 +2692,8 @@ TACPLUS_SERVER: 'tacplus-server';
 
 TAG: 'tag';
 
+TAG2: 'tag2';
+
 TALK: 'talk';
 
 TARGET: 'target';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
@@ -22,6 +22,11 @@ is_ignore_attached_bit
   IGNORE_ATTACHED_BIT
 ;
 
+is_import
+:
+  IMPORT name = junos_name
+;
+
 is_interface
 :
   INTERFACE
@@ -267,6 +272,7 @@ p_isis
     apply
     | is_export
     | is_ignore_attached_bit
+    | is_import
     | is_interface
     | is_level
     | is_null

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -168,6 +168,7 @@ pops_from
       | popsf_route_type
       | popsf_source_address_filter
       | popsf_tag
+      | popsf_tag2
    )
 ;
 
@@ -364,6 +365,11 @@ popsf_source_address_filter
 popsf_tag
 :
    TAG uint32
+;
+
+popsf_tag2
+:
+   TAG2 uint32
 ;
 
 popsfpl_exact

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5205,7 +5205,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitIs_import(Is_importContext ctx) {
     _configuration.referenceStructure(
-        POLICY_STATEMENT, ctx.name.getText(), ISIS_IMPORT_POLICY, getLine(ctx.name.getStart()));
+        POLICY_STATEMENT, toString(ctx.name), ISIS_IMPORT_POLICY, getLine(ctx.name.getStart()));
     todo(ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -27,7 +27,6 @@ import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_I
 import static org.batfish.representation.juniper.JuniperStructureType.IKE_GATEWAY;
 import static org.batfish.representation.juniper.JuniperStructureType.IKE_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureType.IKE_PROPOSAL;
-import static org.batfish.representation.juniper.JuniperStructureType.IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureType.INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureType.IPSEC_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureType.IPSEC_PROPOSAL;
@@ -91,6 +90,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.IPSEC_VPN
 import static org.batfish.representation.juniper.JuniperStructureUsage.IPSEC_VPN_IKE_GATEWAY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.IPSEC_VPN_IPSEC_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ISIS_EXPORT_POLICY;
+import static org.batfish.representation.juniper.JuniperStructureUsage.ISIS_IMPORT_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ISIS_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.NAT_DESTINATINATION_RULE_SET_RULE_THEN;
 import static org.batfish.representation.juniper.JuniperStructureUsage.NAT_RULE_SET_FROM_INTERFACE;
@@ -2775,10 +2775,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     todo(ctx);
   }
 
-  public void enterIs_import(Is_importContext ctx) {
-    _configuration.defineStructure(IMPORT, ctx.name.getText(), ctx);
-  }
-
   @Override
   public void enterIs_interface(Is_interfaceContext ctx) {
     if (ctx.ALL() != null) {
@@ -5208,6 +5204,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitIs_import(Is_importContext ctx) {
+    _configuration.referenceStructure(
+        POLICY_STATEMENT, ctx.name.getText(), ISIS_IMPORT_POLICY, getLine(ctx.name.getStart()));
     todo(ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -27,6 +27,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_I
 import static org.batfish.representation.juniper.JuniperStructureType.IKE_GATEWAY;
 import static org.batfish.representation.juniper.JuniperStructureType.IKE_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureType.IKE_PROPOSAL;
+import static org.batfish.representation.juniper.JuniperStructureType.IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureType.INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureType.IPSEC_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureType.IPSEC_PROPOSAL;
@@ -390,6 +391,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ipv6_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ipv6_prefixContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_ignore_attached_bitContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_importContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_levelContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Is_no_ipv4_routingContext;
@@ -490,6 +492,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_prefix_list_filte
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_protocolContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_ribContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_route_filterContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_tag2Context;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_tagContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_address_maskContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_exactContext;
@@ -2770,6 +2773,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitSepctxptp_application_services(Sepctxptp_application_servicesContext ctx) {
     todo(ctx);
+  }
+
+  public void enterIs_import(Is_importContext ctx) {
+    _configuration.defineStructure(IMPORT, ctx.name.getText(), ctx);
   }
 
   @Override
@@ -5200,6 +5207,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
+  public void exitIs_import(Is_importContext ctx) {
+    todo(ctx);
+  }
+
+  @Override
   public void exitIs_interface(Is_interfaceContext ctx) {
     _currentIsisInterfaceSettings = null;
   }
@@ -5767,6 +5779,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void exitPopsf_tag(Popsf_tagContext ctx) {
     long tag = toLong(ctx.uint32());
     _currentPsTerm.getFroms().addFromTag(new PsFromTag(tag));
+  }
+
+  @Override
+  public void exitPopsf_tag2(Popsf_tag2Context ctx) {
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
@@ -24,6 +24,7 @@ public enum JuniperStructureType implements StructureType {
   IKE_GATEWAY("ike gateway"),
   IKE_POLICY("ike policy"),
   IKE_PROPOSAL("ike proposal"),
+  IMPORT("import"),
   INTERFACE("interface"),
   IPSEC_POLICY("ipsec policy"),
   IPSEC_PROPOSAL("ipsec proposal"),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
@@ -24,7 +24,6 @@ public enum JuniperStructureType implements StructureType {
   IKE_GATEWAY("ike gateway"),
   IKE_POLICY("ike policy"),
   IKE_PROPOSAL("ike proposal"),
-  IMPORT("import"),
   INTERFACE("interface"),
   IPSEC_POLICY("ipsec policy"),
   IPSEC_PROPOSAL("ipsec proposal"),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -47,6 +47,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   IPSEC_VPN_IKE_GATEWAY("ipsec vpn ike gateway"),
   IPSEC_VPN_IPSEC_POLICY("ipsec vpn ipsec policy"),
   ISIS_EXPORT_POLICY("isis export"),
+  ISIS_IMPORT_POLICY("isis import"),
   ISIS_INTERFACE("isis interface"),
   NAT_DESTINATINATION_RULE_SET_RULE_THEN("nat destination rule-set rule then pool"),
   NAT_RULE_SET_FROM_INTERFACE("nat rule-set rule from interface"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8097,5 +8097,11 @@ public final class FlatJuniperGrammarTest {
     parseConfig("interfaces-vlan-map");
   }
 
+  @Test
+  public void testIsisImport() {
+    // Should not crash.
+    parseConfig("isis-import");
+  }
+
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-import
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-import
@@ -1,0 +1,6 @@
+#
+set system host-name isis-import
+#
+set protocols isis import ISIS-ROUTE
+#
+set policy-options policy-statement ISIS-ROUTE term ISIS-TERM from tag2 1000


### PR DESCRIPTION
This parses previously unsupported statements like
`set protocols isis import ISIS-ROUTE`
and
`set policy-options policy-statement ISIS-ROUTE term ISIS-TERM from tag2 1000`.

I tried to add reference tracking based on looking at other code but am not sure I did it right, because it wasn't exactly parallel to the example code.