### PR TITLE
FileBasedStorage: skip string when writing pojo topology

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -1111,7 +1111,7 @@ public class FileBasedStorage implements StorageProvider {
       throws IOException {
     Path path = getPojoTopologyPath(networkId, snapshotId);
     path.getParent().toFile().mkdirs();
-    writeStringToFile(path, BatfishObjectMapper.writeString(topology), UTF_8);
+    writeJsonFile(path, topology);
   }
 
   @Override


### PR DESCRIPTION
User reports that on a very large snapshot this causes a 2GiB limit to be hit.