### PR TITLE
parboiled: convert from + to String.format

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/AsPathRegex.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/AsPathRegex.java
@@ -17,6 +17,7 @@ import org.parboiled.annotations.SuppressSubnodes;
 import org.parboiled.common.StringBuilderSink;
 import org.parboiled.parserunners.BasicParseRunner;
 import org.parboiled.parserunners.TracingParseRunner;
+import org.parboiled.support.DebuggingValueStack;
 import org.parboiled.support.ParsingResult;
 
 /**
@@ -208,10 +209,15 @@ public class AsPathRegex extends BaseParser<String> {
   static @Nonnull String debugConvertToJavaRegex(String regex) {
     AsPathRegex parser = Parboiled.createParser(AsPathRegex.class);
     TracingParseRunner<String> runner =
-        new TracingParseRunner<String>(parser.TopLevel()).withLog(new StringBuilderSink());
+        (TracingParseRunner<String>)
+            new TracingParseRunner<String>(parser.TopLevel())
+                .withLog(new StringBuilderSink())
+                .withValueStack(new DebuggingValueStack<>(new StringBuilderSink()));
+    DebuggingValueStack<String> stack = (DebuggingValueStack<String>) runner.getValueStack();
     ParsingResult<String> result = runner.run(regex);
     if (!result.matched) {
-      throw new IllegalArgumentException("Unhandled input: " + regex + "\n" + runner.getLog());
+      throw new IllegalArgumentException(
+          "Unhandled input: " + regex + "\n" + runner.getLog() + "\n" + stack.log);
     }
     return result.resultValue;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/AsPathRegex.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/AsPathRegex.java
@@ -142,7 +142,7 @@ public class AsPathRegex extends BaseParser<String> {
   // Like Number(), but requires either start of string or preceding space.
   @SuppressSubnodes
   Rule ASN() {
-    return Sequence(Number(), push(MAYBE_SEPARATOR + pop()));
+    return Sequence(Number(), push(String.format("%s%s", MAYBE_SEPARATOR, pop())));
   }
 
   // A decimal number.
@@ -154,7 +154,8 @@ public class AsPathRegex extends BaseParser<String> {
   @SuppressSubnodes
   Rule BareAsnRange() {
     return Sequence(
-        Sequence(Number(), '-', Number()), push(MAYBE_SEPARATOR + rangeToOr(pop(1), pop())));
+        Sequence(Number(), '-', Number()),
+        push(String.format("%s%s", MAYBE_SEPARATOR, rangeToOr(pop(1), pop()))));
   }
 
   Rule BareOr() {
@@ -166,7 +167,7 @@ public class AsPathRegex extends BaseParser<String> {
             IgnoreSpace(),
             T_TopLevel(), // pop()
             push(String.format("%s|%s", pop(1), pop()))),
-        push("(" + pop() + ')'));
+        push(String.format("(%s)", pop())));
   }
 
   // BareAsnRange, with [] around it. BareAsnRange does all the stack manipulation.
@@ -186,7 +187,7 @@ public class AsPathRegex extends BaseParser<String> {
     checkArgument(start <= end, "Invalid range %s-%s", start, end);
     String bigOr =
         LongStream.range(start, end + 1).mapToObj(Long::toString).collect(Collectors.joining("|"));
-    return "(" + bigOr + ')';
+    return String.format("(%s)", bigOr);
   }
 
   /** Converts the given Juniper AS Path regular expression to a Java regular expression. */

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/GroupWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/GroupWildcard.java
@@ -30,7 +30,7 @@ public class GroupWildcard extends BaseParser<String> {
             Element(), // pop(1)
             ZeroOrMore(
                 Element(), // pop()
-                push(pop(1) + pop()))),
+                push(String.format("%s%s", pop(1), pop())))),
         EOI);
   }
 
@@ -47,7 +47,9 @@ public class GroupWildcard extends BaseParser<String> {
   Rule CharacterClass() {
     return Sequence(
         Ch('['),
-        Sequence(push(""), Optional(FirstOf(Op_Bang(), Op_Carat()), push(pop(1) + pop()))),
+        Sequence(
+            push(""),
+            Optional(FirstOf(Op_Bang(), Op_Carat()), push(String.format("%s%s", pop(1), pop())))),
         ClassLiterals(),
         Ch(']'),
         push(String.format("[%s%s]", pop(1), pop())));
@@ -77,7 +79,7 @@ public class GroupWildcard extends BaseParser<String> {
     Rule base = FirstOf(ClassLiterals(), Dot());
     return Sequence(
         base, // pop()
-        ZeroOrMore(base, push(pop(1) + pop())));
+        ZeroOrMore(base, push(String.format("%s%s", pop(1), pop()))));
   }
 
   Rule Dot() {


### PR DESCRIPTION
See: https://github.com/sirthias/parboiled/issues/203

For some reason, when upgrading beyond Java 8 something about String concatenation optimizations
breaks Parboiled. This is a workaround to let us keep moving forward despite using this unmaintained
library.

---

**Stack**:
- #9106
- #9105 ⬅
- #9104


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*