### PR TITLE
Add risky warning for juniper policy statements with terminal terms that result in unreachable subsequent terms

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Warnings.java
@@ -202,6 +202,12 @@ public class Warnings implements Serializable {
     redFlag(FATAL_FLAG + String.format(msg, args));
   }
 
+  /** Indicate that this red flag warning is a risky construct */
+  @FormatMethod
+  public void riskyRedFlag(String msg, Object... args) {
+    redFlag(RISKY_FLAG + String.format(msg, args));
+  }
+
   /** Get all red flag warnings that are fatal error */
   @JsonIgnore
   public SortedSet<Warning> getFatalRedFlagWarnings() {
@@ -212,6 +218,18 @@ public class Warnings implements Serializable {
       }
     }
     return fatalWarnings;
+  }
+
+  /** Get all red flag warnings that are risky */
+  @JsonIgnore
+  public SortedSet<Warning> getRiskyRedFlagWarnings() {
+    SortedSet<Warning> riskyWarnings = new TreeSet<>();
+    for (Warning warning : _redFlagWarnings) {
+      if (warning.getText().startsWith(RISKY_FLAG)) {
+        riskyWarnings.add(warning);
+      }
+    }
+    return riskyWarnings;
   }
 
   /** Get all red flag warnings that are fatal error */

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -243,11 +243,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warning;
 import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.common.matchers.WarningMatchers;
@@ -8899,6 +8901,42 @@ public final class FlatJuniperGrammarTest {
     // Test that "any type" policy matches both E1 and E2 routes
     assertTrue("Any type policy should match E1 route", anyTypePolicy.processReadOnly(ospfE1Route));
     assertTrue("Any type policy should match E2 route", anyTypePolicy.processReadOnly(ospfE2Route));
+  }
+
+  @Test
+  public void testRiskyTerminalTermsInPolicyStatements() throws IOException {
+    String hostname = "risky-terminal-actions";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    SortedSet<Warning> riskyWarnings = ccae.getWarnings().get(hostname).getRiskyRedFlagWarnings();
+
+    assertThat("Should have exactly 3 RISKY warnings", riskyWarnings, hasSize(3));
+
+    String expectedRiskyRejectWarning =
+        "RISK: 'policy-statement RISKY-REJECT term UNCONDITIONAL-REJECT then reject' always ends"
+            + " processing, but there are 2 subsequent terms that will not be evaluated";
+    assertThat(
+        "Should have exact warning for RISKY-REJECT policy",
+        riskyWarnings,
+        hasItem(WarningMatchers.hasText(expectedRiskyRejectWarning)));
+
+    String expectedRiskyAcceptWarning =
+        "RISK: 'policy-statement RISKY-ACCEPT term UNCONDITIONAL-ACCEPT then accept' always ends"
+            + " processing, but there is 1 subsequent term that will not be evaluated";
+    assertThat(
+        "Should have exact warning for RISKY-ACCEPT policy",
+        riskyWarnings,
+        hasItem(WarningMatchers.hasText(expectedRiskyAcceptWarning)));
+
+    String expectedRiskyNextPolicyWarning =
+        "RISK: 'policy-statement RISKY-NEXT-POLICY term UNCONDITIONAL-NEXT-POLICY then next policy'"
+            + " always ends processing, but there is 1 subsequent term that will not be evaluated";
+    assertThat(
+        "Should have exact warning for RISKY-NEXT-POLICY policy",
+        riskyWarnings,
+        hasItem(WarningMatchers.hasText(expectedRiskyNextPolicyWarning)));
   }
 
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/risky-terminal-actions
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/risky-terminal-actions
@@ -1,0 +1,42 @@
+#
+set system host-name risky-terminal-actions
+#
+# === ESSENTIAL RISKY CASES (should generate RISKY warnings) ===
+#
+# Risky Case 1: Unconditional reject followed by other terms
+set policy-options policy-statement RISKY-REJECT term UNCONDITIONAL-REJECT then reject
+set policy-options policy-statement RISKY-REJECT term UNREACHABLE-TERM1 from protocol bgp
+set policy-options policy-statement RISKY-REJECT term UNREACHABLE-TERM1 then accept
+set policy-options policy-statement RISKY-REJECT term UNREACHABLE-TERM2 from community TEST-COMM
+set policy-options policy-statement RISKY-REJECT term UNREACHABLE-TERM2 then reject
+#
+# Risky Case 2: Unconditional accept followed by other terms
+set policy-options policy-statement RISKY-ACCEPT term UNCONDITIONAL-ACCEPT then accept
+set policy-options policy-statement RISKY-ACCEPT term UNREACHABLE-TERM from protocol ospf
+set policy-options policy-statement RISKY-ACCEPT term UNREACHABLE-TERM then reject
+#
+# Risky Case 3: Unconditional next policy followed by other terms
+set policy-options policy-statement RISKY-NEXT-POLICY term UNCONDITIONAL-NEXT-POLICY then next policy
+set policy-options policy-statement RISKY-NEXT-POLICY term UNREACHABLE-TERM from protocol bgp
+set policy-options policy-statement RISKY-NEXT-POLICY term UNREACHABLE-TERM then accept
+#
+#
+# === ESSENTIAL SAFE CASES (should NOT generate warnings) ===
+#
+# Safe Case 1: Only conditional terms
+set policy-options policy-statement SAFE-CONDITIONAL term CONDITIONAL-REJECT from protocol bgp
+set policy-options policy-statement SAFE-CONDITIONAL term CONDITIONAL-REJECT then reject
+set policy-options policy-statement SAFE-CONDITIONAL term CONDITIONAL-ACCEPT from community TEST-COMM
+set policy-options policy-statement SAFE-CONDITIONAL term CONDITIONAL-ACCEPT then accept
+#
+# Safe Case 2: Unconditional terminal as last term (not risky)
+set policy-options policy-statement SAFE-LAST-TERMINAL term CONDITIONAL-FIRST from protocol ospf
+set policy-options policy-statement SAFE-LAST-TERMINAL term CONDITIONAL-FIRST then accept
+set policy-options policy-statement SAFE-LAST-TERMINAL term UNCONDITIONAL-LAST then reject
+#
+# Safe Case 3: Single-term policy (boundary condition)
+set policy-options policy-statement SINGLE-TERM term ONLY-TERM then accept
+#
+# Community definitions for testing
+set policy-options community TEST-COMM members 65001:100
+#


### PR DESCRIPTION
This provides a special risky warning if a term in the middle of a policy statement matches everything AND has a terminal action (reject or accept). This makes all subsequent terms in the policy statement unreachable. 



