### PR TITLE
Fix GitHub API endpoint for PR labels

### DIFF
--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -28,7 +28,7 @@ jobs:
           fi
         elif [ "${{ github.event.action }}" = "synchronize" ]; then
           # Check if PR has 'lab-validation' label when new commits are pushed
-          LABELS=$(gh api repos/batfish/batfish/pulls/${{ github.event.number }}/labels --jq '.[].name')
+          LABELS=$(gh api repos/batfish/batfish/issues/${{ github.event.number }}/labels --jq '.[].name')
           if echo "$LABELS" | grep -q "lab-validation"; then
             SHOULD_RUN="true"
             PR_NUMBER="${{ github.event.number }}"

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -2483,9 +2483,10 @@ public final class AristaConfiguration extends VendorConfiguration {
               .forEach(
                   (prefix, srm) -> {
                     for (StaticRoute staticRoute : srm.getVariants()) {
-                      newVrf
-                          .getStaticRoutes()
-                          .add(Conversions.toStaticRoute(c, prefix, staticRoute, srm.getTag()));
+                      //                      newVrf
+                      //                          .getStaticRoutes()
+                      //                          .add(Conversions.toStaticRoute(c, prefix,
+                      // staticRoute, srm.getTag()));
                     }
                   });
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -2483,10 +2483,9 @@ public final class AristaConfiguration extends VendorConfiguration {
               .forEach(
                   (prefix, srm) -> {
                     for (StaticRoute staticRoute : srm.getVariants()) {
-                      //                      newVrf
-                      //                          .getStaticRoutes()
-                      //                          .add(Conversions.toStaticRoute(c, prefix,
-                      // staticRoute, srm.getTag()));
+                      newVrf
+                          .getStaticRoutes()
+                          .add(Conversions.toStaticRoute(c, prefix, staticRoute, srm.getTag()));
                     }
                   });
 


### PR DESCRIPTION
The lab validation workflow was failing with a 404 error when trying to check PR labels on synchronize events.

**Issue:** The workflow was using  which doesn't exist in GitHub's API.

**Fix:** Changed to  which is the correct endpoint, as PRs are treated as issues for label operations in GitHub's REST API.

**Testing:** Verified the API call works locally:
```bash
gh api repos/batfish/batfish/issues/9494/labels --jq '.[].name'
# Returns: lab-validation  
```

This should resolve the 404 errors when the workflow runs on PR synchronize events.