### PR TITLE
Make Jackson ignore fatal red flag warnings

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -193,6 +193,7 @@ public class Warnings implements Serializable {
   }
 
   /** Get all red flag warnings that are fatal error */
+  @JsonIgnore
   public SortedSet<Warning> getFatalRedFlagWarnings() {
     SortedSet<Warning> fatalWarnings = new TreeSet<>();
     for (Warning warning : _redFlagWarnings) {


### PR DESCRIPTION
`@JsonIgnore` was added due to the error `Caused by: java.lang.UnsupportedOperationException: Should never call set() on setterless property ('fatalRedFlagWarnings')` because Jackson marks fatalRedFlagWarnings as a property.