### PR TITLE
TransferBDD: clear unreachable paths earlier

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -630,6 +630,9 @@ public class TransferBDD {
       throw new UnsupportedOperationException(expr.toString());
     }
 
+    // Clear any paths that are not reachable from the inputs.
+    finalResults.removeIf(tr -> tr.getReturnValue().getInputConstraints().isZero());
+
     // in most cases above we have only provided the path corresponding to the predicate being true
     // so lastly, we add the path corresponding to the predicate being false
 


### PR DESCRIPTION
This is a no-op in the long run, because answerers make sure to present
reachable paths with examples. But it will improve efficiency, especially
if we later add richer input constraints, to filter during path
computation.