### PR TITLE
BDDRoute: expand well formedness to include all finite domains

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -436,14 +436,29 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    */
   public BDD bgpWellFormednessConstraints() {
 
-    // the protocol should be one of the ones allowed in a BgpRoute
-    BDD protocolConstraint = anyElementOf(ALL_BGP_PROTOCOLS, this.getProtocolHistory());
     // the prefix length should be 32 or less
     BDD prefLenConstraint = _prefixLength.leq(32);
     // the next hop should be neither the min nor the max possible IP
     // this constraint is enforced by NextHopIp's constructor
     BDD nextHopConstraint = _nextHop.range(Ip.ZERO.asLong() + 1, Ip.MAX.asLong() - 1);
-    return protocolConstraint.andWith(prefLenConstraint).andWith(nextHopConstraint);
+    // The various BDD Domains should all lie in the domain (needed if the domain is not power-of-2
+    // in size).
+    BDD asPathRegexValid = _asPathRegexAtomicPredicates.getIsValidConstraint();
+    BDD nextHopInterfacesValid = _nextHopInterfaces.getIsValidConstraint();
+    BDD originTypeValid = _originType.getIsValidConstraint();
+    BDD ospfMetricValid = _ospfMetric.getIsValidConstraint();
+    // Protocol domain constraint is stronger: only one of the ones allowed in a BgpRoute.
+    BDD protocolConstraint = anyElementOf(ALL_BGP_PROTOCOLS, this.getProtocolHistory());
+    BDD sourceVrfValid = _sourceVrfs.getIsValidConstraint();
+    return _factory.andAllAndFree(
+        prefLenConstraint,
+        nextHopConstraint,
+        asPathRegexValid,
+        nextHopInterfacesValid,
+        originTypeValid,
+        ospfMetricValid,
+        protocolConstraint,
+        sourceVrfValid);
   }
 
   /*

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDDomainTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDDomainTest.java
@@ -1,0 +1,91 @@
+package org.batfish.minesweeper.bdd;
+
+import static org.batfish.common.bdd.BDDMatchers.isOne;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThrows;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import net.sf.javabdd.JFactory;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.MutableBDDInteger;
+import org.junit.Test;
+
+public class BDDDomainTest {
+  @Test
+  public void testEquals() {
+    BDDFactory factory = BDDPacket.defaultFactory(JFactory::init);
+    factory.setVarNum(5);
+    BDDDomain<String> base = new BDDDomain<>(factory, ImmutableList.of("a", "b"), 0);
+
+    new EqualsTester()
+        .addEqualityGroup(
+            base,
+            new BDDDomain<>(factory, ImmutableList.of("a", "b"), 0),
+            // Documentation test that values are ignored.
+            new BDDDomain<>(factory, ImmutableList.of("b", "c"), 0),
+            new BDDDomain<>(base))
+        .addEqualityGroup(new BDDDomain<>(factory, ImmutableList.of("a", "b", "c"), 0))
+        .addEqualityGroup(new BDDDomain<>(factory, ImmutableList.of("a", "b"), 1))
+        .addEqualityGroup(new BDDDomain<>(factory.nithVar(4), base))
+        .testEquals();
+  }
+
+  @Test
+  public void testIsValidConstraint() {
+    BDDFactory factory = BDDPacket.defaultFactory(JFactory::init);
+    factory.setVarNum(5);
+
+    // TODO: do domains of size 0 or 1 make sense? They have no underlying bits, so
+    // they cannot represent a constraint on the input.
+    BDDDomain<String> zero = new BDDDomain<>(factory, ImmutableList.of(), 0);
+    assertThat(zero.getIsValidConstraint(), isOne());
+
+    BDDDomain<String> one = new BDDDomain<>(factory, ImmutableList.of("a"), 0);
+    assertThat(one.getIsValidConstraint(), isOne());
+    assertThat(one.getIsValidConstraint(), equalTo(one.value("a")));
+
+    BDDDomain<String> two = new BDDDomain<>(factory, ImmutableList.of("a", "b"), 0);
+    assertThat(two.getIsValidConstraint(), isOne());
+
+    BDDDomain<String> three = new BDDDomain<>(factory, ImmutableList.of("a", "b", "c"), 0);
+    assertThat(three.getIsValidConstraint(), not(isOne()));
+    assertThat(three.getIsValidConstraint().or(factory.ithVar(0).and(factory.ithVar(1))), isOne());
+  }
+
+  @Test
+  public void testValue() {
+    BDDFactory factory = BDDPacket.defaultFactory(JFactory::init);
+    factory.setVarNum(5);
+    BDDDomain<String> two = new BDDDomain<>(factory, ImmutableList.of("a", "b"), 0);
+    assertThat(two.getIsValidConstraint(), isOne());
+
+    assertThat(two.value("a"), equalTo(factory.nithVar(0)));
+    assertThat(two.value("b"), equalTo(factory.ithVar(0)));
+
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> two.value("c"));
+    assertThat(thrown, hasMessage(equalTo("c is not in the domain [a, b]")));
+  }
+
+  @Test
+  public void testSetValue() {
+    BDDFactory factory = BDDPacket.defaultFactory(JFactory::init);
+    factory.setVarNum(5);
+    BDDDomain<String> two = new BDDDomain<>(factory, ImmutableList.of("a", "b"), 0);
+    BDD inputA = two.value("a");
+    BDD inputB = two.value("b");
+    MutableBDDInteger integer = two.getInteger();
+
+    // setValue("a") means that the output will be "a" for all inputs.
+    two.setValue("a");
+    assertThat(integer.satAssignmentToInt(factory.one()), equalTo(0));
+    assertThat(two.satAssignmentToValue(inputA), equalTo("a"));
+    assertThat(two.satAssignmentToValue(inputB), equalTo("a"));
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
@@ -1,13 +1,19 @@
 package org.batfish.minesweeper.bdd;
 
+import static org.batfish.common.bdd.BDDMatchers.isZero;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.JFactory;
 import org.batfish.common.bdd.MutableBDDInteger;
 import org.batfish.datamodel.OriginType;
 import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
 
 /** Tests for {@link BDDRoute}. */
 public class BDDRouteTest {
@@ -37,5 +43,24 @@ public class BDDRouteTest {
     r5.setWeight(MutableBDDInteger.makeFromValue(factory, 16, 34));
     b = r1.equalsForTesting(r5);
     assertFalse(b);
+  }
+
+  @Test
+  public void testWellFormedOriginType() {
+    BDDFactory factory = JFactory.init(100, 100);
+    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0);
+
+    BDD anyOriginType =
+        factory.orAll(
+            route.getOriginType().value(OriginType.EGP),
+            route.getOriginType().value(OriginType.IGP),
+            route.getOriginType().value(OriginType.INCOMPLETE));
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> route.getOriginType().satAssignmentToValue(anyOriginType.not()));
+    assertThat(
+        thrown, ThrowableMessageMatcher.hasMessage(containsString("is not valid in this domain")));
+    assertThat(route.bgpWellFormednessConstraints().and(anyOriginType.not()), isZero());
   }
 }


### PR DESCRIPTION
Only protocols were validated for well-formedness; extend this to all the others such as
origin type, source VRFs, and more.

commit-id:87938a12

---

**Stack**:
- #9082
- #9081
- #9079 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*