### PR TITLE
Fix lab validation workflow syntax errors

### DIFF
--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -38,6 +38,8 @@ jobs:
         
         echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ github.token }}
 
   # Build Batfish JAR from the PR branch
   build-batfish:
@@ -58,6 +60,8 @@ jobs:
         echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
         echo "Testing PR #${{ needs.check-trigger.outputs.pr_number }}: $PR_TITLE"
         echo "Branch: $PR_REF"
+      env:
+        GH_TOKEN: ${{ github.token }}
     
     - name: Checkout PR branch
       uses: actions/checkout@v4
@@ -116,6 +120,8 @@ jobs:
         Testing: All available lab scenarios
 
         [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+      env:
+        GH_TOKEN: ${{ github.token }}
 
   # Run lab validation using the built JAR
   lab-validation:
@@ -164,3 +170,5 @@ jobs:
 
         **💡 How to trigger lab validation:**
         Add the \`lab-validation\` label to this PR. Validation will rerun automatically when you push new commits."
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -38,6 +38,8 @@ jobs:
         
         echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Build Batfish JAR from the PR branch
   build-batfish:
@@ -58,6 +60,8 @@ jobs:
         echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
         echo "Testing PR #${{ needs.check-trigger.outputs.pr_number }}: $PR_TITLE"
         echo "Branch: $PR_REF"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Checkout PR branch
       uses: actions/checkout@v4
@@ -116,6 +120,8 @@ jobs:
         Testing: All available lab scenarios
 
         [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run lab validation
       uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
@@ -162,3 +168,5 @@ jobs:
 
         **💡 How to trigger lab validation:**
         Add the \`lab-validation\` label to this PR. Validation will rerun automatically when you push new commits."
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -104,8 +104,8 @@ jobs:
           questions.tgz
         retention-days: 1
 
-  # Run lab validation using the built JAR
-  lab-validation:
+  # Add PR comment before running lab validation  
+  add-starting-comment:
     runs-on: ubuntu-latest
     needs: [check-trigger, build-batfish]
     steps:
@@ -123,15 +123,17 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Run lab validation
-      uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
-      with:
-        batfish_ref: ${{ needs.build-batfish.outputs.pr_ref }}
+  # Run lab validation using the built JAR
+  lab-validation:
+    needs: [check-trigger, build-batfish, add-starting-comment]
+    uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
+    with:
+      batfish_ref: ${{ needs.build-batfish.outputs.pr_ref }}
 
   # Post results as PR comment
   post-results:
     runs-on: ubuntu-latest
-    needs: [check-trigger, build-batfish, lab-validation]
+    needs: [check-trigger, build-batfish, add-starting-comment, lab-validation]
     if: always() && needs.check-trigger.outputs.should_run == 'true'  # Run even if lab validation fails, but only if we started
     steps:
     - name: Add PR comment - Results

--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -38,8 +38,6 @@ jobs:
         
         echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Build Batfish JAR from the PR branch
   build-batfish:
@@ -60,8 +58,6 @@ jobs:
         echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
         echo "Testing PR #${{ needs.check-trigger.outputs.pr_number }}: $PR_TITLE"
         echo "Branch: $PR_REF"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Checkout PR branch
       uses: actions/checkout@v4
@@ -120,8 +116,6 @@ jobs:
         Testing: All available lab scenarios
 
         [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Run lab validation using the built JAR
   lab-validation:
@@ -170,5 +164,3 @@ jobs:
 
         **💡 How to trigger lab validation:**
         Add the \`lab-validation\` label to this PR. Validation will rerun automatically when you push new commits."
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes syntax errors in the lab validation workflow that were causing workflow runs to fail with "Invalid workflow file" errors.

## Issues Fixed

1. **Reusable workflow syntax error**: The reusable workflow was incorrectly referenced as a step instead of at the job level
2. **gh CLI authentication**: The gh CLI requires `GH_TOKEN` environment variable, not `GITHUB_TOKEN`
3. **Workflow structure**: Split into proper job dependencies to support the reusable workflow pattern

## Changes Made

- Move reusable workflow reference from step level to job level using proper `uses:` syntax
- Split workflow into separate jobs: `add-starting-comment`, `lab-validation`, `post-results`
- Add `GH_TOKEN: ${{ github.token }}` to steps that use gh CLI commands
- Update job dependencies to maintain proper execution order

## Root Causes

### 1. Invalid reusable workflow syntax
The original workflow attempted to call the reusable workflow as a step:
```yaml
steps:
  - name: Run lab validation
    uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
```

This is invalid syntax. Reusable workflows must be referenced at the job level:
```yaml  
jobs:
  lab-validation:
    uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
```

### 2. gh CLI authentication failure
The gh CLI in GitHub Actions requires `GH_TOKEN`, not `GITHUB_TOKEN`:
```yaml
env:
  GH_TOKEN: ${{ github.token }}  # Correct
  # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Incorrect
```

## Verification

The workflow should now pass GitHub Actions validation and execute properly when triggered with the `lab-validation` label.