### PR TITLE
TrackResults: change interface to Table

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneTrackEvaluator.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneTrackEvaluator.java
@@ -1,6 +1,7 @@
 package org.batfish.dataplane.ibdp;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Table;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -37,16 +38,16 @@ public final class DataplaneTrackEvaluator implements TrackMethodEvaluator {
 
   /**
    * Create a provider for {@link DataplaneTrackEvaluator}s given current results for all
-   * dataplane-based tracking checks..
+   * dataplane-based tracking checks.
    */
   public static @Nonnull DataPlaneTrackMethodEvaluatorProvider createTrackMethodEvaluatorProvider(
-      Map<String, Map<TrackReachability, Boolean>> trackReachabilityResultsByHostname,
-      Map<String, Map<TrackRoute, Boolean>> trackRouteResultsByHostname) {
+      Table<String, TrackReachability, Boolean> trackReachabilityResults,
+      Table<String, TrackRoute, Boolean> trackRouteResults) {
     return configuration ->
         new DataplaneTrackEvaluator(
             configuration,
-            trackReachabilityResultsByHostname.get(configuration.getHostname()),
-            trackRouteResultsByHostname.get(configuration.getHostname()));
+            trackReachabilityResults.row(configuration.getHostname()),
+            trackRouteResults.row(configuration.getHostname()));
   }
 
   @Override


### PR DESCRIPTION
Easier to use, compare, etc.

No functional changes for now, but unblocks follow-up work improving
logging during dataplane reconvergence.

---

**Stack**:
- #8911
- #8910 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*