### PR TITLE
Optimizations for CompareRoutePolicies

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -3,12 +3,14 @@ package org.batfish.common.bdd;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.common.bdd.BDDUtils.bitvector;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import org.batfish.datamodel.Ip;
@@ -218,6 +220,13 @@ public final class MutableBDDInteger extends BDDInteger {
       val._bitvec[i] = pred.and(_bitvec[i]);
     }
     return val;
+  }
+
+  public BDD xor(BDDInteger other) {
+    return _factory.orAll(
+        IntStream.range(0, _bitvec.length)
+            .mapToObj(i -> _bitvec[i].xor(other._bitvec[i]))
+            .collect(ImmutableList.toImmutableList()));
   }
 
   /*

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -224,12 +224,14 @@ public final class MutableBDDInteger extends BDDInteger {
 
   /**
    * Produces a BDD whose models represent all possible differences between the two BDDIntegers --
-   * valuations of the BDD variables that cause the two BDDIntegers to have different values.
+   * valuations of the BDD variables that cause the two BDDIntegers to have different values. The
+   * two BDDIntegers are assumed to have the same length.
    *
    * @param other the second BDDInteger
    * @return a predicate represented as a BDD
    */
   public BDD allDifferences(BDDInteger other) {
+    assert _bitvec.length == other._bitvec.length;
     return _factory.orAll(
         IntStream.range(0, _bitvec.length)
             .mapToObj(i -> _bitvec[i].xor(other._bitvec[i]))

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -222,7 +222,14 @@ public final class MutableBDDInteger extends BDDInteger {
     return val;
   }
 
-  public BDD xor(BDDInteger other) {
+  /**
+   * Produces a BDD whose models represent all possible differences between the two BDDIntegers --
+   * valuations of the BDD variables that cause the two BDDIntegers to have different values.
+   *
+   * @param other the second BDDInteger
+   * @return a predicate represented as a BDD
+   */
+  public BDD allDifferences(BDDInteger other) {
     return _factory.orAll(
         IntStream.range(0, _bitvec.length)
             .mapToObj(i -> _bitvec[i].xor(other._bitvec[i]))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
@@ -110,4 +110,18 @@ public class MutableBDDIntegerTest {
     assertEquals(x.geq(30), xPlus1.value(31)); // x >= 31 ==> x+1 == 31
     assertEquals(x.geq(15), xPlus16.value(31)); // x >= 15 ==> x+16 == 31
   }
+
+  @Test
+  public void testAllDifferences() {
+    BDDFactory factory = BDDUtils.bddFactory(10);
+    MutableBDDInteger x = MutableBDDInteger.makeFromIndex(factory, 5, 0, false);
+    MutableBDDInteger constant1 = MutableBDDInteger.makeFromValue(factory, 5, 1);
+    MutableBDDInteger xPlus1 = x.add(constant1);
+
+    BDD allDiffs1 = x.allDifferences(constant1);
+    BDD allDiffs2 = x.allDifferences(xPlus1);
+
+    assertEquals(allDiffs1, x.value(0).or(x.geq(2)));
+    assertEquals(allDiffs2, factory.one());
+  }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -344,6 +344,7 @@ public final class CompareRoutePoliciesUtils {
         return result;
       }
     }
+    // none of the differences are compatible with the input constraints
     return factory.zero();
   }
 
@@ -443,7 +444,7 @@ public final class CompareRoutePoliciesUtils {
 
         // If the sets of input routes between the two paths intersect, then these paths describe
         // some common input routes and their behavior should match.
-        // It's cheaper to just test for satisfiability of the conjunction and only compute the full
+        // It's cheaper to test for satisfiability of the conjunction and only compute the full
         // intersection if necessary.
         if (inputRoutesOther.andSat(inputRoutes)) {
           BDD intersection = inputRoutesOther.and(inputRoutes).and(wf);

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesAnswererTest.java
@@ -1303,6 +1303,53 @@ public class CompareRoutePoliciesAnswererTest {
                 hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
   }
 
+  /**
+   * Test that there are no differences found even when one route map has more paths than the other,
+   * due to the input conditions under which each path is traversed.
+   */
+  @Test
+  public void testNoDifferencesMultiplePaths() {
+    Community comm = StandardCommunity.parse("1:1");
+
+    RoutingPolicy policy_reference =
+        _policyBuilderDelta
+            .addStatement(
+                new If(
+                    new MatchCommunities(
+                        InputCommunities.instance(), new HasCommunity(new CommunityIs(comm))),
+                    ImmutableList.of(new StaticStatement(Statements.ExitAccept)),
+                    ImmutableList.of(
+                        new SetCommunities(
+                            CommunitySetUnion.of(
+                                InputCommunities.instance(),
+                                new LiteralCommunitySet(CommunitySet.of(comm)))),
+                        new StaticStatement(Statements.ExitAccept))))
+            .build();
+
+    RoutingPolicy policy_new =
+        _policyBuilderBase
+            .addStatement(
+                new SetCommunities(
+                    CommunitySetUnion.of(
+                        InputCommunities.instance(),
+                        new LiteralCommunitySet(CommunitySet.of(comm)))))
+            .addStatement(new StaticStatement(Statements.ExitAccept))
+            .build();
+
+    org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesQuestion question =
+        new org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesQuestion(
+            DEFAULT_DIRECTION, policy_new.getName(), policy_reference.getName(), HOSTNAME);
+    org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesAnswerer answerer =
+        new org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesAnswerer(
+            question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    assertThat(answer.getRows().getData(), Matchers.empty());
+  }
+
   /** Tests multiple differences in set values. */
   @Test
   public void testMultipleSetDifferences() {


### PR DESCRIPTION
A few performance optimizations for CompareRoutePolicies:
* When identifying differences between two BDDRoutes, ignore the input constraints at first; only impose them later on specific differences that are found (rather than on the entire BDDRoute as done previously)
* Don't compute the intersection between two path conditions unless it is actually needed