### PR TITLE
DefinedStructureInfo: canonicalize ranges

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
@@ -41,7 +42,7 @@ public class DefinedStructureInfo implements Serializable {
   }
 
   public void addDefinitionLines(int line) {
-    _definitionLines.add(Range.singleton(line));
+    _definitionLines.add(Range.closedOpen(line, line + 1));
   }
 
   public void addDefinitionLines(RangeSet<Integer> lines) {
@@ -49,7 +50,7 @@ public class DefinedStructureInfo implements Serializable {
   }
 
   public void addDefinitionLines(Range<Integer> lines) {
-    _definitionLines.add(lines);
+    _definitionLines.add(lines.canonical(DiscreteDomain.integers()));
   }
 
   @JsonProperty(PROP_NUM_REFERRERS)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -264,7 +264,7 @@ public abstract class VendorConfiguration implements Serializable {
     IntSet lines = new IntHashSet();
     collectLines(ctx, parser, _extraLines, lines::add);
     ImmutableRangeSet.Builder<Integer> ranges = ImmutableRangeSet.builder();
-    lines.iterator().forEachRemaining(c -> ranges.add(Range.singleton(c.value)));
+    lines.iterator().forEachRemaining(c -> ranges.add(Range.closedOpen(c.value, c.value + 1)));
     _structureManager.getOrDefine(type, name).addDefinitionLines(ranges.build());
   }
 


### PR DESCRIPTION
Without using the canonical range `closedOpen(a, a+1)` we were not able to
combine `a` and `a+1`. This is because `[a,a] union [a+1,a+1]` is not `[a,a+1]`
in a number line. You need `[a,a+1) union [a+1, a+2)` which does become `[a, a+2)`.

We handled this inside `IntegerSpace`, but since there's no mutable version we
did it again.

---

**Stack**:
- #9373
- #9372 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*