### PR TITLE
Junos: Add fatal error validation for description length

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1161,6 +1161,29 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testDescriptionValidationFatalError() throws IOException {
+    String fileKey = "description-validation";
+    String warningKey = "configs/" + fileKey;
+
+    Batfish batfish = getBatfishForConfigurationNames(fileKey);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    ParseVendorConfigurationAnswerElement pvcae =
+        batfish.loadParseVendorConfigurationAnswerElement(batfish.getSnapshot());
+
+    // Should generate fatal errors for both empty descriptions (length 0) and long descriptions
+    // (>255 chars)
+    assertThat(
+        pvcae.getWarnings().get(warningKey).getFatalRedFlagWarnings(),
+        contains(
+            WarningMatchers.hasText(
+                containsString("Description length 0 is not within range (1..255)")),
+            WarningMatchers.hasText(
+                containsString("Description length 278 is not within range (1..255)")),
+            WarningMatchers.hasText(
+                containsString("Description length 290 is not within range (1..255)"))));
+  }
+
+  @Test
   public void testBgpKeepExtraction() {
     JuniperConfiguration c = parseJuniperConfig("bgp-keep");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/description-validation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/description-validation
@@ -1,0 +1,15 @@
+#
+set system host-name description-validation
+#
+set routing-options autonomous-system 1
+# Empty BGP neighbor description 
+set routing-instances TEST-RI protocols bgp group TEST-GROUP type external
+set routing-instances TEST-RI protocols bgp group TEST-GROUP neighbor 10.0.0.1 description ""
+set routing-instances TEST-RI protocols bgp group TEST-GROUP neighbor 10.0.0.1 local-address 10.0.0.2
+set routing-instances TEST-RI protocols bgp group TEST-GROUP neighbor 10.0.0.1 peer-as 65001
+# Long BGP neighbor description (over 255 chars)
+set routing-instances TEST-RI protocols bgp group TEST-GROUP neighbor 10.0.0.3 description "This is a very long description that exceeds the 255 character limit imposed by Juniper routers. This description should trigger a fatal error because it is too long for Juniper to accept. The limit is 255 characters and this description will definitely exceed that limit making it invalid."
+# Empty interface description
+set interfaces ge-0/0/0 description ""
+# Long interface description (over 255 chars)  
+set interfaces ge-0/0/1 description "This is another very long description that exceeds the 255 character limit imposed by Juniper routers. This description should trigger a fatal error because it is too long for Juniper to accept. The limit is 255 characters and this description will definitely exceed that limit."


### PR DESCRIPTION
## Summary
Junos rejects descriptions outside the range (1..255). This change makes Batfish generate fatal errors for invalid descriptions to match Junos behavior.

## Changes
- Centralized description validation in `toString(DescriptionContext)` method
- Generate fatal errors for empty and overly long descriptions
- Applies to both BGP neighbor and interface descriptions

Fixes configurations being accepted by Batfish that would be rejected by actual Junos devices.