### PR TITLE
github workflows: upgrade from set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=ymd::$(date +'%Y-%m-%d')"
+        run: echo "name=ymd::$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
     outputs:
       ymd: ${{ steps.date.outputs.ymd }}
   format:
@@ -147,7 +147,7 @@ jobs:
       - name: Generate report
         uses: codecov/codecov-action@v3
         env:
-            CODECOV_TOKEN: ${{ secrets.BATFISH_CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.BATFISH_CODECOV_TOKEN }}
         with:
           files: bazel-out/_coverage/_coverage_report.dat
           fail_ci_if_error: true


### PR DESCRIPTION
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/