### PR TITLE
ConvertConfigurationJob: optimize use of InvalidVendorStructureIdEraser

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -432,6 +432,7 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
    * org.batfish.datamodel.TraceElement}s.
    */
   @VisibleForTesting
+  @SuppressWarnings("unused") // https://github.com/batfish/batfish/issues/9267
   static void removeInvalidVendorStructureIds(Configuration c, VendorConfiguration vc, Warnings w) {
     InvalidVendorStructureIdEraser vsidEraser =
         new InvalidVendorStructureIdEraser(vc.getFilename(), vc.getStructureManager());
@@ -447,15 +448,19 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
    * org.batfish.datamodel.TraceElement}s.
    */
   @VisibleForTesting
-  static void assertVendorStructureIdsValid(Configuration c, VendorConfiguration vc, Warnings w) {
+  static boolean assertVendorStructureIdsValid(
+      Configuration c, VendorConfiguration vc, Warnings w) {
     InvalidVendorStructureIdEraser eraser =
         new InvalidVendorStructureIdEraser(vc.getFilename(), vc.getStructureManager());
     // Erase invalid VSIDs and confirm no changes occur
     for (IpAccessList acl : c.getIpAccessLists().values()) {
       for (AclLine line : acl.getLines()) {
-        assert line.equals(eraser.visit(line));
+        if (!line.equals(eraser.visit(line))) {
+          return false;
+        }
       }
     }
+    return true;
   }
 
   /**
@@ -488,8 +493,9 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     removeInvalidStaticRoutes(c, w);
     removeUndefinedTrackReferences(c, w);
     // Make tests fail if they have invalid VSIDs
-    assertVendorStructureIdsValid(c, vc, w);
-    removeInvalidVendorStructureIds(c, vc, w);
+    assert assertVendorStructureIdsValid(c, vc, w);
+    // Too slow right now: https://github.com/batfish/batfish/issues/9267
+    // removeInvalidVendorStructureIds(c, vc, w);
 
     c.setAsPathAccessLists(
         verifyAndToImmutableMap(c.getAsPathAccessLists(), AsPathAccessList::getName, w));

--- a/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ConvertConfigurationJobTest.java
@@ -636,9 +636,7 @@ public final class ConvertConfigurationJobTest {
     VendorConfiguration vc = new CiscoConfiguration();
     vc.setFilename(filename);
 
-    // No answer element, should fail assertion
-    _thrown.expect(AssertionError.class);
-    assertVendorStructureIdsValid(c, vc, w);
+    assertFalse(assertVendorStructureIdsValid(c, vc, w));
   }
 
   @Test
@@ -665,9 +663,7 @@ public final class ConvertConfigurationJobTest {
     VendorConfiguration vc = new CiscoConfiguration();
     vc.setFilename(filename);
 
-    // No matching defined structure, should fail assertion
-    _thrown.expect(AssertionError.class);
-    assertVendorStructureIdsValid(c, vc, w);
+    assertFalse(assertVendorStructureIdsValid(c, vc, w));
   }
 
   @Test
@@ -697,7 +693,7 @@ public final class ConvertConfigurationJobTest {
     vc.defineSingleLineStructure(type, validStructureName, 1);
 
     // Matching defined structure, should not fail assertion
-    assertVendorStructureIdsValid(c, vc, w);
+    assertTrue(assertVendorStructureIdsValid(c, vc, w));
   }
 
   private static class SaveStructureInfoSingleFileTestVendorConfiguration


### PR DESCRIPTION
See https://github.com/batfish/batfish/issues/9267. For now, only run it
when assertions are enabled, as in developer mode.