### PR TITLE
Junos: reduce blast radius of missing quote in hierarchical configs

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
@@ -104,7 +104,7 @@ F_ParenString
 fragment
 F_QuotedString
 :
-   '"' ~'"'* '"'
+   '"' ~["\r\n]* '"'
 ;
 
 // This may appear before a semicolon if settings are present to hide certain secrets.

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3057,6 +3057,20 @@ public final class FlatJuniperGrammarTest {
     assertThat(parseTextConfigs(hostname).keySet(), contains(hostname));
   }
 
+  /**
+   * Test that when a hierarchical config has a single missing quote, we can still extract later
+   * data.
+   */
+  @Test
+  public void testNestedConfigWithQuoteBug() throws IOException {
+    String hostname = "nested-config-with-quote-bug";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    batfish.getSettings().setDisableUnrecognized(false);
+    Map<String, Configuration> configs = batfish.loadConfigurations(batfish.getSnapshot());
+    assertThat(configs, hasKeys(hostname));
+    assertThat(configs.get(hostname).getVrfs(), hasKey("VRF_NAME"));
+  }
+
   /** Test for https://github.com/batfish/batfish/issues/7225. */
   @Test
   public void testNestedConfigWithSecretData() {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-with-quote-bug
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-with-quote-bug
@@ -1,0 +1,16 @@
+#RANCID-CONTENT-TYPE: juniper
+system {
+    host-name nested-config-with-quote-bug;
+    license {
+        keys {
+            key foo bar";
+        }
+    }
+}
+routing-instances {
+    VRF_NAME {
+        routing-options {
+            autonomous-system 1;
+        }
+    }
+}


### PR DESCRIPTION
Junos requires quoted strings to be on one line anyway, as far as I can tell online and in configs.