### PR TITLE
fix_java_format.sh: redo to work better with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,11 @@ repos:
     hooks:
     -   id: java-format
         name: java-format
-        entry: ./tools/fix_java_format.sh --diff
+        entry: ./tools/fix_java_format.sh --replace
         language: script
         files: '\.java$'
-        pass_filenames: false  # this is a global check, only run it once
+        require_serial: true
+        pass_filenames: true
     -   id: buildifier
         name: buildifier
         entry: bazel --noblock_for_lock run //:buildifier.fix


### PR DESCRIPTION
1. Pass filenames in and use it.
2. Run serially, as google-java-format already parallelizes internally. This
means that pre-commit will run all files in batches, with size controlled by
pre-commit. It would actually be ideal if it was only one batch, but the hit
is not so bad.