### PR TITLE
Junos: add IPv6 interface address extraction

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConcreteInterfaceAddress6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConcreteInterfaceAddress6.java
@@ -5,15 +5,21 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-/** A concrete IPv6 address assigned to an interface */
+/**
+ * A concrete IPv6 address assigned to an interface
+ *
+ * <p>TODO: Consider extending InterfaceAddress if needed for polymorphism in the future
+ */
 @ParametersAreNonnullByDefault
-public final class ConcreteInterfaceAddress6 extends InterfaceAddress {
+public final class ConcreteInterfaceAddress6
+    implements Comparable<ConcreteInterfaceAddress6>, Serializable {
 
   private static final Comparator<ConcreteInterfaceAddress6> COMPARATOR =
       Comparator.comparing(ConcreteInterfaceAddress6::getIp)
@@ -71,11 +77,8 @@ public final class ConcreteInterfaceAddress6 extends InterfaceAddress {
   }
 
   @Override
-  public int compareTo(InterfaceAddress rhs) {
-    if (rhs instanceof ConcreteInterfaceAddress6) {
-      return COMPARATOR.compare(this, (ConcreteInterfaceAddress6) rhs);
-    }
-    return 1;
+  public int compareTo(ConcreteInterfaceAddress6 rhs) {
+    return COMPARATOR.compare(this, rhs);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConcreteInterfaceAddress6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConcreteInterfaceAddress6.java
@@ -1,0 +1,114 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import java.util.Comparator;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** A concrete IPv6 address assigned to an interface */
+@ParametersAreNonnullByDefault
+public final class ConcreteInterfaceAddress6 extends InterfaceAddress {
+
+  private static final Comparator<ConcreteInterfaceAddress6> COMPARATOR =
+      Comparator.comparing(ConcreteInterfaceAddress6::getIp)
+          .thenComparing(ConcreteInterfaceAddress6::getNetworkBits);
+
+  private final @Nonnull Ip6 _ip;
+  private final int _networkBits;
+
+  private ConcreteInterfaceAddress6(Ip6 ip, int networkBits) {
+    _ip = ip;
+    _networkBits = networkBits;
+  }
+
+  @JsonCreator
+  private static ConcreteInterfaceAddress6 jsonCreator(@Nullable String text) {
+    checkArgument(text != null, "Cannot create ConcreteInterfaceAddress6 from null string");
+    return parse(text);
+  }
+
+  public static ConcreteInterfaceAddress6 create(Ip6 ip, int networkBits) {
+    checkArgument(
+        networkBits > 0 && networkBits <= Prefix6.MAX_PREFIX_LENGTH,
+        "Invalid network mask %s, must be between 1 and %s",
+        networkBits,
+        Prefix6.MAX_PREFIX_LENGTH);
+    assert Prefix6.create(ip, networkBits).toIp6Space().containsIp(ip, ImmutableMap.of())
+        : String.format(
+            "ConcreteInterfaceAddress6: IP is not a host IP. ip=%s, networkBits=%d",
+            ip, networkBits);
+    return new ConcreteInterfaceAddress6(ip, networkBits);
+  }
+
+  public static ConcreteInterfaceAddress6 parse(String text) {
+    String[] parts = text.split("/");
+    checkArgument(
+        parts.length == 2,
+        "Invalid %s string: \"%s\"",
+        ConcreteInterfaceAddress6.class.getSimpleName(),
+        text);
+    Ip6 ip = Ip6.parse(parts[0]);
+    int networkBits = Integer.parseUnsignedInt(parts[1]);
+    return create(ip, networkBits);
+  }
+
+  /**
+   * Return an {@link Optional} {@link ConcreteInterfaceAddress6} from a string, or {@link
+   * Optional#empty} if the string does not represent a {@link ConcreteInterfaceAddress6}.
+   */
+  public static @Nonnull Optional<ConcreteInterfaceAddress6> tryParse(String text) {
+    try {
+      return Optional.of(parse(text));
+    } catch (IllegalArgumentException e) {
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public int compareTo(InterfaceAddress rhs) {
+    if (rhs instanceof ConcreteInterfaceAddress6) {
+      return COMPARATOR.compare(this, (ConcreteInterfaceAddress6) rhs);
+    }
+    return 1;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof ConcreteInterfaceAddress6)) {
+      return false;
+    }
+    ConcreteInterfaceAddress6 rhs = (ConcreteInterfaceAddress6) o;
+    return _ip.equals(rhs._ip) && _networkBits == rhs._networkBits;
+  }
+
+  public @Nonnull Ip6 getIp() {
+    return _ip;
+  }
+
+  public int getNetworkBits() {
+    return _networkBits;
+  }
+
+  public @Nonnull Prefix6 getPrefix() {
+    return Prefix6.create(_ip, _networkBits);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * _ip.hashCode() + _networkBits;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return _ip + "/" + _networkBits;
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConcreteInterfaceAddress6Test.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConcreteInterfaceAddress6Test.java
@@ -1,0 +1,74 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Optional;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests of {@link ConcreteInterfaceAddress6} */
+public class ConcreteInterfaceAddress6Test {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testEquals() {
+    ConcreteInterfaceAddress6 cia = ConcreteInterfaceAddress6.parse("2001:db8::1/64");
+    new EqualsTester()
+        .addEqualityGroup(cia, cia, ConcreteInterfaceAddress6.parse("2001:db8::1/64"))
+        .addEqualityGroup(ConcreteInterfaceAddress6.parse("2001:db8::2/64"))
+        .addEqualityGroup(ConcreteInterfaceAddress6.parse("2001:db8::1/128"))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testParse() {
+    assertThat(
+        ConcreteInterfaceAddress6.parse("2001:db8::1/64"),
+        equalTo(ConcreteInterfaceAddress6.create(Ip6.parse("2001:db8::1"), 64)));
+  }
+
+  @Test
+  public void testTryParse() {
+    assertThat(
+        ConcreteInterfaceAddress6.tryParse("2001:db8::1/64"),
+        equalTo(Optional.of(ConcreteInterfaceAddress6.create(Ip6.parse("2001:db8::1"), 64))));
+    assertThat(ConcreteInterfaceAddress6.tryParse("garbade"), equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    ConcreteInterfaceAddress6 cia = ConcreteInterfaceAddress6.parse("2001:db8::1/64");
+    assertThat(SerializationUtils.clone(cia), equalTo(cia));
+  }
+
+  @Test
+  public void testJsonSerialization() {
+    ConcreteInterfaceAddress6 cia = ConcreteInterfaceAddress6.parse("2001:db8::1/64");
+    assertThat(BatfishObjectMapper.clone(cia, ConcreteInterfaceAddress6.class), equalTo(cia));
+  }
+
+  @Test
+  public void testInvalidNumBitsLow() {
+    thrown.expect(IllegalArgumentException.class);
+    ConcreteInterfaceAddress6.create(Ip6.parse("2001:db8::1"), 0);
+  }
+
+  @Test
+  public void testInvalidNumBitsHigh() {
+    thrown.expect(IllegalArgumentException.class);
+    ConcreteInterfaceAddress6.create(Ip6.parse("2001:db8::1"), 129);
+  }
+
+  @Test
+  public void testGetPrefix() {
+    assertThat(
+        ConcreteInterfaceAddress6.parse("2001:db8::55/64").getPrefix(),
+        equalTo(Prefix6.parse("2001:db8::/64")));
+  }
+}

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -383,11 +383,29 @@ if_inet6
    INET6
    (
       apply
+      | ifi6_address
       | ifi6_destination_udp_port
       | ifi6_filter
       | ifi6_mtu
    )
 ;
+
+ifi6_address
+:
+   ADDRESS
+   (
+      ipv6_address
+      | ipv6_prefix
+      | wildcard
+   )
+   (
+      ifi6a_preferred
+      | ifi6a_primary
+   )?
+;
+
+ifi6a_preferred: PREFERRED;
+ifi6a_primary: PRIMARY;
 
 ifi6_destination_udp_port: DESTINATION_UDP_PORT port_number;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -384,7 +384,10 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_interface_modeConte
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_native_vlan_idContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_port_modeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_vlanContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6_destination_udp_portContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6a_preferredContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6a_primaryContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6f_inputContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi_destination_udp_portContext;
@@ -2303,6 +2306,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   private ConcreteInterfaceAddress _currentInterfaceAddress;
 
+  private Prefix6 _currentInterfaceAddress6;
+
   private IpsecPolicy _currentIpsecPolicy;
 
   private IpsecProposal _currentIpsecProposal;
@@ -2789,11 +2794,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     ConcreteInterfaceAddress address;
     if (ctx.ip_prefix() != null) {
       address = toConcreteInterfaceAddress(ctx.ip_prefix());
-    } else if (ctx.ip_address() != null) {
+    } else {
+      assert ctx.ip_address() != null;
       Ip ip = toIp(ctx.ip_address());
       address = ConcreteInterfaceAddress.create(ip, Prefix.MAX_PREFIX_LENGTH);
-    } else {
-      throw new BatfishException("Invalid or missing address");
     }
     _currentInterfaceAddress = address;
     if (_currentInterfaceOrRange.getPrimaryAddress() == null) {
@@ -5345,6 +5349,42 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitIfm_destination_udp_port(Ifm_destination_udp_portContext ctx) {
     todo(ctx);
+  }
+
+  @Override
+  public void enterIfi6_address(Ifi6_addressContext ctx) {
+    Set<Prefix6> allAddresses6 = _currentInterfaceOrRange.getAllAddresses6();
+    Prefix6 address;
+    if (ctx.ipv6_prefix() != null) {
+      address = toPrefix6(ctx.ipv6_prefix());
+    } else {
+      assert ctx.ipv6_address() != null;
+      Ip6 ip = toIp6(ctx.ipv6_address());
+      address = Prefix6.create(ip, Prefix6.MAX_PREFIX_LENGTH);
+    }
+    _currentInterfaceAddress6 = address;
+    if (_currentInterfaceOrRange.getPrimaryAddress6() == null) {
+      _currentInterfaceOrRange.setPrimaryAddress6(address);
+    }
+    if (_currentInterfaceOrRange.getPreferredAddress6() == null) {
+      _currentInterfaceOrRange.setPreferredAddress6(address);
+    }
+    allAddresses6.add(address);
+  }
+
+  @Override
+  public void exitIfi6_address(Ifi6_addressContext ctx) {
+    _currentInterfaceAddress6 = null;
+  }
+
+  @Override
+  public void exitIfi6a_preferred(Ifi6a_preferredContext ctx) {
+    _currentInterfaceOrRange.setPreferredAddress6(_currentInterfaceAddress6);
+  }
+
+  @Override
+  public void exitIfi6a_primary(Ifi6a_primaryContext ctx) {
+    _currentInterfaceOrRange.setPrimaryAddress6(_currentInterfaceAddress6);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5362,11 +5362,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       Ip6 ip = Ip6.parse(parts[0]);
       int prefixLength = Integer.parseInt(parts[1]);
       address = ConcreteInterfaceAddress6.create(ip, prefixLength);
-    } else if (ctx.ipv6_address() != null) {
+    } else {
+      assert ctx.ipv6_address() != null;
       Ip6 ip = toIp6(ctx.ipv6_address());
       address = ConcreteInterfaceAddress6.create(ip, Prefix6.MAX_PREFIX_LENGTH);
-    } else {
-      throw new BatfishException("Invalid or missing IPv6 address");
     }
     _currentInterfaceAddress6 = address;
     if (_currentInterfaceOrRange.getPrimaryAddress6() == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -15,6 +15,7 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IsoAddress;
+import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.SubRange;
 
 public class Interface implements Serializable {
@@ -146,6 +147,7 @@ public class Interface implements Serializable {
   private boolean _active;
   private Set<Ip> _additionalArpIps;
   private final Set<ConcreteInterfaceAddress> _allAddresses;
+  private final Set<Prefix6> _allAddresses6;
   // Dumb name to appease checkstyle
   private String _agg8023adInterface;
   private final Set<Ip> _allAddressIps;
@@ -168,7 +170,9 @@ public class Interface implements Serializable {
   private @Nullable List<String> _outgoingFilterList;
   private Interface _parent;
   private InterfaceAddress _preferredAddress;
+  private @Nullable Prefix6 _preferredAddress6;
   private ConcreteInterfaceAddress _primaryAddress;
+  private @Nullable Prefix6 _primaryAddress6;
   private boolean _primary;
   private @Nullable String _redundantParentInterface;
   private RoutingInstance _routingInstance;
@@ -183,6 +187,7 @@ public class Interface implements Serializable {
     _active = true;
     _additionalArpIps = ImmutableSet.of();
     _allAddresses = new LinkedHashSet<>();
+    _allAddresses6 = new LinkedHashSet<>();
     _allAddressIps = new LinkedHashSet<>();
     _bandwidth = getDefaultBandwidthByName(name);
     _defined = false;
@@ -209,6 +214,10 @@ public class Interface implements Serializable {
 
   public Set<ConcreteInterfaceAddress> getAllAddresses() {
     return _allAddresses;
+  }
+
+  public Set<Prefix6> getAllAddresses6() {
+    return _allAddresses6;
   }
 
   public Set<Ip> getAllAddressIps() {
@@ -291,8 +300,16 @@ public class Interface implements Serializable {
     return _preferredAddress;
   }
 
+  public @Nullable Prefix6 getPreferredAddress6() {
+    return _preferredAddress6;
+  }
+
   public ConcreteInterfaceAddress getPrimaryAddress() {
     return _primaryAddress;
+  }
+
+  public @Nullable Prefix6 getPrimaryAddress6() {
+    return _primaryAddress6;
   }
 
   /**
@@ -479,8 +496,16 @@ public class Interface implements Serializable {
     _preferredAddress = address;
   }
 
+  public void setPreferredAddress6(@Nullable Prefix6 address) {
+    _preferredAddress6 = address;
+  }
+
   public void setPrimaryAddress(ConcreteInterfaceAddress address) {
     _primaryAddress = address;
+  }
+
+  public void setPrimaryAddress6(@Nullable Prefix6 address) {
+    _primaryAddress6 = address;
   }
 
   public void setPrimary(boolean primary) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -12,10 +12,10 @@ import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.ConcreteInterfaceAddress6;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IsoAddress;
-import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.SubRange;
 
 public class Interface implements Serializable {
@@ -147,7 +147,7 @@ public class Interface implements Serializable {
   private boolean _active;
   private Set<Ip> _additionalArpIps;
   private final Set<ConcreteInterfaceAddress> _allAddresses;
-  private final Set<Prefix6> _allAddresses6;
+  private final Set<ConcreteInterfaceAddress6> _allAddresses6;
   // Dumb name to appease checkstyle
   private String _agg8023adInterface;
   private final Set<Ip> _allAddressIps;
@@ -170,9 +170,9 @@ public class Interface implements Serializable {
   private @Nullable List<String> _outgoingFilterList;
   private Interface _parent;
   private InterfaceAddress _preferredAddress;
-  private @Nullable Prefix6 _preferredAddress6;
+  private @Nullable ConcreteInterfaceAddress6 _preferredAddress6;
   private ConcreteInterfaceAddress _primaryAddress;
-  private @Nullable Prefix6 _primaryAddress6;
+  private @Nullable ConcreteInterfaceAddress6 _primaryAddress6;
   private boolean _primary;
   private @Nullable String _redundantParentInterface;
   private RoutingInstance _routingInstance;
@@ -216,7 +216,7 @@ public class Interface implements Serializable {
     return _allAddresses;
   }
 
-  public Set<Prefix6> getAllAddresses6() {
+  public Set<ConcreteInterfaceAddress6> getAllAddresses6() {
     return _allAddresses6;
   }
 
@@ -300,7 +300,7 @@ public class Interface implements Serializable {
     return _preferredAddress;
   }
 
-  public @Nullable Prefix6 getPreferredAddress6() {
+  public @Nullable ConcreteInterfaceAddress6 getPreferredAddress6() {
     return _preferredAddress6;
   }
 
@@ -308,7 +308,7 @@ public class Interface implements Serializable {
     return _primaryAddress;
   }
 
-  public @Nullable Prefix6 getPrimaryAddress6() {
+  public @Nullable ConcreteInterfaceAddress6 getPrimaryAddress6() {
     return _primaryAddress6;
   }
 
@@ -496,7 +496,7 @@ public class Interface implements Serializable {
     _preferredAddress = address;
   }
 
-  public void setPreferredAddress6(@Nullable Prefix6 address) {
+  public void setPreferredAddress6(@Nullable ConcreteInterfaceAddress6 address) {
     _preferredAddress6 = address;
   }
 
@@ -504,7 +504,7 @@ public class Interface implements Serializable {
     _primaryAddress = address;
   }
 
-  public void setPrimaryAddress6(@Nullable Prefix6 address) {
+  public void setPrimaryAddress6(@Nullable ConcreteInterfaceAddress6 address) {
     _primaryAddress6 = address;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3904,14 +3904,14 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         units1.get("ge-0/0/1.0").getAllAddresses6(),
         containsInAnyOrder(
-            ConcreteInterfaceAddress6.parse("2001:db8:1::1/64"),
-            ConcreteInterfaceAddress6.parse("2001:db8:2::1/64")));
+            ConcreteInterfaceAddress6.parse("2001:db8::1/64"),
+            ConcreteInterfaceAddress6.parse("2001:db8::2/64")));
     assertThat(
         units1.get("ge-0/0/1.0").getPrimaryAddress6(),
-        equalTo(ConcreteInterfaceAddress6.parse("2001:db8:1::1/64")));
+        equalTo(ConcreteInterfaceAddress6.parse("2001:db8::1/64")));
     assertThat(
         units1.get("ge-0/0/1.0").getPreferredAddress6(),
-        equalTo(ConcreteInterfaceAddress6.parse("2001:db8:2::1/64")));
+        equalTo(ConcreteInterfaceAddress6.parse("2001:db8::2/64")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -277,6 +277,7 @@ import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Bgpv4Route.Builder;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.ConcreteInterfaceAddress6;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ConnectedRoute;
@@ -3876,6 +3877,41 @@ public final class FlatJuniperGrammarTest {
         c,
         hasInterface(
             "vtnet0.0", hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.1.2.1/30")))));
+  }
+
+  @Test
+  public void testInterfaceInet6Address() {
+    String hostname = "interface-inet6-address";
+    JuniperConfiguration jc = parseJuniperConfig(hostname);
+
+    Map<String, org.batfish.representation.juniper.Interface> units0 =
+        jc.getMasterLogicalSystem().getInterfaces().get("ge-0/0/0").getUnits();
+    Map<String, org.batfish.representation.juniper.Interface> units1 =
+        jc.getMasterLogicalSystem().getInterfaces().get("ge-0/0/1").getUnits();
+
+    // ge-0/0/0.0 has a single IPv6 address
+    assertThat(
+        units0.get("ge-0/0/0.0").getAllAddresses6(),
+        contains(ConcreteInterfaceAddress6.parse("2001:db8::1/64")));
+    assertThat(
+        units0.get("ge-0/0/0.0").getPrimaryAddress6(),
+        equalTo(ConcreteInterfaceAddress6.parse("2001:db8::1/64")));
+    assertThat(
+        units0.get("ge-0/0/0.0").getPreferredAddress6(),
+        equalTo(ConcreteInterfaceAddress6.parse("2001:db8::1/64")));
+
+    // ge-0/0/1.0 has two IPv6 addresses with explicit primary and preferred
+    assertThat(
+        units1.get("ge-0/0/1.0").getAllAddresses6(),
+        containsInAnyOrder(
+            ConcreteInterfaceAddress6.parse("2001:db8:1::1/64"),
+            ConcreteInterfaceAddress6.parse("2001:db8:2::1/64")));
+    assertThat(
+        units1.get("ge-0/0/1.0").getPrimaryAddress6(),
+        equalTo(ConcreteInterfaceAddress6.parse("2001:db8:1::1/64")));
+    assertThat(
+        units1.get("ge-0/0/1.0").getPreferredAddress6(),
+        equalTo(ConcreteInterfaceAddress6.parse("2001:db8:2::1/64")));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-inet6-address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-inet6-address
@@ -1,0 +1,10 @@
+#
+set system host-name interface-inet6-address
+#
+set interfaces ge-0/0/0 unit 0 family inet6 address 2001:db8::1/64
+#
+set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:1::1/64
+set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:1::1/64 primary
+set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:2::1/64
+set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:2::1/64 preferred
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-inet6-address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-inet6-address
@@ -3,8 +3,8 @@ set system host-name interface-inet6-address
 #
 set interfaces ge-0/0/0 unit 0 family inet6 address 2001:db8::1/64
 #
-set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:1::1/64
-set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:1::1/64 primary
-set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:2::1/64
-set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:2::1/64 preferred
+set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8::1/64
+set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8::1/64 primary
+set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8::2/64
+set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8::2/64 preferred
 #


### PR DESCRIPTION
## Summary

Add IPv6 interface address extraction support for Junos configurations.

- Add `ConcreteInterfaceAddress6` class to preserve full IPv6 host addresses without normalization
- Add grammar rules to parse IPv6 interface addresses with primary/preferred modifiers
- Update Juniper vendor-specific model to track IPv6 addresses separately from IPv4
- Add extraction logic to populate IPv6 address fields
- Add comprehensive unit tests for both the model and extraction

## Changes

**New ConcreteInterfaceAddress6 class:**
- Similar to `ConcreteInterfaceAddress` for IPv4, preserves full host address
- Does not normalize to network address like `Prefix6` does
- Independent from `InterfaceAddress` hierarchy (with TODO to reconsider if needed)
- Includes full test coverage (equality, parsing, serialization, validation)

**Grammar changes:**
- Add `ifi6_address` rule to parse addresses under `family inet6`
- Support `ipv6_address`, `ipv6_prefix`, and `wildcard` formats
- Add `ifi6a_primary` and `ifi6a_preferred` modifiers

**Vendor-specific model (Interface.java):**
- Add `_allAddresses6` field to track all IPv6 addresses on an interface
- Add `_primaryAddress6` and `_preferredAddress6` fields
- Add corresponding getters and setters

**Extraction logic (ConfigurationBuilder.java):**
- Implement `enterIfi6_address()` to extract addresses from parse tree
- Handle primary and preferred modifiers
- Parse addresses directly to avoid normalization

**Tests:**
- Add extraction test verifying basic address extraction
- Test primary and preferred address modifiers
- Test multiple addresses on single interface
- Verify host bits are preserved (not normalized to network address)

## Test plan
- [x] Unit tests pass for `ConcreteInterfaceAddress6Test`
- [x] Extraction test passes for `testInterfaceInet6Address`
- [x] Build succeeds