### PR TITLE
Junos: add parsing support for policy-statement "from metric2"

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -187,6 +187,7 @@ pops_from
       | popsf_level
       | popsf_local_preference
       | popsf_metric
+      | popsf_metric2
       | popsf_neighbor
       | popsf_next_hop
       | popsf_origin
@@ -304,7 +305,18 @@ popsf_metric
 :
    METRIC
    (
-      metric = dec
+      // The range seems to depend on protocol, but uint32 is the highest for any of them.
+      metric = uint32
+      | apply_groups
+   )
+;
+
+popsf_metric2
+:
+   METRIC2
+   (
+      // The range seems to depend on protocol, but uint32 is the highest for any of them.
+      metric = uint32
       | apply_groups
    )
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -535,6 +535,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_instanceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_levelContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_local_preferenceContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_metric2Context;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_neighborContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsf_next_hopContext;
@@ -5892,8 +5893,14 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitPopsf_metric(Popsf_metricContext ctx) {
-    int metric = toInt(ctx.metric);
+    long metric = toLong(ctx.metric);
     _currentPsTerm.getFroms().setFromMetric(new PsFromMetric(metric));
+  }
+
+  @Override
+  public void exitPopsf_metric2(Popsf_metric2Context ctx) {
+    todo(ctx);
+    _currentPsTerm.getFroms().setFromUnsupported(new PsFromUnsupported());
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromMetric.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromMetric.java
@@ -10,13 +10,13 @@ import org.batfish.datamodel.routing_policy.expr.MatchMetric;
 /** Represents a "from metric" line in a {@link PsTerm} */
 public class PsFromMetric extends PsFrom {
 
-  private final int _metric;
+  private final long _metric;
 
-  public PsFromMetric(int metric) {
+  public PsFromMetric(long metric) {
     _metric = metric;
   }
 
-  public int getMetric() {
+  public long getMetric() {
     return _metric;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5108,6 +5108,27 @@ public final class FlatJuniperGrammarTest {
     assertThat(result.getBooleanValue(), equalTo(false));
   }
 
+  @Test
+  public void testJuniperPolicyStatementFromMetric2Parsing() {
+    // Test that "from metric2" statements parse and are marked as unsupported
+    String hostname = "juniper-policy-statement-from-metric2";
+    JuniperConfiguration vc = parseJuniperConfig(hostname);
+
+    // Verify that the configuration generates expected unsupported warnings
+    List<ParseWarning> parseWarnings = vc.getWarnings().getParseWarnings();
+    assertThat(
+        parseWarnings,
+        contains(
+            allOf(hasComment("This feature is not currently supported"), hasText("metric2 0")),
+            allOf(hasComment("This feature is not currently supported"), hasText("metric2 100"))));
+
+    // Verify that the METRIC2_POLICY was parsed into the policy statement map
+    assertThat(vc.getMasterLogicalSystem().getPolicyStatements(), hasKey("METRIC2_POLICY"));
+    PolicyStatement metric2Policy =
+        vc.getMasterLogicalSystem().getPolicyStatements().get("METRIC2_POLICY");
+    assertThat(metric2Policy.getTerms(), hasKey("T1"));
+  }
+
   private static Environment envWithRoute(Configuration c, AbstractRoute route) {
     return envWithRoute(c, route, Direction.OUT);
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-from-metric2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-from-metric2
@@ -1,0 +1,7 @@
+#
+set system host-name juniper-policy-statement-from-metric2
+#
+set policy-options policy-statement METRIC2_POLICY term T1 from metric2 0
+set policy-options policy-statement METRIC2_POLICY term T1 from metric2 100
+set policy-options policy-statement METRIC2_POLICY term T1 then accept
+#


### PR DESCRIPTION
Previously, "from metric2" statements were unrecognized syntax and caused
parse errors. Now they are parsed and marked as unsupported with appropriate
warnings.

Also update PsFromMetric to use long instead of int to match uint32 grammar
and eliminate unnecessary downcasting.

Changes:
- Add popsf_metric2 grammar rule with uint32 metric value
- Add exitPopsf_metric2 handler that creates PsFromUnsupported and todo
- Update PsFromMetric field and methods to use long instead of int
- Remove downcast from ConfigurationBuilder.exitPopsf_metric
- Add comprehensive test for metric2 parsing behavior