### PR TITLE
BooleanExprVarCollector: handle missing policies in CallExpr

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutingPolicyCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutingPolicyCollector.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.as_path.MatchAsPath;
 import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
 import org.batfish.datamodel.routing_policy.communities.SetCommunities;
@@ -273,9 +274,12 @@ public class RoutingPolicyCollector<T>
     // Otherwise update the set of seen policies and recurse.
     arg.getFirst().add(callExpr.getCalledPolicyName());
 
-    return visitAll(
-        arg.getSecond().getRoutingPolicies().get(callExpr.getCalledPolicyName()).getStatements(),
-        arg);
+    RoutingPolicy routingPolicy =
+        arg.getSecond().getRoutingPolicies().get(callExpr.getCalledPolicyName());
+    if (routingPolicy == null) {
+      return ImmutableSet.of();
+    }
+    return visitAll(routingPolicy.getStatements(), arg);
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.as_path.MatchAsPath;
 import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
@@ -66,13 +67,12 @@ public class BooleanExprVarCollector
     // Otherwise update the set of seen policies and recurse.
     arg.getFirst().add(callExpr.getCalledPolicyName());
 
-    return new RoutePolicyStatementVarCollector()
-        .visitAll(
-            arg.getSecond()
-                .getRoutingPolicies()
-                .get(callExpr.getCalledPolicyName())
-                .getStatements(),
-            arg);
+    RoutingPolicy routingPolicy =
+        arg.getSecond().getRoutingPolicies().get(callExpr.getCalledPolicyName());
+    if (routingPolicy == null) {
+      return ImmutableSet.of();
+    }
+    return new RoutePolicyStatementVarCollector().visitAll(routingPolicy.getStatements(), arg);
   }
 
   @Override

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/RoutingPolicyCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/aspath/RoutingPolicyCollectorTest.java
@@ -1,5 +1,7 @@
 package org.batfish.minesweeper.aspath;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -19,6 +21,7 @@ import org.batfish.datamodel.routing_policy.as_path.AsPathMatchRegex;
 import org.batfish.datamodel.routing_policy.as_path.InputAsPath;
 import org.batfish.datamodel.routing_policy.as_path.MatchAsPath;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
+import org.batfish.datamodel.routing_policy.expr.CallExpr;
 import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
 import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
 import org.batfish.datamodel.routing_policy.expr.NextHopIp;
@@ -151,5 +154,13 @@ public class RoutingPolicyCollectorTest {
         _asPathCollector.visitAll(
             policy.getStatements(), new Tuple<>(new HashSet<>(), _baseConfig));
     assertEquals(ifResult, callStmtResult);
+  }
+
+  @Test
+  public void testVisitCallMissingPolicy() {
+    assertThat(
+        _asPathCollector.visitCallExpr(
+            new CallExpr("foo"), new Tuple<>(new HashSet<>(), _baseConfig)),
+        empty());
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/BooleanExprVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/BooleanExprVarCollectorTest.java
@@ -20,6 +20,7 @@ import org.batfish.datamodel.routing_policy.communities.InputCommunities;
 import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
 import org.batfish.datamodel.routing_policy.communities.SetCommunities;
+import org.batfish.datamodel.routing_policy.expr.CallExpr;
 import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.ConjunctionChain;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
@@ -201,5 +202,12 @@ public class BooleanExprVarCollectorTest {
             .collect(ImmutableSet.toImmutableSet());
 
     assertEquals(expected, result);
+  }
+
+  @Test
+  public void testVisitCallMissingPolicy() {
+    assertThat(
+        _varCollector.visitCallExpr(new CallExpr("foo"), new Tuple<>(new HashSet<>(), _baseConfig)),
+        empty());
   }
 }


### PR DESCRIPTION
Not all callexprs are guaranteed to be well-formed 