### PR TITLE
Junos: return false for from policy when policy doesn't exist

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPolicyStatement.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPolicyStatement.java
@@ -3,6 +3,7 @@ package org.batfish.representation.juniper;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
+import org.batfish.datamodel.routing_policy.expr.BooleanExprs;
 import org.batfish.datamodel.routing_policy.expr.CallExpr;
 
 /** Represents a "from policy" line in a {@link PsTerm} */
@@ -20,6 +21,9 @@ public final class PsFromPolicyStatement extends PsFrom {
 
   @Override
   public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
+    if (!c.getRoutingPolicies().containsKey(_policyStatement)) {
+      return BooleanExprs.FALSE;
+    }
     return new CallExpr(_policyStatement);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromPolicyStatementTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromPolicyStatementTest.java
@@ -1,0 +1,37 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.expr.BooleanExprs;
+import org.batfish.datamodel.routing_policy.expr.CallExpr;
+import org.junit.Test;
+
+public class PsFromPolicyStatementTest {
+  @Test
+  public void testConversion() {
+    JuniperConfiguration jc = new JuniperConfiguration();
+    Configuration c =
+        Configuration.builder()
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .setHostname("c")
+            .build();
+    c.setRoutingPolicies(
+        java.util.Map.of(
+            "existingPolicy",
+            RoutingPolicy.builder().setName("existingPolicy").setOwner(c).build()));
+    Warnings w = new Warnings();
+
+    assertThat(
+        new PsFromPolicyStatement("existingPolicy").toBooleanExpr(jc, c, w),
+        equalTo(new CallExpr("existingPolicy")));
+
+    assertThat(
+        new PsFromPolicyStatement("nonexistent").toBooleanExpr(jc, c, w),
+        equalTo(BooleanExprs.FALSE));
+  }
+}


### PR DESCRIPTION
---
Prompt:
```
This code (toBooleanExpr in PsFromPolicyStatement) should create a false expression instead of a call expr if c.getRoutingPolicies() doesn't have an entry for _policyStatement. Fix it and add a concise unit test.
```

Co-authored-by: abanghar <abanghar@noreply.github.com>