### PR TITLE
Add support for symbolic modeling of HasAsPathLength

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/AsPathMatchExprToRegexes.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/AsPathMatchExprToRegexes.java
@@ -11,6 +11,8 @@ import org.batfish.datamodel.routing_policy.as_path.AsPathMatchRegex;
 import org.batfish.datamodel.routing_policy.as_path.AsSetsMatchingRanges;
 import org.batfish.datamodel.routing_policy.as_path.HasAsPathLength;
 import org.batfish.datamodel.routing_policy.as_path.MatchAsPath;
+import org.batfish.datamodel.routing_policy.expr.IntComparison;
+import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
 
 /**
@@ -48,9 +50,34 @@ public class AsPathMatchExprToRegexes
     return ImmutableSet.of(new SymbolicAsPathRegex(asSetsMatchingRanges));
   }
 
+  /**
+   * Reasonable cap on AS Path length in a non-attack scenario. Chosen semi-arbitrarily and used to
+   * model {@link HasAsPathLength} which is likely only used to reject attacker-looking (or other
+   * resource limitations) advertisements.
+   */
+  public static int ASSUMED_MAX_AS_PATH_LENGTH = 64;
+
   @Override
   public Set<SymbolicAsPathRegex> visitHasAsPathLength(
       HasAsPathLength hasAsPathLength, CommunitySetMatchExprToBDD.Arg arg) {
-    throw new UnsupportedOperationException(hasAsPathLength.toString());
+    IntComparison cmp = hasAsPathLength.getComparison();
+    if (!(cmp.getExpr() instanceof LiteralInt)) {
+      throw new UnsupportedOperationException(hasAsPathLength.toString());
+    }
+
+    // Similar to CommunitySet.HasSize, this construct is mainly useful for checking that the AS
+    // path isn't so long it looks like an attack. Pick a semi-arbitrary threshold (64 ASNs) and
+    // assume every realistic AS Path is shorter than that.
+    // Return true if the filter allows all paths length 64 or less, and false otherwise.
+    int val = ((LiteralInt) cmp.getExpr()).getValue();
+    Set<SymbolicAsPathRegex> any = ImmutableSet.of(SymbolicAsPathRegex.ALL_AS_PATHS);
+    Set<SymbolicAsPathRegex> none = ImmutableSet.of();
+    return switch (cmp.getComparator()) {
+      case EQ -> throw new UnsupportedOperationException(hasAsPathLength.toString());
+      case GE -> val <= 0 ? any : none;
+      case GT -> val < 0 ? any : none;
+      case LE -> val >= ASSUMED_MAX_AS_PATH_LENGTH ? any : none;
+      case LT -> val > ASSUMED_MAX_AS_PATH_LENGTH ? any : none;
+    };
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -383,14 +383,14 @@ public class TransferBDD {
                                     new Arg(this, currRoute, context))
                                 .stream())
                 .collect(ImmutableSet.toImmutableSet());
-        finalResults.add(
-            result
-                .setReturnValueBDD(
-                    asPathRegexesToBDD(
-                        ImmutableSet.of(SymbolicAsPathRegex.union(asPathRegexes)),
-                        _asPathRegexAtomicPredicates,
-                        routeForMatching(p, context)))
-                .setReturnValueAccepted(true));
+        BDD asPathRegexBDD =
+            asPathRegexes.isEmpty()
+                ? _factory.zero()
+                : asPathRegexesToBDD(
+                    ImmutableSet.of(SymbolicAsPathRegex.union(asPathRegexes)),
+                    _asPathRegexAtomicPredicates,
+                    routeForMatching(p, context));
+        finalResults.add(result.setReturnValueBDD(asPathRegexBDD).setReturnValueAccepted(true));
       } else {
         List<TransferResult> currResults = new ArrayList<>();
         // the default result is false

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/AsPathMatchExprAsPathCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/AsPathMatchExprAsPathCollectorTest.java
@@ -1,5 +1,9 @@
 package org.batfish.minesweeper.aspath;
 
+import static org.batfish.minesweeper.bdd.AsPathMatchExprToRegexes.ASSUMED_MAX_AS_PATH_LENGTH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -13,6 +17,10 @@ import org.batfish.datamodel.routing_policy.as_path.AsPathMatchAny;
 import org.batfish.datamodel.routing_policy.as_path.AsPathMatchExprReference;
 import org.batfish.datamodel.routing_policy.as_path.AsPathMatchRegex;
 import org.batfish.datamodel.routing_policy.as_path.AsSetsMatchingRanges;
+import org.batfish.datamodel.routing_policy.as_path.HasAsPathLength;
+import org.batfish.datamodel.routing_policy.expr.IntComparator;
+import org.batfish.datamodel.routing_policy.expr.IntComparison;
+import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,5 +86,35 @@ public class AsPathMatchExprAsPathCollectorTest {
         AsSetsMatchingRanges.of(false, true, ImmutableList.of(Range.closed(11L, 14L)));
     assertEquals(
         ImmutableSet.of(new SymbolicAsPathRegex(expr)), expr.accept(_collector, _baseConfig));
+  }
+
+  @Test
+  public void testHasAsPathLength() {
+    // Boundary conditions that evaluate to false (or crash, in EQ's case).
+    for (HasAsPathLength expr :
+        ImmutableList.of(
+            HasAsPathLength.of(new IntComparison(IntComparator.EQ, new LiteralInt(10))),
+            HasAsPathLength.of(new IntComparison(IntComparator.GE, new LiteralInt(1))),
+            HasAsPathLength.of(new IntComparison(IntComparator.GT, new LiteralInt(0))),
+            HasAsPathLength.of(
+                new IntComparison(IntComparator.LT, new LiteralInt(ASSUMED_MAX_AS_PATH_LENGTH))),
+            HasAsPathLength.of(
+                new IntComparison(
+                    IntComparator.LE, new LiteralInt(ASSUMED_MAX_AS_PATH_LENGTH - 1))))) {
+      assertThat(expr.accept(_collector, _baseConfig), empty());
+    }
+
+    // Boundary conditions that evaluate to true.
+    for (HasAsPathLength expr :
+        ImmutableList.of(
+            HasAsPathLength.of(new IntComparison(IntComparator.GE, new LiteralInt(0))),
+            HasAsPathLength.of(new IntComparison(IntComparator.GT, new LiteralInt(-1))),
+            HasAsPathLength.of(
+                new IntComparison(
+                    IntComparator.LT, new LiteralInt(ASSUMED_MAX_AS_PATH_LENGTH + 1))),
+            HasAsPathLength.of(
+                new IntComparison(IntComparator.LE, new LiteralInt(ASSUMED_MAX_AS_PATH_LENGTH))))) {
+      assertThat(expr.accept(_collector, _baseConfig), contains(SymbolicAsPathRegex.ALL_AS_PATHS));
+    }
   }
 }


### PR DESCRIPTION
This is in the same spirit as batfish/batfish#9069 for symbolic modeling of
community set size. Since this construct is likely only used to reject routes
that may overflow some resource limit, model it as true as long as it is only
matching 'all reasonable' AS paths. As for communities, semi-arbitrarily used
64 as the limit -- 'all reasonable AS Paths' have fewer than 64 entries.