### PR TITLE
Refactor ANTLR grammar generation into Starlark rule

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "arista_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.arista",
+)
+
 java_library(
     name = "arista",
-    srcs = [
-        ":AristaLexer.java",
-        ":AristaParser.java",
-        ":AristaParserBaseListener.java",
-        ":AristaParserListener.java",
-    ],
+    srcs = [":arista_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/arista/parsing:arista_base_parser",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "arista_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "AristaLexer.tokens",
-        "AristaLexer.java",
-        "AristaParser.java",
-        "AristaParserBaseListener.java",
-        "AristaParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location AristaLexer.g4) \
-       $(location AristaParser.g4) \
-    -package org.batfish.grammar.arista \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "cisco_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.cisco",
+)
+
 java_library(
     name = "cisco",
-    srcs = [
-        ":CiscoLexer.java",
-        ":CiscoParser.java",
-        ":CiscoParserBaseListener.java",
-        ":CiscoParserListener.java",
-    ],
+    srcs = [":cisco_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cisco/parsing:cisco_base_parser",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "cisco_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "CiscoLexer.java",
-        "CiscoLexer.tokens",
-        "CiscoParser.java",
-        "CiscoParserBaseListener.java",
-        "CiscoParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location CiscoLexer.g4) \
-       $(location CiscoParser.g4) \
-    -package org.batfish.grammar.cisco \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "cisco_asa_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.cisco_asa",
+)
+
 java_library(
     name = "cisco_asa",
-    srcs = [
-        ":AsaLexer.java",
-        ":AsaParser.java",
-        ":AsaParserBaseListener.java",
-        ":AsaParserListener.java",
-    ],
+    srcs = [":cisco_asa_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/parsing:cisco_asa_base_parser",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "cisco_asa_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "AsaLexer.java",
-        "AsaLexer.tokens",
-        "AsaParser.java",
-        "AsaParserBaseListener.java",
-        "AsaParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location AsaLexer.g4) \
-       $(location AsaParser.g4) \
-    -package org.batfish.grammar.cisco_asa \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "cisco_nxos_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.cisco_nxos",
+)
+
 java_library(
     name = "cisco_nxos",
-    srcs = [
-        ":CiscoNxosLexer.java",
-        ":CiscoNxosParser.java",
-        ":CiscoNxosParserBaseListener.java",
-        ":CiscoNxosParserListener.java",
-    ],
+    srcs = [":cisco_nxos_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/parsing:cisco_nxos_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "cisco_nxos_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "CiscoNxosLexer.java",
-        "CiscoNxosLexer.tokens",
-        "CiscoNxosParser.java",
-        "CiscoNxosParserBaseListener.java",
-        "CiscoNxosParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location CiscoNxosLexer.g4) \
-       $(location CiscoNxosParser.g4) \
-    -package org.batfish.grammar.cisco_nxos \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "cisco_xr_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.cisco_xr",
+)
+
 java_library(
     name = "cisco_xr",
-    srcs = [
-        ":CiscoXrLexer.java",
-        ":CiscoXrParser.java",
-        ":CiscoXrParserBaseListener.java",
-        ":CiscoXrParserListener.java",
-    ],
+    srcs = [":cisco_xr_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/parsing:cisco_xr_base_parser",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "cisco_xr_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "CiscoXrLexer.java",
-        "CiscoXrLexer.tokens",
-        "CiscoXrParser.java",
-        "CiscoXrParserBaseListener.java",
-        "CiscoXrParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location CiscoXrLexer.g4) \
-       $(location CiscoXrParser.g4) \
-    -package org.batfish.grammar.cisco_xr \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_concatenated/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_concatenated/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "cumulus_concatenated_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.cumulus_concatenated",
+)
+
 java_library(
     name = "cumulus_concatenated",
-    srcs = [
-        ":CumulusConcatenatedLexer.java",
-        ":CumulusConcatenatedParser.java",
-        ":CumulusConcatenatedParserBaseListener.java",
-        ":CumulusConcatenatedParserListener.java",
-    ],
+    srcs = [":cumulus_concatenated_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "cumulus_concatenated_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "CumulusConcatenatedLexer.java",
-        "CumulusConcatenatedLexer.tokens",
-        "CumulusConcatenatedParser.java",
-        "CumulusConcatenatedParserBaseListener.java",
-        "CumulusConcatenatedParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location CumulusConcatenatedLexer.g4) \
-       $(location CumulusConcatenatedParser.g4) \
-    -package org.batfish.grammar.cumulus_concatenated \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "cumulus_interfaces_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.cumulus_interfaces",
+)
+
 java_library(
     name = "cumulus_interfaces",
-    srcs = [
-        ":CumulusInterfacesLexer.java",
-        ":CumulusInterfacesParser.java",
-        ":CumulusInterfacesParserBaseListener.java",
-        ":CumulusInterfacesParserListener.java",
-    ],
+    srcs = [":cumulus_interfaces_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/parsing:cumulus_interfaces_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "cumulus_interfaces_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "CumulusInterfacesLexer.java",
-        "CumulusInterfacesLexer.tokens",
-        "CumulusInterfacesParser.java",
-        "CumulusInterfacesParserBaseListener.java",
-        "CumulusInterfacesParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location CumulusInterfacesLexer.g4) \
-       $(location CumulusInterfacesParser.g4) \
-    -package org.batfish.grammar.cumulus_interfaces \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "cumulus_nclu_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.cumulus_nclu",
+)
+
 java_library(
     name = "cumulus_nclu",
-    srcs = [
-        ":CumulusNcluLexer.java",
-        ":CumulusNcluParser.java",
-        ":CumulusNcluParserBaseListener.java",
-        ":CumulusNcluParserListener.java",
-    ],
+    srcs = [":cumulus_nclu_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/cumulus_nclu/parsing:cumulus_nclu_base_parser",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "cumulus_nclu_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "CumulusNcluLexer.java",
-        "CumulusNcluLexer.tokens",
-        "CumulusNcluParser.java",
-        "CumulusNcluParserBaseListener.java",
-        "CumulusNcluParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location CumulusNcluLexer.g4) \
-       $(location CumulusNcluParser.g4) \
-    -package org.batfish.grammar.cumulus_nclu \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_ports/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_ports/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "cumulus_ports_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.cumulus_ports",
+)
+
 java_library(
     name = "cumulus_ports",
-    srcs = [
-        ":CumulusPortsLexer.java",
-        ":CumulusPortsParser.java",
-        ":CumulusPortsParserBaseListener.java",
-        ":CumulusPortsParserListener.java",
-    ],
+    srcs = [":cumulus_ports_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cumulus_ports/parsing:cumulus_ports_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "cumulus_ports_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "CumulusPortsLexer.java",
-        "CumulusPortsLexer.tokens",
-        "CumulusPortsParser.java",
-        "CumulusPortsParserBaseListener.java",
-        "CumulusPortsParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location CumulusPortsLexer.g4) \
-       $(location CumulusPortsParser.g4) \
-    -package org.batfish.grammar.cumulus_ports \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "f5_bigip_imish_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.f5_bigip_imish",
+)
+
 java_library(
     name = "f5_bigip_imish",
-    srcs = [
-        ":F5BigipImishLexer.java",
-        ":F5BigipImishParser.java",
-        ":F5BigipImishParserBaseListener.java",
-        ":F5BigipImishParserListener.java",
-    ],
+    srcs = [":f5_bigip_imish_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/parsing:f5_bigip_imish_base_parser",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "f5_bigip_imish_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "F5BigipImishLexer.java",
-        "F5BigipImishLexer.tokens",
-        "F5BigipImishParser.java",
-        "F5BigipImishParserBaseListener.java",
-        "F5BigipImishParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location F5BigipImishLexer.g4) \
-       $(location F5BigipImishParser.g4) \
-    -package org.batfish.grammar.f5_bigip_imish \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_structured/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_structured/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "f5_bigip_structured_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.f5_bigip_structured",
+)
+
 java_library(
     name = "f5_bigip_structured",
-    srcs = [
-        ":F5BigipStructuredLexer.java",
-        ":F5BigipStructuredParser.java",
-        ":F5BigipStructuredParserBaseListener.java",
-        ":F5BigipStructuredParserListener.java",
-    ],
+    srcs = [":f5_bigip_structured_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/parsing:f5_bigip_structured_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "f5_bigip_structured_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "F5BigipStructuredLexer.java",
-        "F5BigipStructuredLexer.tokens",
-        "F5BigipStructuredParser.java",
-        "F5BigipStructuredParserBaseListener.java",
-        "F5BigipStructuredParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location F5BigipStructuredLexer.g4) \
-       $(location F5BigipStructuredParser.g4) \
-    -package org.batfish.grammar.f5_bigip_structured \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "flatjuniper_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.flatjuniper",
+)
+
 java_library(
     name = "flatjuniper",
-    srcs = [
-        ":FlatJuniperLexer.java",
-        ":FlatJuniperParser.java",
-        ":FlatJuniperParserBaseListener.java",
-        ":FlatJuniperParserListener.java",
-    ],
+    srcs = [":flatjuniper_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/parsing:flatjuniper_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "flatjuniper_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "FlatJuniperLexer.java",
-        "FlatJuniperLexer.tokens",
-        "FlatJuniperParser.java",
-        "FlatJuniperParserBaseListener.java",
-        "FlatJuniperParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location FlatJuniperLexer.g4) \
-       $(location FlatJuniperParser.g4) \
-    -package org.batfish.grammar.flatjuniper \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "flatvyos_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.flatvyos",
+)
+
 java_library(
     name = "flatvyos",
-    srcs = [
-        ":FlatVyosLexer.java",
-        ":FlatVyosParser.java",
-        ":FlatVyosParserBaseListener.java",
-        ":FlatVyosParserListener.java",
-    ],
+    srcs = [":flatvyos_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "flatvyos_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "FlatVyosLexer.java",
-        "FlatVyosLexer.tokens",
-        "FlatVyosParser.java",
-        "FlatVyosParserBaseListener.java",
-        "FlatVyosParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location FlatVyosLexer.g4) \
-       $(location FlatVyosParser.g4) \
-    -package org.batfish.grammar.flatvyos \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "fortios_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.fortios",
+)
+
 java_library(
     name = "fortios",
-    srcs = [
-        ":FortiosLexer.java",
-        ":FortiosParser.java",
-        ":FortiosParserBaseListener.java",
-        ":FortiosParserListener.java",
-    ],
+    srcs = [":fortios_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/fortios/parsing:fortios_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "fortios_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "FortiosLexer.java",
-        "FortiosLexer.tokens",
-        "FortiosParser.java",
-        "FortiosParserBaseListener.java",
-        "FortiosParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location FortiosLexer.g4) \
-       $(location FortiosParser.g4) \
-    -package org.batfish.grammar.fortios \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/frr/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "frr_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.frr",
+)
+
 java_library(
     name = "frr",
-    srcs = [
-        ":FrrLexer.java",
-        ":FrrParser.java",
-        ":FrrParserBaseListener.java",
-        ":FrrParserListener.java",
-    ],
+    srcs = [":frr_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/frr/parsing:frr_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "frr_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "FrrLexer.java",
-        "FrrLexer.tokens",
-        "FrrParser.java",
-        "FrrParserBaseListener.java",
-        "FrrParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location FrrLexer.g4) \
-       $(location FrrParser.g4) \
-    -package org.batfish.grammar.frr \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/iptables/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/iptables/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "iptables_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.iptables",
+)
+
 java_library(
     name = "iptables",
-    srcs = [
-        ":IptablesLexer.java",
-        ":IptablesParser.java",
-        ":IptablesParserBaseListener.java",
-        ":IptablesParserListener.java",
-    ],
+    srcs = [":iptables_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "iptables_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "IptablesLexer.java",
-        "IptablesLexer.tokens",
-        "IptablesParser.java",
-        "IptablesParserBaseListener.java",
-        "IptablesParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location IptablesLexer.g4) \
-       $(location IptablesParser.g4) \
-    -package org.batfish.grammar.iptables \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "juniper_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.juniper",
+)
+
 java_library(
     name = "juniper",
-    srcs = [
-        ":JuniperLexer.java",
-        ":JuniperParser.java",
-        ":JuniperParserBaseListener.java",
-        ":JuniperParserListener.java",
-    ],
+    srcs = [":juniper_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/juniper/parsing:juniper_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "juniper_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "JuniperLexer.java",
-        "JuniperLexer.tokens",
-        "JuniperParser.java",
-        "JuniperParserBaseListener.java",
-        "JuniperParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location JuniperLexer.g4) \
-       $(location JuniperParser.g4) \
-    -package org.batfish.grammar.juniper \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/mrv/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/mrv/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "mrv_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.mrv",
+)
+
 java_library(
     name = "mrv",
-    srcs = [
-        ":MrvLexer.java",
-        ":MrvParser.java",
-        ":MrvParserBaseListener.java",
-        ":MrvParserListener.java",
-    ],
+    srcs = [":mrv_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "mrv_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "MrvLexer.java",
-        "MrvLexer.tokens",
-        "MrvParser.java",
-        "MrvParserBaseListener.java",
-        "MrvParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location MrvLexer.g4) \
-       $(location MrvParser.g4) \
-    -package org.batfish.grammar.mrv \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "palo_alto_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.palo_alto",
+)
+
 java_library(
     name = "palo_alto",
-    srcs = [
-        ":PaloAltoLexer.java",
-        ":PaloAltoParser.java",
-        ":PaloAltoParserBaseListener.java",
-        ":PaloAltoParserListener.java",
-    ],
+    srcs = [":palo_alto_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing:palo_alto_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "palo_alto_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "PaloAltoLexer.java",
-        "PaloAltoLexer.tokens",
-        "PaloAltoParser.java",
-        "PaloAltoParserBaseListener.java",
-        "PaloAltoParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location PaloAltoLexer.g4) \
-       $(location PaloAltoParser.g4) \
-    -package org.batfish.grammar.palo_alto \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto_nested/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto_nested/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "palo_alto_nested_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.palo_alto_nested",
+)
+
 java_library(
     name = "palo_alto_nested",
-    srcs = [
-        ":PaloAltoNestedLexer.java",
-        ":PaloAltoNestedParser.java",
-        ":PaloAltoNestedParserBaseListener.java",
-        ":PaloAltoNestedParserListener.java",
-    ],
+    srcs = [":palo_alto_nested_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/parsing:palo_alto_nested_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "palo_alto_nested_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "PaloAltoNestedLexer.java",
-        "PaloAltoNestedLexer.tokens",
-        "PaloAltoNestedParser.java",
-        "PaloAltoNestedParserBaseListener.java",
-        "PaloAltoNestedParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location PaloAltoNestedLexer.g4) \
-       $(location PaloAltoNestedParser.g4) \
-    -package org.batfish.grammar.palo_alto_nested \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/eos/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/eos/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "eos_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.routing_table.eos",
+)
+
 java_library(
     name = "eos",
-    srcs = [
-        ":EosRoutingTableLexer.java",
-        ":EosRoutingTableParser.java",
-        ":EosRoutingTableParserBaseListener.java",
-        ":EosRoutingTableParserListener.java",
-    ],
+    srcs = [":eos_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "eos_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "EosRoutingTableLexer.java",
-        "EosRoutingTableLexer.tokens",
-        "EosRoutingTableParser.java",
-        "EosRoutingTableParserBaseListener.java",
-        "EosRoutingTableParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location EosRoutingTableLexer.g4) \
-       $(location EosRoutingTableParser.g4) \
-    -package org.batfish.grammar.routing_table.eos \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/ios/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/ios/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "ios_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.routing_table.ios",
+)
+
 java_library(
     name = "ios",
-    srcs = [
-        ":IosRoutingTableLexer.java",
-        ":IosRoutingTableParser.java",
-        ":IosRoutingTableParserBaseListener.java",
-        ":IosRoutingTableParserListener.java",
-    ],
+    srcs = [":ios_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "ios_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "IosRoutingTableLexer.java",
-        "IosRoutingTableLexer.tokens",
-        "IosRoutingTableParser.java",
-        "IosRoutingTableParserBaseListener.java",
-        "IosRoutingTableParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location IosRoutingTableLexer.g4) \
-       $(location IosRoutingTableParser.g4) \
-    -package org.batfish.grammar.routing_table.ios \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/nxos/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/nxos/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "nxos_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.routing_table.nxos",
+)
+
 java_library(
     name = "nxos",
-    srcs = [
-        ":NxosRoutingTableLexer.java",
-        ":NxosRoutingTableParser.java",
-        ":NxosRoutingTableParserBaseListener.java",
-        ":NxosRoutingTableParserListener.java",
-    ],
+    srcs = [":nxos_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "nxos_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "NxosRoutingTableLexer.java",
-        "NxosRoutingTableLexer.tokens",
-        "NxosRoutingTableParser.java",
-        "NxosRoutingTableParserBaseListener.java",
-        "NxosRoutingTableParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location NxosRoutingTableLexer.g4) \
-       $(location NxosRoutingTableParser.g4) \
-    -package org.batfish.grammar.routing_table.nxos \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/vyos/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/vyos/BUILD.bazel
@@ -1,43 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "vyos_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.grammar.vyos",
+)
+
 java_library(
     name = "vyos",
-    srcs = [
-        ":VyosLexer.java",
-        ":VyosParser.java",
-        ":VyosParserBaseListener.java",
-        ":VyosParserListener.java",
-    ],
+    srcs = [":vyos_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "vyos_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "VyosLexer.java",
-        "VyosLexer.tokens",
-        "VyosParser.java",
-        "VyosParserBaseListener.java",
-        "VyosParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location VyosLexer.g4) \
-       $(location VyosParser.g4) \
-    -package org.batfish.grammar.vyos \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "grammar_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.vendor.a10.grammar",
+)
+
 java_library(
     name = "grammar",
-    srcs = [
-        ":A10Lexer.java",
-        ":A10Parser.java",
-        ":A10ParserBaseListener.java",
-        ":A10ParserListener.java",
-    ],
+    srcs = [":grammar_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/vendor/a10/grammar:a10_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "grammar_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "A10Lexer.java",
-        "A10Lexer.tokens",
-        "A10Parser.java",
-        "A10ParserBaseListener.java",
-        "A10ParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location A10Lexer.g4) \
-       $(location A10Parser.g4) \
-    -package org.batfish.vendor.a10.grammar \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/check_point_gateway/grammar/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/check_point_gateway/grammar/BUILD.bazel
@@ -1,44 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
 
 package(default_visibility = ["//visibility:public"])
 
+antlr_grammar(
+    name = "grammar_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.vendor.check_point_gateway.grammar",
+)
+
 java_library(
     name = "grammar",
-    srcs = [
-        ":CheckPointGatewayLexer.java",
-        ":CheckPointGatewayParser.java",
-        ":CheckPointGatewayParserBaseListener.java",
-        ":CheckPointGatewayParserListener.java",
-    ],
+    srcs = [":grammar_generated"],
     javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/vendor/check_point_gateway/grammar:check_point_gateway_base",
         "@maven//:org_antlr_antlr4_runtime",
     ],
-)
-
-genrule(
-    name = "grammar_generated",
-    srcs = glob([
-        "*.g4",
-    ]),
-    outs = [
-        "CheckPointGatewayLexer.java",
-        "CheckPointGatewayLexer.tokens",
-        "CheckPointGatewayParser.java",
-        "CheckPointGatewayParserBaseListener.java",
-        "CheckPointGatewayParserListener.java",
-    ],
-    cmd = """
-java -cp $(location @antlr4_tool//jar) \
-    org.antlr.v4.Tool \
-    -Xexact-output-dir \
-       $(location CheckPointGatewayLexer.g4) \
-       $(location CheckPointGatewayParser.g4) \
-    -package org.batfish.vendor.check_point_gateway.grammar \
-    -encoding UTF-8 \
-    -Werror \
-    -o $(@D)""",
-    tools = ["@antlr4_tool//jar"],
 )

--- a/skylark/antlr.bzl
+++ b/skylark/antlr.bzl
@@ -1,0 +1,64 @@
+"""Rules for generating ANTLR parsers from grammar files."""
+
+def _antlr_grammar_impl(ctx):
+    """Implementation function for antlr_grammar rule."""
+    srcs = ctx.files.srcs
+    package = ctx.attr.package
+
+    # Lexer and Parser files to pass to ANTLR (not all .g4 files)
+    lexer_parser_files = [f for f in srcs if f.basename.endswith("Lexer.g4") or f.basename.endswith("Parser.g4")]
+
+    # Determine output files based on lexer/parser files
+    outs = []
+    for src in lexer_parser_files:
+        base_name = src.basename.removesuffix(".g4")
+        if base_name.endswith("Lexer"):
+            outs.append(ctx.actions.declare_file(base_name + ".java"))
+            outs.append(ctx.actions.declare_file(base_name + ".tokens"))
+        elif base_name.endswith("Parser"):
+            outs.append(ctx.actions.declare_file(base_name + ".java"))
+            outs.append(ctx.actions.declare_file(base_name + "BaseListener.java"))
+            outs.append(ctx.actions.declare_file(base_name + "Listener.java"))
+
+    # Get ANTLR tool
+    antlr_jar = ctx.file.antlr_tool
+
+    # Build ANTLR command
+    cmd = "java -cp %s org.antlr.v4.Tool -Xexact-output-dir %s -package %s -encoding UTF-8 -Werror -o %s" % (
+        antlr_jar.path,
+        " ".join([f.path for f in lexer_parser_files]),
+        package,
+        outs[0].dirname,
+    )
+
+    # Run ANTLR (all srcs are inputs for dependencies, but only lexer/parser are in command line)
+    ctx.actions.run_shell(
+        command = cmd,
+        inputs = depset(direct = srcs + [antlr_jar]),
+        outputs = outs,
+        mnemonic = "AntlrGeneration",
+        progress_message = "Generating ANTLR parser for %s" % package,
+    )
+
+    return [DefaultInfo(files = depset(outs))]
+
+antlr_grammar = rule(
+    implementation = _antlr_grammar_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = [".g4"],
+            mandatory = True,
+            doc = "ANTLR grammar files (.g4) - files ending in Lexer.g4 or Parser.g4 will be passed to ANTLR, others are dependencies",
+        ),
+        "package": attr.string(
+            mandatory = True,
+            doc = "Java package name for generated files",
+        ),
+        "antlr_tool": attr.label(
+            allow_single_file = True,
+            default = "@antlr4_tool//jar",
+            doc = "ANTLR tool JAR",
+        ),
+    },
+    doc = "Generates Java parser files from ANTLR grammar files.",
+)


### PR DESCRIPTION
Created antlr_grammar rule in skylark/antlr.bzl that encapsulates
the pattern for generating ANTLR parsers. This eliminates repetition
across 26 BUILD files.

The rule:
- Automatically identifies Lexer.g4 and Parser.g4 files to process
- Infers output files based on grammar file names
- Simplifies BUILD files from ~40 lines to ~20 lines per grammar

Replaces genrule-based approach with more maintainable rule-based
approach following patterns from pmd_test and ref_tests.

---

**Stack**:
- #9541
- #9540 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*