### PR TITLE
GenericRibReadOnly: rename functions for clarity

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -96,7 +96,7 @@ public final class FibImpl implements Fib {
   public <R extends AbstractRouteDecorator> FibImpl(
       GenericRib<R> rib, ResolutionRestriction<R> restriction) {
     _root = new PrefixTrieMultiMap<>();
-    rib.getTypedRoutes().stream()
+    rib.getRoutes().stream()
         .map(AbstractRouteDecorator::getAbstractRoute)
         .filter(r -> !r.getNonForwarding())
         .forEach(r -> _root.putAll(r.getNetwork(), resolveRoute(rib, r, restriction)));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
@@ -9,16 +9,16 @@ public interface GenericRibReadOnly<R extends AbstractRouteDecorator> {
   boolean containsRoute(AbstractRouteDecorator route);
 
   /** Return set of {@link AbstractRoute abstract routes} this RIB contains. */
-  Set<AbstractRoute> getRoutes();
+  Set<AbstractRoute> getUnannotatedRoutes();
 
   /** Return set of routes stored for this exact prefix, if any. */
   Set<R> getRoutes(Prefix prefix);
 
   /** Return set of {@link R typed routes} this RIB contains. */
-  Set<R> getTypedRoutes();
+  Set<R> getRoutes();
 
   /** Return set of backup {@link R typed routes} this RIB contains. */
-  Set<R> getTypedBackupRoutes();
+  Set<R> getBackupRoutes();
 
   /**
    * Execute the longest prefix match for a given IP address.

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -101,26 +101,26 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
   }
 
   @Override
-  public Set<AbstractRoute> getRoutes() {
-    return getTypedRoutes().stream()
+  public Set<AbstractRoute> getUnannotatedRoutes() {
+    return getRoutes().stream()
         .map(AbstractRouteDecorator::getAbstractRoute)
         .collect(ImmutableSet.toImmutableSet());
   }
 
   @Override
   public Set<AnnotatedRoute<AbstractRoute>> getRoutes(Prefix prefix) {
-    return getTypedRoutes().stream()
+    return getRoutes().stream()
         .filter(r -> r.getNetwork().equals(prefix))
         .collect(ImmutableSet.toImmutableSet());
   }
 
   @Override
-  public Set<AnnotatedRoute<AbstractRoute>> getTypedRoutes() {
+  public Set<AnnotatedRoute<AbstractRoute>> getRoutes() {
     return _routes;
   }
 
   @Override
-  public Set<AnnotatedRoute<AbstractRoute>> getTypedBackupRoutes() {
+  public Set<AnnotatedRoute<AbstractRoute>> getBackupRoutes() {
     return _backupRoutes;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -635,7 +635,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       assert _ebgpv4DeltaBestPathBuilder.isEmpty();
 
       if (!_exportFromBgpRib) {
-        _mainRibPrev = _mainRib.getTypedRoutes();
+        _mainRibPrev = _mainRib.getRoutes();
       }
     } else {
       assert _mainRibPrev.isEmpty();
@@ -1317,7 +1317,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     // This kind of generation policy should not need access to the main rib
     GeneratedRoute.Builder builder =
         GeneratedRouteHelper.activateGeneratedRoute(
-            generatedRoute, policy, _mainRib.getTypedRoutes(), _successfulWatchedTracks::contains);
+            generatedRoute, policy, _mainRib.getRoutes(), _successfulWatchedTracks::contains);
     return builder != null
         ? BgpProtocolHelper.convertGeneratedRouteToBgp(
             builder.build(), attrPolicy, _process.getRouterId(), nextHopIp, false)
@@ -1400,10 +1400,10 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       return RibDelta.empty();
     }
     Set<? extends AbstractRoute> currentRoutes =
-        _generateAggregatesFromMainRib ? _mainRib.getRoutes() : _bgpv4Rib.getTypedRoutes();
+        _generateAggregatesFromMainRib ? _mainRib.getUnannotatedRoutes() : _bgpv4Rib.getRoutes();
     RibDelta.Builder<Bgpv4Route> aggDeltaBuilder = RibDelta.builder();
     // Withdraw old aggregates. Withdrawals may be canceled out by activated aggregates below.
-    _bgpv4Rib.getTypedRoutes().stream()
+    _bgpv4Rib.getRoutes().stream()
         .filter(r -> r.getProtocol() == RoutingProtocol.AGGREGATE)
         .forEach(prevAggregate -> aggDeltaBuilder.remove(prevAggregate, Reason.WITHDRAW));
     Multimap<Prefix, AbstractRoute> potentialContributorsByAggregatePrefix =
@@ -2214,7 +2214,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     return Streams.concat(
             Stream.of(
                 // RIBs
-                _bgpv4Rib.getTypedRoutes(),
+                _bgpv4Rib.getRoutes(),
                 _evpnType3Rib.getTypedRoutes(),
                 _evpnType5Rib.getTypedRoutes(),
                 // Outgoing RIB deltas
@@ -2470,8 +2470,8 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     // Take a snapshot of current RIBs so we know to to send to new add-path sessions.
     _anySessionHasAdditionalPaths = computeAnySessionHasAdditionalPaths();
     if (_anySessionHasAdditionalPaths) {
-      _bgpv4Prev = _bgpv4Rib.getTypedRoutes();
-      _ebgpv4Prev = _ebgpv4Rib.getTypedRoutes();
+      _bgpv4Prev = _bgpv4Rib.getRoutes();
+      _ebgpv4Prev = _ebgpv4Rib.getRoutes();
     } else {
       _bgpv4Prev = ImmutableSet.of();
       _ebgpv4Prev = ImmutableSet.of();
@@ -2506,7 +2506,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       assert _ebgpv4DeltaBestPathBuilder.isEmpty();
       if (_mainRibPrev.isEmpty()) {
         // Save previous main RIB routes if they were not already saved during topology update.
-        _mainRibPrev = _mainRib.getTypedRoutes();
+        _mainRibPrev = _mainRib.getRoutes();
       }
     }
   }
@@ -2639,12 +2639,12 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
    * Return a set of all bgpv4 routes. Excludes locally-generated (redistributed) routes for now.
    */
   public @Nonnull Set<Bgpv4Route> getV4Routes() {
-    return _bgpv4Rib.getTypedRoutes();
+    return _bgpv4Rib.getRoutes();
   }
 
   /** Return a set of all bgpv4 backup routes */
   public @Nonnull Set<Bgpv4Route> getV4BackupRoutes() {
-    return _bgpv4Rib.getTypedBackupRoutes();
+    return _bgpv4Rib.getBackupRoutes();
   }
 
   /** Return a set of all multipath-best evpn routes. */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -513,14 +513,13 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
       Collection<EigrpEdge> edgesWentUp, Map<String, Node> allNodes, NetworkConfigurations nc) {
     for (EigrpEdge edge : edgesWentUp) {
       sendOutInternalRoutesPerNeighbor(
-          RibDelta.<EigrpInternalRoute>builder().add(_internalRib.getTypedRoutes()).build(),
+          RibDelta.<EigrpInternalRoute>builder().add(_internalRib.getRoutes()).build(),
           allNodes,
           edge,
           nc);
       sendOutExternalRoutesPerNeighbor(
           filterExternalRoutes(
-              RibDelta.<EigrpExternalRoute>builder().add(_externalRib.getTypedRoutes()).build(),
-              edge),
+              RibDelta.<EigrpExternalRoute>builder().add(_externalRib.getRoutes()).build(), edge),
           allNodes,
           edge,
           nc);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -978,7 +978,7 @@ final class IncrementalBdpEngine {
     ae.getBgpMultipathRibRoutesByIteration()
         .put(dependentRoutesIterations, numBgpMultipathRibRoutes);
     int numMainRibRoutes =
-        vrs.parallelStream().mapToInt(vr -> vr.getMainRib().getTypedRoutes().size()).sum();
+        vrs.parallelStream().mapToInt(vr -> vr.getMainRib().getRoutes().size()).sum();
     ae.getMainRibRoutesByIteration().put(dependentRoutesIterations, numMainRibRoutes);
   }
 
@@ -997,7 +997,7 @@ final class IncrementalBdpEngine {
             toImmutableSortedMap(
                 nodeEntry.getValue(),
                 Entry::getKey,
-                vrfEntry -> ImmutableSet.copyOf(vrfEntry.getValue().getRoutes())));
+                vrfEntry -> ImmutableSet.copyOf(vrfEntry.getValue().getUnannotatedRoutes())));
   }
 
   private static final int MAX_OSPF_INTERNAL_ITERATIONS = 100000;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -45,7 +45,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
                 VirtualRouter::getName,
                 vr ->
                     FinalMainRib.of(
-                        vr.getMainRib().getTypedRoutes().stream()
+                        vr.getMainRib().getRoutes().stream()
                             .map(AnnotatedRoute::getAbstractRoute))));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -789,7 +789,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
      Both are only applicable to fully incremental computation
      */
     Stream<Long> contributingMetrics =
-        _intraAreaRib.getTypedRoutes().stream()
+        _intraAreaRib.getRoutes().stream()
             .filter(
                 /*
                  * Only routes in the same area and within the summary prefix can
@@ -844,7 +844,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
 
      Both are only applicable to fully incremental computation
      */
-    if (!_intraAreaRib.getTypedRoutes().stream()
+    if (!_intraAreaRib.getRoutes().stream()
         .anyMatch(
             /*
              * Only routes in the same area and within the summary prefix can
@@ -1702,7 +1702,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
             _activatedGeneratedRoutes.stream(),
             // RIB state
             Stream.of(_intraAreaRib, _interAreaRib, _internalSummaryRib, _type1Rib, _type2Rib)
-                .map(AbstractRib::getTypedRoutes))
+                .map(AbstractRib::getRoutes))
         .collect(toOrderedHashCode());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -64,7 +64,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   public static @Nonnull <U extends AbstractRoute, T extends U> RibDelta<U> importRib(
       AbstractRib<U> importingRib, AbstractRib<T> exportingRib) {
     RibDelta.Builder<U> builder = RibDelta.builder();
-    exportingRib.getTypedRoutes().forEach(r -> builder.from(importingRib.mergeRouteGetDelta(r)));
+    exportingRib.getRoutes().forEach(r -> builder.from(importingRib.mergeRouteGetDelta(r)));
     return builder.build();
   }
 
@@ -82,7 +82,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
           AnnotatedRib<U> importingRib, AbstractRib<T> exportingRib, String vrfName) {
     RibDelta.Builder<AnnotatedRoute<U>> builder = RibDelta.builder();
     exportingRib
-        .getTypedRoutes()
+        .getRoutes()
         .forEach(
             r -> builder.from(importingRib.mergeRouteGetDelta(new AnnotatedRoute<>(r, vrfName))));
     return builder.build();
@@ -102,7 +102,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
           AnnotatedRib<U> importingRib, AnnotatedRib<T> exportingRib) {
     RibDelta.Builder<AnnotatedRoute<U>> builder = RibDelta.builder();
     exportingRib
-        .getTypedRoutes()
+        .getRoutes()
         .forEach(
             r ->
                 builder.from(
@@ -140,8 +140,8 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   }
 
   @Override
-  public @Nonnull Set<AbstractRoute> getRoutes() {
-    return getTypedRoutes().stream()
+  public @Nonnull Set<AbstractRoute> getUnannotatedRoutes() {
+    return getRoutes().stream()
         .map(AbstractRouteDecorator::getAbstractRoute)
         .collect(ImmutableSet.toImmutableSet());
   }
@@ -157,7 +157,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   }
 
   @Override
-  public final @Nonnull Set<R> getTypedRoutes() {
+  public final @Nonnull Set<R> getRoutes() {
     if (_allRoutes == null) {
       _allRoutes = computeTypedRoutes();
     }
@@ -169,7 +169,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   }
 
   @Override
-  public @Nonnull Set<R> getTypedBackupRoutes() {
+  public @Nonnull Set<R> getBackupRoutes() {
     return Optional.ofNullable(_backupRoutes)
         .map(Multimap::values)
         .map(ImmutableSet::copyOf)
@@ -269,8 +269,8 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   /**
    * Check if two RIBs have exactly same sets of routes.
    *
-   * <p>Designed to be faster (in an average case) than doing two calls to {@link #getTypedRoutes}
-   * and then testing the sets for equality.
+   * <p>Designed to be faster (in an average case) than doing two calls to {@link #getRoutes} and
+   * then testing the sets for equality.
    *
    * @param other the other RIB
    * @return True if both ribs contain identical routes

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/EvpnMasterRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/EvpnMasterRib.java
@@ -38,7 +38,7 @@ public final class EvpnMasterRib<R extends EvpnRoute<?, ?>> {
 
   public @Nonnull Set<R> getTypedRoutes() {
     return _ribsByRd.values().stream()
-        .flatMap(rib -> rib.getTypedRoutes().stream())
+        .flatMap(rib -> rib.getRoutes().stream())
         .collect(ImmutableSet.toImmutableSet());
   }
 
@@ -48,7 +48,7 @@ public final class EvpnMasterRib<R extends EvpnRoute<?, ?>> {
 
   public @Nonnull Set<R> getTypedBackupRoutes() {
     return _ribsByRd.values().stream()
-        .flatMap(rib -> rib.getTypedBackupRoutes().stream())
+        .flatMap(rib -> rib.getBackupRoutes().stream())
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -372,7 +372,7 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
    * Create a new empty RIB. If {@code resolutionRestriction} is not {@code null}, then merged
    * recursive routes that are not resolvable under the provided {@code resolutionRestriction} will
    * remain inactive until they become resolvable again. Inactive routes will not be returned by
-   * {@link #getRoutes()}, {@link #getTypedRoutes()}, nor {@link #getTypedBackupRoutes()}.
+   * {@link #getRoutes()}, {@link #getRoutes()}, nor {@link #getBackupRoutes()}.
    */
   public Rib(@Nullable ResolutionRestriction<AnnotatedRoute<AbstractRoute>> resolutionRestriction) {
     super(true);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/BgpRibGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/BgpRibGroupsTest.java
@@ -273,7 +273,7 @@ public class BgpRibGroupsTest {
 
     // Only 2.2.2.0/24 in VRF2
     Set<AnnotatedRoute<AbstractRoute>> vrf2Routes =
-        dp.getRibsForTesting().get("r1").get(VRF_2).getTypedRoutes();
+        dp.getRibsForTesting().get("r1").get(VRF_2).getRoutes();
     assertThat(vrf2Routes, hasSize(1));
     assertThat(
         vrf2Routes,
@@ -296,7 +296,7 @@ public class BgpRibGroupsTest {
 
     // 3.3.3.0/24 as expected in default VRF
     Set<AnnotatedRoute<AbstractRoute>> defaultVrfRoutes =
-        dp.getRibsForTesting().get("r1").get(Configuration.DEFAULT_VRF_NAME).getTypedRoutes();
+        dp.getRibsForTesting().get("r1").get(Configuration.DEFAULT_VRF_NAME).getRoutes();
     assertThat(
         defaultVrfRoutes,
         hasItem(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -133,11 +133,11 @@ public class BgpRoutingProcessTest {
   @Test
   public void testInitRibsEmpty() {
     // iBGP
-    assertThat(_routingProcess._ibgpv4Rib.getRoutes(), empty());
+    assertThat(_routingProcess._ibgpv4Rib.getUnannotatedRoutes(), empty());
     // eBGP
-    assertThat(_routingProcess._ebgpv4Rib.getRoutes(), empty());
+    assertThat(_routingProcess._ebgpv4Rib.getUnannotatedRoutes(), empty());
     // Combined bgp
-    assertThat(_routingProcess._bgpv4Rib.getRoutes(), empty());
+    assertThat(_routingProcess._bgpv4Rib.getUnannotatedRoutes(), empty());
   }
 
   @Test
@@ -658,7 +658,7 @@ public class BgpRoutingProcessTest {
     _routingProcess.initialize(node);
     _routingProcess.executeIteration(ImmutableMap.of());
     assertThat(
-        _routingProcess._bgpv4Rib.getRoutes(),
+        _routingProcess._bgpv4Rib.getUnannotatedRoutes(),
         contains(
             isBgpv4RouteThat(
                 allOf(hasPrefix(prefix1), hasProtocol(RoutingProtocol.BGP), isNonRouting(true)))));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
@@ -241,7 +241,7 @@ public class EvpnTest {
                       hasCommunities(ExtendedCommunity.target(65000, 10020))))));
       // Ensure not in main RIB
       assertThat(
-          mainRibRoutes.get(exitGw).get(vrf1).getRoutes(),
+          mainRibRoutes.get(exitGw).get(vrf1).getUnannotatedRoutes(),
           not(hasItem(hasPrefix(leaf1VtepPrefix))));
       // Locally-generated routes will have no next hop ip in the EVPN rib
       assertThat(
@@ -280,7 +280,7 @@ public class EvpnTest {
                       hasCommunities(ExtendedCommunity.target(65000, 10020))))));
       // Ensure not in main RIB
       assertThat(
-          mainRibRoutes.get(leaf1).get(vrf1).getRoutes(),
+          mainRibRoutes.get(leaf1).get(vrf1).getUnannotatedRoutes(),
           not(hasItem(hasPrefix(exitgwVtepPrefix))));
       // Locally-generated routes will have no next hop ip in the EVPN rib
       assertThat(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -194,13 +194,13 @@ public class IsisTest {
     Prefix r2LoopbackPrefix = R2_LOOPBACK_IP.toPrefix();
 
     Set<IsisRoute> r1L1RibRoutes =
-        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
+        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
     Set<IsisRoute> r2L1RibRoutes =
-        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
+        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
     Set<IsisRoute> r1L2RibRoutes =
-        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
+        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getRoutes();
     Set<IsisRoute> r2L2RibRoutes =
-        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
+        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getRoutes();
 
     // L1 RIBs lack the other's loopback, but have default route (see VirtualRouter.initIsisImports)
     assertThat(
@@ -253,13 +253,13 @@ public class IsisTest {
     Prefix r2LoopbackPrefix = R2_LOOPBACK_IP.toPrefix();
 
     Set<IsisRoute> r1L1RibRoutes =
-        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
+        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
     Set<IsisRoute> r2L1RibRoutes =
-        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
+        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes();
     Set<IsisRoute> r1L2RibRoutes =
-        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
+        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getRoutes();
     Set<IsisRoute> r2L2RibRoutes =
-        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
+        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getRoutes();
 
     // L1 RIBs have the other's loopback and default route (see VirtualRouter.initIsisImports)
     assertThat(
@@ -523,16 +523,26 @@ public class IsisTest {
 
     // Assert r1/r2 have empty l1 rib
     assertThat(
-        dp.getNodes().get("r1").getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes(),
+        dp.getNodes()
+            .get("r1")
+            .getVirtualRouterOrThrow(DEFAULT_VRF_NAME)
+            ._isisL1Rib
+            .getUnannotatedRoutes(),
         empty());
     assertThat(
-        dp.getNodes().get("r2").getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes(),
+        dp.getNodes()
+            .get("r2")
+            .getVirtualRouterOrThrow(DEFAULT_VRF_NAME)
+            ._isisL1Rib
+            .getUnannotatedRoutes(),
         empty());
 
     // Assert r3 has disjoint l1/l2 ribs
     VirtualRouter r3Vr = dp.getNodes().get("r3").getVirtualRouterOrThrow(DEFAULT_VRF_NAME);
     assertThat(
-        Sets.intersection(r3Vr._isisL1Rib.getRoutes(), r3Vr._isisL2Rib.getRoutes()), empty());
+        Sets.intersection(
+            r3Vr._isisL1Rib.getUnannotatedRoutes(), r3Vr._isisL2Rib.getUnannotatedRoutes()),
+        empty());
   }
 
   /* Sets up a 4-node network. See details in testIsisOverload() */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -248,7 +248,7 @@ public class VirtualRouterTest {
     vr.activateStaticRoutes(new PreDataPlaneTrackMethodEvaluator(vr.getConfiguration()));
 
     // Assert dependent route is not there
-    assertThat(vr.getMainRib().getRoutes(), not(hasItem(dependentRoute)));
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), not(hasItem(dependentRoute)));
   }
 
   /** Check that initialization of Connected RIB is as expected */
@@ -264,7 +264,7 @@ public class VirtualRouterTest {
 
     // Assert that all interface prefixes have been processed
     assertThat(
-        vr.getConnectedRib().getTypedRoutes(),
+        vr.getConnectedRib().getRoutes(),
         equalTo(
             exampleInterfaceAddresses.entrySet().stream()
                 .map(
@@ -312,7 +312,7 @@ public class VirtualRouterTest {
     // The kernel routes not requiring owned IPs should be present in the independent RIB.
     // All others should be present in _kernelConditionalRoutes.
     assertThat(
-        vr._independentRib.getTypedRoutes(),
+        vr._independentRib.getRoutes(),
         containsInAnyOrder(vr.annotateRoute(noRequiredOwnedIpRoute)));
     assertThat(
         vr._kernelConditionalRoutes,
@@ -362,7 +362,7 @@ public class VirtualRouterTest {
 
     // Assert that all interface prefixes have been processed
     assertThat(
-        vr._localRib.getTypedRoutes(),
+        vr._localRib.getRoutes(),
         equalTo(
             exampleInterfaceAddresses.entrySet().stream()
                 .filter(e -> e.getValue().getPrefix().getPrefixLength() < Prefix.MAX_PREFIX_LENGTH)
@@ -417,9 +417,9 @@ public class VirtualRouterTest {
     // Test
     vr.initStaticRibs();
 
-    assertThat(vr._staticUnconditionalRib.getTypedRoutes(), containsInAnyOrder(routes.get(3)));
+    assertThat(vr._staticUnconditionalRib.getRoutes(), containsInAnyOrder(routes.get(3)));
     assertThat(
-        vr._staticConditionalRib.getTypedRoutes(),
+        vr._staticConditionalRib.getRoutes(),
         containsInAnyOrder(routes.get(0), routes.get(1), routes.get(2)));
   }
 
@@ -431,18 +431,18 @@ public class VirtualRouterTest {
     vr.initRibs();
 
     // Simple RIBs
-    assertThat(vr.getConnectedRib().getRoutes(), empty());
-    assertThat(vr._staticConditionalRib.getRoutes(), empty());
-    assertThat(vr._staticUnconditionalRib.getRoutes(), empty());
-    assertThat(vr._independentRib.getRoutes(), empty());
+    assertThat(vr.getConnectedRib().getUnannotatedRoutes(), empty());
+    assertThat(vr._staticConditionalRib.getUnannotatedRoutes(), empty());
+    assertThat(vr._staticUnconditionalRib.getUnannotatedRoutes(), empty());
+    assertThat(vr._independentRib.getUnannotatedRoutes(), empty());
 
     // RIP RIBs
-    assertThat(vr._ripInternalRib.getRoutes(), empty());
-    assertThat(vr._ripInternalStagingRib.getRoutes(), empty());
-    assertThat(vr._ripRib.getRoutes(), empty());
+    assertThat(vr._ripInternalRib.getUnannotatedRoutes(), empty());
+    assertThat(vr._ripInternalStagingRib.getUnannotatedRoutes(), empty());
+    assertThat(vr._ripRib.getUnannotatedRoutes(), empty());
 
     // Main RIB
-    assertThat(vr.getMainRib().getRoutes(), empty());
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), empty());
   }
 
   /** Check that initialization of RIP internal routes happens correctly */
@@ -455,7 +455,7 @@ public class VirtualRouterTest {
     vr.initBaseRipRoutes();
 
     // Check that nothing happens
-    assertThat(vr._ripInternalRib.getRoutes(), empty());
+    assertThat(vr._ripInternalRib.getUnannotatedRoutes(), empty());
 
     // Complete setup by adding a process
     RipProcess ripProcess = new RipProcess();
@@ -465,7 +465,7 @@ public class VirtualRouterTest {
     vr.initBaseRipRoutes();
 
     assertThat(
-        vr._ripInternalRib.getTypedRoutes(),
+        vr._ripInternalRib.getRoutes(),
         equalTo(
             exampleInterfaceAddresses.entrySet().stream()
                 .map(
@@ -500,7 +500,7 @@ public class VirtualRouterTest {
     // Test
     vr.initStaticRibs();
 
-    assertThat(vr._staticConditionalRib.getTypedRoutes(), equalTo(routeSet));
+    assertThat(vr._staticConditionalRib.getRoutes(), equalTo(routeSet));
   }
 
   /** Test basic message queuing operations */
@@ -843,7 +843,7 @@ public class VirtualRouterTest {
     emptyVr.initCrossVrfQueues();
     emptyVr.initCrossVrfImports();
     emptyVr.processCrossVrfRoutes();
-    assertThat(emptyVr.getMainRib().getTypedRoutes(), equalTo(annotatedRoutes));
+    assertThat(emptyVr.getMainRib().getRoutes(), equalTo(annotatedRoutes));
 
     // Clear emptyVr's RIB and queues and run intermediate leaking (i.e. what would happen in one
     // computeDependentRoutesIteration()); all routes should leak from vrWithRoutes' main RIB delta
@@ -851,7 +851,7 @@ public class VirtualRouterTest {
     emptyVr.initCrossVrfQueues();
     emptyVr.queueCrossVrfImports();
     emptyVr.processCrossVrfRoutes();
-    assertThat(emptyVr.getMainRib().getTypedRoutes(), equalTo(annotatedRoutes));
+    assertThat(emptyVr.getMainRib().getRoutes(), equalTo(annotatedRoutes));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
@@ -195,64 +195,64 @@ public class BgpRibTest {
       Bgpv4Rib rib = makeRib.get();
 
       rib.mergeRoute(nh1);
-      assertThat(rib.getTypedRoutes(), contains(nh1));
+      assertThat(rib.getRoutes(), contains(nh1));
       assertThat(rib.getRoutes(Prefix.ZERO), contains(nh1));
 
       rib.mergeRoute(nh2better);
-      assertThat(rib.getTypedRoutes(), containsInAnyOrder(nh1, nh2better));
+      assertThat(rib.getRoutes(), containsInAnyOrder(nh1, nh2better));
       assertThat(rib.getRoutes(Prefix.ZERO), containsInAnyOrder(nh1, nh2better));
 
       assertThat(
           rib.multipathMergeRouteGetDelta(nh2worse).getMultipathDelta(), equalTo(RibDelta.empty()));
-      assertThat(rib.getTypedRoutes(), containsInAnyOrder(nh1, nh2better));
+      assertThat(rib.getRoutes(), containsInAnyOrder(nh1, nh2better));
       assertThat(rib.getRoutes(Prefix.ZERO), containsInAnyOrder(nh1, nh2better));
     }
     {
       Bgpv4Rib rib = makeRib.get();
 
       rib.mergeRoute(nh1);
-      assertThat(rib.getTypedRoutes(), contains(nh1));
+      assertThat(rib.getRoutes(), contains(nh1));
       assertThat(rib.getRoutes(Prefix.ZERO), contains(nh1));
 
       rib.mergeRoute(nh2worse);
-      assertThat(rib.getTypedRoutes(), containsInAnyOrder(nh1, nh2worse));
+      assertThat(rib.getRoutes(), containsInAnyOrder(nh1, nh2worse));
       assertThat(rib.getRoutes(Prefix.ZERO), containsInAnyOrder(nh1, nh2worse));
 
       assertThat(
           rib.multipathMergeRouteGetDelta(nh2better).getMultipathDelta(),
           equalTo(RibDelta.builder().remove(nh2worse, Reason.REPLACE).add(nh2better).build()));
-      assertThat(rib.getTypedRoutes(), containsInAnyOrder(nh1, nh2better));
+      assertThat(rib.getRoutes(), containsInAnyOrder(nh1, nh2better));
       assertThat(rib.getRoutes(Prefix.ZERO), containsInAnyOrder(nh1, nh2better));
 
       assertThat(
           rib.multipathRemoveRouteGetDelta(nh2better).getMultipathDelta(),
           equalTo(RibDelta.builder().remove(nh2better, Reason.WITHDRAW).add(nh2worse).build()));
-      assertThat(rib.getTypedRoutes(), containsInAnyOrder(nh1, nh2worse));
+      assertThat(rib.getRoutes(), containsInAnyOrder(nh1, nh2worse));
       assertThat(rib.getRoutes(Prefix.ZERO), containsInAnyOrder(nh1, nh2worse));
     }
     {
       Bgpv4Rib rib = makeRib.get();
 
       rib.mergeRoute(nh2worse);
-      assertThat(rib.getTypedRoutes(), contains(nh2worse));
+      assertThat(rib.getRoutes(), contains(nh2worse));
       assertThat(rib.getRoutes(Prefix.ZERO), contains(nh2worse));
 
       assertThat(
           rib.multipathMergeRouteGetDelta(nh2better).getMultipathDelta(),
           equalTo(RibDelta.builder().remove(nh2worse, Reason.REPLACE).add(nh2better).build()));
-      assertThat(rib.getTypedRoutes(), contains(nh2better));
+      assertThat(rib.getRoutes(), contains(nh2better));
       assertThat(rib.getRoutes(Prefix.ZERO), contains(nh2better));
 
       assertThat(
           rib.multipathMergeRouteGetDelta(nh3best).getMultipathDelta(),
           equalTo(RibDelta.builder().remove(nh2better, Reason.REPLACE).add(nh3best).build()));
-      assertThat(rib.getTypedRoutes(), contains(nh3best));
+      assertThat(rib.getRoutes(), contains(nh3best));
       assertThat(rib.getRoutes(Prefix.ZERO), contains(nh3best));
 
       assertThat(
           rib.multipathRemoveRouteGetDelta(nh3best).getMultipathDelta(),
           equalTo(RibDelta.builder().remove(nh3best, Reason.WITHDRAW).add(nh2better).build()));
-      assertThat(rib.getTypedRoutes(), contains(nh2better));
+      assertThat(rib.getRoutes(), contains(nh2better));
       assertThat(rib.getRoutes(Prefix.ZERO), contains(nh2better));
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
@@ -178,7 +178,7 @@ public class Bgpv4RibTest {
     // update resolvability in BGP RIB.
     bestPathRib.updateActiveRoutes(rb1ResolverDelta);
     // rb1 should not be activated now, since it should have been erased when rb2 was added.
-    assertThat(bestPathRib.getRoutes(), not(hasItem(rb1)));
+    assertThat(bestPathRib.getUnannotatedRoutes(), not(hasItem(rb1)));
   }
 
   @Test
@@ -277,7 +277,7 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(best));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
@@ -289,7 +289,7 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(best));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
@@ -300,7 +300,7 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(best));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
@@ -312,7 +312,7 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(best));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
@@ -325,11 +325,11 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(worst);
     _multiPathRib.mergeRoute(medium);
 
-    assertThat(_multiPathRib.getRoutes(), contains(medium));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(medium));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(medium));
 
     _multiPathRib.mergeRoute(best);
-    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(best));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
@@ -341,7 +341,7 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(best));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
@@ -353,7 +353,7 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(best));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
@@ -385,7 +385,7 @@ public class Bgpv4RibTest {
 
     rib.mergeRoute(worse);
     rib.mergeRoute(best);
-    assertThat(rib.getRoutes(), contains(best));
+    assertThat(rib.getUnannotatedRoutes(), contains(best));
     assertThat(rib.getBestPathRoutes(), contains(best));
   }
 
@@ -424,7 +424,7 @@ public class Bgpv4RibTest {
 
     rib.mergeRoute(worse);
     rib.mergeRoute(best);
-    assertThat(rib.getRoutes(), contains(best));
+    assertThat(rib.getUnannotatedRoutes(), contains(best));
     assertThat(rib.getBestPathRoutes(), contains(best));
   }
 
@@ -471,7 +471,7 @@ public class Bgpv4RibTest {
 
     rib.mergeRoute(worse);
     rib.mergeRoute(best);
-    assertThat(rib.getRoutes(), contains(best));
+    assertThat(rib.getUnannotatedRoutes(), contains(best));
     assertThat(rib.getBestPathRoutes(), contains(best));
   }
 
@@ -504,7 +504,7 @@ public class Bgpv4RibTest {
     rib.mergeRoute(base);
     assertTrue("Exact AS path match, allow merge", rib.mergeRoute(candidate1));
     assertFalse("Not an exact AS path match, don't merge", rib.mergeRoute(candidate2));
-    assertThat(rib.getRoutes(), hasSize(2));
+    assertThat(rib.getUnannotatedRoutes(), hasSize(2));
     assertThat(rib.getBestPathRoutes(), hasSize(1));
   }
 
@@ -537,7 +537,7 @@ public class Bgpv4RibTest {
     rib.mergeRoute(base);
     assertTrue("Exact AS path match, allow merge", rib.mergeRoute(candidate1));
     assertFalse("Not an exact AS path match, don't merge", rib.mergeRoute(candidate2));
-    assertThat(rib.getRoutes(), hasSize(2));
+    assertThat(rib.getUnannotatedRoutes(), hasSize(2));
     assertThat(rib.getBestPathRoutes(), hasSize(1));
   }
 
@@ -555,7 +555,7 @@ public class Bgpv4RibTest {
             .setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3")))
             .build());
     _multiPathRib.mergeRoute(bestPath);
-    assertThat(_multiPathRib.getRoutes(), hasSize(3));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), hasSize(3));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
@@ -586,7 +586,7 @@ public class Bgpv4RibTest {
             .build());
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), hasSize(3));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), hasSize(3));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(earliest));
   }
 
@@ -606,7 +606,7 @@ public class Bgpv4RibTest {
             .setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.4")))
             .build());
 
-    assertThat(_multiPathRib.getRoutes(), hasSize(3));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), hasSize(3));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
@@ -623,7 +623,7 @@ public class Bgpv4RibTest {
             .build());
     _multiPathRib.mergeRoute(bestPath);
 
-    assertThat(_multiPathRib.getRoutes(), hasSize(3));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), hasSize(3));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
@@ -634,7 +634,7 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(bestPath);
     _multiPathRib.mergeRoute(bestPath);
 
-    assertThat(_multiPathRib.getRoutes(), hasSize(1));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), hasSize(1));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
@@ -653,12 +653,12 @@ public class Bgpv4RibTest {
             .setNextHop(NextHopIp.of(Ip.parse("2.2.2.3")))
             .build());
 
-    assertThat(_multiPathRib.getRoutes(), hasSize(3));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), hasSize(3));
     assertThat(_multiPathRib.getBestPathRoutes(), hasSize(1));
     Bgpv4Route bestPath = _rb.setLocalPreference(1000).build();
     _multiPathRib.mergeRoute(bestPath);
 
-    assertThat(_multiPathRib.getRoutes(), contains(bestPath));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), contains(bestPath));
     assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
@@ -680,7 +680,7 @@ public class Bgpv4RibTest {
     bestPathRib.mergeRoute(_rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("2.2.2.3"))).build());
     bestPathRib.mergeRoute(bestPath);
 
-    assertThat(bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(bestPathRib.getUnannotatedRoutes(), contains(bestPath));
     assertThat(bestPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
@@ -690,8 +690,8 @@ public class Bgpv4RibTest {
     _multiPathRib.mergeRoute(_rb.setNetwork(Prefix.parse("10.1.0.0/16")).build());
     _multiPathRib.mergeRoute(_rb.setNetwork(Prefix.parse("10.1.1.0/24")).build());
 
-    assertThat(_multiPathRib.getRoutes(), hasSize(3));
-    assertThat(_multiPathRib.getRoutes(), equalTo(_multiPathRib.getBestPathRoutes()));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), hasSize(3));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), equalTo(_multiPathRib.getBestPathRoutes()));
 
     _multiPathRib.mergeRoute(
         _rb.setNetwork(Prefix.parse("10.1.1.0/24"))
@@ -699,7 +699,7 @@ public class Bgpv4RibTest {
             .setNextHop(NextHopIp.of(Ip.parse("22.22.22.22")))
             .setReceivedFrom(ReceivedFromIp.of(Ip.parse("22.22.22.22")))
             .build());
-    assertThat(_multiPathRib.getRoutes(), hasSize(4));
+    assertThat(_multiPathRib.getUnannotatedRoutes(), hasSize(4));
     assertThat(_multiPathRib.getBestPathRoutes(), hasSize(3));
   }
 
@@ -709,7 +709,7 @@ public class Bgpv4RibTest {
     Bgpv4Route bestPath = _rb.setLocalPreference(200).build();
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(_bestPathRib.getUnannotatedRoutes(), contains(bestPath));
   }
 
   @Test
@@ -719,7 +719,7 @@ public class Bgpv4RibTest {
     Bgpv4Route bestPath = _rb.setOriginatorIp(Ip.parse("1.1.0.1")).build();
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(_bestPathRib.getUnannotatedRoutes(), contains(bestPath));
   }
 
   @Test
@@ -729,7 +729,7 @@ public class Bgpv4RibTest {
     Bgpv4Route bestPath = _rb.setReceivedFrom(ReceivedFromIp.of(Ip.parse("1.1.0.1"))).build();
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(_bestPathRib.getUnannotatedRoutes(), contains(bestPath));
   }
 
   @Test
@@ -754,7 +754,7 @@ public class Bgpv4RibTest {
             .setReceivedFrom(ReceivedFromIp.of(Ip.parse("1.1.0.1")))
             .build());
 
-    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(_bestPathRib.getUnannotatedRoutes(), contains(bestPath));
   }
 
   @Test
@@ -778,7 +778,7 @@ public class Bgpv4RibTest {
     _bestPathRib.mergeRoute(earliestPath);
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(_bestPathRib.getUnannotatedRoutes(), contains(bestPath));
   }
 
   @Test
@@ -807,7 +807,7 @@ public class Bgpv4RibTest {
     _bestPathRib.mergeRoute(earliestPath);
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(_bestPathRib.getUnannotatedRoutes(), contains(bestPath));
   }
 
   @Test
@@ -836,7 +836,7 @@ public class Bgpv4RibTest {
     _bestPathRib.mergeRoute(earliestPath);
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(_bestPathRib.getUnannotatedRoutes(), contains(bestPath));
   }
 
   /** We should not merge routes for which next hop is unreachable */
@@ -1006,7 +1006,7 @@ public class Bgpv4RibTest {
     /*
      * Initialize the matchers with respect to the output route set
      */
-    Set<Bgpv4Route> postMergeRoutes = bmr.getTypedRoutes();
+    Set<Bgpv4Route> postMergeRoutes = bmr.getRoutes();
     Matcher<Bgpv4Route> present = in(postMergeRoutes);
     Matcher<Bgpv4Route> absent = not(present);
 
@@ -1333,7 +1333,7 @@ public class Bgpv4RibTest {
 
       // Add dependent route. It should not be activated since it isn't resolvable in the main RIB
       assertThat(bgpRib.mergeRouteGetDelta(dependentRoute), equalTo(RibDelta.empty()));
-      assertThat(bgpRib.getTypedRoutes(), empty());
+      assertThat(bgpRib.getRoutes(), empty());
 
       // Add resolving route to main RIB and update BGP. Dependent route should be activated
       RibDelta<AnnotatedRoute<AbstractRoute>> mainRibDelta =
@@ -1341,7 +1341,7 @@ public class Bgpv4RibTest {
       assertThat(
           bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
           equalTo(RibDelta.adding(dependentRoute)));
-      assertThat(bgpRib.getTypedRoutes(), contains(dependentRoute));
+      assertThat(bgpRib.getRoutes(), contains(dependentRoute));
     }
     {
       // Main RIB initially does contain resolving route
@@ -1362,7 +1362,7 @@ public class Bgpv4RibTest {
       // Add dependent route. It should be activated because it is resolvable in the main RIB
       assertThat(
           bgpRib.mergeRouteGetDelta(dependentRoute), equalTo(RibDelta.adding(dependentRoute)));
-      assertThat(bgpRib.getTypedRoutes(), contains(dependentRoute));
+      assertThat(bgpRib.getRoutes(), contains(dependentRoute));
 
       // Remove resolving route from main RIB and update BGP. Dependent route should be deactivated
       RibDelta<AnnotatedRoute<AbstractRoute>> mainRibDelta =
@@ -1370,14 +1370,14 @@ public class Bgpv4RibTest {
       assertThat(
           bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
           equalTo(RibDelta.of(RouteAdvertisement.withdrawing(dependentRoute))));
-      assertThat(bgpRib.getTypedRoutes(), empty());
+      assertThat(bgpRib.getRoutes(), empty());
 
       // Re-add resolving route from main RIB and update BGP. Dependent route should be reactivated
       mainRibDelta = mainRib.mergeRouteGetDelta(resolvingRoute);
       assertThat(
           bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
           equalTo(RibDelta.of(RouteAdvertisement.adding(dependentRoute))));
-      assertThat(bgpRib.getTypedRoutes(), contains(dependentRoute));
+      assertThat(bgpRib.getRoutes(), contains(dependentRoute));
     }
     {
       // Test of next hop IP LPM resolver restriction
@@ -1401,7 +1401,7 @@ public class Bgpv4RibTest {
 
       // Add dependent route. It should be inactive because there is no resolver in the main RIB
       assertThat(bgpRib.mergeRouteGetDelta(dependentRoute), equalTo(RibDelta.empty()));
-      assertThat(bgpRib.getTypedRoutes(), empty());
+      assertThat(bgpRib.getRoutes(), empty());
 
       // Add resolving route that DOES NOT pass restriction to main RIB and update BGP. No change
       // should occur to BGP RIB.
@@ -1409,7 +1409,7 @@ public class Bgpv4RibTest {
           mainRib.mergeRouteGetDelta(resolvingRoute1);
       assertThat(
           bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(), equalTo(RibDelta.empty()));
-      assertThat(bgpRib.getTypedRoutes(), empty());
+      assertThat(bgpRib.getRoutes(), empty());
 
       // Add resolving route that DOES pass restriction to main RIB and update BGP. BGP RIB should
       // gain dependent route.
@@ -1417,7 +1417,7 @@ public class Bgpv4RibTest {
       assertThat(
           bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
           equalTo(RibDelta.of(RouteAdvertisement.adding(dependentRoute))));
-      assertThat(bgpRib.getTypedRoutes(), contains(dependentRoute));
+      assertThat(bgpRib.getRoutes(), contains(dependentRoute));
     }
   }
 
@@ -1458,7 +1458,7 @@ public class Bgpv4RibTest {
       // Add less preferred NHIP route
       assertThat(
           bgpRib.mergeRouteGetDelta(highestNhipRoute), equalTo(RibDelta.adding(highestNhipRoute)));
-      assertThat(bgpRib.getTypedRoutes(), contains(highestNhipRoute));
+      assertThat(bgpRib.getRoutes(), contains(highestNhipRoute));
 
       // Add more preferred NHIP route. Less preferred route should be removed, and should not
       // appear in backup.
@@ -1468,7 +1468,7 @@ public class Bgpv4RibTest {
           containsInAnyOrder(
               RouteAdvertisement.adding(lowestNhipRoute),
               RouteAdvertisement.withdrawing(highestNhipRoute)));
-      assertThat(bgpRib.getTypedBackupRoutes(), not(hasItem(highestNhipRoute)));
+      assertThat(bgpRib.getBackupRoutes(), not(hasItem(highestNhipRoute)));
 
       // Remove less preferred NHIP route. There should be no delta.
       assertThat(bgpRib.removeRouteGetDelta(highestNhipRoute), equalTo(RibDelta.empty()));
@@ -1516,7 +1516,7 @@ public class Bgpv4RibTest {
       // Add less preferred NHIP route
       assertThat(
           bgpRib.mergeRouteGetDelta(lowestNhipRoute), equalTo(RibDelta.adding(lowestNhipRoute)));
-      assertThat(bgpRib.getTypedRoutes(), contains(lowestNhipRoute));
+      assertThat(bgpRib.getRoutes(), contains(lowestNhipRoute));
 
       // Add more preferred NHIP route. Less preferred route should be removed, and should not
       // appear in backup.
@@ -1526,7 +1526,7 @@ public class Bgpv4RibTest {
           containsInAnyOrder(
               RouteAdvertisement.adding(highestNhipRoute),
               RouteAdvertisement.withdrawing(lowestNhipRoute)));
-      assertThat(bgpRib.getTypedBackupRoutes(), not(hasItem(lowestNhipRoute)));
+      assertThat(bgpRib.getBackupRoutes(), not(hasItem(lowestNhipRoute)));
 
       // Remove less preferred NHIP route. There should be no delta.
       assertThat(bgpRib.removeRouteGetDelta(lowestNhipRoute), equalTo(RibDelta.empty()));
@@ -1574,7 +1574,7 @@ public class Bgpv4RibTest {
       // Add less preferred NHIP route
       assertThat(
           bgpRib.mergeRouteGetDelta(highestNhipRoute), equalTo(RibDelta.adding(highestNhipRoute)));
-      assertThat(bgpRib.getTypedRoutes(), contains(highestNhipRoute));
+      assertThat(bgpRib.getRoutes(), contains(highestNhipRoute));
 
       // Add more preferred NHIP route. Less preferred route should be removed, and should not
       // appear in backup.
@@ -1584,7 +1584,7 @@ public class Bgpv4RibTest {
           containsInAnyOrder(
               RouteAdvertisement.adding(lowestNhipRoute),
               RouteAdvertisement.withdrawing(highestNhipRoute)));
-      assertThat(bgpRib.getTypedBackupRoutes(), not(hasItem(highestNhipRoute)));
+      assertThat(bgpRib.getBackupRoutes(), not(hasItem(highestNhipRoute)));
 
       // Remove less preferred NHIP route. There should be no delta.
       assertThat(bgpRib.removeRouteGetDelta(highestNhipRoute), equalTo(RibDelta.empty()));
@@ -1632,7 +1632,7 @@ public class Bgpv4RibTest {
       // Add less preferred NHIP route
       assertThat(
           bgpRib.mergeRouteGetDelta(lowestNhipRoute), equalTo(RibDelta.adding(lowestNhipRoute)));
-      assertThat(bgpRib.getTypedRoutes(), contains(lowestNhipRoute));
+      assertThat(bgpRib.getRoutes(), contains(lowestNhipRoute));
 
       // Add more preferred NHIP route. Less preferred route should be removed, and should not
       // appear in backup.
@@ -1642,7 +1642,7 @@ public class Bgpv4RibTest {
           containsInAnyOrder(
               RouteAdvertisement.adding(highestNhipRoute),
               RouteAdvertisement.withdrawing(lowestNhipRoute)));
-      assertThat(bgpRib.getTypedBackupRoutes(), not(hasItem(lowestNhipRoute)));
+      assertThat(bgpRib.getBackupRoutes(), not(hasItem(lowestNhipRoute)));
 
       // Remove less preferred NHIP route. There should be no delta.
       assertThat(bgpRib.removeRouteGetDelta(lowestNhipRoute), equalTo(RibDelta.empty()));
@@ -1691,7 +1691,7 @@ public class Bgpv4RibTest {
       bgpRib.mergeRouteGetDelta(redistributeRoute);
 
       // both routes should be present and equally preferred
-      assertThat(bgpRib.getTypedRoutes(), containsInAnyOrder(networkRoute, redistributeRoute));
+      assertThat(bgpRib.getRoutes(), containsInAnyOrder(networkRoute, redistributeRoute));
     }
     {
       // Test origination type tie-breaker: prefer network
@@ -1726,10 +1726,9 @@ public class Bgpv4RibTest {
       bgpRib.mergeRouteGetDelta(redistributeRoute);
 
       // Only network route should be present.
-      assertThat(bgpRib.getTypedRoutes(), contains(networkRoute));
+      assertThat(bgpRib.getRoutes(), contains(networkRoute));
       // Backup should contain redistribute route.
-      assertThat(
-          bgpRib.getTypedBackupRoutes(), containsInAnyOrder(networkRoute, redistributeRoute));
+      assertThat(bgpRib.getBackupRoutes(), containsInAnyOrder(networkRoute, redistributeRoute));
     }
     {
       // Test origination type tie-breaker: prefer redistribute
@@ -1764,10 +1763,9 @@ public class Bgpv4RibTest {
       bgpRib.mergeRouteGetDelta(redistributeRoute);
 
       // Only redistribute route should be present.
-      assertThat(bgpRib.getTypedRoutes(), contains(redistributeRoute));
+      assertThat(bgpRib.getRoutes(), contains(redistributeRoute));
       // Backup should contain network route.
-      assertThat(
-          bgpRib.getTypedBackupRoutes(), containsInAnyOrder(networkRoute, redistributeRoute));
+      assertThat(bgpRib.getBackupRoutes(), containsInAnyOrder(networkRoute, redistributeRoute));
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
@@ -260,6 +260,6 @@ public class RibDeltaTest {
     // Test
     RibDelta.importRibDelta(rib, delta);
     // r1 remains due to different protocol
-    assertThat(rib.getRoutes(), contains(r2));
+    assertThat(rib.getUnannotatedRoutes(), contains(r2));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class RibTest {
   @Test
   public void testCreatedEmpty() {
-    assertThat(new Rib().getRoutes(), empty());
+    assertThat(new Rib().getUnannotatedRoutes(), empty());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -6678,8 +6678,7 @@ public final class FlatJuniperGrammarTest {
     IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
     ImmutableMap<String, Set<AnnotatedRoute<AbstractRoute>>> routes =
         dp.getRibsForTesting().get(hostname).entrySet().stream()
-            .collect(
-                ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getTypedRoutes()));
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getRoutes()));
 
     assertThat(
         routes.get(DEFAULT_VRF_NAME),
@@ -6699,8 +6698,7 @@ public final class FlatJuniperGrammarTest {
 
     ImmutableMap<String, Set<AnnotatedRoute<AbstractRoute>>> routes =
         dp.getRibsForTesting().get(hostname).entrySet().stream()
-            .collect(
-                ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getTypedRoutes()));
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getRoutes()));
     String vrf2Name = "VRF2";
 
     Set<AnnotatedRoute<AbstractRoute>> defaultExpectedRoutes =
@@ -6742,8 +6740,7 @@ public final class FlatJuniperGrammarTest {
 
     ImmutableMap<String, Set<AnnotatedRoute<AbstractRoute>>> routes =
         dp.getRibsForTesting().get(hostname).entrySet().stream()
-            .collect(
-                ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getTypedRoutes()));
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getRoutes()));
     String vrf2Name = "VRF2";
 
     Set<AnnotatedRoute<AbstractRoute>> vrf2ExpectedRoutes =
@@ -6804,8 +6801,7 @@ public final class FlatJuniperGrammarTest {
 
     ImmutableMap<String, Set<AnnotatedRoute<AbstractRoute>>> routes =
         dp.getRibsForTesting().get(hostname).entrySet().stream()
-            .collect(
-                ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getTypedRoutes()));
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, e -> e.getValue().getRoutes()));
     String vrf2Name = "VRF2";
 
     Set<AnnotatedRoute<AbstractRoute>> defaultExpectedRoutes =

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -1038,7 +1038,7 @@ public class RoutesAnswererTest {
     }
 
     @Override
-    public Set<AbstractRoute> getRoutes() {
+    public Set<AbstractRoute> getUnannotatedRoutes() {
       return _routes.stream()
           .map(AbstractRouteDecorator::getAbstractRoute)
           .collect(ImmutableSet.toImmutableSet());
@@ -1052,12 +1052,12 @@ public class RoutesAnswererTest {
     }
 
     @Override
-    public Set<R> getTypedRoutes() {
+    public Set<R> getRoutes() {
       return _routes;
     }
 
     @Override
-    public Set<R> getTypedBackupRoutes() {
+    public Set<R> getBackupRoutes() {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Rather than calling out (some of the) typed functions, call out the untyped ones.
Note that the old getRoutes(Prefix) was typed, but not named so.