### PR TITLE
Junos: BGP group keep all/none extraction

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -113,6 +113,7 @@ b_common
    | b_export
    | b_family
    | b_import
+   | b_keep
    | b_local_address
    | b_local_as
    | b_multihop
@@ -193,6 +194,11 @@ b_group
 b_import
 :
    IMPORT expr = policy_expression
+;
+
+b_keep
+:
+   KEEP (ALL | NONE)
 ;
 
 b_local_address

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -264,7 +264,6 @@ b_null
       | BFD_LIVENESS_DETECTION
       | GRACEFUL_RESTART
       | HOLD_TIME
-      | KEEP
       | LOG_UPDOWN
       | MTU_DISCOVERY
       | OUT_DELAY

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2589,8 +2589,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void enterB_keep(B_keepContext ctx) {
-    boolean keepNone = ctx.NONE() != null;
-    _currentBgpGroup.setKeepNone(keepNone);
+    BgpGroup.BgpKeepType keep =
+        ctx.NONE() != null ? BgpGroup.BgpKeepType.NONE : BgpGroup.BgpKeepType.ALL;
+    _currentBgpGroup.setKeep(keep);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -252,6 +252,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_enforce_first_asConte
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_groupContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_importContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_keepContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_local_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_multihopContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_multipathContext;
@@ -2584,6 +2585,12 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
           BGP_NEIGHBOR_SELF_REFERENCE,
           getLine(ctx.start));
     }
+  }
+
+  @Override
+  public void enterB_keep(B_keepContext ctx) {
+    boolean keepNone = ctx.NONE() != null;
+    _currentBgpGroup.setKeepNone(keepNone);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
@@ -15,6 +15,11 @@ public class BgpGroup implements Serializable {
     INTERNAL
   }
 
+  public enum BgpKeepType {
+    ALL,
+    NONE
+  }
+
   private @Nullable AddPath _addPath;
   private Boolean _advertiseExternal;
   private Boolean _advertiseInactive;
@@ -33,7 +38,7 @@ public class BgpGroup implements Serializable {
   private final List<String> _importPolicies;
   protected transient boolean _inherited;
   private boolean _ipv6;
-  private boolean _keepNone;
+  private @Nullable BgpKeepType _keep;
   private Ip _localAddress;
   private Long _localAs;
   private Integer _loops;
@@ -101,6 +106,9 @@ public class BgpGroup implements Serializable {
       }
       if (_importPolicies.isEmpty()) {
         _importPolicies.addAll(_parent._importPolicies);
+      }
+      if (_keep == null) {
+        _keep = _parent._keep;
       }
       if (_localAs == null) {
         _localAs = _parent._localAs;
@@ -211,8 +219,8 @@ public class BgpGroup implements Serializable {
     return _ipv6;
   }
 
-  public boolean getKeepNone() {
-    return _keepNone;
+  public BgpKeepType getKeep() {
+    return _keep;
   }
 
   public final Ip getLocalAddress() {
@@ -315,8 +323,8 @@ public class BgpGroup implements Serializable {
     _ipv6 = ipv6;
   }
 
-  public void setKeepNone(boolean keepNone) {
-    _keepNone = keepNone;
+  public void setKeep(@Nullable BgpKeepType keep) {
+    _keep = keep;
   }
 
   public final void setLocalAddress(Ip localAddress) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
@@ -33,6 +33,7 @@ public class BgpGroup implements Serializable {
   private final List<String> _importPolicies;
   protected transient boolean _inherited;
   private boolean _ipv6;
+  private boolean _keepNone;
   private Ip _localAddress;
   private Long _localAs;
   private Integer _loops;
@@ -210,6 +211,10 @@ public class BgpGroup implements Serializable {
     return _ipv6;
   }
 
+  public boolean getKeepNone() {
+    return _keepNone;
+  }
+
   public final Ip getLocalAddress() {
     return _localAddress;
   }
@@ -308,6 +313,10 @@ public class BgpGroup implements Serializable {
 
   public void setIpv6(boolean ipv6) {
     _ipv6 = ipv6;
+  }
+
+  public void setKeepNone(boolean keepNone) {
+    _keepNone = keepNone;
   }
 
   public final void setLocalAddress(Ip localAddress) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1173,7 +1173,7 @@ public final class FlatJuniperGrammarTest {
     n2.cascadeInheritance();
     assertEquals(n2.getKeep(), BgpGroup.BgpKeepType.NONE); // inherit from group
 
-    // Routing instance R1 does set keep
+    // Routing instance R2 does set keep
     RoutingInstance r2 = c.getMasterLogicalSystem().getRoutingInstances().get("R2");
     assertEquals(r2.getMasterBgpGroup().getKeep(), BgpGroup.BgpKeepType.NONE);
     assertEquals(r2.getNamedBgpGroups().get("G1").getKeep(), BgpGroup.BgpKeepType.NONE);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1153,6 +1153,15 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testBgpKeepExtraction() {
+    JuniperConfiguration c = parseJuniperConfig("bgp-keep");
+    RoutingInstance ri = c.getMasterLogicalSystem().getDefaultRoutingInstance();
+    assertTrue(ri.getNamedBgpGroups().get("G1").getKeepNone());
+    assertFalse(ri.getNamedBgpGroups().get("G2").getKeepNone());
+    assertFalse(ri.getNamedBgpGroups().get("G3").getKeepNone());
+  }
+
+  @Test
   public void testBgpMultipath() {
     assertThat(
         parseConfig("bgp-multipath").getDefaultVrf(),

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-keep
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-keep
@@ -1,0 +1,6 @@
+#RANCID-CONTENT-TYPE: juniper
+set system host-name bgp-keep
+#
+set protocols bgp group G1 keep none
+set protocols bgp group G2 keep all
+set protocols bgp group G3

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-keep
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-keep
@@ -13,11 +13,5 @@ set routing-instances R2 protocols bgp keep none
 set routing-instances R2 protocols bgp group G1 keep none
 set routing-instances R2 protocols bgp group G2 keep all
 set routing-instances R2 protocols bgp group G3
-#
-# R3 has keep set at protocol-level
-set routing-instances R2 protocols bgp keep none
-set routing-instances R2 protocols bgp group G1 keep none
-set routing-instances R2 protocols bgp group G2 keep all
-set routing-instances R2 protocols bgp group G3
 set routing-instances R2 protocols bgp group G3 neighbor 1.1.1.1 keep all
 set routing-instances R2 protocols bgp group G3 neighbor 2.2.2.2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-keep
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-keep
@@ -1,6 +1,23 @@
 #RANCID-CONTENT-TYPE: juniper
 set system host-name bgp-keep
 #
-set protocols bgp group G1 keep none
-set protocols bgp group G2 keep all
-set protocols bgp group G3
+# R1 does not have keep set at protocol-level
+set routing-instances R1 protocols bgp group G1 keep none
+set routing-instances R1 protocols bgp group G1 neighbor 1.1.1.1 keep all
+set routing-instances R1 protocols bgp group G1 neighbor 2.2.2.2
+set routing-instances R1 protocols bgp group G2 keep all
+set routing-instances R1 protocols bgp group G3
+#
+# R2 has keep set at protocol-level
+set routing-instances R2 protocols bgp keep none
+set routing-instances R2 protocols bgp group G1 keep none
+set routing-instances R2 protocols bgp group G2 keep all
+set routing-instances R2 protocols bgp group G3
+#
+# R3 has keep set at protocol-level
+set routing-instances R2 protocols bgp keep none
+set routing-instances R2 protocols bgp group G1 keep none
+set routing-instances R2 protocols bgp group G2 keep all
+set routing-instances R2 protocols bgp group G3
+set routing-instances R2 protocols bgp group G3 neighbor 1.1.1.1 keep all
+set routing-instances R2 protocols bgp group G3 neighbor 2.2.2.2


### PR DESCRIPTION
Add parsing and extraction for Junos' BGP group keep all/none configuration.

https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/topic-map/basic-routing-policies.html