### PR TITLE
Junos: parse if-route-exists ip address

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -56,9 +56,9 @@ pocond_if_route_exists
   )
 ;
 
-pocondiafi_prefix: prefix = ip_prefix;
+pocondiafi_prefix: prefix = ip_prefix_default_32;
 
-pocondiafi_prefix6: prefix = ipv6_prefix;
+pocondiafi_prefix6: prefix = ipv6_prefix_default_128;
 
 pocondiafi_table: TABLE name = junos_name;
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -7738,7 +7738,9 @@ public final class FlatJuniperGrammarTest {
             .getFroms()
             .getFromConditions(),
         contains(new PsFromCondition("c1")));
-    assertThat(jc.getMasterLogicalSystem().getConditions(), hasKeys("c1", "c2", "c3", "c4", "c5"));
+    assertThat(
+        jc.getMasterLogicalSystem().getConditions(),
+        hasKeys("c1", "c2", "c3", "c4", "c5", "c6", "c7"));
     {
       Condition c = jc.getMasterLogicalSystem().getConditions().get("c1");
       assertThat(c.getIfRouteExists(), notNullValue());
@@ -7769,6 +7771,18 @@ public final class FlatJuniperGrammarTest {
       assertThat(c.getIfRouteExists(), notNullValue());
       assertThat(c.getIfRouteExists().getPrefix6(), equalTo(Prefix6.parse("::1.2.3.4/127")));
     }
+    {
+      Condition c = jc.getMasterLogicalSystem().getConditions().get("c6");
+      assertThat(c.getIfRouteExists(), notNullValue());
+      assertThat(c.getIfRouteExists().getPrefix(), equalTo(Prefix.parse("192.0.2.1/32")));
+    }
+    {
+      Condition c = jc.getMasterLogicalSystem().getConditions().get("c7");
+      assertThat(c.getIfRouteExists(), notNullValue());
+      assertThat(
+          c.getIfRouteExists().getPrefix6(),
+          equalTo(Prefix6.parse("2001:db8:1234:5678:abc1:2345:6789:abcd/128")));
+    }
   }
 
   @Test
@@ -7779,12 +7793,21 @@ public final class FlatJuniperGrammarTest {
     String c3TrackName = computeConditionTrackName("c3");
     String c4TrackName = computeConditionTrackName("c4");
     String c5TrackName = computeConditionTrackName("c5");
+    String c6TrackName = computeConditionTrackName("c6");
+    String c7TrackName = computeConditionTrackName("c7");
     Configuration c = parseConfig(hostname);
 
     // Conditions should be converted to tracks
     assertThat(
         c.getTrackingGroups(),
-        hasKeys(c1TrackName, c2TrackName, c3TrackName, c4TrackName, c5TrackName));
+        hasKeys(
+            c1TrackName,
+            c2TrackName,
+            c3TrackName,
+            c4TrackName,
+            c5TrackName,
+            c6TrackName,
+            c7TrackName));
     assertThat(
         c.getTrackingGroups().get(c1TrackName),
         equalTo(
@@ -7797,11 +7820,22 @@ public final class FlatJuniperGrammarTest {
         equalTo(TrackMethods.route(Prefix.strict("3.0.0.0/24"), ImmutableSet.of(), "ri3")));
     assertThat(c.getTrackingGroups().get(c4TrackName), equalTo(TrackMethods.alwaysTrue()));
     assertThat(c.getTrackingGroups().get(c5TrackName), equalTo(TrackMethods.alwaysFalse()));
+    assertThat(
+        c.getTrackingGroups().get(c6TrackName),
+        equalTo(TrackMethods.route(Prefix.strict("192.0.2.1/32"), ImmutableSet.of(), "default")));
+    assertThat(c.getTrackingGroups().get(c7TrackName), equalTo(TrackMethods.alwaysFalse()));
 
     // BGP process should watch tracks for conditions
     assertThat(
         c.getDefaultVrf().getBgpProcess().getTracks(),
-        containsInAnyOrder(c1TrackName, c2TrackName, c3TrackName, c4TrackName, c5TrackName));
+        containsInAnyOrder(
+            c1TrackName,
+            c2TrackName,
+            c3TrackName,
+            c4TrackName,
+            c5TrackName,
+            c6TrackName,
+            c7TrackName));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8493,7 +8493,10 @@ public final class FlatJuniperGrammarTest {
 
     assertThat(
         ccae.getWarnings().get(hostname).getFatalRedFlagWarnings(),
-        hasItem(
+        contains(
+            WarningMatchers.hasText(
+                "FATAL: Missing route address for if-route-exists condition c0. Config will not"
+                    + " pass commit checks."),
             WarningMatchers.hasText(
                 "FATAL: Missing route address for if-route-exists condition c1. Config will not"
                     + " pass commit checks.")));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-condition
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-condition
@@ -9,6 +9,8 @@ set policy-options condition c3 if-route-exists address-family inet 3.0.0.0/24
 set policy-options condition c3 if-route-exists address-family inet table ri3.inet.0
 set policy-options condition c4 if-route-exists address-family ccc ignored ignored
 set policy-options condition c5 if-route-exists ::1.2.3.4/127
+set policy-options condition c6 if-route-exists 192.0.2.1
+set policy-options condition c7 if-route-exists 2001:db8:1234:5678:abc1:2345:6789:abcd
 #
 set routing-instances ri2 instance-type vrf
 set policy-options policy-statement p1 term t1 from condition c1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-missing-prefix-condition
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-missing-prefix-condition
@@ -1,5 +1,30 @@
 #
 set system host-name juniper-missing-prefix-condition
-#
-set policy-options condition c1 if-route-exists table inet.0
-#
+
+# No IP address or prefix
+set policy-options condition c0 if-route-exists table TABLE-NAME.inet.0
+set policy-options condition c1 if-route-exists table TABLE-NAME.inet6.0
+
+# IPv4
+set policy-options condition c2 if-route-exists 192.0.2.1
+set policy-options condition c2 if-route-exists table TABLE-NAME.inet.0
+
+# IPv6
+set policy-options condition c3 if-route-exists 2001:db8:1234:5678:abc1:2345:6789:abcd
+set policy-options condition c3 if-route-exists table TABLE-NAME.inet6.0
+
+# IPv4 prefix
+set policy-options condition c4 if-route-exists 192.0.2.0/24
+set policy-options condition c4 if-route-exists table TABLE-NAME.inet.0
+
+# IPv6 prefix
+set policy-options condition c5 if-route-exists 2001:db8::/32
+set policy-options condition c5 if-route-exists table TABLE-NAME.inet6.0
+
+# IPv4MappedToIpv6
+set policy-options condition c6 if-route-exists ::ffff:192.0.2.1
+set policy-options condition c6 if-route-exists table TABLE-NAME.inet6.0
+
+
+
+


### PR DESCRIPTION
This PR modifies the Junos parser grammar so that `if-route-exists` can parse IPv4 and IPv6 addresses, following the documentation https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/if-route-exists-edit-policy-options-condition.html.

The test file uses IPv4 and IPv6 prefix reserved for documentation and testing ([RFC5737](https://tools.ietf.org/html/rfc5737) and [RFC3849](https://tools.ietf.org/html/rfc3849))





