### PR TITLE
IOS: remove many BatfishExceptions, fix crashing on unhandled interface type

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -56,7 +56,7 @@ public class Interface implements Serializable {
 
   public static @Nullable Double getDefaultBandwidth(
       @Nonnull String name, @Nonnull ConfigurationFormat format) {
-    Double defaultSpeed = getDefaultSpeed(name, format);
+    Double defaultSpeed = getDefaultSpeed(name);
     if (defaultSpeed != null) {
       return defaultSpeed;
     } else if (name.startsWith("Loopback")) {
@@ -74,14 +74,15 @@ public class Interface implements Serializable {
     }
   }
 
-  public static @Nullable Double getDefaultSpeed(
-      @Nonnull String name, @Nonnull ConfigurationFormat format) {
+  public static @Nullable Double getDefaultSpeed(@Nonnull String name) {
     if (name.startsWith("Ethernet")) {
       return DEFAULT_IOS_ETHERNET_SPEED;
     } else if (name.startsWith("FastEthernet")) {
       return DEFAULT_FAST_ETHERNET_SPEED;
     } else if (name.startsWith("FiftyGig")) {
       return 50E9D;
+    } else if (name.startsWith("FiveGigabit")) {
+      return 5E9D;
     } else if (name.startsWith("FortyGig")) {
       return 40E9D;
     } else if (name.startsWith("GigabitEthernet")) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1589,11 +1589,15 @@ public final class CiscoGrammarTest {
     assertThat(c, hasInterface("FiftyGigE2/0/0", hasBandwidth(50e9)));
     assertThat(c, hasInterface("FiftyGigE3/0/0", hasBandwidth(50e9)));
     //
+    assertThat(c, hasInterface("FiveGigabitEthernet1/0/1", hasBandwidth(5e9)));
+    //
     assertThat(c, hasInterface("FortyGigabitEthernet1/0/0", hasBandwidth(40e9)));
     assertThat(c, hasInterface("FortyGigabitEthernet2/0/0", hasBandwidth(40e9)));
     //
     assertThat(c, hasInterface("HundredGigabitEthernet1/0/0", hasBandwidth(100e9)));
     assertThat(c, hasInterface("HundredGigabitEthernet2/0/0", hasBandwidth(100e9)));
+    // Bad interface names don't cause problems and get some default bandwidth.
+    assertThat(c, hasInterface("TwoPiGigabitEthernet1/0/1", hasBandwidth(1e12)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface
@@ -10,6 +10,9 @@ interface FiftyGigE2/0/0
 interface Fif3/0/0
  no shutdown
 !
+interface FiveGigabitEthernet1/0/1
+ no shutdown
+!
 interface FortyGigabitEthernet1/0/0
  no shutdown
 !
@@ -20,5 +23,9 @@ interface HundredGigabitEthernet1/0/0
  no shutdown
 !
 interface Hu2/0/0
+ no shutdown
+!
+! One that hopefully never exists, should proceed and not crash.
+interface TwoPiGigabitEthernet1/0/1
  no shutdown
 !


### PR DESCRIPTION
Continue killing BatfishException, which should never be used. In general, parser should never
crash but should warn, risky, fatal, or otherwise proceed. BatfishException in parsers is the
worst combination.

Most of the changes in the grammar are unreachable as catch-alls where we think we might add
an alternative without a test (what?!) So get rid of those.

For interface names, we should proceed happily instead of crashing when a new prefix
is added.