### PR TITLE
Junos: Support incomplete extended and large community

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/CommunityMemberParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/CommunityMemberParseResult.java
@@ -1,6 +1,5 @@
 package org.batfish.representation.juniper;
 
-import com.google.common.primitives.Ints;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -18,6 +17,7 @@ public class CommunityMemberParseResult {
   private final @Nullable String _warning;
   private static final Pattern DIGITS_ONLY_PATTERN = Pattern.compile("^\\d+$");
   private static final Pattern STANDARD_PATTERN = Pattern.compile("^\\d*:\\d*$");
+  private static final Pattern EXTENDED_PATTERN = Pattern.compile("^([^:]+):[^:]*:$");
 
   public CommunityMemberParseResult(CommunityMember member, @Nullable String warning) {
     _member = member;
@@ -34,13 +34,13 @@ public class CommunityMemberParseResult {
 
   /** Converts a community value into a {@link CommunityMember} and stores any warnings */
   public static CommunityMemberParseResult parseCommunityMember(String text) {
+    if (DIGITS_ONLY_PATTERN.matcher(text).matches()) {
+      return new CommunityMemberParseResult(new RegexCommunityMember(text), null);
+    }
+
     Optional<CommunityMemberParseResult> specialCase = handleSpecialStandardCommunity(text);
     if (specialCase.isPresent()) {
       return specialCase.get();
-    }
-
-    if (DIGITS_ONLY_PATTERN.matcher(text).matches()) {
-      return new CommunityMemberParseResult(new RegexCommunityMember(text), null);
     }
 
     Community literalCommunity = tryParseLiteralCommunity(text);
@@ -59,43 +59,61 @@ public class CommunityMemberParseResult {
     return new CommunityMemberParseResult(new RegexCommunityMember(text), warning);
   }
 
+  /** Create community string from incomplete cases and try to parse */
   private static Optional<CommunityMemberParseResult> handleSpecialStandardCommunity(String text) {
-    if (!STANDARD_PATTERN.matcher(text).matches()) {
-      return Optional.empty();
-    }
-
-    if (text.equals(":")) {
-      return Optional.of(
-          new CommunityMemberParseResult(
-              new LiteralCommunityMember(StandardCommunity.of(0, 0)),
-              String.format("RISK: Community string '%s' is interpreted as '0:0'", text)));
-    }
-
-    if (text.endsWith(":")) {
-      String asStr = text.substring(0, text.length() - 1);
-      Integer asNum = Ints.tryParse(asStr);
-      if (asNum != null) {
-        return Optional.of(
-            new CommunityMemberParseResult(
-                new LiteralCommunityMember(StandardCommunity.of(asNum, 0)),
-                String.format(
-                    "RISK: Community string '%s' is interpreted as '%s:0'", text, asStr)));
+    if (STANDARD_PATTERN.matcher(text).matches()) {
+      // For a standard community, admin and value can be empty
+      int colonIndex = text.indexOf(':');
+      if (colonIndex == 0 || colonIndex == text.length() - 1) {
+        String highStr = colonIndex > 0 ? text.substring(0, colonIndex) : "0";
+        String lowStr = colonIndex < text.length() - 1 ? text.substring(colonIndex + 1) : "0";
+        String normalizedText = highStr + ":" + lowStr;
+        Optional<StandardCommunity> standardCommunity =
+            StandardCommunity.tryParse(highStr + ":" + lowStr);
+        if (standardCommunity.isPresent()) {
+          return createSpecialCommunityResult(standardCommunity.get(), text, normalizedText);
+        }
+      }
+    } else if (text.toLowerCase().startsWith("large")) {
+      // For a large community, global admin, local data 1, and local data 2 can be empty
+      String[] parts = text.split(":", -1);
+      boolean hasEmptyParts = false;
+      for (int i = 1; i < parts.length; i++) {
+        if (parts[i].isEmpty()) {
+          hasEmptyParts = true;
+          break;
+        }
+      }
+      if (hasEmptyParts) {
+        String[] normalizedParts = new String[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+          normalizedParts[i] = parts[i].isEmpty() ? "0" : parts[i];
+        }
+        String normalizedText = String.join(":", normalizedParts);
+        Optional<LargeCommunity> largeCommunity = LargeCommunity.tryParse(normalizedText);
+        if (largeCommunity.isPresent()) {
+          return createSpecialCommunityResult(largeCommunity.get(), text, normalizedText);
+        }
+      }
+    } else if (EXTENDED_PATTERN.matcher(text).matches()) {
+      // For an extended community, only local admin is allowed to be empty
+      String normalizedText = text + "0";
+      Optional<ExtendedCommunity> extendedCommunity = ExtendedCommunity.tryParse(normalizedText);
+      if (extendedCommunity.isPresent()) {
+        return createSpecialCommunityResult(extendedCommunity.get(), text, normalizedText);
       }
     }
-
-    if (text.startsWith(":")) {
-      String valueStr = text.substring(1);
-      Integer value = Ints.tryParse(valueStr);
-      if (value != null) {
-        return Optional.of(
-            new CommunityMemberParseResult(
-                new LiteralCommunityMember(StandardCommunity.of(0, value)),
-                String.format(
-                    "RISK: Community string '%s' is interpreted as '0:%s'", text, value)));
-      }
-    }
-
     return Optional.empty();
+  }
+
+  private static Optional<CommunityMemberParseResult> createSpecialCommunityResult(
+      Community community, String originalText, String normalizedText) {
+    return Optional.of(
+        new CommunityMemberParseResult(
+            new LiteralCommunityMember(community),
+            String.format(
+                "RISK: Community string '%s' is interpreted as '%s'",
+                originalText, normalizedText)));
   }
 
   /** Returns a {@link Community} if {@code text} can be parsed as one, or else {@code null}. */

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/CommunityMemberParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/CommunityMemberParseResult.java
@@ -38,7 +38,7 @@ public class CommunityMemberParseResult {
       return new CommunityMemberParseResult(new RegexCommunityMember(text), null);
     }
 
-    Optional<CommunityMemberParseResult> specialCase = handleSpecialStandardCommunity(text);
+    Optional<CommunityMemberParseResult> specialCase = tryParseJuniperIncompleteLiteral(text);
     if (specialCase.isPresent()) {
       return specialCase.get();
     }
@@ -60,7 +60,8 @@ public class CommunityMemberParseResult {
   }
 
   /** Create community string from incomplete cases and try to parse */
-  private static Optional<CommunityMemberParseResult> handleSpecialStandardCommunity(String text) {
+  private static Optional<CommunityMemberParseResult> tryParseJuniperIncompleteLiteral(
+      String text) {
     if (STANDARD_PATTERN.matcher(text).matches()) {
       // For a standard community, admin and value can be empty
       int colonIndex = text.indexOf(':');
@@ -71,7 +72,7 @@ public class CommunityMemberParseResult {
         Optional<StandardCommunity> standardCommunity =
             StandardCommunity.tryParse(highStr + ":" + lowStr);
         if (standardCommunity.isPresent()) {
-          return createSpecialCommunityResult(standardCommunity.get(), text, normalizedText);
+          return createLiteralCommunityWithWarning(standardCommunity.get(), text, normalizedText);
         }
       }
     } else if (text.toLowerCase().startsWith("large")) {
@@ -92,7 +93,7 @@ public class CommunityMemberParseResult {
         String normalizedText = String.join(":", normalizedParts);
         Optional<LargeCommunity> largeCommunity = LargeCommunity.tryParse(normalizedText);
         if (largeCommunity.isPresent()) {
-          return createSpecialCommunityResult(largeCommunity.get(), text, normalizedText);
+          return createLiteralCommunityWithWarning(largeCommunity.get(), text, normalizedText);
         }
       }
     } else if (EXTENDED_PATTERN.matcher(text).matches()) {
@@ -100,13 +101,13 @@ public class CommunityMemberParseResult {
       String normalizedText = text + "0";
       Optional<ExtendedCommunity> extendedCommunity = ExtendedCommunity.tryParse(normalizedText);
       if (extendedCommunity.isPresent()) {
-        return createSpecialCommunityResult(extendedCommunity.get(), text, normalizedText);
+        return createLiteralCommunityWithWarning(extendedCommunity.get(), text, normalizedText);
       }
     }
     return Optional.empty();
   }
 
-  private static Optional<CommunityMemberParseResult> createSpecialCommunityResult(
+  private static Optional<CommunityMemberParseResult> createLiteralCommunityWithWarning(
       Community community, String originalText, String normalizedText) {
     return Optional.of(
         new CommunityMemberParseResult(


### PR DESCRIPTION
Adding more special case handling for standard and large communities.
For standard and large community, all the values are allowed to be 0. For extended community, only local admin (string after last colon) is allowed to be 0.

```
# extended community special cases
origin:111: -> origin:111:0
# large community special cases
large:111:222: -> large:111:222:0
large:111:: -> large:111:0:0
large::: -> large:0:0:0
```

I approached this by constructing a new community string to fill the 0 before passing it to the existing `tryParse` function in the respective Community classes.