### PR TITLE
CommunitySetMatchExprToBDD: streamline community constraints

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -166,6 +166,8 @@ public class TransferBDD {
    */
   private final Map<CommunityVar, Set<Integer>> _communityAtomicPredicates;
 
+  private final Map<BDD, List<Integer>> _communitySetConstraintCache;
+
   private final Map<SymbolicAsPathRegex, Set<Integer>> _asPathRegexAtomicPredicates;
 
   private final ConfigAtomicPredicates _configAtomicPredicates;
@@ -191,6 +193,12 @@ public class TransferBDD {
     RegexAtomicPredicates<CommunityVar> standardCommAPs =
         _configAtomicPredicates.getStandardCommunityAtomicPredicates();
     _communityAtomicPredicates = new HashMap<>(standardCommAPs.getRegexAtomicPredicates());
+    _communitySetConstraintCache = new HashMap<>();
+    for (int i = 0; i < _originalRoute.getCommunityAtomicPredicates().length; i++) {
+      // Pre-cache all individual APs which are exclusive with all other APs by definition.
+      _communitySetConstraintCache.put(
+          _originalRoute.getCommunityAtomicPredicates()[i], ImmutableList.of(i));
+    }
     // add the atomic predicates for the extended/large community literals
     _configAtomicPredicates
         .getNonStandardCommunityLiterals()
@@ -1484,6 +1492,11 @@ public class TransferBDD {
 
   public ConfigAtomicPredicates getConfigAtomicPredicates() {
     return _configAtomicPredicates;
+  }
+
+  /** A cache for {@link CommunitySetMatchExprToBDD#toCommunitySetConstraint(BDD, Arg)}. */
+  public @Nonnull Map<BDD, List<Integer>> getCommunitySetConstraintCache() {
+    return _communitySetConstraintCache;
   }
 
   public BDDRoute getOriginalRoute() {


### PR DESCRIPTION
1. Add a cache
2. Short-circuit single exact communities
3. Exit early when constraint is proven
4. Less garbage in allNegativeLiterals

---

**Stack**:
- #9161
- #9160
- #9156 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*