### PR TITLE
Junos: make replace preserve order

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -40,6 +40,12 @@ delete_line
    DELETE delete_line_tail NEWLINE
 ;
 
+replace_line
+:
+   // Replace abuses delete_line_tail since we will delete everything anyway.
+   REPLACE delete_line_tail NEWLINE
+;
+
 delete_line_tail
 :
    hierarchy_element*
@@ -79,6 +85,7 @@ flat_juniper_configuration
       | delete_line
       | insert_line
       | protect_line
+      | replace_line
       | set_line
       | newline
    )+ EOF

--- a/projects/batfish/src/main/java/org/batfish/grammar/hierarchical/StatementTree.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/hierarchical/StatementTree.java
@@ -32,6 +32,11 @@ public class StatementTree {
     return _parent;
   }
 
+  /** Deletes all subtrees. */
+  public void deleteAllSubtrees() {
+    _children.clear();
+  }
+
   /** Deletes subtree keyed by {@code word}. */
   public void deleteSubtree(String word) {
     _children.remove(word);

--- a/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
@@ -178,7 +178,7 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
       return "delete";
     } else {
       assert ctx.REPLACE() != null;
-      return "delete";
+      return "replace";
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/main/FlattenTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/FlattenTest.java
@@ -68,6 +68,12 @@ public final class FlattenTest {
   }
 
   @Test
+  public void testJunosReplaceOrder() throws IOException {
+    assertInputOutputPair(
+        "junos-order-sensitive-replace-before", "junos-order-sensitive-replace-flattened");
+  }
+
+  @Test
   public void testActiveOnly() throws IOException {
     assertInputOutputPair("active_only", "active_only_flattened");
   }

--- a/projects/batfish/src/test/java/org/batfish/main/PreprocessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/PreprocessTest.java
@@ -102,6 +102,12 @@ public final class PreprocessTest {
   }
 
   @Test
+  public void testJuniperReplacePreservesOrder() throws IOException {
+    assertValidPair(
+        "junos-order-sensitive-replace-before", "junos-order-sensitive-replace-preprocessed");
+  }
+
+  @Test
   public void testMainBadArgs() throws IOException {
     _thrown.expect(IllegalArgumentException.class);
     main(new String[] {});

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/junos-order-sensitive-replace-before
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/junos-order-sensitive-replace-before
@@ -1,0 +1,17 @@
+set system host-name junos-order-sensitive-replace-before
+set policy-options policy-statement PS term T1 then reject
+set policy-options policy-statement PS term T2 then accept
+set policy-options policy-statement PS term T3 then reject
+set policy-options policy-statement PS term T4 then accept
+# Now replace T3, it should keep its order.
+policy-options {
+    policy-statement PS {
+        replace: term T3 {
+            from community C1;
+            then {
+                metric 5;
+                accept;
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/junos-order-sensitive-replace-flattened
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/junos-order-sensitive-replace-flattened
@@ -1,0 +1,10 @@
+####BATFISH FLATTENED JUNIPER CONFIG####
+set system host-name junos-order-sensitive-replace-before
+set policy-options policy-statement PS term T1 then reject
+set policy-options policy-statement PS term T2 then accept
+set policy-options policy-statement PS term T3 then reject
+set policy-options policy-statement PS term T4 then accept
+replace policy-options policy-statement PS term T3
+set policy-options policy-statement PS term T3 from community C1
+set policy-options policy-statement PS term T3 then metric 5
+set policy-options policy-statement PS term T3 then accept

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/junos-order-sensitive-replace-preprocessed
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/junos-order-sensitive-replace-preprocessed
@@ -1,0 +1,8 @@
+####BATFISH PRE-PROCESSED JUNIPER CONFIG####
+set system host-name junos-order-sensitive-replace-before
+set policy-options policy-statement PS term T1 then reject
+set policy-options policy-statement PS term T2 then accept
+set policy-options policy-statement PS term T3 from community C1
+set policy-options policy-statement PS term T3 then metric 5
+set policy-options policy-statement PS term T3 then accept
+set policy-options policy-statement PS term T4 then accept

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/multiple_tags_flattened
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/multiple_tags_flattened
@@ -1,4 +1,4 @@
 ####BATFISH FLATTENED JUNIPER CONFIG####
-delete system host-name multiple_tags
+replace system host-name multiple_tags
 activate system host-name multiple_tags
 set system host-name multiple_tags

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/replace_filter_flattened
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/replace_filter_flattened
@@ -4,7 +4,7 @@ set firewall family inet filter example-filter term term-1 from source-address 1
 set firewall family inet filter example-filter term term-1 then accept
 set firewall family inet filter example-filter2 term term-1 from source-address 10.0.0.0/8
 set firewall family inet filter example-filter2 term term-1 then accept
-delete firewall family inet filter example-filter
+replace firewall family inet filter example-filter
 set firewall family inet filter example-filter term term-1 from destination-address 10.0.0.0/8
 set firewall family inet filter example-filter term term-1 then accept
 set firewall family inet filter example-filter2 term term-1 from destination-address 10.0.0.0/8

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/replace_flat_mix_flattened
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/replace_flat_mix_flattened
@@ -1,5 +1,5 @@
 ####BATFISH FLATTENED JUNIPER CONFIG####
 set system host-name replace_flat_mix
 set policy-options policy-statement PS term TERM then local-preference 10
-delete policy-options policy-statement PS
+replace policy-options policy-statement PS
 set policy-options policy-statement PS term TERM then metric 20

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/replace_only_flattened
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/replace_only_flattened
@@ -1,3 +1,3 @@
 ####BATFISH FLATTENED JUNIPER CONFIG####
-delete system host-name replace_only
+replace system host-name replace_only
 set system host-name replace_only


### PR DESCRIPTION
We were treating it like delete, but this meant that the order
of terms in a sequence would be lost.

```
set policy-options policy-statement PS term T1
set policy-options policy-statement PS term T2
replace: T1 {
...
}
```

Should keep T1 before T2, but delete would move the new T1 below T2.

Instead, add replace handling to InsertDeleteApplicator that
preserves the order.