### PR TITLE
BDDRoute: remove communityAPs from hashCode

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -740,7 +740,6 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
         _nextHop,
         _prefix,
         _prefixLength,
-        Arrays.hashCode(_communityAtomicPredicates),
         _asPathRegexAtomicPredicates,
         _prependedASes);
   }


### PR DESCRIPTION
Prefer to only hash fixed-work fields. Community APs can get *big*.

---

**Stack**:
- #9156
- #9159 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*