### PR TITLE
TracerouteEngineImpl: limit number of traces materialized from TraceDag.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDag.java
@@ -10,6 +10,9 @@ import org.batfish.datamodel.flow.TraceAndReverseFlow;
  */
 public interface TraceDag {
 
+  /** Maximum number of traces returned by {@link getTraces}. */
+  static final int TRACE_LIMIT = 10000;
+
   /** Returns the number of edges in the DAG. */
   int countEdges();
 
@@ -19,6 +22,16 @@ public interface TraceDag {
   /** Returns the number of traces, aka the number of paths through the DAG. */
   int size();
 
-  /** Returns a stream of the {@link TraceAndReverseFlow} corresponding to the traces in this DAG */
-  Stream<TraceAndReverseFlow> getTraces();
+  /**
+   * Returns a stream of the {@link TraceAndReverseFlow} corresponding to the traces in this DAG,
+   * with at most {@link TraceDag#TRACE_LIMIT} traces.
+   */
+  default Stream<TraceAndReverseFlow> getTraces() {
+    return getAllTraces().limit(TRACE_LIMIT);
+  }
+
+  /**
+   * Returns a stream of the {@link TraceAndReverseFlow} corresponding to the traces in this DAG.
+   */
+  Stream<TraceAndReverseFlow> getAllTraces();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDagImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDagImpl.java
@@ -2,13 +2,17 @@ package org.batfish.common.traceroute;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.batfish.common.util.FlatMapIterator.flatMapIterator;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.common.util.FlatMapIterator;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
@@ -115,7 +119,7 @@ public final class TraceDagImpl implements TraceDag {
     }
   }
 
-  private Stream<TraceAndReverseFlow> getTraces(
+  private Iterator<TraceAndReverseFlow> getTraces(
       List<Hop> hopsInput, List<FirewallSessionTraceInfo> sessionsInput, int rootId) {
     Node node = _nodes.get(rootId);
 
@@ -142,9 +146,11 @@ public final class TraceDagImpl implements TraceDag {
       FlowDisposition disposition =
           checkNotNull(node._flowDisposition, "failed to determine disposition from hop");
       Trace trace = new Trace(disposition, hops);
-      return Stream.of(new TraceAndReverseFlow(trace, node._returnFlow, sessions));
+      return ImmutableList.of(new TraceAndReverseFlow(trace, node._returnFlow, sessions))
+          .iterator();
     } else {
-      return successors.stream().flatMap(successorId -> getTraces(hops, sessions, successorId));
+      return new FlatMapIterator<>(
+          successors.iterator(), successorId -> getTraces(hops, sessions, successorId));
     }
   }
 
@@ -158,12 +164,14 @@ public final class TraceDagImpl implements TraceDag {
     return _nodes.size();
   }
 
-  private Stream<TraceAndReverseFlow> getTraces(int rootId) {
+  private Iterator<TraceAndReverseFlow> getTraces(int rootId) {
     return getTraces(ImmutableList.of(), new Stack<>(), rootId);
   }
 
   @Override
   public Stream<TraceAndReverseFlow> getTraces() {
-    return _rootIds.stream().flatMap(this::getTraces);
+    Iterable<TraceAndReverseFlow> iterable =
+        () -> flatMapIterator(_rootIds.iterator(), this::getTraces);
+    return StreamSupport.stream(iterable.spliterator(), false);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDagImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDagImpl.java
@@ -169,7 +169,7 @@ public final class TraceDagImpl implements TraceDag {
   }
 
   @Override
-  public Stream<TraceAndReverseFlow> getTraces() {
+  public Stream<TraceAndReverseFlow> getAllTraces() {
     Iterable<TraceAndReverseFlow> iterable =
         () -> flatMapIterator(_rootIds.iterator(), this::getTraces);
     return StreamSupport.stream(iterable.spliterator(), false);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/FlatMapIterator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/FlatMapIterator.java
@@ -1,0 +1,48 @@
+package org.batfish.common.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+/** An implementation of {@code flatMap} for {@link Iterator}. */
+public final class FlatMapIterator<Outer, Inner> implements Iterator<Inner> {
+  Iterator<Outer> _outer;
+  Iterator<Inner> _inner;
+  Function<Outer, Iterator<Inner>> _nextInner;
+
+  public FlatMapIterator(Iterator<Outer> outer, Function<Outer, Iterator<Inner>> nextInner) {
+    _outer = outer;
+    _nextInner = nextInner;
+    _inner = null;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (_inner != null && _inner.hasNext()) {
+      return true;
+    }
+    _inner = null;
+    // loop invariant: _inner == null || _inner.hasNext()
+    while (_outer.hasNext()) {
+      _inner = _nextInner.apply(_outer.next());
+      if (_inner.hasNext()) {
+        return true;
+      }
+      _inner = null;
+    }
+    return false;
+  }
+
+  @Override
+  public Inner next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    return _inner.next();
+  }
+
+  public static <Outer, Inner> Iterator<Inner> flatMapIterator(
+      Iterator<Outer> outer, Function<Outer, Iterator<Inner>> nextInner) {
+    return new FlatMapIterator<>(outer, nextInner);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/FlatMapIterator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/FlatMapIterator.java
@@ -5,12 +5,12 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 
 /** An implementation of {@code flatMap} for {@link Iterator}. */
-public final class FlatMapIterator<Outer, Inner> implements Iterator<Inner> {
-  Iterator<Outer> _outer;
-  Iterator<Inner> _inner;
-  Function<Outer, Iterator<Inner>> _nextInner;
+public final class FlatMapIterator<OuterT, InnerT> implements Iterator<InnerT> {
+  Iterator<OuterT> _outer;
+  Iterator<InnerT> _inner;
+  Function<OuterT, Iterator<InnerT>> _nextInner;
 
-  public FlatMapIterator(Iterator<Outer> outer, Function<Outer, Iterator<Inner>> nextInner) {
+  public FlatMapIterator(Iterator<OuterT> outer, Function<OuterT, Iterator<InnerT>> nextInner) {
     _outer = outer;
     _nextInner = nextInner;
     _inner = null;
@@ -34,15 +34,15 @@ public final class FlatMapIterator<Outer, Inner> implements Iterator<Inner> {
   }
 
   @Override
-  public Inner next() {
+  public InnerT next() {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
     return _inner.next();
   }
 
-  public static <Outer, Inner> Iterator<Inner> flatMapIterator(
-      Iterator<Outer> outer, Function<Outer, Iterator<Inner>> nextInner) {
+  public static <OuterT, InnerT> Iterator<InnerT> flatMapIterator(
+      Iterator<OuterT> outer, Function<OuterT, Iterator<InnerT>> nextInner) {
     return new FlatMapIterator<>(outer, nextInner);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/FlatMapIteratorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/FlatMapIteratorTest.java
@@ -1,0 +1,32 @@
+package org.batfish.common.util;
+
+import static org.batfish.common.util.FlatMapIterator.flatMapIterator;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.junit.Test;
+
+/** Test for {@link FlatMapIterator}. */
+public final class FlatMapIteratorTest {
+  private static <T> Stream<T> toStream(Iterator<T> iter) {
+    Iterable<T> iterable = () -> iter;
+    return StreamSupport.stream(iterable.spliterator(), false);
+  }
+
+  @Test
+  public void testSimple() {
+    // double each integer from 0 to 5 (exclusive)
+    List<Integer> actual =
+        toStream(
+                flatMapIterator(
+                    ImmutableList.of(0, 1, 2, 3, 4).iterator(),
+                    i -> ImmutableList.of(i, i).iterator()))
+            .collect(Collectors.toList());
+    assertEquals(ImmutableList.of(0, 0, 1, 1, 2, 2, 3, 3, 4, 4), actual);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
@@ -137,7 +137,7 @@ public final class VxlanTopologyUtilsTest {
                       }
 
                       @Override
-                      public Stream<TraceAndReverseFlow> getTraces() {
+                      public Stream<TraceAndReverseFlow> getAllTraces() {
                         return result.stream();
                       }
                     };

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
@@ -63,7 +63,11 @@ public final class TracerouteEngineImpl implements TracerouteEngine {
             entry ->
                 new SimpleEntry<>(
                     entry.getKey(),
-                    entry.getValue().getTraces().collect(ImmutableList.toImmutableList())))
+                    entry
+                        .getValue()
+                        .getTraces()
+                        .limit(10000)
+                        .collect(ImmutableList.toImmutableList())))
         .collect(
             ImmutableSortedMap.toImmutableSortedMap(
                 Ordering.natural(), Entry::getKey, Entry::getValue));


### PR DESCRIPTION
TraceDags have been observed to contain huge numbers of traces, too many to materialize into a list. Limiting to 10k for now. Rewrote TraceDagImpl to use iterators internally, as limit() wasn't working on the previous implementation based on recursive streams flattened with flatMap. Something about the stream implementation materializes many more traces than the limit, which wastes compute time and risks OOM. Rewriting using the same style of code but based on iterators solved the problem.