### PR TITLE
Rename junos StaticRoute class to StaticRouteV4

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1006,7 +1006,7 @@ import org.batfish.representation.juniper.RoutingInformationBase;
 import org.batfish.representation.juniper.RoutingInstance;
 import org.batfish.representation.juniper.Screen;
 import org.batfish.representation.juniper.ScreenAction;
-import org.batfish.representation.juniper.StaticRoute;
+import org.batfish.representation.juniper.StaticRouteV4;
 import org.batfish.representation.juniper.StubSettings;
 import org.batfish.representation.juniper.TcpFinNoAck;
 import org.batfish.representation.juniper.TcpNoFlag;
@@ -1029,7 +1029,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   private static final BgpGroup DUMMY_BGP_GROUP = new BgpGroup();
 
-  private static final StaticRoute DUMMY_STATIC_ROUTE = new StaticRoute(Prefix.ZERO);
+  private static final StaticRouteV4 DUMMY_STATIC_ROUTE = new StaticRouteV4(Prefix.ZERO);
 
   private static final QualifiedNextHop DUMMY_QUALIFIED_NEXT_HOP =
       new QualifiedNextHop(new NextHop(Ip.ZERO));
@@ -2318,7 +2318,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   private SnmpServer _currentSnmpServer;
 
-  private StaticRoute _currentStaticRoute;
+  private StaticRouteV4 _currentStaticRoute;
 
   private TacplusServer _currentTacplusServer;
 
@@ -3446,8 +3446,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void enterRos_route4(Ros_route4Context ctx) {
     Prefix prefix = toPrefix(ctx.prefix);
-    Map<Prefix, StaticRoute> staticRoutes = _currentRib.getStaticRoutes();
-    _currentStaticRoute = staticRoutes.computeIfAbsent(prefix, StaticRoute::new);
+    Map<Prefix, StaticRouteV4> staticRoutes = _currentRib.getStaticRoutes();
+    _currentStaticRoute = staticRoutes.computeIfAbsent(prefix, StaticRouteV4::new);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3276,7 +3276,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         statements);
   }
 
-  private Set<org.batfish.datamodel.StaticRoute> toStaticRoutes(StaticRoute route) {
+  private Set<org.batfish.datamodel.StaticRoute> toStaticRoutes(StaticRouteV4 route) {
     String nextTable = route.getNextTable();
     Prefix prefix = route.getPrefix();
     String nextVrf = null;
@@ -3741,7 +3741,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       }
 
       // static routes
-      for (StaticRoute route : ri.getRibs().get(RIB_IPV4_UNICAST).getStaticRoutes().values()) {
+      for (StaticRouteV4 route : ri.getRibs().get(RIB_IPV4_UNICAST).getStaticRoutes().values()) {
         vrf.getStaticRoutes().addAll(toStaticRoutes(route));
       }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/QualifiedNextHop.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/QualifiedNextHop.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** Represents a qualified next-hop configured for a {@link StaticRoute} */
+/** Represents a qualified next-hop configured for a {@link StaticRouteV4} */
 public class QualifiedNextHop implements Serializable {
   private @Nullable Integer _metric;
   private @Nonnull NextHop _nextHop;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInformationBase.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInformationBase.java
@@ -19,7 +19,7 @@ public class RoutingInformationBase implements Serializable {
   private final Map<Prefix, AggregateRoute> _aggregateRoutes;
   private final Map<Prefix, GeneratedRoute> _generatedRoutes;
   private final String _name;
-  private final Map<Prefix, StaticRoute> _staticRoutes;
+  private final Map<Prefix, StaticRouteV4> _staticRoutes;
 
   public RoutingInformationBase(@Nonnull String name) {
     _name = name;
@@ -40,7 +40,7 @@ public class RoutingInformationBase implements Serializable {
     return _name;
   }
 
-  public @Nonnull Map<Prefix, StaticRoute> getStaticRoutes() {
+  public @Nonnull Map<Prefix, StaticRouteV4> getStaticRoutes() {
     return _staticRoutes;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRouteV4.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRouteV4.java
@@ -14,7 +14,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.bgp.community.Community;
 
-public class StaticRoute implements Serializable {
+public class StaticRouteV4 implements Serializable {
 
   /* https://www.juniper.net/documentation/en_US/junos/topics/reference/general/routing-protocols-default-route-preference-values.html */
   private static final int DEFAULT_ADMIN_DISTANCE = 5;
@@ -53,7 +53,7 @@ public class StaticRoute implements Serializable {
 
   private @Nullable Long _tag2;
 
-  public StaticRoute(Prefix prefix) {
+  public StaticRouteV4(Prefix prefix) {
     _communities = new TreeSet<>();
     _prefix = prefix;
     _policies = new ArrayList<>();

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -471,6 +471,7 @@ import org.batfish.representation.juniper.RoutingInstance;
 import org.batfish.representation.juniper.Screen;
 import org.batfish.representation.juniper.ScreenAction;
 import org.batfish.representation.juniper.ScreenOption;
+import org.batfish.representation.juniper.StaticRouteV4;
 import org.batfish.representation.juniper.TcpFinNoAck;
 import org.batfish.representation.juniper.TcpNoFlag;
 import org.batfish.representation.juniper.TcpSynFin;
@@ -6287,21 +6288,17 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testStaticRouteOverwrite() {
     JuniperConfiguration c = parseJuniperConfig("static-route-overwrite");
-    Map<Prefix, org.batfish.representation.juniper.StaticRoute> staticRoutes =
+    Map<Prefix, StaticRouteV4> staticRoutes =
         c.getMasterLogicalSystem()
             .getRoutingInstances()
             .get(DEFAULT_VRF_NAME)
             .getRibs()
             .get(RIB_IPV4_UNICAST)
             .getStaticRoutes();
-    org.batfish.representation.juniper.StaticRoute r0 =
-        staticRoutes.get(Prefix.parse("10.0.0.0/16"));
-    org.batfish.representation.juniper.StaticRoute r1 =
-        staticRoutes.get(Prefix.parse("10.1.0.0/16"));
-    org.batfish.representation.juniper.StaticRoute r2 =
-        staticRoutes.get(Prefix.parse("10.2.0.0/16"));
-    org.batfish.representation.juniper.StaticRoute r3 =
-        staticRoutes.get(Prefix.parse("10.3.0.0/16"));
+    StaticRouteV4 r0 = staticRoutes.get(Prefix.parse("10.0.0.0/16"));
+    StaticRouteV4 r1 = staticRoutes.get(Prefix.parse("10.1.0.0/16"));
+    StaticRouteV4 r2 = staticRoutes.get(Prefix.parse("10.2.0.0/16"));
+    StaticRouteV4 r3 = staticRoutes.get(Prefix.parse("10.3.0.0/16"));
 
     // Old next-hops are cleared
     assertFalse(r0.getDrop());
@@ -6453,14 +6450,14 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testStaticRouteParsing() {
     JuniperConfiguration c = parseJuniperConfig("static-routes");
-    Map<Prefix, org.batfish.representation.juniper.StaticRoute> routes =
+    Map<Prefix, StaticRouteV4> routes =
         c.getMasterLogicalSystem()
             .getRoutingInstances()
             .get("default")
             .getRibs()
             .get(RIB_IPV4_UNICAST)
             .getStaticRoutes();
-    Map<Prefix, org.batfish.representation.juniper.StaticRoute> routes2 =
+    Map<Prefix, StaticRouteV4> routes2 =
         c.getMasterLogicalSystem()
             .getRoutingInstances()
             .get("ri2")


### PR DESCRIPTION
Just a quick rename CR, next CR will add a StaticRoute base class and StaticRouteV6 class and renaming in the same CR seemed noisy. 