### PR TITLE
Junos: start implementing policy-statement term then correctly with overrides

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3092,7 +3092,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       terms.add(ps.getDefaultTerm());
     }
     for (PsTerm term : terms) {
-      List<Statement> thens = toStatements(term.getThens());
+      List<Statement> thens = toStatements(term.getThens().getAllThens());
       if (term.hasAtLeastOneFrom()) {
         If ifStatement = new If();
         ifStatement.setComment(term.getName());
@@ -3122,7 +3122,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
                   new MatchPrefixSet(
                       DestinationNetwork.instance(), new NamedPrefixSet(lineListName));
               lineSpecificIfStatement.setGuard(mrf);
-              lineSpecificIfStatement.getTrueStatements().addAll(toStatements(line.getThens()));
+              lineSpecificIfStatement
+                  .getTrueStatements()
+                  .addAll(toStatements(line.getThens().getAllThens()));
               statements.add(lineSpecificIfStatement);
             }
           }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsTerm.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsTerm.java
@@ -1,8 +1,6 @@
 package org.batfish.representation.juniper;
 
 import java.io.Serializable;
-import java.util.LinkedHashSet;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -11,12 +9,12 @@ public final class PsTerm implements Serializable {
 
   private final @Nonnull PsFroms _froms;
   private final @Nonnull String _name;
-  private final @Nonnull Set<PsThen> _thens;
+  private final @Nonnull PsThens _thens;
 
   public PsTerm(String name) {
     _froms = new PsFroms();
     _name = name;
-    _thens = new LinkedHashSet<>();
+    _thens = new PsThens();
   }
 
   public @Nonnull PsFroms getFroms() {
@@ -27,7 +25,7 @@ public final class PsTerm implements Serializable {
     return _name;
   }
 
-  public @Nonnull Set<PsThen> getThens() {
+  public @Nonnull PsThens getThens() {
     return _thens;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunityAdd.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunityAdd.java
@@ -39,4 +39,17 @@ public final class PsThenCommunityAdd extends PsThen {
   }
 
   private final String _name;
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof PsThenCommunityAdd that)) {
+      return false;
+    }
+    return _name.equals(that._name);
+  }
+
+  @Override
+  public int hashCode() {
+    return _name.hashCode();
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunitySet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunitySet.java
@@ -35,4 +35,17 @@ public final class PsThenCommunitySet extends PsThen {
   }
 
   private final String _name;
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof PsThenCommunitySet that)) {
+      return false;
+    }
+    return _name.equals(that._name);
+  }
+
+  @Override
+  public int hashCode() {
+    return _name.hashCode();
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
@@ -1,0 +1,108 @@
+package org.batfish.representation.juniper;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Represents all {@link PsThen} statements in a single {@link PsTerm} */
+public final class PsThens implements Serializable {
+
+  /**
+   * Incorporates the given {@code then foo} statement in this {@link PsThens}. Returns the list of
+   * prior {@code then foo} that may have been cleared or overwritten by this operation.
+   */
+  public @Nonnull List<String> addPsThen(PsThen then) {
+    if (then instanceof PsThenAsPathExpand) {
+      return setAsPathExpand((PsThenAsPathExpand) then);
+    } else if (then instanceof PsThenAsPathPrepend) {
+      return setAsPathPrepend((PsThenAsPathPrepend) then);
+    } else if (then instanceof PsThenCommunitySet) {
+      return setCommunitySet((PsThenCommunitySet) then);
+    } else if (then instanceof PsThenCommunityAdd) {
+      return addCommunityAdd((PsThenCommunityAdd) then);
+    }
+    _others.add(then);
+    return ImmutableList.of();
+  }
+
+  public @Nonnull Set<PsThen> getAllThens() {
+    ImmutableSet.Builder<PsThen> allThens = ImmutableSet.builder();
+    if (_asPathPrepend != null) {
+      allThens.add(_asPathPrepend);
+    }
+    if (_asPathExpand != null) {
+      allThens.add(_asPathExpand);
+    }
+    if (_communitySet != null) {
+      allThens.add(_communitySet);
+    }
+    if (!_communityAdds.isEmpty()) {
+      allThens.addAll(_communityAdds);
+    }
+    allThens.addAll(_others);
+    return allThens.build();
+  }
+
+  public boolean isEmpty() {
+    return getAllThens().isEmpty();
+  }
+
+  private @Nullable PsThenAsPathExpand _asPathExpand;
+  private @Nullable PsThenAsPathPrepend _asPathPrepend;
+
+  private @Nullable PsThenCommunitySet _communitySet;
+  private final @Nonnull List<PsThenCommunityAdd> _communityAdds;
+
+  private final @Nonnull List<PsThen> _others;
+
+  PsThens() {
+    _communityAdds = new ArrayList<>(0);
+    _others = new ArrayList<>(0);
+  }
+
+  private @Nonnull List<String> setAsPathExpand(@Nullable PsThenAsPathExpand asPathExpand) {
+    List<String> cleared = new ArrayList<>();
+    if (_asPathExpand != null) {
+      cleared.add("as-path-expand");
+    }
+    _asPathExpand = asPathExpand;
+    return cleared;
+  }
+
+  private List<String> setAsPathPrepend(@Nullable PsThenAsPathPrepend asPathPrepend) {
+    List<String> cleared = new ArrayList<>();
+    if (_asPathPrepend != null) {
+      cleared.add("as-path-prepend");
+    }
+    _asPathPrepend = asPathPrepend;
+    return cleared;
+  }
+
+  private List<String> setCommunitySet(PsThenCommunitySet set) {
+    List<String> cleared = new ArrayList<>();
+    if (_communitySet != null) {
+      cleared.add("community set");
+    }
+    if (!_communityAdds.isEmpty()) {
+      cleared.add("community add");
+    }
+    _communitySet = set;
+    _communityAdds.clear();
+    // TODO: do we also clear deletes?
+    return cleared;
+  }
+
+  private List<String> addCommunityAdd(PsThenCommunityAdd add) {
+    _communityAdds.add(add);
+    return ImmutableList.of();
+  }
+
+  private @Nonnull List<PsThen> getOthers() {
+    return _others;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLine.java
@@ -1,7 +1,5 @@
 package org.batfish.representation.juniper;
 
-import java.util.HashSet;
-import java.util.Set;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterList;
 
@@ -9,17 +7,9 @@ public abstract class Route4FilterLine extends RouteFilterLine {
 
   protected final Prefix _prefix;
 
-  private final Set<PsThen> _thens;
-
   public Route4FilterLine(Prefix prefix) {
     _prefix = prefix;
-    _thens = new HashSet<>();
   }
 
   public abstract void applyTo(RouteFilterList rfl);
-
-  @Override
-  public Set<PsThen> getThens() {
-    return _thens;
-  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route6FilterLine.java
@@ -1,25 +1,15 @@
 package org.batfish.representation.juniper;
 
-import java.util.HashSet;
-import java.util.Set;
 import org.batfish.datamodel.Prefix6;
 
 public abstract class Route6FilterLine extends RouteFilterLine {
   protected final Prefix6 _prefix6;
 
-  private final Set<PsThen> _thens;
-
   public Route6FilterLine(Prefix6 prefix6) {
     _prefix6 = prefix6;
-    _thens = new HashSet<>();
   }
 
   public final Prefix6 getPrefix6() {
     return _prefix6;
-  }
-
-  @Override
-  public Set<PsThen> getThens() {
-    return _thens;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RouteFilterLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RouteFilterLine.java
@@ -1,21 +1,20 @@
 package org.batfish.representation.juniper;
 
 import java.io.Serializable;
-import java.util.HashSet;
-import java.util.Set;
+import javax.annotation.Nonnull;
 
 public abstract class RouteFilterLine implements Serializable {
 
-  private final Set<PsThen> _thens;
+  private final @Nonnull PsThens _thens;
 
   public RouteFilterLine() {
-    _thens = new HashSet<>();
+    _thens = new PsThens();
   }
 
   @Override
   public abstract boolean equals(Object o);
 
-  public Set<PsThen> getThens() {
+  public final @Nonnull PsThens getThens() {
     return _thens;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -465,6 +465,8 @@ import org.batfish.representation.juniper.PsTerm;
 import org.batfish.representation.juniper.PsThenAsPathExpandAsList;
 import org.batfish.representation.juniper.PsThenAsPathExpandLastAs;
 import org.batfish.representation.juniper.PsThenAsPathPrepend;
+import org.batfish.representation.juniper.PsThenCommunityAdd;
+import org.batfish.representation.juniper.PsThenCommunitySet;
 import org.batfish.representation.juniper.PsThenLocalPreference;
 import org.batfish.representation.juniper.PsThenLocalPreference.Operator;
 import org.batfish.representation.juniper.PsThenTag;
@@ -4596,6 +4598,20 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testJuniperPolicyStatementThenCommunity() {
+    JuniperConfiguration c = parseJuniperConfig("juniper-ps-then-community");
+    Map<String, PsTerm> pses =
+        c.getMasterLogicalSystem().getPolicyStatements().get("PS").getTerms();
+    assertThat(
+        pses.get("MULTI_SET").getThens().getAllThens(), contains(new PsThenCommunitySet("COMM2")));
+    assertThat(
+        pses.get("SET_ADD").getThens().getAllThens(),
+        contains(new PsThenCommunitySet("COMM1"), new PsThenCommunityAdd("COMM2")));
+    assertThat(
+        pses.get("ADD_SET").getThens().getAllThens(), contains(new PsThenCommunitySet("COMM2")));
+  }
+
+  @Test
   public void testJuniperPolicyStatementTermThenExtraction() {
     JuniperConfiguration c = parseJuniperConfig("juniper-policy-statement-then");
     {
@@ -4610,30 +4626,32 @@ public final class FlatJuniperGrammarTest {
           c.getMasterLogicalSystem().getPolicyStatements().get("LOCAL_PREFERENCE_POLICY");
       assertThat(policy.getTerms(), hasKeys("TSETMIN", "TADDMAX", "TSUB3"));
       assertThat(
-          policy.getTerms().get("TSETMIN").getThens(),
+          policy.getTerms().get("TSETMIN").getThens().getAllThens(),
           contains(new PsThenLocalPreference(0, Operator.SET)));
       assertThat(
-          policy.getTerms().get("TADDMAX").getThens(),
+          policy.getTerms().get("TADDMAX").getThens().getAllThens(),
           contains(new PsThenLocalPreference(MAX_LOCAL_PREFERENCE, Operator.ADD)));
       assertThat(
-          policy.getTerms().get("TSUB3").getThens(),
+          policy.getTerms().get("TSUB3").getThens().getAllThens(),
           contains(new PsThenLocalPreference(3, Operator.SUBTRACT)));
     }
     {
       PolicyStatement policy = c.getMasterLogicalSystem().getPolicyStatements().get("TAG_POLICY");
       assertThat(policy.getTerms(), hasKeys("TMIN", "TMAX"));
-      assertThat(policy.getTerms().get("TMIN").getThens(), contains(new PsThenTag(0)));
-      assertThat(policy.getTerms().get("TMAX").getThens(), contains(new PsThenTag(MAX_TAG)));
+      assertThat(
+          policy.getTerms().get("TMIN").getThens().getAllThens(), contains(new PsThenTag(0)));
+      assertThat(
+          policy.getTerms().get("TMAX").getThens().getAllThens(), contains(new PsThenTag(MAX_TAG)));
     }
     {
       PolicyStatement policy =
           c.getMasterLogicalSystem().getPolicyStatements().get("TUNNEL_ATTR_POLICY");
       assertThat(policy.getTerms(), hasKeys("SET_TUNNEL_ATTR", "REMOVE_TUNNEL_ATTR"));
       assertThat(
-          policy.getTerms().get("SET_TUNNEL_ATTR").getThens(),
+          policy.getTerms().get("SET_TUNNEL_ATTR").getThens().getAllThens(),
           contains(new PsThenTunnelAttributeSet("TA")));
       assertThat(
-          policy.getTerms().get("REMOVE_TUNNEL_ATTR").getThens(),
+          policy.getTerms().get("REMOVE_TUNNEL_ATTR").getThens().getAllThens(),
           contains(PsThenTunnelAttributeRemove.INSTANCE));
     }
   }
@@ -8089,27 +8107,30 @@ public final class FlatJuniperGrammarTest {
           vc.getMasterLogicalSystem().getPolicyStatements().get("last-as-no-count");
       assertThat(ps.getTerms(), aMapWithSize(1));
       PsTerm term = Iterables.getOnlyElement(ps.getTerms().values());
-      assertThat(term.getThens(), contains(instanceOf(PsThenAsPathExpandLastAs.class)));
+      assertThat(
+          term.getThens().getAllThens(), contains(instanceOf(PsThenAsPathExpandLastAs.class)));
       PsThenAsPathExpandLastAs then =
-          (PsThenAsPathExpandLastAs) Iterables.getOnlyElement(term.getThens());
+          (PsThenAsPathExpandLastAs) Iterables.getOnlyElement(term.getThens().getAllThens());
       assertThat(then.getCount(), equalTo(1));
     }
     {
       PolicyStatement ps = vc.getMasterLogicalSystem().getPolicyStatements().get("last-as-count-2");
       assertThat(ps.getTerms(), aMapWithSize(1));
       PsTerm term = Iterables.getOnlyElement(ps.getTerms().values());
-      assertThat(term.getThens(), contains(instanceOf(PsThenAsPathExpandLastAs.class)));
+      assertThat(
+          term.getThens().getAllThens(), contains(instanceOf(PsThenAsPathExpandLastAs.class)));
       PsThenAsPathExpandLastAs then =
-          (PsThenAsPathExpandLastAs) Iterables.getOnlyElement(term.getThens());
+          (PsThenAsPathExpandLastAs) Iterables.getOnlyElement(term.getThens().getAllThens());
       assertThat(then.getCount(), equalTo(2));
     }
     {
       PolicyStatement ps = vc.getMasterLogicalSystem().getPolicyStatements().get("as-list");
       assertThat(ps.getTerms(), aMapWithSize(1));
       PsTerm term = Iterables.getOnlyElement(ps.getTerms().values());
-      assertThat(term.getThens(), contains(instanceOf(PsThenAsPathExpandAsList.class)));
+      assertThat(
+          term.getThens().getAllThens(), contains(instanceOf(PsThenAsPathExpandAsList.class)));
       PsThenAsPathExpandAsList then =
-          (PsThenAsPathExpandAsList) Iterables.getOnlyElement(term.getThens());
+          (PsThenAsPathExpandAsList) Iterables.getOnlyElement(term.getThens().getAllThens());
       assertThat(then.getAsList(), contains(123L, (456L << 16) + 789L));
     }
     {
@@ -8118,16 +8139,17 @@ public final class FlatJuniperGrammarTest {
       assertThat(ps.getTerms(), aMapWithSize(1));
       PsTerm term = Iterables.getOnlyElement(ps.getTerms().values());
       assertThat(
-          term.getThens(),
+          term.getThens().getAllThens(),
           contains(
               // reverse of declared order is expected
               instanceOf(PsThenAsPathPrepend.class), instanceOf(PsThenAsPathExpandAsList.class)));
 
-      PsThenAsPathPrepend prepend = (PsThenAsPathPrepend) Iterables.get(term.getThens(), 0);
+      PsThenAsPathPrepend prepend =
+          (PsThenAsPathPrepend) Iterables.get(term.getThens().getAllThens(), 0);
       assertThat(prepend.getAsList(), contains(456L));
 
       PsThenAsPathExpandAsList expand =
-          (PsThenAsPathExpandAsList) Iterables.get(term.getThens(), 1);
+          (PsThenAsPathExpandAsList) Iterables.get(term.getThens().getAllThens(), 1);
       assertThat(expand.getAsList(), contains(123L));
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -903,7 +903,7 @@ public class JuniperConfigurationTest {
 
     PolicyStatement ps = new PolicyStatement("ps");
     PsTerm term = new PsTerm("psterm");
-    term.getThens().add(new PsThenTag(234L));
+    term.getThens().addPsThen(new PsThenTag(234L));
     ps.getTerms().put(term.getName(), term);
 
     // no Froms case: expect a traceable (for the then we added) and end of policy

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThensTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThensTest.java
@@ -1,0 +1,36 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+public class PsThensTest {
+  @Test
+  public void testCommunities() {
+    PsThenCommunitySet set = new PsThenCommunitySet("set");
+    PsThenCommunityAdd add1 = new PsThenCommunityAdd("add1");
+    PsThenCommunityAdd add2 = new PsThenCommunityAdd("add2");
+
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(set), empty());
+    assertThat(ps.addPsThen(set), contains("community set"));
+    assertThat(ps.addPsThen(add1), empty());
+    assertThat(ps.addPsThen(add2), empty());
+    assertThat(ps.addPsThen(set), contains("community set", "community add"));
+  }
+
+  @Test
+  public void testAsPath() {
+    PsThenAsPathPrepend prepend = new PsThenAsPathPrepend(ImmutableList.of(1L, 2L, 3L));
+    PsThenAsPathExpand expand = new PsThenAsPathExpandLastAs(3);
+
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(prepend), empty());
+    assertThat(ps.addPsThen(prepend), contains("as-path-prepend"));
+    assertThat(ps.addPsThen(expand), empty());
+    assertThat(ps.addPsThen(expand), contains("as-path-expand"));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-ps-then-community
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-ps-then-community
@@ -1,0 +1,15 @@
+#
+set system host-name juniper-ps-then-community
+#
+set policy-options community COMM1 members 1:2
+set policy-options community COMM2 members 2:3
+#
+set policy-options policy-statement PS term MULTI_SET then community set COMM1
+set policy-options policy-statement PS term MULTI_SET then community set COMM2
+#
+set policy-options policy-statement PS term SET_ADD then community set COMM1
+set policy-options policy-statement PS term SET_ADD then community add COMM2
+#
+set policy-options policy-statement PS term ADD_SET then community add COMM1
+set policy-options policy-statement PS term ADD_SET then community set COMM2
+#

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1409,6 +1409,27 @@
       },
       {
         "Filename" : "configs/juniper_policy_statement",
+        "Line" : 23,
+        "Text" : "as-path-prepend 123.456",
+        "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "Overwriting existing then as-path-prepend"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
+        "Line" : 24,
+        "Text" : "as-path-prepend \"456 789",
+        "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "Overwriting existing then as-path-prepend"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
+        "Line" : 25,
+        "Text" : "as-path-prepend \"456 123.1 789",
+        "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "Overwriting existing then as-path-prepend"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
         "Line" : 32,
         "Text" : "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
         "Parser_Context" : "[popstnh_ipv6 popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
@@ -1479,10 +1500,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 205 results",
+      "notes" : "Found 208 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 205
+      "numResults" : 208
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71286,6 +71286,24 @@
               "Text" : "protocol access-internal"
             },
             {
+              "Comment" : "Overwriting existing then as-path-prepend",
+              "Line" : 23,
+              "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "as-path-prepend 123.456"
+            },
+            {
+              "Comment" : "Overwriting existing then as-path-prepend",
+              "Line" : 24,
+              "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "as-path-prepend \"456 789"
+            },
+            {
+              "Comment" : "Overwriting existing then as-path-prepend",
+              "Line" : 25,
+              "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "as-path-prepend \"456 123.1 789"
+            },
+            {
               "Comment" : "This feature is not currently supported",
               "Line" : 32,
               "Parser_Context" : "[popstnh_ipv6 popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",


### PR DESCRIPTION
For many properties, repeated sets or adds clear each other. We did this
refactoring for PsFrom, but not yet for PsThen.  Starting it here, and adding
useful errors, with more to come.

This also opens up more efficient conversion in future: for example,
CommunitySet+Add can be combined into one community mutation set, rather than a
set and then a bunch of unions.