### PR TITLE
minesweeper: implement equals

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -36,7 +36,7 @@ import org.batfish.minesweeper.OspfType;
  *
  * @author Ryan Beckett
  */
-public class BDDRoute implements IDeepCopy<BDDRoute> {
+public final class BDDRoute implements IDeepCopy<BDDRoute> {
 
   /*
    * For each bit i of a route announcement we have both a BDD variable vi, which
@@ -696,10 +696,14 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     _unsupported = unsupported;
   }
 
-  // BDDRoutes are mutable so in general the default pointer equality is the right thing to use;
-  // This method is used only to test the results of our symbolic route analysis.
-  @VisibleForTesting
-  boolean equalsForTesting(BDDRoute other) {
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (o == null || !(o instanceof BDDRoute)) {
+      return false;
+    }
+    BDDRoute other = (BDDRoute) o;
     return Objects.equals(_adminDist, other._adminDist)
         && Objects.equals(_ospfMetric, other._ospfMetric)
         && Objects.equals(_originType, other._originType)
@@ -722,5 +726,24 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
         && Arrays.equals(_tracks, other._tracks)
         && _tunnelEncapsulationAttribute.equals(other._tunnelEncapsulationAttribute)
         && Objects.equals(_unsupported, other._unsupported);
+  }
+
+  @Override
+  public int hashCode() {
+    // does not include all fields, but that's okay as hash code doesn't need to be perfect.
+    return Objects.hash(
+        _adminDist,
+        _originType,
+        _med,
+        _localPref,
+        _clusterListLength,
+        _tag,
+        _weight,
+        _nextHop,
+        _prefix,
+        _prefixLength,
+        Arrays.hashCode(_communityAtomicPredicates),
+        _asPathRegexAtomicPredicates,
+        _prependedASes);
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
@@ -1,7 +1,8 @@
 package org.batfish.minesweeper.bdd;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 
@@ -23,8 +24,7 @@ import net.sf.javabdd.BDD;
  * <p>3. A boolean indicating whether the path accepts or rejects the input announcement.
  */
 @ParametersAreNonnullByDefault
-public class TransferReturn {
-
+public final class TransferReturn {
   private final @Nonnull BDDRoute _outputRoute;
   private final @Nonnull BDD _inputConstraints;
   private final boolean _accepted;
@@ -52,21 +52,29 @@ public class TransferReturn {
   }
 
   public String debug() {
-    return getOutputRoute().dot(getInputConstraints());
+    return _outputRoute.dot(_inputConstraints);
   }
 
-  // TransferReturns are mutable (because the BDDRoutes that they contain are mutable), so in
-  // general the default pointer equality is the right thing to use;
-  // This method is used only to test the results of our symbolic route analysis.
-  @VisibleForTesting
-  boolean equalsForTesting(TransferReturn other) {
-    return this.getOutputRoute().equalsForTesting(other.getOutputRoute())
-        && this.getInputConstraints().equals(other.getInputConstraints())
-        && this.getAccepted() == other.getAccepted();
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    } else if (o == null || !(o instanceof TransferReturn)) {
+      return false;
+    }
+    TransferReturn other = (TransferReturn) o;
+    return this._outputRoute.equals(other._outputRoute)
+        && this._inputConstraints.equals(other._inputConstraints)
+        && this._accepted == other._accepted;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_outputRoute, _inputConstraints, _accepted);
   }
 
   @Override
   public String toString() {
-    return "<" + getOutputRoute() + "," + getInputConstraints() + "," + _accepted + ">";
+    return "<" + _outputRoute + "," + _inputConstraints + "," + _accepted + ">";
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
@@ -3,47 +3,96 @@ package org.batfish.minesweeper.bdd;
 import static org.batfish.common.bdd.BDDMatchers.isZero;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.JFactory;
-import org.batfish.common.bdd.MutableBDDInteger;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.minesweeper.OspfType;
+import org.batfish.minesweeper.bdd.BDDRoute.NextHopType;
+import org.batfish.minesweeper.bdd.BDDTunnelEncapsulationAttribute.Value;
 import org.junit.Test;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 
 /** Tests for {@link BDDRoute}. */
 public class BDDRouteTest {
-
   @Test
-  public void testCopyConstructorAndEquality() {
+  public void testEquals() {
     BDDFactory factory = JFactory.init(100, 100);
-    BDDRoute r1 = new BDDRoute(factory, 3, 4, 5, 6, 2, ImmutableList.of());
-    BDDRoute r2 = new BDDRoute(r1);
-    boolean b = r1.equalsForTesting(r2);
-    assertTrue(b);
-
-    // test a few equality violations
-    BDDRoute r3 = new BDDRoute(r1);
-    BDDDomain<OriginType> newOT = new BDDDomain<>(r3.getOriginType());
-    newOT.setValue(OriginType.INCOMPLETE);
-    r3.setOriginType(newOT);
-    b = r1.equalsForTesting(r3);
-    assertFalse(b);
-
-    BDDRoute r4 = new BDDRoute(r1);
-    r4.setUnsupported(true);
-    b = r1.equalsForTesting(r4);
-    assertFalse(b);
-
-    BDDRoute r5 = new BDDRoute(r1);
-    r5.setWeight(MutableBDDInteger.makeFromValue(factory, 16, 34));
-    b = r1.equalsForTesting(r5);
-    assertFalse(b);
+    BDDRoute orig = new BDDRoute(factory, 3, 4, 5, 6, 2, ImmutableList.of());
+    BDDRoute admin = new BDDRoute(orig);
+    admin.getAdminDist().setValue(1);
+    BDDRoute asPathRegex = new BDDRoute(orig);
+    asPathRegex.getAsPathRegexAtomicPredicates().setValue(1);
+    BDDRoute clusterListLength = new BDDRoute(orig);
+    clusterListLength.getClusterListLength().setValue(1);
+    BDDRoute communities = new BDDRoute(orig);
+    communities.getCommunityAtomicPredicates()[0] = factory.one();
+    BDDRoute localPref = new BDDRoute(orig);
+    localPref.getLocalPref().setValue(1);
+    BDDRoute med = new BDDRoute(orig);
+    med.getMed().setValue(1);
+    BDDRoute nextHop = new BDDRoute(orig);
+    nextHop.getNextHop().setValue(1);
+    BDDRoute nextHopInterfaces = new BDDRoute(orig);
+    nextHopInterfaces.getNextHopInterfaces().setValue(1);
+    BDDRoute nextHopSet = new BDDRoute(orig);
+    nextHopSet.setNextHopSet(true);
+    BDDRoute nextHopType = new BDDRoute(orig);
+    nextHopType.setNextHopType(NextHopType.BGP_PEER_ADDRESS);
+    BDDRoute originType = new BDDRoute(orig);
+    originType.getOriginType().setValue(OriginType.EGP);
+    BDDRoute ospfMetric = new BDDRoute(orig);
+    ospfMetric.getOspfMetric().setValue(OspfType.E1);
+    BDDRoute prefix = new BDDRoute(orig);
+    prefix.getPrefix().setValue(1);
+    BDDRoute prefixLength = new BDDRoute(orig);
+    prefixLength.getPrefixLength().setValue(1);
+    BDDRoute prependedAses = new BDDRoute(orig);
+    prependedAses.getPrependedASes().add(1L);
+    BDDRoute protocolHistory = new BDDRoute(orig);
+    protocolHistory.getProtocolHistory().setValue(RoutingProtocol.STATIC);
+    BDDRoute sourceVrfs = new BDDRoute(orig);
+    sourceVrfs.getSourceVrfs().setValue(1);
+    BDDRoute tag = new BDDRoute(orig);
+    tag.getTag().setValue(1);
+    BDDRoute tracks = new BDDRoute(orig);
+    tracks.getTracks()[0] = factory.one();
+    BDDRoute tunnelEncapsulationAttribute = new BDDRoute(orig);
+    tunnelEncapsulationAttribute.getTunnelEncapsulationAttribute().setValue(Value.absent());
+    BDDRoute unsupported = new BDDRoute(orig);
+    unsupported.setUnsupported(true);
+    BDDRoute weight = new BDDRoute(orig);
+    weight.getWeight().setValue(1);
+    new EqualsTester()
+        .addEqualityGroup(orig, new BDDRoute(orig))
+        .addEqualityGroup(admin)
+        .addEqualityGroup(asPathRegex)
+        .addEqualityGroup(clusterListLength)
+        .addEqualityGroup(communities)
+        .addEqualityGroup(localPref)
+        .addEqualityGroup(med)
+        .addEqualityGroup(nextHop)
+        .addEqualityGroup(nextHopInterfaces)
+        .addEqualityGroup(nextHopType)
+        .addEqualityGroup(nextHopSet)
+        .addEqualityGroup(originType)
+        .addEqualityGroup(ospfMetric)
+        .addEqualityGroup(prefix)
+        .addEqualityGroup(prefixLength)
+        .addEqualityGroup(prependedAses)
+        .addEqualityGroup(protocolHistory)
+        .addEqualityGroup(sourceVrfs)
+        .addEqualityGroup(tag)
+        .addEqualityGroup(tracks)
+        .addEqualityGroup(tunnelEncapsulationAttribute)
+        .addEqualityGroup(unsupported)
+        .addEqualityGroup(weight)
+        .testEquals();
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.JFactory;
@@ -220,12 +219,6 @@ public class TransferBDDTest {
     return new BDDRoute(factory, 1, 1, 0, 0, 0, ImmutableList.of());
   }
 
-  // test whether two lists contain pairwise semantically equal TransferReturns
-  private static boolean equalsForTesting(List<TransferReturn> l1, List<TransferReturn> l2) {
-    return l1.size() == l2.size()
-        && IntStream.range(0, l1.size()).allMatch(i -> l1.get(i).equalsForTesting(l2.get(i)));
-  }
-
   private MatchPrefixSet matchPrefixSet(List<PrefixRange> prList) {
     return new MatchPrefixSet(
         DestinationNetwork.instance(), new ExplicitPrefixSet(new PrefixSpace(prList)));
@@ -304,7 +297,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -320,7 +313,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -334,7 +327,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(_policyBuilder.build(), paths, tbdd.getFactory()));
   }
 
@@ -357,12 +350,11 @@ public class TransferBDDTest {
         isRelevantForDestination(
             anyRoute, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRoute(tbdd.getFactory()), expectedBDD, true),
-                new TransferReturn(anyRoute(tbdd.getFactory()), expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRoute(tbdd.getFactory()), expectedBDD, true),
+            new TransferReturn(anyRoute(tbdd.getFactory()), expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -388,7 +380,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -414,7 +406,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -432,7 +424,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -457,12 +449,11 @@ public class TransferBDDTest {
         isRelevantForDestination(
             anyRoute, new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(32, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRoute(tbdd.getFactory()), expectedBDD, false),
-                new TransferReturn(anyRoute(tbdd.getFactory()), expectedBDD.not(), true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRoute(tbdd.getFactory()), expectedBDD, false),
+            new TransferReturn(anyRoute(tbdd.getFactory()), expectedBDD.not(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -495,14 +486,13 @@ public class TransferBDDTest {
         isRelevantForDestination(
             anyRoute, new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(32, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRoute, suppressed.and(unsuppressed), true),
-                new TransferReturn(anyRoute, suppressed.and(unsuppressed.not()), false),
-                new TransferReturn(anyRoute, suppressed.not().and(unsuppressed), true),
-                new TransferReturn(anyRoute, suppressed.not().and(unsuppressed.not()), true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRoute, suppressed.and(unsuppressed), true),
+            new TransferReturn(anyRoute, suppressed.and(unsuppressed.not()), false),
+            new TransferReturn(anyRoute, suppressed.not().and(unsuppressed), true),
+            new TransferReturn(anyRoute, suppressed.not().and(unsuppressed.not()), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -521,7 +511,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -540,7 +530,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -578,13 +568,12 @@ public class TransferBDDTest {
     BDDRoute localPref3 = anyRoute(tbdd.getFactory());
     localPref3.setLocalPref(MutableBDDInteger.makeFromValue(tbdd.getFactory(), 32, 3));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRoute(tbdd.getFactory()), if1, true),
-                new TransferReturn(localPref3, if1.not().and(if2), true),
-                new TransferReturn(anyRoute(tbdd.getFactory()), if1.not().and(if2.not()), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRoute(tbdd.getFactory()), if1, true),
+            new TransferReturn(localPref3, if1.not().and(if2), true),
+            new TransferReturn(anyRoute(tbdd.getFactory()), if1.not().and(if2.not()), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -622,13 +611,12 @@ public class TransferBDDTest {
     BDDRoute localPref3 = anyRoute(tbdd.getFactory());
     localPref3.setLocalPref(MutableBDDInteger.makeFromValue(tbdd.getFactory(), 32, 3));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRoute(tbdd.getFactory()), if1, true),
-                new TransferReturn(localPref3, if1.not().and(if2), false),
-                new TransferReturn(anyRoute(tbdd.getFactory()), if1.not().and(if2.not()), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRoute(tbdd.getFactory()), if1, true),
+            new TransferReturn(localPref3, if1.not().and(if2), false),
+            new TransferReturn(anyRoute(tbdd.getFactory()), if1.not().and(if2.not()), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -671,13 +659,12 @@ public class TransferBDDTest {
     BDDRoute localPref3 = anyRoute(tbdd.getFactory());
     localPref3.setLocalPref(MutableBDDInteger.makeFromValue(tbdd.getFactory(), 32, 3));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(localPref2, if1, true),
-                new TransferReturn(localPref3, if1.not().and(if2), false),
-                new TransferReturn(anyRoute(tbdd.getFactory()), if1.not().and(if2.not()), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(localPref2, if1, true),
+            new TransferReturn(localPref3, if1.not().and(if2), false),
+            new TransferReturn(anyRoute(tbdd.getFactory()), if1.not().and(if2.not()), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -709,13 +696,12 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(31, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, if1.and(if2), true),
-                new TransferReturn(any, if1.and(if2.not()), false),
-                new TransferReturn(any, if1.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, if1.and(if2), true),
+            new TransferReturn(any, if1.and(if2.not()), false),
+            new TransferReturn(any, if1.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -735,7 +721,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -756,7 +742,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -783,11 +769,10 @@ public class TransferBDDTest {
                 any, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24)))
             .not();
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, if1.not(), false), new TransferReturn(any, if1, true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, if1.not(), false), new TransferReturn(any, if1, true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -815,12 +800,11 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("1.2.0.0/16"), new SubRange(25, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, expectedBDD1.or(expectedBDD2), true),
-                new TransferReturn(any, expectedBDD1.or(expectedBDD2).not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, expectedBDD1.or(expectedBDD2), true),
+            new TransferReturn(any, expectedBDD1.or(expectedBDD2).not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -852,13 +836,12 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("1.2.0.0/16"), new SubRange(20, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, expectedBDD1.not(), false),
-                new TransferReturn(any, expectedBDD1.and(expectedBDD2.not()), false),
-                new TransferReturn(any, expectedBDD1.and(expectedBDD2), true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, expectedBDD1.not(), false),
+            new TransferReturn(any, expectedBDD1.and(expectedBDD2.not()), false),
+            new TransferReturn(any, expectedBDD1.and(expectedBDD2), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -876,7 +859,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -908,12 +891,11 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(31, 31)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, expectedBDD, true),
-                new TransferReturn(any, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, expectedBDD, true),
+            new TransferReturn(any, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -935,7 +917,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -958,7 +940,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -977,10 +959,8 @@ public class TransferBDDTest {
     BDDRoute expectedRoute = anyRoute(tbdd.getFactory());
     expectedRoute.getOriginType().setValue(OriginType.INCOMPLETE);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(new TransferReturn(expectedRoute, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expectedRoute, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -999,10 +979,8 @@ public class TransferBDDTest {
     BDDRoute expectedRoute = anyRoute(tbdd.getFactory());
     expectedRoute.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(new TransferReturn(expectedRoute, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expectedRoute, tbdd.getFactory().one(), true)));
   }
 
   @Test
@@ -1020,10 +998,8 @@ public class TransferBDDTest {
     BDDRoute expectedRoute = anyRoute(tbdd.getFactory());
     expectedRoute.getOspfMetric().setValue(OspfType.E1);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(new TransferReturn(expectedRoute, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expectedRoute, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1042,10 +1018,8 @@ public class TransferBDDTest {
     BDDRoute expectedRoute = anyRoute(tbdd.getFactory());
     expectedRoute.getOspfMetric().setValue(OspfType.E2);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(new TransferReturn(expectedRoute, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expectedRoute, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1067,7 +1041,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1090,7 +1064,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1113,7 +1087,7 @@ public class TransferBDDTest {
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
 
     List<TransferReturn> paths = tbdd.computePaths();
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1133,7 +1107,7 @@ public class TransferBDDTest {
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
 
     List<TransferReturn> paths = tbdd.computePaths();
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1155,7 +1129,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1176,7 +1150,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
   }
 
   @Test
@@ -1197,7 +1171,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1218,7 +1192,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
   }
 
   @Test
@@ -1237,12 +1211,11 @@ public class TransferBDDTest {
 
     BDDRoute any = anyRoute(tbdd.getFactory());
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, any.getTag().value(42), true),
-                new TransferReturn(any, any.getTag().value(42).not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, any.getTag().value(42), true),
+            new TransferReturn(any, any.getTag().value(42).not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1266,12 +1239,11 @@ public class TransferBDDTest {
     MutableBDDInteger tag = expected.getTag();
     expected.setTag(MutableBDDInteger.makeFromValue(tag.getFactory(), 32, 42));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(expected, any.getTag().value(42), true),
-                new TransferReturn(expected, any.getTag().value(42).not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expected, any.getTag().value(42), true),
+            new TransferReturn(expected, any.getTag().value(42).not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // now do the analysis again but use the output attributes for matching
@@ -1280,9 +1252,8 @@ public class TransferBDDTest {
     tbdd = new TransferBDD(_configAPs, policy);
     paths = tbdd.computePaths();
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // do the analysis once more, but after a directive to read from intermediate attributes
@@ -1299,9 +1270,8 @@ public class TransferBDDTest {
     tbdd = new TransferBDD(_configAPs, policy);
     paths = tbdd.computePaths();
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1323,12 +1293,10 @@ public class TransferBDDTest {
 
     BDD tag01 = any.getTag().value(0).or(any.getTag().value(1));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, tag01, true),
-                new TransferReturn(any, tag01.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, tag01, true), new TransferReturn(any, tag01.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1348,12 +1316,11 @@ public class TransferBDDTest {
 
     BDDRoute any = anyRoute(tbdd.getFactory());
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, any.getMed().value(42), true),
-                new TransferReturn(any, any.getMed().value(42).not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, any.getMed().value(42), true),
+            new TransferReturn(any, any.getMed().value(42).not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1375,12 +1342,11 @@ public class TransferBDDTest {
 
     BDD metricGETwo = any.getMed().value(0).or(any.getMed().value(1)).not();
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, metricGETwo, true),
-                new TransferReturn(any, metricGETwo.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, metricGETwo, true),
+            new TransferReturn(any, metricGETwo.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1404,12 +1370,11 @@ public class TransferBDDTest {
     MutableBDDInteger metric = expected.getMed();
     expected.setMed(MutableBDDInteger.makeFromValue(metric.getFactory(), 32, 42));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(expected, any.getMed().value(42), true),
-                new TransferReturn(expected, any.getMed().value(42).not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expected, any.getMed().value(42), true),
+            new TransferReturn(expected, any.getMed().value(42).not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // now do the analysis again but use the output attributes for matching
@@ -1418,9 +1383,8 @@ public class TransferBDDTest {
     tbdd = new TransferBDD(_configAPs, policy);
     paths = tbdd.computePaths();
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1441,9 +1405,7 @@ public class TransferBDDTest {
     BDDRoute any = anyRoute(tbdd.getFactory());
     any.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false)));
   }
 
   @Test
@@ -1462,12 +1424,11 @@ public class TransferBDDTest {
 
     BDDRoute any = anyRoute(tbdd.getFactory());
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, any.getClusterListLength().value(42), true),
-                new TransferReturn(any, any.getClusterListLength().value(42).not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, any.getClusterListLength().value(42), true),
+            new TransferReturn(any, any.getClusterListLength().value(42).not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1493,12 +1454,11 @@ public class TransferBDDTest {
             .or(any.getClusterListLength().value(1))
             .or(any.getClusterListLength().value(2));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, clusterListLengthLETwo, true),
-                new TransferReturn(any, clusterListLengthLETwo.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, clusterListLengthLETwo, true),
+            new TransferReturn(any, clusterListLengthLETwo.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1519,9 +1479,7 @@ public class TransferBDDTest {
     BDDRoute any = anyRoute(tbdd.getFactory());
     any.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false)));
   }
 
   @Test
@@ -1541,12 +1499,11 @@ public class TransferBDDTest {
     BDDRoute any = new BDDRoute(tbdd.getFactory(), _configAPs);
     BDD trackPred = any.getTracks()[0];
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, trackPred, true),
-                new TransferReturn(any, trackPred.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, trackPred, true),
+            new TransferReturn(any, trackPred.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1567,12 +1524,11 @@ public class TransferBDDTest {
     BDDRoute any = new BDDRoute(tbdd.getFactory(), _configAPs);
     BDD sourcePred = any.getSourceVrfs().value(1);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, sourcePred, true),
-                new TransferReturn(any, sourcePred.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, sourcePred, true),
+            new TransferReturn(any, sourcePred.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1593,12 +1549,10 @@ public class TransferBDDTest {
     BDDRoute any = new BDDRoute(tbdd.getFactory(), _configAPs);
     BDD intPred = any.getNextHopInterfaces().value(1).or(any.getNextHopInterfaces().value(2));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, intPred, true),
-                new TransferReturn(any, intPred.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, intPred, true), new TransferReturn(any, intPred.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1623,12 +1577,11 @@ public class TransferBDDTest {
 
     BDD expectedBDD = any.getNextHop().toBDD(Prefix.parse("1.0.0.0/32"));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, expectedBDD, true),
-                new TransferReturn(any, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, expectedBDD, true),
+            new TransferReturn(any, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1651,9 +1604,7 @@ public class TransferBDDTest {
 
     BDDRoute any = anyRoute(tbdd.getFactory());
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1680,7 +1631,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
   }
 
   @Test
@@ -1700,7 +1651,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1721,7 +1672,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1742,7 +1693,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1764,7 +1715,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1787,7 +1738,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1806,7 +1757,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
   }
 
   @Test
@@ -1829,12 +1780,11 @@ public class TransferBDDTest {
 
     BDD expectedBDD = protocol.value(RoutingProtocol.BGP).or(protocol.value(RoutingProtocol.OSPF));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, expectedBDD, true),
-                new TransferReturn(any, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, expectedBDD, true),
+            new TransferReturn(any, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1855,9 +1805,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths();
 
     BDDRoute any = anyRoute(tbdd.getFactory());
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), true))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1883,12 +1831,11 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, expectedBDD, true),
-                new TransferReturn(any, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, expectedBDD, true),
+            new TransferReturn(any, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1916,12 +1863,11 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, expectedBDD, false),
-                new TransferReturn(any, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, expectedBDD, false),
+            new TransferReturn(any, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1942,9 +1888,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths();
 
     BDDRoute any = anyRoute(tbdd.getFactory());
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), true))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -1966,7 +1910,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2006,12 +1950,11 @@ public class TransferBDDTest {
 
     BDD expectedBDD = aps.value(ap);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRouteWithAPs, expectedBDD, true),
-                new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRouteWithAPs, expectedBDD, true),
+            new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false)));
 
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
@@ -2044,12 +1987,11 @@ public class TransferBDDTest {
 
     BDD expectedBDD = aps.value(ap1).or(aps.value(ap2));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRouteWithAPs, expectedBDD, true),
-                new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRouteWithAPs, expectedBDD, true),
+            new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // now do the analysis again for a platform that matches on the output route;
@@ -2058,12 +2000,11 @@ public class TransferBDDTest {
     tbdd = new TransferBDD(_configAPs, policy);
     paths = tbdd.computePaths();
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRouteWithAPs, expectedBDD, true),
-                new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRouteWithAPs, expectedBDD, true),
+            new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2096,13 +2037,12 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(24, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, conj1.not(), false),
-                new TransferReturn(any, conj1.and(conj2.not()), false),
-                new TransferReturn(any, conj1.and(conj2), true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, conj1.not(), false),
+            new TransferReturn(any, conj1.and(conj2.not()), false),
+            new TransferReturn(any, conj1.and(conj2), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2139,13 +2079,12 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(24, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, conj1.not(), false),
-                new TransferReturn(unsupported, conj1.and(conj2.not()), false),
-                new TransferReturn(unsupported, conj1.and(conj2), true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, conj1.not(), false),
+            new TransferReturn(unsupported, conj1.and(conj2.not()), false),
+            new TransferReturn(unsupported, conj1.and(conj2), true)));
   }
 
   @Test
@@ -2182,10 +2121,8 @@ public class TransferBDDTest {
     BDDRoute expectedOut = anyRoute(tbdd.getFactory());
     expectedOut.setLocalPref(MutableBDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(new TransferReturn(expectedOut, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expectedOut, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2222,9 +2159,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths();
 
     BDDRoute any = anyRoute(tbdd.getFactory());
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2273,12 +2208,11 @@ public class TransferBDDTest {
     MutableBDDInteger localPref = localPref300.getLocalPref();
     localPref300.setLocalPref(MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 300));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, conj1.not(), true),
-                new TransferReturn(localPref300, conj1, true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, conj1.not(), true),
+            new TransferReturn(localPref300, conj1, true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2295,9 +2229,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths();
 
     BDDRoute any = anyRoute(tbdd.getFactory());
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), true))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2330,13 +2262,12 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(24, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, disj1, true),
-                new TransferReturn(any, disj1.not().and(disj2), true),
-                new TransferReturn(any, disj1.not().and(disj2.not()), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, disj1, true),
+            new TransferReturn(any, disj1.not().and(disj2), true),
+            new TransferReturn(any, disj1.not().and(disj2.not()), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2373,13 +2304,12 @@ public class TransferBDDTest {
         isRelevantForDestination(
             any, new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(24, 32)));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, disj1, true),
-                new TransferReturn(unsupported, disj1.not().and(disj2), true),
-                new TransferReturn(unsupported, disj1.not().and(disj2.not()), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, disj1, true),
+            new TransferReturn(unsupported, disj1.not().and(disj2), true),
+            new TransferReturn(unsupported, disj1.not().and(disj2.not()), false)));
   }
 
   @Test
@@ -2424,12 +2354,11 @@ public class TransferBDDTest {
     BDDRoute localPref32 = new BDDRoute(any);
     localPref32.setLocalPref(MutableBDDInteger.makeFromValue(tbdd.getFactory(), 32, 300));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, firstDisjunctBDD, true),
-                new TransferReturn(localPref32, firstDisjunctBDD.not(), true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, firstDisjunctBDD, true),
+            new TransferReturn(localPref32, firstDisjunctBDD.not(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2446,9 +2375,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths();
 
     BDDRoute any = anyRoute(tbdd.getFactory());
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2485,12 +2412,11 @@ public class TransferBDDTest {
 
     BDD expectedBDD = aps.value(ap);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRouteWithAPs, expectedBDD, true),
-                new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRouteWithAPs, expectedBDD, true),
+            new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2520,12 +2446,11 @@ public class TransferBDDTest {
 
     BDD expectedBDD = aps.value(ap);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRouteWithAPs, expectedBDD, true),
-                new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRouteWithAPs, expectedBDD, true),
+            new TransferReturn(anyRouteWithAPs, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2562,9 +2487,8 @@ public class TransferBDDTest {
       expected.getCommunityAtomicPredicates()[ap] = tbdd.getFactory().zero();
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2600,9 +2524,8 @@ public class TransferBDDTest {
       expected.getCommunityAtomicPredicates()[ap] = tbdd.getFactory().one();
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2644,9 +2567,8 @@ public class TransferBDDTest {
       expected.getCommunityAtomicPredicates()[ap] = tbdd.getFactory().zero();
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2685,9 +2607,8 @@ public class TransferBDDTest {
       expected.getCommunityAtomicPredicates()[ap] = tbdd.getFactory().one();
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // do the analysis once more, but after a directive to read from intermediate attributes
@@ -2710,9 +2631,8 @@ public class TransferBDDTest {
             .get(CommunityVar.from(StandardCommunity.parse("4:44")))) {
       expected.getCommunityAtomicPredicates()[ap] = tbdd.getFactory().one();
     }
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2753,9 +2673,8 @@ public class TransferBDDTest {
       }
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2792,9 +2711,8 @@ public class TransferBDDTest {
       }
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2830,9 +2748,8 @@ public class TransferBDDTest {
       }
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2865,9 +2782,8 @@ public class TransferBDDTest {
       }
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2908,9 +2824,8 @@ public class TransferBDDTest {
       }
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2944,12 +2859,11 @@ public class TransferBDDTest {
     BDD expectedBDD =
         tbdd.getFactory().orAll(ap30.stream().map(i -> aps[i]).collect(Collectors.toList()));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRoute, expectedBDD, true),
-                new TransferReturn(anyRoute, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRoute, expectedBDD, true),
+            new TransferReturn(anyRoute, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -2998,12 +2912,11 @@ public class TransferBDDTest {
         tbdd.getFactory()
             .orAll(intersection.stream().map(i -> aps[i]).collect(Collectors.toList()));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(anyRoute, expectedBDD, true),
-                new TransferReturn(anyRoute, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(anyRoute, expectedBDD, true),
+            new TransferReturn(anyRoute, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3044,12 +2957,11 @@ public class TransferBDDTest {
       aps[i] = tbdd.getFactory().one();
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(expected, expectedBDD, true),
-                new TransferReturn(expected, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expected, expectedBDD, true),
+            new TransferReturn(expected, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // now do the analysis again but use the output attributes for matching
@@ -3059,9 +2971,8 @@ public class TransferBDDTest {
     paths = tbdd.computePaths();
 
     // all input routes satisfy the if statement now, so there is only one path
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3107,12 +3018,11 @@ public class TransferBDDTest {
       aps[i] = tbdd.getFactory().one();
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(expected, expectedBDD, true),
-                new TransferReturn(expected, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expected, expectedBDD, true),
+            new TransferReturn(expected, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // now do the analysis again but use the output attributes for matching
@@ -3121,12 +3031,11 @@ public class TransferBDDTest {
     tbdd = new TransferBDD(_configAPs, policy);
     paths = tbdd.computePaths();
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(expected, expectedBDD, true),
-                new TransferReturn(expected, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expected, expectedBDD, true),
+            new TransferReturn(expected, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3165,12 +3074,11 @@ public class TransferBDDTest {
       aps[i] = tbdd.getFactory().zero();
     }
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(expected, expectedBDD, true),
-                new TransferReturn(expected, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expected, expectedBDD, true),
+            new TransferReturn(expected, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // now do the analysis again but use the output attributes for matching
@@ -3179,9 +3087,8 @@ public class TransferBDDTest {
     tbdd = new TransferBDD(_configAPs, policy);
     paths = tbdd.computePaths();
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3218,7 +3125,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(localPref300, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3259,7 +3166,7 @@ public class TransferBDDTest {
 
     List<TransferReturn> expectedPaths =
         ImmutableList.of(new TransferReturn(localPref300, tbdd.getFactory().one(), true));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3309,12 +3216,11 @@ public class TransferBDDTest {
     BDDRoute expectedOut = new BDDRoute(anyRoute);
     expectedOut.setLocalPref(MutableBDDInteger.makeFromValue(expectedOut.getFactory(), 32, 300));
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(expectedOut, expectedBDD, true),
-                new TransferReturn(anyRoute, expectedBDD.not(), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expectedOut, expectedBDD, true),
+            new TransferReturn(anyRoute, expectedBDD.not(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3344,7 +3250,7 @@ public class TransferBDDTest {
     List<TransferReturn> expectedPaths =
         ImmutableList.of(
             new TransferReturn(anyRoute(tbdd.getFactory()), tbdd.getFactory().one(), false));
-    assertTrue(equalsForTesting(expectedPaths, paths));
+    assertEquals(expectedPaths, paths);
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3373,9 +3279,8 @@ public class TransferBDDTest {
     MutableBDDInteger localPref = expected.getLocalPref();
     expected.setLocalPref(MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 44));
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3392,9 +3297,8 @@ public class TransferBDDTest {
     BDDRoute expected = anyRoute(tbdd.getFactory());
     expected.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false)));
   }
 
   @Test
@@ -3415,9 +3319,8 @@ public class TransferBDDTest {
     BDDRoute expected = anyRoute(tbdd.getFactory());
     expected.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false)));
   }
 
   @Test
@@ -3434,9 +3337,8 @@ public class TransferBDDTest {
     BDDRoute expected = anyRoute(tbdd.getFactory());
     expected.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
   }
 
   @Test
@@ -3453,9 +3355,8 @@ public class TransferBDDTest {
     BDDRoute expected = anyRoute(tbdd.getFactory());
     expected.setPrependedASes(ImmutableList.of(42L));
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
     // now do the analysis again for a platform that reads from output attributes;
@@ -3464,9 +3365,8 @@ public class TransferBDDTest {
     tbdd = new TransferBDD(_configAPs, policy);
     paths = tbdd.computePaths();
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3488,9 +3388,8 @@ public class TransferBDDTest {
     // the first
     expected.setPrependedASes(ImmutableList.of(44L, 4L, 42L));
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3542,13 +3441,12 @@ public class TransferBDDTest {
 
     BDD if2 = any.getProtocolHistory().value(RoutingProtocol.BGP);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, if1, true),
-                new TransferReturn(any, if1.not().and(if2), true),
-                new TransferReturn(any, if1.not().and(if2.not()), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, if1, true),
+            new TransferReturn(any, if1.not().and(if2), true),
+            new TransferReturn(any, if1.not().and(if2.not()), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3600,13 +3498,12 @@ public class TransferBDDTest {
 
     BDD if2 = any.getProtocolHistory().value(RoutingProtocol.BGP);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(any, if1, false),
-                new TransferReturn(any, if1.not().and(if2), true),
-                new TransferReturn(any, if1.not().and(if2.not()), false))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, if1, false),
+            new TransferReturn(any, if1.not().and(if2), true),
+            new TransferReturn(any, if1.not().and(if2.not()), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3646,9 +3543,7 @@ public class TransferBDDTest {
 
     BDDRoute any = anyRoute(tbdd.getFactory());
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(any, any.getFactory().one(), false))));
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, any.getFactory().one(), false)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3727,9 +3622,8 @@ public class TransferBDDTest {
     expected.setTag(MutableBDDInteger.makeFromValue(tag.getFactory(), 32, 42));
 
     // the tag set in policy1 is matched upon in policy2
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3779,9 +3673,8 @@ public class TransferBDDTest {
     expected.setTag(MutableBDDInteger.makeFromValue(tag.getFactory(), 32, 10));
 
     // the tag set in policy1 is overwritten in policy2
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3832,9 +3725,8 @@ public class TransferBDDTest {
     expected.setMed(MutableBDDInteger.makeFromValue(med.getFactory(), 32, 42));
 
     // the updates from both policies take effect
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
@@ -3867,12 +3759,11 @@ public class TransferBDDTest {
     expectedOut.setNextHopSet(true);
     expectedOut.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths,
-            ImmutableList.of(
-                new TransferReturn(expectedOut, expectedBDD, true),
-                new TransferReturn(any, expectedBDD.not(), true))));
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expectedOut, expectedBDD, true),
+            new TransferReturn(any, expectedBDD.not(), true)));
   }
 
   @Test
@@ -3889,9 +3780,8 @@ public class TransferBDDTest {
     BDDRoute expected = anyRoute(tbdd.getFactory());
     expected.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
   }
 
   @Test
@@ -3908,9 +3798,8 @@ public class TransferBDDTest {
     BDDRoute expected = anyRoute(tbdd.getFactory());
     expected.setUnsupported(true);
 
-    assertTrue(
-        equalsForTesting(
-            paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false))));
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), false)));
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferReturnTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferReturnTest.java
@@ -1,0 +1,26 @@
+package org.batfish.minesweeper.bdd;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import net.sf.javabdd.BDDFactory;
+import net.sf.javabdd.JFactory;
+import org.junit.Test;
+
+public class TransferReturnTest {
+  @Test
+  public void testEquals() {
+    BDDFactory factory = JFactory.init(100, 100);
+    BDDRoute route1 = new BDDRoute(factory, 0, 0, 0, 0, 0, ImmutableList.of());
+    BDDRoute route2 = new BDDRoute(route1);
+    route2.getAdminDist().setValue(1);
+
+    new EqualsTester()
+        .addEqualityGroup(
+            new TransferReturn(route1, factory.zero(), false),
+            new TransferReturn(route1, factory.zero(), false))
+        .addEqualityGroup(new TransferReturn(route2, factory.zero(), false))
+        .addEqualityGroup(new TransferReturn(route2, factory.one(), false))
+        .addEqualityGroup(new TransferReturn(route2, factory.one(), true))
+        .testEquals();
+  }
+}


### PR DESCRIPTION
And implement hashCode to honor Java contracts.

---

**Stack**:
- #9096
- #9095
- #9094
- #9093 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*