### PR TITLE
TransferBDD: Support for static routes

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -455,7 +455,7 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
    * obtaining models would be incorrect, because it would not ensure that the well-formedness
    * constraints hold.
    *
-   * @param onlyBGPRoutes whether to constrain the input routes to only BGP routes
+   * @param onlyBGPRoutes whether to constrain the input routes to be BGP routes
    * @return the constraints
    */
   public BDD wellFormednessConstraints(boolean onlyBGPRoutes) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -443,10 +443,9 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
   }
 
   /**
-   * Not all assignments to the BDD variables that make up a BDDRoute represent valid BGP routes.
-   * This method produces constraints that well-formed BGP routes must satisfy, represented as a
-   * BDD. It is useful when the goal is to produce concrete example BGP routes from a BDDRoute, for
-   * instance.
+   * Not all assignments to the BDD variables that make up a BDDRoute represent valid routes. This
+   * method produces constraints that well-formed routes must satisfy, represented as a BDD. It is
+   * useful when the goal is to produce concrete example routes from a BDDRoute, for instance.
    *
    * <p>Note that it does not suffice to enforce these constraints as part of symbolic route
    * analysis (see {@link TransferBDD}). That analysis computes a BDD representing the input routes
@@ -456,9 +455,10 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
    * obtaining models would be incorrect, because it would not ensure that the well-formedness
    * constraints hold.
    *
+   * @param onlyBGPRoutes whether to constrain the input routes to only BGP routes
    * @return the constraints
    */
-  public BDD bgpWellFormednessConstraints() {
+  public BDD wellFormednessConstraints(boolean onlyBGPRoutes) {
 
     // the prefix length should be 32 or less
     BDD prefLenConstraint = _prefixLength.leq(32);
@@ -471,6 +471,8 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     BDD nextHopInterfacesValid = _nextHopInterfaces.getIsValidConstraint();
     BDD originTypeValid = _originType.getIsValidConstraint();
     BDD ospfMetricValid = _ospfMetric.getIsValidConstraint();
+    BDD protocolConstraint =
+        onlyBGPRoutes ? anyElementOf(ALL_BGP_PROTOCOLS, this.getProtocolHistory()) : _factory.one();
     BDD sourceVrfValid = _sourceVrfs.getIsValidConstraint();
     BDD tunnelEncapValid = _tunnelEncapsulationAttribute.getIsValidConstraint();
     return _factory.andAllAndFree(
@@ -480,6 +482,7 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
         nextHopInterfacesValid,
         originTypeValid,
         ospfMetricValid,
+        protocolConstraint,
         sourceVrfValid,
         tunnelEncapValid);
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -471,8 +471,6 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     BDD nextHopInterfacesValid = _nextHopInterfaces.getIsValidConstraint();
     BDD originTypeValid = _originType.getIsValidConstraint();
     BDD ospfMetricValid = _ospfMetric.getIsValidConstraint();
-    // Protocol domain constraint is stronger: only one of the ones allowed in a BgpRoute.
-    BDD protocolConstraint = anyElementOf(ALL_BGP_PROTOCOLS, this.getProtocolHistory());
     BDD sourceVrfValid = _sourceVrfs.getIsValidConstraint();
     BDD tunnelEncapValid = _tunnelEncapsulationAttribute.getIsValidConstraint();
     return _factory.andAllAndFree(
@@ -482,7 +480,6 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
         nextHopInterfacesValid,
         originTypeValid,
         ospfMetricValid,
-        protocolConstraint,
         sourceVrfValid,
         tunnelEncapValid);
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
@@ -235,9 +235,7 @@ public class ModelGeneration {
     RoutingProtocol p = bddRoute.getProtocolHistory().satAssignmentToValue(model);
     if (p == RoutingProtocol.STATIC) {
       return satAssignmentToStaticInputRoute(model, configAPs);
-    } else if (ImmutableList.of(
-            RoutingProtocol.AGGREGATE, RoutingProtocol.BGP, RoutingProtocol.IBGP)
-        .contains(p)) {
+    } else if (BDDRoute.ALL_BGP_PROTOCOLS.contains(p)) {
       return satAssignmentToBgpInputRoute(model, configAPs);
     } else {
       throw new IllegalArgumentException("Unexpected routing protocol " + p);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -2,8 +2,8 @@ package org.batfish.minesweeper.question.compareroutepolicies;
 
 import static org.batfish.minesweeper.bdd.BDDRouteDiff.computeDifferences;
 import static org.batfish.minesweeper.bdd.ModelGeneration.constraintsToModel;
+import static org.batfish.minesweeper.bdd.ModelGeneration.satAssignmentToBgpInputRoute;
 import static org.batfish.minesweeper.bdd.ModelGeneration.satAssignmentToEnvironment;
-import static org.batfish.minesweeper.bdd.ModelGeneration.satAssignmentToInputRoute;
 import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer.simulatePolicy;
 import static org.batfish.question.testroutepolicies.Result.RouteAttributeType.ADMINISTRATIVE_DISTANCE;
 import static org.batfish.question.testroutepolicies.Result.RouteAttributeType.AS_PATH;
@@ -282,7 +282,8 @@ public final class CompareRoutePoliciesUtils {
     assert (!constraints.isZero());
     BDD model = constraintsToModel(constraints, configAPs);
     return new Tuple<>(
-        satAssignmentToInputRoute(model, configAPs), satAssignmentToEnvironment(model, configAPs));
+        satAssignmentToBgpInputRoute(model, configAPs),
+        satAssignmentToEnvironment(model, configAPs));
   }
 
   /**

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -444,7 +444,7 @@ public final class CompareRoutePoliciesUtils {
     TransferBDD tBDD = new TransferBDD(configAPs);
 
     // Generate well-formedness constraints
-    BDD wf = new BDDRoute(tBDD.getFactory(), configAPs).bgpWellFormednessConstraints();
+    BDD wf = new BDDRoute(tBDD.getFactory(), configAPs).wellFormednessConstraints(true);
 
     // The set of paths for the current policy
     List<TransferReturn> paths = computePaths(tBDD, referencePolicy);

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
@@ -111,6 +111,6 @@ public class BDDRouteTest {
             () -> route.getOriginType().satAssignmentToValue(anyOriginType.not()));
     assertThat(
         thrown, ThrowableMessageMatcher.hasMessage(containsString("is not valid in this domain")));
-    assertThat(route.bgpWellFormednessConstraints().and(anyOriginType.not()), isZero());
+    assertThat(route.wellFormednessConstraints(true).and(anyOriginType.not()), isZero());
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtilsTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtilsTest.java
@@ -121,7 +121,7 @@ public class CompareRoutePoliciesUtilsTest {
         findConcreteDifference(
             path,
             otherPath,
-            _bddRoute.bgpWellFormednessConstraints(),
+            _bddRoute.wellFormednessConstraints(true),
             _configAPs,
             _policyBuilderRef
                 .setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()))
@@ -146,7 +146,7 @@ public class CompareRoutePoliciesUtilsTest {
         findConcreteDifference(
             path,
             otherPath,
-            _bddRoute.bgpWellFormednessConstraints(),
+            _bddRoute.wellFormednessConstraints(true),
             _configAPs,
             _policyBuilderRef
                 .setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()))
@@ -174,7 +174,7 @@ public class CompareRoutePoliciesUtilsTest {
         findConcreteDifference(
             path,
             otherPath,
-            _bddRoute.bgpWellFormednessConstraints(),
+            _bddRoute.wellFormednessConstraints(true),
             _configAPs,
             _policyBuilderRef
                 .setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()))
@@ -197,7 +197,7 @@ public class CompareRoutePoliciesUtilsTest {
         findConcreteDifference(
             path,
             otherPath,
-            _bddRoute.bgpWellFormednessConstraints(),
+            _bddRoute.wellFormednessConstraints(true),
             _configAPs,
             _policyBuilderRef
                 .setStatements(

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
@@ -3566,6 +3566,33 @@ public class SearchRoutePoliciesAnswererTest {
   }
 
   @Test
+  public void testMatchStaticRoute() {
+    _policyBuilder.addStatement(
+        new If(
+            new MatchProtocol(RoutingProtocol.STATIC),
+            ImmutableList.of(
+                new SetLocalPreference(new LiteralLong(300)),
+                new StaticStatement(Statements.ExitAccept))));
+    RoutingPolicy policy = _policyBuilder.build();
+
+    SearchRoutePoliciesQuestion question =
+        new SearchRoutePoliciesQuestion(
+            DEFAULT_DIRECTION,
+            EMPTY_CONSTRAINTS,
+            EMPTY_CONSTRAINTS,
+            HOSTNAME,
+            policy.getName(),
+            PERMIT,
+            DEFAULT_PATH_OPTION);
+    SearchRoutePoliciesAnswerer answerer = new SearchRoutePoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer = (TableAnswerElement) answerer.answer(_batfish.getSnapshot());
+
+    // paths that are only taken by non-BGP input routes are ignored
+    assertEquals(answer.getRows().size(), 0);
+  }
+
+  @Test
   public void testPermitPerPathNonOverlap() {
     String regex1 = "^2[0-9]:30$";
     String regex2 = "^2[0-9]:40$";

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
@@ -139,7 +139,7 @@ public class Result<I, O> {
     _relevantInputAttributes = attributes;
   }
 
-  public Result<I, O> setOutputRoute(O outputRoute) {
+  public <ONew> Result<I, ONew> setOutputRoute(ONew outputRoute) {
     return new Result<>(_policyId, _inputRoute, _action, outputRoute, _trace);
   }
 

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/Result.java
@@ -139,7 +139,7 @@ public class Result<I, O> {
     _relevantInputAttributes = attributes;
   }
 
-  public <ONew> Result<I, ONew> setOutputRoute(ONew outputRoute) {
+  public <NewT> Result<I, NewT> setOutputRoute(NewT outputRoute) {
     return new Result<>(_policyId, _inputRoute, _action, outputRoute, _trace);
   }
 

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
@@ -121,7 +121,28 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
     RoutingPolicyId policyId = key.getPolicyId();
     RoutingPolicy policy =
         context.getConfigs().get(policyId.getNode()).getRoutingPolicies().get(policyId.getPolicy());
-    return simulatePolicy(policy, key.getInputRoute(), direction);
+    return simulatePolicyWithBgpRoute(policy, key.getInputRoute(), direction);
+  }
+
+  public static Result<? extends AbstractRoute, Bgpv4Route> simulatePolicy(
+      RoutingPolicy policy,
+      AbstractRoute inputRoute,
+      @Nullable BgpSessionProperties properties,
+      Direction direction,
+      @Nullable Predicate<String> successfulTrack,
+      @Nullable String sourceVrf) {
+    switch (inputRoute.getProtocol()) {
+      case STATIC:
+        return simulatePolicyWithStaticRoute(
+            policy, (StaticRoute) inputRoute, direction, successfulTrack, sourceVrf);
+      case AGGREGATE:
+      case BGP:
+      case IBGP:
+        return simulatePolicyWithBgpRoute(
+            policy, (Bgpv4Route) inputRoute, properties, direction, successfulTrack, sourceVrf);
+      default:
+        throw new IllegalArgumentException("Unexpected route protocol " + inputRoute.getProtocol());
+    }
   }
 
   /**
@@ -132,9 +153,10 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
    * @param direction whether the policy is used on import or export (IN or OUT)
    * @return the results of the simulation
    */
-  private Result<Bgpv4Route, Bgpv4Route> simulatePolicy(
+  private Result<Bgpv4Route, Bgpv4Route> simulatePolicyWithBgpRoute(
       RoutingPolicy policy, Bgpv4Route inputRoute, Direction direction) {
-    return simulatePolicy(policy, inputRoute, _bgpSessionProperties, direction, null, null);
+    return simulatePolicyWithBgpRoute(
+        policy, inputRoute, _bgpSessionProperties, direction, null, null);
   }
 
   /**
@@ -148,7 +170,7 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
    * @param sourceVrf an optional name of the source VRF
    * @return the results of the simulation
    */
-  public static Result<Bgpv4Route, Bgpv4Route> simulatePolicy(
+  public static Result<Bgpv4Route, Bgpv4Route> simulatePolicyWithBgpRoute(
       RoutingPolicy policy,
       Bgpv4Route inputRoute,
       @Nullable BgpSessionProperties properties,

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
@@ -124,6 +124,17 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
     return simulatePolicyWithBgpRoute(policy, key.getInputRoute(), direction);
   }
 
+  /**
+   * Produce the results of simulating the given route policy on the given route.
+   *
+   * @param policy the route policy to simulate
+   * @param inputRoute the input route for the policy
+   * @param properties the properties of the Bgp session being simulated
+   * @param direction whether the policy is used on import or export (IN or OUT)
+   * @param successfulTrack a predicate that indicates which tracks are successful
+   * @param sourceVrf an optional name of the source VRF
+   * @return the results of the simulation
+   */
   public static Result<? extends AbstractRoute, Bgpv4Route> simulatePolicy(
       RoutingPolicy policy,
       AbstractRoute inputRoute,


### PR DESCRIPTION
Adds support to the symbolic route-policy analysis (TransferBDD) for analyzing paths through a route policy that require an input route that is a static route (as opposed to a BGP route).