### PR TITLE
Batfish: disable parse reuse by default

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -387,7 +387,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_MAX_RUNTIME_MS, 0);
     setDefaultProperty(ARG_CHECK_BGP_REACHABILITY, true);
     setDefaultProperty(ARG_NO_SHUFFLE, false);
-    setDefaultProperty(ARG_PARSE_REUSE, true);
+    setDefaultProperty(ARG_PARSE_REUSE, false);
     setDefaultProperty(ARG_PRINT_PARSE_TREES, false);
     setDefaultProperty(ARG_PRINT_PARSE_TREE_LINE_NUMS, false);
     setDefaultProperty(BfConsts.ARG_QUESTION_NAME, null);


### PR DESCRIPTION
When we added this feature, Batfish parsers were ridiculously slow and this
made a big difference. However, after we did a number of improvements to make
the parsers LL1 and in general use modes better and crappy ambiguous grammar
rules less, the parsers sped up dramatically. At this point, the reparsing is
often faster than deserializing prior results, and it uses less I/O.

Refs:
* Adding parse reuse in 2019: https://github.com/batfish/batfish/pull/3070
* grammar improvements, e.g., https://github.com/batfish/batfish/pull/8268
* and this big blank line one: https://github.com/batfish/batfish/pull/6778