### PR TITLE
pre-commit: upgrade to artifacts v4

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -102,9 +102,9 @@ jobs:
           bazel build //projects/allinone:allinone_main_deploy.jar
           cp bazel-bin/projects/allinone/allinone_main_deploy.jar workspace/allinone.jar
       - name: Save JAR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: allinone_jar
+          name: allinone_jar_${{ matrix.java_version }}
           path: workspace/allinone.jar
     strategy:
       matrix:


### PR DESCRIPTION
https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/

Seeing transient errors in other builds, and this upgrade from December
appears to look like it could address it.