### PR TITLE
PaloAlto: support redistribution of more protocols into BGP

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1088,6 +1088,38 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testBgpRedistributeConversion() {
+    Configuration c = parseConfig("bgp-redistribute");
+
+    // test process level common export policy
+    String bgpCommonExportPolicyName = "~BGP_COMMON_EXPORT_POLICY:vr1~";
+    RoutingPolicy bgpCommonExportPolicy = c.getRoutingPolicies().get(bgpCommonExportPolicyName);
+
+    {
+      org.batfish.datamodel.StaticRoute.Builder srb =
+          org.batfish.datamodel.StaticRoute.testBuilder()
+              .setNetwork(Prefix.parse("1.1.1.0/24"))
+              .setAdmin(5)
+              .setMetric(10L);
+
+      Bgpv4Route.Builder bgpBuilder = Bgpv4Route.testBuilder();
+      boolean accepted = bgpCommonExportPolicy.process(srb.build(), bgpBuilder, Direction.OUT);
+      assertTrue(accepted);
+    }
+
+    {
+      ConnectedRoute connectedRoute =
+          ConnectedRoute.builder()
+              .setNetwork(Prefix.parse("1.1.1.0/24"))
+              .setNextHopInterface("iface")
+              .build();
+      Bgpv4Route.Builder bgpBuilder = Bgpv4Route.testBuilder();
+      boolean accepted = bgpCommonExportPolicy.process(connectedRoute, bgpBuilder, Direction.OUT);
+      assertTrue(accepted);
+    }
+  }
+
+  @Test
   public void testOspfExtraction() {
     PaloAltoConfiguration c = parsePaloAltoConfig("ospf");
     VirtualRouter vr = c.getVirtualRouters().get("vr1");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/bgp-redistribute
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/bgp-redistribute
@@ -1,0 +1,21 @@
+#RANCID-CONTENT-TYPE: paloalto
+set deviceconfig system hostname bgp-redistribute
+
+set network interface ethernet ethernet1/3 layer3 units ethernet1/3.5 comment "unit 5"
+set network interface ethernet ethernet1/3 layer3 units ethernet1/3.5 ip 1.1.1.3/24
+set network virtual-router vr1 interface ethernet1/3.5
+
+set network virtual-router vr1 protocol redist-profile rdp1 filter type connect
+set network virtual-router vr1 protocol redist-profile rdp1 filter type static
+set network virtual-router vr1 protocol redist-profile rdp1 filter destination [ 1.1.1.0/24 ]
+set network virtual-router vr1 protocol redist-profile rdp1 priority 1
+set network virtual-router vr1 protocol redist-profile rdp1 action redist
+
+set network virtual-router vr1 protocol bgp enable yes
+set network virtual-router vr1 protocol bgp router-id 12.12.12.12
+set network virtual-router vr1 protocol bgp local-as 12
+
+set network virtual-router vr1 protocol bgp redist-rules rdp1 address-family-identifier ipv4
+set network virtual-router vr1 protocol bgp redist-rules rdp1 route-table unicast
+set network virtual-router vr1 protocol bgp redist-rules rdp1 enable yes
+set network virtual-router vr1 protocol bgp redist-rules rdp1 set-origin igp


### PR DESCRIPTION
Parsing and extraction were there, but conversion only for static routes.

This adds support for redistributing more protocols.