### PR TITLE
RibTree: add function to get the number of routes without materializing it

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -403,6 +403,13 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     return b.build();
   }
 
+  /** Equivalent to {@link #getAllElements()}.{@link Set#size}. */
+  public int getNumElements() {
+    int[] ret = new int[] {0};
+    traverseNodes(node -> ret[0] += node._elements.size());
+    return ret[0];
+  }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(_root);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -78,6 +78,7 @@ public class PrefixTrieMultiMapTest {
     PrefixTrieMultiMap<Integer> ptm1 = new PrefixTrieMultiMap<>();
     assertTrue("Element was added", ptm1.put(Prefix.ZERO, 1));
     assertThat(ptm1.getAllElements(), contains(1));
+    assertThat(ptm1.getNumElements(), equalTo(1));
     assertThat(ptm1.get(Prefix.ZERO), equalTo(ImmutableSet.of(1)));
   }
 
@@ -95,6 +96,7 @@ public class PrefixTrieMultiMapTest {
     PrefixTrieMultiMap<Integer> ptm1 = new PrefixTrieMultiMap<>();
     ptm1.putAll(Prefix.ZERO, ImmutableSet.of(1, 2, 3));
     assertThat(ptm1.getAllElements(), containsInAnyOrder(1, 2, 3));
+    assertThat(ptm1.getNumElements(), equalTo(3));
     assertThat(ptm1.get(Prefix.ZERO), containsInAnyOrder(1, 2, 3));
   }
 
@@ -105,6 +107,7 @@ public class PrefixTrieMultiMapTest {
     assertFalse("Nothing to remove", ptm1.remove(Prefix.ZERO, 2));
     assertTrue("Element removed", ptm1.remove(Prefix.ZERO, 1));
     assertThat(ptm1.getAllElements(), empty());
+    assertThat(ptm1.getNumElements(), equalTo(0));
   }
 
   @Test
@@ -118,6 +121,7 @@ public class PrefixTrieMultiMapTest {
     assertThat(ptm1.get(Prefix.ZERO), empty());
     assertThat(ptm1.get(p), equalTo(ImmutableSet.of(1)));
     assertThat(ptm1.getAllElements(), equalTo(ImmutableSet.of(1)));
+    assertThat(ptm1.getNumElements(), equalTo(1));
   }
 
   @Test
@@ -392,6 +396,7 @@ public class PrefixTrieMultiMapTest {
     map.clear();
 
     assertThat(map.getAllElements(), hasSize(0));
+    assertThat(map.getNumElements(), equalTo(0));
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
@@ -127,6 +127,11 @@ final class RibTree<R extends AbstractRouteDecorator> implements Serializable {
     return ImmutableSet.of();
   }
 
+  /** Equivalent to {@link #getRoutes()}.{@link Set#size}. */
+  public int getNumRoutes() {
+    return _root.getNumElements();
+  }
+
   /**
    * Return a set of all routes contained in this RIB
    *

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTreeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTreeTest.java
@@ -31,8 +31,10 @@ public final class RibTreeTest {
     RibTree<StaticRoute> ribTree = new RibTree<>(owner);
     RibDelta<StaticRoute> addR1 = ribTree.mergeRoute(r1);
     assertThat(addR1, equalTo(RibDelta.adding(r1)));
+    assertThat(ribTree.getNumRoutes(), equalTo(1));
     RibDelta<StaticRoute> addR2 = ribTree.mergeRoute(r2);
     assertThat(addR2, equalTo(RibDelta.adding(r2)));
+    assertThat(ribTree.getNumRoutes(), equalTo(2));
     RibDelta<StaticRoute> addR3 = ribTree.mergeRoute(r3);
     assertThat(
         addR3,
@@ -42,5 +44,6 @@ public final class RibTreeTest {
                 .remove(r2, Reason.REPLACE)
                 .add(r3)
                 .build()));
+    assertThat(ribTree.getNumRoutes(), equalTo(1));
   }
 }


### PR DESCRIPTION
**Stack**:
- #9026 ⬅
- #9025


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*