### PR TITLE
Junos: Add parse and warning for policy-options multipath-resolve command

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -1842,6 +1842,8 @@ MULTIHOP: 'multihop';
 
 MULTIPATH: 'multipath';
 
+MULTIPATH_RESOLVE: 'multipath-resolve';
+
 MULTIPLE_AS: 'multiple-as';
 
 MULTIPLIER: 'multiplier';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -175,9 +175,6 @@ pops_from
 pops_term
 :
    TERM name = junos_name pops_common
-   (
-     THEN MULTIPATH_RESOLVE
-   )
 ;
 
 pops_then
@@ -515,6 +512,7 @@ popst_common
    | popst_metric_igp
    | popst_metric2
    | popst_metric2_expression
+   | popst_multipath_resolve
    | popst_next_hop
    | popst_next_policy
    | popst_next_term
@@ -613,6 +611,11 @@ popst_metric_igp
 popst_metric2_expression
 :
    METRIC2 EXPRESSION metric_expression
+;
+
+popst_multipath_resolve
+:
+   MULTIPATH_RESOLVE
 ;
 
 popst_next_hop

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -175,6 +175,9 @@ pops_from
 pops_term
 :
    TERM name = junos_name pops_common
+   (
+     THEN MULTIPATH_RESOLVE
+   )
 ;
 
 pops_then

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -517,6 +517,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_externalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_local_preferenceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_metric_addContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_multipath_resolveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_next_policyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_next_termContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_originContext;
@@ -2600,7 +2601,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
-  public void exitPops_term(Pops_termContext ctx) {
+  public void exitPopst_multipath_resolve(Popst_multipath_resolveContext ctx) {
     todo(ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2600,6 +2600,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
+  public void exitPops_term(Pops_termContext ctx) {
+    todo(ctx);
+  }
+
+  @Override
   public void enterFo_dhcp_relay(Fo_dhcp_relayContext ctx) {
     _currentDhcpRelayGroup =
         _currentRoutingInstance

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2601,11 +2601,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
-  public void exitPopst_multipath_resolve(Popst_multipath_resolveContext ctx) {
-    todo(ctx);
-  }
-
-  @Override
   public void enterFo_dhcp_relay(Fo_dhcp_relayContext ctx) {
     _currentDhcpRelayGroup =
         _currentRoutingInstance
@@ -5954,6 +5949,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void exitPopst_metric_add(Popst_metric_addContext ctx) {
     int metric = toInt(ctx.metric);
     _currentPsThens.add(new PsThenMetricAdd(metric));
+  }
+
+  @Override
+  public void exitPopst_multipath_resolve(Popst_multipath_resolveContext ctx) {
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8110,6 +8110,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testMultipathResolve() {
+    // Should not crash.
+    parseConfig("multipath-resolve");
+  }
+
+  @Test
   public void testJuniperAsPathExclamationRegex() {
     Configuration c = parseConfig("juniper-as-path-exclamation-regex");
     RoutingPolicy asPathGroupPolicy1 = c.getRoutingPolicies().get("AS_PATH_GROUP_POLICY1");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/multipath-resolve
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/multipath-resolve
@@ -1,0 +1,4 @@
+#
+set system host-name multipath-resolve
+#
+set policy-options policy-statement LOAD-BALANCE-POLICY term LOAD-BALANCE-POLICY then multipath-resolve

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/multipath-resolve
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/multipath-resolve
@@ -1,4 +1,4 @@
 #
 set system host-name multipath-resolve
 #
-set policy-options policy-statement LOAD-BALANCE-POLICY term LOAD-BALANCE-POLICY then multipath-resolve
+set policy-options policy-statement POLICY_NAME term TERM_NAME then multipath-resolve


### PR DESCRIPTION
Add parse and warning for ` policy-options multipath-resolve` command. 
