### PR TITLE
Support more rib names in Junos parser

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -16,6 +16,7 @@ tokens {
    ACK,
    AS_PATH_REGEX,
    BANG,
+   BGP_RIB_NAME,
    CERTIFICATE_STRING,
    DOUBLE_QUOTED_NAME,
    DYNAMIC_DB,
@@ -39,6 +40,7 @@ tokens {
    SYN,
    UINT32L,
    VERSION_STRING,
+   VXLAN_RIB_NAME,
    WILDCARD_ARTIFACT
 }
 
@@ -1608,6 +1610,10 @@ L2_INTERFACE
 ;
 
 L2_LEARNING: 'l2-learning';
+
+L3VPN: 'l3vpn';
+
+L3VPN_INET6: 'l3vpn-inet6';
 
 L3_INTERFACE
 :
@@ -4991,5 +4997,7 @@ M_RibName_INET: (F_RoutingInstanceName PERIOD)? INET PERIOD UINT8 -> type(INET_R
 M_RibName_INET6: (F_RoutingInstanceName PERIOD)? INET6 PERIOD UINT8 -> type(INET6_RIB_NAME), popMode;
 M_RibName_MPLS: MPLS PERIOD UINT8 -> type(MPLS_RIB_NAME), popMode;
 M_RibName_ISO: ISO PERIOD UINT8 -> type(ISO_RIB_NAME), popMode;
+M_RibName_BGP: BGP PERIOD ( L2VPN | L3VPN | L3VPN_INET6 ) PERIOD UINT8 -> type(BGP_RIB_NAME), popMode;
+M_RibName_VXLAN: COLON VXLAN PERIOD INET PERIOD UINT8 -> type(VXLAN_RIB_NAME), popMode;
 M_RibName_WS: F_WhitespaceChar+ -> skip;
 M_RibName_NEWLINE: F_Newline -> type(NEWLINE), popMode;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
@@ -81,6 +81,11 @@ bgp_priority_queue_id
    | PRIORITY bgp_priority_queue_number
 ;
 
+bgp_rib_name
+:
+    BGP_RIB_NAME
+;
+
 dec
 :
   UINT8
@@ -215,7 +220,7 @@ MPLS_RIB_NAME
 
 rib_name
 :
-(inet_rib_name | inet6_rib_name | iso_rib_name | mpls_rib_name )
+(bgp_rib_name | inet_rib_name | inet6_rib_name | iso_rib_name | mpls_rib_name | vxlan_rib_name )
 ;
 
 interface_id: INTERFACE_ID;
@@ -749,6 +754,11 @@ uint32
 uint32l
 :
   UINT32L
+;
+
+vxlan_rib_name
+:
+    VXLAN_RIB_NAME
 ;
 
 wildcard

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -6094,6 +6094,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testRibNamesMiscParsing() {
+    // Just don't have parse warnings
+    parseJuniperConfig("routing-options-misc");
+  }
+
+  @Test
   public void testRoutingPolicy() {
     Configuration c = parseConfig("routing-policy");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/rib-name-misc
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/rib-name-misc
@@ -1,0 +1,9 @@
+#
+set system host-name rib-name-misc
+#
+set routing-options rib :vxlan.inet.0 martians 240.0.0.0/4 orlonger allow
+#
+set policy-options policy-statement POLICY-NAME term TERM from rib bgp.l2vpn.0
+set policy-options policy-statement POLICY-NAME term TERM from rib bgp.l3vpn.0
+set policy-options policy-statement POLICY-NAME term TERM from rib bgp.l3vpn-inet6.0
+#


### PR DESCRIPTION
No extraction - just parsing more rib names in Junos:
rib bgp.l2vpn.0
rib bgp.l3vpn-inet6.0
rib bgp.l3vpn.0
rib :vxlan.inet.0

https://www.juniper.net/documentation/us/en/software/junos/static-routing/topics/topic-map/config_junos_routing_table.html#id-example-exporting-specific-routes-from-one-routing-table-into-another-routing-table