### PR TITLE
ConfigAtomicPredicates: simplify API and refactor test code to testlib

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/ConfigAtomicPredicates.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/ConfigAtomicPredicates.java
@@ -1,8 +1,7 @@
 package org.batfish.minesweeper;
 
-import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
-
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.Collections;
@@ -10,12 +9,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Predicate;
-import javax.annotation.Nonnull;
+import java.util.TreeSet;
 import javax.annotation.Nullable;
-import org.batfish.common.NetworkSnapshot;
-import org.batfish.common.plugin.IBatfish;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -38,6 +36,7 @@ import org.batfish.minesweeper.utils.Tuple;
  * and source VRFs, because they are all independent of one another, so each gets a corresponding
  * BDD variable.)
  */
+@ParametersAreNonnullByDefault
 public final class ConfigAtomicPredicates {
 
   /**
@@ -64,154 +63,69 @@ public final class ConfigAtomicPredicates {
   /** The list of source VRFs that appear in the given configuration. */
   private final List<String> _sourceVrfs;
 
-  /**
-   * Compute atomic predicates for the given router's configuration.
-   *
-   * @param batfish the batfish object
-   * @param snapshot the current snapshot
-   * @param router the name of the router whose configuration is being analyzed
-   */
-  public ConfigAtomicPredicates(IBatfish batfish, NetworkSnapshot snapshot, String router) {
-    this(batfish, snapshot, router, null, null);
-  }
-
-  /**
-   * Compute atomic predicates for the given router's configuration.
-   *
-   * @param batfish the batfish object
-   * @param snapshot the current snapshot
-   * @param router the name of the router whose configuration is being analyzed
-   * @param communities additional community regexes to track, from user-defined constraints
-   * @param asPathRegexes additional as-path regexes to track, from user-defined constraints
-   */
-  public ConfigAtomicPredicates(
-      IBatfish batfish,
-      NetworkSnapshot snapshot,
-      String router,
-      @Nullable Set<CommunityVar> communities,
-      @Nullable Set<String> asPathRegexes) {
-    this(batfish, snapshot, router, communities, asPathRegexes, null);
-  }
-
-  /**
-   * Compute atomic predicates for the given router's configuration.
-   *
-   * @param batfish the batfish object
-   * @param snapshot the current snapshot
-   * @param router the name of the router whose configuration is being analyzed
-   * @param communities additional community regexes to track, from user-defined constraints
-   * @param asPathRegexes additional as-path regexes to track, from user-defined constraints
-   * @param policies the set of policies to create AtomicPredicates for
-   */
-  public ConfigAtomicPredicates(
-      IBatfish batfish,
-      NetworkSnapshot snapshot,
-      String router,
-      @Nullable Set<CommunityVar> communities,
-      @Nullable Set<String> asPathRegexes,
-      @Nullable Collection<RoutingPolicy> policies) {
-    this(
-        batfish,
-        snapshot,
-        null,
-        router,
-        communities,
-        asPathRegexes,
-        policies == null
-            ? batfish.loadConfigurations(snapshot).get(router).getRoutingPolicies().values()
-            : policies,
-        null);
-  }
-
-  /**
-   * Compute atomic predicates for the given router's configuration.
-   *
-   * @param batfish the batfish object
-   * @param snapshot the current snapshot
-   * @param reference the reference snapshot - can be null if this is not called from a differential
-   *     question, such as SRP.
-   * @param router the name of the router whose configuration is being analyzed
-   * @param communities additional community regexes to track, from user-defined constraints
-   * @param asPathRegexes additional as-path regexes to track, from user-defined constraints
-   * @param policies the set of policies to create AtomicPredicates for
-   * @param referencePolicies the set of policies in the reference snapshot to create
-   *     AtomicPredicates for
-   */
-  public ConfigAtomicPredicates(
-      IBatfish batfish,
-      NetworkSnapshot snapshot,
-      @Nullable NetworkSnapshot reference,
-      String router,
-      @Nullable Set<CommunityVar> communities,
-      @Nullable Set<String> asPathRegexes,
-      @Nonnull Collection<RoutingPolicy> policies,
-      @Nullable Collection<RoutingPolicy> referencePolicies) {
-    Configuration configuration = batfish.loadConfigurations(snapshot).get(router);
-    Configuration referenceConfiguration = null;
-    if (reference != null) {
-      referenceConfiguration = batfish.loadConfigurations(reference).get(router);
+  private static boolean isStandardCommunity(CommunityVar var) {
+    if (var.getType() == CommunityVar.Type.REGEX) {
+      // assume all regexes are on standard communities
+      return true;
     }
+    assert var.getType() == CommunityVar.Type.EXACT;
+    return var.getLiteralValue() instanceof StandardCommunity;
+  }
 
-    // Gather the communities from both (if differential) configs + any user provided communities.
-    Set<CommunityVar> allCommunities = findAllCommunities(communities, policies, configuration);
+  /**
+   * Creates a {@link ConfigAtomicPredicates} that supports all relevant constructs referenced in
+   * the given policies, also incorporating the given extra communities or AS-path regexes.
+   *
+   * @param extraCommunities additional community regexes to track, from user-defined constraints
+   * @param extraAsPathRegexes additional as-path regexes to track, from user-defined constraints
+   */
+  public ConfigAtomicPredicates(
+      List<Map.Entry<Configuration, Collection<RoutingPolicy>>> configAndPolicies,
+      Set<CommunityVar> extraCommunities,
+      Set<String> extraAsPathRegexes) {
+    ImmutableSet.Builder<CommunityVar> allCommunitiesB = ImmutableSet.builder();
+    ImmutableSet.Builder<SymbolicAsPathRegex> allAsPathRegexesB = ImmutableSet.builder();
+    Set<String> allTrackNames = new TreeSet<>();
+    Set<String> allNextHopInterfaceNames = new TreeSet<>();
+    Set<String> allSourceVrfNames = new TreeSet<>();
+    allCommunitiesB.addAll(extraCommunities);
+    extraAsPathRegexes.forEach(s -> allAsPathRegexesB.add(new SymbolicAsPathRegex(s)));
 
-    if (reference != null) {
-      allCommunities.addAll(
-          findAllCommunities(Collections.emptySet(), referencePolicies, referenceConfiguration));
+    for (Entry<Configuration, Collection<RoutingPolicy>> pair : configAndPolicies) {
+      Configuration config = pair.getKey();
+      Collection<RoutingPolicy> policies = pair.getValue();
+      allCommunitiesB.addAll(findAllCommunities(ImmutableSet.of(), policies, config));
+      allAsPathRegexesB.addAll(findAllAsPathRegexes(ImmutableSet.of(), policies, config));
+      allTrackNames.addAll(findAllTracks(policies, config));
+      allNextHopInterfaceNames.addAll(findAllNextHopInterfaces(policies, config));
+      allSourceVrfNames.addAll(findAllSourceVrfs(policies, config));
     }
-
-    // currently we only support regex matching for standard communities
-    Predicate<CommunityVar> isStandardCommunity =
-        cvar ->
-            cvar.getType() == CommunityVar.Type.REGEX
-                || cvar.getLiteralValue() instanceof StandardCommunity;
+    Set<CommunityVar> allCommunities = allCommunitiesB.build();
 
     // compute atomic predicates for all regexes and standard community literals
     _standardCommunityAtomicPredicates =
         new RegexAtomicPredicates<>(
             allCommunities.stream()
-                .filter(isStandardCommunity)
+                .filter(ConfigAtomicPredicates::isStandardCommunity)
                 .collect(ImmutableSet.toImmutableSet()),
             CommunityVar.ALL_STANDARD_COMMUNITIES);
 
     // assign an atomic predicate to each extended/large community literal
-    CommunityVar[] nonStandardCommunityVars =
-        allCommunities.stream().filter(isStandardCommunity.negate()).toArray(CommunityVar[]::new);
     int numAPs = _standardCommunityAtomicPredicates.getNumAtomicPredicates();
-    _nonStandardCommunityLiterals = new HashMap<>();
-    for (int i = 0; i < nonStandardCommunityVars.length; i++) {
-      _nonStandardCommunityLiterals.put(i + numAPs, nonStandardCommunityVars[i]);
+    Map<Integer, CommunityVar> nonStandardCommunityLiterals = new HashMap<>();
+    for (CommunityVar var : allCommunities) {
+      if (isStandardCommunity(var)) {
+        continue;
+      }
+      assert var.getType() == CommunityVar.Type.EXACT;
+      nonStandardCommunityLiterals.put(nonStandardCommunityLiterals.size() + numAPs, var);
     }
 
-    // Collect as path regexes from both (if differential) configs
-    Set<String> asPaths = firstNonNull(asPathRegexes, ImmutableSet.of());
-    Set<SymbolicAsPathRegex> asPathAps =
-        new HashSet<>(
-            findAllAsPathRegexes(
-                asPaths.stream()
-                    .map(SymbolicAsPathRegex::new)
-                    .collect(ImmutableSet.toImmutableSet()),
-                policies,
-                configuration));
-    if (reference != null) {
-      asPathAps.addAll(
-          findAllAsPathRegexes(Collections.emptySet(), referencePolicies, referenceConfiguration));
-    }
-    _asPathRegexAtomicPredicates = new AsPathRegexAtomicPredicates(ImmutableSet.copyOf(asPathAps));
-
-    // Collect several other items from both (if differential) configs
-    Set<String> nextHopInterfaces =
-        new HashSet<>(findAllNextHopInterfaces(policies, configuration));
-    Set<String> tracks = new HashSet<>(findAllTracks(policies, configuration));
-    Set<String> sourceVRFs = new HashSet<>(findAllSourceVrfs(policies, configuration));
-    if (reference != null) {
-      nextHopInterfaces.addAll(findAllNextHopInterfaces(referencePolicies, referenceConfiguration));
-      tracks.addAll(findAllTracks(referencePolicies, referenceConfiguration));
-      sourceVRFs.addAll(findAllSourceVrfs(referencePolicies, referenceConfiguration));
-    }
-    _nextHopInterfaces = ImmutableList.copyOf(nextHopInterfaces);
-    _tracks = ImmutableList.copyOf(tracks);
-    _sourceVrfs = ImmutableList.copyOf(sourceVRFs);
+    _nonStandardCommunityLiterals = ImmutableMap.copyOf(nonStandardCommunityLiterals);
+    _asPathRegexAtomicPredicates = new AsPathRegexAtomicPredicates(allAsPathRegexesB.build());
+    _nextHopInterfaces = ImmutableList.copyOf(allNextHopInterfaceNames);
+    _tracks = ImmutableList.copyOf(allTrackNames);
+    _sourceVrfs = ImmutableList.copyOf(allSourceVrfNames);
   }
 
   public ConfigAtomicPredicates(ConfigAtomicPredicates other) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -8,6 +8,7 @@ import static org.batfish.specifier.NameRegexRoutingPolicySpecifier.ALL_ROUTING_
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.questions.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -199,18 +201,18 @@ public final class CompareRoutePoliciesUtils {
       currentPoliciesList.removeIf(p -> !intersection.contains(p.getName()));
     }
 
+    Configuration snapshotConfig = _batfish.loadConfigurations(snapshot).get(node);
+    Configuration refConfig = _batfish.loadConfigurations(reference).get(node);
+
     ConfigAtomicPredicates configAPs =
         new ConfigAtomicPredicates(
-            _batfish,
-            snapshot,
-            reference,
-            node,
+            ImmutableList.of(
+                new SimpleImmutableEntry<>(snapshotConfig, currentPoliciesList),
+                new SimpleImmutableEntry<>(refConfig, referencePoliciesList)),
             _communityRegexes.stream()
                 .map(CommunityVar::from)
                 .collect(ImmutableSet.toImmutableSet()),
-            _asPathRegexes,
-            currentPoliciesList,
-            referencePoliciesList);
+            _asPathRegexes);
 
     if (crossPolicies) {
       // In this case we cross-compare all routing policies in the two sets regardless of their

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import dk.brics.automaton.Automaton;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -578,14 +579,10 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
    * @param policies all route policies in that node
    * @return all results from analyzing those route policies
    */
-  private Stream<Row> searchPoliciesForNode(
-      Configuration config, Set<RoutingPolicy> policies, NetworkSnapshot snapshot) {
-    String node = config.getHostname();
+  private Stream<Row> searchPoliciesForNode(Configuration config, Set<RoutingPolicy> policies) {
     ConfigAtomicPredicates configAPs =
         new ConfigAtomicPredicates(
-            _batfish,
-            snapshot,
-            node,
+            ImmutableList.of(new SimpleImmutableEntry<>(config, policies)),
             _communityRegexes.stream()
                 .flatMap(
                     rc -> {
@@ -607,8 +604,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
                 .collect(ImmutableSet.toImmutableSet()),
             _asPathRegexes.stream()
                 .map(RegexConstraint::getRegex)
-                .collect(ImmutableSet.toImmutableSet()),
-            policies);
+                .collect(ImmutableSet.toImmutableSet()));
 
     return policies.stream().flatMap(policy -> searchPolicy(policy, configAPs).stream());
   }
@@ -650,9 +646,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             .flatMap(
                 node ->
                     searchPoliciesForNode(
-                        context.getConfigs().get(node),
-                        _policySpecifier.resolve(node, context),
-                        snapshot))
+                        context.getConfigs().get(node), _policySpecifier.resolve(node, context)))
             .collect(ImmutableList.toImmutableList());
 
     TableAnswerElement answerElement = new TableAnswerElement(TestRoutePoliciesAnswerer.metadata());

--- a/projects/minesweeper/src/test/java/BUILD.bazel
+++ b/projects/minesweeper/src/test/java/BUILD.bazel
@@ -2,6 +2,17 @@ load("@batfish//skylark:junit.bzl", "junit_tests")
 
 package(default_visibility = ["//visibility:public"])
 
+java_library(
+    name = "minesweeper_testlib",
+    srcs = ["org/batfish/minesweeper/ConfigAtomicPredicatesTestUtils.java"],
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "//projects/minesweeper",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+    ],
+)
+
 junit_tests(
     name = "minesweeper_tests",
     size = "small",
@@ -13,6 +24,7 @@ junit_tests(
         "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
     deps = [
+        ":minesweeper_testlib",
         "//projects/batfish",
         "//projects/batfish:batfish_testlib",
         "//projects/batfish-common-protocol:common",

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/ConfigAtomicPredicatesTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/ConfigAtomicPredicatesTest.java
@@ -1,5 +1,6 @@
 package org.batfish.minesweeper;
 
+import static org.batfish.minesweeper.ConfigAtomicPredicatesTestUtils.forDevice;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -88,8 +89,7 @@ public class ConfigAtomicPredicatesTest {
 
   @Test
   public void testConstructor1() {
-    ConfigAtomicPredicates cap =
-        new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    ConfigAtomicPredicates cap = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     RegexAtomicPredicates<CommunityVar> commAPs = cap.getStandardCommunityAtomicPredicates();
     RegexAtomicPredicates<SymbolicAsPathRegex> asAPs = cap.getAsPathRegexAtomicPredicates();
@@ -109,8 +109,7 @@ public class ConfigAtomicPredicatesTest {
 
   @Test
   public void testConstructor2Null() {
-    ConfigAtomicPredicates cap =
-        new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME, null, null);
+    ConfigAtomicPredicates cap = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     RegexAtomicPredicates<CommunityVar> commAPs = cap.getStandardCommunityAtomicPredicates();
     RegexAtomicPredicates<SymbolicAsPathRegex> asAPs = cap.getAsPathRegexAtomicPredicates();
@@ -131,7 +130,7 @@ public class ConfigAtomicPredicatesTest {
   @Test
   public void testConstructor2() {
     ConfigAtomicPredicates cap =
-        new ConfigAtomicPredicates(
+        forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,
@@ -157,7 +156,7 @@ public class ConfigAtomicPredicatesTest {
   @Test
   public void testConstructor3() {
     ConfigAtomicPredicates cap =
-        new ConfigAtomicPredicates(
+        forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,
@@ -186,7 +185,7 @@ public class ConfigAtomicPredicatesTest {
   @Test
   public void testCopyConstructor() {
     ConfigAtomicPredicates cap =
-        new ConfigAtomicPredicates(
+        forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,
@@ -236,8 +235,7 @@ public class ConfigAtomicPredicatesTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of("firstPolicy", firstPolicy, "secondPolicy", secondPolicy));
-    ConfigAtomicPredicates cap =
-        new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    ConfigAtomicPredicates cap = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     assertEquals(3, cap.getStandardCommunityAtomicPredicates().getNumAtomicPredicates());
   }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/ConfigAtomicPredicatesTestUtils.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/ConfigAtomicPredicatesTestUtils.java
@@ -1,0 +1,49 @@
+package org.batfish.minesweeper;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Configuration;
+
+public final class ConfigAtomicPredicatesTestUtils {
+
+  /** Create a {@link ConfigAtomicPredicates} for all routing policies on the named device. */
+  public static ConfigAtomicPredicates forDevice(
+      IBatfish batfish, NetworkSnapshot snapshot, String hostname) {
+    return forDevice(batfish, snapshot, hostname, null, null);
+  }
+
+  /**
+   * Create a {@link ConfigAtomicPredicates} for all routing policies on the named device.
+   *
+   * @param batfish the batfish object
+   * @param snapshot the current snapshot
+   * @param hostname the name of the device whose configuration is being analyzed
+   * @param extraCommunities additional community regexes to track, from user-defined constraints
+   * @param extraAsPathRegexes additional as-path regexes to track, from user-defined constraints
+   */
+  public static ConfigAtomicPredicates forDevice(
+      IBatfish batfish,
+      NetworkSnapshot snapshot,
+      String hostname,
+      @Nullable Set<CommunityVar> extraCommunities,
+      @Nullable Set<String> extraAsPathRegexes) {
+    Map<String, Configuration> configs = batfish.loadConfigurations(snapshot);
+    @Nullable Configuration config = configs.get(hostname);
+    checkArgument(config != null, "Missing configuration for device %s", hostname);
+    return new ConfigAtomicPredicates(
+        ImmutableList.of(new SimpleImmutableEntry<>(config, config.getRoutingPolicies().values())),
+        firstNonNull(extraCommunities, ImmutableSet.of()),
+        firstNonNull(extraAsPathRegexes, ImmutableSet.of()));
+  }
+
+  private ConfigAtomicPredicatesTestUtils() {}
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/AsPathMatchExprToRegexesTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/AsPathMatchExprToRegexesTest.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.routing_policy.expr.IntComparator;
 import org.batfish.datamodel.routing_policy.expr.IntComparison;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.batfish.minesweeper.ConfigAtomicPredicatesTestUtils;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
 import org.junit.Before;
 import org.junit.Rule;
@@ -57,7 +58,7 @@ public class AsPathMatchExprToRegexesTest {
         new TransferBDDTest.MockBatfish(ImmutableSortedMap.of(HOSTNAME, _baseConfig));
 
     ConfigAtomicPredicates configAPs =
-        new ConfigAtomicPredicates(
+        ConfigAtomicPredicatesTestUtils.forDevice(
             batfish, batfish.getSnapshot(), HOSTNAME, null, ImmutableSet.of(ASPATH1, ASPATH2));
     TransferBDD transferBDD =
         new TransferBDD(

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDDTest.java
@@ -51,6 +51,7 @@ import org.batfish.datamodel.routing_policy.expr.LongComparison;
 import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.CommunityVar.Type;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.batfish.minesweeper.ConfigAtomicPredicatesTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,7 +81,7 @@ public class CommunityMatchExprToBDDTest {
     _batfish = new TransferBDDTest.MockBatfish(ImmutableSortedMap.of(HOSTNAME, _baseConfig));
 
     ConfigAtomicPredicates configAPs =
-        new ConfigAtomicPredicates(
+        ConfigAtomicPredicatesTestUtils.forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetExprToBDDTest.java
@@ -28,6 +28,7 @@ import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighLow
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.batfish.minesweeper.ConfigAtomicPredicatesTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,7 +59,7 @@ public class CommunitySetExprToBDDTest {
     _batfish = new TransferBDDTest.MockBatfish(ImmutableSortedMap.of(HOSTNAME, _baseConfig));
 
     _configAPs =
-        new ConfigAtomicPredicates(
+        ConfigAtomicPredicatesTestUtils.forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDDTest.java
@@ -37,6 +37,7 @@ import org.batfish.datamodel.routing_policy.expr.IntComparison;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.batfish.minesweeper.ConfigAtomicPredicatesTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,7 +68,7 @@ public class CommunitySetMatchExprToBDDTest {
     _batfish = new TransferBDDTest.MockBatfish(ImmutableSortedMap.of(HOSTNAME, _baseConfig));
 
     _configAPs =
-        new ConfigAtomicPredicates(
+        ConfigAtomicPredicatesTestUtils.forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/SetCommunitiesVisitorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/SetCommunitiesVisitorTest.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighLow
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.batfish.minesweeper.ConfigAtomicPredicatesTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,7 +53,7 @@ public class SetCommunitiesVisitorTest {
     _batfish = new TransferBDDTest.MockBatfish(ImmutableSortedMap.of(HOSTNAME, _baseConfig));
 
     _configAPs =
-        new ConfigAtomicPredicates(
+        ConfigAtomicPredicatesTestUtils.forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -1,5 +1,6 @@
 package org.batfish.minesweeper.bdd;
 
+import static org.batfish.minesweeper.ConfigAtomicPredicatesTestUtils.forDevice;
 import static org.batfish.minesweeper.bdd.TransferBDD.isRelevantForDestination;
 import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer.simulatePolicy;
 import static org.junit.Assert.assertEquals;
@@ -289,7 +290,7 @@ public class TransferBDDTest {
   public void testExitAccept() {
     RoutingPolicy policy =
         _policyBuilder.addStatement(new StaticStatement(Statements.ExitAccept)).build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -305,7 +306,7 @@ public class TransferBDDTest {
   public void testExitReject() {
     RoutingPolicy policy =
         _policyBuilder.addStatement(new StaticStatement(Statements.ExitReject)).build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -320,7 +321,7 @@ public class TransferBDDTest {
   @Test
   public void testEmptyPolicy() {
 
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
     TransferBDD tbdd = new TransferBDD(_configAPs, _policyBuilder.build());
 
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -339,7 +340,7 @@ public class TransferBDDTest {
                 ImmutableList.of(new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24)))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -373,7 +374,7 @@ public class TransferBDDTest {
                 Statements.ExitAccept.toStaticStatement())));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -399,7 +400,7 @@ public class TransferBDDTest {
                 Statements.ExitAccept.toStaticStatement())));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -417,7 +418,7 @@ public class TransferBDDTest {
     _policyBuilder.addStatement(Statements.ExitAccept.toStaticStatement());
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -439,7 +440,7 @@ public class TransferBDDTest {
     _policyBuilder.addStatement(Statements.ExitAccept.toStaticStatement());
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -475,7 +476,7 @@ public class TransferBDDTest {
     _policyBuilder.addStatement(Statements.ExitAccept.toStaticStatement());
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -506,7 +507,7 @@ public class TransferBDDTest {
         .addStatement(Statements.DefaultAction.toStaticStatement());
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -525,7 +526,7 @@ public class TransferBDDTest {
         .addStatement(Statements.ReturnLocalDefaultAction.toStaticStatement());
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -554,7 +555,7 @@ public class TransferBDDTest {
                 Statements.ExitAccept.toStaticStatement())));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -598,7 +599,7 @@ public class TransferBDDTest {
                 Statements.ReturnFalse.toStaticStatement())));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -643,7 +644,7 @@ public class TransferBDDTest {
                 Statements.ReturnFalse.toStaticStatement())));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -688,7 +689,7 @@ public class TransferBDDTest {
                     ImmutableList.of(Statements.ExitAccept.toStaticStatement())))));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -721,7 +722,7 @@ public class TransferBDDTest {
                     BooleanExprs.FALSE,
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -741,7 +742,7 @@ public class TransferBDDTest {
                     MatchIpv4.instance(),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -763,7 +764,7 @@ public class TransferBDDTest {
                         new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -794,7 +795,7 @@ public class TransferBDDTest {
                     new PrefixRange(Prefix.parse("1.2.0.0/16"), new SubRange(20, 32)))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -831,7 +832,7 @@ public class TransferBDDTest {
                             new PrefixRange(Prefix.parse("1.2.0.0/16"), new SubRange(20, 32)))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -862,7 +863,7 @@ public class TransferBDDTest {
             matchPrefixSet(ImmutableList.of()),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -890,7 +891,7 @@ public class TransferBDDTest {
             new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(name)),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -917,7 +918,7 @@ public class TransferBDDTest {
             .addStatement(new SetLocalPreference(new LiteralLong(42)))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -939,7 +940,7 @@ public class TransferBDDTest {
             .addStatement(new SetLocalPreference(new LiteralLong(42)))
             .addStatement(new StaticStatement(Statements.ExitReject))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -962,7 +963,7 @@ public class TransferBDDTest {
             .addStatement(new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, null)))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -984,7 +985,7 @@ public class TransferBDDTest {
             .addStatement(new SetOrigin(new VarOrigin("var")))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1005,7 +1006,7 @@ public class TransferBDDTest {
             .addStatement(new SetOspfMetricType(OspfMetricType.E1))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1027,7 +1028,7 @@ public class TransferBDDTest {
             .addStatement(new SetOspfMetricType(OspfMetricType.E2))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1049,7 +1050,7 @@ public class TransferBDDTest {
             .addStatement(new SetMetric(new LiteralLong(50)))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1071,7 +1072,7 @@ public class TransferBDDTest {
             .addStatement(new SetTag(new LiteralLong(42)))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -1094,7 +1095,7 @@ public class TransferBDDTest {
             .addStatement(new SetWeight(new LiteralInt(42)))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1116,7 +1117,7 @@ public class TransferBDDTest {
             .addStatement(new SetWeight(new VarInt("var")))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1136,7 +1137,7 @@ public class TransferBDDTest {
             .addStatement(new SetAdministrativeCost(new LiteralInt(255)))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1158,7 +1159,7 @@ public class TransferBDDTest {
             .addStatement(new SetAdministrativeCost(new VarInt("var")))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1180,7 +1181,7 @@ public class TransferBDDTest {
                     new MatchTag(IntComparator.EQ, new LiteralLong(42)),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1205,7 +1206,7 @@ public class TransferBDDTest {
                 new MatchTag(IntComparator.EQ, new LiteralLong(42)),
                 ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     // the analysis will use the original route for matching
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
@@ -1264,7 +1265,7 @@ public class TransferBDDTest {
                     new MatchTag(IntComparator.LT, new LiteralLong(2)),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1291,7 +1292,7 @@ public class TransferBDDTest {
                     new MatchMetric(IntComparator.EQ, new LiteralLong(42)),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1316,7 +1317,7 @@ public class TransferBDDTest {
                     new MatchMetric(IntComparator.GE, new LiteralLong(2)),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1343,7 +1344,7 @@ public class TransferBDDTest {
                 new MatchMetric(IntComparator.EQ, new LiteralLong(42)),
                 ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     // the analysis will use the original route for matching
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
@@ -1383,7 +1384,7 @@ public class TransferBDDTest {
                     new MatchMetric(IntComparator.EQ, new VarLong("var")),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1405,7 +1406,7 @@ public class TransferBDDTest {
                     MatchClusterListLength.of(IntComparator.EQ, new LiteralInt(42)),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1430,7 +1431,7 @@ public class TransferBDDTest {
                     MatchClusterListLength.of(IntComparator.LE, new LiteralInt(2)),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1461,7 +1462,7 @@ public class TransferBDDTest {
                     MatchClusterListLength.of(IntComparator.EQ, new VarInt("var")),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1483,7 +1484,7 @@ public class TransferBDDTest {
                     new TrackSucceeded("mytrack"),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1509,7 +1510,7 @@ public class TransferBDDTest {
                     new MatchSourceVrf("mysource"),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1535,7 +1536,7 @@ public class TransferBDDTest {
                     new MatchInterface(ImmutableSet.of("int1", "int2")),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1563,7 +1564,7 @@ public class TransferBDDTest {
                         ImmutableList.of(PrefixRange.fromPrefix(Prefix.parse("1.0.0.0/32")))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -1593,7 +1594,7 @@ public class TransferBDDTest {
                         ImmutableList.of(PrefixRange.fromPrefix(Prefix.parse("1.0.0.0/8")))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -1620,7 +1621,7 @@ public class TransferBDDTest {
                 ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1639,7 +1640,7 @@ public class TransferBDDTest {
         .addStatement(new SetNextHop(DiscardNextHop.INSTANCE))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1660,7 +1661,7 @@ public class TransferBDDTest {
         .addStatement(new SetNextHop(SelfNextHop.getInstance()))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1681,7 +1682,7 @@ public class TransferBDDTest {
         .addStatement(new SetNextHop(BgpPeerAddressNextHop.getInstance()))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1702,7 +1703,7 @@ public class TransferBDDTest {
         .addStatement(new SetNextHop(new IpNextHop(ImmutableList.of(Ip.parse("1.1.1.1")))))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1725,7 +1726,7 @@ public class TransferBDDTest {
         .addStatement(new SetNextHop(new IpNextHop(ImmutableList.of(Ip.parse("1.1.1.1")))))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1745,7 +1746,7 @@ public class TransferBDDTest {
   public void testUnsupportedSetNextHop() {
     _policyBuilder.addStatement(new SetNextHop(UnchangedNextHop.getInstance()));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1768,7 +1769,7 @@ public class TransferBDDTest {
                     new MatchProtocol(RoutingProtocol.BGP, RoutingProtocol.OSPF),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -1799,7 +1800,7 @@ public class TransferBDDTest {
                     ImmutableList.of(new StaticStatement(Statements.SetDefaultActionAccept))))
             .addStatement(new StaticStatement(Statements.DefaultAction))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1823,7 +1824,7 @@ public class TransferBDDTest {
                     ImmutableList.of(new StaticStatement(Statements.SetDefaultActionAccept))))
             .addStatement(new StaticStatement(Statements.DefaultAction))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1856,7 +1857,7 @@ public class TransferBDDTest {
                         new StaticStatement(Statements.ExitReject))))
             .addStatement(new StaticStatement(Statements.DefaultAction))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1886,7 +1887,7 @@ public class TransferBDDTest {
                     ImmutableList.of(new SetDefaultTag(new LiteralLong(0L))),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1905,7 +1906,7 @@ public class TransferBDDTest {
             .addStatement(new BufferedStatement(new SetLocalPreference(new LiteralLong(42))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1937,7 +1938,7 @@ public class TransferBDDTest {
             new LegacyMatchAsPath(new NamedAsPathSet(AS_PATH_NAME)),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -1976,7 +1977,7 @@ public class TransferBDDTest {
                     ImmutableList.of(AsPathMatchRegex.of(" 40$"), AsPathMatchRegex.of("^$")))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2031,7 +2032,7 @@ public class TransferBDDTest {
                             new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(24, 32)))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -2072,7 +2073,7 @@ public class TransferBDDTest {
                             new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(24, 32)))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -2124,7 +2125,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(calledPolicyName, calledPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2166,7 +2167,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(calledPolicyName, calledPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2207,7 +2208,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(calledPolicyName, calledPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -2239,7 +2240,7 @@ public class TransferBDDTest {
             new Conjunction(ImmutableList.of()),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2265,7 +2266,7 @@ public class TransferBDDTest {
                             new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(24, 32)))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -2306,7 +2307,7 @@ public class TransferBDDTest {
                             new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(24, 32)))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -2361,7 +2362,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(calledPolicyName, calledPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2390,7 +2391,7 @@ public class TransferBDDTest {
             new Disjunction(ImmutableList.of()),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2411,7 +2412,7 @@ public class TransferBDDTest {
                 MatchAsPath.of(InputAsPath.instance(), AsPathMatchRegex.of("^$"))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2453,7 +2454,7 @@ public class TransferBDDTest {
             MatchAsPath.of(InputAsPath.instance(), asExpr),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2492,7 +2493,7 @@ public class TransferBDDTest {
             .build();
 
     _configAPs =
-        new ConfigAtomicPredicates(
+        forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,
@@ -2530,7 +2531,7 @@ public class TransferBDDTest {
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
     _configAPs =
-        new ConfigAtomicPredicates(
+        forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,
@@ -2574,7 +2575,7 @@ public class TransferBDDTest {
             .build();
 
     _configAPs =
-        new ConfigAtomicPredicates(
+        forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,
@@ -2615,7 +2616,7 @@ public class TransferBDDTest {
             new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
     _configAPs =
-        new ConfigAtomicPredicates(
+        forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,
@@ -2676,7 +2677,7 @@ public class TransferBDDTest {
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
     _configAPs =
-        new ConfigAtomicPredicates(
+        forDevice(
             _batfish,
             _batfish.getSnapshot(),
             HOSTNAME,
@@ -2724,7 +2725,7 @@ public class TransferBDDTest {
                             CommunitySet.of(ExtendedCommunity.parse("0:4:44"))))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2760,7 +2761,7 @@ public class TransferBDDTest {
                     new LiteralCommunitySet(CommunitySet.of(ExtendedCommunity.parse("0:4:44")))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2795,7 +2796,7 @@ public class TransferBDDTest {
                     new LiteralCommunitySet(CommunitySet.of(LargeCommunity.of(10, 20, 30)))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2835,7 +2836,7 @@ public class TransferBDDTest {
                                 new LiteralInt(40), new LiteralInt(40))))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2877,7 +2878,7 @@ public class TransferBDDTest {
                                 new IntComparison(IntComparator.EQ, new LiteralInt(30))))),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2921,7 +2922,7 @@ public class TransferBDDTest {
                                             IntComparator.EQ, new LiteralInt(20))))))),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -2970,7 +2971,7 @@ public class TransferBDDTest {
                     InputCommunities.instance(), new HasCommunity(new CommunityIs(comm))),
                 ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     // the analysis will use the original route for matching
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
@@ -3029,7 +3030,7 @@ public class TransferBDDTest {
                     InputCommunities.instance(), new HasCommunity(new CommunityIs(comm2))),
                 ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     // the analysis will use the original route for matching
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
@@ -3092,7 +3093,7 @@ public class TransferBDDTest {
                     InputCommunities.instance(), new HasCommunity(new CommunityIs(comm))),
                 ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     // the analysis will use the original route for matching
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
@@ -3157,7 +3158,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(calledPolicyName, calledPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -3198,7 +3199,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(calledPolicyName, calledPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
 
@@ -3246,7 +3247,7 @@ public class TransferBDDTest {
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(
             calledPolicyName2, calledPolicy2, calledPolicyName, calledPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3287,7 +3288,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(calledPolicyName, calledPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3311,7 +3312,7 @@ public class TransferBDDTest {
                         new StaticStatement(Statements.ExitAccept))))
             .build();
 
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3334,7 +3335,7 @@ public class TransferBDDTest {
     _policyBuilder.addStatement(
         new If(new MatchColor(0L), ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3357,7 +3358,7 @@ public class TransferBDDTest {
                 new HasCommunity(AllStandardCommunities.instance())),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3376,7 +3377,7 @@ public class TransferBDDTest {
         .addStatement(new ExcludeAsPath(new LiteralAsList(ImmutableList.of())))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3395,7 +3396,7 @@ public class TransferBDDTest {
         .addStatement(new PrependAsPath(new LiteralAsList(ImmutableList.of(new ExplicitAs(42L)))))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3429,7 +3430,7 @@ public class TransferBDDTest {
                 new LiteralAsList(ImmutableList.of(new ExplicitAs(44L), new ExplicitAs(4L)))))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3481,7 +3482,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(policy1Name, policy1, policy2Name, policy2, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3539,7 +3540,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(policy1Name, policy1, policy2Name, policy2, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3589,7 +3590,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(policy1Name, policy1, defaultName, defaultPolicy, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3621,7 +3622,7 @@ public class TransferBDDTest {
             .build();
 
     _baseConfig.setRoutingPolicies(ImmutableMap.of(policy1Name, policy1, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     _expectedException.expect(BatfishException.class);
@@ -3666,7 +3667,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(policy1Name, policy1, policy2Name, policy2, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3718,7 +3719,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(policy1Name, policy1, policy2Name, policy2, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3769,7 +3770,7 @@ public class TransferBDDTest {
 
     _baseConfig.setRoutingPolicies(
         ImmutableMap.of(policy1Name, policy1, policy2Name, policy2, POLICY_NAME, policy));
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3802,7 +3803,7 @@ public class TransferBDDTest {
                     new StaticStatement(Statements.ExitAccept))))
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3831,7 +3832,7 @@ public class TransferBDDTest {
         .addStatement(Statements.RemovePrivateAs.toStaticStatement())
         .addStatement(new StaticStatement(Statements.ExitAccept));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3850,7 +3851,7 @@ public class TransferBDDTest {
         .addStatement(new SetTag(new VarLong("var")))
         .addStatement(new StaticStatement(Statements.ExitReject));
     RoutingPolicy policy = _policyBuilder.build();
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     TransferBDD tbdd = new TransferBDD(_configAPs, policy);
     List<TransferReturn> paths = tbdd.computePaths(ImmutableSet.of());
@@ -3901,20 +3902,20 @@ public class TransferBDDTest {
   public void testUseOutputAttributes() {
     // useOutputAttributes is false for CISCO_IOS
     setup(ConfigurationFormat.CISCO_IOS);
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
     TransferBDD tbdd = new TransferBDD(_configAPs, _policyBuilder.build());
     assertFalse(tbdd.getUseOutputAttributes());
 
     // useOutputAttributes is true for JUNIPER
     setup(ConfigurationFormat.JUNIPER);
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
     tbdd = new TransferBDD(_configAPs, _policyBuilder.build());
     assertTrue(tbdd.getUseOutputAttributes());
   }
 
   @Test
   public void testDistinctBDDFactories() {
-    _configAPs = new ConfigAtomicPredicates(_batfish, _batfish.getSnapshot(), HOSTNAME);
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
     TransferBDD tbdd1 = new TransferBDD(_configAPs, _policyBuilder.build());
     TransferBDD tbdd2 = new TransferBDD(_configAPs, _policyBuilder.build());
     assertNotSame(tbdd1.getFactory(), tbdd2.getFactory());


### PR DESCRIPTION
The old implementation felt very overfit to the two existing callers, with new
constructors being added for every new use case.

Replace this with basically one API, which takes in a list of
<Configuration,RoutingPolicy[]> pairs and optional extras, then port all the
other creation methods onto it.

Move all the magic device loading from snapshot into testing utilities which is
the only place it's used. (With minor cleanup that simplifies the real question anyway).