### PR TITLE
Junos: fix incorrect fatal warning on missing interface

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2994,8 +2994,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       }
       if (_currentOspfSettings == null) {
         warn(ctx, "Could not find interface with ip address: " + ip);
-        // create dummy object to store what follows; this dangling object will be ignore
+        // create dummy object to store what follows; this dangling object will be ignored
         _currentOspfSettings = new OspfInterfaceSettings(Ip.ZERO);
+        return;
       }
     } else {
       Interface iface = initRoutingInterface(ctx.id);

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -7885,6 +7885,18 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testOspfAreaInterfaceIpMissing() throws IOException {
+    String hostname = "ospf-area-interface-ip-missing";
+    String fileKey = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    ParseVendorConfigurationAnswerElement pvcae =
+        batfish.loadParseVendorConfigurationAnswerElement(batfish.getSnapshot());
+
+    assertThat(pvcae.getWarnings().get(fileKey).getFatalRedFlagWarnings(), empty());
+  }
+
+  @Test
   public void testConditionExtraction() {
     String hostname = "juniper-condition";
     JuniperConfiguration jc = parseJuniperConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-area-interface-ip-missing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-area-interface-ip-missing
@@ -1,0 +1,5 @@
+#
+set system host-name ospf-area-interface-ip-missing
+#
+set protocols ospf area 255.255.255.255 interface 1.2.3.4 metric 17
+#


### PR DESCRIPTION
When the interface that has an IP isn't found, we should just stop rather than
continue trying to look for bugs.

---

**Stack**:
- #9425
- #9424
- #9423 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*