### PR TITLE
Junos: parse and ignore vlan "default"

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -465,6 +465,8 @@ DEAD_PEER_DETECTION: 'dead-peer-detection';
 
 DECAPSULATE: 'decapsulate';
 
+DEFAULT: 'default';
+
 DEFAULT_ACTION: 'default-action';
 
 DEFAULT_ADDRESS_SELECTION: 'default-address-selection';
@@ -4335,6 +4337,8 @@ M_Version_WS
 mode M_VlanMembers;
 
 M_VlanMembers_ALL: 'all' -> type(ALL), popMode;
+
+M_VlanMembers_DEFAULT: 'default' -> type(DEFAULT), popMode;
 
 M_VlanMembers_WS: F_WhitespaceChar+ -> skip;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -453,6 +453,7 @@ ife_vlan
    VLAN MEMBERS
    (
       ALL
+      | DEFAULT
       | range
       | name = junos_name
    )

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5032,6 +5032,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       _currentInterfaceOrRange.getEthernetSwitching().getVlanMembers().add(new VlanReference(name));
     } else if (ctx.ALL() != null) {
       _currentInterfaceOrRange.getEthernetSwitching().getVlanMembers().add(AllVlans.instance());
+    } else if (ctx.DEFAULT() != null) {
+      _currentInterfaceOrRange.getEthernetSwitching().getVlanMembers().clear();
     } else {
       todo(ctx);
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3561,7 +3561,10 @@ public final class FlatJuniperGrammarTest {
                     .build())));
 
     // Vlan "default" is ignored
-    assertThat(c, hasInterface("ge-0/10/0.0", hasAllowedVlans(IntegerSpace.EMPTY)));
+    assertThat(
+        c,
+        hasInterface(
+            "ge-0/10/0.0", allOf(hasAccessVlan(nullValue()), hasAllowedVlans(IntegerSpace.EMPTY))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3560,7 +3560,7 @@ public final class FlatJuniperGrammarTest {
                     .including(500)
                     .build())));
 
-    // Vlan "default" is ignored
+    // Vlan "default" resets the vlan config
     assertThat(
         c,
         hasInterface(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3559,6 +3559,9 @@ public final class FlatJuniperGrammarTest {
                     .including(new SubRange("300-400"))
                     .including(500)
                     .build())));
+
+    // Vlan "default" is ignored
+    assertThat(c, hasInterface("ge-0/10/0.0", hasAllowedVlans(IntegerSpace.EMPTY)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
@@ -22,6 +22,7 @@ set interfaces ge-0/8/0 unit 0 family ethernet-switching vlan members VLAN_ID_LI
 set interfaces ge-0/9/0 unit 0 family ethernet-switching interface-mode trunk
 set interfaces ge-0/9/0 unit 0 family ethernet-switching vlan members VLAN_ID_LIST_TEST_SINGLETON
 set interfaces ge-0/9/0 unit 0 family ethernet-switching vlan members VLAN_ID_LIST_TEST_RANGE
+set interfaces ge-0/10/0 unit 0 family ethernet-switching vlan members default
 
 # vlan-id-list should be overruled by vlan-id
 set vlans VLAN_ID_TEST vlan-id-list 100

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
@@ -22,6 +22,7 @@ set interfaces ge-0/8/0 unit 0 family ethernet-switching vlan members VLAN_ID_LI
 set interfaces ge-0/9/0 unit 0 family ethernet-switching interface-mode trunk
 set interfaces ge-0/9/0 unit 0 family ethernet-switching vlan members VLAN_ID_LIST_TEST_SINGLETON
 set interfaces ge-0/9/0 unit 0 family ethernet-switching vlan members VLAN_ID_LIST_TEST_RANGE
+set interfaces ge-0/10/0 unit 0 family ethernet-switching vlan members 5
 set interfaces ge-0/10/0 unit 0 family ethernet-switching vlan members default
 
 # vlan-id-list should be overruled by vlan-id

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -54033,7 +54033,7 @@
             "            (fo_null*",
             "              STORM_CONTROL_PROFILES:'storm-control-profiles'",
             "              (null_filler*",
-            "                UNRECOGNIZED_WORD:'default'",
+            "                DEFAULT:'default'",
             "                ALL:'all'))))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",


### PR DESCRIPTION
From [junos docs](https://www.juniper.net/documentation/us/en/software/junos/multicast-l2/topics/topic-map/bridging-and-vlans.html#:~:text=A%20Default%20VLAN%20Is%20Configured%20on%20Most%20Switches,-Some%20switches%20running&text=On%20these%20switches%2C%20each%20interface,not%20support%20a%20default%20VLAN):

> Some switches running Junos OS that do not support the ELS configuration style are preconfigured with a VLAN named default that does not tag packets and operates only with untagged packets. On these switches, each interface already belongs to the VLAN named default and all traffic uses this VLAN until you configure more VLANs and assign traffic to those VLANs.

Parse and ignore the `default` vlan, and don't count it as a reference to a vlan variable.