### PR TITLE
Junos parsing and conversion for policy-statement from external type 1 and 2

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/CommunityStructuresVerifier.java
@@ -74,6 +74,7 @@ import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
 import org.batfish.datamodel.routing_policy.expr.MatchLocalPreference;
 import org.batfish.datamodel.routing_policy.expr.MatchLocalRouteSourcePrefixLength;
 import org.batfish.datamodel.routing_policy.expr.MatchMetric;
+import org.batfish.datamodel.routing_policy.expr.MatchOspfExternalType;
 import org.batfish.datamodel.routing_policy.expr.MatchPeerAddress;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProcessAsn;
@@ -250,6 +251,12 @@ public final class CommunityStructuresVerifier {
 
     @Override
     public Void visitMatchMetric(MatchMetric matchMetric, CommunityStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchOspfExternalType(
+        MatchOspfExternalType matchOspfExternalType, CommunityStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/as_path/AsPathStructuresVerifier.java
@@ -28,6 +28,7 @@ import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
 import org.batfish.datamodel.routing_policy.expr.MatchLocalPreference;
 import org.batfish.datamodel.routing_policy.expr.MatchLocalRouteSourcePrefixLength;
 import org.batfish.datamodel.routing_policy.expr.MatchMetric;
+import org.batfish.datamodel.routing_policy.expr.MatchOspfExternalType;
 import org.batfish.datamodel.routing_policy.expr.MatchPeerAddress;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProcessAsn;
@@ -203,6 +204,12 @@ public final class AsPathStructuresVerifier {
 
     @Override
     public Void visitMatchMetric(MatchMetric matchMetric, AsPathStructuresVerifierContext arg) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchOspfExternalType(
+        MatchOspfExternalType matchOspfExternalType, AsPathStructuresVerifierContext arg) {
       return null;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BooleanExprVisitor.java
@@ -46,6 +46,8 @@ public interface BooleanExprVisitor<T, U> {
 
   T visitMatchMetric(MatchMetric matchMetric, U arg);
 
+  T visitMatchOspfExternalType(MatchOspfExternalType matchOspfExternalType, U arg);
+
   T visitMatchPeerAddress(MatchPeerAddress matchPeerAddress, U arg);
 
   T visitMatchPrefixSet(MatchPrefixSet matchPrefixSet, U arg);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchOspfExternalType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchOspfExternalType.java
@@ -1,0 +1,79 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import javax.annotation.Nullable;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.ospf.OspfMetricType;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Result;
+
+/**
+ * Boolean expression that matches if a route is an OSPF external route of a specific type (E1 or
+ * E2). If type is null, matches any OSPF external route.
+ */
+public final class MatchOspfExternalType extends BooleanExpr {
+
+  private final @Nullable OspfMetricType _type;
+
+  public MatchOspfExternalType(@Nullable OspfMetricType type) {
+    _type = type;
+  }
+
+  @Override
+  public Result evaluate(Environment environment) {
+    if (environment.getOriginalRoute() == null) {
+      return new Result(false);
+    }
+
+    // Check if the route is an OSPF external route
+    RoutingProtocol protocol = environment.getOriginalRoute().getProtocol();
+    boolean isOspfExternal =
+        protocol == RoutingProtocol.OSPF_E1 || protocol == RoutingProtocol.OSPF_E2;
+
+    if (!isOspfExternal) {
+      return new Result(false);
+    }
+
+    // If no specific type is specified, match any external route
+    if (_type == null) {
+      return new Result(true);
+    }
+
+    // Check if the route's OSPF metric type matches the specified type
+    boolean matchesType =
+        (_type == OspfMetricType.E1 && protocol == RoutingProtocol.OSPF_E1)
+            || (_type == OspfMetricType.E2 && protocol == RoutingProtocol.OSPF_E2);
+
+    return new Result(matchesType);
+  }
+
+  @Override
+  public <T, U> T accept(BooleanExprVisitor<T, U> visitor, U arg) {
+    return visitor.visitMatchOspfExternalType(this, arg);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof MatchOspfExternalType)) {
+      return false;
+    }
+    MatchOspfExternalType other = (MatchOspfExternalType) obj;
+    return _type == other._type;
+  }
+
+  @Override
+  public int hashCode() {
+    return _type == null ? 0 : _type.ordinal();
+  }
+
+  public @Nullable OspfMetricType getType() {
+    return _type;
+  }
+
+  @Override
+  public String toString() {
+    return "MatchOspfExternalType{type=" + _type + "}";
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchOspfExternalTypeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchOspfExternalTypeTest.java
@@ -1,0 +1,122 @@
+package org.batfish.datamodel.routing_policy.expr;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OspfExternalRoute;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.ospf.OspfMetricType;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.Environment.Direction;
+import org.junit.Test;
+
+public class MatchOspfExternalTypeTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new MatchOspfExternalType(OspfMetricType.E1),
+            new MatchOspfExternalType(OspfMetricType.E1))
+        .addEqualityGroup(new MatchOspfExternalType(OspfMetricType.E2))
+        .addEqualityGroup(new MatchOspfExternalType(null), new MatchOspfExternalType(null))
+        .testEquals();
+  }
+
+  @Test
+  public void testEvaluate() {
+    MatchOspfExternalType matchE1 = new MatchOspfExternalType(OspfMetricType.E1);
+    MatchOspfExternalType matchE2 = new MatchOspfExternalType(OspfMetricType.E2);
+    MatchOspfExternalType matchAny = new MatchOspfExternalType(null);
+
+    // Use a valid IP address for NextHopIp
+    Ip validIp = Ip.parse("192.0.2.1"); // Using a TEST-NET-1 address (RFC 5737)
+
+    // Create a non-OSPF route (static route) for negative testing
+    StaticRoute nonOspfRoute =
+        StaticRoute.builder()
+            .setNetwork(Prefix.ZERO)
+            .setNextHop(NextHopIp.of(validIp))
+            .setAdmin(100)
+            .setMetric(10)
+            .build();
+
+    // Create OSPF E1 route
+    OspfExternalRoute ospfE1Route =
+        OspfExternalRoute.builder()
+            .setNetwork(Prefix.ZERO)
+            .setNextHop(NextHopIp.of(validIp))
+            .setAdmin(100)
+            .setMetric(10)
+            .setLsaMetric(10)
+            .setArea(0)
+            .setCostToAdvertiser(10)
+            .setAdvertiser("test")
+            .setOspfMetricType(OspfMetricType.E1)
+            .setNonRouting(true) // Set nonRouting flag to true to allow next-hop IP only
+            .build();
+
+    // Create OSPF E2 route
+    OspfExternalRoute ospfE2Route =
+        OspfExternalRoute.builder()
+            .setNetwork(Prefix.ZERO)
+            .setNextHop(NextHopIp.of(validIp))
+            .setAdmin(100)
+            .setMetric(10)
+            .setLsaMetric(10)
+            .setArea(0)
+            .setCostToAdvertiser(10)
+            .setAdvertiser("test")
+            .setOspfMetricType(OspfMetricType.E2)
+            .setNonRouting(true) // Set nonRouting flag to true to allow next-hop IP only
+            .build();
+
+    // Create a configuration for the environment
+    Configuration config =
+        Configuration.builder()
+            .setHostname("test-host")
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .build();
+
+    // Create environments with different routes
+    Environment envNonOspf =
+        Environment.builder(config)
+            .setOriginalRoute(nonOspfRoute)
+            .setDirection(Direction.IN)
+            .build();
+    Environment envOspfE1 =
+        Environment.builder(config)
+            .setOriginalRoute(ospfE1Route)
+            .setDirection(Direction.IN)
+            .build();
+    Environment envOspfE2 =
+        Environment.builder(config)
+            .setOriginalRoute(ospfE2Route)
+            .setDirection(Direction.IN)
+            .build();
+    Environment envNull = Environment.builder(config).setDirection(Direction.IN).build();
+
+    // Test matching E1 routes
+    assertFalse(matchE1.evaluate(envNonOspf).getBooleanValue());
+    assertTrue(matchE1.evaluate(envOspfE1).getBooleanValue());
+    assertFalse(matchE1.evaluate(envOspfE2).getBooleanValue());
+    assertFalse(matchE1.evaluate(envNull).getBooleanValue());
+
+    // Test matching E2 routes
+    assertFalse(matchE2.evaluate(envNonOspf).getBooleanValue());
+    assertFalse(matchE2.evaluate(envOspfE1).getBooleanValue());
+    assertTrue(matchE2.evaluate(envOspfE2).getBooleanValue());
+    assertFalse(matchE2.evaluate(envNull).getBooleanValue());
+
+    // Test matching any external routes (null type)
+    assertFalse(matchAny.evaluate(envNonOspf).getBooleanValue());
+    assertTrue(matchAny.evaluate(envOspfE1).getBooleanValue());
+    assertTrue(matchAny.evaluate(envOspfE2).getBooleanValue());
+    assertFalse(matchAny.evaluate(envNull).getBooleanValue());
+  }
+}

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -163,6 +163,7 @@ pops_from
       | popsf_community
       | popsf_community_count
       | popsf_condition
+      | popsf_external
       | popsf_family
       | popsf_instance
       | popsf_interface
@@ -373,6 +374,11 @@ popsf_route_type
       EXTERNAL
       | INTERNAL
    )
+;
+
+popsf_external
+:
+   EXTERNAL (TYPE dec)?
 ;
 
 popsf_source_address_filter

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -526,6 +526,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_as_path_groupCont
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_colorContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_communityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_community_countContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_externalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_familyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_instanceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_interfaceContext;
@@ -974,6 +975,7 @@ import org.batfish.representation.juniper.PsFromCommunity;
 import org.batfish.representation.juniper.PsFromCommunityCount;
 import org.batfish.representation.juniper.PsFromCommunityCount.Mode;
 import org.batfish.representation.juniper.PsFromCondition;
+import org.batfish.representation.juniper.PsFromExternal;
 import org.batfish.representation.juniper.PsFromFamily;
 import org.batfish.representation.juniper.PsFromInstance;
 import org.batfish.representation.juniper.PsFromInterface;
@@ -5986,6 +5988,23 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _currentRouteFilter = null;
     _currentRouteFilterLine = null;
     _currentRoute6FilterLine = null;
+  }
+
+  @Override
+  public void exitPopsf_external(Popsf_externalContext ctx) {
+    if (ctx.dec() == null) {
+      // No type specified - match all external routes
+      _currentPsTerm.getFroms().setFromExternal(new PsFromExternal(null));
+    } else {
+      int type = toInt(ctx.dec());
+      if (type == 1) {
+        _currentPsTerm.getFroms().setFromExternal(new PsFromExternal(OspfMetricType.E1));
+      } else if (type == 2) {
+        _currentPsTerm.getFroms().setFromExternal(new PsFromExternal(OspfMetricType.E2));
+      } else {
+        _w.redFlagf("unimplemented: from %s", getFullText(ctx));
+      }
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3247,6 +3247,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (!froms.getFromProtocols().isEmpty()) {
       conj.getConjuncts().add(new Disjunction(toBooleanExprs(froms.getFromProtocols())));
     }
+    if (froms.getFromExternal() != null) {
+      conj.getConjuncts().add(froms.getFromExternal().toBooleanExpr(this, _c, _w));
+    }
     if (froms.getFromRouteType() != null) {
       conj.getConjuncts().add(froms.getFromRouteType().toBooleanExpr(this, _c, _w));
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromExternal.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromExternal.java
@@ -1,0 +1,40 @@
+package org.batfish.representation.juniper;
+
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ospf.OspfMetricType;
+import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
+import org.batfish.datamodel.routing_policy.expr.MatchOspfExternalType;
+
+/** Represents a "from external type" line in a {@link PsTerm} */
+public final class PsFromExternal extends PsFrom {
+
+  private final @Nonnull OspfMetricType _type;
+
+  public PsFromExternal(@Nonnull OspfMetricType type) {
+    _type = type;
+  }
+
+  public @Nonnull OspfMetricType getType() {
+    return _type;
+  }
+
+  @Override
+  public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
+    return new MatchOspfExternalType(_type);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof PsFromExternal that)) {
+      return false;
+    }
+    return _type == that._type;
+  }
+
+  @Override
+  public int hashCode() {
+    return _type.ordinal();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFroms.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFroms.java
@@ -34,6 +34,7 @@ public final class PsFroms implements Serializable {
   private final Set<PsFromPrefixListFilterOrLonger> _fromPrefixListFilterOrLongers;
   private final Set<PsFromProtocol> _fromProtocols;
   private final Set<PsFromRouteFilter> _fromRouteFilters;
+  private PsFromExternal _fromExternal;
   private PsFromRouteType _fromRouteType;
   private final Set<PsFromTag> _fromTags;
   private PsFromUnsupported _fromUnsupported;
@@ -127,6 +128,11 @@ public final class PsFroms implements Serializable {
   public void addFromRouteFilter(@Nonnull PsFromRouteFilter fromRouteFilter) {
     _atLeastOneFrom = true;
     _fromRouteFilters.add(fromRouteFilter);
+  }
+
+  public void setFromExternal(@Nonnull PsFromExternal fromExternal) {
+    _atLeastOneFrom = true;
+    _fromExternal = fromExternal;
   }
 
   public void setFromRouteType(@Nonnull PsFromRouteType fromRouteType) {
@@ -235,6 +241,10 @@ public final class PsFroms implements Serializable {
   @Nonnull
   Set<PsFromRouteFilter> getFromRouteFilters() {
     return _fromRouteFilters;
+  }
+
+  public @Nullable PsFromExternal getFromExternal() {
+    return _fromExternal;
   }
 
   public @Nullable PsFromRouteType getFromRouteType() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -367,6 +367,7 @@ import org.batfish.datamodel.matchers.StubSettingsMatchers;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
+import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.ospf.OspfProcess;
 import org.batfish.datamodel.ospf.StubType;
@@ -377,6 +378,7 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.expr.MatchOspfExternalType;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
@@ -460,6 +462,7 @@ import org.batfish.representation.juniper.PathSelectionMode;
 import org.batfish.representation.juniper.PolicyStatement;
 import org.batfish.representation.juniper.PsFromColor;
 import org.batfish.representation.juniper.PsFromCondition;
+import org.batfish.representation.juniper.PsFromExternal;
 import org.batfish.representation.juniper.PsFromLocalPreference;
 import org.batfish.representation.juniper.PsFromTag;
 import org.batfish.representation.juniper.PsTerm;
@@ -8789,6 +8792,113 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         riskyParseWarnings,
         containsInAnyOrder(hasComment("RISK: Overwriting existing then community set")));
+  }
+
+  @Test
+  public void testPsFromExternal() {
+    String hostname = "policy-statement-from-external";
+    JuniperConfiguration juniperConfig = parseJuniperConfig(hostname);
+    Configuration c = parseConfig(hostname);
+    Warnings w = new Warnings();
+
+    // Test policy statement with "from external type 1"
+    PsTerm termType1 =
+        juniperConfig
+            .getMasterLogicalSystem()
+            .getPolicyStatements()
+            .get("test-external-type-1")
+            .getTerms()
+            .get("t1");
+    assertNotNull(termType1);
+
+    PsFromExternal fromExternalType1 = termType1.getFroms().getFromExternal();
+    assertNotNull(fromExternalType1);
+    assertThat(fromExternalType1.getType(), equalTo(OspfMetricType.E1));
+
+    // Verify conversion to vendor-independent model
+    assertThat(
+        fromExternalType1.toBooleanExpr(juniperConfig, c, w),
+        equalTo(new MatchOspfExternalType(OspfMetricType.E1)));
+
+    // Test policy statement with "from external type 2"
+    PsTerm termType2 =
+        juniperConfig
+            .getMasterLogicalSystem()
+            .getPolicyStatements()
+            .get("test-external-type-2")
+            .getTerms()
+            .get("t1");
+    assertNotNull(termType2);
+
+    PsFromExternal fromExternalType2 = termType2.getFroms().getFromExternal();
+    assertNotNull(fromExternalType2);
+    assertThat(fromExternalType2.getType(), equalTo(OspfMetricType.E2));
+
+    // Verify conversion to vendor-independent model
+    assertThat(
+        fromExternalType2.toBooleanExpr(juniperConfig, c, w),
+        equalTo(new MatchOspfExternalType(OspfMetricType.E2)));
+
+    // Test policy statement with just "from external" (no type specified)
+    PsTerm termAny =
+        juniperConfig
+            .getMasterLogicalSystem()
+            .getPolicyStatements()
+            .get("test-external-any")
+            .getTerms()
+            .get("t1");
+    assertNotNull(termAny);
+
+    PsFromExternal fromExternalAny = termAny.getFroms().getFromExternal();
+    assertNotNull(fromExternalAny);
+    assertThat(fromExternalAny.getType(), nullValue());
+
+    // Verify conversion to vendor-independent model - should match any external type
+    assertThat(
+        fromExternalAny.toBooleanExpr(juniperConfig, c, w),
+        equalTo(new MatchOspfExternalType(null)));
+
+    // Get the converted routing policies
+    RoutingPolicy type1Policy = c.getRoutingPolicies().get("test-external-type-1");
+    RoutingPolicy type2Policy = c.getRoutingPolicies().get("test-external-type-2");
+    RoutingPolicy anyTypePolicy = c.getRoutingPolicies().get("test-external-any");
+    assertNotNull(anyTypePolicy);
+
+    // Create OSPF External Type 1 and Type 2 routes
+    Prefix testPrefix = Prefix.parse("192.0.2.0/24");
+    OspfExternalType1Route ospfE1Route =
+        (OspfExternalType1Route)
+            OspfExternalType1Route.testBuilder()
+                .setNetwork(testPrefix)
+                .setMetric(20)
+                .setAdmin(100)
+                .build();
+
+    OspfExternalType2Route ospfE2Route =
+        (OspfExternalType2Route)
+            OspfExternalType2Route.builder()
+                .setNetwork(testPrefix)
+                .setNextHopIp(Ip.parse("10.0.0.1"))
+                .setArea(0)
+                .setMetric(20)
+                .setCostToAdvertiser(10)
+                .setLsaMetric(10)
+                .setAdvertiser("advertiser")
+                .setAdmin(100)
+                .setNonRouting(true) // Required when using NextHopIp
+                .build();
+
+    assertTrue("Type 1 policy should match E1 route", type1Policy.processReadOnly(ospfE1Route));
+    assertFalse(
+        "Type 1 policy should not match E2 route", type1Policy.processReadOnly(ospfE2Route));
+
+    assertTrue("Type 2 policy should match E2 route", type2Policy.processReadOnly(ospfE2Route));
+    assertFalse(
+        "Type 2 policy should not match E1 route", type2Policy.processReadOnly(ospfE1Route));
+
+    // Test that "any type" policy matches both E1 and E2 routes
+    assertTrue("Any type policy should match E1 route", anyTypePolicy.processReadOnly(ospfE1Route));
+    assertTrue("Any type policy should match E2 route", anyTypePolicy.processReadOnly(ospfE2Route));
   }
 
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromExternalTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromExternalTest.java
@@ -1,0 +1,41 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.ospf.OspfMetricType;
+import org.batfish.datamodel.routing_policy.expr.MatchOspfExternalType;
+import org.junit.Test;
+
+public class PsFromExternalTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new PsFromExternal(OspfMetricType.E1), new PsFromExternal(OspfMetricType.E1))
+        .addEqualityGroup(new PsFromExternal(OspfMetricType.E2))
+        .testEquals();
+  }
+
+  @Test
+  public void testToBooleanExpr() {
+    JuniperConfiguration jc = new JuniperConfiguration();
+    Configuration c =
+        Configuration.builder()
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .setHostname("c")
+            .build();
+    Warnings w = new Warnings();
+
+    assertThat(
+        new PsFromExternal(OspfMetricType.E1).toBooleanExpr(jc, c, w),
+        equalTo(new MatchOspfExternalType(OspfMetricType.E1)));
+    assertThat(
+        new PsFromExternal(OspfMetricType.E2).toBooleanExpr(jc, c, w),
+        equalTo(new MatchOspfExternalType(OspfMetricType.E2)));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/policy-statement-from-external
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/policy-statement-from-external
@@ -1,0 +1,15 @@
+#
+set system host-name policy-statement-from-external
+#
+# Policy statement with "from external type 1"
+set policy-options policy-statement test-external-type-1 term t1 from external type 1
+set policy-options policy-statement test-external-type-1 term t1 then accept
+#
+# Policy statement with "from external type 2"
+set policy-options policy-statement test-external-type-2 term t1 from external type 2
+set policy-options policy-statement test-external-type-2 term t1 then accept
+#
+# Policy statement with just "from external" (no type specified)
+set policy-options policy-statement test-external-any term t1 from external
+set policy-options policy-statement test-external-any term t1 then accept
+#

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutingPolicyCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/aspath/RoutingPolicyCollector.java
@@ -373,6 +373,13 @@ public class RoutingPolicyCollector<T>
   }
 
   @Override
+  public Set<T> visitMatchOspfExternalType(
+      org.batfish.datamodel.routing_policy.expr.MatchOspfExternalType matchOspfExternalType,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
   public Set<T> visitMatchPeerAddress(
       MatchPeerAddress matchPeerAddress, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/BooleanExprVarCollector.java
@@ -181,6 +181,13 @@ public class BooleanExprVarCollector
   }
 
   @Override
+  public Set<CommunityVar> visitMatchOspfExternalType(
+      org.batfish.datamodel.routing_policy.expr.MatchOspfExternalType matchOspfExternalType,
+      Tuple<Set<String>, Configuration> arg) {
+    return ImmutableSet.of();
+  }
+
+  @Override
   public Set<CommunityVar> visitMatchPeerAddress(
       MatchPeerAddress matchPeerAddress, Tuple<Set<String>, Configuration> arg) {
     return ImmutableSet.of();


### PR DESCRIPTION
Adds external type 1 and 2 to `policy-statement from` grammar - per junos docs https://www.juniper.net/documentation/us/en/software/junos/routing-policy/topics/concept/policy-configuring-match-conditions-in-routing-policy-terms.html the type is optional. 