### PR TITLE
Add on-demand lab validation workflow for PRs

### DIFF
--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -38,6 +38,8 @@ jobs:
         
         echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Build Batfish JAR from the PR branch
   build-batfish:
@@ -58,6 +60,8 @@ jobs:
         echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
         echo "Testing PR #${{ needs.check-trigger.outputs.pr_number }}: $PR_TITLE"
         echo "Branch: $PR_REF"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Checkout PR branch
       uses: actions/checkout@v4
@@ -116,6 +120,8 @@ jobs:
         Testing: All available lab scenarios
 
         [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run lab validation
       uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
@@ -162,3 +168,5 @@ jobs:
 
         **💡 How to trigger lab validation:**
         Add the \`lab-validation\` label to this PR. Validation will rerun automatically when you push new commits."
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -104,8 +104,8 @@ jobs:
           questions.tgz
         retention-days: 1
 
-  # Run lab validation using the built JAR
-  lab-validation:
+  # Add PR comment before running lab validation  
+  add-starting-comment:
     runs-on: ubuntu-latest
     needs: [check-trigger, build-batfish]
     steps:
@@ -123,15 +123,17 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Run lab validation
-      uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
-      with:
-        batfish_ref: ${{ needs.build-batfish.outputs.pr_ref }}
+  # Run lab validation using the built JAR
+  lab-validation:
+    needs: [check-trigger, build-batfish, add-starting-comment]
+    uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
+    with:
+      batfish_ref: ${{ needs.build-batfish.outputs.pr_ref }}
 
   # Post results as PR comment
   post-results:
     runs-on: ubuntu-latest
-    needs: [check-trigger, build-batfish, lab-validation]
+    needs: [check-trigger, build-batfish, add-starting-comment, lab-validation]
     if: always() && needs.check-trigger.outputs.should_run == 'true'  # Run even if lab validation fails, but only if we started
     steps:
     - name: Add PR comment - Results

--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -38,8 +38,6 @@ jobs:
         
         echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Build Batfish JAR from the PR branch
   build-batfish:
@@ -60,8 +58,6 @@ jobs:
         echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
         echo "Testing PR #${{ needs.check-trigger.outputs.pr_number }}: $PR_TITLE"
         echo "Branch: $PR_REF"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Checkout PR branch
       uses: actions/checkout@v4
@@ -120,8 +116,6 @@ jobs:
         Testing: All available lab scenarios
 
         [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Run lab validation using the built JAR
   lab-validation:
@@ -170,5 +164,3 @@ jobs:
 
         **💡 How to trigger lab validation:**
         Add the \`lab-validation\` label to this PR. Validation will rerun automatically when you push new commits."
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that enables on-demand lab validation for pull requests using a simple label-based trigger.

## Changes

- **New workflow**: 
- **Trigger mechanism**: Add the  label to any PR
- **Auto-rerun**: Validation reruns automatically when new commits are pushed (if label is present)
- **Integration**: Uses the existing  reusable workflow

## How it works

1. When the  label is added to a PR, the workflow triggers
2. Builds a Batfish JAR from the PR branch
3. Runs lab validation using the built JAR via the reusable workflow
4. Posts results as PR comments with success/failure status
5. Automatically reruns when new commits are pushed (if label remains)

## Testing

The workflow can be tested by:
1. Adding the  label to any PR
2. Checking the Actions tab for the workflow run
3. Viewing the PR comments for validation status

The workflow validates all available lab scenarios and reports results directly in the PR.