### PR TITLE
rules_jvm_external: upgrade to 6.6 and fix new compiler error

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,9 +32,9 @@ bazel_skylib_workspace()
 # External Java dependencies (from Maven)                #
 ##########################################################
 
-RULES_JVM_EXTERNAL_TAG = "6.4"
+RULES_JVM_EXTERNAL_TAG = "6.6"
 
-RULES_JVM_EXTERNAL_SHA = "85776be6d8fe64abf26f463a8e12cd4c15be927348397180a01693610da7ec90"
+RULES_JVM_EXTERNAL_SHA = "3afe5195069bd379373528899c03a3072f568d33bd96fe037bd43b1f590535e7"
 
 http_archive(
     name = "rules_jvm_external",

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
@@ -1,8 +1,6 @@
 package org.batfish.datamodel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
+import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -16,10 +14,11 @@ public class VerboseEdgeTest {
   @Test
   public void testEquals() {
     Interface i1 = Interface.builder().setName("eth0").build();
-    VerboseEdge edge1 = new VerboseEdge(i1, i1, Edge.of("node1", "eth0", "node2", "eth0"));
-    assertEquals(edge1, edge1);
-
-    VerboseEdge edge2 = new VerboseEdge(i1, i1, Edge.of("node2", "eth0", "node1", "eth0"));
-    assertNotEquals(edge1, edge2);
+    new EqualsTester()
+        .addEqualityGroup(
+            new VerboseEdge(i1, i1, Edge.of("node1", "eth0", "node2", "eth0")),
+            new VerboseEdge(i1, i1, Edge.of("node1", "eth0", "node2", "eth0")))
+        .addEqualityGroup(new VerboseEdge(i1, i1, Edge.of("node2", "eth0", "node1", "eth0")))
+        .testEquals();
   }
 }


### PR DESCRIPTION
```
projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java:20: error: [SelfAssertion] You are passing identical arguments to the assertEquals method, so this assertion always passes. THIS IS LIKELY A BUG! If you are trying to test the correctness of an equals() implementation, use EqualsTester instead.
assertEquals(edge1, edge1);
^
(see https://errorprone.info/bugpattern/SelfAssertion)
```