### PR TITLE
Junos: warn if a standard community regex is used that can match longer strings

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5594,6 +5594,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       if (literalCommunity != null) {
         return new LiteralCommunityMember(literalCommunity);
       }
+      List<String> unintendedMatches = RegexCommunityMember.getUnintendedCommunityMatches(text);
+      if (!unintendedMatches.isEmpty()) {
+        warn(
+            ctx,
+            "RISK: Community regex "
+                + text
+                + " allows longer matches such as "
+                + String.join(" and ", unintendedMatches));
+      }
+      ;
       return new RegexCommunityMember(text);
     } else {
       assert ctx.sc_named() != null;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BUILD.bazel
@@ -15,6 +15,7 @@ java_library(
         "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
+        "@maven//:dk_brics_automaton",
         "@maven//:org_apache_commons_commons_lang3",
     ],
 )

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -391,13 +391,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   private static final String FIRST_LOOPBACK_INTERFACE_NAME = "lo0";
 
-  private static String communityRegexToJavaRegex(String regex) {
-    String out = regex;
-    out = out.replace(":*", ":.*");
-    out = out.replaceFirst("^\\*", ".*");
-    return out;
-  }
-
   Configuration _c;
 
   /** Map of policy name to routing instances referenced in the policy, in the order they appear */
@@ -1062,8 +1055,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     public CommunityMatchExpr visitRegexCommunityMember(RegexCommunityMember regexCommunityMember) {
       // TODO: verify regex semantics and rendering
       return new CommunityMatchRegex(
-          ColonSeparatedRendering.instance(),
-          communityRegexToJavaRegex(regexCommunityMember.getRegex()));
+          ColonSeparatedRendering.instance(), regexCommunityMember.getJavaRegex());
     }
 
     private static final CommunityMemberToCommunityMatchExpr INSTANCE =

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RegexCommunityMember.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RegexCommunityMember.java
@@ -1,5 +1,10 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableList;
+import dk.brics.automaton.Automaton;
+import dk.brics.automaton.RegExp;
+import java.util.LinkedList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.community.Community;
@@ -7,6 +12,88 @@ import org.batfish.datamodel.bgp.community.Community;
 /** A {@link CommunityMember} representing a regex match condition for a {@link Community}. */
 @ParametersAreNonnullByDefault
 public final class RegexCommunityMember implements CommunityMember {
+  /**
+   * In Junos regexes, you can use {@code *} as a shortcut for {@code .*}, if it's alone. That is,
+   * {@code *:5$} is the same as {@code .*:5$} or {@code [0-9]*:5$}.
+   *
+   * <p>Handle this by converting standalone {@code *} literals to {@code .*} for use in Java
+   * regexes.
+   *
+   * <p>TODO: this likely needs more work for regexes over extended communities or malformed
+   * regexes.
+   *
+   * <p>See <a
+   * href="https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/policy-bgp-communities-extended-communities-evaluation-in-routing-policy-match-conditions.html">Junos
+   * documentation</a>}
+   */
+  private static String communityRegexToJavaRegex(String regex) {
+    String out = regex;
+    out = out.replace(":*", ":.*");
+    out = out.replaceFirst("^\\*", ".*");
+    return out;
+  }
+
+  /**
+   * Returns a list of {@link Community} literals that may be unintended matches for the given
+   * regex. The definition of "unintended" is if it matches the given regex, but does not match if
+   * the regex is limited with {@code ^} and {@code $}.
+   *
+   * <p>Note that in modern Junos releases, you do not need to truncate "longest possible" matches
+   * like {@code 11111:*} because there is no standard-community that starts with 6 digits. So we
+   * must constrain to regex-type-specific regexes.
+   *
+   * <p>TODO: this function currently handles only standard community regexes.
+   *
+   * <p>See <a
+   * href="https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/policy-bgp-communities-extended-communities-evaluation-in-routing-policy-match-conditions.html">Junos
+   * documentation</a>}
+   */
+  public static List<String> getUnintendedCommunityMatches(String junosRegex) {
+    if (junosRegex.split(":", -1).length != 2) {
+      return ImmutableList.of();
+    }
+    String javaRegex = communityRegexToJavaRegex(junosRegex);
+
+    // In Junos, a valid standard community regex is u16:u16.
+    //
+    // Note: this assumes a user doesn't do something like [community FOO members "no-ex.ort"]
+    // to turn a well-known community into a regex. It may not work anyway, but we haven't tested
+    // it. There's no good reason for this to happen, as community matches can mix regexes and
+    // literals, unlike many Cisco-style platforms.
+    String u16 = "((0|[1-9][0-9]*)&<0-65535>)";
+    // The user's regex may already have ^$, but we will unconditionally append them. Therefore, we
+    // must permit ^^ and $$. The automaton library does not implement ^ and $ as start/stop.
+    Automaton valid = new RegExp("^^" + u16 + ":" + u16 + "$$").toAutomaton();
+
+    // This replacement is necessary because otherwise something like .....:..... will be treated as
+    // allowing shorter communities such as 1:2 by matching, e.g., xx^^1:2$$xx. Make the . only
+    // match numbers to disallow this. This stems from the lack of ^$ support.
+    String regex = javaRegex.replaceAll("\\.", "[0-9]");
+
+    RegExp r = new RegExp(".*" + regex + ".*");
+    RegExp rClipped = new RegExp("^?^" + regex + "$$?");
+    Automaton validR = r.toAutomaton().intersection(valid);
+    Automaton validClipped = rClipped.toAutomaton().intersection(valid);
+    if (validR.equals(validClipped)) {
+      return ImmutableList.of();
+    }
+    Automaton exampleExtendingFront =
+        new RegExp(".*" + regex + "$.*").toAutomaton().intersection(valid).minus(validClipped);
+    Automaton exampleExtendingEnd =
+        new RegExp(".*^" + regex + ".*").toAutomaton().intersection(valid).minus(validClipped);
+    List<String> examples = new LinkedList<>();
+    if (!exampleExtendingFront.minus(validClipped).isEmpty()) {
+      String example = exampleExtendingFront.getShortestExample(true);
+      assert example.startsWith("^^") && example.endsWith("$$");
+      examples.add(example.substring(2, example.length() - 2));
+    }
+    if (!exampleExtendingEnd.minus(validClipped).isEmpty()) {
+      String example = exampleExtendingEnd.getShortestExample(true);
+      assert example.startsWith("^^") && example.endsWith("$$");
+      examples.add(example.substring(2, example.length() - 2));
+    }
+    return examples;
+  }
 
   public RegexCommunityMember(String regex) {
     _regex = regex;
@@ -17,8 +104,22 @@ public final class RegexCommunityMember implements CommunityMember {
     return visitor.visitRegexCommunityMember(this);
   }
 
+  /**
+   * The raw text of the regex in Junos syntax.
+   *
+   * @see #getJavaRegex()
+   */
   public @Nonnull String getRegex() {
     return _regex;
+  }
+
+  /**
+   * A representation of this regex that can be used in Java to match against community strings.
+   *
+   * @see #getRegex()
+   */
+  public @Nonnull String getJavaRegex() {
+    return communityRegexToJavaRegex(_regex);
   }
 
   private final @Nonnull String _regex;

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/RegexCommunityMemberTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/RegexCommunityMemberTest.java
@@ -1,0 +1,34 @@
+package org.batfish.representation.juniper;
+
+import static org.batfish.representation.juniper.RegexCommunityMember.getUnintendedCommunityMatches;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import org.junit.Test;
+
+public class RegexCommunityMemberTest {
+
+  @Test
+  public void testIsRiskyCommunityRegex() {
+    assertThat(getUnintendedCommunityMatches("^1:2$"), empty());
+    assertThat(getUnintendedCommunityMatches("12345:23456"), empty());
+    assertThat(getUnintendedCommunityMatches(".....:....."), empty());
+    assertThat(getUnintendedCommunityMatches(".*:.*"), empty());
+    assertThat(getUnintendedCommunityMatches("*:*"), empty());
+    assertThat(getUnintendedCommunityMatches("12345:*"), empty());
+    assertThat(getUnintendedCommunityMatches("*:12345"), empty());
+    assertThat(getUnintendedCommunityMatches("[0-9]*:[0-9]*"), empty());
+    assertThat(getUnintendedCommunityMatches("[0-9]+:[0-9]+"), empty());
+    assertThat(getUnintendedCommunityMatches("[0-9]{5}:[0-9]{5}"), empty());
+    assertThat(getUnintendedCommunityMatches("12345:6..$"), empty());
+    assertThat(getUnintendedCommunityMatches("12345:4{5}"), empty());
+    assertThat(getUnintendedCommunityMatches("12345:[67]...."), empty());
+
+    assertThat(getUnintendedCommunityMatches("123:4"), contains("1123:4", "123:40"));
+    assertThat(getUnintendedCommunityMatches("^123:4"), contains("123:40"));
+    assertThat(getUnintendedCommunityMatches("123:4$"), contains("1123:4"));
+    assertThat(getUnintendedCommunityMatches("12345:5[12][34]"), contains("12345:5130"));
+    assertThat(getUnintendedCommunityMatches("12345:"), contains("12345:0"));
+  }
+}

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -11255,7 +11255,35 @@
           ]
         }
       },
-      "version" : "0.36.0"
+      "version" : "0.36.0",
+      "warnings" : {
+        "configs/as1border1.cfg" : {
+          "Parse warnings" : [
+            {
+              "Comment" : "RISK: Community regex 2:* allows longer matches such as 12:0",
+              "Line" : 52,
+              "Parser_Context" : "[poc_members_member poc_members po_community s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "2:*"
+            }
+          ]
+        },
+        "configs/as1border2.cfg" : {
+          "Parse warnings" : [
+            {
+              "Comment" : "RISK: Community regex 3:* allows longer matches such as 13:0",
+              "Line" : 60,
+              "Parser_Context" : "[poc_members_member poc_members po_community s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "3:*"
+            },
+            {
+              "Comment" : "RISK: Community regex 4:* allows longer matches such as 14:0",
+              "Line" : 62,
+              "Parser_Context" : "[poc_members_member poc_members po_community s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "4:*"
+            }
+          ]
+        }
+      }
     },
     {
       "class" : "org.batfish.datamodel.answers.ConvertConfigurationAnswerElement",

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1275,6 +1275,13 @@
         "Comment" : "This feature is not currently supported"
       },
       {
+        "Filename" : "configs/juniper_extended_community",
+        "Line" : 6,
+        "Text" : "8075:[1][0][0-3,5-9][0-9][0-9]$",
+        "Parser_Context" : "[poc_members_member poc_members po_community s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "RISK: Community regex 8075:[1][0][0-3,5-9][0-9][0-9]$ allows longer matches such as 18075:10000"
+      },
+      {
         "Filename" : "configs/juniper_firewall",
         "Line" : 13,
         "Text" : "icmp-type mask-reply",
@@ -1472,10 +1479,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 204 results",
+      "notes" : "Found 205 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 204
+      "numResults" : 205
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71110,6 +71110,16 @@
             }
           ]
         },
+        "configs/juniper_extended_community" : {
+          "Parse warnings" : [
+            {
+              "Comment" : "RISK: Community regex 8075:[1][0][0-3,5-9][0-9][0-9]$ allows longer matches such as 18075:10000",
+              "Line" : 6,
+              "Parser_Context" : "[poc_members_member poc_members po_community s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "8075:[1][0][0-3,5-9][0-9][0-9]$"
+            }
+          ]
+        },
         "configs/juniper_firewall" : {
           "Parse warnings" : [
             {


### PR DESCRIPTION
Junos community regexes are not implicitly truncated so can match longer
strings in many cases. This is risky, as unintended community matches can lead
to unexpected bad routing behaviors. Add a warning for these regexes.

Do not warn in common cases that do work even though the regex is not
truncated: as of modern Junos releases, the regex is not matched against
non-standard communities so 12345:3$, for example, is fine as no standard
community has 6 digits in the first half.

---

**Stack**:
- #9168
- #9167 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*