### PR TITLE
minesweeper: handwavy implementation of CommunitySet HasSize

### DIFF
--- a/projects/minesweeper/src/test/java/BUILD.bazel
+++ b/projects/minesweeper/src/test/java/BUILD.bazel
@@ -29,6 +29,7 @@ junit_tests(
         "//projects/batfish:batfish_testlib",
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol/src/test:common_testlib",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd:matchers",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
         "//projects/bdd",
         "//projects/minesweeper",


### PR DESCRIPTION
Filtering on community set size is an extremely fragile capability. The primary
way we've seen it used is as a safeguard against, say, 1000 communities on a route.
In practical networks, we rarely see more than a dozen communities.

Make minesweeper approximate HasSize in a way that lines up with that use case,
which may need adaptation if we learn of others. This improves behavior
in a common case.