### PR TITLE
PAN: fix OSPF metric to allow 16 bits and use default if not configured

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_ospf.g4
@@ -38,8 +38,10 @@ ospf_interface_transit_delay
 
 ospf_metric
 :
-// 0-255
-    uint8
+// 0-65535
+// from https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-networking-admin/ospf/configure-ospf
+//     Metric—Enter an OSPF metric for this interface (range is 0-65,535; default is 10).
+    uint16
 ;
 
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -181,6 +181,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Ip_rangeContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ospf_areaContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ospf_enableContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ospf_graceful_restartContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Ospf_metricContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ospf_reject_default_routeContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ospf_router_idContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ospfa_interfaceContext;
@@ -1310,7 +1311,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
 
   @Override
   public void exitOspfai_metric(Ospfai_metricContext ctx) {
-    _currentOspfInterface.setMetric(toInteger(ctx.metric.uint8()));
+    _currentOspfInterface.setMetric(toInteger(ctx.metric));
   }
 
   @Override
@@ -1375,7 +1376,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
 
   @Override
   public void exitOspfatsdr_advertise_metric(Ospfatsdr_advertise_metricContext ctx) {
-    _currentOspfStubAreaType.setDefaultRouteMetric(toInteger(ctx.metric.uint8()));
+    _currentOspfStubAreaType.setDefaultRouteMetric(toInteger(ctx.metric));
   }
 
   @Override
@@ -1410,7 +1411,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
 
   @Override
   public void exitOspfatndra_metric(Ospfatndra_metricContext ctx) {
-    _currentOspfNssaAreaType.setDefaultRouteMetric(toInteger(ctx.metric.uint8()));
+    _currentOspfNssaAreaType.setDefaultRouteMetric(toInteger(ctx.metric));
   }
 
   @Override
@@ -3391,6 +3392,10 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   /////////////////////////////////////////
   ///// Range-aware type conversions. /////
   /////////////////////////////////////////
+
+  private int toInteger(Ospf_metricContext ctx) {
+    return toInteger(ctx.uint16());
+  }
 
   private int toInteger(Port_numberContext ctx) {
     return toInteger(ctx.uint16());

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -197,6 +197,9 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
   public static final String SHARED_VSYS_NAME = "~SHARED_VSYS~";
 
+  // https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-networking-admin/ospf/configure-ospf.
+  private static final int DEFAULT_OSPF_METRIC = 10;
+
   private Configuration _c;
 
   private List<CryptoProfile> _cryptoProfiles;
@@ -2859,7 +2862,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     assert vsOspfIface.getEnable() != null;
     assert vsOspfIface.getPassive() != null;
     OspfInterfaceSettings.Builder ospfSettings = OspfInterfaceSettings.builder();
-    ospfSettings.setCost(vsOspfIface.getMetric());
+    ospfSettings.setCost(firstNonNull(vsOspfIface.getMetric(), DEFAULT_OSPF_METRIC));
     ospfSettings.setPassive(vsOspfIface.getPassive());
     ospfSettings.setEnabled(vsOspfIface.getEnable());
     ospfSettings.setAreaName(areaId);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1134,7 +1134,7 @@ public final class PaloAltoGrammarTest {
     OspfInterface ospfIface = ospfArea.getInterfaces().get(ifaceName);
     assertThat(ospfIface.getEnable(), equalTo(Boolean.FALSE));
     assertThat(ospfIface.getPassive(), equalTo(Boolean.FALSE));
-    assertThat(ospfIface.getMetric(), equalTo(10));
+    assertThat(ospfIface.getMetric(), nullValue());
     assertThat(ospfIface.getPriority(), equalTo(1));
     assertThat(ospfIface.getHelloInterval(), equalTo(10));
     assertThat(ospfIface.getDeadCounts(), equalTo(4));
@@ -1185,7 +1185,7 @@ public final class PaloAltoGrammarTest {
         equalTo(
             OspfInterfaceSettings.builder()
                 .setAreaName(1L)
-                .setCost(14)
+                .setCost(5001)
                 .setDeadInterval(8 * 15)
                 .setEnabled(true)
                 .setHelloInterval(15)

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ospf
@@ -21,7 +21,7 @@ set network virtual-router vr1 protocol ospf area 0.0.0.3 type nssa accept-summa
 # putting ethernet1/3.4 in area 0.0.0.1
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 enable yes
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 passive yes
-set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 metric 14
+set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 metric 5001
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 priority 2
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 hello-interval 15
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 dead-counts 8
@@ -35,7 +35,7 @@ set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.
 # putting ethernet1/3.5 in area 0.0.0.3
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 enable no
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 passive no
-set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 metric 10
+# default metric
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 priority 1
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 hello-interval 10
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 dead-counts 4


### PR DESCRIPTION
Fix batfish/batfish#9013, thanks @netops501!