### PR TITLE
Basic tracking of "to" conditions in Junos policy-statement terms

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -583,6 +583,8 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstnh_ipv6Context;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstnh_peer_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstnh_rejectContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstnh_selfContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsto_levelContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsto_ribContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Port_numberContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Port_rangeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Proposal_set_typeContext;
@@ -6042,6 +6044,18 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void exitPopsf_tag2(Popsf_tag2Context ctx) {
     todo(ctx);
     _currentPsTerm.getFroms().setFromUnsupported(new PsFromUnsupported());
+  }
+
+  @Override
+  public void exitPopsto_level(Popsto_levelContext ctx) {
+    todo(ctx);
+    _currentPsTerm.setHasToConditions(true);
+  }
+
+  @Override
+  public void exitPopsto_rib(Popsto_ribContext ctx) {
+    todo(ctx);
+    _currentPsTerm.setHasToConditions(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -4435,11 +4435,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // A term makes subsequent terms unreachable if:
       // 1. It has no match conditions (no "from" AND no "to"), AND
       // 2. It has a terminal action (accept/reject)
-      //
-      // Note: Currently only checking "from" conditions since "to" conditions
-      // are not yet implemented
-      // TODO: When "to" conditions are implemented, update this to also check for "to" conditions
-      if (!currentTerm.hasAtLeastOneFrom()) {
+      if (!currentTerm.hasAtLeastOneFrom() && !currentTerm.hasAtLeastOneTo()) {
 
         Optional<PsThen> terminalAction = getTerminalAction(currentTerm);
         if (terminalAction.isPresent()) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsTerm.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsTerm.java
@@ -8,6 +8,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public final class PsTerm implements Serializable {
 
   private final @Nonnull PsFroms _froms;
+  private boolean _hasToConditions = false;
   private final @Nonnull String _name;
   private final @Nonnull PsThens _thens;
 
@@ -31,5 +32,13 @@ public final class PsTerm implements Serializable {
 
   public boolean hasAtLeastOneFrom() {
     return _froms.hasAtLeastOneFrom();
+  }
+
+  public boolean hasAtLeastOneTo() {
+    return _hasToConditions;
+  }
+
+  public void setHasToConditions(boolean hasToConditions) {
+    _hasToConditions = hasToConditions;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8939,5 +8939,47 @@ public final class FlatJuniperGrammarTest {
         hasItem(WarningMatchers.hasText(expectedRiskyNextPolicyWarning)));
   }
 
+  @Test
+  public void testPsToConditionsFlag() throws IOException {
+    String hostname = "risky-terminal-actions";
+    JuniperConfiguration juniperConfig = parseJuniperConfig(hostname);
+
+    // Test policy with only "to" condition
+    PolicyStatement policyToOnly =
+        juniperConfig.getMasterLogicalSystem().getPolicyStatements().get("TO-ONLY");
+    PsTerm toConditionTerm = policyToOnly.getTerms().get("TO-CONDITION-TERM");
+
+    assertThat(
+        "Term with 'to' condition should have hasToConditions=true",
+        toConditionTerm.hasAtLeastOneTo());
+    assertThat(
+        "Term with 'to' condition should not have any 'from' conditions",
+        !toConditionTerm.hasAtLeastOneFrom());
+
+    // Test policy with both "from" and "to" conditions
+    PolicyStatement policyFromAndTo =
+        juniperConfig.getMasterLogicalSystem().getPolicyStatements().get("FROM-AND-TO");
+    PsTerm fromToConditionTerm = policyFromAndTo.getTerms().get("FROM-TO-CONDITION-TERM");
+
+    assertThat(
+        "Term with both 'from' and 'to' conditions should have hasToConditions=true",
+        fromToConditionTerm.hasAtLeastOneTo());
+    assertThat(
+        "Term with both 'from' and 'to' conditions should have hasAtLeastOneFrom=true",
+        fromToConditionTerm.hasAtLeastOneFrom());
+
+    // Test policy with only "from" conditions (negative test case for hasToConditions)
+    PolicyStatement policyFromOnly =
+        juniperConfig.getMasterLogicalSystem().getPolicyStatements().get("SAFE-CONDITIONAL");
+    PsTerm fromOnlyTerm = policyFromOnly.getTerms().get("CONDITIONAL-REJECT");
+
+    assertThat(
+        "Term with only 'from' conditions should have hasToConditions=false",
+        !fromOnlyTerm.hasAtLeastOneTo());
+    assertThat(
+        "Term with only 'from' conditions should have hasAtLeastOneFrom=true",
+        fromOnlyTerm.hasAtLeastOneFrom());
+  }
+
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/risky-terminal-actions
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/risky-terminal-actions
@@ -40,3 +40,18 @@ set policy-options policy-statement SINGLE-TERM term ONLY-TERM then accept
 # Community definitions for testing
 set policy-options community TEST-COMM members 65001:100
 #
+# === SAFE CASES WITH "TO" CONDITIONS ===
+#
+# Safe Case 4: Terminal action with "to" condition only (not risky because it has a match condition)
+set policy-options policy-statement TO-ONLY term TO-CONDITION-TERM to level 1
+set policy-options policy-statement TO-ONLY term TO-CONDITION-TERM then accept
+set policy-options policy-statement TO-ONLY term REACHABLE-TERM from protocol bgp
+set policy-options policy-statement TO-ONLY term REACHABLE-TERM then reject
+#
+# Safe Case 5: Terminal action with both "from" and "to" conditions (not risky because it has match conditions)
+set policy-options policy-statement FROM-AND-TO term FROM-TO-CONDITION-TERM from protocol ospf
+set policy-options policy-statement FROM-AND-TO term FROM-TO-CONDITION-TERM to rib inet.0
+set policy-options policy-statement FROM-AND-TO term FROM-TO-CONDITION-TERM then accept
+set policy-options policy-statement FROM-AND-TO term REACHABLE-TERM from protocol bgp
+set policy-options policy-statement FROM-AND-TO term REACHABLE-TERM then reject
+#


### PR DESCRIPTION
- Add todo's for further extraction
- Otherwise just add a flag to track if there are any "to"'s, to enable proper logging of risky terminal actions. 