### PR TITLE
BgpPeerProperty: fallback to EVPN address family if IPv4 Unicast not enabled

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
@@ -53,6 +53,22 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
   public static final String EXPORT_POLICY = "Export_Policy";
   public static final String SEND_COMMUNITY = "Send_Community";
 
+  /**
+   * Some properties are reported by address family, and some peers don't have all address families
+   * present.
+   *
+   * <p>Prefer reporting properties for IPv4 Unicast address family, but fall back if that is not
+   * present.
+   */
+  private static @Nonnull Optional<AddressFamily> getReportingAddressFamily(BgpPeerConfig c) {
+    if (c.getIpv4UnicastAddressFamily() != null) {
+      return Optional.of(c.getIpv4UnicastAddressFamily());
+    } else if (c.getEvpnAddressFamily() != null) {
+      return Optional.of(c.getEvpnAddressFamily());
+    }
+    return Optional.empty();
+  }
+
   private static final Map<String, PropertyDescriptor<BgpPeerConfig>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<BgpPeerConfig>>()
           .put(
@@ -80,7 +96,7 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
               ROUTE_REFLECTOR_CLIENT,
               new PropertyDescriptor<>(
                   c ->
-                      Optional.ofNullable(c.getIpv4UnicastAddressFamily())
+                      getReportingAddressFamily(c)
                           .map(AddressFamily::getRouteReflectorClient)
                           .orElse(false),
                   Schema.BOOLEAN,
@@ -101,7 +117,7 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
               IMPORT_POLICY,
               new PropertyDescriptor<>(
                   c ->
-                      Optional.ofNullable(c.getIpv4UnicastAddressFamily())
+                      getReportingAddressFamily(c)
                           .map(AddressFamily::getImportPolicySources)
                           .orElse(ImmutableSortedSet.of()),
                   Schema.set(Schema.STRING),
@@ -110,7 +126,7 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
               EXPORT_POLICY,
               new PropertyDescriptor<>(
                   c ->
-                      Optional.ofNullable(c.getIpv4UnicastAddressFamily())
+                      getReportingAddressFamily(c)
                           .map(AddressFamily::getExportPolicySources)
                           .orElse(ImmutableSortedSet.of()),
                   Schema.set(Schema.STRING),
@@ -119,7 +135,7 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
               SEND_COMMUNITY,
               new PropertyDescriptor<>(
                   c ->
-                      Optional.ofNullable(c.getIpv4UnicastAddressFamily())
+                      getReportingAddressFamily(c)
                           .map(AddressFamily::getAddressFamilyCapabilities)
                           .map(AddressFamilyCapabilities::getSendCommunity)
                           .orElse(false),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifierTest.java
@@ -1,12 +1,18 @@
 package org.batfish.datamodel.questions;
 
+import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.SEND_COMMUNITY;
 import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.getIsPassive;
+import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.getPropertyDescriptor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpUnnumberedPeerConfig;
+import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
+import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.junit.Test;
 
@@ -30,5 +36,25 @@ public class BgpPeerPropertySpecifierTest {
             BgpPassivePeerConfig.builder()
                 .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
                 .build()));
+  }
+
+  @Test
+  public void testReportEVPNPropertiesIfIPv4NotPresent() {
+    // Neither v4 nor EVPN defaults
+    assertThat(
+        getPropertyDescriptor(SEND_COMMUNITY)
+            .getGetter()
+            .apply(BgpActivePeerConfig.builder().build()),
+        equalTo(false));
+
+    // Neither EVPN present, overrides that default
+    EvpnAddressFamily evpnAf =
+        EvpnAddressFamily.builder()
+            .setAddressFamilyCapabilities(
+                AddressFamilyCapabilities.builder().setSendCommunity(true).build())
+            .setPropagateUnmatched(true)
+            .build();
+    BgpActivePeerConfig c = BgpActivePeerConfig.builder().setEvpnAddressFamily(evpnAf).build();
+    assertThat(getPropertyDescriptor(SEND_COMMUNITY).getGetter().apply(c), equalTo(true));
   }
 }


### PR DESCRIPTION
Fix batfish/batfish#9047