### PR TITLE
Differentiate risky parse warnings from other parse warnings

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.FormatMethod;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -47,7 +48,11 @@ public class Warnings implements Serializable {
     }
   }
 
+  // Indicates that this warning will cause the config to not successfully commit onto the device
   public static final String FATAL_FLAG = "FATAL: ";
+  // Indicates that this warning is for a construct on the device that may result in unexpected
+  // undesired behavior
+  public static final String RISKY_FLAG = "RISK: ";
 
   public static final String TAG_PEDANTIC = "MISCELLANEOUS";
 
@@ -202,6 +207,14 @@ public class Warnings implements Serializable {
       }
     }
     return fatalWarnings;
+  }
+
+  /** Get all red flag warnings that are fatal error */
+  @JsonIgnore
+  public List<ParseWarning> getRiskyParseWarnings() {
+    return _parseWarnings.stream()
+        .filter(warning -> warning.getComment().startsWith(RISKY_FLAG))
+        .collect(ImmutableList.toImmutableList());
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2325,8 +2325,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       warn(
           ctx,
           String.format(
-              "Overwriting existing %s %s",
-              cleared.size() > 1 ? "thens" : "then", String.join(", ", cleared)));
+              Warnings.RISKY_FLAG + "Overwriting existing %s %s",
+              cleared.size() > 1 ? "thens" : "then",
+              String.join(", ", cleared)));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/CommunityMemberParseResult.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/CommunityMemberParseResult.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.LargeCommunity;
@@ -52,7 +53,8 @@ public class CommunityMemberParseResult {
     String warning = null;
     if (!unintendedMatches.isEmpty()) {
       warning =
-          "RISK: Community regex "
+          Warnings.RISKY_FLAG
+              + "Community regex "
               + text
               + " allows longer matches such as "
               + String.join(" and ", unintendedMatches);
@@ -114,8 +116,9 @@ public class CommunityMemberParseResult {
         new CommunityMemberParseResult(
             new LiteralCommunityMember(community),
             String.format(
-                "RISK: Community string '%s' is interpreted as '%s'",
-                originalText, normalizedText)));
+                Warnings.RISKY_FLAG + "Community string '%s' is interpreted as '%s'",
+                originalText,
+                normalizedText)));
   }
 
   /** Returns a {@link Community} if {@code text} can be parsed as one, or else {@code null}. */

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8741,5 +8741,43 @@ public final class FlatJuniperGrammarTest {
                     + " set action")));
   }
 
+  @Test
+  public void testRiskyRegexWarnings() throws IOException {
+    String hostname = "risky-regexes";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    List<ParseWarning> riskyParseWarnings =
+        batfish
+            .loadParseVendorConfigurationAnswerElement(batfish.getSnapshot())
+            .getWarnings()
+            .get("configs/" + hostname)
+            .getRiskyParseWarnings();
+
+    assertThat(
+        riskyParseWarnings,
+        containsInAnyOrder(
+            hasComment(
+                "RISK: Community regex 8075:[1][0][0-3,5-9][0-9][0-9]$ allows longer matches such"
+                    + " as 18075:10000"),
+            hasComment("RISK: Community string ':111' is interpreted as '0:111'")));
+  }
+
+  @Test
+  public void testCommunityOverlapWarnings() throws IOException {
+    String hostname = "overlapping-policy";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    List<ParseWarning> riskyParseWarnings =
+        batfish
+            .loadParseVendorConfigurationAnswerElement(batfish.getSnapshot())
+            .getWarnings()
+            .get("configs/" + hostname)
+            .getRiskyParseWarnings();
+
+    assertThat(
+        riskyParseWarnings,
+        containsInAnyOrder(hasComment("RISK: Overwriting existing then community set")));
+  }
+
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/overlapping-policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/overlapping-policy
@@ -1,0 +1,11 @@
+#
+set version aaa
+set system host-name overlapping-policy
+#
+set policy-options community LOC1 members 1
+set policy-options community LOC2 members 2
+set policy-options community LOC3 members 3
+set policy-options policy-statement p1 term t1 then community set LOC1
+set policy-options policy-statement p1 term t1 then community set LOC2
+set policy-options policy-statement p2 term t1 then community set LOC2
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/risky-regexes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/risky-regexes
@@ -1,0 +1,9 @@
+#
+set version aaa
+set system host-name risky-regexes
+#
+set policy-options community COMM_ALL members "target:123456L:.*$"
+set policy-options community COMM_RISKY_LONG_MATCHES members "8075:[1][0][0-3,5-9][0-9][0-9]$"
+set policy-options community COMM_REGEX members "^_200_5?(1-3)*\?:[^3]+$"
+set policy-options community COMM_RISKY_INTERPRETED members ":111"
+#

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1489,21 +1489,21 @@
         "Line" : 23,
         "Text" : "as-path-prepend 123.456",
         "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-        "Comment" : "Overwriting existing then as-path-prepend"
+        "Comment" : "RISK: Overwriting existing then as-path-prepend"
       },
       {
         "Filename" : "configs/juniper_policy_statement",
         "Line" : 24,
         "Text" : "as-path-prepend \"456 789",
         "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-        "Comment" : "Overwriting existing then as-path-prepend"
+        "Comment" : "RISK: Overwriting existing then as-path-prepend"
       },
       {
         "Filename" : "configs/juniper_policy_statement",
         "Line" : 25,
         "Text" : "as-path-prepend \"456 123.1 789",
         "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-        "Comment" : "Overwriting existing then as-path-prepend"
+        "Comment" : "RISK: Overwriting existing then as-path-prepend"
       },
       {
         "Filename" : "configs/juniper_policy_statement",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71484,19 +71484,19 @@
               "Text" : "rib inet6.0"
             },
             {
-              "Comment" : "Overwriting existing then as-path-prepend",
+              "Comment" : "RISK: Overwriting existing then as-path-prepend",
               "Line" : 23,
               "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "as-path-prepend 123.456"
             },
             {
-              "Comment" : "Overwriting existing then as-path-prepend",
+              "Comment" : "RISK: Overwriting existing then as-path-prepend",
               "Line" : 24,
               "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "as-path-prepend \"456 789"
             },
             {
-              "Comment" : "Overwriting existing then as-path-prepend",
+              "Comment" : "RISK: Overwriting existing then as-path-prepend",
               "Line" : 25,
               "Parser_Context" : "[popst_as_path_prepend popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "as-path-prepend \"456 123.1 789"


### PR DESCRIPTION
Parse warnings sometimes indicate constructs that Batfish just doesn't support - I want to differentiate the case where the warning indicates a potential risk of unexpected behavior in the config.