### PR TITLE
Simplify lab validation workflow by removing GitHub API complexity

### DIFF
--- a/.github/workflows/lab-validation-pr.yml
+++ b/.github/workflows/lab-validation-pr.yml
@@ -1,81 +1,23 @@
 name: Lab Validation for PR
 
 on:
-  # Trigger when label is added to PR or new commits are pushed (if label exists)
   pull_request:
     types: [labeled, synchronize]
 
 jobs:
-  # Check if we should run based on trigger type
-  check-trigger:
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-      pr_number: ${{ steps.check.outputs.pr_number }}
-    steps:
-    - name: Check trigger conditions
-      id: check
-      run: |
-        SHOULD_RUN="false"
-        PR_NUMBER=""
-        
-        if [ "${{ github.event.action }}" = "labeled" ]; then
-          # Check if 'lab-validation' label was added
-          if [ "${{ github.event.label.name }}" = "lab-validation" ]; then
-            SHOULD_RUN="true"
-            PR_NUMBER="${{ github.event.number }}"
-            echo "🏷️ Label 'lab-validation' added to PR #$PR_NUMBER"
-          fi
-        elif [ "${{ github.event.action }}" = "synchronize" ]; then
-          # Check if PR has 'lab-validation' label when new commits are pushed
-          LABELS=$(gh api repos/batfish/batfish/issues/${{ github.event.number }}/labels --jq '.[].name')
-          if echo "$LABELS" | grep -q "lab-validation"; then
-            SHOULD_RUN="true"
-            PR_NUMBER="${{ github.event.number }}"
-            echo "🔄 New commits pushed to PR #$PR_NUMBER with 'lab-validation' label"
-          fi
-        fi
-        
-        echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
-        echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-      env:
-        GH_TOKEN: ${{ github.token }}
-
-  # Get PR information for lab validation
-  get-pr-info:
-    runs-on: ubuntu-latest
-    needs: check-trigger
-    if: needs.check-trigger.outputs.should_run == 'true'
-    outputs:
-      pr_ref: ${{ steps.get_pr.outputs.pr_ref }}
-      pr_title: ${{ steps.get_pr.outputs.pr_title }}
-    steps:
-    - name: Get PR information
-      id: get_pr
-      run: |
-        PR_DATA=$(gh api repos/batfish/batfish/pulls/${{ needs.check-trigger.outputs.pr_number }})
-        PR_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
-        PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
-        echo "pr_ref=$PR_REF" >> $GITHUB_OUTPUT
-        echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
-        echo "Testing PR #${{ needs.check-trigger.outputs.pr_number }}: $PR_TITLE"
-        echo "Branch: $PR_REF"
-      env:
-        GH_TOKEN: ${{ github.token }}
-
   # Add PR comment before running lab validation  
   add-starting-comment:
     runs-on: ubuntu-latest
-    needs: [check-trigger, get-pr-info]
+    if: contains(github.event.pull_request.labels.*.name, 'lab-validation')
     steps:
     - name: Add PR comment - Starting validation
       run: |
-        gh api repos/batfish/batfish/issues/${{ needs.check-trigger.outputs.pr_number }}/comments \
+        gh api repos/batfish/batfish/issues/${{ github.event.pull_request.number }}/comments \
           --method POST \
           --field body="🧪 **Lab Validation Started**
 
-        Running lab validation for PR #${{ needs.check-trigger.outputs.pr_number }}: ${{ needs.get-pr-info.outputs.pr_title }}
-        Branch: \`${{ needs.get-pr-info.outputs.pr_ref }}\`
+        Running lab validation for PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
+        Branch: \`${{ github.event.pull_request.head.ref }}\`
         Testing: All available lab scenarios
 
         [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
@@ -84,16 +26,17 @@ jobs:
 
   # Run lab validation using the PR branch
   lab-validation:
-    needs: [check-trigger, get-pr-info, add-starting-comment]
+    needs: [add-starting-comment]
+    if: contains(github.event.pull_request.labels.*.name, 'lab-validation')
     uses: batfish/lab-validation/.github/workflows/reusable-lab-validation.yml@main
     with:
-      batfish_ref: ${{ needs.get-pr-info.outputs.pr_ref }}
+      batfish_ref: ${{ github.event.pull_request.head.ref }}
 
   # Post results as PR comment
   post-results:
     runs-on: ubuntu-latest
-    needs: [check-trigger, get-pr-info, add-starting-comment, lab-validation]
-    if: always() && needs.check-trigger.outputs.should_run == 'true'  # Run even if lab validation fails, but only if we started
+    needs: [add-starting-comment, lab-validation]
+    if: always() && contains(github.event.pull_request.labels.*.name, 'lab-validation')
     steps:
     - name: Add PR comment - Results
       run: |
@@ -105,12 +48,12 @@ jobs:
           EMOJI="⚠️"
         fi
 
-        gh api repos/batfish/batfish/issues/${{ needs.check-trigger.outputs.pr_number }}/comments \
+        gh api repos/batfish/batfish/issues/${{ github.event.pull_request.number }}/comments \
           --method POST \
           --field body="$EMOJI $STATUS
 
-        PR #${{ needs.check-trigger.outputs.pr_number }}: ${{ needs.get-pr-info.outputs.pr_title }}
-        Branch: \`${{ needs.get-pr-info.outputs.pr_ref }}\`
+        PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
+        Branch: \`${{ github.event.pull_request.head.ref }}\`
         Tested: All available lab scenarios
 
         [View detailed results](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
This PR simplifies the lab validation workflow by:

- Using `contains(github.event.pull_request.labels.*.name, 'lab-validation')` for both labeled and synchronize events
- Removing unnecessary `check-trigger` and `get-pr-info` jobs that used GitHub API calls
- Accessing PR data directly from `github.event.pull_request` context
- Eliminating GitHub API calls for basic PR information that's already available in the event payload

The simplified workflow should work identically to the previous version but with much less complexity and no API calls.

To test: Add the `lab-validation` label to this PR and verify it runs correctly.