### PR TITLE
Junos: more graceful handling of invalid wildcards

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ApplyPathApplicator.java
@@ -48,11 +48,13 @@ public class ApplyPathApplicator extends FlatJuniperParserBaseListener {
     String[] pathComponents = pathWithoutQuotes.split("\\s+");
     for (String pathComponent : pathComponents) {
       if (pathComponent.charAt(0) == '<') {
-        if (pathComponent.charAt(pathComponent.length() - 1) != '>') {
+        try {
+          applyPathPath.addWildcardNode(pathComponent, line);
+        } catch (IllegalArgumentException e) {
+          _w.redFlagf("Could not parse %s as a wildcard", pathComponent);
           // Malformed wildcard - don't try to expand this apply-path
           return;
         }
-        applyPathPath.addWildcardNode(pathComponent, line);
       } else {
         applyPathPath.addNode(pathComponent, line);
       }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
@@ -31,7 +31,6 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.antlr.v4.runtime.tree.TerminalNodeImpl;
-import org.batfish.common.BatfishException;
 import org.batfish.common.util.PatternProvider;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
@@ -690,10 +689,11 @@ final class Hierarchy {
 
       private HierarchyWildcardNode(String text, int lineNumber) {
         super(text, lineNumber);
-        if (_unquotedText.charAt(0) != '<'
-            || _unquotedText.charAt(_unquotedText.length() - 1) != '>') {
-          throw new BatfishException("Improperly-formatted wildcard: " + text);
-        }
+        checkArgument(
+            _unquotedText.charAt(0) == '<'
+                && _unquotedText.charAt(_unquotedText.length() - 1) == '>',
+            "Improperly-formatted wildcard: %s",
+            _unquotedText);
         _wildcard = _unquotedText.substring(1, _unquotedText.length() - 1);
         _wildcardPattern = PatternProvider.fromString(GroupWildcard.toJavaRegex(_wildcard));
       }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
@@ -19,11 +19,14 @@ set protocols ospf area 0.0.0.1 interface et-0/0/0.0 passive
 set policy-options prefix-list p4 apply-path "snmp community <*> clients <*>"
 set snmp community "foo" clients 4.4.4.4/32
 set snmp community "<removed>" clients 5.5.5.5/32
-## p5 should have no addresses because of the invalid wildcard
-set policy-options prefix-list p5 apply-path "protocols bgp group <*> neighbor <*>;"
 set firewall family inet filter FILTER term PERMIT-ALL from protocol tcp
 set firewall family inet filter FILTER term PERMIT-ALL then accept
 set groups g4 interfaces "<em[0,1]>" unit <*> family inet filter input FILTER
 set interfaces em0 unit 0 family inet address 10.0.0.1/24
 set apply-groups g4
+#
+# p5-6-7 should have no addresses because of the invalid wildcard which shows up as a warning
+set policy-options prefix-list p5 apply-path "protocols bgp group <*> neighbor <*>;"
+set policy-options prefix-list p6 apply-path "interfaces < unit 0 family inet address <*>"
+set policy-options prefix-list p7 apply-path "interfaces <*> unit 0 family inet address <%>"
 #


### PR DESCRIPTION
We had previously special-cased improper truncating, but we need to handle
failure to convert the regex as well.