### PR TITLE
CommunitySet: bump cache up to 16M values

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import java.math.BigInteger;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -326,7 +325,8 @@ public final class ExtendedCommunity extends Community {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_type, _subType, _value);
+    int valueHash = (int) (_value ^ (_value >>> 32));
+    return 31 * 31 * valueHash + 31 * _type + _subType;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
@@ -133,11 +133,11 @@ public final class CommunitySet implements Serializable {
   }
 
   // Soft values: let it be garbage collected in times of pressure.
-  // Maximum size 2^16: Just some upper bound on cache size, well less than GiB.
+  // Maximum size 2^24: Just some upper bound on cache size, well less than GiB.
   private static final LoadingCache<Set<Community>, CommunitySet> CACHE =
       CacheBuilder.newBuilder()
           .softValues()
-          .maximumSize(1 << 16)
+          .maximumSize(1 << 24)
           .build(
               CacheLoader.from(
                   set -> {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
@@ -100,18 +100,12 @@ public final class CommunitySet implements Serializable {
       return false;
     }
     CommunitySet other = (CommunitySet) obj;
-    return (_hashCode == other._hashCode || _hashCode == 0 || other._hashCode == 0)
-        && _communities.equals(other._communities);
+    return _communities.equals(other._communities);
   }
 
   @Override
   public int hashCode() {
-    int h = _hashCode;
-    if (h == 0) {
-      h = _communities.hashCode();
-      _hashCode = h;
-    }
-    return h;
+    return _communities.hashCode();
   }
 
   @Override
@@ -156,8 +150,6 @@ public final class CommunitySet implements Serializable {
     return of(_communities);
   }
 
-  /* Cache the hashcode */
-  private transient int _hashCode = 0;
   /* Cache conversions to _extendedCommunities and _standardCommunities. */
   private transient @Nullable Set<ExtendedCommunity> _extendedCommunities;
   private transient @Nullable Set<StandardCommunity> _standardCommunities;


### PR DESCRIPTION
Still only 128 MiB of (soft) space, but increases hit rate in networks that put
put ASNs in communities.

---

**Stack**:
- #9037 ⬅
- #9036
- #9035


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*