### PR TITLE
CommunitySet: stop memoizing hashCode

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import java.math.BigInteger;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -326,7 +325,8 @@ public final class ExtendedCommunity extends Community {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_type, _subType, _value);
+    int valueHash = (int) (_value ^ (_value >>> 32));
+    return 31 * 31 * valueHash + 31 * _type + _subType;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
@@ -100,18 +100,12 @@ public final class CommunitySet implements Serializable {
       return false;
     }
     CommunitySet other = (CommunitySet) obj;
-    return (_hashCode == other._hashCode || _hashCode == 0 || other._hashCode == 0)
-        && _communities.equals(other._communities);
+    return _communities.equals(other._communities);
   }
 
   @Override
   public int hashCode() {
-    int h = _hashCode;
-    if (h == 0) {
-      h = _communities.hashCode();
-      _hashCode = h;
-    }
-    return h;
+    return _communities.hashCode();
   }
 
   @Override
@@ -156,8 +150,6 @@ public final class CommunitySet implements Serializable {
     return of(_communities);
   }
 
-  /* Cache the hashcode */
-  private transient int _hashCode = 0;
   /* Cache conversions to _extendedCommunities and _standardCommunities. */
   private transient @Nullable Set<ExtendedCommunity> _extendedCommunities;
   private transient @Nullable Set<StandardCommunity> _standardCommunities;


### PR DESCRIPTION
We have previously thought that we needed to memoize the
hash code because ImmutableSet does not, but RegularImmutableSet
does, and this covers all practical cases.

---

**Stack**:
- #9037
- #9036 ⬅
- #9035


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*