### PR TITLE
Ip6: parse/stringify ipv4-mapped addresses

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6Test.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6Test.java
@@ -28,5 +28,6 @@ public class Ip6Test {
     assertThat("longest zeros", Ip6.parse("4:0:0:5:0:0:0:0").toString(), equalTo("4:0:0:5::"));
     assertThat("longest zeros", Ip6.parse("4:0:0:5:6:0:0:0").toString(), equalTo("4:0:0:5:6::"));
     assertThat("tie-break left", Ip6.parse("4:0:0:5:6:7:0:0").toString(), equalTo("4::5:6:7:0:0"));
+    assertThat("localhost", Ip6.parse("::1").toString(), equalTo("::1"));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Prefix6Test.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Prefix6Test.java
@@ -11,5 +11,10 @@ public class Prefix6Test {
     assertThat(Prefix6.ZERO.toString(), equalTo("::/0"));
     assertThat(Prefix6.parse("::/64").toString(), equalTo("::/64"));
     assertThat(Prefix6.parse("0:1:2:3:4:5:6:7/128").toString(), equalTo("0:1:2:3:4:5:6:7/128"));
+    // IPv4-compatible IPv6 address (legacy)
+    assertThat(Prefix6.parse("::249.10.49.80/124").toString(), equalTo("::249.10.49.80/124"));
+    // IPv4-mapped IPv6 address
+    assertThat(
+        Prefix6.parse("::ffff:249.10.49.80/124").toString(), equalTo("::ffff:249.10.49.80/124"));
   }
 }


### PR DESCRIPTION
Previously parsing them resulted in incorrect high-order bits, and also confusing toString (using all hex chars)