### PR TITLE
Update Cisco XR acl grammar to support single line access-list entries

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -452,12 +452,12 @@ public final class XrGrammarTest {
     assertThat(c.getIpv4Acls(), hasKeys("acl"));
     Ipv4AccessList acl = c.getIpv4Acls().get("acl");
     // TODO: get the remark line in there too.
-    assertThat(acl.getLines(), aMapWithSize(9));
+    assertThat(acl.getLines(), aMapWithSize(11));
 
     assertThat(c.getIpv6Acls(), hasKeys("aclv6"));
     Ipv6AccessList aclv6 = c.getIpv6Acls().get("aclv6");
     // TODO: get the remark line in there too.
-    assertThat(aclv6.getLines(), hasSize(4));
+    assertThat(aclv6.getLines(), hasSize(5));
   }
 
   @Test
@@ -466,10 +466,10 @@ public final class XrGrammarTest {
     assertThat(c.getIpAccessLists(), hasKeys("acl"));
     IpAccessList acl = c.getIpAccessLists().get("acl");
     // TODO: get the remark line in there too.
-    assertThat(acl.getLines(), hasSize(9));
+    assertThat(acl.getLines(), hasSize(11));
     {
       // Test reordering - (20, 30, 31, rather than 31 last)
-      assertThat(acl.getLines().get(2).getName(), equalTo("31 permit ipv4 31.31.31.31/32 any"));
+      assertThat(acl.getLines().get(2).getName(), equalTo("permit ipv4 31.31.31.31/32 any"));
     }
     {
       // Test fragments.
@@ -3777,12 +3777,12 @@ public final class XrGrammarTest {
                     hasComment(
                         "ACL based forwarding can only be configured on an ACL line with a permit"
                             + " action"),
-                    hasText("100 deny tcp any host 10.0.10.1 nexthop1 ipv4 10.10.10.10")),
+                    hasText("deny tcp any host 10.0.10.1 nexthop1 ipv4 10.10.10.10")),
                 allOf(
                     hasComment(
                         "ACL based forwarding can only be configured on an ACL line with a permit"
                             + " action"),
-                    hasText("100 deny tcp any host 1111:: nexthop1 ipv6 1112::")))));
+                    hasText("deny tcp any host 1111:: nexthop1 ipv6 1112::")))));
   }
 
   /** Test conversion of ACL based forwarding constructs in IP access-lists */
@@ -3916,16 +3916,16 @@ public final class XrGrammarTest {
         hasRedFlagWarning(
             hostname,
             containsString(
-                "Access-list lines with different nexthop VRFs are not yet supported. Line '60"
-                    + " permit tcp any host 10.0.1.1 nexthop1 vrf vrf1 ipv4 10.0.11.1 nexthop2 vrf"
+                "Access-list lines with different nexthop VRFs are not yet supported. Line '"
+                    + "permit tcp any host 10.0.1.1 nexthop1 vrf vrf1 ipv4 10.0.11.1 nexthop2 vrf"
                     + " vrfOther ipv4 10.0.11.2' in ACL aclv4 will be ignored.")));
     assertThat(
         ccae,
         hasRedFlagWarning(
             hostname,
             containsString(
-                "Access-list lines with different nexthop VRFs are not yet supported. Line '70"
-                    + " permit tcp any host 10.0.1.1 nexthop1 vrf vrf1 ipv4 10.0.11.1 nexthop2 vrf"
+                "Access-list lines with different nexthop VRFs are not yet supported. Line '"
+                    + "permit tcp any host 10.0.1.1 nexthop1 vrf vrf1 ipv4 10.0.11.1 nexthop2 vrf"
                     + " vrf1 ipv4 10.0.11.2 nexthop3 vrf vrfOther ipv4 10.0.11.3' in ACL aclv4 will"
                     + " be ignored.")));
     assertThat(
@@ -3933,16 +3933,16 @@ public final class XrGrammarTest {
         hasRedFlagWarning(
             hostname,
             containsString(
-                "Access-list lines with different nexthop VRFs are not yet supported. Line '80"
-                    + " permit tcp any host 10.0.1.1 nexthop1 vrf vrf1 ipv4 10.0.11.1 nexthop2 ipv4"
+                "Access-list lines with different nexthop VRFs are not yet supported. Line '"
+                    + "permit tcp any host 10.0.1.1 nexthop1 vrf vrf1 ipv4 10.0.11.1 nexthop2 ipv4"
                     + " 10.0.11.2' in ACL aclv4 will be ignored.")));
     assertThat(
         ccae,
         hasRedFlagWarning(
             hostname,
             containsString(
-                "Access-list lines with different nexthop VRFs are not yet supported. Line '90"
-                    + " permit tcp any host 10.0.1.1 nexthop1 ipv4 10.0.11.1 nexthop2 vrf vrfOther"
+                "Access-list lines with different nexthop VRFs are not yet supported. Line '"
+                    + "permit tcp any host 10.0.1.1 nexthop1 ipv4 10.0.11.1 nexthop2 vrf vrfOther"
                     + " ipv4 10.0.11.2' in ACL aclv4 will be ignored.")));
     assertThat(
         ccae,

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/acl
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/acl
@@ -17,12 +17,21 @@ ipv4 access-list acl
  ! One out of order line should be reordered up top.
  31 permit ipv4 31.31.31.31/32 any
 !
+ipv4 access-list acl remark this is a remark
+ipv4 access-list acl permit tcp host 1.1.1.1 any eq 22
+ipv4 access-list acl permit tcp host 2.2.2.2 any eq 22
+ipv4 access-list acl remark *new remark*
+
 ipv6 access-list aclv6
  10 remark Some remark
  20 permit tcp any 1111:1111:1111:1111::/64 eq 8080
  30 permit tcp any 1111:1111:1111:1111::/64 eq www
  40 permit udp 1111:1111::/32 2222:2222:2222:2222::/64 eq 8080
  50 permit icmpv6 any fe80::/10
+!
+ipv6 access-list aclv6 remark Some remark
+ipv6 access-list aclv6 permit tcp any 1111:1111:1111:1111::/64 eq 8080
+ipv6 access-list aclv6 remark Some remark
 !
 !
 ! test no:


### PR DESCRIPTION
Added support for inline `access-list` entries in the ACL config where there was previously only grammar rules for multi-line variants. This behavior isn't in [Cisco's XR documentation](https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r4-0/addr_serv/configuration/guide/ic40xr12kbook_chapter1.html); however, it was observed to be sufficient after verifying on an emulated device.