### PR TITLE
Fix gh CLI authentication in lab validation workflow

### DIFF
--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -38,6 +38,8 @@ jobs:
         
         echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ github.token }}
 
   # Build Batfish JAR from the PR branch
   build-batfish:
@@ -58,6 +60,8 @@ jobs:
         echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
         echo "Testing PR #${{ needs.check-trigger.outputs.pr_number }}: $PR_TITLE"
         echo "Branch: $PR_REF"
+      env:
+        GH_TOKEN: ${{ github.token }}
     
     - name: Checkout PR branch
       uses: actions/checkout@v4
@@ -116,6 +120,8 @@ jobs:
         Testing: All available lab scenarios
 
         [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+      env:
+        GH_TOKEN: ${{ github.token }}
 
   # Run lab validation using the built JAR
   lab-validation:
@@ -164,3 +170,5 @@ jobs:
 
         **💡 How to trigger lab validation:**
         Add the \`lab-validation\` label to this PR. Validation will rerun automatically when you push new commits."
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Fixes gh CLI authentication failures in the lab validation workflow by adding the required `GH_TOKEN` environment variable.

## Problem

The lab validation workflow was failing with authentication errors:
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
##[error]Process completed with exit code 4.
```

## Solution

Added `GH_TOKEN: ${{ github.token }}` environment variable to all steps that use `gh` CLI commands:

- `check-trigger` step: Uses `gh api` to check PR labels
- `get_pr` step: Uses `gh api` to get PR metadata  
- `add-starting-comment` step: Uses `gh api` to post PR comments
- `post-results` step: Uses `gh api` to post PR comments

## Technical Details

The GitHub CLI in Actions requires `GH_TOKEN` specifically, not `GITHUB_TOKEN`:
- ✅ `GH_TOKEN: ${{ github.token }}` 
- ❌ `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`

## Verification

This should resolve the workflow authentication failures and allow the lab validation to run successfully when triggered with the `lab-validation` label.