### PR TITLE
BDD: rename onehot to onehotVars and add a generic version

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -1030,7 +1030,7 @@ public class JFactory extends BDDFactory implements Serializable {
   }
 
   @Override
-  public BDD onehot(BDD... variables) {
+  public BDD onehotVars(BDD... variables) {
     if (variables.length == 0) {
       return makeBDD(BDDZERO);
     }
@@ -1054,12 +1054,21 @@ public class JFactory extends BDDFactory implements Serializable {
     INITREF();
     PUSHREF(onehot);
     PUSHREF(allFalse);
+    int lastLevel = Integer.MAX_VALUE;
 
     for (int i = variables.length - 1; i >= 0; i--) {
       BDD var = variables[i];
       checkArgument(var.isVar(), "Variable %s is not a variable: %s", i, var);
       int id = ((BDDImpl) var)._index;
       int level = LEVEL(id);
+      checkArgument(
+          level < lastLevel,
+          "Levels are not strictly increasing: index %s (level %s) is >= index %s (level %s)",
+          i,
+          level,
+          i + 1,
+          lastLevel);
+      lastLevel = level;
       onehot = bdd_makenode(level, onehot, allFalse);
       SETREF(0, onehot);
       allFalse = bdd_makenode(level, allFalse, BDDZERO);

--- a/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -648,6 +649,26 @@ public class JFactoryTest {
     assertThat(
         _factory.onehot(a, b, c),
         equalTo(a.diff(b).diff(c).or(b.diff(a).diff(c)).or(c.diff(a).diff(b))));
+  }
+
+  @Test
+  public void testOnehotVars() {
+    _factory.setVarNum(3);
+    BDD a = _factory.ithVar(0);
+    BDD b = _factory.ithVar(1);
+    BDD c = _factory.ithVar(2);
+    assertThat(_factory.onehotVars(), equalTo(_factory.zero()));
+    assertThat(_factory.onehotVars(a), equalTo(a));
+    assertThat(_factory.onehotVars(c), equalTo(c));
+    assertThat(_factory.onehotVars(b, c), equalTo(b.xor(c)));
+    assertThat(_factory.onehotVars(a, c), equalTo(a.xor(c)));
+    assertThat(
+        _factory.onehotVars(a, b, c),
+        equalTo(a.diff(b).diff(c).or(b.diff(a).diff(c)).or(c.diff(a).diff(b))));
+
+    // Error cases
+    assertThrows(IllegalArgumentException.class, () -> _factory.onehotVars(c, a));
+    assertThrows(IllegalArgumentException.class, () -> _factory.onehotVars(a, b.not()));
   }
 
   @Test

--- a/tools/benchmarks/BUILD.bazel
+++ b/tools/benchmarks/BUILD.bazel
@@ -24,7 +24,7 @@ jmh_java_benchmarks(
 
 jmh_java_benchmarks(
     name = "onehot",
-    srcs = ["BenchmarkOneHot.java"],
+    srcs = ["BenchmarkOnehot.java"],
     deps = [
         "//projects/bdd",
     ],

--- a/tools/benchmarks/BenchmarkOnehot.java
+++ b/tools/benchmarks/BenchmarkOnehot.java
@@ -20,13 +20,13 @@ import org.openjdk.jmh.annotations.TearDown;
 
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
-public class BenchmarkOneHot {
+public class BenchmarkOnehot {
   private static final int NUM_VARIANTS = 1 << 16;
 
   private BDDFactory _factory;
   private Random _rng;
 
-  @Param({"8", "32", "128", "512"})
+  @Param({"32", "128", "512"})
   public int _numDisjuncts;
 
   private List<BDD[]> _trials;
@@ -58,7 +58,13 @@ public class BenchmarkOneHot {
   }
 
   @Benchmark
-  public void benchOneHot() {
+  public void benchOnehotVars() {
+    BDD[] trial = _trials.get(_rng.nextInt(_trials.size()));
+    _factory.onehotVars(trial).free();
+  }
+
+  @Benchmark
+  public void benchOnehot() {
     BDD[] trial = _trials.get(_rng.nextInt(_trials.size()));
     _factory.onehot(trial).free();
   }


### PR DESCRIPTION
This generic version is not specialized to variables. In a quick benchmark, it
is a little worse than 2x the in-library version for equivalent input.

```
Benchmark                        (_numDisjuncts)   Mode  Cnt       Score       Error  Units
BenchmarkOnehot.benchOnehot                   32  thrpt   25  152720.567 ±  7480.285  ops/s
BenchmarkOnehot.benchOnehot                  128  thrpt   25   38162.239 ±  2804.592  ops/s
BenchmarkOnehot.benchOnehot                  512  thrpt   25    9086.845 ±   405.937  ops/s
BenchmarkOnehot.benchOnehotVars               32  thrpt   25  346198.834 ± 24806.409  ops/s
BenchmarkOnehot.benchOnehotVars              128  thrpt   25   82864.962 ±  1937.790  ops/s
BenchmarkOnehot.benchOnehotVars              512  thrpt   25   20393.980 ±   218.186  ops/s
```