### PR TITLE
VendorConfiguration: improve performance for flattened configs

### DIFF
--- a/projects/batfish-common-protocol/BUILD.bazel
+++ b/projects/batfish-common-protocol/BUILD.bazel
@@ -158,6 +158,7 @@ java_library(
     deps = [
         ":parser_common",
         "//projects/bdd",
+        "@maven//:com_carrotsearch_hppc",
         "@maven//:com_fasterxml_jackson_core_jackson_annotations",
         "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_fasterxml_jackson_core_jackson_databind",

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
@@ -44,6 +44,10 @@ public class DefinedStructureInfo implements Serializable {
     _definitionLines.add(Range.singleton(line));
   }
 
+  public void addDefinitionLines(RangeSet<Integer> lines) {
+    _definitionLines.addAll(lines);
+  }
+
   public void addDefinitionLines(Range<Integer> lines) {
     _definitionLines.add(lines);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -1,8 +1,11 @@
 package org.batfish.vendor;
 
+import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.IntSet;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import java.io.Serializable;
@@ -258,8 +261,11 @@ public abstract class VendorConfiguration implements Serializable {
    */
   public void defineFlattenedStructure(
       StructureType type, String name, RuleContext ctx, BatfishCombinedParser<?, ?> parser) {
-    collectLines(
-        ctx, parser, _extraLines, _structureManager.getOrDefine(type, name)::addDefinitionLines);
+    IntSet lines = new IntHashSet();
+    collectLines(ctx, parser, _extraLines, lines::add);
+    ImmutableRangeSet.Builder<Integer> ranges = ImmutableRangeSet.builder();
+    lines.iterator().forEachRemaining(c -> ranges.add(Range.singleton(c.value)));
+    _structureManager.getOrDefine(type, name).addDefinitionLines(ranges.build());
   }
 
   /**


### PR DESCRIPTION
Unioning a small set and a large set is much faster than
unioning many singleton sets into a large set.