### PR TITLE
Add preprocessed configuration diff tool

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/BUILD.bazel
@@ -62,6 +62,7 @@ java_library(
         "@maven//:com_google_guava_guava",
         "@maven//:com_ibm_icu_icu4j",
         "@maven//:commons_io_commons_io",
+        "@maven//:io_github_java_diff_utils_java_diff_utils",
         "@maven//:jakarta_ws_rs_jakarta_ws_rs_api",
         "@maven//:org_antlr_antlr4_runtime",
         "@maven//:org_apache_commons_commons_collections4",

--- a/projects/batfish/src/main/java/org/batfish/main/preprocess/DiffOptions.java
+++ b/projects/batfish/src/main/java/org/batfish/main/preprocess/DiffOptions.java
@@ -1,0 +1,28 @@
+package org.batfish.main.preprocess;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Configuration options for preprocessed configuration diffing. */
+@ParametersAreNonnullByDefault
+public final class DiffOptions {
+  private final int _contextLines;
+
+  private DiffOptions(int contextLines) {
+    _contextLines = contextLines;
+  }
+
+  /** Number of context lines to show around changes in unified diff format. */
+  public int getContextLines() {
+    return _contextLines;
+  }
+
+  /** Create DiffOptions with default settings (3 context lines). */
+  public static DiffOptions defaults() {
+    return new DiffOptions(3);
+  }
+
+  /** Create DiffOptions with specified context lines. */
+  public static DiffOptions withContextLines(int contextLines) {
+    return new DiffOptions(contextLines);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/main/preprocess/DiffResult.java
+++ b/projects/batfish/src/main/java/org/batfish/main/preprocess/DiffResult.java
@@ -1,0 +1,52 @@
+package org.batfish.main.preprocess;
+
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Result of a preprocessed configuration diff operation. */
+@ParametersAreNonnullByDefault
+public final class DiffResult {
+  private final String _unifiedDiff;
+  private final boolean _successful;
+  private final String _errorMessage;
+
+  private DiffResult(String unifiedDiff, boolean successful, String errorMessage) {
+    _unifiedDiff = unifiedDiff;
+    _successful = successful;
+    _errorMessage = errorMessage;
+  }
+
+  /** The unified diff output. Empty string if files are identical or if operation failed. */
+  public @Nonnull String getUnifiedDiff() {
+    return _unifiedDiff;
+  }
+
+  /** True if the files are identical after preprocessing (no differences found). */
+  public boolean isEmpty() {
+    return _successful && _unifiedDiff.isEmpty();
+  }
+
+  /**
+   * True if the diff operation completed successfully (regardless of whether differences were
+   * found).
+   */
+  public boolean wasSuccessful() {
+    return _successful;
+  }
+
+  /** Error message if the operation failed. */
+  public Optional<String> getErrorMessage() {
+    return _errorMessage != null ? Optional.of(_errorMessage) : Optional.empty();
+  }
+
+  /** Create a successful result with the given unified diff output. */
+  static DiffResult success(String unifiedDiff) {
+    return new DiffResult(unifiedDiff, true, null);
+  }
+
+  /** Create a failed result with the given error message. */
+  static DiffResult failure(String errorMessage) {
+    return new DiffResult("", false, errorMessage);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/main/preprocess/PreprocessedDiff.java
+++ b/projects/batfish/src/main/java/org/batfish/main/preprocess/PreprocessedDiff.java
@@ -1,0 +1,103 @@
+package org.batfish.main.preprocess;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.UnifiedDiffUtils;
+import com.github.difflib.patch.Patch;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
+import org.batfish.config.Settings;
+
+/** Library for computing diffs between preprocessed configuration files. */
+@ParametersAreNonnullByDefault
+public final class PreprocessedDiff {
+
+  /**
+   * Compute a diff between two configuration files after preprocessing.
+   *
+   * @param file1 Path to first configuration file
+   * @param file2 Path to second configuration file
+   * @param options Diff options (context lines, etc.)
+   * @return DiffResult containing unified diff output or error information
+   */
+  public static @Nonnull DiffResult diffFiles(Path file1, Path file2, DiffOptions options) {
+    try {
+      // Read both files
+      String content1 = Files.readString(file1);
+      String content2 = Files.readString(file2);
+
+      return diffStrings(content1, content2, file1.toString(), file2.toString(), options);
+    } catch (IOException e) {
+      return DiffResult.failure("Error reading files: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Compute a diff between two configuration strings after preprocessing.
+   *
+   * @param content1 Content of first configuration
+   * @param content2 Content of second configuration
+   * @param filename1 Name/path of first file (for diff headers)
+   * @param filename2 Name/path of second file (for diff headers)
+   * @param options Diff options (context lines, etc.)
+   * @return DiffResult containing unified diff output or error information
+   */
+  public static @Nonnull DiffResult diffStrings(
+      String content1, String content2, String filename1, String filename2, DiffOptions options) {
+
+    try {
+      // Create settings for preprocessing
+      Settings settings = new Settings(new String[] {"-storagebase", "/"});
+
+      // Preprocess both configurations
+      Warnings warnings1 = new Warnings();
+      Warnings warnings2 = new Warnings();
+
+      String preprocessed1 =
+          Preprocessor.preprocess(settings, content1, Path.of(filename1), warnings1);
+      String preprocessed2 =
+          Preprocessor.preprocess(settings, content2, Path.of(filename2), warnings2);
+
+      // Compute unified diff
+      String unifiedDiff =
+          computeUnifiedDiff(preprocessed1, preprocessed2, filename1, filename2, options);
+
+      return DiffResult.success(unifiedDiff);
+
+    } catch (IOException e) {
+      return DiffResult.failure("Error preprocessing configurations: " + e.getMessage());
+    } catch (Exception e) {
+      return DiffResult.failure("Unexpected error: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Computes a unified diff of the input strings, returning the empty string if the strings are
+   * equal. Based on org.batfish.client.Client.getPatch().
+   */
+  private static @Nonnull String computeUnifiedDiff(
+      String expected,
+      String actual,
+      String expectedFileName,
+      String actualFileName,
+      DiffOptions options) {
+    List<String> referenceLines = Arrays.asList(expected.split("\n"));
+    List<String> testLines = Arrays.asList(actual.split("\n"));
+    Patch<String> patch = DiffUtils.diff(referenceLines, testLines);
+    if (patch.getDeltas().isEmpty()) {
+      return "";
+    } else {
+      List<String> patchLines =
+          UnifiedDiffUtils.generateUnifiedDiff(
+              expectedFileName, actualFileName, referenceLines, patch, options.getContextLines());
+      return String.join("\n", patchLines);
+    }
+  }
+
+  private PreprocessedDiff() {} // prevent instantiation
+}

--- a/projects/batfish/src/test/java/org/batfish/main/preprocess/PreprocessedDiffTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/preprocess/PreprocessedDiffTest.java
@@ -1,0 +1,161 @@
+package org.batfish.main.preprocess;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+
+/** Tests for {@link PreprocessedDiff}. */
+public class PreprocessedDiffTest {
+
+  @Test
+  public void testDiffStrings_identical() {
+    String config1 = "hostname router1\nip route 0.0.0.0 0.0.0.0 192.168.1.1";
+    String config2 = "hostname router1\nip route 0.0.0.0 0.0.0.0 192.168.1.1";
+
+    DiffResult result =
+        PreprocessedDiff.diffStrings(config1, config2, "file1", "file2", DiffOptions.defaults());
+
+    assertThat("Diff should succeed", result.wasSuccessful(), equalTo(true));
+    assertThat("Identical configs should have empty diff", result.isEmpty(), equalTo(true));
+    assertThat("Unified diff should be empty", result.getUnifiedDiff(), equalTo(""));
+  }
+
+  @Test
+  public void testDiffStrings_different() {
+    String config1 = "hostname router1\nip route 0.0.0.0 0.0.0.0 192.168.1.1";
+    String config2 = "hostname router2\nip route 0.0.0.0 0.0.0.0 192.168.1.1";
+
+    DiffResult result =
+        PreprocessedDiff.diffStrings(config1, config2, "file1", "file2", DiffOptions.defaults());
+
+    assertThat("Diff should succeed", result.wasSuccessful(), equalTo(true));
+    assertThat("Different configs should have non-empty diff", result.isEmpty(), equalTo(false));
+    assertThat(
+        "Unified diff should contain change", result.getUnifiedDiff(), containsString("router1"));
+    assertThat(
+        "Unified diff should contain change", result.getUnifiedDiff(), containsString("router2"));
+    assertThat(
+        "Unified diff should contain file names", result.getUnifiedDiff(), containsString("file1"));
+    assertThat(
+        "Unified diff should contain file names", result.getUnifiedDiff(), containsString("file2"));
+  }
+
+  @Test
+  public void testDiffStrings_emptyFiles() {
+    String config1 = "";
+    String config2 = "";
+
+    DiffResult result =
+        PreprocessedDiff.diffStrings(config1, config2, "file1", "file2", DiffOptions.defaults());
+
+    assertThat("Diff should succeed", result.wasSuccessful(), equalTo(true));
+    assertThat("Empty configs should have empty diff", result.isEmpty(), equalTo(true));
+  }
+
+  @Test
+  public void testDiffOptions_contextLines() {
+    String config1 = "line1\nline2\nline3\nline4\nline5";
+    String config2 = "line1\nline2\nCHANGED\nline4\nline5";
+
+    DiffResult result =
+        PreprocessedDiff.diffStrings(
+            config1, config2, "file1", "file2", DiffOptions.withContextLines(1));
+
+    assertThat("Diff should succeed", result.wasSuccessful(), equalTo(true));
+    assertThat("Different configs should have non-empty diff", result.isEmpty(), equalTo(false));
+    String diff = result.getUnifiedDiff();
+    assertThat("Unified diff should contain changed line", diff, containsString("CHANGED"));
+    assertThat("Unified diff should contain context", diff, containsString("line2"));
+    assertThat("Unified diff should contain context", diff, containsString("line4"));
+  }
+
+  @Test
+  public void testDiffStrings_configPreprocessing() {
+    // Test that configs actually get preprocessed if they are in a supported format
+    // For configs that don't get preprocessed, they should still diff correctly
+    String config1 = "hostname router1\ninterface eth0\n ip address 1.1.1.1/24";
+    String config2 = "hostname router2\ninterface eth0\n ip address 1.1.1.2/24";
+
+    DiffResult result =
+        PreprocessedDiff.diffStrings(
+            config1, config2, "config1", "config2", DiffOptions.defaults());
+
+    assertThat("Diff should succeed", result.wasSuccessful(), equalTo(true));
+    assertThat("Different configs should have non-empty diff", result.isEmpty(), equalTo(false));
+    String diff = result.getUnifiedDiff();
+    assertThat("Diff should show hostname difference", diff, containsString("router1"));
+    assertThat("Diff should show hostname difference", diff, containsString("router2"));
+    assertThat("Diff should show IP difference", diff, containsString("1.1.1.1"));
+    assertThat("Diff should show IP difference", diff, containsString("1.1.1.2"));
+  }
+
+  @Test
+  public void testDiffStrings_nonPreprocessibleConfig() {
+    // Test with config format that doesn't get preprocessed (like generic text)
+    String config1 = "some random text\nthat won't be preprocessed";
+    String config2 = "some different text\nthat won't be preprocessed";
+
+    DiffResult result =
+        PreprocessedDiff.diffStrings(
+            config1, config2, "file1.txt", "file2.txt", DiffOptions.defaults());
+
+    assertThat("Diff should succeed", result.wasSuccessful(), equalTo(true));
+    assertThat("Different configs should have non-empty diff", result.isEmpty(), equalTo(false));
+    String diff = result.getUnifiedDiff();
+    assertThat("Diff should contain original content", diff, containsString("random"));
+    assertThat("Diff should contain changed content", diff, containsString("different"));
+  }
+
+  @Test
+  public void testDiffStrings_largeConfig() {
+    // Test with larger config to ensure it handles size reasonably
+    StringBuilder config1 = new StringBuilder();
+    StringBuilder config2 = new StringBuilder();
+
+    for (int i = 0; i < 100; i++) {
+      config1.append("line ").append(i).append("\n");
+      config2.append("line ").append(i == 50 ? "CHANGED" : i).append("\n");
+    }
+
+    DiffResult result =
+        PreprocessedDiff.diffStrings(
+            config1.toString(),
+            config2.toString(),
+            "large1.txt",
+            "large2.txt",
+            DiffOptions.defaults());
+
+    assertThat("Diff should succeed", result.wasSuccessful(), equalTo(true));
+    assertThat("Different configs should have non-empty diff", result.isEmpty(), equalTo(false));
+    String diff = result.getUnifiedDiff();
+    assertThat("Diff should contain change", diff, containsString("CHANGED"));
+    assertThat("Diff should contain line numbers", diff, containsString("@@"));
+  }
+
+  @Test
+  public void testDiffOptions_defaultsVsCustom() {
+    String config1 = "line1\nline2\nline3\nline4\nline5\nline6\nline7";
+    String config2 = "line1\nline2\nCHANGED\nline4\nline5\nline6\nline7";
+
+    DiffResult defaultResult =
+        PreprocessedDiff.diffStrings(config1, config2, "file1", "file2", DiffOptions.defaults());
+    DiffResult customResult =
+        PreprocessedDiff.diffStrings(
+            config1, config2, "file1", "file2", DiffOptions.withContextLines(1));
+
+    assertThat("Both diffs should succeed", defaultResult.wasSuccessful(), equalTo(true));
+    assertThat("Both diffs should succeed", customResult.wasSuccessful(), equalTo(true));
+    assertThat("Both should detect changes", defaultResult.isEmpty(), equalTo(false));
+    assertThat("Both should detect changes", customResult.isEmpty(), equalTo(false));
+
+    // Default should have more context than custom (3 vs 1)
+    String defaultDiff = defaultResult.getUnifiedDiff();
+    String customDiff = customResult.getUnifiedDiff();
+
+    // Both should contain the changed line
+    assertThat("Default diff should contain change", defaultDiff, containsString("CHANGED"));
+    assertThat("Custom diff should contain change", customDiff, containsString("CHANGED"));
+  }
+}


### PR DESCRIPTION
Implements a library and CLI tool to compute diffs between preprocessed
configuration files. This allows users to see the meaningful differences
between configs after Batfish preprocessing (group expansion, etc.).

Key features:
- Library API with PreprocessedDiff, DiffResult, and DiffOptions classes
- CLI integration via --diff mode in existing Preprocess tool
- Reuses existing preprocessing and diff logic for consistency
- Comprehensive unit tests covering various config types and edge cases

Usage:
bazel run //tools:preprocess -- --diff <file1> <file2>
bazel run //tools:preprocess -- --diff <file1> <file2> --output <file>