### PR TITLE
ComparePeerGroupPolicies: deduplicate context differences.

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
@@ -80,8 +80,7 @@ public final class ComparePeerGroupPoliciesUtils {
       SyntacticDifference d =
           new SyntacticDifference(
               syntacticCompare.getCurrentConfig().getRoutingPolicies().get(currentPolicy),
-              syntacticCompare.getReferenceConfig().getRoutingPolicies().get(referencePolicy),
-              syntacticCompare.getContextDiff());
+              syntacticCompare.getReferenceConfig().getRoutingPolicies().get(referencePolicy));
       SortedSet<String> routers = differences.computeIfAbsent(d, k -> new TreeSet<>());
       routers.add(router);
     }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
@@ -679,8 +679,8 @@ public class ComparePeerGroupPoliciesAnswererTest {
         Matchers.contains(
             allOf(
                 hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
-                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
-                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_POLICY_NAME, equalTo("RM2"), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo("RM2"), Schema.STRING),
                 hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
                 hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
                 hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),
@@ -688,8 +688,8 @@ public class ComparePeerGroupPoliciesAnswererTest {
                 hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS)),
             allOf(
                 hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
-                hasColumn(COL_POLICY_NAME, equalTo("RM2"), Schema.STRING),
-                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo("RM2"), Schema.STRING),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
                 hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
                 hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
                 hasColumn(deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING),

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticDifferenceTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticDifferenceTest.java
@@ -125,14 +125,8 @@ public class SyntacticDifferenceTest {
             .addStatement(new Statements.StaticStatement(Statements.ExitReject))
             .build();
 
-    SyntacticDifference d1 =
-        new SyntacticDifference(
-            base, delta, new RoutingPolicyContextDiff(base.getOwner(), delta.getOwner()));
-    SyntacticDifference d2 =
-        new SyntacticDifference(
-            baseOther,
-            deltaOther,
-            new RoutingPolicyContextDiff(baseOther.getOwner(), deltaOther.getOwner()));
+    SyntacticDifference d1 = new SyntacticDifference(base, delta);
+    SyntacticDifference d2 = new SyntacticDifference(baseOther, deltaOther);
     assertEquals(0, d1.compareTo(d2));
   }
 
@@ -156,15 +150,9 @@ public class SyntacticDifferenceTest {
             .addStatement(new Statements.StaticStatement(Statements.ExitReject))
             .build();
 
-    SyntacticDifference d1 =
-        new SyntacticDifference(
-            base, delta, new RoutingPolicyContextDiff(base.getOwner(), delta.getOwner()));
-    SyntacticDifference d2 =
-        new SyntacticDifference(
-            baseOther,
-            deltaOther,
-            new RoutingPolicyContextDiff(baseOther.getOwner(), deltaOther.getOwner()));
-    assertNotEquals(0, d1.compareTo(d2));
+    SyntacticDifference d1 = new SyntacticDifference(base, delta);
+    SyntacticDifference d2 = new SyntacticDifference(baseOther, deltaOther);
+    assertEquals(0, d1.compareTo(d2));
   }
 
   @Test
@@ -187,14 +175,8 @@ public class SyntacticDifferenceTest {
             .addStatement(new Statements.StaticStatement(Statements.ExitReject))
             .build();
 
-    SyntacticDifference d1 =
-        new SyntacticDifference(
-            base, delta, new RoutingPolicyContextDiff(base.getOwner(), delta.getOwner()));
-    SyntacticDifference d2 =
-        new SyntacticDifference(
-            baseOther,
-            deltaOther,
-            new RoutingPolicyContextDiff(baseOther.getOwner(), deltaOther.getOwner()));
+    SyntacticDifference d1 = new SyntacticDifference(base, delta);
+    SyntacticDifference d2 = new SyntacticDifference(baseOther, deltaOther);
     assertNotEquals(0, d1.compareTo(d2));
   }
 
@@ -218,14 +200,8 @@ public class SyntacticDifferenceTest {
             .addStatement(new Statements.StaticStatement(Statements.ExitReject))
             .build();
 
-    SyntacticDifference d1 =
-        new SyntacticDifference(
-            base, delta, new RoutingPolicyContextDiff(base.getOwner(), delta.getOwner()));
-    SyntacticDifference d2 =
-        new SyntacticDifference(
-            baseOther,
-            deltaOther,
-            new RoutingPolicyContextDiff(baseOther.getOwner(), deltaOther.getOwner()));
+    SyntacticDifference d1 = new SyntacticDifference(base, delta);
+    SyntacticDifference d2 = new SyntacticDifference(baseOther, deltaOther);
     assertNotEquals(0, d1.compareTo(d2));
   }
 
@@ -251,17 +227,23 @@ public class SyntacticDifferenceTest {
 
     base.getOwner().setRouteFilterLists(ImmutableMap.of());
 
-    SyntacticDifference d1 =
+    SyntacticDifference d1 = new SyntacticDifference(base, delta);
+    SyntacticDifference d2 = new SyntacticDifference(baseOther, deltaOther);
+    assertEquals(0, d1.compareTo(d2));
+
+    // But they will differ if we take contexts into consideration.
+    SyntacticDifference d1Context =
         new SyntacticDifference(
             base, delta, new RoutingPolicyContextDiff(base.getOwner(), delta.getOwner()));
-    SyntacticDifference d2 =
+    SyntacticDifference d2Context =
         new SyntacticDifference(
             baseOther,
             deltaOther,
             new RoutingPolicyContextDiff(baseOther.getOwner(), deltaOther.getOwner()));
-    assertNotEquals(0, d1.compareTo(d2));
+    assertNotEquals(0, d1Context.compareTo(d2Context));
   }
 
+  /* Differences in nested calls do not matter. */
   @Test
   public void testDifference_recursive() {
     RoutingPolicy calledPolicyBase =
@@ -305,23 +287,17 @@ public class SyntacticDifferenceTest {
     deltaOther.getOwner().getRoutingPolicies().put("RM2", calledPolicyDeltaOther);
 
     // Compare the differences between the two callers.
-    SyntacticDifference d1 =
-        new SyntacticDifference(
-            base, delta, new RoutingPolicyContextDiff(base.getOwner(), delta.getOwner()));
-    SyntacticDifference d2 =
-        new SyntacticDifference(
-            baseOther,
-            deltaOther,
-            new RoutingPolicyContextDiff(baseOther.getOwner(), deltaOther.getOwner()));
+    SyntacticDifference d1 = new SyntacticDifference(base, delta);
+    SyntacticDifference d2 = new SyntacticDifference(baseOther, deltaOther);
     assertEquals(0, d1.compareTo(d2));
 
     // If we change the called reference policy on one of the two devices, then the two differences
-    // will be different.
+    // remain unchanged.
     calledPolicyDeltaOther.setStatements(
         ImmutableList.of(
             new Statements.StaticStatement(Statements.ExitAccept),
             new Statements.StaticStatement(Statements.ExitAccept)));
-    assertNotEquals(0, d1.compareTo(d2));
+    assertEquals(0, d1.compareTo(d2));
 
     // Likewise, if we change the called base policy. (first restore the delta policy)
     calledPolicyDeltaOther.setStatements(
@@ -331,6 +307,6 @@ public class SyntacticDifferenceTest {
             new Statements.StaticStatement(Statements.ExitAccept),
             new Statements.StaticStatement(Statements.ExitAccept)));
 
-    assertNotEquals(0, d1.compareTo(d2));
+    assertEquals(0, d1.compareTo(d2));
   }
 }


### PR DESCRIPTION
The goal of this CR is for ComparePeerGroupPolicies to dedup differences across devices even if the devices have different context (e.g., different prefix-lists or community-lists). Initially, the thinking was that completeness (do not miss a difference in any device) was very important, but using the question I realize that this approach produces a lot of redundant information, for example when two devices have slightly different definitions of a prefix-list or a community-list. 
Perhaps the best approach to finding erroneous differences is another question to do a direct comparison of those definitions instead.


Changes:
1. `SyntacticDifference` the class that determines whether two pairs of current/reference routing policy are the same, no longer compares the list definitions (context). It also does not recursively compare sub-calls, rather only compares the top-level which contains the route-map name (sub-calls contain statements with IP addresses/communities which often differ across devices).
2. Fixes a bug with `SyntacticDifference::compareTo` where it was a) not consistent with `equalsTo` and b) not deterministic due to the way the comparison was done in the non-equals case (i.e., it was possible that `a == b`, `b < c` and `a > c`).


