### PR TITLE
Arista: partial implementation of ip nat destination

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Legacy_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Legacy_interface.g4
@@ -420,9 +420,16 @@ if_ip_nat
   )
 ;
 
-ifipn_destination
-:
-   DESTINATION STATIC IP_ADDRESS ACCESS_LIST acl = variable IP_ADDRESS
+
+
+ifipn_destination: DESTINATION ifipnd_static;
+
+ifipnd_static:
+   STATIC
+   original_ip = IP_ADDRESS (original_port = port_number)?
+   (ACCESS_LIST acl = variable)?
+   tx_ip = IP_ADDRESS (tx_port = port_number)?
+   (PROTOCOL (TCP | UDP))?
    NEWLINE
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -1311,6 +1311,11 @@ public final class AristaConfiguration extends VendorConfiguration {
      */
     generateDynamicSourceNats(newIface, iface.getDynamicSourceNats());
     generateStaticSourceNats(newIface, iface.getStaticSourceNats(), c);
+    /*
+     * Destination static NATs match the above description, but translate when receiving rather than
+     * sending.
+     */
+    generateDestinationStaticNats(newIface, iface.getDestinationStaticNats());
 
     String routingPolicyName = iface.getRoutingPolicy();
     if (routingPolicyName != null) {
@@ -1318,6 +1323,24 @@ public final class AristaConfiguration extends VendorConfiguration {
     }
 
     return newIface;
+  }
+
+  private void generateDestinationStaticNats(
+      org.batfish.datamodel.Interface newIface, List<AristaDestinationStaticNat> nats) {
+    if (nats.isEmpty()) {
+      // Nothing to do
+      return;
+    }
+
+    Transformation nextIn = newIface.getIncomingTransformation();
+    Transformation nextOut = newIface.getOutgoingTransformation();
+    for (AristaDestinationStaticNat nat : Lists.reverse(nats)) {
+      // TODO: ACL support
+      nextIn = nat.toIncomingTransformation(nextIn);
+      nextOut = nat.toOutgoingTransformation(nextOut);
+    }
+    newIface.setIncomingTransformation(nextIn);
+    newIface.setOutgoingTransformation(nextOut);
   }
 
   private void generateStaticSourceNats(

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaDestinationStaticNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaDestinationStaticNat.java
@@ -13,7 +13,6 @@ import static org.batfish.datamodel.transformation.TransformationStep.assignDest
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
-import static org.batfish.representation.arista.Conversions.nameOfSourceNatIpSpaceFromAcl;
 
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
@@ -22,29 +21,26 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
-import org.batfish.datamodel.IpSpace;
-import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationStep;
 
-/** Interface-level configuration of {@code ip nat source static}. */
+/** Interface-level configuration of {@code ip nat destination static}. */
 @ParametersAreNonnullByDefault
-public final class AristaStaticSourceNat implements Serializable {
-
+public final class AristaDestinationStaticNat implements Serializable {
   private final @Nonnull Ip _originalIp;
   private final @Nullable Integer _originalPort;
   private final @Nonnull Ip _translatedIp;
   private final @Nullable Integer _translatedPort;
-  private final @Nullable String _extendedAclName;
+  private final @Nullable String _aclName;
   private final @Nonnull NatProtocol _protocol;
 
-  public AristaStaticSourceNat(
+  public AristaDestinationStaticNat(
       Ip originalIp,
       @Nullable Integer originalPort,
       Ip translatedIp,
       @Nullable Integer translatedPort,
-      @Nullable String extendedAclName,
+      @Nullable String aclName,
       NatProtocol protocol) {
     checkArgument(
         (originalPort == null) == (translatedPort == null),
@@ -53,12 +49,12 @@ public final class AristaStaticSourceNat implements Serializable {
     _originalPort = originalPort;
     _translatedIp = translatedIp;
     _translatedPort = translatedPort;
-    _extendedAclName = extendedAclName;
+    _aclName = aclName;
     _protocol = protocol;
   }
 
-  public @Nullable String getExtendedAclName() {
-    return _extendedAclName;
+  public @Nullable String getAclName() {
+    return _aclName;
   }
 
   public @Nonnull Ip getOriginalIp() {
@@ -81,12 +77,20 @@ public final class AristaStaticSourceNat implements Serializable {
     return _translatedPort;
   }
 
+  /**
+   * Returns the {@link Transformation} representing the match and assignments from this destination
+   * NAT rule.
+   *
+   * <p>Destination NAT is applied upon receiving a packet, matching the original protocol/IP/port
+   * and translating it as specified. This corresponds to {@code forward} being {@literal true}.
+   */
   private Transformation toTransformation(@Nullable Transformation orElse, boolean forward) {
     assert (_originalPort == null) == (_translatedPort == null); // invariant
+    boolean usesPorts = _originalPort != null;
     ImmutableList.Builder<AclLineMatchExpr> conditions = ImmutableList.builder();
-    conditions.add(forward ? matchSrc(_originalIp) : matchDst(_translatedIp));
-    if (_originalPort != null) {
-      conditions.add(forward ? matchSrcPort(_originalPort) : matchDstPort(_translatedPort));
+    conditions.add(forward ? matchDst(_originalIp) : matchSrc(_translatedIp));
+    if (usesPorts) {
+      conditions.add(forward ? matchDstPort(_originalPort) : matchSrcPort(_translatedPort));
     }
     switch (_protocol) {
       case TCP:
@@ -96,32 +100,28 @@ public final class AristaStaticSourceNat implements Serializable {
         conditions.add(matchIpProtocol(IpProtocol.UDP));
         break;
       default:
-        if (_originalPort != null) {
-          // Matching and translating port, treat "ANY" as TCP or UDP.
+        if (usesPorts) {
+          // ANY means anything with ports, so TCP or UDP.
           conditions.add(or(matchIpProtocol(IpProtocol.TCP), matchIpProtocol(IpProtocol.UDP)));
         }
         break;
     }
-    if (_extendedAclName != null) {
-      IpSpace space = new IpSpaceReference(nameOfSourceNatIpSpaceFromAcl(_extendedAclName));
-      conditions.add(forward ? matchDst(space) : matchSrc(space));
-    }
+    // TODO: ACL support.
     ImmutableList.Builder<TransformationStep> steps = ImmutableList.builder();
-    steps.add(
-        forward ? assignSourceIp(_translatedIp, _translatedIp) : assignDestinationIp(_originalIp));
-    if (_originalPort != null) {
-      steps.add(forward ? assignSourcePort(_translatedPort) : assignDestinationPort(_originalPort));
+    steps.add(forward ? assignDestinationIp(_translatedIp) : assignSourceIp(_originalIp));
+    if (usesPorts) {
+      steps.add(forward ? assignDestinationPort(_translatedPort) : assignSourcePort(_originalPort));
     }
     return when(and(conditions.build())).apply(steps.build()).setOrElse(orElse).build();
   }
 
-  /** Translate from original source IP when sending. */
+  /** Translate back to original packet when sending out the receiving interface. */
   public Transformation toOutgoingTransformation(@Nullable Transformation orElse) {
-    return toTransformation(orElse, true);
+    return toTransformation(orElse, false);
   }
 
-  /** Translate back to original source IP when receiving. */
+  /** Translate into translated packet when receiving a packet from this interface. */
   public Transformation toIncomingTransformation(@Nullable Transformation orElse) {
-    return toTransformation(orElse, false);
+    return toTransformation(orElse, true);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/Interface.java
@@ -2,6 +2,7 @@ package org.batfish.representation.arista;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
@@ -79,6 +80,7 @@ public class Interface implements Serializable {
 
   private @Nullable IntegerSpace _allowedVlans;
 
+  private List<AristaDestinationStaticNat> _destinationStaticNats;
   private List<AristaDynamicSourceNat> _dynamicSourceNats;
 
   private List<AristaStaticSourceNat> _staticSourceNats;
@@ -179,6 +181,7 @@ public class Interface implements Serializable {
     _shutdown = false;
     _autoState = true;
     _declaredNames = ImmutableSortedSet.of();
+    _destinationStaticNats = ImmutableList.of();
     _dhcpRelayAddresses = new TreeSet<>();
     _isisInterfaceMode = IsisInterfaceMode.UNSET;
     _memberInterfaces = new HashSet<>();
@@ -383,6 +386,18 @@ public class Interface implements Serializable {
 
   public @Nullable Double getSpeed() {
     return _speed;
+  }
+
+  public List<AristaDestinationStaticNat> getDestinationStaticNats() {
+    return _destinationStaticNats;
+  }
+
+  public void addDestinationStaticNat(@Nonnull AristaDestinationStaticNat nat) {
+    _destinationStaticNats =
+        ImmutableList.<AristaDestinationStaticNat>builder()
+            .addAll(_destinationStaticNats)
+            .add(nat)
+            .build();
   }
 
   public List<AristaStaticSourceNat> getStaticSourceNats() {

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/NatProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/NatProtocol.java
@@ -1,0 +1,8 @@
+package org.batfish.representation.arista;
+
+/** The protocol filter on the static source NAT, if applicable. */
+public enum NatProtocol {
+  ANY,
+  TCP,
+  UDP
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/arista/AristaStaticSourceNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/arista/AristaStaticSourceNatTest.java
@@ -27,13 +27,12 @@ import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.transformation.Transformation;
-import org.batfish.representation.arista.AristaStaticSourceNat.Protocol;
 import org.junit.Test;
 
 public class AristaStaticSourceNatTest {
   private final AristaStaticSourceNat _nat =
       new AristaStaticSourceNat(
-          Ip.parse("1.1.1.1"), 11, Ip.parse("2.2.2.2"), 22, "someAcl", Protocol.ANY);
+          Ip.parse("1.1.1.1"), 11, Ip.parse("2.2.2.2"), 22, "someAcl", NatProtocol.ANY);
   private final Transformation _orElse = when(TRUE).apply(assignDestinationPort(74, 1000)).build();
 
   /** All fields, in direction. */
@@ -89,7 +88,7 @@ public class AristaStaticSourceNatTest {
   public void testProtocolGuard() {
     AristaStaticSourceNat anyNoPorts =
         new AristaStaticSourceNat(
-            Ip.parse("1.1.1.1"), null, Ip.parse("2.2.2.2"), null, null, Protocol.ANY);
+            Ip.parse("1.1.1.1"), null, Ip.parse("2.2.2.2"), null, null, NatProtocol.ANY);
     assertThat(
         anyNoPorts.toOutgoingTransformation(_orElse).getGuard(),
         equalTo(matchSrc(Ip.parse("1.1.1.1"))));
@@ -99,14 +98,14 @@ public class AristaStaticSourceNatTest {
 
     AristaStaticSourceNat tcpNoPorts =
         new AristaStaticSourceNat(
-            Ip.parse("1.1.1.1"), null, Ip.parse("2.2.2.2"), null, null, Protocol.TCP);
+            Ip.parse("1.1.1.1"), null, Ip.parse("2.2.2.2"), null, null, NatProtocol.TCP);
     assertThat(
         tcpNoPorts.toOutgoingTransformation(_orElse).getGuard(),
         equalTo(and(matchSrc(Ip.parse("1.1.1.1")), matchIpProtocol(IpProtocol.TCP))));
 
     AristaStaticSourceNat tcpPorts =
         new AristaStaticSourceNat(
-            Ip.parse("1.1.1.1"), 11, Ip.parse("2.2.2.2"), 22, null, Protocol.TCP);
+            Ip.parse("1.1.1.1"), 11, Ip.parse("2.2.2.2"), 22, null, NatProtocol.TCP);
     assertThat(
         tcpPorts.toOutgoingTransformation(_orElse).getGuard(),
         equalTo(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/ip-nat-destination
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/ip-nat-destination
@@ -1,0 +1,13 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname ip-nat-destination
+!
+! See: https://github.com/batfish/batfish/issues/8923
+! ip nat destination static ORIGINAL [FILTER] TRANSLATED [PROT_TYPE][group group_number]
+interface Ethernet1
+   ip nat destination static 1.1.1.1 172.16.52.9
+   ip nat destination static 1.1.1.2 5001 172.16.52.9 5002
+   ip nat destination static 1.1.1.3 access-list ACL 172.16.52.9
+   ip nat destination static 1.1.1.4 5001 access-list ACL 172.16.52.9 5002
+   ip nat destination static 1.1.1.5 5001 access-list ACL 172.16.52.9 5002 protocol tcp
+!


### PR DESCRIPTION
Fix batfish/batfish#8923.

Arista destination NAT was never implemented. While there are many variants,
implement the lowest hanging fruit of IP-only, IP-and-port, and/or IP Protocol.
This covers the user bug report, retains reference tracking, and adds a missing
warning for unsupported use cases.