### PR TITLE
CompareRoutePolicies: Allow structured route map differences to be compared to one another

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteCommunityDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpRouteCommunityDiff.java
@@ -4,9 +4,10 @@ import static com.google.common.collect.Ordering.natural;
 
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.SortedSet;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.bgp.community.Community;
 
-public class BgpRouteCommunityDiff {
+public class BgpRouteCommunityDiff implements Comparable<BgpRouteCommunityDiff> {
 
   private final SortedSet<Community> _added;
   private final SortedSet<Community> _removed;
@@ -82,5 +83,15 @@ public class BgpRouteCommunityDiff {
       return false;
     }
     return _removed.equals(that._removed);
+  }
+
+  @Override
+  public int compareTo(@Nonnull BgpRouteCommunityDiff that) {
+    int addedComp = StructuredBgpRouteDiffs.sortedSetCompareTo(this._added, that._added);
+    if (addedComp != 0) {
+      return addedComp;
+    } else {
+      return StructuredBgpRouteDiffs.sortedSetCompareTo(this._removed, that._removed);
+    }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffs.java
@@ -4,16 +4,18 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Ordering.natural;
 
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.SortedSet;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 
 /**
  * A class for structured BGP Route differences. This class might keep more information than just
  * the old/new value for a field. Currently, only community sets have a richer representation that
  * includes a delta between old/new value but in the future we might do the same for as-paths.
  */
-public class StructuredBgpRouteDiffs {
+public class StructuredBgpRouteDiffs implements Comparable<StructuredBgpRouteDiffs> {
 
   private final SortedSet<BgpRouteDiff> _diffs;
   private final Optional<BgpRouteCommunityDiff> _communityDiff;
@@ -69,6 +71,55 @@ public class StructuredBgpRouteDiffs {
       return false;
     }
     return _communityDiff.equals(that._communityDiff);
+  }
+
+  /**
+   * Compares two sorted sets in lexicographic order.
+   *
+   * @param o1 the first sorted set
+   * @param o2 the second sorted set
+   * @return an integer indicating whether the first set is less than, equal to, or greater than the
+   *     second set
+   * @param <T> the type of the sets' elements
+   */
+  static <T extends Comparable<T>> int sortedSetCompareTo(SortedSet<T> o1, SortedSet<T> o2) {
+    Iterator<T> o1Iter = o1.iterator();
+    Iterator<T> o2Iter = o2.iterator();
+    while (o1Iter.hasNext() && o2Iter.hasNext()) {
+      int comp = o1Iter.next().compareTo(o2Iter.next());
+      if (comp != 0) {
+        return comp;
+      }
+    }
+    return o1Iter.hasNext() ? 1 : o2Iter.hasNext() ? -1 : 0;
+  }
+
+  /**
+   * Compares a {@link StructuredBgpRouteDiffs} object against another one. The comparison is in
+   * lexicographic order, with community differences compared first, followed by all other
+   * differences.
+   *
+   * @param other the other object to compare against
+   * @return an integer indicating whether the first object is less than, equal to, or greater than
+   *     the second one
+   */
+  @Override
+  public int compareTo(@Nonnull StructuredBgpRouteDiffs other) {
+    boolean thisPresent = this._communityDiff.isPresent();
+    boolean otherPresent = other._communityDiff.isPresent();
+    if (thisPresent && otherPresent) {
+      int commComp = this._communityDiff.get().compareTo(other._communityDiff.get());
+      if (commComp != 0) {
+        return commComp;
+      }
+    }
+    if (thisPresent == otherPresent) {
+      return sortedSetCompareTo(this._diffs, other._diffs);
+    } else if (thisPresent) {
+      return 1;
+    } else {
+      return -1;
+    }
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffs.java
@@ -76,11 +76,11 @@ public class StructuredBgpRouteDiffs implements Comparable<StructuredBgpRouteDif
   /**
    * Compares two sorted sets in lexicographic order.
    *
+   * @param <T> the type of the sets' elements
    * @param o1 the first sorted set
    * @param o2 the second sorted set
    * @return an integer indicating whether the first set is less than, equal to, or greater than the
    *     second set
-   * @param <T> the type of the sets' elements
    */
   static <T extends Comparable<T>> int sortedSetCompareTo(SortedSet<T> o1, SortedSet<T> o2) {
     Iterator<T> o1Iter = o1.iterator();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteCommunityDiffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteCommunityDiffTest.java
@@ -65,4 +65,40 @@ public class BgpRouteCommunityDiffTest {
     // but not equal according to BgpRouteDiff
     assertNotEquals(comms1.toRouteDiff(), comms2.toRouteDiff());
   }
+
+  @Test
+  public void testDeltaCompareTo() {
+    // [0:0, 1:1] -> [1:1, 2:2]
+    SortedSet<Community> oldComms1 = new TreeSet<>();
+    SortedSet<Community> newComms1 = new TreeSet<>();
+    oldComms1.add(StandardCommunity.of(0, 0));
+    oldComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(1, 1));
+    newComms1.add(StandardCommunity.of(2, 2));
+    BgpRouteCommunityDiff comms1 = new BgpRouteCommunityDiff(oldComms1, newComms1);
+
+    // [0:0] -> [2:2]
+    SortedSet<Community> oldComms2 = new TreeSet<>();
+    SortedSet<Community> newComms2 = new TreeSet<>();
+    oldComms2.add(StandardCommunity.of(0, 0));
+    newComms2.add(StandardCommunity.of(2, 2));
+    BgpRouteCommunityDiff comms2 = new BgpRouteCommunityDiff(oldComms2, newComms2);
+
+    // [0:0] -> [3:1]
+    SortedSet<Community> oldComms3 = new TreeSet<>();
+    SortedSet<Community> newComms3 = new TreeSet<>();
+    oldComms3.add(StandardCommunity.of(0, 0));
+    newComms3.add(StandardCommunity.of(3, 1));
+    BgpRouteCommunityDiff comms3 = new BgpRouteCommunityDiff(oldComms3, newComms3);
+
+    // [0:0] -> []
+    SortedSet<Community> oldComms4 = new TreeSet<>();
+    SortedSet<Community> newComms4 = new TreeSet<>();
+    oldComms4.add(StandardCommunity.of(0, 0));
+    BgpRouteCommunityDiff comms4 = new BgpRouteCommunityDiff(oldComms4, newComms4);
+
+    assert comms1.compareTo(comms2) == 0;
+    assert comms1.compareTo(comms3) < 0;
+    assert comms1.compareTo(comms4) > 0;
+  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/StructuredBgpRouteDiffsTest.java
@@ -46,6 +46,39 @@ public class StructuredBgpRouteDiffsTest {
   }
 
   @Test
+  public void testCompareTo() {
+    // [0:0, 1:1] -> []
+    SortedSet<Community> oldComms1 = new TreeSet<>();
+    SortedSet<Community> newComms1 = new TreeSet<>();
+    oldComms1.add(StandardCommunity.of(0, 0));
+    oldComms1.add(StandardCommunity.of(1, 1));
+    BgpRouteCommunityDiff comms1 = new BgpRouteCommunityDiff(oldComms1, newComms1);
+
+    StructuredBgpRouteDiffs d1 =
+        new StructuredBgpRouteDiffs(
+            ImmutableSortedSet.of(new BgpRouteDiff(BgpRoute.PROP_AS_PATH, "B", "C")),
+            Optional.of(comms1));
+    StructuredBgpRouteDiffs d2 =
+        new StructuredBgpRouteDiffs(ImmutableSortedSet.of(), Optional.of(comms1));
+    StructuredBgpRouteDiffs d3 =
+        new StructuredBgpRouteDiffs(ImmutableSortedSet.of(), Optional.empty());
+    StructuredBgpRouteDiffs d4 =
+        new StructuredBgpRouteDiffs(
+            ImmutableSortedSet.of(new BgpRouteDiff(BgpRoute.PROP_METRIC, "B", "C")),
+            Optional.of(comms1));
+    StructuredBgpRouteDiffs d5 =
+        new StructuredBgpRouteDiffs(
+            ImmutableSortedSet.of(new BgpRouteDiff(BgpRoute.PROP_AS_PATH, "B", "C")),
+            Optional.of(comms1));
+
+    assert d1.compareTo(d2) > 0;
+    assert d3.compareTo(d2) < 0;
+    assert d4.compareTo(d2) > 0;
+    assert d1.compareTo(d4) < 0;
+    assert d1.compareTo(d5) == 0;
+  }
+
+  @Test
   public void testHasDifferences() {
 
     StructuredBgpRouteDiffs d1 = new StructuredBgpRouteDiffs();


### PR DESCRIPTION
Makes the objects that represent structured route map differences Comparable, so they can be compared to one another for purposes of deduplication and ordering.