### PR TITLE
Junos: Support group wildcard with comma

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/GroupWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/parboiled/GroupWildcard.java
@@ -68,7 +68,8 @@ public class GroupWildcard extends BaseParser<String> {
                 Ch('-'),
                 Ch('_'),
                 Ch(':'),
-                Ch('/'))),
+                Ch('/'),
+                Ch(','))),
         push(match()));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5047,6 +5047,8 @@ public final class FlatJuniperGrammarTest {
     /* prefix-list p5 with trailing semicolon in apply-path should exist but be empty */
     assertThat(c, hasRouteFilterLists(hasKey("p5")));
     assertThat(c.getRouteFilterLists().get("p5").getLines(), empty());
+    assertThat(c, hasIpAccessList("FILTER"));
+    assertThat(c, hasInterface("em0.0", hasIncomingFilter(hasName("FILTER"))));
   }
 
   @Test
@@ -5065,7 +5067,7 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(
-            filename, PREFIX_LIST, "p1", containsInAnyOrder(4, 9, 10)));
+            filename, PREFIX_LIST, "p1", containsInAnyOrder(4, 9, 10, 27)));
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
@@ -21,4 +21,9 @@ set snmp community "foo" clients 4.4.4.4/32
 set snmp community "<removed>" clients 5.5.5.5/32
 ## p5 should have no addresses because of the invalid wildcard
 set policy-options prefix-list p5 apply-path "protocols bgp group <*> neighbor <*>;"
+set firewall family inet filter FILTER term PERMIT-ALL from protocol tcp
+set firewall family inet filter FILTER term PERMIT-ALL then accept
+set groups g4 interfaces "<em[0,1]>" unit <*> family inet filter input FILTER
+set interfaces em0 unit 0 family inet address 10.0.0.1/24
+set apply-groups g4
 #


### PR DESCRIPTION
Batfish is throwing exceptions when creating groups with `,` inside `<>` for lines such as `set groups g4 interfaces "<em[0,1]>" unit <*> family inet filter input FILTER`. This is valid syntax.