### PR TITLE
bugfix: add route reflector configuration for Arista EVPN neighbors

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -763,6 +763,7 @@ final class AristaConversions {
       if (importPolicyName != null && c.getRoutingPolicies().get(importPolicyName) != null) {
         evpnFamilyBuilder.setImportPolicy(importPolicyName);
       }
+      evpnFamilyBuilder.setRouteReflectorClient(firstNonNull(neighbor.getRouteReflectorClient(), Boolean.FALSE));
       newNeighborBuilder.setEvpnAddressFamily(evpnFamilyBuilder.build());
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -763,7 +763,8 @@ final class AristaConversions {
       if (importPolicyName != null && c.getRoutingPolicies().get(importPolicyName) != null) {
         evpnFamilyBuilder.setImportPolicy(importPolicyName);
       }
-      evpnFamilyBuilder.setRouteReflectorClient(firstNonNull(neighbor.getRouteReflectorClient(), Boolean.FALSE));
+      evpnFamilyBuilder.setRouteReflectorClient(
+          firstNonNull(neighbor.getRouteReflectorClient(), Boolean.FALSE));
       newNeighborBuilder.setEvpnAddressFamily(evpnFamilyBuilder.build());
     }
 


### PR DESCRIPTION
This commit adds support for the route reflector configuration in the EVPN neighbor conversion process for Arista. Without this configuration, the spine cannot reflect EVPN routes in the iBGP VXLAN configuration.