### PR TITLE
VendorConfigurationFormatDetector: lower iptables priority

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -504,7 +504,6 @@ public final class VendorConfigurationFormatDetector {
     format = (format == null) ? checkF5() : format;
     format = (format == null) ? checkCiscoXr() : format;
     format = (format == null) ? checkFlatVyos() : format;
-    format = (format == null) ? checkIpTables() : format;
     format = (format == null) ? checkMetamako() : format;
     format = (format == null) ? checkMrv() : format;
     format = (format == null) ? checkMrvCommands() : format;
@@ -518,6 +517,7 @@ public final class VendorConfigurationFormatDetector {
     format = (format == null) ? checkMss() : format;
     format = (format == null) ? checkArubaOS() : format;
     format = (format == null) ? checkCisco() : format;
+    format = (format == null) ? checkIpTables() : format;
     return (format == null) ? ConfigurationFormat.UNKNOWN : format;
   }
 }

--- a/projects/batfish/src/test/java/BUILD.bazel
+++ b/projects/batfish/src/test/java/BUILD.bazel
@@ -57,6 +57,7 @@ junit_tests(
         "@maven//:com_google_guava_guava_testlib",
         "@maven//:commons_io_commons_io",
         "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
 )

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -197,6 +198,12 @@ public class VendorConfigurationFormatDetectorTest {
         ImmutableList.of(bundleEtherInDesc, partialKw, inComment, notFirstWord)) {
       assertThat(identifyConfigurationFormat(fileText), not(equalTo(CISCO_IOS_XR)));
     }
+  }
+
+  @Test
+  public void testIpTablesFalsePositives() {
+    String fileText = StringUtils.join("set system host-name test", "set FORWARD INPUT OUTPUT");
+    assertThat(identifyConfigurationFormat(fileText), equalTo(FLAT_JUNIPER));
   }
 
   @Test


### PR DESCRIPTION
The recognition is shaky and those strings may appear in files
from any configuration language.