### PR TITLE
Junos: convert last F_DecByte to F_Uint8

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3201,16 +3201,6 @@ UNRECOGNIZED_WORD: F_NonWhitespaceChar+;
 // Fragments
 
 fragment
-F_DecByte
-:
-  F_Digit
-  | F_PositiveDigit F_Digit
-  | '1' F_Digit F_Digit
-  | '2' [0-4] F_Digit
-  | '25' [0-5]
-;
-
-fragment
 F_Digit
 :
   [0-9]
@@ -3439,7 +3429,7 @@ F_InterfaceMediaType
 fragment
 F_IpAddress
 :
-  F_DecByte '.' F_DecByte '.' F_DecByte '.' F_DecByte
+  F_Uint8 '.' F_Uint8 '.' F_Uint8 '.' F_Uint8
 ;
 
 fragment

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3434,6 +3434,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testIpAddressParsing() throws IOException {
+    // Doesn't throw.
+    parseConfig("ip_address");
+  }
+
+  @Test
   public void testJuniperOspfIntervals() {
     JuniperConfiguration config = parseJuniperConfig("ospf-intervals");
     Map<String, org.batfish.representation.juniper.Interface> ifaces =

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ip_address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ip_address
@@ -1,0 +1,5 @@
+#
+set system host-name ip_address
+#
+set system name-server 1.2.3.4
+set system name-server 11.22.33.04


### PR DESCRIPTION
Juniper allows leading 0s in numbers, generally, including IP addresses. We already handle
this in F_Uint8, but somehow we had a nearly-equivalent F_DecByte that was only used
in IP address that did not allow zeros. Fix this last case, add a test, and delete
the now unused fragment.