### PR TITLE
Junos: add support for protocol icmp6 in applications

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_common.g4
@@ -264,6 +264,7 @@ ip_protocol
   | GRE
   | HOP_BY_HOP
   | ICMP
+  | ICMP6
   | IGMP
   | IPIP
   | IPV6

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2056,6 +2056,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       return IpProtocol.HOPOPT;
     } else if (ctx.ICMP() != null) {
       return IpProtocol.ICMP;
+    } else if (ctx.ICMP6() != null) {
+      return IpProtocol.IPV6_ICMP;
     } else if (ctx.IGMP() != null) {
       return IpProtocol.IGMP;
     } else if (ctx.IPIP() != null) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -817,6 +817,35 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testApplicationIcmp6() {
+    String hostname = "application-icmp6";
+    JuniperConfiguration vc = parseJuniperConfig(hostname);
+
+    // Verify that ICMP6 applications are parsed and extracted correctly
+    assertThat(
+        vc.getMasterLogicalSystem().getApplications(), hasKeys("icmp6-app", "icmp-app", "tcp-app"));
+
+    // The ICMP6 application should contain IPV6_ICMP protocol
+    BaseApplication icmp6App = vc.getMasterLogicalSystem().getApplications().get("icmp6-app");
+    assertThat(
+        icmp6App.getMainTerm().getHeaderSpace().getIpProtocols(), contains(IpProtocol.IPV6_ICMP));
+
+    // ICMP6 applications should convert to MatchHeaderSpace like other protocol applications
+    AclLineMatchExpr icmp6Expr = icmp6App.toAclLineMatchExpr(vc, new Warnings());
+    assertThat(icmp6Expr, instanceOf(MatchHeaderSpace.class));
+
+    // For comparison, ICMP should also work normally
+    BaseApplication icmpApp = vc.getMasterLogicalSystem().getApplications().get("icmp-app");
+    AclLineMatchExpr icmpExpr = icmpApp.toAclLineMatchExpr(vc, new Warnings());
+    assertThat(icmpExpr, instanceOf(MatchHeaderSpace.class));
+
+    // TCP applications should also work normally
+    BaseApplication tcpApp = vc.getMasterLogicalSystem().getApplications().get("tcp-app");
+    AclLineMatchExpr tcpExpr = tcpApp.toAclLineMatchExpr(vc, new Warnings());
+    assertThat(tcpExpr, instanceOf(MatchHeaderSpace.class));
+  }
+
+  @Test
   public void testAuthenticationKeyChain() throws IOException {
     String hostname = "authentication-key-chain";
     String filename = "configs/" + hostname;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/application-icmp6
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/application-icmp6
@@ -1,0 +1,8 @@
+#
+set system host-name application-icmp6
+#
+set applications application icmp6-app protocol icmp6
+set applications application icmp-app protocol icmp
+set applications application tcp-app protocol tcp
+set applications application tcp-app destination-port 80
+#


### PR DESCRIPTION
## Summary
Add parsing and extraction support for `protocol icmp6` in Juniper application definitions. Previously, configurations using `protocol icmp6` would generate undefined reference errors.

## Changes
- **Grammar**: Add `ICMP6` token to `ip_protocol` rule in `FlatJuniper_common.g4`
- **Extraction**: Add ICMP6 handling in `ConfigurationBuilder.toIpProtocol()` to map to `IpProtocol.IPV6_ICMP`
- **Testing**: Add comprehensive test coverage for ICMP6 protocol parsing and extraction

## Test Plan
- [x] Added `testApplicationIcmp6()` test that verifies ICMP6 applications are parsed and extracted correctly
- [x] Verified ICMP6 applications convert to `MatchHeaderSpace` like other protocol applications
- [x] All existing tests continue to pass
- [x] Build completes successfully

## Example Configuration
The following configuration now parses without errors:
```
set applications application my-icmp6-app protocol icmp6
```

This resolves issues with configurations that reference ICMP6 protocols in application definitions.