### PR TITLE
Warn when if-route-exist has no prefix

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -47,6 +47,8 @@ public class Warnings implements Serializable {
     }
   }
 
+  public static final String FATAL_FLAG = "FATAL: ";
+
   public static final String TAG_PEDANTIC = "MISCELLANEOUS";
 
   public static final String TAG_RED_FLAG = "MISCELLANEOUS";
@@ -184,10 +186,21 @@ public class Warnings implements Serializable {
     redFlag(String.format(format, args));
   }
 
-  /** Indicate that this is a fatal error */
+  /** Indicate that this red flag warning is a fatal error */
   @FormatMethod
   public void fatalRedFlag(String msg, Object... args) {
-    redFlag("FATAL: " + String.format(msg, args));
+    redFlag(FATAL_FLAG + String.format(msg, args));
+  }
+
+  /** Get all red flag warnings that are fatal error */
+  public SortedSet<Warning> getFatalRedFlagWarnings() {
+    SortedSet<Warning> fatalWarnings = new TreeSet<>();
+    for (Warning warning : _redFlagWarnings) {
+      if (warning.getText().startsWith(FATAL_FLAG)) {
+        fatalWarnings.add(warning);
+      }
+    }
+    return fatalWarnings;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -184,9 +184,10 @@ public class Warnings implements Serializable {
     redFlag(String.format(format, args));
   }
 
-  /** Prepend fatal error sentinel string to message */
-  public void fatalRedFlag(String msg) {
-    redFlag("FATAL: " + msg);
+  /** Indicate that this is a fatal error */
+  @FormatMethod
+  public void fatalRedFlag(String msg, Object... args) {
+    redFlag("FATAL: " + String.format(msg, args));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -184,6 +184,11 @@ public class Warnings implements Serializable {
     redFlag(String.format(format, args));
   }
 
+  /** Prepend fatal error sentinel string to message */
+  public void fatalRedFlag(String msg) {
+    redFlag("FATAL: " + msg);
+  }
+
   /**
    * Adds a note that there is work to do to handle the given {@link ParserRuleContext}. The output
    * will include the text of the given {@code line} and, for debugging/implementation, the current

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3870,7 +3870,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (ifr.getPrefix6() != null) {
         return TrackMethods.alwaysFalse();
       }
-      _w.fatalRedFlag("Missing route address for if-route-exists condition");
+      _w.fatalRedFlag(
+          "Missing route address for if-route-exists condition %s. Config will not pass commit"
+              + " checks.",
+          condition.getName());
       // TODO: verify missing prefix means true
       return TrackMethods.alwaysTrue();
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3870,6 +3870,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (ifr.getPrefix6() != null) {
         return TrackMethods.alwaysFalse();
       }
+      _w.fatalRedFlag("Missing route address for if-route-exists condition");
       // TODO: verify missing prefix means true
       return TrackMethods.alwaysTrue();
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8484,5 +8484,19 @@ public final class FlatJuniperGrammarTest {
     assertThat(result.getBooleanValue(), equalTo(true));
   }
 
+  @Test
+  public void testIfRouteExistMissingPrefix() throws IOException {
+    String hostname = "juniper-missing-prefix-condition";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Should warn with sentinel string that if-route-exist needs a prefix
+    assertThat(
+        ccae,
+        hasRedFlagWarning(
+            hostname, equalTo("FATAL: Missing route address for if-route-exists condition")));
+  }
+
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8491,11 +8491,14 @@ public final class FlatJuniperGrammarTest {
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
 
-    // Should warn with sentinel string that if-route-exist needs a prefix
+    // Should warn with FATAL string that if-route-exist needs a prefix
     assertThat(
         ccae,
         hasRedFlagWarning(
-            hostname, equalTo("FATAL: Missing route address for if-route-exists condition")));
+            hostname,
+            equalTo(
+                "FATAL: Missing route address for if-route-exists condition c1. Config will not"
+                    + " pass commit checks.")));
   }
 
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8491,12 +8491,10 @@ public final class FlatJuniperGrammarTest {
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
 
-    // Should warn with FATAL string that if-route-exist needs a prefix
     assertThat(
-        ccae,
-        hasRedFlagWarning(
-            hostname,
-            equalTo(
+        ccae.getWarnings().get(hostname).getFatalRedFlagWarnings(),
+        hasItem(
+            WarningMatchers.hasText(
                 "FATAL: Missing route address for if-route-exists condition c1. Config will not"
                     + " pass commit checks.")));
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-missing-prefix-condition
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-missing-prefix-condition
@@ -1,0 +1,5 @@
+#
+set system host-name juniper-missing-prefix-condition
+#
+set policy-options condition c1 if-route-exists table inet.0
+#


### PR DESCRIPTION
Juniper requires that `if-route-exist` have a prefix defined or else deployment would fail.