### PR TITLE
TransferBDD: MatchPeerAddress

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/ConfigAtomicPredicates.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/ConfigAtomicPredicates.java
@@ -15,6 +15,7 @@ import java.util.TreeSet;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -23,6 +24,7 @@ import org.batfish.minesweeper.aspath.AsPathRegexCollector;
 import org.batfish.minesweeper.aspath.RoutingPolicyCollector;
 import org.batfish.minesweeper.aspath.TunnelEncapsulationAttributeCollector;
 import org.batfish.minesweeper.communities.RoutePolicyStatementVarCollector;
+import org.batfish.minesweeper.env.PeerAddressCollector;
 import org.batfish.minesweeper.env.SourceVrfCollector;
 import org.batfish.minesweeper.env.TrackCollector;
 import org.batfish.minesweeper.utils.Tuple;
@@ -58,6 +60,9 @@ public final class ConfigAtomicPredicates {
   /** The list of next-hop interface names that appear in the given configuration. */
   private final List<String> _nextHopInterfaces;
 
+  /** The list of peer IP addresses that appear in the given configuration. */
+  private final List<Ip> _peerAddresses;
+
   /** The list of "tracks" that appear in the given configuration. */
   private final List<String> _tracks;
 
@@ -90,6 +95,7 @@ public final class ConfigAtomicPredicates {
     ImmutableSet.Builder<SymbolicAsPathRegex> allAsPathRegexesB = ImmutableSet.builder();
     Set<String> allTrackNames = new TreeSet<>();
     Set<String> allNextHopInterfaceNames = new TreeSet<>();
+    Set<Ip> allPeerAddresses = new TreeSet<>();
     Set<String> allSourceVrfNames = new TreeSet<>();
     ImmutableSet.Builder<TunnelEncapsulationAttribute> allTunnelEncapsulationAttributes =
         ImmutableSet.builder();
@@ -103,6 +109,7 @@ public final class ConfigAtomicPredicates {
       allAsPathRegexesB.addAll(findAllAsPathRegexes(ImmutableSet.of(), policies, config));
       allTrackNames.addAll(findAllTracks(policies, config));
       allNextHopInterfaceNames.addAll(findAllNextHopInterfaces(policies, config));
+      allPeerAddresses.addAll(findAllPeerAddresses(policies, config));
       allSourceVrfNames.addAll(findAllSourceVrfs(policies, config));
       allTunnelEncapsulationAttributes.addAll(findAllTunnelAttributes(policies, config));
     }
@@ -130,6 +137,7 @@ public final class ConfigAtomicPredicates {
     _nonStandardCommunityLiterals = ImmutableMap.copyOf(nonStandardCommunityLiterals);
     _asPathRegexAtomicPredicates = new AsPathRegexAtomicPredicates(allAsPathRegexesB.build());
     _nextHopInterfaces = ImmutableList.copyOf(allNextHopInterfaceNames);
+    _peerAddresses = ImmutableList.copyOf(allPeerAddresses);
     _tracks = ImmutableList.copyOf(allTrackNames);
     _sourceVrfs = ImmutableList.copyOf(allSourceVrfNames);
     _tunnelEncapsulationAttributes = ImmutableList.copyOf(allTunnelEncapsulationAttributes.build());
@@ -142,6 +150,7 @@ public final class ConfigAtomicPredicates {
     _asPathRegexAtomicPredicates =
         new AsPathRegexAtomicPredicates(other._asPathRegexAtomicPredicates);
     _nextHopInterfaces = other._nextHopInterfaces;
+    _peerAddresses = other._peerAddresses;
     _tracks = other._tracks;
     _sourceVrfs = other._sourceVrfs;
     _tunnelEncapsulationAttributes = other._tunnelEncapsulationAttributes;
@@ -254,6 +263,19 @@ public final class ConfigAtomicPredicates {
   }
 
   /**
+   * Collect up all peer IP addresses names that appear in the given policies.
+   *
+   * @param policies the set of policies to collect interface names from.
+   * @param configuration the batfish configuration
+   * @return a set of all peer IP addresses that appear
+   */
+  private static Set<Ip> findAllPeerAddresses(
+      Collection<RoutingPolicy> policies, Configuration configuration) {
+    return findAllMatchItems(
+        ImmutableSet.of(), policies, configuration, new PeerAddressCollector());
+  }
+
+  /**
    * Collect up all tracks that appear in the given policies.
    *
    * @param policies the set of policies to collect tracks from.
@@ -303,6 +325,10 @@ public final class ConfigAtomicPredicates {
 
   public List<String> getNextHopInterfaces() {
     return _nextHopInterfaces;
+  }
+
+  public List<Ip> getPeerAddresses() {
+    return _peerAddresses;
   }
 
   public List<String> getTracks() {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/ConfigAtomicPredicates.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/ConfigAtomicPredicates.java
@@ -60,7 +60,7 @@ public final class ConfigAtomicPredicates {
   /** The list of next-hop interface names that appear in the given configuration. */
   private final List<String> _nextHopInterfaces;
 
-  /** The list of peer IP addresses that appear in the given configuration. */
+  /** The list of peer IP addresses that appear in the given configuration's route policies. */
   private final List<Ip> _peerAddresses;
 
   /** The list of "tracks" that appear in the given configuration. */

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -225,7 +225,9 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
             // "none", since these are optional parts of a route
             + numBits(numNextHopInterfaces + 1)
             + numBits(numSourceVrfs + 1)
-            + numBits(numPeerAddresses)
+            // we track one extra value for the peer address to represent the case where the address
+            // is something other than the ones that are specifically matched upon in route policies
+            + numBits(numPeerAddresses + 1)
             + numTracks
             + BDDTunnelEncapsulationAttribute.numBitsFor(tunnelEncapsulationAttributes)
             + numBits(OriginType.values().length)
@@ -295,21 +297,19 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     addBitNames("as-path atomic predicates", len, idx, false);
     idx += len;
 
-    // we track one extra value for the next-hop interfaces and source VRFs, to represent
-    // "none", since these are optional parts of a route
+    // we use the value -1 below to denote that an optional value is not there, or (in the case of
+    // peer addresses) that the address is something other than one of the ones being tracked
     _nextHopInterfaces =
         new BDDDomain<>(
             factory,
-            IntStream.range(0, numNextHopInterfaces + 1).boxed().collect(Collectors.toList()),
+            IntStream.range(-1, numNextHopInterfaces).boxed().collect(Collectors.toList()),
             idx);
     len = _nextHopInterfaces.getInteger().size();
     addBitNames("next-hop interfaces", len, idx, false);
     idx += len;
     _sourceVrfs =
         new BDDDomain<>(
-            factory,
-            IntStream.range(0, numSourceVrfs + 1).boxed().collect(Collectors.toList()),
-            idx);
+            factory, IntStream.range(-1, numSourceVrfs).boxed().collect(Collectors.toList()), idx);
     len = _sourceVrfs.getInteger().size();
     addBitNames("source VRFs", len, idx, false);
     idx += len;
@@ -317,7 +317,7 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     _peerAddress =
         new BDDDomain<>(
             factory,
-            IntStream.range(0, numPeerAddresses).boxed().collect(Collectors.toList()),
+            IntStream.range(-1, numPeerAddresses).boxed().collect(Collectors.toList()),
             idx);
     len = _peerAddress.getInteger().size();
     addBitNames("peer address", len, idx, false);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
@@ -47,7 +47,7 @@ import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
 import org.batfish.minesweeper.bdd.BDDTunnelEncapsulationAttribute.Value;
 import org.batfish.minesweeper.bdd.BDDTunnelEncapsulationAttribute.Value.Type;
-import org.batfish.minesweeper.utils.RoutingEnvironment;
+import org.batfish.minesweeper.utils.RouteMapEnvironment;
 import org.batfish.question.testroutepolicies.Result;
 import org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer;
 
@@ -437,13 +437,13 @@ public class ModelGeneration {
 
   /**
    * Given a satisfying assignment to the constraints from symbolic route analysis, produce a
-   * concrete routing environment that is consistent with the assignment.
+   * concrete environment that is consistent with the assignment.
    *
    * @param model the satisfying assignment
    * @param configAPs an object that provides information about the community atomic predicates
-   * @return a routing environment that is consistent with the given model
+   * @return a environment that is consistent with the given model
    */
-  public static RoutingEnvironment satAssignmentToEnvironment(
+  public static RouteMapEnvironment satAssignmentToEnvironment(
       BDD model, ConfigAtomicPredicates configAPs) {
 
     BDDRoute r = new BDDRoute(model.getFactory(), configAPs);
@@ -453,7 +453,7 @@ public class ModelGeneration {
     // get the optional (and hence possibly null) source VRF
     String sourceVrf = optionalSatisfyingItem(configAPs.getSourceVrfs(), r.getSourceVrfs(), model);
 
-    return new RoutingEnvironment(successfulTracks::contains, sourceVrf);
+    return new RouteMapEnvironment(successfulTracks::contains, sourceVrf);
   }
 
   // Return a list of all items whose corresponding BDD is consistent with the given variable

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -48,7 +47,7 @@ import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
 import org.batfish.minesweeper.bdd.BDDTunnelEncapsulationAttribute.Value;
 import org.batfish.minesweeper.bdd.BDDTunnelEncapsulationAttribute.Value.Type;
-import org.batfish.minesweeper.utils.Tuple;
+import org.batfish.minesweeper.utils.RoutingEnvironment;
 import org.batfish.question.testroutepolicies.Result;
 import org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer;
 
@@ -438,14 +437,13 @@ public class ModelGeneration {
 
   /**
    * Given a satisfying assignment to the constraints from symbolic route analysis, produce a
-   * concrete environment (for now, a predicate on tracks as well as an optional source VRF) that is
-   * consistent with the assignment.
+   * concrete routing environment that is consistent with the assignment.
    *
    * @param model the satisfying assignment
    * @param configAPs an object that provides information about the community atomic predicates
-   * @return a pair of a predicate on tracks and an optional source VRF
+   * @return a routing environment that is consistent with the given model
    */
-  public static Tuple<Predicate<String>, String> satAssignmentToEnvironment(
+  public static RoutingEnvironment satAssignmentToEnvironment(
       BDD model, ConfigAtomicPredicates configAPs) {
 
     BDDRoute r = new BDDRoute(model.getFactory(), configAPs);
@@ -455,7 +453,7 @@ public class ModelGeneration {
     // get the optional (and hence possibly null) source VRF
     String sourceVrf = optionalSatisfyingItem(configAPs.getSourceVrfs(), r.getSourceVrfs(), model);
 
-    return new Tuple<>(successfulTracks::contains, sourceVrf);
+    return new RoutingEnvironment(successfulTracks::contains, sourceVrf);
   }
 
   // Return a list of all items whose corresponding BDD is consistent with the given variable

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -655,8 +655,7 @@ public class TransferBDD {
 
     } else if (expr instanceof MatchSourceVrf) {
       MatchSourceVrf msv = (MatchSourceVrf) expr;
-      // we add 1 to the index since 0 in the BDDDomain is used to represent the absence of a value
-      int index = _configAtomicPredicates.getSourceVrfs().indexOf(msv.getSourceVrf()) + 1;
+      int index = _configAtomicPredicates.getSourceVrfs().indexOf(msv.getSourceVrf());
       BDD sourceVrfPred = p.getData().getSourceVrfs().value(index);
       finalResults.add(result.setReturnValueBDD(sourceVrfPred).setReturnValueAccepted(true));
 
@@ -678,9 +677,7 @@ public class TransferBDD {
           mi.getInterfaces().stream()
               .map(
                   nhi -> {
-                    // we add 1 to the index since 0 in the BDDDomain is used to represent the
-                    // absence of a value
-                    int index = _configAtomicPredicates.getNextHopInterfaces().indexOf(nhi) + 1;
+                    int index = _configAtomicPredicates.getNextHopInterfaces().indexOf(nhi);
                     return p.getData().getNextHopInterfaces().value(index);
                   })
               .reduce(_factory.zero(), BDD::or);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -82,6 +82,7 @@ import org.batfish.datamodel.routing_policy.expr.MatchClusterListLength;
 import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
 import org.batfish.datamodel.routing_policy.expr.MatchMetric;
+import org.batfish.datamodel.routing_policy.expr.MatchPeerAddress;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.MatchSourceVrf;
@@ -684,6 +685,17 @@ public class TransferBDD {
                   })
               .reduce(_factory.zero(), BDD::or);
       finalResults.add(result.setReturnValueBDD(miPred).setReturnValueAccepted(true));
+
+    } else if (expr instanceof MatchPeerAddress) {
+      MatchPeerAddress mp = (MatchPeerAddress) expr;
+      Set<Ip> ips = mp.getPeers();
+      BDD matchPABDD =
+          _originalRoute.anyElementOf(
+              ips.stream()
+                  .map(ip -> _configAtomicPredicates.getPeerAddresses().indexOf(ip))
+                  .collect(Collectors.toSet()),
+              p.getData().getPeerAddress());
+      finalResults.add(result.setReturnValueBDD(matchPABDD).setReturnValueAccepted(true));
 
     } else {
       throw new UnsupportedOperationException(expr.toString());

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/env/PeerAddressCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/env/PeerAddressCollector.java
@@ -1,0 +1,23 @@
+package org.batfish.minesweeper.env;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.routing_policy.expr.MatchPeerAddress;
+import org.batfish.minesweeper.aspath.RoutingPolicyCollector;
+import org.batfish.minesweeper.utils.Tuple;
+
+/**
+ * Collect all peer IP addresses (see {@link MatchPeerAddress}) in a {@link
+ * org.batfish.datamodel.routing_policy.RoutingPolicy}.
+ */
+@ParametersAreNonnullByDefault
+public class PeerAddressCollector extends RoutingPolicyCollector<Ip> {
+  @Override
+  public Set<Ip> visitMatchPeerAddress(
+      MatchPeerAddress matchPeerAddress, Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.copyOf(matchPeerAddress.getPeers());
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -51,7 +51,7 @@ import org.batfish.minesweeper.bdd.BDDRoute;
 import org.batfish.minesweeper.bdd.BDDRouteDiff;
 import org.batfish.minesweeper.bdd.TransferBDD;
 import org.batfish.minesweeper.bdd.TransferReturn;
-import org.batfish.minesweeper.utils.RoutingEnvironment;
+import org.batfish.minesweeper.utils.RouteMapEnvironment;
 import org.batfish.minesweeper.utils.Tuple;
 import org.batfish.question.testroutepolicies.Result;
 import org.batfish.specifier.AllNodesNodeSpecifier;
@@ -277,7 +277,7 @@ public final class CompareRoutePoliciesUtils {
    * @return An input route, a predicate on tracks, and a (possibly null) source VRF that conform to
    *     the given constraints.
    */
-  private static @Nonnull Tuple<Bgpv4Route, RoutingEnvironment> constraintsToInputs(
+  private static @Nonnull Tuple<Bgpv4Route, RouteMapEnvironment> constraintsToInputs(
       BDD constraints, ConfigAtomicPredicates configAPs) {
     assert (!constraints.isZero());
     BDD model = constraintsToModel(constraints, configAPs);
@@ -540,7 +540,7 @@ public final class CompareRoutePoliciesUtils {
     }
 
     // we have found a difference, so let's get a concrete example of the difference
-    Tuple<Bgpv4Route, RoutingEnvironment> t = constraintsToInputs(finalConstraints, configAPs);
+    Tuple<Bgpv4Route, RouteMapEnvironment> t = constraintsToInputs(finalConstraints, configAPs);
     Result<BgpRoute, BgpRoute> refResult =
         simulatePolicy(policy, t.getFirst(), direction, t.getSecond(), path.getOutputRoute());
     Result<BgpRoute, BgpRoute> otherResult =

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -29,7 +29,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -52,6 +51,7 @@ import org.batfish.minesweeper.bdd.BDDRoute;
 import org.batfish.minesweeper.bdd.BDDRouteDiff;
 import org.batfish.minesweeper.bdd.TransferBDD;
 import org.batfish.minesweeper.bdd.TransferReturn;
+import org.batfish.minesweeper.utils.RoutingEnvironment;
 import org.batfish.minesweeper.utils.Tuple;
 import org.batfish.question.testroutepolicies.Result;
 import org.batfish.specifier.AllNodesNodeSpecifier;
@@ -277,7 +277,7 @@ public final class CompareRoutePoliciesUtils {
    * @return An input route, a predicate on tracks, and a (possibly null) source VRF that conform to
    *     the given constraints.
    */
-  private static @Nonnull Tuple<Bgpv4Route, Tuple<Predicate<String>, String>> constraintsToInputs(
+  private static @Nonnull Tuple<Bgpv4Route, RoutingEnvironment> constraintsToInputs(
       BDD constraints, ConfigAtomicPredicates configAPs) {
     assert (!constraints.isZero());
     BDD model = constraintsToModel(constraints, configAPs);
@@ -540,8 +540,7 @@ public final class CompareRoutePoliciesUtils {
     }
 
     // we have found a difference, so let's get a concrete example of the difference
-    Tuple<Bgpv4Route, Tuple<Predicate<String>, String>> t =
-        constraintsToInputs(finalConstraints, configAPs);
+    Tuple<Bgpv4Route, RoutingEnvironment> t = constraintsToInputs(finalConstraints, configAPs);
     Result<BgpRoute, BgpRoute> refResult =
         simulatePolicy(policy, t.getFirst(), direction, t.getSecond(), path.getOutputRoute());
     Result<BgpRoute, BgpRoute> otherResult =

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -65,7 +64,7 @@ import org.batfish.minesweeper.bdd.TransferBDD.Context;
 import org.batfish.minesweeper.bdd.TransferReturn;
 import org.batfish.minesweeper.communities.CommunityMatchExprVarCollector;
 import org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesQuestion.PathOption;
-import org.batfish.minesweeper.utils.Tuple;
+import org.batfish.minesweeper.utils.RoutingEnvironment;
 import org.batfish.question.testroutepolicies.Result;
 import org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer;
 import org.batfish.specifier.AllNodesNodeSpecifier;
@@ -170,8 +169,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
       BDD model = ModelGeneration.constraintsToModel(constraints, configAPs);
 
       Bgpv4Route inRoute = ModelGeneration.satAssignmentToBgpInputRoute(model, configAPs);
-      Tuple<Predicate<String>, String> env =
-          ModelGeneration.satAssignmentToEnvironment(model, configAPs);
+      RoutingEnvironment env = ModelGeneration.satAssignmentToEnvironment(model, configAPs);
 
       if (_action == PERMIT) {
         // the AS path on the produced route represents the AS path that will result after
@@ -212,7 +210,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
       RoutingPolicy policy,
       Bgpv4Route inRoute,
       Environment.Direction direction,
-      Tuple<Predicate<String>, String> env,
+      RoutingEnvironment env,
       BDDRoute bddRoute) {
     Result<Bgpv4Route, Bgpv4Route> simResult =
         TestRoutePoliciesAnswerer.simulatePolicyWithBgpRoute(
@@ -220,8 +218,8 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             inRoute,
             DUMMY_BGP_SESSION_PROPERTIES,
             direction,
-            env.getFirst(),
-            env.getSecond());
+            env.getSuccessfulTracks(),
+            env.getSourceVrf());
     return toQuestionResult(simResult, bddRoute);
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -64,7 +64,7 @@ import org.batfish.minesweeper.bdd.TransferBDD.Context;
 import org.batfish.minesweeper.bdd.TransferReturn;
 import org.batfish.minesweeper.communities.CommunityMatchExprVarCollector;
 import org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesQuestion.PathOption;
-import org.batfish.minesweeper.utils.RoutingEnvironment;
+import org.batfish.minesweeper.utils.RouteMapEnvironment;
 import org.batfish.question.testroutepolicies.Result;
 import org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer;
 import org.batfish.specifier.AllNodesNodeSpecifier;
@@ -169,7 +169,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
       BDD model = ModelGeneration.constraintsToModel(constraints, configAPs);
 
       Bgpv4Route inRoute = ModelGeneration.satAssignmentToBgpInputRoute(model, configAPs);
-      RoutingEnvironment env = ModelGeneration.satAssignmentToEnvironment(model, configAPs);
+      RouteMapEnvironment env = ModelGeneration.satAssignmentToEnvironment(model, configAPs);
 
       if (_action == PERMIT) {
         // the AS path on the produced route represents the AS path that will result after
@@ -210,7 +210,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
       RoutingPolicy policy,
       Bgpv4Route inRoute,
       Environment.Direction direction,
-      RoutingEnvironment env,
+      RouteMapEnvironment env,
       BDDRoute bddRoute) {
     Result<Bgpv4Route, Bgpv4Route> simResult =
         TestRoutePoliciesAnswerer.simulatePolicyWithBgpRoute(

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -32,10 +32,8 @@ import org.batfish.common.bdd.BDDInteger;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.AsSet;
-import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.Prefix;
@@ -88,20 +86,6 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
 
   private final @Nonnull Set<RegexConstraint> _communityRegexes;
   private final @Nonnull Set<RegexConstraint> _asPathRegexes;
-
-  /**
-   * Some route-map statements, notably setting the next hop to the address of the BGP peer, can
-   * only be simulated by Batfish if a {@link BgpSessionProperties} object exists in the {@link
-   * Environment}. For our purposes the specific property values can be anything, so we use this
-   * dummy object.
-   */
-  public static @Nonnull BgpSessionProperties DUMMY_BGP_SESSION_PROPERTIES =
-      BgpSessionProperties.builder()
-          .setLocalAs(1)
-          .setLocalIp(Ip.parse("1.1.1.1"))
-          .setRemoteAs(2)
-          .setRemoteIp(Ip.parse("2.2.2.2"))
-          .build();
 
   /** Helper class that contains both a row and and Bgpv4Route for a result */
   private static class RowAndRoute {
@@ -216,7 +200,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
         TestRoutePoliciesAnswerer.simulatePolicyWithBgpRoute(
             policy,
             inRoute,
-            DUMMY_BGP_SESSION_PROPERTIES,
+            env.getSessionProperties(),
             direction,
             env.getSuccessfulTracks(),
             env.getSourceVrf());

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/utils/RouteMapEnvironment.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/utils/RouteMapEnvironment.java
@@ -10,8 +10,8 @@ import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Ip;
 
 /**
- * Information about the environment that may be needed to evaluate a route map. Ultimately this can
- * include anything that a route map's behavior may depend upon, other than the route being
+ * Information about the environment that may be needed to evaluate a route map. Ultimately this
+ * should include anything that a route map's behavior may depend upon, other than the route being
  * processed.
  */
 public class RouteMapEnvironment {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/utils/RouteMapEnvironment.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/utils/RouteMapEnvironment.java
@@ -6,9 +6,11 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.Ip;
 
 /**
- * Information about the environment that is needed to evaluate a route map. Ultimately this can
+ * Information about the environment that may be needed to evaluate a route map. Ultimately this can
  * include anything that a route map's behavior may depend upon, other than the route being
  * processed.
  */
@@ -18,10 +20,26 @@ public class RouteMapEnvironment {
 
   private final @Nullable String _sourceVrf;
 
+  private final @Nonnull BgpSessionProperties _sessionProperties;
+
   public RouteMapEnvironment(
-      @Nullable Predicate<String> successfulTracks, @Nullable String sourceVrf) {
+      @Nullable Predicate<String> successfulTracks,
+      @Nullable String sourceVrf,
+      @Nonnull Ip remoteIp) {
     _successfulTracks = firstNonNull(successfulTracks, s -> false);
     _sourceVrf = sourceVrf;
+    // dummy values for required fields
+    _sessionProperties =
+        BgpSessionProperties.builder()
+            .setLocalAs(1)
+            .setLocalIp(Ip.parse("1.1.1.1"))
+            .setRemoteAs(2)
+            .setRemoteIp(remoteIp)
+            .build();
+  }
+
+  public @Nonnull BgpSessionProperties getSessionProperties() {
+    return _sessionProperties;
   }
 
   public @Nonnull Predicate<String> getSuccessfulTracks() {
@@ -38,12 +56,13 @@ public class RouteMapEnvironment {
       return false;
     }
     RouteMapEnvironment other = (RouteMapEnvironment) o;
-    return Objects.equals(_successfulTracks, other._successfulTracks)
+    return Objects.equals(_sessionProperties, other._sessionProperties)
+        && Objects.equals(_successfulTracks, other._successfulTracks)
         && Objects.equals(_sourceVrf, other._sourceVrf);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_successfulTracks, _sourceVrf);
+    return Objects.hash(_sessionProperties, _successfulTracks, _sourceVrf);
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/utils/RouteMapEnvironment.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/utils/RouteMapEnvironment.java
@@ -7,13 +7,18 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class RoutingEnvironment {
+/**
+ * Information about the environment that is needed to evaluate a route map. Ultimately this can
+ * include anything that a route map's behavior may depend upon, other than the route being
+ * processed.
+ */
+public class RouteMapEnvironment {
 
   private final @Nonnull Predicate<String> _successfulTracks;
 
   private final @Nullable String _sourceVrf;
 
-  public RoutingEnvironment(
+  public RouteMapEnvironment(
       @Nullable Predicate<String> successfulTracks, @Nullable String sourceVrf) {
     _successfulTracks = firstNonNull(successfulTracks, s -> false);
     _sourceVrf = sourceVrf;
@@ -29,10 +34,10 @@ public class RoutingEnvironment {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof RoutingEnvironment)) {
+    if (!(o instanceof RouteMapEnvironment)) {
       return false;
     }
-    RoutingEnvironment other = (RoutingEnvironment) o;
+    RouteMapEnvironment other = (RouteMapEnvironment) o;
     return Objects.equals(_successfulTracks, other._successfulTracks)
         && Objects.equals(_sourceVrf, other._sourceVrf);
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/utils/RoutingEnvironment.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/utils/RoutingEnvironment.java
@@ -1,0 +1,44 @@
+package org.batfish.minesweeper.utils;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class RoutingEnvironment {
+
+  private final @Nonnull Predicate<String> _successfulTracks;
+
+  private final @Nullable String _sourceVrf;
+
+  public RoutingEnvironment(
+      @Nullable Predicate<String> successfulTracks, @Nullable String sourceVrf) {
+    _successfulTracks = firstNonNull(successfulTracks, s -> false);
+    _sourceVrf = sourceVrf;
+  }
+
+  public @Nonnull Predicate<String> getSuccessfulTracks() {
+    return _successfulTracks;
+  }
+
+  public @Nullable String getSourceVrf() {
+    return _sourceVrf;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof RoutingEnvironment)) {
+      return false;
+    }
+    RoutingEnvironment other = (RoutingEnvironment) o;
+    return Objects.equals(_successfulTracks, other._successfulTracks)
+        && Objects.equals(_sourceVrf, other._sourceVrf);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_successfulTracks, _sourceVrf);
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
@@ -23,7 +23,7 @@ public class BDDRouteTest {
   @Test
   public void testEquals() {
     BDDFactory factory = JFactory.init(100, 100);
-    BDDRoute orig = new BDDRoute(factory, 3, 4, 5, 6, 2, ImmutableList.of());
+    BDDRoute orig = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
     BDDRoute admin = new BDDRoute(orig);
     admin.getAdminDist().setValue(1);
     BDDRoute asPathRegex = new BDDRoute(orig);
@@ -62,6 +62,8 @@ public class BDDRouteTest {
     tag.getTag().setValue(1);
     BDDRoute tracks = new BDDRoute(orig);
     tracks.getTracks()[0] = factory.one();
+    BDDRoute peerAddress = new BDDRoute(orig);
+    peerAddress.getPeerAddress().setValue(1);
     BDDRoute tunnelEncapsulationAttribute = new BDDRoute(orig);
     tunnelEncapsulationAttribute.getTunnelEncapsulationAttribute().setValue(Value.absent());
     BDDRoute unsupported = new BDDRoute(orig);
@@ -82,6 +84,7 @@ public class BDDRouteTest {
         .addEqualityGroup(nextHopSet)
         .addEqualityGroup(originType)
         .addEqualityGroup(ospfMetric)
+        .addEqualityGroup(peerAddress)
         .addEqualityGroup(prefix)
         .addEqualityGroup(prefixLength)
         .addEqualityGroup(prependedAses)
@@ -98,7 +101,7 @@ public class BDDRouteTest {
   @Test
   public void testWellFormedOriginType() {
     BDDFactory factory = JFactory.init(100, 100);
-    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, ImmutableList.of());
+    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
 
     BDD anyOriginType =
         factory.orAll(

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityAPDispositionsTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityAPDispositionsTest.java
@@ -18,7 +18,7 @@ public class CommunityAPDispositionsTest {
       new CommunityAPDispositions(
           4, IntegerSpace.of(1), IntegerSpace.builder().including(0, 2, 3).build());
   private final BDDRoute _bddRoute =
-      new BDDRoute(JFactory.init(100, 100), 4, 0, 0, 0, 0, ImmutableList.of());
+      new BDDRoute(JFactory.init(100, 100), 4, 0, 0, 0, 0, 0, ImmutableList.of());
 
   @Test
   public void testUnion() {

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDStateTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDStateTest.java
@@ -10,7 +10,7 @@ public class TransferBDDStateTest {
   @Test
   public void testEquals() {
     BDDFactory factory = JFactory.init(100, 100);
-    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, ImmutableList.of());
+    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
     TransferParam p = new TransferParam(route, false);
     TransferReturn ret = new TransferReturn(route, factory.one(), false);
     TransferResult r1 = new TransferResult(ret, false, false, false, false);

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -158,7 +158,7 @@ import org.batfish.minesweeper.OspfType;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
 import org.batfish.minesweeper.bdd.BDDTunnelEncapsulationAttribute.Value;
 import org.batfish.minesweeper.bdd.TransferBDD.Context;
-import org.batfish.minesweeper.utils.RoutingEnvironment;
+import org.batfish.minesweeper.utils.RouteMapEnvironment;
 import org.batfish.question.testroutepolicies.Result;
 import org.batfish.specifier.Location;
 import org.batfish.specifier.LocationInfo;
@@ -258,7 +258,7 @@ public class TransferBDDTest {
               .and(new BDDRoute(factory, _configAPs).wellFormednessConstraints(false));
       BDD fullModel = ModelGeneration.constraintsToModel(fullConstraints, _configAPs);
       AbstractRoute inRoute = ModelGeneration.satAssignmentToInputRoute(fullModel, _configAPs);
-      RoutingEnvironment env = ModelGeneration.satAssignmentToEnvironment(fullModel, _configAPs);
+      RouteMapEnvironment env = ModelGeneration.satAssignmentToEnvironment(fullModel, _configAPs);
 
       // simulate the input route in that environment;
       // for good measure we simulate twice, with the policy respectively considered an import and

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
@@ -159,7 +158,7 @@ import org.batfish.minesweeper.OspfType;
 import org.batfish.minesweeper.SymbolicAsPathRegex;
 import org.batfish.minesweeper.bdd.BDDTunnelEncapsulationAttribute.Value;
 import org.batfish.minesweeper.bdd.TransferBDD.Context;
-import org.batfish.minesweeper.utils.Tuple;
+import org.batfish.minesweeper.utils.RoutingEnvironment;
 import org.batfish.question.testroutepolicies.Result;
 import org.batfish.specifier.Location;
 import org.batfish.specifier.LocationInfo;
@@ -259,8 +258,7 @@ public class TransferBDDTest {
               .and(new BDDRoute(factory, _configAPs).wellFormednessConstraints(false));
       BDD fullModel = ModelGeneration.constraintsToModel(fullConstraints, _configAPs);
       AbstractRoute inRoute = ModelGeneration.satAssignmentToInputRoute(fullModel, _configAPs);
-      Tuple<Predicate<String>, String> env =
-          ModelGeneration.satAssignmentToEnvironment(fullModel, _configAPs);
+      RoutingEnvironment env = ModelGeneration.satAssignmentToEnvironment(fullModel, _configAPs);
 
       // simulate the input route in that environment;
       // for good measure we simulate twice, with the policy respectively considered an import and
@@ -271,8 +269,8 @@ public class TransferBDDTest {
               inRoute,
               DUMMY_BGP_SESSION_PROPERTIES,
               Environment.Direction.IN,
-              env.getFirst(),
-              env.getSecond());
+              env.getSuccessfulTracks(),
+              env.getSourceVrf());
 
       Result<? extends AbstractRoute, Bgpv4Route> outResult =
           simulatePolicy(
@@ -280,8 +278,8 @@ public class TransferBDDTest {
               inRoute,
               DUMMY_BGP_SESSION_PROPERTIES,
               Environment.Direction.OUT,
-              env.getFirst(),
-              env.getSecond());
+              env.getSuccessfulTracks(),
+              env.getSourceVrf());
 
       // convert the output route of each result to a form that can be compared against the results
       // of symbolic analysis

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -3,7 +3,6 @@ package org.batfish.minesweeper.bdd;
 import static org.batfish.minesweeper.ConfigAtomicPredicatesTestUtils.forDevice;
 import static org.batfish.minesweeper.bdd.AsPathMatchExprToRegexes.ASSUMED_MAX_AS_PATH_LENGTH;
 import static org.batfish.minesweeper.bdd.TransferBDD.isRelevantForDestination;
-import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer.DUMMY_BGP_SESSION_PROPERTIES;
 import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer.toSymbolicBgpOutputRoute;
 import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.simulatePolicy;
 import static org.batfish.question.testroutepolicies.TestRoutePoliciesAnswerer.toQuestionBgpRoute;
@@ -267,7 +266,7 @@ public class TransferBDDTest {
           simulatePolicy(
               policy,
               inRoute,
-              DUMMY_BGP_SESSION_PROPERTIES,
+              env.getSessionProperties(),
               Environment.Direction.IN,
               env.getSuccessfulTracks(),
               env.getSourceVrf());
@@ -276,7 +275,7 @@ public class TransferBDDTest {
           simulatePolicy(
               policy,
               inRoute,
-              DUMMY_BGP_SESSION_PROPERTIES,
+              env.getSessionProperties(),
               Environment.Direction.OUT,
               env.getSuccessfulTracks(),
               env.getSourceVrf());
@@ -1502,7 +1501,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths(policy);
 
     BDDRoute any = new BDDRoute(tbdd.getFactory(), _configAPs);
-    BDD sourcePred = any.getSourceVrfs().value(1);
+    BDD sourcePred = any.getSourceVrfs().value(0);
 
     assertEquals(
         paths,
@@ -1527,7 +1526,7 @@ public class TransferBDDTest {
     List<TransferReturn> paths = tbdd.computePaths(policy);
 
     BDDRoute any = new BDDRoute(tbdd.getFactory(), _configAPs);
-    BDD intPred = any.getNextHopInterfaces().value(1).or(any.getNextHopInterfaces().value(2));
+    BDD intPred = any.getNextHopInterfaces().value(0).or(any.getNextHopInterfaces().value(1));
 
     assertEquals(
         paths,
@@ -1564,7 +1563,7 @@ public class TransferBDDTest {
             new TransferReturn(any, peerPred1, true),
             new TransferReturn(any, peerPred2, false),
             new TransferReturn(any, peerPred1.not().and(peerPred2.not()), false)));
-    //    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -230,7 +230,7 @@ public class TransferBDDTest {
   }
 
   private BDDRoute anyRoute(BDDFactory factory) {
-    return new BDDRoute(factory, 1, 1, 0, 0, 0, ImmutableList.of());
+    return new BDDRoute(factory, 1, 1, 0, 0, 0, 0, ImmutableList.of());
   }
 
   private MatchPrefixSet matchPrefixSet(List<PrefixRange> prList) {

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferParamTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferParamTest.java
@@ -13,7 +13,7 @@ public class TransferParamTest {
   @Test
   public void testEquals() {
     BDDFactory factory = JFactory.init(100, 100);
-    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, ImmutableList.of());
+    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
     BDDRoute route2 = new BDDRoute(route);
     route2.getAdminDist().setValue(1);
     TransferParam p = new TransferParam(route, false);

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferResultTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferResultTest.java
@@ -10,7 +10,7 @@ public class TransferResultTest {
   @Test
   public void testEquals() {
     BDDFactory factory = JFactory.init(100, 100);
-    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, ImmutableList.of());
+    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
     TransferReturn r1 = new TransferReturn(route, factory.one(), false);
     TransferReturn r2 = new TransferReturn(route, factory.nithVar(0), false);
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferReturnTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferReturnTest.java
@@ -10,7 +10,7 @@ public class TransferReturnTest {
   @Test
   public void testEquals() {
     BDDFactory factory = JFactory.init(100, 100);
-    BDDRoute route1 = new BDDRoute(factory, 0, 0, 0, 0, 0, ImmutableList.of());
+    BDDRoute route1 = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
     BDDRoute route2 = new BDDRoute(route1);
     route2.getAdminDist().setValue(1);
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/env/PeerAddressCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/env/PeerAddressCollectorTest.java
@@ -1,0 +1,116 @@
+package org.batfish.minesweeper.env;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.Set;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.routing_policy.expr.Conjunction;
+import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
+import org.batfish.datamodel.routing_policy.expr.Disjunction;
+import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
+import org.batfish.datamodel.routing_policy.expr.MatchPeerAddress;
+import org.batfish.datamodel.routing_policy.expr.Not;
+import org.batfish.minesweeper.utils.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link org.batfish.minesweeper.env.PeerAddressCollector}. */
+public class PeerAddressCollectorTest {
+  private static final String HOSTNAME = "hostname";
+  private Configuration _baseConfig;
+  private PeerAddressCollector _collector;
+
+  private static final Ip ONES = Ip.parse("1.1.1.1");
+  private static final Ip TWOS = Ip.parse("2.2.2.2");
+  private static final Ip THREES = Ip.parse("3.3.3.3");
+  private static final MatchPeerAddress PA1 = new MatchPeerAddress(ONES, TWOS);
+  private static final MatchPeerAddress PA2 = new MatchPeerAddress(THREES);
+
+  @Before
+  public void setup() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder()
+            .setHostname(HOSTNAME)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _baseConfig = cb.build();
+    nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+
+    _collector = new PeerAddressCollector();
+  }
+
+  @Test
+  public void testVisitConjunction() {
+
+    Conjunction c = new Conjunction(ImmutableList.of(PA1, PA2));
+
+    Set<Ip> result = _collector.visitConjunction(c, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    Set<Ip> expected = ImmutableSet.of(ONES, TWOS, THREES);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testVisitConjunctionChain() {
+
+    ConjunctionChain cc = new ConjunctionChain(ImmutableList.of(PA1, PA2));
+
+    Set<Ip> result =
+        _collector.visitConjunctionChain(cc, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    Set<Ip> expected = ImmutableSet.of(ONES, TWOS, THREES);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testVisitDisjunction() {
+
+    Disjunction d = new Disjunction(ImmutableList.of(PA1, PA2));
+
+    Set<Ip> result = _collector.visitDisjunction(d, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    Set<Ip> expected = ImmutableSet.of(ONES, TWOS, THREES);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testVisitFirstMatchChain() {
+
+    FirstMatchChain fmc = new FirstMatchChain(ImmutableList.of(PA1, PA2));
+
+    Set<Ip> result =
+        _collector.visitFirstMatchChain(fmc, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    Set<Ip> expected = ImmutableSet.of(ONES, TWOS, THREES);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testVisitMatchPeerAddress() {
+    assertEquals(
+        _collector.visitMatchPeerAddress(PA1, new Tuple<>(new HashSet<>(), _baseConfig)),
+        ImmutableSet.of(ONES, TWOS));
+  }
+
+  @Test
+  public void testVisitNot() {
+
+    Not n = new Not(PA1);
+
+    Set<Ip> result = _collector.visitNot(n, new Tuple<>(new HashSet<>(), _baseConfig));
+
+    Set<Ip> expected = ImmutableSet.of(ONES, TWOS);
+
+    assertEquals(expected, result);
+  }
+}


### PR DESCRIPTION
Adds support for the MatchPeerAddress statement to the symbolic routing analysis.