### PR TITLE
TransferReturn: improve readability

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDDState.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDDState.java
@@ -21,7 +21,7 @@ public class TransferBDDState {
     // the TransferParam and the TransferResult, but it would require non-trivial updates
     // to the analysis.
     checkArgument(
-        param.getData() == result.getReturnValue().getFirst(),
+        param.getData() == result.getReturnValue().getOutputRoute(),
         "TransferParam and TransferReturn should contain the same BDDRoute object");
     _param = param;
     _result = result;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
@@ -48,14 +48,15 @@ public class TransferResult {
 
   /**
    * Construct a TransferResult from a BDDRoute. By default we use TRUE as the initial path
-   * condition and FALSE as the initial value for having hit a return/exit/fallthrough statement. *
+   * condition and FALSE as the initial value for having hit a return/exit/fallthrough statement.
    */
   public TransferResult(BDDRoute bddRoute) {
-    this(new TransferReturn(bddRoute, bddRoute.getFactory().one()), false);
-  }
-
-  public TransferResult(TransferReturn ret, boolean defaultVal) {
-    this(ret, defaultVal, defaultVal, defaultVal, defaultVal);
+    this(
+        new TransferReturn(bddRoute, bddRoute.getFactory().one(), false),
+        false,
+        false,
+        false,
+        false);
   }
 
   public TransferResult(
@@ -75,19 +76,19 @@ public class TransferResult {
     return _returnValue;
   }
 
-  public @Nonnull boolean getSuppressedValue() {
+  public boolean getSuppressedValue() {
     return _suppressedValue;
   }
 
-  public @Nonnull boolean getFallthroughValue() {
+  public boolean getFallthroughValue() {
     return _fallthroughValue;
   }
 
-  public @Nonnull boolean getExitAssignedValue() {
+  public boolean getExitAssignedValue() {
     return _exitAssignedValue;
   }
 
-  public @Nonnull boolean getReturnAssignedValue() {
+  public boolean getReturnAssignedValue() {
     return _returnAssignedValue;
   }
 
@@ -102,12 +103,13 @@ public class TransferResult {
 
   public @Nonnull TransferResult setReturnValueBDD(BDD newBDD) {
     return setReturnValue(
-        new TransferReturn(_returnValue.getFirst(), newBDD, _returnValue.getAccepted()));
+        new TransferReturn(_returnValue.getOutputRoute(), newBDD, _returnValue.getAccepted()));
   }
 
   public @Nonnull TransferResult setReturnValueBDDRoute(BDDRoute newBDDRoute) {
     return setReturnValue(
-        new TransferReturn(newBDDRoute, _returnValue.getSecond(), _returnValue.getAccepted()));
+        new TransferReturn(
+            newBDDRoute, _returnValue.getInputConstraints(), _returnValue.getAccepted()));
   }
 
   public @Nonnull TransferResult setSuppressedValue(boolean suppressedValue) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
@@ -1,8 +1,9 @@
 package org.batfish.minesweeper.bdd;
 
 import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
-import org.batfish.minesweeper.utils.Tuple;
 
 /**
  * The data produced by the symbolic route policy analysis performed in {@link TransferBDD}. It is a
@@ -21,17 +22,25 @@ import org.batfish.minesweeper.utils.Tuple;
  *
  * <p>3. A boolean indicating whether the path accepts or rejects the input announcement.
  */
-public class TransferReturn extends Tuple<BDDRoute, BDD> {
+@ParametersAreNonnullByDefault
+public class TransferReturn {
 
+  private final @Nonnull BDDRoute _outputRoute;
+  private final @Nonnull BDD _inputConstraints;
   private final boolean _accepted;
 
-  TransferReturn(BDDRoute r, BDD b, boolean accepted) {
-    super(r, b);
+  TransferReturn(BDDRoute outputRoute, BDD inputConstraints, boolean accepted) {
+    _outputRoute = outputRoute;
+    _inputConstraints = inputConstraints;
     _accepted = accepted;
   }
 
-  TransferReturn(BDDRoute r, BDD b) {
-    this(r, b, false);
+  public @Nonnull BDDRoute getOutputRoute() {
+    return _outputRoute;
+  }
+
+  public @Nonnull BDD getInputConstraints() {
+    return _inputConstraints;
   }
 
   public boolean getAccepted() {
@@ -39,11 +48,11 @@ public class TransferReturn extends Tuple<BDDRoute, BDD> {
   }
 
   public TransferReturn setAccepted(boolean accepted) {
-    return new TransferReturn(getFirst(), getSecond(), accepted);
+    return new TransferReturn(_outputRoute, _inputConstraints, accepted);
   }
 
   public String debug() {
-    return getFirst().dot(getSecond());
+    return getOutputRoute().dot(getInputConstraints());
   }
 
   // TransferReturns are mutable (because the BDDRoutes that they contain are mutable), so in
@@ -51,13 +60,13 @@ public class TransferReturn extends Tuple<BDDRoute, BDD> {
   // This method is used only to test the results of our symbolic route analysis.
   @VisibleForTesting
   boolean equalsForTesting(TransferReturn other) {
-    return this.getFirst().equalsForTesting(other.getFirst())
-        && this.getSecond().equals(other.getSecond())
+    return this.getOutputRoute().equalsForTesting(other.getOutputRoute())
+        && this.getInputConstraints().equals(other.getInputConstraints())
         && this.getAccepted() == other.getAccepted();
   }
 
   @Override
   public String toString() {
-    return "<" + getFirst() + "," + getSecond() + "," + _accepted + ">";
+    return "<" + getOutputRoute() + "," + getInputConstraints() + "," + _accepted + ">";
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -377,11 +377,11 @@ public final class CompareRoutePoliciesUtils {
     ConfigAtomicPredicates configAPsCopy = new ConfigAtomicPredicates(configAPs);
     org.batfish.minesweeper.AsPathRegexAtomicPredicates aps =
         configAPsCopy.getAsPathRegexAtomicPredicates();
-    aps.prependAPs(path.getFirst().getPrependedASes());
+    aps.prependAPs(path.getOutputRoute().getPrependedASes());
 
     return org.batfish.minesweeper.bdd.ModelGeneration.validateModel(
         fullModel,
-        path.getFirst(),
+        path.getOutputRoute(),
         configAPsCopy,
         path.getAccepted() ? LineAction.PERMIT : LineAction.DENY,
         direction,
@@ -438,13 +438,14 @@ public final class CompareRoutePoliciesUtils {
     // The set of paths for the proposed policy, also indexed by input routes.
     List<TransferReturn> otherPaths = computePaths(otherTBDD);
     Map<BDD, TransferReturn> otherPathIndex =
-        otherPaths.stream().collect(ImmutableMap.toImmutableMap(t -> t.getSecond(), t -> t));
+        otherPaths.stream()
+            .collect(ImmutableMap.toImmutableMap(t -> t.getInputConstraints(), t -> t));
 
     // The set of differences if any.
     List<Tuple<Result<BgpRoute>, Result<BgpRoute>>> differences = new ArrayList<>();
 
     for (TransferReturn path : paths) {
-      BDD inputRoutes = path.getSecond();
+      BDD inputRoutes = path.getInputConstraints();
       // Optimization: since the inputRoutes for a given List are mutually disjoint, we can
       // avoid linear comparison when the same set is in the other group. This likely applies
       // when the input policies are very similar.
@@ -474,8 +475,8 @@ public final class CompareRoutePoliciesUtils {
       RoutingPolicy policy,
       RoutingPolicy otherPolicy,
       Environment.Direction direction) {
-    BDD inputRoutes = path.getSecond();
-    BDD inputRoutesOther = otherPath.getSecond();
+    BDD inputRoutes = path.getInputConstraints();
+    BDD inputRoutesOther = otherPath.getInputConstraints();
     BDD intersection = inputRoutesOther.and(inputRoutes).andEq(wellFormedConstraints);
     if (intersection.isZero()) {
       // No common input routes to check equivalence.
@@ -492,8 +493,8 @@ public final class CompareRoutePoliciesUtils {
       // If both policies perform the same action, then check that their outputs match.
       // We only need to compare the outputs if the routes were permitted.
       if (path.getAccepted()) {
-        BDDRoute outputRoutes = path.getFirst();
-        BDDRoute outputRoutesOther = otherPath.getFirst();
+        BDDRoute outputRoutes = path.getOutputRoute();
+        BDDRoute outputRoutesOther = otherPath.getOutputRoute();
         // Identify all differences in the two routes, ignoring the input constraints
         List<BDDRouteDiff.DifferenceType> diffs =
             computeDifferences(outputRoutes, outputRoutesOther);
@@ -520,9 +521,9 @@ public final class CompareRoutePoliciesUtils {
     Tuple<Bgpv4Route, Tuple<Predicate<String>, String>> t =
         constraintsToInputs(finalConstraints, configAPs);
     Result<BgpRoute> otherResult =
-        simulatePolicy(policy, t.getFirst(), direction, t.getSecond(), otherPath.getFirst());
+        simulatePolicy(policy, t.getFirst(), direction, t.getSecond(), otherPath.getOutputRoute());
     Result<BgpRoute> refResult =
-        simulatePolicy(otherPolicy, t.getFirst(), direction, t.getSecond(), path.getFirst());
+        simulatePolicy(otherPolicy, t.getFirst(), direction, t.getSecond(), path.getOutputRoute());
 
     // As a sanity check, compare the simulated results above with what the symbolic route analysis
     // predicts will happen.

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -525,7 +525,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             // consider only the subset of paths that have the desired action (permit or deny)
             .filter(p -> p.getAccepted() == (_action == PERMIT))
             // separate the paths that encountered an unsupported statement from the others
-            .collect(Collectors.partitioningBy(tr -> tr.getFirst().getUnsupported()));
+            .collect(Collectors.partitioningBy(tr -> tr.getOutputRoute().getUnsupported()));
     // consider the paths that do not encounter an unsupported feature first, to avoid the potential
     // for false positives as much as possible
     List<TransferReturn> relevantPaths = pathMap.get(false);
@@ -536,8 +536,8 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             _inputConstraints, new BDDRoute(tbdd.getFactory(), configAPs), false, tbdd);
     ImmutableList.Builder<Row> builder = ImmutableList.builder();
     for (TransferReturn path : relevantPaths) {
-      BDD pathAnnouncements = path.getSecond();
-      BDDRoute outputRoute = path.getFirst();
+      BDD pathAnnouncements = path.getInputConstraints();
+      BDDRoute outputRoute = path.getOutputRoute();
       BDD intersection = pathAnnouncements.and(inConstraints);
       for (PrefixSpace blockedPrefix : blockedPrefixes) {
         intersection = intersection.andWith(prefixSpaceToBDD(blockedPrefix, outputRoute, true));

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/ModelGenerationTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/ModelGenerationTest.java
@@ -73,24 +73,30 @@ public class ModelGenerationTest {
     {
       List<TransferReturn> matchingPaths =
           paths.stream()
-              .filter(p -> p.getSecond().andSat(matches10_8))
+              .filter(p -> p.getInputConstraints().andSat(matches10_8))
               .collect(Collectors.toList());
       assertThat(matchingPaths, hasSize(1));
       TransferReturn result = matchingPaths.get(0);
       assertThat(
-          result.getFirst().getTunnelEncapsulationAttribute().satAssignmentToValue(factory.one()),
+          result
+              .getOutputRoute()
+              .getTunnelEncapsulationAttribute()
+              .satAssignmentToValue(factory.one()),
           equalTo(Value.literal(attr)));
     }
 
     {
       List<TransferReturn> otherPaths =
           paths.stream()
-              .filter(p -> p.getSecond().diffSat(matches10_8))
+              .filter(p -> p.getInputConstraints().diffSat(matches10_8))
               .collect(Collectors.toList());
       assertThat(otherPaths, hasSize(1));
       TransferReturn result = otherPaths.get(0);
       assertThat(
-          result.getFirst().getTunnelEncapsulationAttribute().satAssignmentToValue(factory.one()),
+          result
+              .getOutputRoute()
+              .getTunnelEncapsulationAttribute()
+              .satAssignmentToValue(factory.one()),
           equalTo(Value.absent()));
     }
   }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -247,7 +247,8 @@ public class TransferBDDTest {
     for (TransferReturn path : paths) {
       // solve for an input route and environment that causes execution to go down this path
       BDD fullConstraints =
-          path.getSecond().and(new BDDRoute(factory, _configAPs).bgpWellFormednessConstraints());
+          path.getInputConstraints()
+              .and(new BDDRoute(factory, _configAPs).bgpWellFormednessConstraints());
       BDD fullModel = ModelGeneration.constraintsToModel(fullConstraints, _configAPs);
       Bgpv4Route inRoute = ModelGeneration.satAssignmentToInputRoute(fullModel, _configAPs);
       Tuple<Predicate<String>, String> env =
@@ -257,21 +258,21 @@ public class TransferBDDTest {
       // for good measure we simulate twice, with the policy respectively considered an import and
       // export policy
       Result<BgpRoute> inResult =
-          simulatePolicy(policy, inRoute, Environment.Direction.IN, env, path.getFirst());
+          simulatePolicy(policy, inRoute, Environment.Direction.IN, env, path.getOutputRoute());
       Result<BgpRoute> outResult =
-          simulatePolicy(policy, inRoute, Environment.Direction.OUT, env, path.getFirst());
+          simulatePolicy(policy, inRoute, Environment.Direction.OUT, env, path.getOutputRoute());
 
       // update the atomic predicates to include any prepended ASes on this path
       ConfigAtomicPredicates configAPsCopy = new ConfigAtomicPredicates(_configAPs);
       AsPathRegexAtomicPredicates aps = configAPsCopy.getAsPathRegexAtomicPredicates();
-      aps.prependAPs(path.getFirst().getPrependedASes());
+      aps.prependAPs(path.getOutputRoute().getPrependedASes());
 
       // compare the simulated results to that produced by the symbolic analysis
       LineAction action = path.getAccepted() ? LineAction.PERMIT : LineAction.DENY;
       boolean inValidate =
           ModelGeneration.validateModel(
               fullModel,
-              path.getFirst(),
+              path.getOutputRoute(),
               configAPsCopy,
               action,
               Environment.Direction.IN,
@@ -279,7 +280,7 @@ public class TransferBDDTest {
       boolean outValidate =
           ModelGeneration.validateModel(
               fullModel,
-              path.getFirst(),
+              path.getOutputRoute(),
               configAPsCopy,
               action,
               Environment.Direction.OUT,


### PR DESCRIPTION
1. Add fields and named getters, get rid of Tuple
2. Inline a few non-obvious defaults especially if used in only one place.
3. Improve comments mildly.

---

**Stack**:
- #9096
- #9095
- #9094
- #9093
- #9092 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*