### PR TITLE
Junos: remove incorrect todo

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -6406,7 +6406,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _currentAggregateRoute
         .getPolicies()
         .add(toComplexPolicyStatement(ctx.expr, AGGREGATE_ROUTE_POLICY));
-    todo(ctx);
   }
 
   @Override

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1520,13 +1520,6 @@
         "Comment" : "This feature is not currently supported"
       },
       {
-        "Filename" : "configs/juniper_routing_options",
-        "Line" : 9,
-        "Text" : "policy AGGREGATE_ROUTE_POLICY",
-        "Parser_Context" : "[roa_policy roa_common roa_route ro_aggregate s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
         "Filename" : "configs/juniper_security",
         "Line" : 16,
         "Text" : "destination-address-excluded",
@@ -1577,10 +1570,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 219 results",
+      "notes" : "Found 218 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 219
+      "numResults" : 218
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71519,16 +71519,6 @@
             }
           ]
         },
-        "configs/juniper_routing_options" : {
-          "Parse warnings" : [
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 9,
-              "Parser_Context" : "[roa_policy roa_common roa_route ro_aggregate s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "policy AGGREGATE_ROUTE_POLICY"
-            }
-          ]
-        },
         "configs/juniper_security" : {
           "Parse warnings" : [
             {


### PR DESCRIPTION
This todo was added in batfish/batfish#2734 but the functionality was implemented 2 days later
in batfish/batfish#2740; we just didn't delete the todo.

(I am sure there are sophisticated corner cases we don't yet handle, but the basic filtering
is indeed implemented and that's primarily what customers use.)