### PR TITLE
PaloAlto: destination prefixes optional during redistribution

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Conversions.java
@@ -227,15 +227,16 @@ final class Conversions {
     }
     redistConditions.add(new MatchProtocol(protocolConditions.build()));
 
-    // TODO: I believe the set of prefixes can be empty and it means universe prefix space, not
-    // empty set.
-    PrefixSpace prefixSpace = new PrefixSpace();
-    MatchPrefixSet matchPrefixSet =
-        new MatchPrefixSet(DestinationNetwork.instance(), new ExplicitPrefixSet(prefixSpace));
-    for (Prefix prefix : filter.getDestinationPrefixes()) {
-      prefixSpace.addPrefix(prefix);
+    // If prefixes are specified, match them. If not, any prefix is allowed.
+    if (!filter.getDestinationPrefixes().isEmpty()) {
+      PrefixSpace prefixSpace = new PrefixSpace();
+      for (Prefix prefix : filter.getDestinationPrefixes()) {
+        prefixSpace.addPrefix(prefix);
+      }
+      MatchPrefixSet matchPrefixSet =
+          new MatchPrefixSet(DestinationNetwork.instance(), new ExplicitPrefixSet(prefixSpace));
+      redistConditions.add(matchPrefixSet);
     }
-    redistConditions.add(matchPrefixSet);
 
     ImmutableList.Builder<Statement> trueStatements = ImmutableList.builder();
     if (redistRule.getOrigin() != null) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/bgp-redistribute
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/bgp-redistribute
@@ -7,7 +7,6 @@ set network virtual-router vr1 interface ethernet1/3.5
 
 set network virtual-router vr1 protocol redist-profile rdp1 filter type connect
 set network virtual-router vr1 protocol redist-profile rdp1 filter type static
-set network virtual-router vr1 protocol redist-profile rdp1 filter destination [ 1.1.1.0/24 ]
 set network virtual-router vr1 protocol redist-profile rdp1 priority 1
 set network virtual-router vr1 protocol redist-profile rdp1 action redist
 


### PR DESCRIPTION
Previously code assumed that destination prefixes are required and empty set meant no match. In practice, empty set means "any prefix"