### PR TITLE
SymbolicRegex: Dot should not match the start-of-string or end-of-string characters

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicRegex.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/SymbolicRegex.java
@@ -28,7 +28,8 @@ public abstract class SymbolicRegex {
   // modify the given regex to conform to the grammar of the Automaton library that we use to
   // analyze regexes
   private @Nonnull String toAutomatonRegex(String regex) {
-    // the Automaton library does not support the character class \d
-    return regex.replace("\\d", "[0-9]");
+    // the Automaton library does not support the character class \d;
+    // the Automaton library treats ^ and $ as ordinary characters, but they shouldn't match .
+    return regex.replace("\\d", "[0-9]").replace(".", "[^^$]");
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
@@ -35,6 +35,9 @@ public class CommunityVarTest {
     // ensure we get well-formed numbers
     CommunityVar cv6 = CommunityVar.from("^0:.0$");
 
+    // ensure that the ^ and $ markers are not treated as ordinary characters
+    CommunityVar cv7 = CommunityVar.from("..:..");
+
     assertThat(cv0.toAutomaton(), equalTo(new RegExp("^20:30$").toAutomaton()));
     assertThat(cv1.toAutomaton(), equalTo(new RegExp("^20:30$").toAutomaton()));
     assertThat(cv2.toAutomaton(), equalTo(new RegExp("^large:10:20:30$").toAutomaton()));
@@ -45,6 +48,11 @@ public class CommunityVarTest {
     assertThat(cv5.toAutomaton(), equalTo(new RegExp("^40:50$").toAutomaton()));
 
     assertThat(cv6.toAutomaton(), equalTo(new RegExp("^0:[1-9]0$").toAutomaton()));
+
+    String atLeastTwoDigits = "(" + COMMUNITY_NUM_REGEX + "&<10-65535>)";
+    assertThat(
+        cv7.toAutomaton(),
+        equalTo(new RegExp("^" + atLeastTwoDigits + ":" + atLeastTwoDigits + "$").toAutomaton()));
   }
 
   @Test


### PR DESCRIPTION
The automaton library that we use treats ^ and $ as ordinary characters, but they should not be allowed to match against the . regex, or else for instance we'd allow "^5:5$" as a valid instance of the community regex "..:..".