### PR TITLE
Junos: support apply group wildcards on static route prefixes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -663,7 +663,7 @@ ros_rib_group
 
 ros_route4
 :
-    ROUTE prefix = ip_prefix_default_32
+    ROUTE (wildcard | prefix = ip_prefix_default_32)
    (
       rosr_common
       | rosr_qualified_next_hop
@@ -672,7 +672,7 @@ ros_route4
 
 ros_route6
 :
-    ROUTE prefix = ipv6_prefix_default_128
+    ROUTE (wildcard | prefix = ipv6_prefix_default_128)
    (
       rosr_common
       | rosr_qualified_next_hop6

--- a/projects/batfish/src/test/java/org/batfish/main/PreprocessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/PreprocessTest.java
@@ -74,6 +74,13 @@ public final class PreprocessTest {
   }
 
   @Test
+  public void testApplyGroupsStaticRoute() throws IOException {
+    assertValidPair(
+        "preprocess-apply-groups-static-route-before",
+        "preprocess-apply-groups-static-route-after");
+  }
+
+  @Test
   public void testFlatPaloAlto() throws IOException {
     assertValidPair("preprocess-flat-pa-before", "preprocess-flat-pa-after");
   }

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-apply-groups-static-route-after
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-apply-groups-static-route-after
@@ -1,0 +1,9 @@
+####BATFISH PRE-PROCESSED JUNIPER CONFIG####
+set system host-name preprocess-apply-groups-static-route
+set routing-options static route 0.0.0.0/0 discard
+set routing-options static route 0.0.0.0/0 no-install
+set routing-options static route 0.0.0.0/0 preference 100
+set routing-options rib inet6.0 static route ::/0 discard
+set routing-options rib inet6.0 static route ::/0 no-install
+set routing-options rib inet6.0 static route ::/0 preference 200
+set apply-groups MYGROUP

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-apply-groups-static-route-before
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-apply-groups-static-route-before
@@ -1,0 +1,12 @@
+####BATFISH PRE-PROCESSED JUNIPER CONFIG####
+set system host-name preprocess-apply-groups-static-route
+
+set routing-options static route 0.0.0.0/0 preference 100
+set routing-options rib inet6.0 static route ::/0 preference 200
+
+set groups MYGROUP routing-options rib inet6.0 static route <*> discard
+set groups MYGROUP routing-options rib inet6.0 static route <*> no-install
+set groups MYGROUP routing-options static route <*> discard
+set groups MYGROUP routing-options static route <*> no-install
+
+set apply-groups MYGROUP


### PR DESCRIPTION
Allowing static route prefixes to be wildcarded in an apply group. 