### PR TITLE
AclLineMatchExprs: add helpers for destIp and srcIp

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
@@ -35,7 +35,9 @@ import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
 import org.batfish.datamodel.acl.GenericAclLineVisitor;
+import org.batfish.datamodel.acl.MatchDestinationIp;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSourceIp;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
@@ -332,8 +334,18 @@ public abstract class IpAccessListToBdd {
     }
 
     @Override
+    public BDD visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+      return _headerSpaceToBDD.getDstIpSpaceToBdd().visit(matchDestinationIp.getIps());
+    }
+
+    @Override
     public final BDD visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
       return _headerSpaceToBDD.toBDD(matchHeaderSpace.getHeaderspace());
+    }
+
+    @Override
+    public BDD visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+      return _headerSpaceToBDD.getSrcIpSpaceToBdd().visit(matchSourceIp.getIps());
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.DscpType;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IcmpCode;
 import org.batfish.datamodel.IntegerSpace;
@@ -151,14 +152,20 @@ public final class AclLineMatchExprs {
   }
 
   public static AclLineMatchExpr matchDst(IpSpace ipSpace) {
-    return matchDst(ipSpace, null);
+    return matchDst(ipSpace, (TraceElement) null);
+  }
+
+  public static AclLineMatchExpr matchDst(IpSpace ipSpace, String traceText) {
+    return matchDst(ipSpace, TraceElement.of(traceText));
   }
 
   public static AclLineMatchExpr matchDst(IpSpace ipSpace, @Nullable TraceElement traceElement) {
     if (ipSpace.equals(UniverseIpSpace.INSTANCE)) {
       return traceElement == null ? TRUE : new TrueExpr(traceElement);
+    } else if (ipSpace.equals(EmptyIpSpace.INSTANCE)) {
+      return traceElement == null ? FALSE : new FalseExpr(traceElement);
     }
-    return new MatchHeaderSpace(HeaderSpace.builder().setDstIps(ipSpace).build(), traceElement);
+    return new MatchDestinationIp(ipSpace, traceElement);
   }
 
   public static AclLineMatchExpr matchDst(Ip ip) {
@@ -201,14 +208,20 @@ public final class AclLineMatchExprs {
   }
 
   public static AclLineMatchExpr matchSrc(IpSpace ipSpace) {
-    return matchSrc(ipSpace, null);
+    return matchSrc(ipSpace, (TraceElement) null);
+  }
+
+  public static AclLineMatchExpr matchSrc(IpSpace ipSpace, String traceText) {
+    return matchSrc(ipSpace, TraceElement.of(traceText));
   }
 
   public static AclLineMatchExpr matchSrc(IpSpace ipSpace, @Nullable TraceElement traceElement) {
     if (ipSpace.equals(UniverseIpSpace.INSTANCE)) {
       return traceElement == null ? TRUE : new TrueExpr(traceElement);
+    } else if (ipSpace.equals(EmptyIpSpace.INSTANCE)) {
+      return traceElement == null ? FALSE : new FalseExpr(traceElement);
     }
-    return new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(ipSpace).build(), traceElement);
+    return new MatchSourceIp(ipSpace, traceElement);
   }
 
   public static @Nonnull AclLineMatchExpr matchFragmentOffset(int fragmentOffset) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -256,9 +256,21 @@ public final class AclTracer extends AclLineEvaluator {
   }
 
   @Override
+  public Boolean visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+    setTraceElement(matchDestinationIp.getTraceElement());
+    return traceDstIp(matchDestinationIp.getIps());
+  }
+
+  @Override
   public Boolean visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
     setTraceElement(matchHeaderSpace.getTraceElement());
     return trace(matchHeaderSpace.getHeaderspace());
+  }
+
+  @Override
+  public Boolean visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+    setTraceElement(matchSourceIp.getTraceElement());
+    return traceSrcIp(matchSourceIp.getIps());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
@@ -60,8 +60,18 @@ public class Evaluator implements GenericAclLineMatchExprVisitor<Boolean> {
   }
 
   @Override
+  public Boolean visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+    return matchDestinationIp.getIps().containsIp(_flow.getDstIp(), _namedIpSpaces);
+  }
+
+  @Override
   public Boolean visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
     return matchHeaderSpace.getHeaderspace().matches(_flow, _namedIpSpaces);
+  }
+
+  @Override
+  public Boolean visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+    return matchSourceIp.getIps().containsIp(_flow.getSrcIp(), _namedIpSpaces);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/FalseExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/FalseExpr.java
@@ -53,7 +53,10 @@ public class FalseExpr extends AclLineMatchExpr {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(getClass()).toString();
+    return MoreObjects.toStringHelper(getClass())
+        .omitNullValues()
+        .add(PROP_TRACE_ELEMENT, _traceElement)
+        .toString();
   }
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/GenericAclLineMatchExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/GenericAclLineMatchExprVisitor.java
@@ -12,7 +12,11 @@ public interface GenericAclLineMatchExprVisitor<R> {
 
   R visitFalseExpr(FalseExpr falseExpr);
 
+  R visitMatchDestinationIp(MatchDestinationIp matchDestinationIp);
+
   R visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace);
+
+  R visitMatchSourceIp(MatchSourceIp matchSourceIp);
 
   R visitMatchSrcInterface(MatchSrcInterface matchSrcInterface);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/MatchDestinationIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/MatchDestinationIp.java
@@ -1,0 +1,57 @@
+package org.batfish.datamodel.acl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.TraceElement;
+
+/** ACL term that matches destination IPs. */
+public class MatchDestinationIp extends AclLineMatchExpr {
+  private static final String PROP_IPS = "ips";
+
+  private final IpSpace _ipSpace;
+
+  MatchDestinationIp(IpSpace ips, @Nullable TraceElement traceElement) {
+    super(traceElement);
+    _ipSpace = ips;
+  }
+
+  @Override
+  public <R> R accept(GenericAclLineMatchExprVisitor<R> visitor) {
+    return visitor.visitMatchDestinationIp(this);
+  }
+
+  @Override
+  protected boolean exprEquals(Object o) {
+    return Objects.equals(_ipSpace, ((MatchDestinationIp) o)._ipSpace);
+  }
+
+  @JsonProperty(PROP_IPS)
+  public IpSpace getIps() {
+    return _ipSpace;
+  }
+
+  @Override
+  public int hashCode() {
+    return _ipSpace.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(getClass())
+        .omitNullValues()
+        .add(PROP_IPS, _ipSpace)
+        .add(PROP_TRACE_ELEMENT, getTraceElement())
+        .toString();
+  }
+
+  @JsonCreator
+  private static MatchDestinationIp jsonCreator(
+      @JsonProperty(PROP_IPS) IpSpace ips,
+      @JsonProperty(PROP_TRACE_ELEMENT) @Nullable TraceElement traceElement) {
+    return new MatchDestinationIp(ips, traceElement);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/MatchSourceIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/MatchSourceIp.java
@@ -1,0 +1,57 @@
+package org.batfish.datamodel.acl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.TraceElement;
+
+/** ACL term that matches source IPs. */
+public class MatchSourceIp extends AclLineMatchExpr {
+  private static final String PROP_IPS = "ips";
+
+  private final IpSpace _ipSpace;
+
+  MatchSourceIp(IpSpace ips, @Nullable TraceElement traceElement) {
+    super(traceElement);
+    _ipSpace = ips;
+  }
+
+  @Override
+  public <R> R accept(GenericAclLineMatchExprVisitor<R> visitor) {
+    return visitor.visitMatchSourceIp(this);
+  }
+
+  @Override
+  protected boolean exprEquals(Object o) {
+    return Objects.equals(_ipSpace, ((MatchSourceIp) o)._ipSpace);
+  }
+
+  @JsonProperty(PROP_IPS)
+  public IpSpace getIps() {
+    return _ipSpace;
+  }
+
+  @Override
+  public int hashCode() {
+    return _ipSpace.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(getClass())
+        .omitNullValues()
+        .add(PROP_IPS, _ipSpace)
+        .add(PROP_TRACE_ELEMENT, getTraceElement())
+        .toString();
+  }
+
+  @JsonCreator
+  private static MatchSourceIp jsonCreator(
+      @JsonProperty(PROP_IPS) IpSpace ips,
+      @JsonProperty(PROP_TRACE_ELEMENT) @Nullable TraceElement traceElement) {
+    return new MatchSourceIp(ips, traceElement);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
@@ -114,7 +114,17 @@ public final class SourcesReferencedByIpAccessLists {
     }
 
     @Override
+    public Void visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+      return null;
+    }
+
+    @Override
     public Void visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchSourceIp(MatchSourceIp matchSourceIp) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TrueExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TrueExpr.java
@@ -52,7 +52,10 @@ public class TrueExpr extends AclLineMatchExpr {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(getClass()).toString();
+    return MoreObjects.toStringHelper(getClass())
+        .omitNullValues()
+        .add(PROP_TRACE_ELEMENT, _traceElement)
+        .toString();
   }
 
   @JsonCreator

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/Noop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/Noop.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.flow.TransformationStep.TransformationType.S
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -59,5 +60,10 @@ public final class Noop implements TransformationStep, Serializable {
   @JsonProperty(PROP_TRANSFORMATION_TYPE)
   public TransformationType getType() {
     return _type;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add(PROP_TRANSFORMATION_TYPE, _type).toString();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/ReturnFlowTransformation.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/ReturnFlowTransformation.java
@@ -17,7 +17,9 @@ import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
+import org.batfish.datamodel.acl.MatchDestinationIp;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSourceIp;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
@@ -108,6 +110,11 @@ public final class ReturnFlowTransformation {
     }
 
     @Override
+    public AclLineMatchExpr visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+      return AclLineMatchExprs.matchSrc(matchDestinationIp.getIps());
+    }
+
+    @Override
     public AclLineMatchExpr visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
       HeaderSpace forwardHeaderSpace = matchHeaderSpace.getHeaderspace();
       return new MatchHeaderSpace(
@@ -121,6 +128,11 @@ public final class ReturnFlowTransformation {
               .setNotSrcPorts(forwardHeaderSpace.getNotDstPorts())
               .setNotDstPorts(forwardHeaderSpace.getNotSrcPorts())
               .build());
+    }
+
+    @Override
+    public AclLineMatchExpr visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+      return AclLineMatchExprs.matchDst(matchSourceIp.getIps());
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/HeaderSpaceConverter.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/HeaderSpaceConverter.java
@@ -6,7 +6,9 @@ import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
+import org.batfish.datamodel.acl.MatchDestinationIp;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSourceIp;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
@@ -41,8 +43,18 @@ public class HeaderSpaceConverter implements GenericAclLineMatchExprVisitor<Head
   }
 
   @Override
+  public HeaderSpace visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+    return HeaderSpace.builder().setDstIps(matchDestinationIp.getIps()).build();
+  }
+
+  @Override
   public HeaderSpace visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
     return matchHeaderSpace.getHeaderspace();
+  }
+
+  @Override
+  public HeaderSpace visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+    return HeaderSpace.builder().setSrcIps(matchSourceIp.getIps()).build();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
@@ -103,13 +103,15 @@ public class PacketHeaderConstraintsUtilTest {
             .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
             .setApplications("ssh, dns")
             .build();
+    IpSpace srcIp = Prefix.parse("1.0.0.0/8").toIpSpace();
+    IpSpace dstIp = Prefix.parse("2.0.0.0/8").toIpSpace();
     assertEquals(
-        toAclLineMatchExpr(phc, EmptyIpSpace.INSTANCE, EmptyIpSpace.INSTANCE),
+        toAclLineMatchExpr(phc, srcIp, dstIp),
         and(
             // src ip
-            match(HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build()),
+            matchSrc(srcIp),
             // dst ip
-            match(HeaderSpace.builder().setDstIps(EmptyIpSpace.INSTANCE).build()),
+            matchDst(dstIp),
             // ip protocols
             match(HeaderSpace.builder().setIpProtocols(IpProtocol.TCP).build()),
             // application

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -526,6 +526,32 @@ public class AclTracerTest {
   }
 
   @Test
+  public void testMatchDestinationIp_withoutTraceElement() {
+    List<TraceTree> trace = trace(new MatchDestinationIp(UniverseIpSpace.INSTANCE, null));
+    assertThat(trace, empty());
+  }
+
+  @Test
+  public void testMatchDestinationIp_withTraceElement() {
+    TraceElement a = TraceElement.of("a");
+    List<TraceTree> trace = trace(new MatchDestinationIp(UniverseIpSpace.INSTANCE, a));
+    assertThat(trace, contains(isTraceTree(a)));
+  }
+
+  @Test
+  public void testMatchSourceIp_withoutTraceElement() {
+    List<TraceTree> trace = trace(new MatchSourceIp(UniverseIpSpace.INSTANCE, null));
+    assertThat(trace, empty());
+  }
+
+  @Test
+  public void testMatchSourceIp_withTraceElement() {
+    TraceElement a = TraceElement.of("a");
+    List<TraceTree> trace = trace(new MatchSourceIp(UniverseIpSpace.INSTANCE, a));
+    assertThat(trace, contains(isTraceTree(a)));
+  }
+
+  @Test
   public void testPermittedByAcl() {
     TraceElement a = TraceElement.of("a");
     String aclName = "acl";

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/MatchDestinationIpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/MatchDestinationIpTest.java
@@ -1,0 +1,38 @@
+package org.batfish.datamodel.acl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.TraceElement;
+import org.junit.Test;
+
+public class MatchDestinationIpTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new MatchDestinationIp(Ip.parse("1.1.1.1").toIpSpace(), null),
+            new MatchDestinationIp(Ip.parse("1.1.1.1").toIpSpace(), null))
+        .addEqualityGroup(new MatchDestinationIp(Ip.parse("2.2.2.2").toIpSpace(), null))
+        .addEqualityGroup(
+            new MatchDestinationIp(Ip.parse("1.1.1.1").toIpSpace(), TraceElement.of("test")))
+        .testEquals();
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    MatchDestinationIp test1 = new MatchDestinationIp(Ip.parse("1.1.1.1").toIpSpace(), null);
+    MatchDestinationIp test2 =
+        new MatchDestinationIp(Ip.parse("1.1.1.1").toIpSpace(), TraceElement.of("test"));
+    for (MatchDestinationIp t : ImmutableList.of(test1, test2)) {
+      assertThat(BatfishObjectMapper.clone(t, AclLineMatchExpr.class), equalTo(t));
+      assertThat(SerializationUtils.clone(t), equalTo(t));
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/MatchSourceIpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/MatchSourceIpTest.java
@@ -1,0 +1,38 @@
+package org.batfish.datamodel.acl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.TraceElement;
+import org.junit.Test;
+
+public class MatchSourceIpTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new MatchSourceIp(Ip.parse("1.1.1.1").toIpSpace(), null),
+            new MatchSourceIp(Ip.parse("1.1.1.1").toIpSpace(), null))
+        .addEqualityGroup(new MatchSourceIp(Ip.parse("2.2.2.2").toIpSpace(), null))
+        .addEqualityGroup(
+            new MatchSourceIp(Ip.parse("1.1.1.1").toIpSpace(), TraceElement.of("test")))
+        .testEquals();
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    MatchSourceIp test1 = new MatchSourceIp(Ip.parse("1.1.1.1").toIpSpace(), null);
+    MatchSourceIp test2 =
+        new MatchSourceIp(Ip.parse("1.1.1.1").toIpSpace(), TraceElement.of("test"));
+    for (MatchSourceIp t : ImmutableList.of(test1, test2)) {
+      assertThat(BatfishObjectMapper.clone(t, AclLineMatchExpr.class), equalTo(t));
+      assertThat(SerializationUtils.clone(t), equalTo(t));
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -76,7 +76,9 @@ import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
 import org.batfish.datamodel.acl.GenericAclLineVisitor;
+import org.batfish.datamodel.acl.MatchDestinationIp;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSourceIp;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
@@ -354,6 +356,12 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     }
 
     @Override
+    public Void visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+      visit(matchDestinationIp.getIps());
+      return null;
+    }
+
+    @Override
     public Void visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
       HeaderSpace hs = matchHeaderSpace.getHeaderspace();
       if (hs == null) {
@@ -363,6 +371,12 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
       visit(firstNonNull(hs.getNotDstIps(), EmptyIpSpace.INSTANCE));
       visit(firstNonNull(hs.getSrcIps(), EmptyIpSpace.INSTANCE));
       visit(firstNonNull(hs.getNotSrcIps(), EmptyIpSpace.INSTANCE));
+      return null;
+    }
+
+    @Override
+    public Void visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+      visit(matchSourceIp.getIps());
       return null;
     }
 

--- a/projects/batfish/src/main/java/org/batfish/job/InvalidVendorStructureIdEraser.java
+++ b/projects/batfish/src/main/java/org/batfish/job/InvalidVendorStructureIdEraser.java
@@ -12,12 +12,15 @@ import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
 import org.batfish.datamodel.acl.GenericAclLineVisitor;
+import org.batfish.datamodel.acl.MatchDestinationIp;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSourceIp;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
@@ -152,12 +155,36 @@ public final class InvalidVendorStructureIdEraser
   }
 
   @Override
+  public AclLineMatchExpr visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+    if (matchDestinationIp.getTraceElement() == null) {
+      return matchDestinationIp;
+    }
+    TraceElement te = eraseInvalid(matchDestinationIp.getTraceElement());
+    if (te.equals(matchDestinationIp.getTraceElement())) {
+      return matchDestinationIp;
+    }
+    return AclLineMatchExprs.matchDst(matchDestinationIp.getIps(), te);
+  }
+
+  @Override
   public AclLineMatchExpr visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
     TraceElement te =
         matchHeaderSpace.getTraceElement() == null
             ? null
             : eraseInvalid(matchHeaderSpace.getTraceElement());
     return new MatchHeaderSpace(matchHeaderSpace.getHeaderspace(), te);
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+    if (matchSourceIp.getTraceElement() == null) {
+      return matchSourceIp;
+    }
+    TraceElement te = eraseInvalid(matchSourceIp.getTraceElement());
+    if (te.equals(matchSourceIp.getTraceElement())) {
+      return matchSourceIp;
+    }
+    return AclLineMatchExprs.matchSrc(matchSourceIp.getIps(), te);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpcEndpointGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpcEndpointGateway.java
@@ -22,7 +22,6 @@ import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.ExprAclLine;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpace;
@@ -32,7 +31,7 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.TraceElement;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.TrueExpr;
 import org.batfish.specifier.LocationInfo;
 
@@ -113,9 +112,7 @@ public final class VpcEndpointGateway extends VpcEndpoint {
         .setLines(
             ExprAclLine.builder()
                 .setTraceElement(PERMIT_SERVICE_IPS)
-                .setMatchCondition(
-                    new MatchHeaderSpace(
-                        HeaderSpace.builder().setDstIps(servicePrefixSpace).build()))
+                .setMatchCondition(AclLineMatchExprs.matchDst(servicePrefixSpace))
                 .setAction(LineAction.PERMIT)
                 .build(),
             ExprAclLine.builder()

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosPolicyConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosPolicyConversions.java
@@ -57,6 +57,7 @@ import org.batfish.datamodel.Names;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.MatchSrcInterface;
@@ -307,20 +308,17 @@ public final class FortiosPolicyConversions {
     List<AclLineMatchExpr> srcAddrExprs =
         Sets.intersection(srcAddrs, namedIpSpaces).stream()
             .map(
-                addr -> {
-                  HeaderSpace hs =
-                      HeaderSpace.builder().setSrcIps(new IpSpaceReference(addr)).build();
-                  return new MatchHeaderSpace(hs, "Matched source address");
-                })
+                addr ->
+                    AclLineMatchExprs.matchSrc(
+                        new IpSpaceReference(addr), "Matched source address"))
             .collect(ImmutableList.toImmutableList());
 
     List<AclLineMatchExpr> dstAddrExprs =
         Sets.intersection(dstAddrs, namedIpSpaces).stream()
             .map(
                 addr -> {
-                  HeaderSpace hs =
-                      HeaderSpace.builder().setDstIps(new IpSpaceReference(addr)).build();
-                  return new MatchHeaderSpace(hs, "Matched destination address");
+                  return AclLineMatchExprs.matchDst(
+                      new IpSpaceReference(addr), TraceElement.of("Matched destination address"));
                 })
             .collect(ImmutableList.toImmutableList());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromApplicationOrApplicationSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromApplicationOrApplicationSet.java
@@ -2,12 +2,11 @@ package org.batfish.representation.juniper;
 
 import java.util.List;
 import org.batfish.common.Warnings;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.FalseExpr;
 
 public final class FwFromApplicationOrApplicationSet implements FwFromApplicationSetMember {
 
@@ -51,7 +50,7 @@ public final class FwFromApplicationOrApplicationSet implements FwFromApplicatio
               _applicationOrApplicationSetName));
 
       // match nothing
-      return new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build());
+      return FalseExpr.INSTANCE;
     }
 
     return application.toAclLineMatchExpr(jc, w);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddress.java
@@ -1,14 +1,13 @@
 package org.batfish.representation.juniper;
 
-import com.google.common.annotations.VisibleForTesting;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+
 import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.juniper.FwTerm.Field;
 
 /** Class for firewall filter from destination-address */
@@ -37,15 +36,10 @@ public final class FwFromDestinationAddress implements FwFrom {
 
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
-    return new MatchHeaderSpace(toHeaderspace(), getTraceElement());
+    return matchDst(_ipWildcard.toIpSpace(), getTraceElement());
   }
 
   private TraceElement getTraceElement() {
     return TraceElement.of(String.format("Matched destination-address %s", _description));
-  }
-
-  @VisibleForTesting
-  HeaderSpace toHeaderspace() {
-    return HeaderSpace.builder().setDstIps(_ipWildcard.toIpSpace()).build();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressBookEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressBookEntry.java
@@ -1,16 +1,16 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+
 import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.juniper.FwTerm.Field;
 
 /** Class for security policy match destination-address */
@@ -37,11 +37,11 @@ public final class FwFromDestinationAddressBookEntry implements FwFrom {
 
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
-    return new MatchHeaderSpace(toHeaderspace(w), getTraceElement());
+    return matchDst(toIpSpace(w), getTraceElement());
   }
 
   @VisibleForTesting
-  HeaderSpace toHeaderspace(Warnings w) {
+  IpSpace toIpSpace(Warnings w) {
     AddressBook addressBook = _zone == null ? _globalAddressBook : _zone.getAddressBook();
     String addressBookName = addressBook.getAddressBookName(_addressBookEntryName);
     IpSpace referencedIpSpace;
@@ -53,7 +53,7 @@ public final class FwFromDestinationAddressBookEntry implements FwFrom {
       String ipSpaceName = addressBookName + "~" + _addressBookEntryName;
       referencedIpSpace = new IpSpaceReference(ipSpaceName);
     }
-    return HeaderSpace.builder().setDstIps(referencedIpSpace).build();
+    return referencedIpSpace;
   }
 
   private TraceElement getTraceElement() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationPrefixList.java
@@ -1,14 +1,14 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+
 import com.google.common.annotations.VisibleForTesting;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.juniper.FwTerm.Field;
 
 /** Class for firewall filter destination-prefix-list */
@@ -27,17 +27,17 @@ public final class FwFromDestinationPrefixList implements FwFrom {
 
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
-    return new MatchHeaderSpace(toHeaderSpace(jc, w), getTraceElement());
+    return matchDst(toIpSpace(jc, w), getTraceElement());
   }
 
   @VisibleForTesting
-  HeaderSpace toHeaderSpace(JuniperConfiguration jc, Warnings w) {
+  IpSpace toIpSpace(JuniperConfiguration jc, Warnings w) {
     PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_name);
 
     if (pl == null) {
       w.redFlag("Reference to undefined destination-prefix-list: \"" + _name + "\"");
       // match nothing
-      return HeaderSpace.builder().setDstIps(EmptyIpSpace.INSTANCE).build();
+      return EmptyIpSpace.INSTANCE;
     }
 
     IpSpace space = pl.toIpSpace();
@@ -46,7 +46,7 @@ public final class FwFromDestinationPrefixList implements FwFrom {
       w.redFlagf("destination-prefix-list \"%s\" is empty", _name);
     }
 
-    return HeaderSpace.builder().setDstIps(space).build();
+    return space;
   }
 
   private TraceElement getTraceElement() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromJunosApplicationSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromJunosApplicationSet.java
@@ -2,12 +2,11 @@ package org.batfish.representation.juniper;
 
 import java.util.List;
 import org.batfish.common.Warnings;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.FalseExpr;
 
 public final class FwFromJunosApplicationSet implements FwFromApplicationSetMember {
 
@@ -36,7 +35,7 @@ public final class FwFromJunosApplicationSet implements FwFromApplicationSetMemb
     if (!_junosApplicationSet.hasDefinition()) {
       w.redFlag("Reference to undefined application: \"" + _junosApplicationSet.name() + "\"");
       // match nothing
-      return new MatchHeaderSpace(HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build());
+      return FalseExpr.INSTANCE;
     }
     return _junosApplicationSet.getApplicationSet().toAclLineMatchExpr(jc, w);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddress.java
@@ -1,13 +1,13 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+
 import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.juniper.FwTerm.Field;
 
 /** Class for firewall filter from source-address */
@@ -36,14 +36,10 @@ public final class FwFromSourceAddress implements FwFrom {
 
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
-    return new MatchHeaderSpace(toHeaderspace(), getTraceElement());
+    return matchSrc(_ipWildcard.toIpSpace(), getTraceElement());
   }
 
   private TraceElement getTraceElement() {
     return TraceElement.of(String.format("Matched source-address %s", _description));
-  }
-
-  private HeaderSpace toHeaderspace() {
-    return HeaderSpace.builder().setSrcIps(_ipWildcard.toIpSpace()).build();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntry.java
@@ -1,16 +1,16 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+
 import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.juniper.FwTerm.Field;
 
 /** Test for security policy match source-address */
@@ -37,11 +37,11 @@ public final class FwFromSourceAddressBookEntry implements FwFrom {
 
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
-    return new MatchHeaderSpace(toHeaderspace(w), getTraceElement());
+    return matchSrc(toIpSpace(w), getTraceElement());
   }
 
   @VisibleForTesting
-  HeaderSpace toHeaderspace(Warnings w) {
+  IpSpace toIpSpace(Warnings w) {
     AddressBook addressBook = _zone == null ? _globalAddressBook : _zone.getAddressBook();
     String addressBookName = addressBook.getAddressBookName(_addressBookEntryName);
     IpSpace referencedIpSpace;
@@ -53,7 +53,7 @@ public final class FwFromSourceAddressBookEntry implements FwFrom {
       String ipSpaceName = addressBookName + "~" + _addressBookEntryName;
       referencedIpSpace = new IpSpaceReference(ipSpaceName);
     }
-    return HeaderSpace.builder().setSrcIps(referencedIpSpace).build();
+    return referencedIpSpace;
   }
 
   private TraceElement getTraceElement() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourcePrefixList.java
@@ -1,14 +1,14 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+
 import com.google.common.annotations.VisibleForTesting;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.juniper.FwTerm.Field;
 
 /** Class for firewall filter from source-prefix-list */
@@ -27,17 +27,17 @@ public final class FwFromSourcePrefixList implements FwFrom {
 
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
-    return new MatchHeaderSpace(toHeaderSpace(jc, w), getTraceElement());
+    return matchSrc(toIpSpace(jc, w), getTraceElement());
   }
 
   @VisibleForTesting
-  HeaderSpace toHeaderSpace(JuniperConfiguration jc, Warnings w) {
+  IpSpace toIpSpace(JuniperConfiguration jc, Warnings w) {
     PrefixList pl = jc.getMasterLogicalSystem().getPrefixLists().get(_name);
 
     if (pl == null) {
       w.redFlag("Reference to undefined source-prefix-list: \"" + _name + "\"");
       // match nothing
-      return HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build();
+      return EmptyIpSpace.INSTANCE;
     }
 
     IpSpace space = pl.toIpSpace();
@@ -46,7 +46,7 @@ public final class FwFromSourcePrefixList implements FwFrom {
       w.redFlagf("source-prefix-list \"%s\" is empty", _name);
     }
 
-    return HeaderSpace.builder().setSrcIps(space).build();
+    return space;
   }
 
   private TraceElement getTraceElement() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JunosApplicationSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JunosApplicationSet.java
@@ -8,14 +8,12 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.HeaderSpace.Builder;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.FalseExpr;
 
 public enum JunosApplicationSet implements ApplicationSetMember {
   JUNOS_CIFS,
@@ -368,9 +366,7 @@ public enum JunosApplicationSet implements ApplicationSetMember {
   @Override
   public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Warnings w) {
     if (!hasDefinition()) {
-      return new MatchHeaderSpace(
-          HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build(),
-          getTraceElement(convertToJuniperName()));
+      return new FalseExpr(getTraceElement(convertToJuniperName()));
     }
     return _applicationSet.get().toAclLineMatchExpr(jc, w);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -124,6 +124,7 @@ import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.NotMatchExpr;
@@ -698,7 +699,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // 2. Match SRC IPs.
-    List<MatchHeaderSpace> srcExprs =
+    List<AclLineMatchExpr> srcExprs =
         aclLineMatchExprsFromRuleEndpointSources(rule.getSource(), vsys, _w, _filename);
     assert !srcExprs.isEmpty();
     conjuncts.add(
@@ -710,7 +711,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // 3. Match DST IPs.
-    List<MatchHeaderSpace> dstExprs =
+    List<AclLineMatchExpr> dstExprs =
         aclLineMatchExprsFromRuleEndpointDestinations(rule.getDestination(), vsys, _w, _filename);
     assert !dstExprs.isEmpty();
     conjuncts.add(
@@ -1599,24 +1600,24 @@ public class PaloAltoConfiguration extends VendorConfiguration {
             .collect(Collectors.toList()));
   }
 
-  private @Nonnull List<MatchHeaderSpace> aclLineMatchExprsFromRuleEndpointSources(
+  private @Nonnull List<AclLineMatchExpr> aclLineMatchExprsFromRuleEndpointSources(
       Collection<RuleEndpoint> endpoints, Vsys vsys, Warnings w, String filename) {
     return endpoints.stream()
         .map(
             source ->
-                new MatchHeaderSpace(
-                    HeaderSpace.builder().setSrcIps(ruleEndpointToIpSpace(source, vsys, w)).build(),
+                AclLineMatchExprs.matchSrc(
+                    ruleEndpointToIpSpace(source, vsys, w),
                     getRuleEndpointTraceElement(source, vsys, filename)))
         .collect(ImmutableList.toImmutableList());
   }
 
-  private @Nonnull List<MatchHeaderSpace> aclLineMatchExprsFromRuleEndpointDestinations(
+  private @Nonnull List<AclLineMatchExpr> aclLineMatchExprsFromRuleEndpointDestinations(
       Collection<RuleEndpoint> endpoints, Vsys vsys, Warnings w, String filename) {
     return endpoints.stream()
         .map(
             dest ->
-                new MatchHeaderSpace(
-                    HeaderSpace.builder().setDstIps(ruleEndpointToIpSpace(dest, vsys, w)).build(),
+                AclLineMatchExprs.matchDst(
+                    ruleEndpointToIpSpace(dest, vsys, w),
                     getRuleEndpointTraceElement(dest, vsys, filename)))
         .collect(ImmutableList.toImmutableList());
   }
@@ -1656,7 +1657,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // 2. Match SRC IPs if specified.
-    List<MatchHeaderSpace> srcExprs =
+    List<AclLineMatchExpr> srcExprs =
         aclLineMatchExprsFromRuleEndpointSources(rule.getSource(), namespaceVsys, _w, _filename);
     if (!srcExprs.isEmpty()) {
       conjuncts.add(
@@ -1669,7 +1670,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
     //////////////////////////////////////////////////////////////////////////////////////////
     // 3. Match DST IPs if specified.
-    List<MatchHeaderSpace> dstExprs =
+    List<AclLineMatchExpr> dstExprs =
         aclLineMatchExprsFromRuleEndpointDestinations(
             rule.getDestination(), namespaceVsys, _w, _filename);
     if (!dstExprs.isEmpty()) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -26,6 +26,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIcmpCode;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIcmpType;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIpProtocol;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.flow.TransformationStep.TransformationType.DEST_NAT;
@@ -3794,21 +3795,14 @@ public final class FlatJuniperGrammarTest {
                             new AndMatchExpr(
                                 ImmutableList.of(
                                     or(
-                                        new MatchHeaderSpace(
-                                            HeaderSpace.builder()
-                                                .setSrcIps(
-                                                    IpWildcard.ipWithWildcardMask(
-                                                            Ip.parse("1.0.3.0"),
-                                                            Ip.parse("0.255.0.255"))
-                                                        .toIpSpace())
-                                                .build(),
+                                        matchSrc(
+                                            IpWildcard.ipWithWildcardMask(
+                                                    Ip.parse("1.0.3.0"), Ip.parse("0.255.0.255"))
+                                                .toIpSpace(),
                                             TraceElement.of(
                                                 "Matched source-address 1.2.3.4/255.0.255.0")),
-                                        new MatchHeaderSpace(
-                                            HeaderSpace.builder()
-                                                .setSrcIps(
-                                                    IpWildcard.parse("2.3.4.5/24").toIpSpace())
-                                                .build(),
+                                        matchSrc(
+                                            IpWildcard.parse("2.3.4.5/24").toIpSpace(),
                                             TraceElement.of(
                                                 "Matched source-address 2.3.4.5/24"))))))
                         .setName("TERM")
@@ -3822,10 +3816,8 @@ public final class FlatJuniperGrammarTest {
                         .setMatchCondition(
                             new AndMatchExpr(
                                 ImmutableList.of(
-                                    new MatchHeaderSpace(
-                                        HeaderSpace.builder()
-                                            .setSrcIps(IpWildcard.parse("0.0.0.0/0").toIpSpace())
-                                            .build(),
+                                    matchSrc(
+                                        IpWildcard.parse("0.0.0.0/0").toIpSpace(),
                                         TraceElement.of("Matched source-address 0.0.0.0/0")),
                                     and(
                                         new MatchHeaderSpace(
@@ -4162,22 +4154,16 @@ public final class FlatJuniperGrammarTest {
                                 new AndMatchExpr(
                                     ImmutableList.of(
                                         or(
-                                            new MatchHeaderSpace(
-                                                HeaderSpace.builder()
-                                                    .setDstIps(
-                                                        IpWildcard.ipWithWildcardMask(
-                                                                Ip.parse("1.0.3.0"),
-                                                                Ip.parse("0.255.0.255"))
-                                                            .toIpSpace())
-                                                    .build(),
+                                            matchDst(
+                                                IpWildcard.ipWithWildcardMask(
+                                                        Ip.parse("1.0.3.0"),
+                                                        Ip.parse("0.255.0.255"))
+                                                    .toIpSpace(),
                                                 TraceElement.of(
                                                     "Matched destination-address"
                                                         + " 1.2.3.4/255.0.255.0")),
-                                            new MatchHeaderSpace(
-                                                HeaderSpace.builder()
-                                                    .setDstIps(
-                                                        IpWildcard.parse("2.3.4.5/24").toIpSpace())
-                                                    .build(),
+                                            matchDst(
+                                                IpWildcard.parse("2.3.4.5/24").toIpSpace(),
                                                 TraceElement.of(
                                                     "Matched destination-address 2.3.4.5/24"))))))
                             .setName("TERM")
@@ -5619,7 +5605,10 @@ public final class FlatJuniperGrammarTest {
     Transformation ruleSet1Transformation =
         when(matchSrcInterface("ge-0/0/0.0"))
             .setAndThen(
-                when(matchDst(Prefix.parse("1.1.1.1/24")))
+                when(match(
+                        HeaderSpace.builder()
+                            .setDstIps(Prefix.parse("1.1.1.1/24").toIpSpace())
+                            .build()))
                     .apply(transformationStep, portTransformationStep)
                     .build())
             .build();
@@ -5628,7 +5617,10 @@ public final class FlatJuniperGrammarTest {
     Transformation ruleSet3Transformation =
         when(matchSrcInterface("ge-0/0/0.0", "ge-0/0/1.0"))
             .setAndThen(
-                when(matchDst(Prefix.parse("3.3.3.3/24")))
+                when(match(
+                        HeaderSpace.builder()
+                            .setDstIps(Prefix.parse("3.3.3.3/24").toIpSpace())
+                            .build()))
                     .apply(transformationStep, portTransformationStep)
                     .setOrElse(ruleSet1Transformation)
                     .build())
@@ -5639,7 +5631,10 @@ public final class FlatJuniperGrammarTest {
     Transformation ruleSet2Transformation =
         when(matchSrcInterface("ge-0/0/0.0"))
             .setAndThen(
-                when(matchDst(Prefix.parse("2.2.2.2/24")))
+                when(match(
+                        HeaderSpace.builder()
+                            .setDstIps(Prefix.parse("2.2.2.2/24").toIpSpace())
+                            .build()))
                     .apply(transformationStep, portTransformationStep)
                     .setOrElse(
                         // routing instance rule set
@@ -6820,10 +6815,8 @@ public final class FlatJuniperGrammarTest {
                             LineAction.PERMIT,
                             new AndMatchExpr(
                                 ImmutableList.of(
-                                    new MatchHeaderSpace(
-                                        HeaderSpace.builder()
-                                            .setSrcIps(IpWildcard.parse("1.2.3.6").toIpSpace())
-                                            .build(),
+                                    matchSrc(
+                                        IpWildcard.parse("1.2.3.6").toIpSpace(),
                                         TraceElement.of("Matched source-address 1.2.3.6")))),
                             "TERM",
                             matchingFirewallFilterTerm(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -3,6 +3,8 @@ package org.batfish.representation.aws;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.IpProtocol.TCP;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.matchers.AclLineMatchers.isExprAclLineThat;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDeviceModel;
@@ -224,8 +226,8 @@ public class ElasticsearchDomainTest {
                 hasMatchCondition(
                     new AndMatchExpr(
                         ImmutableList.of(
-                            new MatchHeaderSpace(
-                                HeaderSpace.builder().setDstIps(UniverseIpSpace.INSTANCE).build(),
+                            matchDst(
+                                UniverseIpSpace.INSTANCE,
                                 traceElementForAddress(
                                     "destination", "0.0.0.0/0", AddressType.CIDR_IP))),
                         getTraceElementForRule(null))))));
@@ -241,10 +243,8 @@ public class ElasticsearchDomainTest {
                             ImmutableList.of(
                                 matchTcp,
                                 matchPorts(45, 50),
-                                new MatchHeaderSpace(
-                                    HeaderSpace.builder()
-                                        .setSrcIps(Ip.parse("1.2.3.4").toIpSpace())
-                                        .build(),
+                                matchSrc(
+                                    Ip.parse("1.2.3.4").toIpSpace(),
                                     traceElementForAddress(
                                         "source", "1.2.3.4/32", AddressType.CIDR_IP))),
                             getTraceElementForRule("Closed interval")),
@@ -255,10 +255,8 @@ public class ElasticsearchDomainTest {
                                 or(
                                     traceTextForAddress(
                                         "source", "Test-Instance-SG", AddressType.SECURITY_GROUP),
-                                    new MatchHeaderSpace(
-                                        HeaderSpace.builder()
-                                            .setSrcIps(Ip.parse("10.193.16.105").toIpSpace())
-                                            .build(),
+                                    matchSrc(
+                                        Ip.parse("10.193.16.105").toIpSpace(),
                                         traceElementEniPrivateIp(
                                             "eni-05e8949c37b78cf4d on i-066b1b9957b9200e7 (Test"
                                                 + " host)")))),

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.aws;
 
 import static org.batfish.datamodel.IpProtocol.TCP;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.datamodel.matchers.TraceTreeMatchers.isTraceTree;
 import static org.batfish.representation.aws.Utils.getTraceElementForRule;
@@ -90,12 +91,8 @@ public class IpPermissionsTest {
     OrMatchExpr matchIpSpaces =
         new OrMatchExpr(
             ImmutableList.of(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder().setSrcIps(Ip.parse("1.1.1.1").toIpSpace()).build(),
-                    traceElementEniPrivateIp(INSTANCE_1)),
-                new MatchHeaderSpace(
-                    HeaderSpace.builder().setSrcIps(Ip.parse("2.2.2.2").toIpSpace()).build(),
-                    traceElementEniPrivateIp(INSTANCE_2))),
+                matchSrc(Ip.parse("1.1.1.1").toIpSpace(), traceElementEniPrivateIp(INSTANCE_1)),
+                matchSrc(Ip.parse("2.2.2.2").toIpSpace(), traceElementEniPrivateIp(INSTANCE_2))),
             traceElementForAddress("source", SG_NAME, AddressType.SECURITY_GROUP));
     assertThat(
         line,

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -2,6 +2,8 @@ package org.batfish.representation.aws;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.matchers.AclLineMatchers.isExprAclLineThat;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
@@ -47,7 +49,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -55,7 +56,6 @@ import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AndMatchExpr;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.vendor_family.AwsFamily;
 import org.batfish.main.Batfish;
@@ -161,8 +161,8 @@ public class RdsInstanceTest {
                 hasMatchCondition(
                     new AndMatchExpr(
                         ImmutableList.of(
-                            new MatchHeaderSpace(
-                                HeaderSpace.builder().setDstIps(UniverseIpSpace.INSTANCE).build(),
+                            matchDst(
+                                UniverseIpSpace.INSTANCE,
                                 traceElementForAddress(
                                     "destination", "0.0.0.0/0", AddressType.CIDR_IP))),
                         getTraceElementForRule(null))))));
@@ -178,10 +178,8 @@ public class RdsInstanceTest {
                             ImmutableList.of(
                                 matchTcp,
                                 matchPorts(45, 50),
-                                new MatchHeaderSpace(
-                                    HeaderSpace.builder()
-                                        .setSrcIps(Ip.parse("1.2.3.4").toIpSpace())
-                                        .build(),
+                                matchSrc(
+                                    Ip.parse("1.2.3.4").toIpSpace(),
                                     traceElementForAddress(
                                         "source", "1.2.3.4/32", AddressType.CIDR_IP))),
                             getTraceElementForRule("Closed interval")),
@@ -192,10 +190,8 @@ public class RdsInstanceTest {
                                 or(
                                     traceTextForAddress(
                                         "source", "Test-Instance-SG", AddressType.SECURITY_GROUP),
-                                    new MatchHeaderSpace(
-                                        HeaderSpace.builder()
-                                            .setSrcIps(Ip.parse("10.193.16.105").toIpSpace())
-                                            .build(),
+                                    matchSrc(
+                                        Ip.parse("10.193.16.105").toIpSpace(),
                                         traceElementEniPrivateIp(
                                             "eni-05e8949c37b78cf4d on i-066b1b9957b9200e7 (Test"
                                                 + " host)")))),

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -5,6 +5,8 @@ import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.IpProtocol.ICMP;
 import static org.batfish.datamodel.IpProtocol.TCP;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.batfish.datamodel.matchers.AclLineMatchers.isExprAclLineThat;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_SECURITY_GROUPS;
@@ -45,6 +47,7 @@ import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.aws.IpPermissions.AddressType;
@@ -61,14 +64,14 @@ public class SecurityGroupsTest {
   private Warnings _warnings;
 
   public static String TEST_ACL = "test_acl";
-  private static final MatchHeaderSpace matchIp =
-      new MatchHeaderSpace(
-          HeaderSpace.builder().setSrcIps(Ip.parse("1.2.3.4").toIpSpace()).build(),
+  private static final AclLineMatchExpr matchIp =
+      matchSrc(
+          Ip.parse("1.2.3.4").toIpSpace(),
           traceElementForAddress("source", "1.2.3.4/32", AddressType.CIDR_IP));
 
-  private static final MatchHeaderSpace matchUniverse =
-      new MatchHeaderSpace(
-          HeaderSpace.builder().setSrcIps(UniverseIpSpace.INSTANCE).build(),
+  private static final AclLineMatchExpr matchUniverse =
+      matchSrc(
+          UniverseIpSpace.INSTANCE,
           traceElementForAddress("source", "0.0.0.0/0", AddressType.CIDR_IP));
 
   private static final MatchHeaderSpace matchTcp =
@@ -362,10 +365,8 @@ public class SecurityGroupsTest {
                     ImmutableList.of(
                         matchTcp,
                         matchPorts(80, 80),
-                        new MatchHeaderSpace(
-                            HeaderSpace.builder()
-                                .setDstIps(Ip.parse("5.6.7.8").toIpSpace())
-                                .build(),
+                        matchDst(
+                            Ip.parse("5.6.7.8").toIpSpace(),
                             traceElementForAddress(
                                 "destination", "5.6.7.8/32", AddressType.CIDR_IP))),
                     getTraceElementForRule(outRangeDesc)))));
@@ -505,10 +506,8 @@ public class SecurityGroupsTest {
                             ImmutableList.of(
                                 matchTcp,
                                 matchPorts(22, 22),
-                                new MatchHeaderSpace(
-                                    HeaderSpace.builder()
-                                        .setSrcIps(Prefix.parse("2.2.2.0/24").toIpSpace())
-                                        .build(),
+                                matchSrc(
+                                    Prefix.parse("2.2.2.0/24").toIpSpace(),
                                     traceElementForAddress(
                                         "source", "2.2.2.0/24", AddressType.CIDR_IP))),
                             getTraceElementForRule(rangeDesc)))

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationAddressBookEntryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationAddressBookEntryTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcard;
 import org.junit.Test;
@@ -29,13 +28,7 @@ public class FwFromDestinationAddressBookEntryTest {
     FwFromDestinationAddressBookEntry from =
         new FwFromDestinationAddressBookEntry(null, globalAddressBook, addressBookEntryName);
 
-    HeaderSpace headerSpace = from.toHeaderspace(w);
-    assertThat(
-        headerSpace,
-        equalTo(
-            HeaderSpace.builder()
-                .setDstIps(new IpSpaceReference("addressBook~addressBookEntry"))
-                .build()));
+    assertThat(from.toIpSpace(w), equalTo(new IpSpaceReference("addressBook~addressBookEntry")));
   }
 
   @Test
@@ -47,8 +40,6 @@ public class FwFromDestinationAddressBookEntryTest {
     FwFromDestinationAddressBookEntry from =
         new FwFromDestinationAddressBookEntry(null, globalAddressBook, addressBookEntryName);
 
-    HeaderSpace headerSpace = from.toHeaderspace(w);
-    assertThat(
-        headerSpace, equalTo(HeaderSpace.builder().setDstIps(EmptyIpSpace.INSTANCE).build()));
+    assertThat(from.toIpSpace(w), equalTo(EmptyIpSpace.INSTANCE));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationAddressTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationAddressTest.java
@@ -1,9 +1,9 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.junit.Test;
 
@@ -11,12 +11,14 @@ import org.junit.Test;
 public class FwFromDestinationAddressTest {
 
   @Test
-  public void testToHeaderspace() {
+  public void testToAclLineMatchExpr() {
     FwFromDestinationAddress from =
         new FwFromDestinationAddress(IpWildcard.parse("1.1.1.0/24"), "1.1.1.0/24");
     assertThat(
-        from.toHeaderspace(),
+        from.toAclLineMatchExpr(null, null, null),
         equalTo(
-            HeaderSpace.builder().setDstIps(IpWildcard.parse("1.1.1.0/24").toIpSpace()).build()));
+            matchDst(
+                IpWildcard.parse("1.1.1.0/24").toIpSpace(),
+                "Matched destination-address 1.1.1.0/24")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
@@ -1,11 +1,9 @@
 package org.batfish.representation.juniper;
 
-import static org.batfish.datamodel.matchers.HeaderSpaceMatchers.hasDstIps;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.batfish.common.Warnings;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Prefix;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,8 +29,6 @@ public class FwFromDestinationPrefixListTest {
   public void testToHeaderSpace() {
     FwFromDestinationPrefixList fwFrom = new FwFromDestinationPrefixList(BASE_PREFIX_LIST_NAME);
 
-    HeaderSpace headerSpace = fwFrom.toHeaderSpace(_jc, _w);
-
-    assertThat(headerSpace, hasDstIps(equalTo(BASE_IP_PREFIX.toIpSpace())));
+    assertThat(fwFrom.toIpSpace(_jc, _w), equalTo(BASE_IP_PREFIX.toIpSpace()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourceAddressBookEntryTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcard;
 import org.junit.Test;
@@ -27,11 +26,7 @@ public class FwFromSourceAddressBookEntryTest {
     FwFromSourceAddressBookEntry from =
         new FwFromSourceAddressBookEntry(null, globalAddressBook, addressBookEntryName);
 
-    assertEquals(
-        from.toHeaderspace(w),
-        HeaderSpace.builder()
-            .setSrcIps(new IpSpaceReference("addressBook~addressBookEntry"))
-            .build());
+    assertEquals(from.toIpSpace(w), new IpSpaceReference("addressBook~addressBookEntry"));
   }
 
   @Test
@@ -43,7 +38,6 @@ public class FwFromSourceAddressBookEntryTest {
     FwFromSourceAddressBookEntry from =
         new FwFromSourceAddressBookEntry(null, globalAddressBook, addressBookEntryName);
 
-    assertEquals(
-        from.toHeaderspace(w), HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build());
+    assertEquals(from.toIpSpace(w), EmptyIpSpace.INSTANCE);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourceAddressTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourceAddressTest.java
@@ -1,11 +1,10 @@
 package org.batfish.representation.juniper;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.junit.Assert.assertEquals;
 
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.TraceElement;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.junit.Test;
 
 /** Test for {@link FwFromSourceAddress} */
@@ -17,8 +16,7 @@ public class FwFromSourceAddressTest {
     FwFromSourceAddress from = new FwFromSourceAddress(ipWildcard, "1.1.1.0/24-desc");
     assertEquals(
         from.toAclLineMatchExpr(null, null, null),
-        new MatchHeaderSpace(
-            HeaderSpace.builder().setSrcIps(ipWildcard.toIpSpace()).build(),
-            TraceElement.of("Matched source-address 1.1.1.0/24-desc")));
+        matchSrc(
+            ipWildcard.toIpSpace(), TraceElement.of("Matched source-address 1.1.1.0/24-desc")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
@@ -6,10 +6,9 @@ import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.TraceElement;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,18 +36,14 @@ public class FwFromSourcePrefixListTest {
     FwFromSourcePrefixList fwFrom = new FwFromSourcePrefixList(BASE_PREFIX_LIST_NAME);
 
     // Apply base IP prefix to headerSpace with null IpSpace
-    assertEquals(
-        fwFrom.toHeaderSpace(_jc, _w),
-        HeaderSpace.builder().setSrcIps(BASE_IP_PREFIX.toIpSpace()).build());
+    assertEquals(fwFrom.toIpSpace(_jc, _w), BASE_IP_PREFIX.toIpSpace());
   }
 
   @Test
   public void testToHeaderSpace_notExist() {
     FwFromSourcePrefixList fwFrom = new FwFromSourcePrefixList("noName");
 
-    assertEquals(
-        fwFrom.toHeaderSpace(_jc, _w),
-        HeaderSpace.builder().setSrcIps(EmptyIpSpace.INSTANCE).build());
+    assertEquals(fwFrom.toIpSpace(_jc, _w), EmptyIpSpace.INSTANCE);
   }
 
   @Test
@@ -57,8 +52,7 @@ public class FwFromSourcePrefixListTest {
 
     assertEquals(
         fwFrom.toAclLineMatchExpr(_jc, _c, _w),
-        new MatchHeaderSpace(
-            fwFrom.toHeaderSpace(_jc, _w),
-            TraceElement.of("Matched source-prefix-list prefixList")));
+        AclLineMatchExprs.matchSrc(
+            fwFrom.toIpSpace(_jc, _w), TraceElement.of("Matched source-prefix-list prefixList")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -4,6 +4,7 @@ import static org.batfish.common.Warnings.TAG_PEDANTIC;
 import static org.batfish.common.matchers.WarningMatchers.hasText;
 import static org.batfish.common.matchers.WarningsMatchers.hasUnimplementedWarning;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.matchers.AclLineMatchers.hasTraceElement;
 import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_DEAD_INTERVAL;
@@ -134,10 +135,8 @@ public class JuniperConfigurationTest {
                 .setMatchCondition(
                     new AndMatchExpr(
                         ImmutableList.of(
-                            new MatchHeaderSpace(
-                                HeaderSpace.builder()
-                                    .setSrcIps(IpWildcard.parse(ipAddrPrefix).toIpSpace())
-                                    .build(),
+                            matchSrc(
+                                IpWildcard.parse(ipAddrPrefix).toIpSpace(),
                                 TraceElement.of("Matched source-address 1.2.3.0/24")))))
                 .build()));
   }
@@ -231,10 +230,8 @@ public class JuniperConfigurationTest {
                         ImmutableList.of(
                             new AndMatchExpr(
                                 ImmutableList.of(
-                                    new MatchHeaderSpace(
-                                        HeaderSpace.builder()
-                                            .setSrcIps(IpWildcard.parse(ipAddrPrefix).toIpSpace())
-                                            .build(),
+                                    matchSrc(
+                                        IpWildcard.parse(ipAddrPrefix).toIpSpace(),
                                         TraceElement.of("Matched source-address 1.2.3.0/24")))),
                             new MatchSrcInterface(zone.getInterfaces()))))
                 .build()));

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
@@ -1,6 +1,6 @@
 package org.batfish.representation.juniper;
 
-import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.match;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.flow.TransformationStep.TransformationType.SOURCE_NAT;
 import static org.batfish.datamodel.transformation.IpField.SOURCE;
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDiff;
+import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.Prefix;
@@ -148,12 +149,12 @@ public class NatRuleSetTest {
     // the transformation for the rules themselves
     Transformation rulesTransformation =
         // first apply natRule1
-        when(matchDst(prefix1))
+        when(match(HeaderSpace.builder().setDstIps(prefix1.toIpSpace()).build()))
             .apply(NOOP_SOURCE_NAT)
             .setAndThen(andThen)
             .setOrElse(
                 // only apply natRule2 if natRule1 doesn't match
-                when(matchDst(prefix2))
+                when(match(HeaderSpace.builder().setDstIps(prefix2.toIpSpace()).build()))
                     .apply(
                         assignSourceIp(poolStart, poolEnd),
                         assignSourcePort(Nat.DEFAULT_FROM_PORT, Nat.DEFAULT_TO_PORT))

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/AclEraser.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/AclEraser.java
@@ -8,12 +8,15 @@ import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
 import org.batfish.datamodel.acl.GenericAclLineVisitor;
+import org.batfish.datamodel.acl.MatchDestinationIp;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSourceIp;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
@@ -79,9 +82,23 @@ public final class AclEraser
   }
 
   @Override
+  public AclLineMatchExpr visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+    return matchDestinationIp.getTraceElement() == null
+        ? matchDestinationIp
+        : AclLineMatchExprs.matchDst(matchDestinationIp.getIps());
+  }
+
+  @Override
   public AclLineMatchExpr visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
     // TODO erase within IpSpaces if/when we add TraceElements to them
     return new MatchHeaderSpace(matchHeaderSpace.getHeaderspace());
+  }
+
+  @Override
+  public AclLineMatchExpr visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+    return matchSourceIp.getTraceElement() == null
+        ? matchSourceIp
+        : AclLineMatchExprs.matchSrc(matchSourceIp.getIps());
   }
 
   @Override

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityUtils.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityUtils.java
@@ -33,7 +33,9 @@ import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.GenericAclLineMatchExprVisitor;
 import org.batfish.datamodel.acl.GenericAclLineVisitor;
+import org.batfish.datamodel.acl.MatchDestinationIp;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSourceIp;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
@@ -207,8 +209,18 @@ public class FilterLineReachabilityUtils {
     }
 
     @Override
+    public Stream<String> visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+      return Stream.empty();
+    }
+
+    @Override
     public Stream<String> visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
       return Stream.of();
+    }
+
+    @Override
+    public Stream<String> visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+      return Stream.empty();
     }
 
     @Override
@@ -280,8 +292,18 @@ public class FilterLineReachabilityUtils {
     }
 
     @Override
+    public Stream<String> visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+      return Stream.empty();
+    }
+
+    @Override
     public Stream<String> visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
       return Stream.of();
+    }
+
+    @Override
+    public Stream<String> visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+      return Stream.empty();
     }
 
     @Override

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/AclEraserTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/AclEraserTest.java
@@ -1,5 +1,10 @@
 package org.batfish.question.filterlinereachability;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -7,6 +12,7 @@ import java.util.List;
 import org.batfish.datamodel.AclAclLine;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.UniverseIpSpace;
@@ -14,7 +20,9 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.MatchDestinationIp;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.MatchSourceIp;
 import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.OrMatchExpr;
@@ -65,6 +73,19 @@ public class AclEraserTest {
       assertEquals(
           new MatchHeaderSpace(headerSpace),
           _eraser.visit(new MatchHeaderSpace(headerSpace, _traceElem)));
+    }
+    {
+      MatchDestinationIp noTrace = (MatchDestinationIp) matchDst(Ip.parse("1.1.1.1"));
+      MatchDestinationIp trace =
+          (MatchDestinationIp) matchDst(Ip.parse("1.1.1.1").toIpSpace(), _traceElem);
+      assertThat(_eraser.visit(noTrace), sameInstance(noTrace));
+      assertThat(_eraser.visit(trace), equalTo(noTrace));
+    }
+    {
+      MatchSourceIp noTrace = (MatchSourceIp) matchSrc(Ip.parse("1.1.1.1"));
+      MatchSourceIp trace = (MatchSourceIp) matchSrc(Ip.parse("1.1.1.1").toIpSpace(), _traceElem);
+      assertThat(_eraser.visit(noTrace), sameInstance(noTrace));
+      assertThat(_eraser.visit(trace), equalTo(noTrace));
     }
   }
 

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -107,13 +107,7 @@
                   "class" : "org.batfish.datamodel.acl.AndMatchExpr",
                   "conjuncts" : [
                     {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstIps" : {
-                          "class" : "org.batfish.datamodel.UniverseIpSpace"
-                        },
-                        "negate" : false
-                      },
+                      "class" : "org.batfish.datamodel.acl.TrueExpr",
                       "traceElement" : {
                         "fragments" : [
                           {
@@ -168,13 +162,10 @@
                       "class" : "org.batfish.datamodel.acl.OrMatchExpr",
                       "disjuncts" : [
                         {
-                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                          "headerSpace" : {
-                            "negate" : false,
-                            "srcIps" : {
-                              "class" : "org.batfish.datamodel.IpIpSpace",
-                              "ip" : "192.168.1.3"
-                            }
+                          "class" : "org.batfish.datamodel.acl.MatchSourceIp",
+                          "ips" : {
+                            "class" : "org.batfish.datamodel.IpIpSpace",
+                            "ip" : "192.168.1.3"
                           },
                           "traceElement" : {
                             "fragments" : [
@@ -344,13 +335,7 @@
                   "class" : "org.batfish.datamodel.acl.AndMatchExpr",
                   "conjuncts" : [
                     {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstIps" : {
-                          "class" : "org.batfish.datamodel.UniverseIpSpace"
-                        },
-                        "negate" : false
-                      },
+                      "class" : "org.batfish.datamodel.acl.TrueExpr",
                       "traceElement" : {
                         "fragments" : [
                           {
@@ -405,13 +390,10 @@
                       "class" : "org.batfish.datamodel.acl.OrMatchExpr",
                       "disjuncts" : [
                         {
-                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                          "headerSpace" : {
-                            "negate" : false,
-                            "srcIps" : {
-                              "class" : "org.batfish.datamodel.IpIpSpace",
-                              "ip" : "192.168.1.3"
-                            }
+                          "class" : "org.batfish.datamodel.acl.MatchSourceIp",
+                          "ips" : {
+                            "class" : "org.batfish.datamodel.IpIpSpace",
+                            "ip" : "192.168.1.3"
                           },
                           "traceElement" : {
                             "fragments" : [
@@ -85042,13 +85024,7 @@
                   "class" : "org.batfish.datamodel.acl.AndMatchExpr",
                   "conjuncts" : [
                     {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstIps" : {
-                          "class" : "org.batfish.datamodel.UniverseIpSpace"
-                        },
-                        "negate" : false
-                      },
+                      "class" : "org.batfish.datamodel.acl.TrueExpr",
                       "traceElement" : {
                         "fragments" : [
                           {
@@ -85137,13 +85113,10 @@
                           }
                         },
                         {
-                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                          "headerSpace" : {
-                            "negate" : false,
-                            "srcIps" : {
-                              "class" : "org.batfish.datamodel.PrefixIpSpace",
-                              "prefix" : "10.193.0.0/16"
-                            }
+                          "class" : "org.batfish.datamodel.acl.MatchSourceIp",
+                          "ips" : {
+                            "class" : "org.batfish.datamodel.PrefixIpSpace",
+                            "prefix" : "10.193.0.0/16"
                           },
                           "traceElement" : {
                             "fragments" : [
@@ -85202,13 +85175,10 @@
                           }
                         },
                         {
-                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                          "headerSpace" : {
-                            "negate" : false,
-                            "srcIps" : {
-                              "class" : "org.batfish.datamodel.IpIpSpace",
-                              "ip" : "107.170.243.58"
-                            }
+                          "class" : "org.batfish.datamodel.acl.MatchSourceIp",
+                          "ips" : {
+                            "class" : "org.batfish.datamodel.IpIpSpace",
+                            "ip" : "107.170.243.58"
                           },
                           "traceElement" : {
                             "fragments" : [
@@ -85267,13 +85237,10 @@
                           }
                         },
                         {
-                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                          "headerSpace" : {
-                            "negate" : false,
-                            "srcIps" : {
-                              "class" : "org.batfish.datamodel.IpIpSpace",
-                              "ip" : "104.236.156.171"
-                            }
+                          "class" : "org.batfish.datamodel.acl.MatchSourceIp",
+                          "ips" : {
+                            "class" : "org.batfish.datamodel.IpIpSpace",
+                            "ip" : "104.236.156.171"
                           },
                           "traceElement" : {
                             "fragments" : [
@@ -85332,13 +85299,10 @@
                           }
                         },
                         {
-                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                          "headerSpace" : {
-                            "negate" : false,
-                            "srcIps" : {
-                              "class" : "org.batfish.datamodel.IpIpSpace",
-                              "ip" : "162.243.144.192"
-                            }
+                          "class" : "org.batfish.datamodel.acl.MatchSourceIp",
+                          "ips" : {
+                            "class" : "org.batfish.datamodel.IpIpSpace",
+                            "ip" : "162.243.144.192"
                           },
                           "traceElement" : {
                             "fragments" : [
@@ -85397,13 +85361,10 @@
                           }
                         },
                         {
-                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                          "headerSpace" : {
-                            "negate" : false,
-                            "srcIps" : {
-                              "class" : "org.batfish.datamodel.IpIpSpace",
-                              "ip" : "67.170.86.87"
-                            }
+                          "class" : "org.batfish.datamodel.acl.MatchSourceIp",
+                          "ips" : {
+                            "class" : "org.batfish.datamodel.IpIpSpace",
+                            "ip" : "67.170.86.87"
                           },
                           "traceElement" : {
                             "fragments" : [


### PR DESCRIPTION
This is the first of a few helpers that should dramatically reduce the use
of MatchHeaderSpace, which is a performance nightmare.