### PR TITLE
Don't warn for an unreachable terminal term if there is exactly one simple terminal term

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8912,7 +8912,8 @@ public final class FlatJuniperGrammarTest {
 
     SortedSet<Warning> riskyWarnings = ccae.getWarnings().get(hostname).getRiskyRedFlagWarnings();
 
-    assertThat("Should have exactly 3 RISKY warnings", riskyWarnings, hasSize(3));
+    // Test risky cases (should generate warnings)
+    assertThat("Should have exactly 6 RISKY warnings", riskyWarnings, hasSize(6));
 
     String expectedRiskyRejectWarning =
         "RISK: 'policy-statement RISKY-REJECT term UNCONDITIONAL-REJECT then reject' always ends"
@@ -8937,6 +8938,33 @@ public final class FlatJuniperGrammarTest {
         "Should have exact warning for RISKY-NEXT-POLICY policy",
         riskyWarnings,
         hasItem(WarningMatchers.hasText(expectedRiskyNextPolicyWarning)));
+
+    String expectedTooManyTerminalWarning =
+        "RISK: 'policy-statement TOO-MANY-TERMINAL term FIRST-UNCONDITIONAL-REJECT then reject'"
+            + " always ends processing, but there are 2 subsequent terms that will not be"
+            + " evaluated";
+    assertThat(
+        "Should have exact warning for TOO-MANY-TERMINAL policy",
+        riskyWarnings,
+        hasItem(WarningMatchers.hasText(expectedTooManyTerminalWarning)));
+
+    String expectedTwoTerminalWarning =
+        "RISK: 'policy-statement RISKY-TWO-TERMINAL term FIRST-UNCONDITIONAL-REJECT then reject'"
+            + " always ends processing, but there are 2 subsequent terms that will not be"
+            + " evaluated";
+    assertThat(
+        "Should have exact warning for RISKY-TWO-TERMINAL policy",
+        riskyWarnings,
+        hasItem(WarningMatchers.hasText(expectedTwoTerminalWarning)));
+
+    String riskyMutatingWarning =
+        "RISK: 'policy-statement RISKY-UNREACHABLE-MUTATING term UNCONDITIONAL-REJECT then reject'"
+            + " always ends processing, but there is 1 subsequent term that will not be"
+            + " evaluated";
+    assertThat(
+        "Should have exact warning for RISKY-UNREACHABLE-MUTATING policy",
+        riskyWarnings,
+        hasItem(WarningMatchers.hasText(riskyMutatingWarning)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/risky-terminal-actions
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/risky-terminal-actions
@@ -37,9 +37,41 @@ set policy-options policy-statement SAFE-LAST-TERMINAL term UNCONDITIONAL-LAST t
 # Safe Case 3: Single-term policy (boundary condition)
 set policy-options policy-statement SINGLE-TERM term ONLY-TERM then accept
 #
+# Safe Case 4: Unconditional "then" non-mutating terms are ok
+set policy-options policy-statement SAFE-MUTATING term UNCONDITIONAL-MUTATING then metric 1
+set policy-options policy-statement SAFE-MUTATING term REACHABLE-TERM from protocol bgp
+set policy-options policy-statement SAFE-MUTATING term REACHABLE-TERM then accept
+#
 # Community definitions for testing
 set policy-options community TEST-COMM members 65001:100
 #
+# === SPECIAL CASE: EXACTLY ONE UNCONDITIONAL TERMINAL TERM AFTER ANOTHER ===
+#
+# Acceptable Case 1: Exactly one unconditional terminal term after another unconditional terminal term
+# (ACCEPT followed by REJECT)
+set policy-options policy-statement ACCEPTABLE-ACCEPT-REJECT term FIRST-UNCONDITIONAL-ACCEPT then accept
+set policy-options policy-statement ACCEPTABLE-ACCEPT-REJECT term SECOND-UNCONDITIONAL-REJECT then reject
+#
+# Acceptable Case 2: Exactly one unconditional terminal term after another unconditional terminal term
+# (REJECT followed by NEXT POLICY)
+set policy-options policy-statement ACCEPTABLE-REJECT-NEXTPOLICY term FIRST-UNCONDITIONAL-REJECT then reject
+set policy-options policy-statement ACCEPTABLE-REJECT-NEXTPOLICY term SECOND-UNCONDITIONAL-NEXTPOLICY then next policy
+#
+# Unacceptable Case: Three is just too many unconditional terms
+set policy-options policy-statement TOO-MANY-TERMINAL term FIRST-UNCONDITIONAL-REJECT then reject
+set policy-options policy-statement TOO-MANY-TERMINAL term SECOND-UNCONDITIONAL-NEXTPOLICY then next policy
+set policy-options policy-statement TOO-MANY-TERMINAL term THIRD-UNCONDITIONAL-ACCEPT then accept
+#
+# Unacceptable Case: Two unconditional terms followed by a conditional term
+set policy-options policy-statement RISKY-TWO-TERMINAL term FIRST-UNCONDITIONAL-REJECT then reject
+set policy-options policy-statement RISKY-TWO-TERMINAL term SECOND-UNCONDITIONAL-NEXTPOLICY then next policy
+set policy-options policy-statement RISKY-TWO-TERMINAL term CONDITIONAL-ACCEPT from community TEST-COMM
+set policy-options policy-statement RISKY-TWO-TERMINAL term CONDITIONAL-ACCEPT then accept
+#
+# Unacceptable Case: The final unconditional term is mutating
+set policy-options policy-statement RISKY-UNREACHABLE-MUTATING term UNCONDITIONAL-REJECT then reject
+set policy-options policy-statement RISKY-UNREACHABLE-MUTATING term UNCONDITIONAL-NEXTPOLICY then metric 1
+set policy-options policy-statement RISKY-UNREACHABLE-MUTATING term UNCONDITIONAL-NEXTPOLICY then next policy
 # === SAFE CASES WITH "TO" CONDITIONS ===
 #
 # Safe Case 4: Terminal action with "to" condition only (not risky because it has a match condition)


### PR DESCRIPTION
Make a special case for terminal term warnings - don't worry if there is exactly one terminal term that is unreachable, as long as it's "simple" - ie, has only one "then". 

Default `reject` or `next policy` is common at the end of a policy statement - but if that `reject` is coupled with something mutating, it is more likely to be an accidentally unreachable term.