### PR TITLE
add @Serial annotation to help code inspections

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -7,6 +7,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -177,6 +178,7 @@ public class BDDPacket implements Serializable {
     _srcIpSpaceToBDD = new IpSpaceToBDD(_srcIp.getVar());
   }
 
+  @Serial
   private void readObject(java.io.ObjectInputStream stream)
       throws IOException, ClassNotFoundException {
     stream.defaultReadObject();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -6,6 +6,7 @@ import static org.batfish.common.bdd.BDDUtils.bitvector;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +38,7 @@ public final class MutableBDDInteger extends BDDInteger {
     setValue(other);
   }
 
+  @Serial
   private void readObject(java.io.ObjectInputStream stream)
       throws IOException, ClassNotFoundException {
     stream.defaultReadObject();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/GlobalBroadcastNoPointToPoint.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/GlobalBroadcastNoPointToPoint.java
@@ -1,6 +1,7 @@
 package org.batfish.common.topology;
 
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -32,6 +33,7 @@ public final class GlobalBroadcastNoPointToPoint implements L3Adjacencies {
   private static final GlobalBroadcastNoPointToPoint INSTANCE = new GlobalBroadcastNoPointToPoint();
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/InterfaceNameComparator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/InterfaceNameComparator.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
@@ -78,6 +79,7 @@ public final class InterfaceNameComparator implements Comparator<String>, Serial
   }
 
   /** Singleton after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpaceLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpaceLine.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Comparator;
 import javax.annotation.Nonnull;
@@ -139,6 +140,7 @@ public class AclIpSpaceLine implements Comparable<AclIpSpaceLine>, Serializable 
   }
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return create(_ipSpace, _action);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -171,6 +172,7 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
   }
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return of(_asSets);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPathAccessList.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -94,6 +95,7 @@ public final class AsPathAccessList implements Serializable {
     return newPermits(asPath);
   }
 
+  @Serial
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
     _deniedCache = Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Ordering;
 import com.google.common.primitives.Longs;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -191,6 +192,7 @@ public class AsSet implements Serializable, Comparable<AsSet> {
   }
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.get(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -10,6 +10,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
@@ -205,6 +206,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
     }
 
     /** Re-intern after deserialization. */
+    @Serial
     private Object readResolve() throws ObjectStreamException {
       return ATTRIBUTE_CACHE.get(this);
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIpSpace.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class EmptyIpSpace extends IpSpace {
@@ -48,6 +49,7 @@ public class EmptyIpSpace extends IpSpace {
   }
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibForward.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibForward.java
@@ -5,6 +5,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -83,6 +84,7 @@ public final class FibForward implements FibAction {
   }
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.get(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import java.io.IOException;
+import java.io.Serial;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -354,6 +355,7 @@ public final class FibImpl implements Fib {
     return builder.build();
   }
 
+  @Serial
   private void readObject(java.io.ObjectInputStream stream)
       throws IOException, ClassNotFoundException {
     stream.defaultReadObject();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibNextVrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibNextVrf.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.visitors.FibActionVisitor;
@@ -52,6 +53,7 @@ public class FibNextVrf implements FibAction {
   }
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.get(_nextVrf);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FinalMainRib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FinalMainRib.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel;
 
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -100,6 +101,7 @@ public final class FinalMainRib implements Serializable {
     _routeTree = tree;
   }
 
+  @Serial
   private Object writeReplace() throws ObjectStreamException {
     return new SerializedForm(_routeTree.getAllElements());
   }
@@ -111,6 +113,7 @@ public final class FinalMainRib implements Serializable {
       _routes = routes;
     }
 
+    @Serial
     private Object readResolve() throws ObjectStreamException {
       return FinalMainRib.of(_routes);
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip.java
@@ -8,6 +8,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -255,6 +256,7 @@ public class Ip implements Comparable<Ip>, Serializable {
   }
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.getUnchecked(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6WildcardSetIp6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6WildcardSetIp6Space.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
@@ -150,6 +151,7 @@ public class Ip6WildcardSetIp6Space extends Ip6Space {
   private transient int _hashCode;
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.get(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpIpSpace.java
@@ -7,6 +7,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class IpIpSpace extends IpSpace {
@@ -62,6 +63,7 @@ public class IpIpSpace extends IpSpace {
   }
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.getUnchecked(_ip);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcard.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcard.java
@@ -9,6 +9,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Comparator;
 import javax.annotation.Nonnull;
@@ -222,6 +223,7 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
   }
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.getUnchecked(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardIpSpace.java
@@ -7,6 +7,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class IpWildcardIpSpace extends IpSpace {
@@ -62,6 +63,7 @@ public class IpWildcardIpSpace extends IpSpace {
   }
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.getUnchecked(_ipWildcard);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardSetIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardSetIpSpace.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
@@ -171,6 +172,7 @@ public final class IpWildcardSetIpSpace extends IpSpace {
   private transient int _hashCode;
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.get(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -9,6 +9,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Ordering;
 import com.google.common.primitives.UnsignedInts;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -262,6 +263,7 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
     return _ip + "/" + _prefixLength;
   }
 
+  @Serial
   private Object writeReplace() throws ObjectStreamException {
     return new SerializedForm(_ip, _prefixLength);
   }
@@ -276,6 +278,7 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
       _length = (byte) prefixLength;
     }
 
+    @Serial
     private Object readResolve() throws ObjectStreamException {
       return CACHE.get(new Prefix(Ip.create(UnsignedInts.toLong(_ip)), _length));
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixIpSpace.java
@@ -7,6 +7,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
@@ -65,6 +66,7 @@ public final class PrefixIpSpace extends IpSpace {
   }
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.getUnchecked(_prefix);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixSpace.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -326,6 +327,7 @@ public class PrefixSpace implements Serializable {
     return !intersection.isEmpty();
   }
 
+  @Serial
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
     _cache = new ConcurrentHashMap<>();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
@@ -567,6 +568,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
       return new SerializedForm<>(keys.build(), values.build());
     }
 
+    @Serial
     public Object readResolve() throws ObjectStreamException {
       PrefixTrieMultiMap<T> ret = new PrefixTrieMultiMap<>();
       for (int i = 0; i < _keys.size(); ++i) {
@@ -576,6 +578,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     }
   }
 
+  @Serial
   private Object writeReplace() throws ObjectStreamException {
     return SerializedForm.of(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ReceivedFromInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ReceivedFromInterface.java
@@ -8,6 +8,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -95,6 +96,7 @@ public final class ReceivedFromInterface implements ReceivedFrom {
   private final @Nonnull Ip _linkLocalIp;
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.get(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ReceivedFromIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ReceivedFromIp.java
@@ -9,6 +9,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -82,6 +83,7 @@ public final class ReceivedFromIp implements ReceivedFrom {
   private final @Nonnull Ip _ip;
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.get(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ReceivedFromSelf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ReceivedFromSelf.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.base.MoreObjects;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -42,6 +43,7 @@ public final class ReceivedFromSelf implements ReceivedFrom {
   private static final ReceivedFromSelf INSTANCE = new ReceivedFromSelf();
 
   /** Deserialize to singleton instance. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UniverseIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UniverseIpSpace.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class UniverseIpSpace extends IpSpace {
@@ -48,6 +49,7 @@ public class UniverseIpSpace extends IpSpace {
   }
 
   /** Cache after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeInterfacePair.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/NodeInterfacePair.java
@@ -9,6 +9,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -95,6 +96,7 @@ public final class NodeInterfacePair implements Serializable, Comparable<NodeInt
   }
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.getUnchecked(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/NextHopInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/NextHopInterface.java
@@ -9,6 +9,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -129,6 +130,7 @@ public final class NextHopInterface implements NextHop {
   }
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.getUnchecked(this);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/NextHopIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/NextHopIp.java
@@ -8,6 +8,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
@@ -78,6 +79,7 @@ public final class NextHopIp implements NextHop {
   }
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return CACHE.get(_ip);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
@@ -10,6 +10,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Set;
 import java.util.SortedSet;
@@ -146,6 +147,7 @@ public final class CommunitySet implements Serializable {
                   }));
 
   /** Re-intern after deserialization. */
+  @Serial
   private Object readResolve() throws ObjectStreamException {
     return of(_communities);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BgpPeerAddressNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BgpPeerAddressNextHop.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.routing_policy.expr;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.Serial;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Ip;
@@ -46,6 +47,7 @@ public final class BgpPeerAddressNextHop extends NextHopExpr {
     return INSTANCE;
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/DiscardNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/DiscardNextHop.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
@@ -39,6 +40,7 @@ public class DiscardNextHop extends NextHopExpr {
     return INSTANCE;
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.Serial;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopIp;
@@ -43,6 +44,7 @@ public class SelfNextHop extends NextHopExpr {
     return INSTANCE;
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/UnchangedNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/UnchangedNextHop.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.Serial;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSessionProperties;
@@ -56,6 +57,7 @@ public class UnchangedNextHop extends NextHopExpr {
     return INSTANCE;
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -78,6 +79,7 @@ public class BDDReachabilityAnalysis implements Serializable {
         Suppliers.memoize(() -> BDDReachabilityUtils.transposeAndMaterialize(_forwardEdgeTable));
   }
 
+  @Serial
   private void readObject(java.io.ObjectInputStream stream)
       throws IOException, ClassNotFoundException {
     stream.defaultReadObject();

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Identity.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Identity.java
@@ -1,5 +1,6 @@
 package org.batfish.bddreachability.transition;
 
+import java.io.Serial;
 import net.sf.javabdd.BDD;
 
 /** A transition that permits all flows unmodified. */
@@ -28,6 +29,7 @@ public final class Identity implements Transition {
     return visitor.visitIdentity(this);
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Zero.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Zero.java
@@ -1,5 +1,6 @@
 package org.batfish.bddreachability.transition;
 
+import java.io.Serial;
 import net.sf.javabdd.BDD;
 
 /** A transition that allows nothing. */
@@ -28,6 +29,7 @@ public final class Zero implements Transition {
     return visitor.visitZero(this);
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/AdminGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/AdminGroup.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import java.io.Serial;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -11,7 +12,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public final class AdminGroup implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 1L;
 
   private final @Nonnull String _name;
   private final int _value;

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -37,6 +37,7 @@ import com.carrotsearch.hppc.procedures.IntProcedure;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -96,6 +97,7 @@ public class JFactory extends BDDFactory implements Serializable {
     _bddReuse = new LinkedList<>();
   }
 
+  @Serial
   private void readObject(java.io.ObjectInputStream stream)
       throws IOException, ClassNotFoundException {
     stream.defaultReadObject();

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/Accept.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/Accept.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class Accept implements StateExpr {
 
   public static final Accept INSTANCE = new Accept();
@@ -14,6 +16,7 @@ public final class Accept implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/BlackHole.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/BlackHole.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 /**
  * Represents a sink for "impossible" flows. For example, flows leaving an interface that are only
  * valid if routed to a different interface.
@@ -20,6 +22,7 @@ public final class BlackHole implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/DeliveredToSubnet.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/DeliveredToSubnet.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class DeliveredToSubnet implements StateExpr {
 
   public static final DeliveredToSubnet INSTANCE = new DeliveredToSubnet();
@@ -16,6 +18,7 @@ public final class DeliveredToSubnet implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/DropAclIn.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/DropAclIn.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class DropAclIn implements StateExpr {
 
   public static final DropAclIn INSTANCE = new DropAclIn();
@@ -16,6 +18,7 @@ public final class DropAclIn implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/DropAclOut.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/DropAclOut.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class DropAclOut implements StateExpr {
 
   public static final DropAclOut INSTANCE = new DropAclOut();
@@ -16,6 +18,7 @@ public final class DropAclOut implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/DropNoRoute.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/DropNoRoute.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class DropNoRoute implements StateExpr {
 
   public static final DropNoRoute INSTANCE = new DropNoRoute();
@@ -16,6 +18,7 @@ public final class DropNoRoute implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/DropNullRoute.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/DropNullRoute.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class DropNullRoute implements StateExpr {
   public static final DropNullRoute INSTANCE = new DropNullRoute();
 
@@ -15,6 +17,7 @@ public final class DropNullRoute implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/ExitsNetwork.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/ExitsNetwork.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class ExitsNetwork implements StateExpr {
 
   public static final ExitsNetwork INSTANCE = new ExitsNetwork();
@@ -16,6 +18,7 @@ public final class ExitsNetwork implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/InsufficientInfo.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/InsufficientInfo.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class InsufficientInfo implements StateExpr {
 
   public static final InsufficientInfo INSTANCE = new InsufficientInfo();
@@ -16,6 +18,7 @@ public final class InsufficientInfo implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NeighborUnreachable.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NeighborUnreachable.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public class NeighborUnreachable implements StateExpr {
 
   public static final NeighborUnreachable INSTANCE = new NeighborUnreachable();
@@ -16,6 +18,7 @@ public class NeighborUnreachable implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/Query.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/Query.java
@@ -1,5 +1,7 @@
 package org.batfish.symbolic.state;
 
+import java.io.Serial;
+
 public final class Query implements StateExpr {
 
   public static final Query INSTANCE = new Query();
@@ -16,6 +18,7 @@ public final class Query implements StateExpr {
     return getClass().getSimpleName();
   }
 
+  @Serial
   private Object readResolve() {
     return INSTANCE;
   }


### PR DESCRIPTION
From Javadoc:

> Indicates that an annotated field or method is part of the Serializable
> serialization mechanism defined by the Java Object Serialization
> Specification. This annotation type is intended to allow compile-time
> checking of serialization-related declarations, analogous to the checking
> enabled by the Override annotation type to validate method overriding.
> Serializable classes are encouraged to use @Serial annotations to help a
> compiler catch mis-declared serialization-related fields and methods,
> mis-declarations that may otherwise be difficult to detect.