### PR TITLE
Junos: Allow empty regex in wildcard

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/GroupWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/GroupWildcard.java
@@ -123,6 +123,9 @@ public class GroupWildcard extends BaseParser<String> {
   }
 
   public static String toJavaRegex(String wildcard) {
+    if (wildcard.isEmpty()) {
+      return "";
+    }
     GroupWildcard parser = Parboiled.createParser(GroupWildcard.class);
     BasicParseRunner<String> runner = new BasicParseRunner<>(parser.TopLevel());
     ParsingResult<String> result = runner.run(wildcard);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-groups-routing-instances
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/apply-groups-routing-instances
@@ -6,3 +6,7 @@ set routing-instances FOO instance-type vrf
 
 # make sure we handle apply-groups immediately after "routing-instances"
 set routing-instances apply-groups RI_GROUP
+
+# empty wildcard is valid syntax
+set groups EMPTY_WILDCARD_GROUP routing-instances <> routing-options router-id 1.1.1.1
+set routing-instances apply-groups EMPTY_WILDCARD_GROUP


### PR DESCRIPTION
Empty wildcards doesn't apply any configuration but is syntactically valid in Juniper configurations. 