### PR TITLE
InterfaceType: remove VPN in favor of TUNNEL

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -3,7 +3,6 @@ package org.batfish.common.topology;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.batfish.common.util.IpsecUtil.initIpsecTopology;
 import static org.batfish.common.util.IpsecUtil.retainCompatibleTunnelEdges;
-import static org.batfish.datamodel.Interface.TUNNEL_INTERFACE_TYPES;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.DiscreteDomain;
@@ -596,10 +595,9 @@ public final class TopologyUtil {
           if (!isValidLayer3Adjacency(iface1, iface2)) {
             continue;
           }
-          // Additionally, don't connect if any of the two endpoint interfaces have Tunnel or VPN
-          // interfaceTypes
-          if (TUNNEL_INTERFACE_TYPES.contains(iface1.getInterfaceType())
-              || TUNNEL_INTERFACE_TYPES.contains(iface2.getInterfaceType())) {
+          // Additionally, don't connect if any of the two endpoint interfaces are tunnels
+          if (iface1.getInterfaceType() == InterfaceType.TUNNEL
+              || iface2.getInterfaceType() == InterfaceType.TUNNEL) {
             continue;
           }
           edges.add(new Edge(iface1, iface2));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -585,8 +585,6 @@ public final class Interface extends ComparableStructure<String> {
   public static final int DEFAULT_MTU = 1500;
   public static final String DYNAMIC_INTERFACE_NAME = "dynamic";
   public static final String NULL_INTERFACE_NAME = "null_interface";
-  public static final Set<InterfaceType> TUNNEL_INTERFACE_TYPES =
-      ImmutableSet.of(InterfaceType.TUNNEL, InterfaceType.VPN);
   public static final String UNSET_LOCAL_INTERFACE = "unset_local_interface";
   public static final String INVALID_LOCAL_INTERFACE = "invalid_local_interface";
   private static final String PROP_ACCESS_VLAN = "accessVlan";
@@ -720,7 +718,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private static InterfaceType computeAwsInterfaceType(String name) {
     if (name.startsWith("vpn")) {
-      return InterfaceType.VPN;
+      return InterfaceType.TUNNEL;
     } else {
       return InterfaceType.PHYSICAL;
     }
@@ -742,7 +740,7 @@ public final class Interface extends ComparableStructure<String> {
     } else if (name.startsWith("cmp-mgmt")) {
       return InterfaceType.PHYSICAL;
     } else if (name.startsWith("Crypto-Engine")) {
-      return InterfaceType.VPN; // IPSec VPN
+      return InterfaceType.TUNNEL; // IPSec VPN
     } else if (name.startsWith("Dialer")) {
       return InterfaceType.PHYSICAL;
     } else if (name.startsWith("Dot11Radio")) {
@@ -890,7 +888,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private static InterfaceType computeJuniperInterfaceType(String name) {
     if (name.startsWith("st")) {
-      return InterfaceType.VPN;
+      return InterfaceType.TUNNEL;
     } else if (name.startsWith("reth") && name.contains(".")) {
       return InterfaceType.REDUNDANT_CHILD;
     } else if (name.startsWith("reth")) {
@@ -912,7 +910,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private static InterfaceType computeVyosInterfaceType(String name) {
     if (name.startsWith("vti")) {
-      return InterfaceType.VPN;
+      return InterfaceType.TUNNEL;
     } else if (name.startsWith("lo")) {
       return InterfaceType.LOOPBACK;
     } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InterfaceType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InterfaceType.java
@@ -24,6 +24,4 @@ public enum InterfaceType {
   UNKNOWN, // for use as sentinel value
   /** Logical VLAN/irb interface */
   VLAN,
-  /** Logical VPN interface, (i.e., IPSec tunnel) */
-  VPN,
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Link.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Link.java
@@ -78,7 +78,7 @@ public class Link extends BfObject {
 
     return switch (iface1type) {
       case PHYSICAL, LOGICAL -> LinkType.PHYSICAL;
-      case AGGREGATED, AGGREGATE_CHILD, REDUNDANT, REDUNDANT_CHILD, TUNNEL, VLAN, VPN ->
+      case AGGREGATED, AGGREGATE_CHILD, REDUNDANT, REDUNDANT_CHILD, TUNNEL, VLAN ->
           LinkType.VIRTUAL;
 
       // loopback and null shouldn't really happen; lets call it unknown

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/TypeInterfaceAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/TypeInterfaceAstNode.java
@@ -10,8 +10,8 @@ final class TypeInterfaceAstNode implements InterfaceAstNode {
     this(((StringAstNode) interfaceType).getStr());
   }
 
-  TypeInterfaceAstNode(String interfaceTyeStr) {
-    _interfaceType = Enum.valueOf(InterfaceType.class, interfaceTyeStr.toUpperCase());
+  TypeInterfaceAstNode(String interfaceTypeStr) {
+    _interfaceType = Enum.valueOf(InterfaceType.class, interfaceTypeStr.toUpperCase());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
@@ -110,7 +110,7 @@ public class TopologyTest {
 
     // create line topology: c1 <-> c2
     org.batfish.datamodel.Interface c12 =
-        nf.interfaceBuilder().setOwner(c1).setName("to-c2").setType(InterfaceType.VPN).build();
+        nf.interfaceBuilder().setOwner(c1).setName("to-c2").setType(InterfaceType.TUNNEL).build();
     org.batfish.datamodel.Interface c21 =
         nf.interfaceBuilder().setOwner(c2).setName("to-c1").setType(InterfaceType.TUNNEL).build();
 
@@ -126,7 +126,7 @@ public class TopologyTest {
         pojoTopology.getInterfaces(),
         equalTo(
             ImmutableSet.of(
-                new Interface("node-c1", "to-c2", InterfaceType.VPN),
+                new Interface("node-c1", "to-c2", InterfaceType.TUNNEL),
                 new Interface("node-c2", "to-c1", InterfaceType.TUNNEL))));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypesInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypesInterfaceSpecifierTest.java
@@ -29,7 +29,6 @@ public class TypesInterfaceSpecifierTest {
   private static final Interface TUNNEL;
   private static final Interface UNKNOWN;
   private static final Interface VLAN;
-  private static final Interface VPN;
 
   private static final String HOSTNAME = "hostname";
   private static final MockSpecifierContext CTXT;
@@ -68,9 +67,6 @@ public class TypesInterfaceSpecifierTest {
     VLAN = ib.build();
     VLAN.updateInterfaceType(InterfaceType.VLAN);
 
-    VPN = ib.build();
-    VPN.updateInterfaceType(InterfaceType.VPN);
-
     CTXT =
         MockSpecifierContext.builder()
             .setConfigs(ImmutableMap.of(config.getHostname(), config))
@@ -102,7 +98,6 @@ public class TypesInterfaceSpecifierTest {
     assertThat(specifiedInterfaces("t.*"), equalTo(ImmutableSet.of(NodeInterfacePair.of(TUNNEL))));
     assertThat(specifiedInterfaces("u.*"), equalTo(ImmutableSet.of(NodeInterfacePair.of(UNKNOWN))));
     assertThat(specifiedInterfaces("vlan"), equalTo(ImmutableSet.of(NodeInterfacePair.of(VLAN))));
-    assertThat(specifiedInterfaces("vpn"), equalTo(ImmutableSet.of(NodeInterfacePair.of(VPN))));
     assertThat(
         specifiedInterfaces(".*"),
         equalTo(
@@ -114,7 +109,6 @@ public class TypesInterfaceSpecifierTest {
                 NodeInterfacePair.of(REDUNDANT),
                 NodeInterfacePair.of(TUNNEL),
                 NodeInterfacePair.of(UNKNOWN),
-                NodeInterfacePair.of(VLAN),
-                NodeInterfacePair.of(VPN))));
+                NodeInterfacePair.of(VLAN))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
@@ -153,10 +153,10 @@ public class ParboiledInterfaceSpecifierTest {
   @Test
   public void testResolveType() {
     _iface11B.setType(InterfaceType.VLAN);
-    _iface12B.setType(InterfaceType.VPN);
+    _iface12B.setType(InterfaceType.TUNNEL);
     build();
     assertThat(
-        new ParboiledInterfaceSpecifier(new TypeInterfaceAstNode("vpn")).resolve(_nodes, _ctxt),
+        new ParboiledInterfaceSpecifier(new TypeInterfaceAstNode("tunnel")).resolve(_nodes, _ctxt),
         contains(NodeInterfacePair.of(_iface12)));
   }
 

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -85618,7 +85618,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "VPN",
+            "type" : "TUNNEL",
             "vrf" : "default"
           },
           "vpn-vpn-ba2e34a8-2" : {
@@ -85646,7 +85646,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "VPN",
+            "type" : "TUNNEL",
             "vrf" : "default"
           }
         },


### PR DESCRIPTION
We never used VPN intentionally and we can't think of a reason to keep it. In the meantime, VPN processing
has bitrotted compared to TUNNEL processing.