### PR TITLE
buildifier: use HTTPS not HTTP

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,7 +120,7 @@ http_archive(
     sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
     strip_prefix = "buildifier-prebuilt-6.4.0",
     urls = [
-        "http://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz",
+        "https://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
**Stack**:
- #8929
- #8928 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*