### PR TITLE
CompareRoutePolicies: Compute relevant route attributes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -90,6 +90,10 @@ public final class MutableBDDInteger extends BDDInteger {
     return bdd.isZero() ? Optional.empty() : Optional.of(satAssignmentToLong(bdd.satOne()));
   }
 
+  public BDD support() {
+    return _factory.andAll(Arrays.stream(_bitvec).map(BDD::support).collect(Collectors.toSet()));
+  }
+
   @Override
   public long satAssignmentToLong(BDD satAssignment) {
     checkArgument(satAssignment.isAssignment(), "not a satisfying assignment");
@@ -102,12 +106,7 @@ public final class MutableBDDInteger extends BDDInteger {
     // very large BDD, which can cause performance issues. instead we only explicitly treat as false
     // the variables that do not appear in the given SAT assignment but are part of the support of
     // this MutableBDDInteger.
-    BDD fullSatAssignment =
-        satAssignment.satOne(
-            satAssignment
-                .getFactory()
-                .andAll(Arrays.stream(_bitvec).map(BDD::support).collect(Collectors.toSet())),
-            false);
+    BDD fullSatAssignment = satAssignment.satOne(support(), false);
 
     long value = 0;
     for (int i = 0; i < _bitvec.length; i++) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -90,10 +90,6 @@ public final class MutableBDDInteger extends BDDInteger {
     return bdd.isZero() ? Optional.empty() : Optional.of(satAssignmentToLong(bdd.satOne()));
   }
 
-  public BDD support() {
-    return _factory.andAll(Arrays.stream(_bitvec).map(BDD::support).collect(Collectors.toSet()));
-  }
-
   @Override
   public long satAssignmentToLong(BDD satAssignment) {
     checkArgument(satAssignment.isAssignment(), "not a satisfying assignment");
@@ -281,6 +277,14 @@ public final class MutableBDDInteger extends BDDInteger {
                 .collect(ImmutableList.toImmutableList()));
     assertNoLeaks(startBDDCount, 1);
     return result;
+  }
+
+  /**
+   * Produces a BDD that represents the support (i.e., the set of BDD variables) of this BDD
+   * integer.
+   */
+  public BDD support() {
+    return _factory.andAll(Arrays.stream(_bitvec).map(BDD::support).collect(Collectors.toSet()));
   }
 
   /*

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -284,7 +284,8 @@ public final class MutableBDDInteger extends BDDInteger {
    * integer.
    */
   public BDD support() {
-    return _factory.andAll(Arrays.stream(_bitvec).map(BDD::support).collect(Collectors.toSet()));
+    return _factory.andAllAndFree(
+        Arrays.stream(_bitvec).map(BDD::support).collect(Collectors.toSet()));
   }
 
   /*

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MutableBDDIntegerTest.java
@@ -163,6 +163,23 @@ public class MutableBDDIntegerTest {
   }
 
   @Test
+  public void testSupport() {
+    BDDFactory factory = BDDUtils.bddFactory(10);
+    MutableBDDInteger x = MutableBDDInteger.makeFromIndex(factory, 5, 0, false);
+    MutableBDDInteger one = MutableBDDInteger.makeFromValue(factory, 5, 1);
+    MutableBDDInteger xPlusX = x.add(x);
+
+    BDD s1 = x.support();
+    BDD s2 = one.support();
+    BDD s3 = xPlusX.support();
+
+    assertEquals(s1, factory.andAll(x._bitvec));
+    assertEquals(s2, factory.one());
+    // the high-order bit is irrelevant
+    assertEquals(s3, factory.andAll(x._bitvec[1], x._bitvec[2], x._bitvec[3], x._bitvec[4]));
+  }
+
+  @Test
   public void testAllDifferences() {
     BDDFactory factory = BDDUtils.bddFactory(10);
     MutableBDDInteger x = MutableBDDInteger.makeFromIndex(factory, 5, 0, false);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -89,6 +89,7 @@ public final class BDDDomain<T> {
     _integer.setValue(idx);
   }
 
+  /** Produces a BDD that represents the support (i.e., the set of BDD variables) of this domain. */
   public BDD support() {
     return _integer.support();
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -89,6 +89,10 @@ public final class BDDDomain<T> {
     _integer.setValue(idx);
   }
 
+  public BDD support() {
+    return _integer.support();
+  }
+
   public MutableBDDInteger getInteger() {
     return _integer;
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttribute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttribute.java
@@ -95,6 +95,10 @@ public final class BDDTunnelEncapsulationAttribute {
     return _domain.getInteger().allDifferences(other._domain.getInteger());
   }
 
+  public BDD support() {
+    return _domain.support();
+  }
+
   /** Returns a new {@link BDDTunnelEncapsulationAttribute} restricted to the given predicate. */
   public @Nonnull BDDTunnelEncapsulationAttribute and(BDD pred) {
     return new BDDTunnelEncapsulationAttribute(new BDDDomain<>(pred, _domain));

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttribute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttribute.java
@@ -95,6 +95,9 @@ public final class BDDTunnelEncapsulationAttribute {
     return _domain.getInteger().allDifferences(other._domain.getInteger());
   }
 
+  /**
+   * Produces a BDD that represents the support (i.e., the set of BDD variables) of this attribute.
+   */
   public BDD support() {
     return _domain.support();
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
@@ -29,7 +29,7 @@ public final class TransferReturn {
   private final @Nonnull BDD _inputConstraints;
   private final boolean _accepted;
 
-  TransferReturn(BDDRoute outputRoute, BDD inputConstraints, boolean accepted) {
+  public TransferReturn(BDDRoute outputRoute, BDD inputConstraints, boolean accepted) {
     _outputRoute = outputRoute;
     _inputConstraints = inputConstraints;
     _accepted = accepted;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -307,19 +307,22 @@ public final class CompareRoutePoliciesUtils {
    * @param r1 the first of the two output routes that were compared
    * @param r2 the second of the two output routes that were compared
    * @param inputConstraints the input constraints within which we want to identify differences
-   * @return A BDD that represents at least one of the differences in the given diffs list and also
-   *     includes the given input constraints. If there are no differences that are compatible with
-   *     the input constraints then the method returns ZERO.
+   * @return A BDD that represents at least one of the differences in the given diffs list. If there
+   *     are no differences that are compatible with the input constraints then the method returns
+   *     ZERO.
    */
-  private static BDD incorporateOutputConstraints(
+  private static BDD computeOutputConstraints(
       List<BDDRouteDiff.DifferenceType> diffs, BDDRoute r1, BDDRoute r2, BDD inputConstraints) {
     for (BDDRouteDiff.DifferenceType d : diffs) {
       // If the diff in this attribute is compatible with the input constraints then we are done
-      BDD inputDiff = allDifferencesForType(d, r1, r2).andEq(inputConstraints);
-      if (!inputDiff.isZero()) {
-        return inputDiff;
+      BDD differences = allDifferencesForType(d, r1, r2);
+      BDD allConstraints = inputConstraints.and(differences);
+      if (!allConstraints.isZero()) {
+        allConstraints.free();
+        return differences;
       }
-      inputDiff.free();
+      differences.free();
+      allConstraints.free();
     }
     // none of the differences are compatible with the input constraints
     return r1.getFactory().zero();
@@ -327,7 +330,7 @@ public final class CompareRoutePoliciesUtils {
 
   /**
    * Return all differences in the two routes for the given attribute. See {@link
-   * #incorporateOutputConstraints(List, BDDRoute, BDDRoute, BDD)}.
+   * #computeOutputConstraints(List, BDDRoute, BDDRoute, BDD)}.
    */
   private static BDD allDifferencesForType(
       BDDRouteDiff.DifferenceType d, BDDRoute r1, BDDRoute r2) {
@@ -433,22 +436,23 @@ public final class CompareRoutePoliciesUtils {
    * Compare two route policies for behavioral differences.
    *
    * @param referencePolicy the routing policy of the reference snapshot
-   * @param policy the routing policy of the current snapshot
-   * @param configAPs an object providing the atomic predicates for the policy's owner configuration
+   * @param otherPolicy the routing policy of the current snapshot
+   * @param configAPs an object providing the atomic predicates for the otherPolicy's owner
+   *     configuration
    * @return a set of differences
    */
   private Stream<Tuple<Result<BgpRoute>, Result<BgpRoute>>> comparePolicies(
-      RoutingPolicy referencePolicy, RoutingPolicy policy, ConfigAtomicPredicates configAPs) {
+      RoutingPolicy referencePolicy, RoutingPolicy otherPolicy, ConfigAtomicPredicates configAPs) {
     BDDFactory factory = JFactory.init(100000, 10000);
     TransferBDD tBDD = new TransferBDD(factory, configAPs, referencePolicy);
-    TransferBDD otherTBDD = new TransferBDD(factory, configAPs, policy);
+    TransferBDD otherTBDD = new TransferBDD(factory, configAPs, otherPolicy);
 
     // Generate well-formedness constraints
     BDD wf = new BDDRoute(tBDD.getFactory(), configAPs).bgpWellFormednessConstraints();
 
-    // The set of paths for the current policy
+    // The set of paths for the current otherPolicy
     List<TransferReturn> paths = computePaths(tBDD);
-    // The set of paths for the proposed policy, also indexed by input routes.
+    // The set of paths for the proposed otherPolicy, also indexed by input routes.
     List<TransferReturn> otherPaths = computePaths(otherTBDD);
     Map<BDD, TransferReturn> otherPathIndex =
         otherPaths.stream()
@@ -469,7 +473,7 @@ public final class CompareRoutePoliciesUtils {
       for (TransferReturn otherPath : iterationPaths) {
         Tuple<Result<BgpRoute>, Result<BgpRoute>> difference =
             findConcreteDifference(
-                path, otherPath, wf, configAPs, policy, referencePolicy, _direction);
+                path, otherPath, wf, configAPs, referencePolicy, otherPolicy, _direction);
         if (difference != null) {
           differences.add(difference);
         }
@@ -490,6 +494,10 @@ public final class CompareRoutePoliciesUtils {
       Environment.Direction direction) {
     BDD inputRoutes = path.getInputConstraints();
     BDD inputRoutesOther = otherPath.getInputConstraints();
+    // in the case that both paths are accepting, additional constraints will be computed later to
+    // ensure that the chosen concrete input route leads to differing output routes in the paths
+    BDD outputConstraints = inputRoutes.getFactory().one();
+
     BDD intersection = inputRoutesOther.and(inputRoutes).andEq(wellFormedConstraints);
     if (intersection.isZero()) {
       // No common input routes to check equivalence.
@@ -513,16 +521,17 @@ public final class CompareRoutePoliciesUtils {
             computeDifferences(outputRoutes, outputRoutesOther);
         if (!diffs.isEmpty()) {
           // Now try to find a difference that is compatible with the input constraints
-          BDD allConstraints =
-              incorporateOutputConstraints(diffs, outputRoutes, outputRoutesOther, intersection);
+          outputConstraints =
+              computeOutputConstraints(diffs, outputRoutes, outputRoutesOther, intersection);
+          BDD allConstraints = intersection.andEq(outputConstraints);
           if (!allConstraints.isZero()) {
             finalConstraints = allConstraints;
           } else {
+            outputConstraints.free();
             allConstraints.free();
           }
         }
       }
-      intersection.free();
     }
 
     if (finalConstraints == null) {
@@ -533,13 +542,19 @@ public final class CompareRoutePoliciesUtils {
     // we have found a difference, so let's get a concrete example of the difference
     Tuple<Bgpv4Route, Tuple<Predicate<String>, String>> t =
         constraintsToInputs(finalConstraints, configAPs);
-    Result<BgpRoute> otherResult =
-        simulatePolicy(policy, t.getFirst(), direction, t.getSecond(), otherPath.getOutputRoute());
     Result<BgpRoute> refResult =
-        simulatePolicy(otherPolicy, t.getFirst(), direction, t.getSecond(), path.getOutputRoute());
+        simulatePolicy(policy, t.getFirst(), direction, t.getSecond(), path.getOutputRoute());
+    Result<BgpRoute> otherResult =
+        simulatePolicy(
+            otherPolicy, t.getFirst(), direction, t.getSecond(), otherPath.getOutputRoute());
 
+    // determine which input route attributes are relevant for this difference, based on the
+    // variables that appear in the input constraints of the two paths as well as the output
+    // constraint generated above. this differs from the variable finalConstraints only in not
+    // including the well-formedness constraint, inclusion of which could cause some
+    // irrelevant attributes to be considered relevant.
     List<Result.RouteAttributeType> relevantAttributes =
-        relevantInputAttributesFor(finalConstraints, configAPs);
+        relevantAttributesFor(inputRoutes.and(inputRoutesOther).and(outputConstraints), configAPs);
     refResult.setRelevantInputAttributes(ImmutableList.copyOf(relevantAttributes));
     otherResult.setRelevantInputAttributes(ImmutableList.copyOf(relevantAttributes));
 
@@ -551,70 +566,61 @@ public final class CompareRoutePoliciesUtils {
   }
 
   /**
-   * Determine which input route attributes are relevant for this particular difference. If a route
-   * attribute is not included in the result, then that attribute is irrelevant in the sense that
-   * any value can be chosen for that attribute.
+   * Determines which route attributes are relevant for the given constraint. If a route attribute
+   * is not included in the result, then that attribute is irrelevant in the sense that any value
+   * can be chosen for that attribute.
    *
    * @param constraint predicate that represents the input space leading to a particular difference
    * @param configAPs information about atomic predicates
    * @return a list of route attributes that are relevant for this difference
    */
-  private static List<Result.RouteAttributeType> relevantInputAttributesFor(
+  public static List<Result.RouteAttributeType> relevantAttributesFor(
       BDD constraint, ConfigAtomicPredicates configAPs) {
     List<Result.RouteAttributeType> result = new ArrayList<>();
 
     BDDFactory factory = constraint.getFactory();
     BDDRoute origRoute = new BDDRoute(factory, configAPs);
 
-    BDD wf = origRoute.bgpWellFormednessConstraints();
-
-    if (varsAreRelevantFor(constraint, origRoute.getAdminDist().support(), wf)) {
+    if (constraint.testsVars(origRoute.getAdminDist().support())) {
       result.add(ADMINISTRATIVE_DISTANCE);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getAsPathRegexAtomicPredicates().support(), wf)) {
+    if (constraint.testsVars(origRoute.getAsPathRegexAtomicPredicates().support())) {
       result.add(AS_PATH);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getClusterListLength().support(), wf)) {
+    if (constraint.testsVars(origRoute.getClusterListLength().support())) {
       result.add(CLUSTER_LIST);
     }
-    if (varsAreRelevantFor(
-        constraint, factory.andAll(origRoute.getCommunityAtomicPredicates()), wf)) {
+    if (constraint.testsVars(factory.andAll(origRoute.getCommunityAtomicPredicates()))) {
       result.add(COMMUNITIES);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getLocalPref().support(), wf)) {
+    if (constraint.testsVars(origRoute.getLocalPref().support())) {
       result.add(LOCAL_PREFERENCE);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getMed().support(), wf)) {
+    if (constraint.testsVars(origRoute.getMed().support())) {
       result.add(METRIC);
     }
-    if (varsAreRelevantFor(
-        constraint,
-        origRoute.getPrefix().support().and(origRoute.getPrefixLength().support()),
-        wf)) {
+    if (constraint.testsVars(
+        origRoute.getPrefix().support().and(origRoute.getPrefixLength().support()))) {
       result.add(NETWORK);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getNextHop().support(), wf)) {
+    if (constraint.testsVars(origRoute.getNextHop().support())) {
       result.add(NEXT_HOP);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getOriginType().support(), wf)) {
+    if (constraint.testsVars(origRoute.getOriginType().support())) {
       result.add(ORIGIN_TYPE);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getProtocolHistory().support(), wf)) {
+    if (constraint.testsVars(origRoute.getProtocolHistory().support())) {
       result.add(PROTOCOL);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getTag().support(), wf)) {
+    if (constraint.testsVars(origRoute.getTag().support())) {
       result.add(TAG);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getTunnelEncapsulationAttribute().support(), wf)) {
+    if (constraint.testsVars(origRoute.getTunnelEncapsulationAttribute().support())) {
       result.add(TUNNEL_ENCAPSULATION_ATTRIBUTE);
     }
-    if (varsAreRelevantFor(constraint, origRoute.getWeight().support(), wf)) {
+    if (constraint.testsVars(origRoute.getWeight().support())) {
       result.add(WEIGHT);
     }
     return result;
-  }
-
-  private static boolean varsAreRelevantFor(BDD constraint, BDD vars, BDD wfConstraint) {
-    return !constraint.project(vars).equals(wfConstraint.project(vars));
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -527,6 +527,8 @@ public final class CompareRoutePoliciesUtils {
             outputConstraints.free();
             allConstraints.free();
           }
+        } else {
+          intersection.free();
         }
       }
     }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDDomainTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDDomainTest.java
@@ -88,4 +88,18 @@ public class BDDDomainTest {
     assertThat(two.satAssignmentToValue(inputA), equalTo("a"));
     assertThat(two.satAssignmentToValue(inputB), equalTo("a"));
   }
+
+  @Test
+  public void testSupport() {
+    BDDFactory factory = BDDPacket.defaultFactory(JFactory::init);
+    factory.setVarNum(5);
+
+    BDDDomain<String> two = new BDDDomain<>(factory, ImmutableList.of("a", "b"), 0);
+    BDD s1 = two.support();
+    assertThat(s1, equalTo(factory.andAll(two.getInteger().support())));
+
+    two.setValue("a");
+    BDD s2 = two.support();
+    assertThat(s2, equalTo(factory.one()));
+  }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttributeTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttributeTest.java
@@ -125,4 +125,21 @@ public class BDDTunnelEncapsulationAttributeTest {
     assertThat(aConditional.allDifferences(alwaysA), equalTo(factory.nithVar(4)));
     assertThat(alwaysA.allDifferences(aConditional), equalTo(factory.nithVar(4)));
   }
+
+  @Test
+  public void testSupport() {
+    BDDFactory factory = BDDPacket.defaultFactory(JFactory::init);
+    factory.setVarNum(5);
+
+    TunnelEncapsulationAttribute a = new TunnelEncapsulationAttribute(Ip.create(1));
+    BDDTunnelEncapsulationAttribute base =
+        BDDTunnelEncapsulationAttribute.create(factory, 0, ImmutableList.of(a));
+
+    BDDTunnelEncapsulationAttribute alwaysA = BDDTunnelEncapsulationAttribute.copyOf(base);
+    alwaysA.setValue(Value.literal(a));
+    BDDTunnelEncapsulationAttribute aConditional = alwaysA.and(factory.ithVar(4));
+
+    assertThat(alwaysA.support(), equalTo(factory.one()));
+    assertThat(aConditional.support(), equalTo(factory.ithVar(4)));
+  }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtilsTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtilsTest.java
@@ -2,6 +2,7 @@ package org.batfish.minesweeper.question.compareroutepolicies;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 import com.google.common.collect.ImmutableList;
@@ -90,10 +91,10 @@ public class CompareRoutePoliciesUtilsTest {
 
     assertThat(
         CompareRoutePoliciesUtils.relevantAttributesFor(none, _configAPs),
-        Matchers.is(ImmutableList.of()));
+        equalTo(ImmutableList.of()));
     assertThat(
         CompareRoutePoliciesUtils.relevantAttributesFor(localPref, _configAPs),
-        Matchers.is(ImmutableList.of(Result.RouteAttributeType.LOCAL_PREFERENCE)));
+        equalTo(ImmutableList.of(Result.RouteAttributeType.LOCAL_PREFERENCE)));
     assertThat(
         CompareRoutePoliciesUtils.relevantAttributesFor(commOrMed, _configAPs),
         Matchers.<Collection<Result.RouteAttributeType>>allOf(
@@ -143,8 +144,8 @@ public class CompareRoutePoliciesUtilsTest {
                     ImmutableList.of(new Statements.StaticStatement(Statements.ExitReject)))
                 .build(),
             Environment.Direction.IN);
-    assertThat(res.getFirst().getRelevantInputAttributes(), Matchers.is(ImmutableList.of()));
-    assertThat(res.getSecond().getRelevantInputAttributes(), Matchers.is(ImmutableList.of()));
+    assertThat(res.getFirst().getRelevantInputAttributes(), equalTo(ImmutableList.of()));
+    assertThat(res.getSecond().getRelevantInputAttributes(), equalTo(ImmutableList.of()));
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtilsTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtilsTest.java
@@ -1,0 +1,148 @@
+package org.batfish.minesweeper.question.compareroutepolicies;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import net.sf.javabdd.JFactory;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.questions.BgpRoute;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.batfish.minesweeper.CommunityVar;
+import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.batfish.minesweeper.bdd.BDDRoute;
+import org.batfish.minesweeper.bdd.TransferReturn;
+import org.batfish.minesweeper.utils.Tuple;
+import org.batfish.question.testroutepolicies.Result;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link
+ * org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesUtils}.
+ */
+public class CompareRoutePoliciesUtilsTest {
+
+  ConfigAtomicPredicates _configAPs;
+  BDDFactory _factory;
+  BDDRoute _bddRoute;
+  Configuration _config;
+
+  RoutingPolicy.Builder _policyBuilderRef;
+  RoutingPolicy.Builder _policyBuilderOther;
+
+  @Before
+  public void setup() {
+    _configAPs =
+        new ConfigAtomicPredicates(
+            ImmutableList.of(),
+            ImmutableSet.of(CommunityVar.from("30:40")),
+            ImmutableSet.of("^20$"));
+    _factory = JFactory.init(100, 100);
+    _bddRoute = new BDDRoute(_factory, _configAPs);
+
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname("host")
+            .setConfigurationFormat(ConfigurationFormat.CUMULUS_CONCATENATED);
+    _config = cb.build();
+
+    _policyBuilderRef = nf.routingPolicyBuilder().setOwner(_config).setName("name");
+    _policyBuilderOther = nf.routingPolicyBuilder().setOwner(_config).setName("name");
+  }
+
+  @Test
+  public void testRelevantInputAttributesFor() {
+    BDD none = _factory.one();
+    BDD localPref = _bddRoute.getLocalPref().value(300);
+    BDD commOrMed = _bddRoute.getCommunityAtomicPredicates()[0].or(_bddRoute.getMed().leq(10));
+    BDD notASAndAD =
+        _bddRoute
+            .getAsPathRegexAtomicPredicates()
+            .value(0)
+            .not()
+            .and(_bddRoute.getAdminDist().range(11, 13));
+    BDD prefixLenAndWeight =
+        _bddRoute.getPrefixLength().value(32).and(_bddRoute.getWeight().geq(4));
+    Prefix p = Prefix.create(Ip.parse("1.1.1.1"), 32);
+    BDD several =
+        _bddRoute
+            .getPrefix()
+            .toBDD(p)
+            .and(_bddRoute.getNextHop().toBDD(p))
+            .or(_bddRoute.getClusterListLength().value(1))
+            .and(_bddRoute.getTag().value(101).not());
+
+    assertThat(
+        CompareRoutePoliciesUtils.relevantAttributesFor(none, _configAPs),
+        Matchers.is(ImmutableList.of()));
+    assertThat(
+        CompareRoutePoliciesUtils.relevantAttributesFor(localPref, _configAPs),
+        Matchers.is(ImmutableList.of(Result.RouteAttributeType.LOCAL_PREFERENCE)));
+    assertThat(
+        CompareRoutePoliciesUtils.relevantAttributesFor(commOrMed, _configAPs),
+        Matchers.<Collection<Result.RouteAttributeType>>allOf(
+            hasSize(2),
+            containsInAnyOrder(
+                Result.RouteAttributeType.COMMUNITIES, Result.RouteAttributeType.METRIC)));
+    assertThat(
+        CompareRoutePoliciesUtils.relevantAttributesFor(notASAndAD, _configAPs),
+        Matchers.<Collection<Result.RouteAttributeType>>allOf(
+            hasSize(2),
+            containsInAnyOrder(
+                Result.RouteAttributeType.AS_PATH,
+                Result.RouteAttributeType.ADMINISTRATIVE_DISTANCE)));
+    assertThat(
+        CompareRoutePoliciesUtils.relevantAttributesFor(prefixLenAndWeight, _configAPs),
+        Matchers.<Collection<Result.RouteAttributeType>>allOf(
+            hasSize(2),
+            containsInAnyOrder(
+                Result.RouteAttributeType.NETWORK, Result.RouteAttributeType.WEIGHT)));
+    assertThat(
+        CompareRoutePoliciesUtils.relevantAttributesFor(several, _configAPs),
+        Matchers.<Collection<Result.RouteAttributeType>>allOf(
+            hasSize(4),
+            containsInAnyOrder(
+                Result.RouteAttributeType.NETWORK,
+                Result.RouteAttributeType.NEXT_HOP,
+                Result.RouteAttributeType.CLUSTER_LIST,
+                Result.RouteAttributeType.TAG)));
+  }
+
+  @Test
+  public void testRelevantInputAttributesForDifferenceNone() {
+
+    TransferReturn path = new TransferReturn(new BDDRoute(_bddRoute), _factory.one(), true);
+    TransferReturn otherPath = new TransferReturn(new BDDRoute(_bddRoute), _factory.one(), false);
+    Tuple<Result<BgpRoute>, Result<BgpRoute>> res =
+        CompareRoutePoliciesUtils.findConcreteDifference(
+            path,
+            otherPath,
+            _bddRoute.bgpWellFormednessConstraints(),
+            _configAPs,
+            _policyBuilderRef
+                .setStatements(
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept)))
+                .build(),
+            _policyBuilderOther
+                .setStatements(
+                    ImmutableList.of(new Statements.StaticStatement(Statements.ExitReject)))
+                .build(),
+            Environment.Direction.IN);
+    assertThat(res.getFirst().getRelevantInputAttributes(), Matchers.is(ImmutableList.of()));
+    assertThat(res.getSecond().getRelevantInputAttributes(), Matchers.is(ImmutableList.of()));
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
@@ -51,8 +51,31 @@ public final class Result<R> {
     }
   }
 
+  /**
+   * A type to represent different attributes of a route, which is used to identify particular
+   * attributes of the input route that are relevant for this result.
+   */
+  public enum RouteAttributeType {
+    ADMINISTRATIVE_DISTANCE,
+    AS_PATH,
+    CLUSTER_LIST,
+    COMMUNITIES,
+    LOCAL_PREFERENCE,
+    METRIC,
+    NETWORK,
+    NEXT_HOP,
+    ORIGIN_TYPE,
+    PROTOCOL,
+    TAG,
+    TUNNEL_ENCAPSULATION_ATTRIBUTE,
+    WEIGHT
+  }
+
   private final RoutingPolicyId _policyId;
   private final R _inputRoute;
+  // if non-null, this list contains the attributes of the input route that are relevant for the
+  // behavior exhibited by this result
+  private @Nullable List<RouteAttributeType> _relevantInputAttributes;
   private final LineAction _action;
   private final @Nullable R _outputRoute;
   private final List<TraceTree> _trace;
@@ -85,6 +108,7 @@ public final class Result<R> {
     return Objects.equals(_policyId, result._policyId)
         && _action == result._action
         && Objects.equals(_inputRoute, result._inputRoute)
+        && Objects.equals(_relevantInputAttributes, result._relevantInputAttributes)
         && Objects.equals(_outputRoute, result._outputRoute)
         && Objects.equals(_trace, result._trace);
   }
@@ -95,6 +119,14 @@ public final class Result<R> {
 
   public R getInputRoute() {
     return _inputRoute;
+  }
+
+  public @Nullable List<RouteAttributeType> getRelevantInputAttributes() {
+    return _relevantInputAttributes;
+  }
+
+  public void setRelevantInputAttributes(List<RouteAttributeType> attributes) {
+    _relevantInputAttributes = attributes;
   }
 
   public Result<R> setOutputRoute(R outputRoute) {
@@ -119,6 +151,7 @@ public final class Result<R> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_policyId, _action, _inputRoute, _outputRoute, _trace);
+    return Objects.hash(
+        _policyId, _action, _inputRoute, _relevantInputAttributes, _outputRoute, _trace);
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
@@ -73,9 +73,13 @@ public final class Result<R> {
 
   private final RoutingPolicyId _policyId;
   private final R _inputRoute;
-  // if non-null, this list contains the attributes of the input route that are relevant for the
-  // behavior exhibited by this result
+
+  /**
+   * If non-null, this list contains the attributes of the input route that are relevant for the
+   * behavior exhibited by this result
+   */
   private @Nullable List<RouteAttributeType> _relevantInputAttributes;
+
   private final LineAction _action;
   private final @Nullable R _outputRoute;
   private final List<TraceTree> _trace;
@@ -121,6 +125,12 @@ public final class Result<R> {
     return _inputRoute;
   }
 
+  /**
+   * If non-null, the returned list contains the attributes of the input route that are relevant for
+   * the behavior exhibited by this result. The key property is that for any attribute A that is not
+   * in the returned list, any concrete value of the appropriate type can be used for A without
+   * affecting the result's behavior.
+   */
   public @Nullable List<RouteAttributeType> getRelevantInputAttributes() {
     return _relevantInputAttributes;
   }

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
@@ -76,7 +76,8 @@ public final class Result<R> {
 
   /**
    * If non-null, this list contains the attributes of the input route that are relevant for the
-   * behavior exhibited by this result
+   * behavior exhibited by this result. If null, then the relevant attributes have not been
+   * computed.
    */
   private @Nullable List<RouteAttributeType> _relevantInputAttributes;
 
@@ -129,7 +130,7 @@ public final class Result<R> {
    * If non-null, the returned list contains the attributes of the input route that are relevant for
    * the behavior exhibited by this result. The key property is that for any attribute A that is not
    * in the returned list, any concrete value of the appropriate type can be used for A without
-   * affecting the result's behavior.
+   * affecting the result's behavior. If null, then the relevant attributes have not been computed.
    */
   public @Nullable List<RouteAttributeType> getRelevantInputAttributes() {
     return _relevantInputAttributes;


### PR DESCRIPTION
For each difference returned by CompareRoutePolicies, compute the set of attributes on the input route that are relevant. The key property is that for any attribute that is deemed irrelevant, any concrete value can be used for that attribute without affecting the behavior of the route policies on the input route.