### PR TITLE
Simplify PR lab validation workflow to avoid duplicate builds

### DIFF
--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -41,8 +41,8 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
-  # Build Batfish JAR from the PR branch
-  build-batfish:
+  # Get PR information for lab validation
+  get-pr-info:
     runs-on: ubuntu-latest
     needs: check-trigger
     if: needs.check-trigger.outputs.should_run == 'true'
@@ -62,52 +62,11 @@ jobs:
         echo "Branch: $PR_REF"
       env:
         GH_TOKEN: ${{ github.token }}
-    
-    - name: Checkout PR branch
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ steps.get_pr.outputs.pr_ref }}
-    
-    - name: Set up Java 17
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-    
-    - name: Bazelisk cache
-      uses: actions/cache@v4
-      with:
-        path: "~/.cache/bazelisk"
-        key: ${{runner.os}}-bazelisk-${{ hashFiles('.bazelversion') }}
-    
-    - name: Bazel cache
-      uses: actions/cache@v4
-      with:
-        path: "~/.cache/bazel"
-        key: ${{runner.os}}-bazel-17-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-${{ github.run_id }}
-        restore-keys: |
-          ${{runner.os}}-bazel-17-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-
-
-    - name: Build Batfish JAR and questions
-      run: |
-        bazel build //projects/allinone:allinone_main_deploy.jar
-        cp bazel-bin/projects/allinone/allinone_main_deploy.jar allinone.jar
-        # Create questions archive following pybatfish pattern
-        tar -czf questions.tgz questions/
-
-    - name: Upload Batfish artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: batfish-pr-artifacts
-        path: |
-          allinone.jar
-          questions.tgz
-        retention-days: 1
 
   # Add PR comment before running lab validation  
   add-starting-comment:
     runs-on: ubuntu-latest
-    needs: [check-trigger, build-batfish]
+    needs: [check-trigger, get-pr-info]
     steps:
     - name: Add PR comment - Starting validation
       run: |
@@ -115,25 +74,25 @@ jobs:
           --method POST \
           --field body="🧪 **Lab Validation Started**
 
-        Running lab validation for PR #${{ needs.check-trigger.outputs.pr_number }}: ${{ needs.build-batfish.outputs.pr_title }}
-        Branch: \`${{ needs.build-batfish.outputs.pr_ref }}\`
+        Running lab validation for PR #${{ needs.check-trigger.outputs.pr_number }}: ${{ needs.get-pr-info.outputs.pr_title }}
+        Branch: \`${{ needs.get-pr-info.outputs.pr_ref }}\`
         Testing: All available lab scenarios
 
         [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
       env:
         GH_TOKEN: ${{ github.token }}
 
-  # Run lab validation using the built JAR
+  # Run lab validation using the PR branch
   lab-validation:
-    needs: [check-trigger, build-batfish, add-starting-comment]
+    needs: [check-trigger, get-pr-info, add-starting-comment]
     uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
     with:
-      batfish_ref: ${{ needs.build-batfish.outputs.pr_ref }}
+      batfish_ref: ${{ needs.get-pr-info.outputs.pr_ref }}
 
   # Post results as PR comment
   post-results:
     runs-on: ubuntu-latest
-    needs: [check-trigger, build-batfish, add-starting-comment, lab-validation]
+    needs: [check-trigger, get-pr-info, add-starting-comment, lab-validation]
     if: always() && needs.check-trigger.outputs.should_run == 'true'  # Run even if lab validation fails, but only if we started
     steps:
     - name: Add PR comment - Results
@@ -150,8 +109,8 @@ jobs:
           --method POST \
           --field body="$EMOJI $STATUS
 
-        PR #${{ needs.check-trigger.outputs.pr_number }}: ${{ needs.build-batfish.outputs.pr_title }}
-        Branch: \`${{ needs.build-batfish.outputs.pr_ref }}\`
+        PR #${{ needs.check-trigger.outputs.pr_number }}: ${{ needs.get-pr-info.outputs.pr_title }}
+        Branch: \`${{ needs.get-pr-info.outputs.pr_ref }}\`
         Tested: All available lab scenarios
 
         [View detailed results](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
The PR lab validation workflow was building Batfish JAR twice:
1. First in the PR workflow itself  
2. Then again in the reusable lab-validation workflow

This changes the approach to:
- Remove the build job from the PR workflow
- Pass the PR branch ref to the reusable workflow  
- Let the reusable workflow handle building from source

This eliminates duplicate compilation and reduces CI time while maintaining the same functionality.