### PR TITLE
Junos: improve presentation of defined structure names

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -267,7 +267,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   public static @Nonnull String computePolicyStatementTermName(
       @Nonnull String policyStatementName, @Nonnull String termName) {
-    return String.format("%s %s", policyStatementName, termName);
+    return String.format("%s term %s", policyStatementName, termName);
   }
 
   @VisibleForTesting

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -11400,27 +11400,27 @@
             }
           },
           "policy-statement term" : {
-            "as1_to_as1 forward" : {
+            "as1_to_as1 term forward" : {
               "definitionLines" : "30-31",
               "numReferrers" : 2
             },
-            "as1_to_as1 originate" : {
+            "as1_to_as1 term originate" : {
               "definitionLines" : "32-33",
               "numReferrers" : 2
             },
-            "as1_to_as2 as3" : {
+            "as1_to_as2 term as3" : {
               "definitionLines" : "38-41",
               "numReferrers" : 4
             },
-            "as1_to_as2 originate" : {
+            "as1_to_as2 term originate" : {
               "definitionLines" : "34-37",
               "numReferrers" : 4
             },
-            "as2_to_as1 1" : {
+            "as2_to_as1 term 1" : {
               "definitionLines" : "42-44",
               "numReferrers" : 3
             },
-            "match_original_prefixes 1" : {
+            "match_original_prefixes term 1" : {
               "definitionLines" : "45-46",
               "numReferrers" : 2
             }
@@ -11550,35 +11550,35 @@
             }
           },
           "policy-statement term" : {
-            "as1_to_as1 forward" : {
+            "as1_to_as1 term forward" : {
               "definitionLines" : "28-29",
               "numReferrers" : 2
             },
-            "as1_to_as1 originate" : {
+            "as1_to_as1 term originate" : {
               "definitionLines" : "30-31",
               "numReferrers" : 2
             },
-            "as1_to_as3 as3" : {
+            "as1_to_as3 term as3" : {
               "definitionLines" : "36-39",
               "numReferrers" : 4
             },
-            "as1_to_as3 originate" : {
+            "as1_to_as3 term originate" : {
               "definitionLines" : "32-35",
               "numReferrers" : 4
             },
-            "as1_to_as4 as3" : {
+            "as1_to_as4 term as3" : {
               "definitionLines" : "47-49",
               "numReferrers" : 3
             },
-            "as1_to_as4 originate" : {
+            "as1_to_as4 term originate" : {
               "definitionLines" : "43-46",
               "numReferrers" : 4
             },
-            "as3_to_as1 1" : {
+            "as3_to_as1 term 1" : {
               "definitionLines" : "40-42",
               "numReferrers" : 3
             },
-            "as4_to_as1 1" : {
+            "as4_to_as1 term 1" : {
               "definitionLines" : "50-53",
               "numReferrers" : 4
             }
@@ -12921,19 +12921,19 @@
             }
           },
           "policy-statement term" : {
-            "as1_to_as1 forward" : {
+            "as1_to_as1 term forward" : {
               "policy-statement term" : [
                 30,
                 31
               ]
             },
-            "as1_to_as1 originate" : {
+            "as1_to_as1 term originate" : {
               "policy-statement term" : [
                 32,
                 33
               ]
             },
-            "as1_to_as2 as3" : {
+            "as1_to_as2 term as3" : {
               "policy-statement term" : [
                 38,
                 39,
@@ -12941,7 +12941,7 @@
                 41
               ]
             },
-            "as1_to_as2 originate" : {
+            "as1_to_as2 term originate" : {
               "policy-statement term" : [
                 34,
                 35,
@@ -12949,14 +12949,14 @@
                 37
               ]
             },
-            "as2_to_as1 1" : {
+            "as2_to_as1 term 1" : {
               "policy-statement term" : [
                 42,
                 43,
                 44
               ]
             },
-            "match_original_prefixes 1" : {
+            "match_original_prefixes term 1" : {
               "policy-statement term" : [
                 45,
                 46
@@ -13125,19 +13125,19 @@
             }
           },
           "policy-statement term" : {
-            "as1_to_as1 forward" : {
+            "as1_to_as1 term forward" : {
               "policy-statement term" : [
                 28,
                 29
               ]
             },
-            "as1_to_as1 originate" : {
+            "as1_to_as1 term originate" : {
               "policy-statement term" : [
                 30,
                 31
               ]
             },
-            "as1_to_as3 as3" : {
+            "as1_to_as3 term as3" : {
               "policy-statement term" : [
                 36,
                 37,
@@ -13145,7 +13145,7 @@
                 39
               ]
             },
-            "as1_to_as3 originate" : {
+            "as1_to_as3 term originate" : {
               "policy-statement term" : [
                 32,
                 33,
@@ -13153,14 +13153,14 @@
                 35
               ]
             },
-            "as1_to_as4 as3" : {
+            "as1_to_as4 term as3" : {
               "policy-statement term" : [
                 47,
                 48,
                 49
               ]
             },
-            "as1_to_as4 originate" : {
+            "as1_to_as4 term originate" : {
               "policy-statement term" : [
                 43,
                 44,
@@ -13168,14 +13168,14 @@
                 46
               ]
             },
-            "as3_to_as1 1" : {
+            "as3_to_as1 term 1" : {
               "policy-statement term" : [
                 40,
                 41,
                 42
               ]
             },
-            "as4_to_as1 1" : {
+            "as4_to_as1 term 1" : {
               "policy-statement term" : [
                 50,
                 51,

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -6332,7 +6332,7 @@
             }
           },
           "policy-statement term" : {
-            "bgp_export 1" : {
+            "bgp_export term 1" : {
               "definitionLines" : "115-116",
               "numReferrers" : 2
             }
@@ -6544,7 +6544,7 @@
             }
           },
           "policy-statement term" : {
-            "bgp_export 1" : {
+            "bgp_export term 1" : {
               "definitionLines" : "98-99",
               "numReferrers" : 2
             }
@@ -6712,7 +6712,7 @@
             }
           },
           "policy-statement term" : {
-            "bgp_export 1" : {
+            "bgp_export term 1" : {
               "definitionLines" : "92-93",
               "numReferrers" : 2
             }
@@ -6953,7 +6953,7 @@
             }
           },
           "policy-statement term" : {
-            "bgp_export 1" : {
+            "bgp_export term 1" : {
               "policy-statement term" : [
                 115,
                 116
@@ -7290,7 +7290,7 @@
             }
           },
           "policy-statement term" : {
-            "bgp_export 1" : {
+            "bgp_export term 1" : {
               "policy-statement term" : [
                 98,
                 99
@@ -7526,7 +7526,7 @@
             }
           },
           "policy-statement term" : {
-            "bgp_export 1" : {
+            "bgp_export term 1" : {
               "policy-statement term" : [
                 92,
                 93

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -73977,23 +73977,23 @@
             }
           },
           "policy-statement term" : {
-            "export-loopback lo0" : {
+            "export-loopback term lo0" : {
               "definitionLines" : "162-165",
               "numReferrers" : 2
             },
-            "fabric fabric" : {
+            "fabric term fabric" : {
               "definitionLines" : "168-174",
               "numReferrers" : 3
             },
-            "fabric vni-100" : {
+            "fabric term vni-100" : {
               "definitionLines" : "175-178",
               "numReferrers" : 2
             },
-            "fabric vni-101" : {
+            "fabric term vni-101" : {
               "definitionLines" : "179-182",
               "numReferrers" : 2
             },
-            "lbpp 1" : {
+            "lbpp term 1" : {
               "definitionLines" : "185-189",
               "numReferrers" : 1
             }
@@ -75273,11 +75273,11 @@
             }
           },
           "policy-statement term" : {
-            "POLICY-NAME AS_PATH" : {
+            "POLICY-NAME term AS_PATH" : {
               "definitionLines" : "40-41",
               "numReferrers" : 2
             },
-            "POLICY-NAME TERM" : {
+            "POLICY-NAME term TERM" : {
               "definitionLines" : "4-39",
               "numReferrers" : 36
             }
@@ -75393,11 +75393,11 @@
             }
           },
           "policy-statement term" : {
-            "route-filter-test-v4 t1" : {
+            "route-filter-test-v4 term t1" : {
               "definitionLines" : "4-9",
               "numReferrers" : 6
             },
-            "route-filter-test-v6 t1" : {
+            "route-filter-test-v6 term t1" : {
               "definitionLines" : "11-16",
               "numReferrers" : 6
             }
@@ -75435,11 +75435,11 @@
             }
           },
           "policy-statement term" : {
-            "POLICY-NAME TERM1" : {
+            "POLICY-NAME term TERM1" : {
               "definitionLines" : "7-8",
               "numReferrers" : 2
             },
-            "POLICY-NAME TERM2" : {
+            "POLICY-NAME term TERM2" : {
               "definitionLines" : "9-10",
               "numReferrers" : 2
             }
@@ -80910,27 +80910,27 @@
             }
           },
           "policy-statement term" : {
-            "export-loopback lo0" : {
+            "export-loopback term lo0" : {
               "policy-statement term" : [
                 162
               ]
             },
-            "fabric fabric" : {
+            "fabric term fabric" : {
               "policy-statement term" : [
                 168
               ]
             },
-            "fabric vni-100" : {
+            "fabric term vni-100" : {
               "policy-statement term" : [
                 175
               ]
             },
-            "fabric vni-101" : {
+            "fabric term vni-101" : {
               "policy-statement term" : [
                 179
               ]
             },
-            "lbpp 1" : {
+            "lbpp term 1" : {
               "policy-statement term" : [
                 185
               ]
@@ -82667,13 +82667,13 @@
             }
           },
           "policy-statement term" : {
-            "POLICY-NAME AS_PATH" : {
+            "POLICY-NAME term AS_PATH" : {
               "policy-statement term" : [
                 40,
                 41
               ]
             },
-            "POLICY-NAME TERM" : {
+            "POLICY-NAME term TERM" : {
               "policy-statement term" : [
                 4,
                 5,
@@ -82880,7 +82880,7 @@
         },
         "configs/juniper_route_filter" : {
           "policy-statement term" : {
-            "route-filter-test-v4 t1" : {
+            "route-filter-test-v4 term t1" : {
               "policy-statement term" : [
                 4,
                 5,
@@ -82890,7 +82890,7 @@
                 9
               ]
             },
-            "route-filter-test-v6 t1" : {
+            "route-filter-test-v6 term t1" : {
               "policy-statement term" : [
                 11,
                 12,
@@ -82949,13 +82949,13 @@
             }
           },
           "policy-statement term" : {
-            "POLICY-NAME TERM1" : {
+            "POLICY-NAME term TERM1" : {
               "policy-statement term" : [
                 7,
                 8
               ]
             },
-            "POLICY-NAME TERM2" : {
+            "POLICY-NAME term TERM2" : {
               "policy-statement term" : [
                 9,
                 10


### PR DESCRIPTION
Hard to read when they're just concatenated like this. This is different from Cisco/Arista where the
second thing is just a number.