### PR TITLE
Junos: don't match apply-groups or apply-path when expanding groups wildcards

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
@@ -725,7 +725,9 @@ final class Hierarchy {
       }
 
       public boolean matches(String text) {
-        return _wildcardPattern.matcher(text).matches();
+        return !text.equals("apply-groups")
+            && !text.equals("apply-path")
+            && _wildcardPattern.matcher(text).matches();
       }
 
       @Override

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-groups-routing-instances
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-groups-routing-instances
@@ -1,7 +1,7 @@
 # RANCID-CONTENT-TYPE: juniper
 set system host-name apply-groups-routing-instances
 
-set groups RI_GROUP routing-instances <F*> routing-options static route 1.1.1.0/24 discard
+set groups RI_GROUP routing-instances <*> routing-options static route 1.1.1.0/24 discard
 set routing-instances FOO instance-type vrf
 
 # make sure we handle apply-groups immediately after "routing-instances"


### PR DESCRIPTION
This creates false recursion that doesn't happen on-box.