### PR TITLE
Juniper: remove default vrf for PBR

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3082,8 +3082,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // A term will become an If statement. If (matchCondition) -> execute "then" statements
       builder.add(
           new org.batfish.datamodel.packet_policy.If(
-              new PacketMatchExpr(matchFwFroms),
-              TermFwThenToPacketPolicyStatement.convert(term, Configuration.DEFAULT_VRF_NAME)));
+              new PacketMatchExpr(matchFwFroms), TermFwThenToPacketPolicyStatement.convert(term)));
     }
 
     // Make the policy, with an implicit deny all at the end as the default action

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatementTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatementTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.IngressInterfaceVrf;
 import org.batfish.datamodel.packet_policy.LiteralVrfName;
 import org.batfish.datamodel.packet_policy.Return;
 import org.junit.Before;
@@ -26,66 +27,65 @@ public class TermFwThenToPacketPolicyStatementTest {
   public void testVisitAccept() {
     _fwTerm.getThens().add(FwThenAccept.INSTANCE);
     assertThat(
-        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
-        equalTo(ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("someVRF"))))));
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm),
+        equalTo(ImmutableList.of(new Return(new FibLookup(IngressInterfaceVrf.instance())))));
   }
 
   @Test
   public void testVisitAcceptAfterNextTerm() {
     _fwTerm.getThens().addAll(ImmutableList.of(FwThenNextTerm.INSTANCE, FwThenAccept.INSTANCE));
-    assertThat(
-        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), equalTo(ImmutableList.of()));
+    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm), equalTo(ImmutableList.of()));
   }
 
   @Test
   public void testVisitNextTermAfterAccept() {
     _fwTerm.getThens().addAll(ImmutableList.of(FwThenAccept.INSTANCE, FwThenNextTerm.INSTANCE));
     assertThat(
-        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
-        equalTo(ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("someVRF"))))));
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm),
+        equalTo(ImmutableList.of(new Return(new FibLookup(IngressInterfaceVrf.instance())))));
   }
 
   @Test
   public void testVisitNop() {
     _fwTerm.getThens().add(FwThenNop.INSTANCE);
-    assertThat(
-        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), equalTo(ImmutableList.of()));
+    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm), equalTo(ImmutableList.of()));
   }
 
   @Test
   public void testVisitDiscard() {
     _fwTerm.getThens().add(FwThenDiscard.INSTANCE);
     assertThat(
-        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm),
         equalTo(ImmutableList.of(new Return(Drop.instance()))));
   }
 
   @Test
   public void testVisitDiscardAfterSkip() {
     _fwTerm.getThens().addAll(ImmutableList.of(FwThenNextTerm.INSTANCE, FwThenDiscard.INSTANCE));
-    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), empty());
+    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm), empty());
   }
 
   @Test
   public void testVisitNextIp() {
     _fwTerm.getThens().add(new FwThenNextIp(Prefix.parse("1.1.1.0/24")));
     // Not implemented yet:
-    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), empty());
+    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm), empty());
   }
 
   @Test
   public void testVisitRoutingInstance() {
     _fwTerm.getThens().add(new FwThenRoutingInstance("otherVRF"));
     assertThat(
-        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm),
         equalTo(ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("otherVRF"))))));
   }
 
+  /** Tests that Junos master RI is correctly mapped to Batfish default VRF. */
   @Test
   public void testVisitMasterRoutingInstance() {
     _fwTerm.getThens().add(new FwThenRoutingInstance("master"));
     assertThat(
-        TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
+        TermFwThenToPacketPolicyStatement.convert(_fwTerm),
         equalTo(ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("default"))))));
   }
 
@@ -94,6 +94,6 @@ public class TermFwThenToPacketPolicyStatementTest {
     _fwTerm
         .getThens()
         .addAll(ImmutableList.of(FwThenNextTerm.INSTANCE, new FwThenRoutingInstance("otherVRF")));
-    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"), empty());
+    assertThat(TermFwThenToPacketPolicyStatement.convert(_fwTerm), empty());
   }
 }


### PR DESCRIPTION
The 'default vrf' should be the routing-instance that we're already in. Otherwise, we
switch back to the master RI if the PBR policy is just 'accept'.