### PR TITLE
TransferBDD: Support intermediate BGP attributes

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDDState.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDDState.java
@@ -1,7 +1,5 @@
 package org.batfish.minesweeper.bdd;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -17,13 +15,6 @@ public class TransferBDDState {
   private final @Nonnull TransferResult _result;
 
   public TransferBDDState(TransferParam param, TransferResult result) {
-    // There should only be one 'active' BDDRoute at any time during symbolic route analysis.
-    // Eventually we may want to refactor things so the BDDRoute does not live in both
-    // the TransferParam and the TransferResult, but it would require non-trivial updates
-    // to the analysis.
-    checkArgument(
-        param.getData() == result.getReturnValue().getOutputRoute(),
-        "TransferParam and TransferReturn should contain the same BDDRoute object");
     _param = param;
     _result = result;
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferParam.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferParam.java
@@ -20,8 +20,6 @@ public class TransferParam {
     NONE
   }
 
-  private @Nonnull BDDRoute _data;
-
   private int _indent;
 
   private @Nonnull PList<String> _scopes;
@@ -38,10 +36,11 @@ public class TransferParam {
 
   private boolean _readIntermediateBgpAttributes;
 
+  private boolean _writeIntermediateBgpAttributes;
+
   private final boolean _debug;
 
-  public TransferParam(@Nonnull BDDRoute data, boolean debug) {
-    _data = data;
+  public TransferParam(boolean debug) {
     _callContext = CallContext.NONE;
     _chainContext = ChainContext.NONE;
     _indent = 0;
@@ -50,11 +49,11 @@ public class TransferParam {
     _defaultAcceptLocal = false;
     _defaultPolicy = null;
     _readIntermediateBgpAttributes = false;
+    _writeIntermediateBgpAttributes = false;
     _debug = debug;
   }
 
   private TransferParam(TransferParam p) {
-    _data = p._data;
     _callContext = p._callContext;
     _chainContext = p._chainContext;
     _indent = p._indent;
@@ -63,11 +62,8 @@ public class TransferParam {
     _defaultAcceptLocal = p._defaultAcceptLocal;
     _defaultPolicy = p._defaultPolicy;
     _readIntermediateBgpAttributes = p._readIntermediateBgpAttributes;
+    _writeIntermediateBgpAttributes = p._writeIntermediateBgpAttributes;
     _debug = p._debug;
-  }
-
-  public @Nonnull BDDRoute getData() {
-    return _data;
   }
 
   public CallContext getCallContext() {
@@ -94,24 +90,16 @@ public class TransferParam {
     return _readIntermediateBgpAttributes;
   }
 
+  public boolean getWriteIntermediateBgpAttributes() {
+    return _writeIntermediateBgpAttributes;
+  }
+
   public boolean getInitialCall() {
     return _indent == 0;
   }
 
   public String getScope() {
     return _scopes.get(0);
-  }
-
-  public TransferParam deepCopy() {
-    TransferParam ret = new TransferParam(this);
-    ret._data = ret._data.deepCopy();
-    return ret;
-  }
-
-  public TransferParam setData(BDDRoute other) {
-    TransferParam ret = new TransferParam(this);
-    ret._data = other;
-    return ret;
   }
 
   public TransferParam setCallContext(CallContext cc) {
@@ -152,6 +140,12 @@ public class TransferParam {
   public TransferParam setReadIntermediateBgpAttributes(boolean b) {
     TransferParam ret = new TransferParam(this);
     ret._readIntermediateBgpAttributes = b;
+    return ret;
+  }
+
+  public TransferParam setWriteIntermediateBgpAttributes(boolean b) {
+    TransferParam ret = new TransferParam(this);
+    ret._writeIntermediateBgpAttributes = b;
     return ret;
   }
 
@@ -197,8 +191,8 @@ public class TransferParam {
         && _defaultAccept == that._defaultAccept
         && _defaultAcceptLocal == that._defaultAcceptLocal
         && _readIntermediateBgpAttributes == that._readIntermediateBgpAttributes
+        && _writeIntermediateBgpAttributes == that._writeIntermediateBgpAttributes
         && _debug == that._debug
-        && _data.equals(that._data)
         && _scopes.equals(that._scopes)
         && _callContext == that._callContext
         && _chainContext == that._chainContext
@@ -208,7 +202,6 @@ public class TransferParam {
   @Override
   public int hashCode() {
     return Objects.hash(
-        _data,
         _indent,
         _scopes,
         _callContext,
@@ -217,6 +210,7 @@ public class TransferParam {
         _defaultAcceptLocal,
         _defaultPolicy,
         _readIntermediateBgpAttributes,
+        _writeIntermediateBgpAttributes,
         _debug);
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
@@ -64,8 +64,10 @@ public class TransferResult {
   }
 
   /**
-   * Construct a TransferResult from a BDDRoute with given input route constraints. This uses FALSE
-   * as the initial value for having hit a return/exit/fallthrough statement.
+   * Construct a TransferResult from a BDDRoute with given input route constraints. The given
+   * BDDRoute is used as the output route that the analysis tracks, and a copy of this BDDRoute is
+   * used as the intermediate route that the analysis tracks. This uses FALSE as the initial value
+   * for having hit a return/exit/fallthrough statement.
    */
   public TransferResult(BDDRoute bddRoute, BDD inputRouteConstraints) {
     this(

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
@@ -22,6 +22,12 @@ public class TransferResult {
    */
   private final @Nonnull TransferReturn _returnValue;
 
+  /**
+   * Intermediate BGP attributes are used by the vendor-independent model to properly encode the
+   * semantics of attribute reads and writes of various vendors. See {@link
+   * org.batfish.datamodel.routing_policy.statement.Statements.StaticStatement} for the statements
+   * that pertain to intermediate attributes.
+   */
   private final @Nonnull BDDRoute _intermediateBgpAttributes;
 
   /**
@@ -139,10 +145,10 @@ public class TransferResult {
         new TransferReturn(_returnValue.getOutputRoute(), newBDD, _returnValue.getAccepted()));
   }
 
-  public @Nonnull TransferResult setReturnValueOutputRoute(BDDRoute newBDDRoute) {
+  public @Nonnull TransferResult setReturnValueOutputRoute(BDDRoute newOutputRoute) {
     return setReturnValue(
         new TransferReturn(
-            newBDDRoute, _returnValue.getInputConstraints(), _returnValue.getAccepted()));
+            newOutputRoute, _returnValue.getInputConstraints(), _returnValue.getAccepted()));
   }
 
   public @Nonnull TransferResult setSuppressedValue(boolean suppressedValue) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
@@ -22,6 +22,8 @@ public class TransferResult {
    */
   private final @Nonnull TransferReturn _returnValue;
 
+  private final @Nonnull BDDRoute _intermediateBgpAttributes;
+
   /**
    * Whether the routes that go down this path should be suppressed (i.e., not announced). Route
    * suppression happens due to aggregation, and this is represented by the {@link
@@ -60,17 +62,25 @@ public class TransferResult {
    * as the initial value for having hit a return/exit/fallthrough statement.
    */
   public TransferResult(BDDRoute bddRoute, BDD inputRouteConstraints) {
-    this(new TransferReturn(bddRoute, inputRouteConstraints, false), false, false, false, false);
+    this(
+        new TransferReturn(bddRoute, inputRouteConstraints, false),
+        bddRoute.deepCopy(),
+        false,
+        false,
+        false,
+        false);
   }
 
   public TransferResult(
       TransferReturn retVal,
+      BDDRoute intermediateBgpAttributes,
       boolean suppressedValue,
       boolean exitAssignedValue,
       boolean fallThroughValue,
       boolean returnAssignedValue) {
     _suppressedValue = suppressedValue;
     _returnValue = retVal;
+    _intermediateBgpAttributes = intermediateBgpAttributes;
     _exitAssignedValue = exitAssignedValue;
     _fallthroughValue = fallThroughValue;
     _returnAssignedValue = returnAssignedValue;
@@ -78,6 +88,10 @@ public class TransferResult {
 
   public @Nonnull TransferReturn getReturnValue() {
     return _returnValue;
+  }
+
+  public @Nonnull BDDRoute getIntermediateBgpAttributes() {
+    return _intermediateBgpAttributes;
   }
 
   public boolean getSuppressedValue() {
@@ -98,7 +112,22 @@ public class TransferResult {
 
   public @Nonnull TransferResult setReturnValue(TransferReturn newReturn) {
     return new TransferResult(
-        newReturn, _suppressedValue, _exitAssignedValue, _fallthroughValue, _returnAssignedValue);
+        newReturn,
+        _intermediateBgpAttributes,
+        _suppressedValue,
+        _exitAssignedValue,
+        _fallthroughValue,
+        _returnAssignedValue);
+  }
+
+  public @Nonnull TransferResult setIntermediateAttributes(BDDRoute newIntermediateAttributes) {
+    return new TransferResult(
+        _returnValue,
+        newIntermediateAttributes,
+        _suppressedValue,
+        _exitAssignedValue,
+        _fallthroughValue,
+        _returnAssignedValue);
   }
 
   public @Nonnull TransferResult setReturnValueAccepted(boolean newAccepted) {
@@ -118,22 +147,42 @@ public class TransferResult {
 
   public @Nonnull TransferResult setSuppressedValue(boolean suppressedValue) {
     return new TransferResult(
-        _returnValue, suppressedValue, _exitAssignedValue, _fallthroughValue, _returnAssignedValue);
+        _returnValue,
+        _intermediateBgpAttributes,
+        suppressedValue,
+        _exitAssignedValue,
+        _fallthroughValue,
+        _returnAssignedValue);
   }
 
   public @Nonnull TransferResult setExitAssignedValue(boolean exitAssignedValue) {
     return new TransferResult(
-        _returnValue, _suppressedValue, exitAssignedValue, _fallthroughValue, _returnAssignedValue);
+        _returnValue,
+        _intermediateBgpAttributes,
+        _suppressedValue,
+        exitAssignedValue,
+        _fallthroughValue,
+        _returnAssignedValue);
   }
 
   public @Nonnull TransferResult setFallthroughValue(boolean fallthroughValue) {
     return new TransferResult(
-        _returnValue, _suppressedValue, _exitAssignedValue, fallthroughValue, _returnAssignedValue);
+        _returnValue,
+        _intermediateBgpAttributes,
+        _suppressedValue,
+        _exitAssignedValue,
+        fallthroughValue,
+        _returnAssignedValue);
   }
 
   public @Nonnull TransferResult setReturnAssignedValue(boolean returnAssignedValue) {
     return new TransferResult(
-        _returnValue, _suppressedValue, _exitAssignedValue, _fallthroughValue, returnAssignedValue);
+        _returnValue,
+        _intermediateBgpAttributes,
+        _suppressedValue,
+        _exitAssignedValue,
+        _fallthroughValue,
+        returnAssignedValue);
   }
 
   @Override
@@ -148,13 +197,15 @@ public class TransferResult {
         && _fallthroughValue == that._fallthroughValue
         && _exitAssignedValue == that._exitAssignedValue
         && _returnAssignedValue == that._returnAssignedValue
-        && Objects.equals(_returnValue, that._returnValue);
+        && Objects.equals(_returnValue, that._returnValue)
+        && Objects.equals(_intermediateBgpAttributes, that._intermediateBgpAttributes);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
         _returnValue,
+        _intermediateBgpAttributes,
         _suppressedValue,
         _fallthroughValue,
         _exitAssignedValue,

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferResult.java
@@ -110,7 +110,7 @@ public class TransferResult {
         new TransferReturn(_returnValue.getOutputRoute(), newBDD, _returnValue.getAccepted()));
   }
 
-  public @Nonnull TransferResult setReturnValueBDDRoute(BDDRoute newBDDRoute) {
+  public @Nonnull TransferResult setReturnValueOutputRoute(BDDRoute newBDDRoute) {
     return setReturnValue(
         new TransferReturn(
             newBDDRoute, _returnValue.getInputConstraints(), _returnValue.getAccepted()));

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
@@ -7,8 +7,9 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 
 /**
- * The data produced by the symbolic route policy analysis performed in {@link TransferBDD}. It
- * represents the analysis results along a particular execution path through the route policy:
+ * The data produced by the symbolic route policy analysis performed in {@link TransferBDD}. It is a
+ * triple representing the analysis results along a particular execution path through the route
+ * policy:
  *
  * <p>1. A {@link BDDRoute} that represents a function from an input announcement to the
  * corresponding output announcement produced by the analyzed route policy on this particular path.
@@ -21,10 +22,6 @@ import net.sf.javabdd.BDD;
  * path.
  *
  * <p>3. A boolean indicating whether the path accepts or rejects the input announcement.
- *
- * <p>4. Another {@link BDDRoute} that are used to record intermediate BGP attributes (see {@link
- * org.batfish.datamodel.routing_policy.Environment}). These attributes are used internally during
- * the analysis but are not meaningful as part of the end result.
  */
 @ParametersAreNonnullByDefault
 public final class TransferReturn {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferReturn.java
@@ -7,9 +7,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 
 /**
- * The data produced by the symbolic route policy analysis performed in {@link TransferBDD}. It is a
- * triple representing the analysis results along a particular execution path through the route
- * policy:
+ * The data produced by the symbolic route policy analysis performed in {@link TransferBDD}. It
+ * represents the analysis results along a particular execution path through the route policy:
  *
  * <p>1. A {@link BDDRoute} that represents a function from an input announcement to the
  * corresponding output announcement produced by the analyzed route policy on this particular path.
@@ -22,6 +21,10 @@ import net.sf.javabdd.BDD;
  * path.
  *
  * <p>3. A boolean indicating whether the path accepts or rejects the input announcement.
+ *
+ * <p>4. Another {@link BDDRoute} that are used to record intermediate BGP attributes (see {@link
+ * org.batfish.datamodel.routing_policy.Environment}). These attributes are used internally during
+ * the analysis but are not meaningful as part of the end result.
  */
 @ParametersAreNonnullByDefault
 public final class TransferReturn {

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDStateTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDStateTest.java
@@ -13,8 +13,8 @@ public class TransferBDDStateTest {
     BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
     TransferParam p = new TransferParam(false);
     TransferReturn ret = new TransferReturn(route, factory.one(), false);
-    TransferResult r1 = new TransferResult(ret, false, false, false, false);
-    TransferResult r2 = new TransferResult(ret, true, false, false, false);
+    TransferResult r1 = new TransferResult(ret, route, false, false, false, false);
+    TransferResult r2 = new TransferResult(ret, route, true, false, false, false);
 
     new EqualsTester()
         .addEqualityGroup(new TransferBDDState(p, r1), new TransferBDDState(p, r1))

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDStateTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDStateTest.java
@@ -11,7 +11,7 @@ public class TransferBDDStateTest {
   public void testEquals() {
     BDDFactory factory = JFactory.init(100, 100);
     BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
-    TransferParam p = new TransferParam(route, false);
+    TransferParam p = new TransferParam(false);
     TransferReturn ret = new TransferReturn(route, factory.one(), false);
     TransferResult r1 = new TransferResult(ret, false, false, false, false);
     TransferResult r2 = new TransferResult(ret, true, false, false, false);

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -2225,7 +2225,7 @@ public class TransferBDDTest {
   @Test
   public void testApplyLongExprModification() {
     TransferBDD tbdd = new TransferBDD(forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME));
-    TransferParam p = new TransferParam(tbdd.getOriginalRoute(), false);
+    TransferParam p = new TransferParam(false);
 
     MutableBDDInteger toBeModified =
         MutableBDDInteger.makeFromIndex(tbdd.getFactory(), 32, 0, false);
@@ -3918,13 +3918,12 @@ public class TransferBDDTest {
 
     BDDRoute routeParam = new BDDRoute(tbdd.getOriginalRoute());
     TransferBDDState initial =
-        new TransferBDDState(new TransferParam(routeParam, false), new TransferResult(routeParam));
+        new TransferBDDState(new TransferParam(false), new TransferResult(routeParam));
     assertThat(
         tbdd.computePaths(initial, manyMatchesSameResult, context, true), hasSize(1 << numIfs));
 
     routeParam = new BDDRoute(tbdd.getOriginalRoute());
-    initial =
-        new TransferBDDState(new TransferParam(routeParam, false), new TransferResult(routeParam));
+    initial = new TransferBDDState(new TransferParam(false), new TransferResult(routeParam));
     assertThat(tbdd.computePaths(initial, manyMatchesSameResult, context, false), hasSize(2));
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -1028,6 +1028,59 @@ public class TransferBDDTest {
   }
 
   @Test
+  public void testTwoIncrements() {
+    List<Statement> stmts =
+        ImmutableList.of(
+            new SetLocalPreference(new IncrementLocalPreference(5)),
+            new SetLocalPreference(new IncrementLocalPreference(5)),
+            new StaticStatement(Statements.ExitAccept));
+    RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
+
+    TransferBDD tbdd = new TransferBDD(_configAPs);
+    List<TransferReturn> paths = tbdd.computePaths(policy);
+
+    BDDRoute expected = anyRoute(tbdd.getFactory());
+    MutableBDDInteger localPref = expected.getLocalPref();
+    // since the increments read from the original route, the first increment is lost
+    expected.setLocalPref(
+        expected
+            .getLocalPref()
+            .addClipping(MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 5)));
+
+    List<TransferReturn> expectedPaths =
+        ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
+    assertEquals(expectedPaths, paths);
+    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+
+    // now do the analysis again, but with reading and writing intermediate attributes
+    setup(ConfigurationFormat.CISCO_IOS);
+    policy =
+        _policyBuilder
+            .setStatements(
+                ImmutableList.<Statement>builder()
+                    .add(new StaticStatement(Statements.SetWriteIntermediateBgpAttributes))
+                    .add(new StaticStatement(Statements.SetReadIntermediateBgpAttributes))
+                    .addAll(stmts)
+                    .build())
+            .build();
+    paths = tbdd.computePaths(policy);
+
+    expected = anyRoute(tbdd.getFactory());
+    localPref = expected.getLocalPref();
+    // now both increments take effect
+    expected.setLocalPref(
+        expected
+            .getLocalPref()
+            .addClipping(MutableBDDInteger.makeFromValue(localPref.getFactory(), 32, 10)));
+
+    expectedPaths = ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true));
+    assertEquals(expectedPaths, paths);
+    // TODO: validation currently fails due to a bug in concrete route simulation
+    // assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+  }
+
+  @Test
   public void testSetTag() {
     RoutingPolicy policy =
         _policyBuilder
@@ -1203,13 +1256,13 @@ public class TransferBDDTest {
 
   @Test
   public void testSetThenMatchTag() {
-    List<Statement> stmts =
-        ImmutableList.of(
-            new SetTag(new LiteralLong(42)),
-            new If(
-                new MatchTag(IntComparator.EQ, new LiteralLong(42)),
-                ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
-    RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
+
+    Statement setTag = new SetTag(new LiteralLong(42));
+    Statement cond =
+        new If(
+            new MatchTag(IntComparator.EQ, new LiteralLong(42)),
+            ImmutableList.of(new StaticStatement(Statements.ExitAccept)));
+    RoutingPolicy policy = _policyBuilder.addStatement(setTag).addStatement(cond).build();
     _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
 
     // the analysis will use the original route for matching
@@ -1230,14 +1283,14 @@ public class TransferBDDTest {
 
     // now do the analysis again but use the output attributes for matching
     setup(ConfigurationFormat.JUNIPER);
-    policy = _policyBuilder.setStatements(stmts).build();
+    policy = _policyBuilder.addStatement(setTag).addStatement(cond).build();
     paths = tbdd.computePaths(policy);
 
     assertEquals(
         paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
 
-    // do the analysis once more, but after a directive to read from intermediate attributes
+    // do the analysis again, but reading and writing to intermediate attributes
     setup(ConfigurationFormat.CISCO_IOS);
     policy =
         _policyBuilder
@@ -1245,11 +1298,58 @@ public class TransferBDDTest {
                 ImmutableList.<Statement>builder()
                     .add(new StaticStatement(Statements.SetWriteIntermediateBgpAttributes))
                     .add(new StaticStatement(Statements.SetReadIntermediateBgpAttributes))
-                    .addAll(stmts)
+                    .add(setTag)
+                    .add(cond)
                     .build())
             .build();
     paths = tbdd.computePaths(policy);
 
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
+    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+
+    // do the analysis again, but where the tag update happens before we start writing to
+    // intermediate attributes
+    setup(ConfigurationFormat.CISCO_IOS);
+    policy =
+        _policyBuilder
+            .setStatements(
+                ImmutableList.<Statement>builder()
+                    .add(setTag)
+                    .add(new StaticStatement(Statements.SetWriteIntermediateBgpAttributes))
+                    .add(new StaticStatement(Statements.SetReadIntermediateBgpAttributes))
+                    .add(cond)
+                    .build())
+            .build();
+    paths = tbdd.computePaths(policy);
+
+    // the tag update is not read
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expected, any.getTag().value(42), true),
+            new TransferReturn(expected, any.getTag().value(42).not(), false)));
+    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+
+    // do the analysis once more, but testing the behavior of unsetting writes to BGP attributes
+    setup(ConfigurationFormat.CISCO_IOS);
+    policy =
+        _policyBuilder
+            .setStatements(
+                ImmutableList.<Statement>builder()
+                    .add(new StaticStatement(Statements.SetWriteIntermediateBgpAttributes))
+                    .add(new StaticStatement(Statements.SetReadIntermediateBgpAttributes))
+                    .add(setTag)
+                    .add(new StaticStatement(Statements.UnsetWriteIntermediateBgpAttributes))
+                    .add(new SetTag(new LiteralLong(0)))
+                    .add(cond)
+                    .build())
+            .build();
+    paths = tbdd.computePaths(policy);
+
+    expected.setTag(MutableBDDInteger.makeFromValue(tag.getFactory(), 32, 0));
+
+    // the second tag update is not read since it was not written to intermediate attributes
     assertEquals(
         paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -2226,24 +2226,27 @@ public class TransferBDDTest {
   public void testApplyLongExprModification() {
     TransferBDD tbdd = new TransferBDD(forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME));
     TransferParam p = new TransferParam(false);
+    BDDRoute orig = tbdd.getOriginalRoute();
+    TransferBDDState state = new TransferBDDState(p, new TransferResult(orig.deepCopy()));
+    Context context = Context.forPolicy(_policyBuilder.build());
 
-    MutableBDDInteger toBeModified =
-        MutableBDDInteger.makeFromIndex(tbdd.getFactory(), 32, 0, false);
     MutableBDDInteger value5 = MutableBDDInteger.makeFromValue(tbdd.getFactory(), 32, 5);
     value5.setValue(5);
 
     assertThat(
-        TransferBDD.applyLongExprModification(p, toBeModified, new IncrementMetric(5)),
-        equalTo(toBeModified.addClipping(value5)));
+        tbdd.applyLongExprModification(state, context, BDDRoute::getMed, new IncrementMetric(5)),
+        equalTo(orig.getMed().addClipping(value5)));
     assertThat(
-        TransferBDD.applyLongExprModification(p, toBeModified, new DecrementMetric(5)),
-        equalTo(toBeModified.subClipping(value5)));
+        tbdd.applyLongExprModification(state, context, BDDRoute::getMed, new DecrementMetric(5)),
+        equalTo(orig.getMed().subClipping(value5)));
     assertThat(
-        TransferBDD.applyLongExprModification(p, toBeModified, new IncrementLocalPreference(5)),
-        equalTo(toBeModified.addClipping(value5)));
+        tbdd.applyLongExprModification(
+            state, context, BDDRoute::getLocalPref, new IncrementLocalPreference(5)),
+        equalTo(orig.getLocalPref().addClipping(value5)));
     assertThat(
-        TransferBDD.applyLongExprModification(p, toBeModified, new DecrementLocalPreference(5)),
-        equalTo(toBeModified.subClipping(value5)));
+        tbdd.applyLongExprModification(
+            state, context, BDDRoute::getLocalPref, new DecrementLocalPreference(5)),
+        equalTo(orig.getLocalPref().subClipping(value5)));
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferParamTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferParamTest.java
@@ -19,6 +19,7 @@ public class TransferParamTest {
         .addEqualityGroup(p.setDefaultAcceptLocal(true))
         .addEqualityGroup(p.setDefaultPolicy(new SetDefaultPolicy("foo")))
         .addEqualityGroup(p.setReadIntermediateBgpAttributes(true))
+        .addEqualityGroup(p.setWriteIntermediateBgpAttributes(true))
         .testEquals();
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferParamTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferParamTest.java
@@ -1,9 +1,6 @@
 package org.batfish.minesweeper.bdd;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import net.sf.javabdd.BDDFactory;
-import net.sf.javabdd.JFactory;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
 import org.batfish.minesweeper.bdd.TransferParam.CallContext;
 import org.batfish.minesweeper.bdd.TransferParam.ChainContext;
@@ -12,17 +9,12 @@ import org.junit.Test;
 public class TransferParamTest {
   @Test
   public void testEquals() {
-    BDDFactory factory = JFactory.init(100, 100);
-    BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
-    BDDRoute route2 = new BDDRoute(route);
-    route2.getAdminDist().setValue(1);
-    TransferParam p = new TransferParam(route, false);
+    TransferParam p = new TransferParam(false);
 
     new EqualsTester()
-        .addEqualityGroup(p, new TransferParam(route, false))
+        .addEqualityGroup(p, new TransferParam(false))
         .addEqualityGroup(p.setCallContext(CallContext.STMT_CALL))
         .addEqualityGroup(p.setChainContext(ChainContext.DISJUNCTION))
-        .addEqualityGroup(p.setData(route2))
         .addEqualityGroup(p.setDefaultAccept(true))
         .addEqualityGroup(p.setDefaultAcceptLocal(true))
         .addEqualityGroup(p.setDefaultPolicy(new SetDefaultPolicy("foo")))

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferResultTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferResultTest.java
@@ -11,18 +11,21 @@ public class TransferResultTest {
   public void testEquals() {
     BDDFactory factory = JFactory.init(100, 100);
     BDDRoute route = new BDDRoute(factory, 0, 0, 0, 0, 0, 0, ImmutableList.of());
+    BDDRoute route2 = new BDDRoute(route);
+    route2.setNextHopSet(true);
     TransferReturn r1 = new TransferReturn(route, factory.one(), false);
     TransferReturn r2 = new TransferReturn(route, factory.nithVar(0), false);
 
     new EqualsTester()
         .addEqualityGroup(
-            new TransferResult(r1, false, false, false, false),
-            new TransferResult(r1, false, false, false, false))
-        .addEqualityGroup(new TransferResult(r2, false, false, false, false))
-        .addEqualityGroup(new TransferResult(r2, true, false, false, false))
-        .addEqualityGroup(new TransferResult(r2, true, true, false, false))
-        .addEqualityGroup(new TransferResult(r2, true, true, true, false))
-        .addEqualityGroup(new TransferResult(r2, true, true, true, true))
+            new TransferResult(r1, route, false, false, false, false),
+            new TransferResult(r1, route, false, false, false, false))
+        .addEqualityGroup(new TransferResult(r1, route2, false, false, false, false))
+        .addEqualityGroup(new TransferResult(r2, route, false, false, false, false))
+        .addEqualityGroup(new TransferResult(r2, route, true, false, false, false))
+        .addEqualityGroup(new TransferResult(r2, route, true, true, false, false))
+        .addEqualityGroup(new TransferResult(r2, route, true, true, true, false))
+        .addEqualityGroup(new TransferResult(r2, route, true, true, true, true))
         .testEquals();
   }
 }


### PR DESCRIPTION
Updates the symbolic route analysis to track and use intermediate BGP attributes, based on the corresponding route-policy statements that enable/disable them, as is done in the concrete route simulation engine.