### PR TITLE
TestRoutePolicies: Add optional parameter for BGP session properties

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpSessionProperties.java
@@ -1,0 +1,98 @@
+package org.batfish.datamodel.questions;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
+
+/** A user facing representation for properties of a BGP session. */
+@ParametersAreNonnullByDefault
+public final class BgpSessionProperties {
+
+  public static final String PROP_LOCAL_AS = "localAs";
+  public static final String PROP_REMOTE_AS = "remoteAs";
+  public static final String PROP_LOCAL_IP = "localIp";
+  public static final String PROP_REMOTE_IP = "remoteIp";
+
+  private final long _localAs;
+  private final long _remoteAs;
+  private final @Nonnull Ip _localIp;
+  private final @Nonnull Ip _remoteIp;
+
+  public BgpSessionProperties(long localAs, long remoteAs, Ip localIp, Ip remoteIp) {
+    _localAs = localAs;
+    _remoteAs = remoteAs;
+    _localIp = localIp;
+    _remoteIp = remoteIp;
+  }
+
+  @JsonCreator
+  private static BgpSessionProperties jsonCreator(
+      @JsonProperty(PROP_LOCAL_AS) @Nullable Long localAs,
+      @JsonProperty(PROP_REMOTE_AS) @Nullable Long remoteAs,
+      @JsonProperty(PROP_LOCAL_IP) @Nullable Ip localIp,
+      @JsonProperty(PROP_REMOTE_IP) @Nullable Ip remoteIp) {
+    checkArgument(localAs != null, "%s must be specified", PROP_LOCAL_AS);
+    checkArgument(remoteAs != null, "%s must be specified", PROP_REMOTE_AS);
+    checkArgument(localIp != null, "%s must be specified", PROP_LOCAL_IP);
+    checkArgument(remoteIp != null, "%s must be specified", PROP_REMOTE_IP);
+
+    return new BgpSessionProperties(localAs, remoteAs, localIp, remoteIp);
+  }
+
+  @JsonProperty(PROP_LOCAL_AS)
+  public long getLocalAs() {
+    return _localAs;
+  }
+
+  @JsonProperty(PROP_REMOTE_AS)
+  public long getRemoteAs() {
+    return _remoteAs;
+  }
+
+  @JsonProperty(PROP_LOCAL_IP)
+  public @Nonnull Ip getLocalIp() {
+    return _localIp;
+  }
+
+  @JsonProperty(PROP_REMOTE_IP)
+  public @Nonnull Ip getRemoteIp() {
+    return _remoteIp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BgpSessionProperties)) {
+      return false;
+    }
+    BgpSessionProperties bgpSessionProperties = (BgpSessionProperties) o;
+    return _localAs == bgpSessionProperties._localAs
+        && _remoteAs == bgpSessionProperties._remoteAs
+        && Objects.equals(_localIp, bgpSessionProperties._localIp)
+        && Objects.equals(_remoteIp, bgpSessionProperties._remoteIp);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_localAs, _remoteAs, _localIp, _remoteIp);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("localAs", _localAs)
+        .add("remoteAs", _remoteAs)
+        .add("localIp", _localIp)
+        .add("remoteIp", _remoteIp)
+        .toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/Variable.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/Variable.java
@@ -34,6 +34,7 @@ public class Variable {
     BGP_ROUTE_CONSTRAINTS("bgpRouteConstraints", false),
     BGP_ROUTE_STATUS_SPEC("bgpRouteStatusSpec", true),
     BGP_SESSION_COMPAT_STATUS_SPEC("bgpSessionCompatStatusSpec", true),
+    BGP_SESSION_PROPERTIES("bgpSessionProperties", false),
     BGP_SESSION_STATUS_SPEC("bgpSessionStatusSpec", true),
     BGP_SESSION_TYPE_SPEC("bgpSessionTypeSpec", true),
     BOOLEAN("boolean", false),

--- a/projects/client/src/main/java/org/batfish/client/Client.java
+++ b/projects/client/src/main/java/org/batfish/client/Client.java
@@ -364,6 +364,13 @@ public class Client extends AbstractClient implements IClient {
               String.format("A Batfish %s must be a JSON string", expectedType.getName()));
         }
         break;
+      case BGP_SESSION_PROPERTIES:
+        if (!value.isObject() && !value.isNull()) {
+          throw new BatfishException(
+              String.format(
+                  "Not a valid BGP session properties object: %s", expectedType.getName()));
+        }
+        break;
       case BGP_SESSION_STATUS_SPEC:
         if (!value.isTextual()) {
           throw new BatfishException(

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
@@ -73,6 +73,8 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
   private final @Nonnull NodeSpecifier _nodeSpecifier;
   private final @Nonnull RoutingPolicySpecifier _policySpecifier;
 
+  private final @Nullable BgpSessionProperties _bgpSessionProperties;
+
   public TestRoutePoliciesAnswerer(TestRoutePoliciesQuestion question, IBatfish batfish) {
     super(question, batfish);
     _direction = question.getDirection();
@@ -86,6 +88,7 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
     _policySpecifier =
         SpecifierFactories.getRoutingPolicySpecifierOrDefault(
             question.getPolicies(), ALL_ROUTING_POLICIES);
+    _bgpSessionProperties = question.getBgpSessionProperties();
   }
 
   private SortedSet<RoutingPolicyId> resolvePolicies(SpecifierContext context) {
@@ -113,9 +116,9 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
    * @param direction whether the policy is used on import or export (IN or OUT)
    * @return the results of the simulation
    */
-  private static Result<Bgpv4Route> simulatePolicy(
+  private Result<Bgpv4Route> simulatePolicy(
       RoutingPolicy policy, Bgpv4Route inputRoute, Direction direction) {
-    return simulatePolicy(policy, inputRoute, null, direction, null, null);
+    return simulatePolicy(policy, inputRoute, _bgpSessionProperties, direction, null, null);
   }
 
   /**

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
@@ -88,7 +88,17 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
     _policySpecifier =
         SpecifierFactories.getRoutingPolicySpecifierOrDefault(
             question.getPolicies(), ALL_ROUTING_POLICIES);
-    _bgpSessionProperties = question.getBgpSessionProperties();
+    org.batfish.datamodel.questions.BgpSessionProperties properties =
+        question.getBgpSessionProperties();
+    _bgpSessionProperties =
+        properties == null
+            ? null
+            : BgpSessionProperties.builder()
+                .setLocalAs(properties.getLocalAs())
+                .setRemoteAs(properties.getRemoteAs())
+                .setLocalIp(properties.getLocalIp())
+                .setRemoteIp(properties.getRemoteIp())
+                .build();
   }
 
   private SortedSet<RoutingPolicyId> resolvePolicies(SpecifierContext context) {

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesQuestion.java
@@ -10,6 +10,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.questions.BgpRoute;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
@@ -22,6 +23,8 @@ public final class TestRoutePoliciesQuestion extends Question {
   private static final String PROP_NODES = "nodes";
   private static final String PROP_POLICIES = "policies";
 
+  private static final String PROP_BGP_SESSION_PROPERTIES = "bgpSessionProperties";
+
   // Defaults are dummy values for now.
   private static final Direction DEFAULT_DIRECTION = Direction.IN;
   private static final List<BgpRoute> DEFAULT_INPUT_ROUTES = ImmutableList.of();
@@ -31,19 +34,23 @@ public final class TestRoutePoliciesQuestion extends Question {
   private final @Nullable String _policies;
   private final @Nonnull List<BgpRoute> _inputRoutes;
 
+  private final @Nullable BgpSessionProperties _bgpSessionProperties;
+
   public TestRoutePoliciesQuestion() {
-    this(DEFAULT_DIRECTION, DEFAULT_INPUT_ROUTES, null, null);
+    this(DEFAULT_DIRECTION, DEFAULT_INPUT_ROUTES, null, null, null);
   }
 
   public TestRoutePoliciesQuestion(
       Direction direction,
       List<BgpRoute> inputRoutes,
       @Nullable String nodes,
-      @Nullable String policies) {
+      @Nullable String policies,
+      @Nullable BgpSessionProperties bgpSessionProperties) {
     _direction = direction;
     _nodes = nodes;
     _policies = policies;
     _inputRoutes = inputRoutes;
+    _bgpSessionProperties = bgpSessionProperties;
   }
 
   @JsonCreator
@@ -51,10 +58,13 @@ public final class TestRoutePoliciesQuestion extends Question {
       @JsonProperty(PROP_DIRECTION) @Nullable Direction direction,
       @JsonProperty(PROP_INPUT_ROUTES) @Nullable List<BgpRoute> inputRoute,
       @JsonProperty(PROP_NODES) @Nullable String nodes,
-      @JsonProperty(PROP_POLICIES) @Nullable String policies) {
+      @JsonProperty(PROP_POLICIES) @Nullable String policies,
+      @JsonProperty(PROP_BGP_SESSION_PROPERTIES) @Nullable
+          BgpSessionProperties bgpSessionProperties) {
     checkNotNull(direction, "%s must not be null", PROP_DIRECTION);
     checkNotNull(inputRoute, "%s must not be null", PROP_INPUT_ROUTES);
-    return new TestRoutePoliciesQuestion(direction, inputRoute, nodes, policies);
+    return new TestRoutePoliciesQuestion(
+        direction, inputRoute, nodes, policies, bgpSessionProperties);
   }
 
   @JsonIgnore
@@ -87,5 +97,10 @@ public final class TestRoutePoliciesQuestion extends Question {
   @JsonProperty(PROP_POLICIES)
   public @Nullable String getPolicies() {
     return _policies;
+  }
+
+  @JsonProperty(PROP_BGP_SESSION_PROPERTIES)
+  public @Nullable BgpSessionProperties getBgpSessionProperties() {
+    return _bgpSessionProperties;
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesQuestion.java
@@ -10,8 +10,8 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.questions.BgpRoute;
+import org.batfish.datamodel.questions.BgpSessionProperties;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 

--- a/projects/question/src/test/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswererTest.java
@@ -33,7 +33,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.AsPath;
-import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -54,6 +53,7 @@ import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.questions.BgpRoute;
 import org.batfish.datamodel.questions.BgpRouteDiff;
 import org.batfish.datamodel.questions.BgpRouteDiffs;
+import org.batfish.datamodel.questions.BgpSessionProperties;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
@@ -86,12 +86,7 @@ public class TestRoutePoliciesAnswererTest {
   private static final String POLICY_NAME = "policy";
 
   private static final BgpSessionProperties BGP_SESSION_PROPERTIES =
-      BgpSessionProperties.builder()
-          .setLocalAs(22)
-          .setLocalIp(Ip.parse("2.2.2.2"))
-          .setRemoteAs(33)
-          .setRemoteIp(Ip.parse("3.3.3.3"))
-          .build();
+      new BgpSessionProperties(22, 33, Ip.parse("2.2.2.2"), Ip.parse("3.3.3.3"));
   private RoutingPolicy.Builder _policyBuilder;
   private RoutingPolicy.Builder _deltaPolicyBuilder;
   private IBatfish _batfish;

--- a/projects/question/src/test/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswererTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -57,6 +58,7 @@ import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.expr.BgpPeerAddressNextHop;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
@@ -64,6 +66,7 @@ import org.batfish.datamodel.routing_policy.expr.MatchMetric;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.SetMetric;
+import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetTag;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
@@ -81,6 +84,14 @@ import org.junit.Test;
 public class TestRoutePoliciesAnswererTest {
   private static final String HOSTNAME = "hostname";
   private static final String POLICY_NAME = "policy";
+
+  private static final BgpSessionProperties BGP_SESSION_PROPERTIES =
+      BgpSessionProperties.builder()
+          .setLocalAs(22)
+          .setLocalIp(Ip.parse("2.2.2.2"))
+          .setRemoteAs(33)
+          .setRemoteIp(Ip.parse("3.3.3.3"))
+          .build();
   private RoutingPolicy.Builder _policyBuilder;
   private RoutingPolicy.Builder _deltaPolicyBuilder;
   private IBatfish _batfish;
@@ -113,7 +124,8 @@ public class TestRoutePoliciesAnswererTest {
   public void testConstructorWithNullsInQuestion() {
     TestRoutePoliciesAnswerer answerer =
         new TestRoutePoliciesAnswerer(
-            new TestRoutePoliciesQuestion(Direction.IN, ImmutableList.of(), null, null), _batfish);
+            new TestRoutePoliciesQuestion(Direction.IN, ImmutableList.of(), null, null, null),
+            _batfish);
     assertEquals(answerer.getNodeSpecifier(), AllNodesNodeSpecifier.INSTANCE);
     assertEquals(answerer.getPolicySpecifier(), ALL_ROUTING_POLICIES);
   }
@@ -135,7 +147,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
@@ -175,7 +187,7 @@ public class TestRoutePoliciesAnswererTest {
     {
       TestRoutePoliciesQuestion question =
           new TestRoutePoliciesQuestion(
-              Direction.IN, ImmutableList.of(r1, r2), HOSTNAME, policy.getName());
+              Direction.IN, ImmutableList.of(r1, r2), HOSTNAME, policy.getName(), null);
       TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
       TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
       List<Row> rows = answer.getRowsList();
@@ -190,7 +202,7 @@ public class TestRoutePoliciesAnswererTest {
     {
       TestRoutePoliciesQuestion question =
           new TestRoutePoliciesQuestion(
-              Direction.IN, ImmutableList.of(r2, r1), HOSTNAME, policy.getName());
+              Direction.IN, ImmutableList.of(r2, r1), HOSTNAME, policy.getName(), null);
       TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
       TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
       List<Row> rows = answer.getRowsList();
@@ -221,7 +233,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.OUT, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.OUT, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
@@ -265,7 +277,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
@@ -309,7 +321,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
@@ -356,7 +368,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
@@ -409,7 +421,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
@@ -431,7 +443,7 @@ public class TestRoutePoliciesAnswererTest {
     policy = _policyBuilder.setStatements(stmts).build();
     question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
     answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     answer = answerer.answer(_batfish.getSnapshot());
@@ -490,7 +502,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
 
     TableAnswerElement answer =
         (new TestRoutePoliciesAnswerer(question, _batfish)).answer(_batfish.getSnapshot());
@@ -505,6 +517,66 @@ public class TestRoutePoliciesAnswererTest {
                 hasColumn(COL_ACTION, equalTo(PERMIT.toString()), Schema.STRING),
                 hasColumn(COL_OUTPUT_ROUTE, equalTo(outputRoute), BGP_ROUTE),
                 hasColumn(COL_DIFF, equalTo(diff), BGP_ROUTE_DIFFS))));
+  }
+
+  @Test
+  public void testSetNextHopRemoteAddress() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(new SetNextHop(BgpPeerAddressNextHop.getInstance()))
+            .addStatement(new StaticStatement(Statements.ExitAccept))
+            .build();
+
+    BgpRoute inputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.ZERO)
+            .setOriginatorIp(Ip.ZERO)
+            .setNextHopIp(Ip.parse("1.1.1.1"))
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .build();
+
+    BgpRoute outputRoute =
+        BgpRoute.builder()
+            .setNetwork(Prefix.ZERO)
+            .setOriginatorIp(Ip.ZERO)
+            .setNextHopIp(Ip.parse("3.3.3.3"))
+            .setOriginMechanism(OriginMechanism.LEARNED)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP)
+            .build();
+
+    TestRoutePoliciesQuestion question =
+        new TestRoutePoliciesQuestion(
+            Direction.IN,
+            ImmutableList.of(inputRoute),
+            HOSTNAME,
+            policy.getName(),
+            BGP_SESSION_PROPERTIES);
+    TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
+
+    BgpRouteDiffs diffs =
+        new BgpRouteDiffs(
+            ImmutableSortedSet.of(
+                new BgpRouteDiff(
+                    BgpRoute.PROP_NEXT_HOP,
+                    new NextHopConcrete(NextHopIp.of(Ip.parse("1.1.1.1"))).toString(),
+                    new NextHopConcrete(NextHopIp.of(Ip.parse("3.3.3.3"))).toString())));
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(policy.getName()), Schema.STRING),
+                hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), BGP_ROUTE),
+                hasColumn(COL_ACTION, equalTo(PERMIT.toString()), Schema.STRING),
+                hasColumn(COL_OUTPUT_ROUTE, equalTo(outputRoute), BGP_ROUTE),
+                // no diff
+                hasColumn(COL_DIFF, equalTo(diffs), BGP_ROUTE_DIFFS))));
   }
 
   @Test
@@ -525,7 +597,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, POLICY_NAME);
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, POLICY_NAME, null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     // both policies permit and make the same modification, so no difference
@@ -559,7 +631,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, POLICY_NAME);
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, POLICY_NAME, null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     // both policies permit and make the same modification, so no difference
@@ -592,7 +664,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, POLICY_NAME);
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, POLICY_NAME, null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     // both policies permit and make the same modification, so no difference
@@ -642,7 +714,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, POLICY_NAME);
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, POLICY_NAME, null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
 
     BgpRouteDiffs diffs =
@@ -690,7 +762,7 @@ public class TestRoutePoliciesAnswererTest {
 
     TestRoutePoliciesQuestion question =
         new TestRoutePoliciesQuestion(
-            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName());
+            Direction.IN, ImmutableList.of(inputRoute), HOSTNAME, policy.getName(), null);
     TestRoutePoliciesAnswerer answerer = new TestRoutePoliciesAnswerer(question, _batfish);
     TableAnswerElement answer = answerer.answer(_batfish.getSnapshot());
 

--- a/questions/experimental/testRoutePolicies.json
+++ b/questions/experimental/testRoutePolicies.json
@@ -5,6 +5,7 @@
     "policies": "${policies}",
     "inputRoutes": "${inputRoutes}",
     "direction": "${direction}",
+    "bgpSessionProperties": "${bgpSessionProperties}",
     "instance": {
         "description": "Evaluates the processing of a route by a given policy.",
         "instanceName": "testRoutePolicies",
@@ -13,7 +14,8 @@
             "nodes",
             "policies",
             "inputRoutes",
-            "direction"
+            "direction",
+            "bgpSessionProperties"
         ],
         "tags": [
             "routing"
@@ -41,6 +43,12 @@
                 "description": "The BGP route announcements to test the policy on",
                 "type": "bgpRoutes",
                 "displayName": "Input Routes"
+            },
+            "bgpSessionProperties": {
+                "description": "The BGP session properties to use when testing routes",
+                "type": "bgpSessionProperties",
+                "optional": true,
+                "displayName": "BGP Session Properties"
             }
         }
     }

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -118,7 +118,7 @@ test -raw tests/questions/experimental/subnetMultipathConsistency.ref validate-t
 test -raw tests/questions/experimental/switchedVlanProperties.ref validate-template switchedVlanProperties excludeShutInterfaces=true, interfaces="i1", nodes="n1", vlans="1-5,7"
 
 # test testRoutePolicies
-test -raw tests/questions/experimental/testRoutePolicies.ref validate-template testRoutePolicies nodes="nodes", policies="policies", direction="in", inputRoutes=[{network="0.0.0.0/0", originatorIp="1.1.1.1", originMechanism="LEARNED", originType="IGP", protocol="BGP"}]
+test -raw tests/questions/experimental/testRoutePolicies.ref validate-template testRoutePolicies nodes="nodes", policies="policies", direction="in", inputRoutes=[{network="0.0.0.0/0", originatorIp="1.1.1.1", originMechanism="LEARNED", originType="IGP", protocol="BGP"}], bgpSessionProperties={localAs="2", remoteAs="3", localIp="2.2.2.2", remoteIp="3.3.3.3"}
 
 # test traceroute
 test -raw tests/questions/experimental/traceroute.ref validate-template traceroute startLocation="location", ignoreFilters=false, maxTraces=0, headers={"dstIps" : "1.1.1.1/32"}

--- a/tests/questions/experimental/testRoutePolicies.ref
+++ b/tests/questions/experimental/testRoutePolicies.ref
@@ -1,5 +1,11 @@
 {
   "class" : "org.batfish.question.testroutepolicies.TestRoutePoliciesQuestion",
+  "bgpSessionProperties" : {
+    "localAs" : 2,
+    "localIp" : "2.2.2.2",
+    "remoteAs" : 3,
+    "remoteIp" : "3.3.3.3"
+  },
   "direction" : "IN",
   "inputRoutes" : [
     {
@@ -33,12 +39,25 @@
       "nodes",
       "policies",
       "inputRoutes",
-      "direction"
+      "direction",
+      "bgpSessionProperties"
     ],
     "tags" : [
       "routing"
     ],
     "variables" : {
+      "bgpSessionProperties" : {
+        "description" : "The BGP session properties to use when testing routes",
+        "displayName" : "BGP Session Properties",
+        "optional" : true,
+        "type" : "bgpSessionProperties",
+        "value" : {
+          "localAs" : "2",
+          "remoteAs" : "3",
+          "localIp" : "2.2.2.2",
+          "remoteIp" : "3.3.3.3"
+        }
+      },
       "direction" : {
         "allowedValues" : [
           "in",


### PR DESCRIPTION
Adds an optional parameter to the TestRoutePolicies question for specifying properties of the BGP session that can be needed in order to properly simulate a route map's behavior.