### PR TITLE
Fixup allowed rtf-prefix-list definitions

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2520,7 +2520,17 @@ RSTP: 'rstp';
 
 RSVP: 'rsvp';
 
-RTF_PREFIX_LIST: 'rtf-prefix-list' -> pushMode(M_Name);
+RTF_PREFIX_LIST
+:
+  'rtf-prefix-list'
+  {
+    if (lastTokenType() == POLICY_OPTIONS) {
+      pushMode(M_RTFPrefixList);
+    } else {
+      pushMode(M_Name);
+    }
+  }
+;
 
 RTSP: 'rtsp';
 
@@ -4921,6 +4931,19 @@ M_Range2_DASH: '-' -> type(DASH);
 M_Range2_COMMA: ',' -> type(COMMA);
 M_Range2_WS: F_WhitespaceChar+ -> skip, popMode;
 M_Range2_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+
+mode M_RTFPrefixList;
+M_RTFPrefixList_NAME: F_Name -> type(NAME), mode(M_RouteTargetFilterPrefix);
+M_RTFPrefixList_WS: F_WhitespaceChar+ -> skip;
+M_RTFPrefixList_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+
+mode M_RouteTargetFilterPrefix;
+M_RouteTargetFilterPrefix_UINT8: F_Uint8 -> type(UINT8);
+M_RouteTargetFilterPrefix_UINT32: F_Uint32 -> type(UINT32);
+M_RouteTargetFilterPrefix_SLASH: '/' -> type(FORWARD_SLASH);
+M_RouteTargetFilterPrefix_COLON: ':' -> type(COLON);
+M_RouteTargetFilterPrefix_WS: F_WhitespaceChar+ -> skip;
+M_RouteTargetFilterPrefix_NEWLINE: F_Newline -> type(NEWLINE), popMode;
 
 mode M_PrefixLengthRange;
 M_PrefixLengthRange_WS: F_WhitespaceChar+ -> skip, mode(M_PrefixLengthRange2);

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -92,13 +92,7 @@ po_prefix_list
 
 po_rtf_prefix_list
 :
-   RTF_PREFIX_LIST (name = junos_name | wildcard)
-   (
-      apply
-      | portfplt_apply_path
-      | portfplt_network
-      | portfplt_network6
-   )
+   RTF_PREFIX_LIST (name = junos_name | wildcard) portfplt_prefix
 ;
 
 po_tunnel_attribute
@@ -155,19 +149,16 @@ poplt_network6
    network = ipv6_prefix_default_128
 ;
 
-portfplt_apply_path
+portfplt_prefix
 :
-   APPLY_PATH path = DOUBLE_QUOTED_STRING
+    prefix = rtf_prefix
 ;
 
-portfplt_network
-:
-   network = ip_prefix_default_32
-;
-
-portfplt_network6
-:
-   network = ipv6_prefix_default_128
+rtf_prefix:
+    // TODO: are IP address variants valid here?
+    asn = uint32
+    COLON rt_hi = uint32 COLON rt_lo = uint32
+    FORWARD_SLASH length = uint8
 ;
 
 pops_common

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/rtf-prefix-lists
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/rtf-prefix-lists
@@ -2,8 +2,8 @@
 set system host-name rtf-prefix-lists
 #
 # Define rtf-prefix-lists
-set policy-options rtf-prefix-list RTF_PL 1.2.3.0/24
-set policy-options rtf-prefix-list RTF_PL_UNUSED 2.3.4.0/24
+set policy-options rtf-prefix-list RTF_PL 64500:200:101/96
+set policy-options rtf-prefix-list RTF_PL_UNUSED 64501:300:102/96
 
 # Reference RTF_PL in a policy statement
 set policy-options policy-statement POLICY_WITH_RTF from rtf-prefix-list RTF_PL


### PR DESCRIPTION
Looking at the docs https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/rtf-prefix-list-edit-policy-options.html the syntax here is AS number:route target extended community/length. Also removed apply-path, which is not an option for rtf-prefix-list. 