### PR TITLE
docs: add BDD memory management best practices

### DIFF
--- a/docs/development/bdd_best_practices.md
+++ b/docs/development/bdd_best_practices.md
@@ -1,0 +1,97 @@
+# BDD Best Practices
+
+This guide covers essential practices for working with Binary Decision Diagrams (BDDs) in Batfish. BDDs are a core component of Batfish's symbolic analysis engine, and proper usage is critical for performance and correctness.
+
+## Memory Management
+
+### Overview
+
+The JavaBDD library does not use Java's garbage collection. Instead, it requires explicit reference counting at the `BDDFactory` level for all BDD operations. Proper memory management is critical for BDD-heavy code—reference leaks prevent BDDs from being freed, consuming heap and cache space, and severely degrading performance.
+
+Because BDDs are recursive structures, leaked references can create effectively unbounded memory growth. Real-world cases exist where adding a single missing `free()` call reduced memory usage from 100+ GiB (with heap overflow) and hours of runtime to under 100 MiB and milliseconds of execution time.
+
+### Reference Counting Rules
+
+#### Base Operations (Create New Reference)
+
+Base BDD operations create **new** references and destroy **none**. Both the input and output BDD objects must be freed separately.
+
+Examples: `bdd.or(other)`, `bdd.and(other)`, `bdd.not()`, `bdd.fullSatOne()`
+
+#### In-Place Operations (No New Reference)
+
+In-place operations modify the target BDD and create **no** new references. The suffix `Eq` indicates "equals" semantics.
+
+Examples: `bdd.orEq(other)`, `bdd.andEq(other)`, `bdd.notEq()`
+
+**CRITICAL**: Do not use with the same object as both operands (e.g., `a.andEq(a)`). Currently produces incorrect results; ideally the code should reject this.
+
+#### Combined Operations (Consume One Reference)
+
+Combined operations create no new references and automatically free one input. The suffix `With` indicates "consume with" semantics.
+
+Example: `bdd.andWith(other)` is equivalent to `bdd.andEq(other); other.free();`
+
+Note: `bdd.andWith(bdd)` is safe (unlike `bdd.andEq(bdd); bdd.free()` which frees `bdd` twice).
+
+#### Copying References
+
+Use `bdd.id()` to create a copy of a BDD reference. This is useful when you need an intermediate value that can be freed independently (e.g., as an accumulator in a loop).
+
+```java
+BDD accumulator = factory.zero().id();  // Create a copy we can mutate
+for (...) {
+  BDD term = ...;
+  accumulator.orWith(term);  // Updates accumulator, frees term
+}
+// Use accumulator, then free it when done
+accumulator.free();
+```
+
+### Ownership and Documentation
+
+Default assumption: callees never free BDD parameters or return values unless documented. For complex call patterns, document ownership explicitly—particularly whether the caller must free the return value.
+
+Example:
+```java
+/**
+ * @return new BDD - caller must free
+ */
+```
+
+Core computation loops must not create BDD garbage—the result is returned, intermediate values are freed.
+
+### Real-World Examples
+
+These pull requests demonstrate the impact of proper BDD memory management:
+
+1. [PR #7852](https://github.com/batfish/batfish/pull/7852) - Fixed missing `free()` calls in `Composite` transition
+2. [PR #7820](https://github.com/batfish/batfish/pull/7820) - Fixed BDD garbage in reachability fixpoint computation
+3. [PR #7847](https://github.com/batfish/batfish/pull/7847) - Fixed BDD factory to avoid internal garbage generation
+
+### Guidelines
+
+Long-lived `BDDFactory` instances (shared across an entire analysis) **must** eliminate all BDD garbage:
+
+1. Use `With` operations when consuming temporary values
+2. Use `Eq` operations when updating accumulators in-place
+3. Explicitly `free()` all intermediate BDDs before returning
+4. Use `id()` when you need independent copies for mutation
+5. Never leak BDD references from loops or recursive calls
+
+Short-lived `BDDFactory` instances can be more relaxed, but we should improve this code over time.
+
+### Common Pitfalls
+
+1. **Same-object operations**: Never use `Eq` operations with the same object (e.g., `a.orEq(a)`)—this modifies the RHS while computing
+2. **Loop accumulators**: Forgetting to use `With` or `Eq` in loops creates garbage on every iteration
+3. **Returned references**: Forgetting that base operations return new references that must be freed
+4. **Recursive calls**: Not freeing intermediate results before returning from recursive functions
+
+### Verification
+
+When modifying BDD-heavy code:
+
+1. Review all base operations—ensure results are eventually freed
+2. Look for loops—ensure no garbage is created per iteration
+3. Check recursive calls—ensure all paths free intermediate values

--- a/docs/symbolic_engine/README.md
+++ b/docs/symbolic_engine/README.md
@@ -61,8 +61,10 @@ Fault tolerance can be verified by comparing network behavior before and after a
 
 # The symbolic engine
 Batfish builds symbolic constraints on flows using [Binary Decision Diagrams (BDDs)](https://en.wikipedia.org/wiki/Binary_decision_diagram),
-which efficiently perform boolean operations on sets of boolean variables. Batfish includes classes for representing 
+which efficiently perform boolean operations on sets of boolean variables. Batfish includes classes for representing
 packets using BDDs and building constraints on them (Java to BDD), and extracting solutions (BDD to Java).
+
+For critical information about BDD memory management and best practices, see the [BDD Best Practices](../development/bdd_best_practices.md) guide.
 
 Representation:
 * [`BDDFactory`](https://github.com/batfish/batfish/blob/master/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java) and [BDD](https://github.com/batfish/batfish/blob/master/projects/bdd/src/main/java/net/sf/javabdd/BDD.java) are at the core of the symbolic analysis engine.


### PR DESCRIPTION
Add comprehensive documentation on BDD memory management, covering
reference counting rules, ownership patterns, and performance impact.
Includes real-world examples showing order-of-magnitude improvements
from proper memory management.

---
Prompt:
```
I want to add good documentation on avoiding garbage in the BDD libraries in the right place in the docs/ subfolder. Here's my high level explanation:

---

The JavaBDD library doesn't use Java's garbage collection, instead it requires users to perform reference counting at the level of the BDDFactory that is used for all BDD operations. When references leak, BDDs cannot be removed from memory, occuping heap space and cache space and slowing down operations. Because BDDs are recursive, the number of BDDs leaked can be effectively unbounded -- and we've seen cases where adding a single missing free took a computation from 100 GiB heap overflow and running for hours, to running in milliseconds with less than 100MiB of RAM.

Here are the patterns for BDD memory management:

- base functions, like bdd.or(other), bdd.and(other) bdd.xor(other), bdd.not(), bdd.fullSatOne(), etc., create NEW references and destroy none. Both java BDD objects need to be freed.
- There are alternatives like bdd.orEq(other) which create no new references, instead changing the value of \`bdd\` to the result.
- There's also bdd.orWith(other), which is equivalent to bdd.orEq(other) followed by other.free().
- Sometimes, you may want to copy a BDD in order to create an intermediate value that you can free later (e.g., as the accumulator in a \`for\` loop). If so, use \`bdd.id()\`.

Using these correctly is extremely important. Since BDD-heavy code often accepts and creates BDDs willy-nilly, it's important to have clear documented ownership of BDD objects. It's also important for core computation loops to ensure they don't create any garbage in the process of producing their output. Sometimes, the code is a little bit more complicated as a result, but it pays off in runtime and memory benefits.

An few PRs that reduced BDD garbage and made a huge difference: https://github.com/batfish/batfish/pull/7852 and https://github.com/batfish/batfish/pull/7820. Here's one where we made the BDD factory itself not produce garbage internally: https://github.com/batfish/batfish/pull/7847.

---

Side note: We're a little bit more relaxed about this for short-lived BDDFactories, but that's more from laziness rather than a desire to do it. We should imrpove this code over time, though it's not urgent.
Side note: I think we should make sure that orEq and other functions like it gracefully handle the case when the input BDD is the same object. Should this be a crash? E.g., a.notEq(a) -- this will change the RHS as well as the left!
Side note: I was lazy about \`code font\` above, but in the docs we should be rigorous about it.

---

Can you turn this into a useful document (token concise and useful for both humans and agents) and add it to a good place in the docs/ folder? Feel free to ask me any questions about the above, read the PRs, etc.
```