### PR TITLE
Junos: skip generating set lines for delete/replace/inactive tags

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/juniper/JuniperFlattener.java
@@ -90,7 +90,10 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
 
   @Override
   public void enterHierarchical_statement(Hierarchical_statementContext ctx) {
-    _inEmptyBracedClause = false;
+    // Only clear _inEmptyBracedClause if this statement has content (no delete tag)
+    if (_inEmptyBracedClause && ctx.tag().stream().noneMatch(tag -> tag.DELETE() != null)) {
+      _inEmptyBracedClause = false;
+    }
 
     int firstWordLine = ctx.words.get(0).getStart().getLine();
     ImmutableSet.Builder<Integer> extraLinesBuilder =
@@ -133,6 +136,10 @@ public class JuniperFlattener extends JuniperParserBaseListener implements Flatt
 
   @Override
   public void exitTerminator(TerminatorContext ctx) {
+    if (_inDelete) {
+      // Tag command already constructed; nothing more to do.
+      return;
+    }
     if (_currentBracketedWords != null) {
       // Make a separate set-line for each of the bracketed words
       for (WordContext bracketedWordCtx : _currentBracketedWords) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/flatten-delete-replace
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/flatten-delete-replace
@@ -1,0 +1,9 @@
+system {
+    replace: host-name "some-device";
+}
+delete: protocols bgp;
+interfaces {
+    xe-0/0/0 {
+        delete: unit 0;
+    }
+}


### PR DESCRIPTION
When a hierarchical statement has a tag (delete:, replace:, inactive:),
the flattener constructs the appropriate tag command with the full path.
Previously, exitTerminator would then construct a spurious "set" line
with an empty stack because _inDelete suppressed word collection.

Fix by returning early from exitTerminator when _inDelete is true, since
the tag command has already been constructed and no set line is needed.

---

**Stack**:
- #9538 ⬅
- #9537


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*