### PR TITLE
Junos: add empty lines

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperParser.g4
@@ -24,7 +24,8 @@ extra_close_brace: CLOSE_BRACE;
 
 statement
 :
-  flat_statement
+  empty_statement
+  | flat_statement
   | hierarchical_statement
 ;
 
@@ -42,6 +43,14 @@ hierarchical_statement
     | bracketed_clause close = CLOSE_BRACKET terminator
     | terminator
   )
+;
+
+empty_statement
+:
+   (
+      MULTILINE_COMMENT
+   )*
+   SEMICOLON
 ;
 
 terminator

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_nested_multiline_comments
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper_nested_multiline_comments
@@ -14,6 +14,7 @@ policy-options {
                 /* not a description because no non-comment follows before end brace */
                 /* community [ foo ]; */
             }
+            /* comment with trailing semicolon is not a description */;
             then reject;
         }
     }


### PR DESCRIPTION
Avoids flattening issues when there's a bare semicolon after a comment.