### PR TITLE
Reduce pre-commit workflow schedule from hourly to daily

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: "0 * * * *" # Hourly
+    - cron: "0 12 * * *" # Daily at 5am Seattle time (12 UTC)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Change scheduled runs from every hour to daily at 5am Seattle time (12 UTC).
Pull request and push triggers remain unchanged.