### PR TITLE
TransferBDDValidation: Only validate peer groups

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -1457,7 +1457,24 @@ public class TransferBDD {
    * org.batfish.question.testroutepolicies.TestRoutePoliciesQuestion}.
    */
   public List<TransferReturn> computePaths(RoutingPolicy policy) {
-    return computePaths(policy.getStatements(), Context.forPolicy(policy));
+    return computePaths(policy.getStatements(), Context.forPolicy(policy), true);
+  }
+
+  /**
+   * The results of symbolic route-map analysis: one {@link
+   * org.batfish.minesweeper.bdd.TransferReturn} per execution path through the given route map. The
+   * list of paths is unordered, and by construction each path is unique, as each path has a unique
+   * condition under which it is taken (the BDD in the TransferResult). The particular statements
+   * executed along a given path are not included in this representation but can be reconstructed by
+   * simulating one route that takes this path using {@link
+   * org.batfish.question.testroutepolicies.TestRoutePoliciesQuestion}.
+   *
+   * <p>If {@code retainAllPaths} is {@code false}, then paths with the same output behavior (aka,
+   * {@link TransferResult} is equivalent except for the input conditions under which the path is
+   * reached) are combined (by unioning those input conditions).
+   */
+  public List<TransferReturn> computePaths(RoutingPolicy policy, boolean retainAllPaths) {
+    return computePaths(policy.getStatements(), Context.forPolicy(policy), retainAllPaths);
   }
 
   /**
@@ -1469,12 +1486,17 @@ public class TransferBDD {
    * <p>The particular statements executed along a given path are not included in this
    * representation but can be reconstructed by simulating one route that takes this path using
    * {@link org.batfish.question.testroutepolicies.TestRoutePoliciesQuestion}.
+   *
+   * <p>If {@code retainAllPaths} is {@code false}, then paths with the same output behavior (aka,
+   * {@link TransferResult} is equivalent except for the input conditions under which the path is
+   * reached) are combined (by unioning those input conditions).
    */
-  public List<TransferReturn> computePaths(List<Statement> statements, Context context) {
+  public List<TransferReturn> computePaths(
+      List<Statement> statements, Context context, boolean retainAllPaths) {
     BDDRoute o = new BDDRoute(_factory, _configAtomicPredicates);
     TransferParam p = new TransferParam(o, false);
     TransferBDDState state = new TransferBDDState(p, new TransferResult(p.getData()));
-    return computePaths(state, statements, context, true).stream()
+    return computePaths(state, statements, context, retainAllPaths).stream()
         .map(TransferResult::getReturnValue)
         .collect(ImmutableList.toImmutableList());
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -507,7 +507,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     Context context = TransferBDD.Context.forPolicy(policy);
     try {
       tbdd = new TransferBDD(configAPs);
-      paths = tbdd.computePaths(policy.getStatements(), context);
+      paths = tbdd.computePaths(policy.getStatements(), context, true);
     } catch (Exception e) {
       throw new BatfishException(
           "Unexpected error analyzing policy "

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationAnswerer.java
@@ -128,7 +128,7 @@ public final class TransferBDDValidationAnswerer extends Answerer {
           continue;
         }
 
-        // Track peer groups we've already processed to avoid duplicates
+        // Track peer groups and policies that we've already validated to avoid duplicates
         Set<String> peerGroupsSeen = new HashSet<>();
         Set<List<Statement>> importPoliciesSeen = new HashSet<>();
         Set<List<Statement>> exportPoliciesSeen = new HashSet<>();
@@ -140,11 +140,11 @@ public final class TransferBDDValidationAnswerer extends Answerer {
             continue;
           }
 
-          // Add this peer group to the set of processed peer groups
           peerGroupsSeen.add(peer.getGroup());
 
           if (peer.getIpv4UnicastAddressFamily() != null) {
 
+            // Validate the import policy
             if (peer.getIpv4UnicastAddressFamily().getImportPolicy() != null) {
               String importPolicyName = peer.getIpv4UnicastAddressFamily().getImportPolicy();
               RoutingPolicy importPolicy = c.getRoutingPolicies().get(importPolicyName);
@@ -157,6 +157,7 @@ public final class TransferBDDValidationAnswerer extends Answerer {
               rows.addAll(validatePaths(importPolicy, paths, tbdd, Environment.Direction.IN));
             }
 
+            // Validate the export policy
             if (peer.getIpv4UnicastAddressFamily().getExportPolicy() != null) {
               String exportPolicyName = peer.getIpv4UnicastAddressFamily().getExportPolicy();
               RoutingPolicy exportPolicy = c.getRoutingPolicies().get(exportPolicyName);
@@ -253,8 +254,8 @@ public final class TransferBDDValidationAnswerer extends Answerer {
         Map<Boolean, List<BDD>> partitioned =
             Arrays.stream(commAPs).collect(Collectors.partitioningBy(support::diffSat));
         List<BDD> unassigned = partitioned.get(true);
-        // choose a random subset of these community APs of sufficient size and require them to be
-        // false
+        // choose a random subset of the unassigned community APs of sufficient size and require
+        // them to be false
         Collections.shuffle(unassigned, _random);
         int minFalse = unassigned.size() - (MAX_COMMUNITIES_SIZE - numPos);
         BDD mustBeFalse =

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationQuestion.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationQuestion.java
@@ -13,38 +13,34 @@ import org.batfish.datamodel.questions.Question;
  * A question for validating symbolic route analysis ({@link
  * org.batfish.minesweeper.bdd.TransferBDD}) against concrete route simulation ({@link
  * org.batfish.question.testroutepolicies.TestRoutePoliciesQuestion}).
+ *
+ * <p>This question validates only the route policies that are used as import or export policies on
+ * BGP peer groups.
  */
 @ParametersAreNonnullByDefault
 public final class TransferBDDValidationQuestion extends Question {
 
   private static final String PROP_NODES = "nodes";
-  private static final String PROP_POLICIES = "policies";
-
   private static final String PROP_SEED = "seed";
 
   private final @Nullable String _nodes;
-  private final @Nullable String _policies;
 
   // A seed for random-number generation
   private final long _seed;
 
   public TransferBDDValidationQuestion() {
-    this(null, null, new Random().nextLong());
+    this(null, new Random().nextLong());
   }
 
-  public TransferBDDValidationQuestion(
-      @Nullable String nodes, @Nullable String policies, long seed) {
+  public TransferBDDValidationQuestion(@Nullable String nodes, long seed) {
     _nodes = nodes;
-    _policies = policies;
     _seed = seed;
   }
 
   @JsonCreator
   private static TransferBDDValidationQuestion jsonCreator(
-      @JsonProperty(PROP_NODES) @Nullable String nodes,
-      @JsonProperty(PROP_POLICIES) @Nullable String policies,
-      @JsonProperty(PROP_SEED) long seed) {
-    return new TransferBDDValidationQuestion(nodes, policies, seed);
+      @JsonProperty(PROP_NODES) @Nullable String nodes, @JsonProperty(PROP_SEED) long seed) {
+    return new TransferBDDValidationQuestion(nodes, seed);
   }
 
   @JsonIgnore
@@ -62,11 +58,6 @@ public final class TransferBDDValidationQuestion extends Question {
   @JsonProperty(PROP_NODES)
   public @Nullable String getNodes() {
     return _nodes;
-  }
-
-  @JsonProperty(PROP_POLICIES)
-  public @Nullable String getPolicies() {
-    return _policies;
   }
 
   @JsonProperty(PROP_SEED)

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationQuestion.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationQuestion.java
@@ -14,33 +14,47 @@ import org.batfish.datamodel.questions.Question;
  * org.batfish.minesweeper.bdd.TransferBDD}) against concrete route simulation ({@link
  * org.batfish.question.testroutepolicies.TestRoutePoliciesQuestion}).
  *
- * <p>This question validates only the route policies that are used as import or export policies on
- * BGP peer groups.
+ * <p>This question currently validates only the route policies that are used as import or export
+ * policies on BGP peers.
  */
 @ParametersAreNonnullByDefault
 public final class TransferBDDValidationQuestion extends Question {
 
   private static final String PROP_NODES = "nodes";
+  private static final String PROP_POLICIES = "policies";
+  private static final String PROP_RETAIN_ALL_PATHS = "retainAllPaths";
   private static final String PROP_SEED = "seed";
 
   private final @Nullable String _nodes;
+  private final @Nullable String _policies;
+
+  // If true, then the symbolic analysis will produce one result per feasible path through the given
+  // route policy, rather than coalescing paths that are compatible with one another (same
+  // permit/deny result and same route updates). Default value is false.
+  private final boolean _retainAllPaths;
 
   // A seed for random-number generation
   private final long _seed;
 
   public TransferBDDValidationQuestion() {
-    this(null, new Random().nextLong());
+    this(null, null, false, new Random().nextLong());
   }
 
-  public TransferBDDValidationQuestion(@Nullable String nodes, long seed) {
+  public TransferBDDValidationQuestion(
+      @Nullable String nodes, @Nullable String policies, boolean retainAllPaths, long seed) {
     _nodes = nodes;
+    _policies = policies;
+    _retainAllPaths = retainAllPaths;
     _seed = seed;
   }
 
   @JsonCreator
   private static TransferBDDValidationQuestion jsonCreator(
-      @JsonProperty(PROP_NODES) @Nullable String nodes, @JsonProperty(PROP_SEED) long seed) {
-    return new TransferBDDValidationQuestion(nodes, seed);
+      @JsonProperty(PROP_NODES) @Nullable String nodes,
+      @JsonProperty(PROP_POLICIES) @Nullable String policies,
+      @JsonProperty(PROP_RETAIN_ALL_PATHS) boolean retainAllPaths,
+      @JsonProperty(PROP_SEED) long seed) {
+    return new TransferBDDValidationQuestion(nodes, policies, retainAllPaths, seed);
   }
 
   @JsonIgnore
@@ -58,6 +72,16 @@ public final class TransferBDDValidationQuestion extends Question {
   @JsonProperty(PROP_NODES)
   public @Nullable String getNodes() {
     return _nodes;
+  }
+
+  @JsonProperty(PROP_POLICIES)
+  public @Nullable String getPolicies() {
+    return _policies;
+  }
+
+  @JsonProperty(PROP_RETAIN_ALL_PATHS)
+  public boolean getRetainAllPaths() {
+    return _retainAllPaths;
   }
 
   @JsonProperty(PROP_SEED)

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationAnswererTest.java
@@ -149,7 +149,10 @@ public class TransferBDDValidationAnswererTest {
         BgpActivePeerConfig.builder()
             .setGroup("testGroup")
             .setIpv4UnicastAddressFamily(
-                Ipv4UnicastAddressFamily.builder().setExportPolicy(POLICY_NAME).build())
+                Ipv4UnicastAddressFamily.builder()
+                    .setImportPolicy(POLICY_NAME)
+                    .setExportPolicy(POLICY_NAME)
+                    .build())
             .build();
     bgp.setNeighbors(ImmutableSortedMap.of(Ip.FIRST_CLASS_A_PRIVATE_IP, bgpPeer));
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationAnswererTest.java
@@ -23,23 +23,33 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.bdd.MutableBDDInteger;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.common.topology.TopologyProvider;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker;
+import org.batfish.datamodel.bgp.NextHopIpTieBreaker;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.questions.BgpRoute;
 import org.batfish.datamodel.questions.BgpRouteDiff;
 import org.batfish.datamodel.questions.BgpRouteDiffs;
+import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.communities.HasSize;
 import org.batfish.datamodel.routing_policy.communities.InputCommunities;
@@ -56,6 +66,7 @@ import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.batfish.minesweeper.bdd.BDDRoute;
 import org.batfish.minesweeper.bdd.TransferBDD;
 import org.batfish.minesweeper.bdd.TransferReturn;
 import org.batfish.specifier.Location;
@@ -118,14 +129,35 @@ public class TransferBDDValidationAnswererTest {
     Configuration.Builder cb =
         _nf.configurationBuilder().setHostname(HOSTNAME).setConfigurationFormat(format);
     _baseConfig = cb.build();
-    _nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
+    Vrf vrf =
+        _nf.vrfBuilder().setOwner(_baseConfig).setName(Configuration.DEFAULT_VRF_NAME).build();
     _policyBuilder = _nf.routingPolicyBuilder().setOwner(_baseConfig).setName(POLICY_NAME);
+
+    BgpProcess bgp =
+        _nf.bgpProcessBuilder()
+            .setRouterId(Ip.FIRST_CLASS_A_PRIVATE_IP)
+            .setEbgpAdminCost(0)
+            .setIbgpAdminCost(0)
+            .setLocalAdminCost(0)
+            .setLocalOriginationTypeTieBreaker(LocalOriginationTypeTieBreaker.NO_PREFERENCE)
+            .setNetworkNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
+            .setRedistributeNextHopIpTieBreaker(NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP)
+            .setVrf(vrf)
+            .build();
+
+    BgpActivePeerConfig bgpPeer =
+        BgpActivePeerConfig.builder()
+            .setGroup("testGroup")
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder().setExportPolicy(POLICY_NAME).build())
+            .build();
+    bgp.setNeighbors(ImmutableSortedMap.of(Ip.FIRST_CLASS_A_PRIVATE_IP, bgpPeer));
 
     SortedMap<String, Configuration> configs = ImmutableSortedMap.of(HOSTNAME, _baseConfig);
     _batfish = new MockBatfish(configs);
     _answerer =
         new TransferBDDValidationAnswerer(
-            new TransferBDDValidationQuestion(null, null, 123456789), _batfish);
+            new TransferBDDValidationQuestion(null, 123456789), _batfish);
   }
 
   @Test
@@ -149,7 +181,7 @@ public class TransferBDDValidationAnswererTest {
 
     TransferBDD tbdd = new TransferBDD(_configAPs);
     List<TransferReturn> paths = tbdd.computePaths(policy);
-    List<Row> rows = _answerer.validatePaths(policy, paths, tbdd);
+    List<Row> rows = _answerer.validatePaths(policy, paths, tbdd, Environment.Direction.IN);
 
     assertThat(rows, empty());
   }
@@ -165,21 +197,14 @@ public class TransferBDDValidationAnswererTest {
     // flip the accepted boolean in the one path, to create a violation
     List<TransferReturn> badPaths = ImmutableList.of(paths.get(0).setAccepted(false));
 
-    List<Row> rows = _answerer.validatePaths(policy, badPaths, tbdd);
+    List<Row> rows = _answerer.validatePaths(policy, badPaths, tbdd, Environment.Direction.OUT);
 
     // there are two answers, since we simulate the path in both the IN and OUT directions
-    assertThat(rows.size(), equalTo(2));
+    assertThat(rows.size(), equalTo(1));
 
     assertThat(
         rows,
         Matchers.contains(
-            allOf(
-                hasColumn(COL_SYMBOLIC_ACTION, equalTo(LineAction.DENY.toString()), Schema.STRING),
-                hasColumn(
-                    COL_CONCRETE_ACTION, equalTo(LineAction.PERMIT.toString()), Schema.STRING),
-                hasColumn(COL_SYMBOLIC_OUTPUT_ROUTE, nullValue(), Schema.OBJECT),
-                hasColumn(COL_CONCRETE_OUTPUT_ROUTE, notNullValue(), Schema.OBJECT),
-                hasColumn(COL_SEED, 123456789L, Schema.LONG)),
             allOf(
                 hasColumn(COL_SYMBOLIC_ACTION, equalTo(LineAction.DENY.toString()), Schema.STRING),
                 hasColumn(
@@ -206,10 +231,10 @@ public class TransferBDDValidationAnswererTest {
             p.getOutputRoute()
                 .setLocalPref(MutableBDDInteger.makeFromValue(tbdd.getFactory(), 32, 300)));
 
-    List<Row> rows = _answerer.validatePaths(policy, badPaths, tbdd);
+    List<Row> rows = _answerer.validatePaths(policy, badPaths, tbdd, Environment.Direction.IN);
 
     // there are two answers, since we simulate the path in both the IN and OUT directions
-    assertThat(rows.size(), equalTo(2));
+    assertThat(rows.size(), equalTo(1));
 
     BgpRouteDiffs diff =
         new BgpRouteDiffs(
@@ -217,15 +242,6 @@ public class TransferBDDValidationAnswererTest {
     assertThat(
         rows,
         Matchers.contains(
-            allOf(
-                hasColumn(
-                    COL_SYMBOLIC_ACTION, equalTo(LineAction.PERMIT.toString()), Schema.STRING),
-                hasColumn(
-                    COL_CONCRETE_ACTION, equalTo(LineAction.PERMIT.toString()), Schema.STRING),
-                hasColumn(COL_SYMBOLIC_OUTPUT_ROUTE, notNullValue(), Schema.OBJECT),
-                hasColumn(COL_CONCRETE_OUTPUT_ROUTE, notNullValue(), Schema.OBJECT),
-                hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS),
-                hasColumn(COL_SEED, 123456789L, Schema.LONG)),
             allOf(
                 hasColumn(
                     COL_SYMBOLIC_ACTION, equalTo(LineAction.PERMIT.toString()), Schema.STRING),
@@ -256,7 +272,7 @@ public class TransferBDDValidationAnswererTest {
             p.getOutputRoute()
                 .setLocalPref(MutableBDDInteger.makeFromValue(tbdd.getFactory(), 32, 300)));
 
-    List<Row> rows = _answerer.validatePaths(policy, badPaths, tbdd);
+    List<Row> rows = _answerer.validatePaths(policy, badPaths, tbdd, Environment.Direction.OUT);
 
     // there are no answers, since paths with unsupported features are ignored
     assertThat(rows, empty());
@@ -289,10 +305,46 @@ public class TransferBDDValidationAnswererTest {
 
     TransferBDD tbdd = new TransferBDD(_configAPs);
     List<TransferReturn> paths = tbdd.computePaths(policy);
-    List<Row> rows = _answerer.validatePaths(policy, paths, tbdd);
+    List<Row> rows = _answerer.validatePaths(policy, paths, tbdd, Environment.Direction.IN);
 
     // there are no answers, since we ensure that routes won't have more than MAX_COMMUNITIES_SIZE
     // communities on them
+    assertThat(rows, empty());
+  }
+
+  @Test
+  public void testManyNegatedCommunities() {
+    RoutingPolicy policy =
+        _policyBuilder.addStatement(Statements.ExitAccept.toStaticStatement()).build();
+    Set<CommunityVar> cvars =
+        IntStream.range(1, MAX_COMMUNITIES_SIZE + 1)
+            .mapToObj(i -> CommunityVar.from(StandardCommunity.parse(String.valueOf(i) + ":100")))
+            .collect(ImmutableSet.toImmutableSet());
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME, cvars, ImmutableSet.of());
+
+    TransferBDD tbdd = new TransferBDD(_configAPs);
+    BDDRoute orig = tbdd.getOriginalRoute();
+    // create a path that requires that none of the communities above be on the input route
+    TransferReturn path =
+        new TransferReturn(
+            tbdd.getOriginalRoute(),
+            tbdd.getFactory()
+                .orAll(
+                    cvars.stream()
+                        .flatMap(
+                            cvar ->
+                                _configAPs
+                                    .getStandardCommunityAtomicPredicates()
+                                    .getRegexAtomicPredicates()
+                                    .get(cvar)
+                                    .stream())
+                        .map(i -> orig.getCommunityAtomicPredicates()[i])
+                        .collect(Collectors.toList()))
+                .not(),
+            true);
+
+    List<Row> rows =
+        _answerer.validatePaths(policy, ImmutableList.of(path), tbdd, Environment.Direction.OUT);
     assertThat(rows, empty());
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/transferbddvalidation/TransferBDDValidationAnswererTest.java
@@ -160,7 +160,7 @@ public class TransferBDDValidationAnswererTest {
     _batfish = new MockBatfish(configs);
     _answerer =
         new TransferBDDValidationAnswerer(
-            new TransferBDDValidationQuestion(null, 123456789), _batfish);
+            new TransferBDDValidationQuestion(null, null, true, 123456789), _batfish);
   }
 
   @Test

--- a/questions/experimental/transferBDDValidation.json
+++ b/questions/experimental/transferBDDValidation.json
@@ -2,15 +2,13 @@
     "class": "org.batfish.minesweeper.question.transferbddvalidation.TransferBDDValidationQuestion",
     "differential": false,
     "nodes": "${nodes}",
-    "policies": "${policies}",
     "seed": "${seed}",
     "instance": {
         "description": "Validates Batfish's symbolic route-policy analysis against its concrete route-policy simulation engine.",
         "instanceName": "transferBDDValidation",
-        "longDescription": "This question validates Batfish's symbolic route-policy analysis, called TransferBDD, against its concrete route-policy simulation engine, called TestRoutePolicies. For every node that matches the given node specifer, for every route policy in that node that matches the given policy specifier, the symbolic route-policy analysis computes the set of feasible paths through the route policy. For each such path, we choose a random input route whose processing takes that path and check whether the predicted behavior of the route policy on that route is identical between the symbolic analysis and concrete simulation. The question returns the list of identified violations.",
+        "longDescription": "This question validates Batfish's symbolic route-policy analysis, called TransferBDD, against its concrete route-policy simulation engine, called TestRoutePolicies. For every node that matches the given node specifer, for every import and export route policy on a peer group in the node, the symbolic route-policy analysis computes the set of feasible paths through the route policy. For each such path, we choose a random input route whose processing takes that path and check whether the predicted behavior of the route policy on that route is identical between the symbolic analysis and concrete simulation. The question returns the list of identified violations.",
         "orderedVariableNames": [
             "nodes",
-            "policies",
             "seed"
         ],
         "tags": [
@@ -22,12 +20,6 @@
                 "type": "nodeSpec",
                 "optional": true,
                 "displayName": "Nodes"
-            },
-            "policies": {
-                "description": "Only consider policies that match this specifier",
-                "type": "routingPolicySpec",
-                "optional": true,
-                "displayName": "Policies"
             },
             "seed": {
                 "description": "A seed for generating random input routes",

--- a/questions/experimental/transferBDDValidation.json
+++ b/questions/experimental/transferBDDValidation.json
@@ -2,13 +2,17 @@
     "class": "org.batfish.minesweeper.question.transferbddvalidation.TransferBDDValidationQuestion",
     "differential": false,
     "nodes": "${nodes}",
+    "policies": "${policies}",
+    "retainAllPaths": "${retainAllPaths}",
     "seed": "${seed}",
     "instance": {
         "description": "Validates Batfish's symbolic route-policy analysis against its concrete route-policy simulation engine.",
         "instanceName": "transferBDDValidation",
-        "longDescription": "This question validates Batfish's symbolic route-policy analysis, called TransferBDD, against its concrete route-policy simulation engine, called TestRoutePolicies. For every node that matches the given node specifer, for every import and export route policy on a peer group in the node, the symbolic route-policy analysis computes the set of feasible paths through the route policy. For each such path, we choose a random input route whose processing takes that path and check whether the predicted behavior of the route policy on that route is identical between the symbolic analysis and concrete simulation. The question returns the list of identified violations.",
+        "longDescription": "This question validates Batfish's symbolic route-policy analysis, called TransferBDD, against its concrete route-policy simulation engine, called TestRoutePolicies. The question currently validates only the route policies that are used as import or export policies on BGP peers. For every node that matches the given node specifer, for every route policy that matches the given policy specifier, the symbolic route-policy analysis computes the set of feasible paths through the route policy. For each such path, we choose a random input route whose processing takes that path and check whether the predicted behavior of the route policy on that route is identical between the symbolic analysis and concrete simulation. The question returns the list of identified violations.",
         "orderedVariableNames": [
             "nodes",
+            "policies",
+            "retainAllPaths",
             "seed"
         ],
         "tags": [
@@ -20,6 +24,18 @@
                 "type": "nodeSpec",
                 "optional": true,
                 "displayName": "Nodes"
+            },
+            "policies": {
+                "description": "Only consider policies that match this specifier",
+                "type": "routingPolicySpec",
+                "optional": true,
+                "displayName": "Policies"
+            },
+            "retainAllPaths": {
+                "description": "Generate one test per path through each route policy, instead of coalescing compatible paths (default value is false)",
+                "type": "boolean",
+                "optional": true,
+                "displayName": "Policies"
             },
             "seed": {
                 "description": "A seed for generating random input routes",


### PR DESCRIPTION
Updates TransferBDD validation to only validate route policies that appear on peer groups. Otherwise we can get false positives by considering route policies that are only ever used as subroutines and not intended to be valid policies on their own.  This PR also includes one small bug fix (missing bounds check) and some minor performance improvements.