### PR TITLE
Routes question: sort cluster lists in diff tables

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -728,7 +728,8 @@ public class RoutesAnswererUtil {
     return routeEntryPresenceStatus;
   }
 
-  private static void populateBgpRouteAttributes(
+  @VisibleForTesting
+  static void populateBgpRouteAttributes(
       RowBuilder rowBuilder, @Nullable RouteRowAttribute routeRowAttribute, boolean base) {
     String prefix = base ? COL_BASE_PREFIX : COL_DELTA_PREFIX;
     rowBuilder
@@ -743,7 +744,11 @@ public class RoutesAnswererUtil {
             routeRowAttribute != null ? routeRowAttribute.getLocalPreference() : null)
         .put(
             prefix + COL_CLUSTER_LIST,
-            routeRowAttribute != null ? routeRowAttribute.getClusterList() : null)
+            routeRowAttribute == null || routeRowAttribute.getClusterList().isEmpty()
+                ? null
+                : routeRowAttribute.getClusterList().stream()
+                    .sorted()
+                    .collect(ImmutableList.toImmutableList()))
         .put(
             prefix + COL_COMMUNITIES,
             routeRowAttribute != null ? routeRowAttribute.getCommunities() : null)

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -744,7 +744,7 @@ public class RoutesAnswererUtil {
             routeRowAttribute != null ? routeRowAttribute.getLocalPreference() : null)
         .put(
             prefix + COL_CLUSTER_LIST,
-            routeRowAttribute == null || routeRowAttribute.getClusterList().isEmpty()
+            routeRowAttribute == null
                 ? null
                 : routeRowAttribute.getClusterList().stream()
                     .sorted()

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -43,6 +43,7 @@ import static org.batfish.question.routes.RoutesAnswererUtil.getRoutesDiff;
 import static org.batfish.question.routes.RoutesAnswererUtil.groupBgpRoutes;
 import static org.batfish.question.routes.RoutesAnswererUtil.groupRoutes;
 import static org.batfish.question.routes.RoutesAnswererUtil.longestMatchingPrefix;
+import static org.batfish.question.routes.RoutesAnswererUtil.populateBgpRouteAttributes;
 import static org.batfish.question.routes.RoutesAnswererUtil.populateRouteAttributes;
 import static org.batfish.question.routes.RoutesAnswererUtil.prefixMatches;
 import static org.hamcrest.Matchers.allOf;
@@ -1500,5 +1501,21 @@ public class RoutesAnswererUtilTest {
     assertThat(longestMatchingPrefix(Prefix.parse("1.1.1.0/8"), routes), equalTo(Optional.empty()));
     assertThat(
         longestMatchingPrefix(Prefix.parse("2.1.1.0/32"), routes), equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testPopulateBgpRouteAttributes() {
+    // deliberately not sorted
+    RouteRowAttribute attr =
+        RouteRowAttribute.builder().setClusterList(ImmutableSet.of(5L, 1L, 3L, 2L)).build();
+    Row.RowBuilder rb = Row.builder();
+    populateBgpRouteAttributes(rb, attr, true);
+    Row row = rb.build();
+    assertThat(
+        row,
+        hasColumn(
+            "Snapshot_" + COL_CLUSTER_LIST,
+            ImmutableList.of(1L, 2L, 3L, 5L),
+            Schema.list(Schema.LONG)));
   }
 }


### PR DESCRIPTION
We already sort cluster lists in single-snapshot answers, do the same in differential mode too.