### PR TITLE
Add support for Juniper recovery-timeout command

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2326,6 +2326,8 @@ RECEIVE: 'receive';
 RECORD_LIFETIME: 'record-lifetime';
 RECORD_ROUTE_OPTION: 'record-route-option';
 
+RECOVERY_TIMEOUT: 'recovery-timeout';
+
 REDIRECT: 'redirect';
 
 REDIRECT_FOR_HOST: 'redirect-for-host';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -352,8 +352,14 @@ if_ethernet_switching
       | ife_interface_mode
       | ife_native_vlan_id
       | ife_port_mode
+      | ife_recovery_timeout_null
       | ife_vlan
    )
+;
+
+ife_recovery_timeout_null
+:
+   RECOVERY_TIMEOUT uint16 null_filler
 ;
 
 if_inet

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8643,6 +8643,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testRecoveryTimeout() {
+    // Should not crash.
+    parseConfig("recovery-timeout");
+  }
+
+  @Test
   public void testJuniperAsPathExclamationRegex() {
     Configuration c = parseConfig("juniper-as-path-exclamation-regex");
     RoutingPolicy asPathGroupPolicy1 = c.getRoutingPolicies().get("AS_PATH_GROUP_POLICY1");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/recovery-timeout
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/recovery-timeout
@@ -1,0 +1,3 @@
+#
+set system host-name recovery-timeout
+set interfaces ge-0/0/0 family ethernet-switching recovery-timeout 180


### PR DESCRIPTION
Implements the Juniper recovery-timeout command as a null rule under the family
ethernet-switching context. This command is used to specify the recovery
timeout for interfaces with ethernet-switching enabled.