### PR TITLE
PAN: fix OSPF metric grammar and values

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_ospf.g4
@@ -6,6 +6,14 @@ options {
     tokenVocab = PaloAltoLexer;
 }
 
+ospf_area_metric
+:
+// 1-255
+// from https://docs.paloaltonetworks.com/pan-os/9-1/pan-os-web-interface-help/network/network-virtual-routers/ospf/ospf-areas-tab
+//     Also, specify whether to include a default route LSA in advertisements to the stub area along with the associated metric value (range is 1-255).
+    uint8
+;
+
 ospf_interface_dead_counts
 :
 // 3-20
@@ -15,6 +23,14 @@ ospf_interface_dead_counts
 ospf_interface_hello_interval
 :
 // 0-3600
+    uint16
+;
+
+ospf_interface_metric
+:
+// 0-65535
+// from https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-networking-admin/ospf/configure-ospf
+//     Metric—Enter an OSPF metric for this interface (range is 0-65,535; default is 10).
     uint16
 ;
 
@@ -35,13 +51,6 @@ ospf_interface_transit_delay
 // 0-3600
     uint16
 ;
-
-ospf_metric
-:
-// 0-255
-    uint8
-;
-
 
 
 vrp_ospf
@@ -155,7 +164,7 @@ ospfai_link_type
 
 ospfai_metric
 :
-    METRIC metric = ospf_metric
+    METRIC metric = ospf_interface_metric
 ;
 
 ospfai_null
@@ -241,7 +250,7 @@ ospfatndr_disable
 
 ospfatndra_metric
 :
-    METRIC metric = ospf_metric
+    METRIC metric = ospf_area_metric
 ;
 
 ospfatndra_type
@@ -265,7 +274,7 @@ ospfats_default_route
 
 ospfatsdr_advertise_metric
 :
-    ADVERTISE METRIC metric = ospf_metric
+    ADVERTISE METRIC metric = ospf_area_metric
 ;
 
 ospfatsdr_disable

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -197,6 +197,9 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
   public static final String SHARED_VSYS_NAME = "~SHARED_VSYS~";
 
+  // https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-networking-admin/ospf/configure-ospf.
+  private static final int DEFAULT_OSPF_METRIC = 10;
+
   private Configuration _c;
 
   private List<CryptoProfile> _cryptoProfiles;
@@ -2859,7 +2862,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     assert vsOspfIface.getEnable() != null;
     assert vsOspfIface.getPassive() != null;
     OspfInterfaceSettings.Builder ospfSettings = OspfInterfaceSettings.builder();
-    ospfSettings.setCost(vsOspfIface.getMetric());
+    ospfSettings.setCost(firstNonNull(vsOspfIface.getMetric(), DEFAULT_OSPF_METRIC));
     ospfSettings.setPassive(vsOspfIface.getPassive());
     ospfSettings.setEnabled(vsOspfIface.getEnable());
     ospfSettings.setAreaName(areaId);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1134,7 +1134,7 @@ public final class PaloAltoGrammarTest {
     OspfInterface ospfIface = ospfArea.getInterfaces().get(ifaceName);
     assertThat(ospfIface.getEnable(), equalTo(Boolean.FALSE));
     assertThat(ospfIface.getPassive(), equalTo(Boolean.FALSE));
-    assertThat(ospfIface.getMetric(), equalTo(10));
+    assertThat(ospfIface.getMetric(), nullValue());
     assertThat(ospfIface.getPriority(), equalTo(1));
     assertThat(ospfIface.getHelloInterval(), equalTo(10));
     assertThat(ospfIface.getDeadCounts(), equalTo(4));
@@ -1185,7 +1185,7 @@ public final class PaloAltoGrammarTest {
         equalTo(
             OspfInterfaceSettings.builder()
                 .setAreaName(1L)
-                .setCost(14)
+                .setCost(5001)
                 .setDeadInterval(8 * 15)
                 .setEnabled(true)
                 .setHelloInterval(15)

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ospf
@@ -21,7 +21,7 @@ set network virtual-router vr1 protocol ospf area 0.0.0.3 type nssa accept-summa
 # putting ethernet1/3.4 in area 0.0.0.1
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 enable yes
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 passive yes
-set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 metric 14
+set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 metric 5001
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 priority 2
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 hello-interval 15
 set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.4 dead-counts 8
@@ -35,7 +35,7 @@ set network virtual-router vr1 protocol ospf area 0.0.0.1 interface ethernet1/3.
 # putting ethernet1/3.5 in area 0.0.0.3
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 enable no
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 passive no
-set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 metric 10
+# default metric
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 priority 1
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 hello-interval 10
 set network virtual-router vr1 protocol ospf area 0.0.0.3 interface ethernet1/3.5 dead-counts 4


### PR DESCRIPTION
There are two types of OSPF metrics with different bounds. Separate them
grammatically and make the interface metric one correctly u16. Improve testing
for new behavior including both 16 bit support and using the PAN default when
metric is not configured in configs.

Fix batfish/batfish#9013, thanks @netops501!