### PR TITLE
Junos: Don't crash on invalid wildcard in apply-path

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
@@ -47,8 +47,11 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
     String pathWithoutQuotes = pathQuoted.substring(1, pathQuoted.length() - 1);
     String[] pathComponents = pathWithoutQuotes.split("\\s+");
     for (String pathComponent : pathComponents) {
-      boolean isWildcard = pathComponent.charAt(0) == '<';
-      if (isWildcard) {
+      if (pathComponent.charAt(0) == '<') {
+        if (pathComponent.charAt(pathComponent.length() - 1) != '>') {
+          // Malformed wildcard - don't try to expand this apply-path
+          return;
+        }
         applyPathPath.addWildcardNode(pathComponent, line);
       } else {
         applyPathPath.addNode(pathComponent, line);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5043,6 +5043,10 @@ public final class FlatJuniperGrammarTest {
 
     /* The wildcard-looking BGP group name should not be pruned since its parse-tree node was not created via preprocessor. */
     assertThat(c, hasDefaultVrf(hasBgpProcess(hasNeighbors(hasKey(neighborIp)))));
+
+    /* prefix-list p5 with trailing semicolon in apply-path should exist but be empty */
+    assertThat(c, hasRouteFilterLists(hasKey("p5")));
+    assertThat(c.getRouteFilterLists().get("p5").getLines(), empty());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
@@ -19,4 +19,6 @@ set protocols ospf area 0.0.0.1 interface et-0/0/0.0 passive
 set policy-options prefix-list p4 apply-path "snmp community <*> clients <*>"
 set snmp community "foo" clients 4.4.4.4/32
 set snmp community "<removed>" clients 5.5.5.5/32
+## p5 should have no addresses because of the invalid wildcard
+set policy-options prefix-list p5 apply-path "protocols bgp group <*> neighbor <*>;"
 #


### PR DESCRIPTION
Juniper allows statements like 

```
set policy-options prefix-list FOO apply-path "protocols bgp group BAR neighbor <*>;" 
```
and even things like

```
set policy-options prefix-list FOO apply-path "protocols bgp group <*>a neighbor <*>b" 
```

These cases would not expand but will also not cause commit error so Batfish should not crash on them.
