### PR TITLE
BDD: add iteWith method to reduce garbage

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
@@ -508,6 +508,18 @@ public abstract class BDD implements Serializable {
   public abstract BDD ite(BDD thenBDD, BDD elseBDD);
 
   /**
+   * Makes this BDD be the if-then-else of three BDDs. The {@code thenBDD} and {@code elseBDD}
+   * parameters are consumed, and can no longer be used.
+   *
+   * <p>Compare to bdd_ite and bdd_delref.
+   *
+   * @param thenBDD the 'then' BDD
+   * @param elseBDD the 'else' BDD
+   * @return the result of the if-then-else operator on the three BDDs
+   */
+  public abstract BDD iteWith(BDD thenBDD, BDD elseBDD);
+
+  /**
    * Returns the logical 'less-than' of two BDDs, equivalent to {@code this.not().and(that)}. This
    * is a shortcut for calling "apply" with the "less" operator.
    *

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -251,6 +251,26 @@ public class JFactory extends BDDFactory implements Serializable {
     }
 
     @Override
+    public BDD iteWith(BDD thenBDD, BDD elseBDD) {
+      int x = _index;
+      int y = ((BDDImpl) thenBDD)._index;
+      int z = ((BDDImpl) elseBDD)._index;
+      int result = bdd_ite(x, y, z);
+      // Update this BDD to point to the result
+      bdd_delref(_index);
+      // Free the then and else BDDs, avoiding double-free if they're the same object
+      if (this != thenBDD) {
+        thenBDD.free();
+      }
+      if (this != elseBDD && thenBDD != elseBDD) {
+        elseBDD.free();
+      }
+      bdd_addref(result);
+      _index = result;
+      return this;
+    }
+
+    @Override
     public BDD relprod(BDD that, BDD var) {
       int x = _index;
       int y = ((BDDImpl) that)._index;

--- a/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -725,4 +725,45 @@ public class JFactoryTest {
     bddClone.not(); // can do operations after deserialization
     assertEquals(bdd.not().toReprString(), bddClone.not().toReprString());
   }
+
+  @Test
+  public void testIteWith() {
+    _factory.setVarNum(3);
+    long startBDDs = _factory.numOutstandingBDDs();
+    BDD v0 = _factory.ithVar(0);
+    BDD v1 = _factory.ithVar(1);
+    BDD v2 = _factory.ithVar(2);
+
+    BDD expected = v0.ite(v1, v2);
+    BDD result = v0.iteWith(v1, v2);
+
+    assertEquals(expected, result);
+    expected.free();
+    result.free();
+    assertEquals(startBDDs, _factory.numOutstandingBDDs());
+  }
+
+  @Test
+  public void testIteWithSameObjectAsCondition() {
+    _factory.setVarNum(3);
+    BDD v0 = _factory.ithVar(0);
+    BDD v1 = _factory.ithVar(1);
+
+    // No crash, correct result.
+    BDD expected = v0.ite(v0, v1);
+    BDD result = v0.iteWith(v0, v1);
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testIteWithSameThenAndElse() {
+    _factory.setVarNum(3);
+    BDD v0 = _factory.ithVar(0);
+    BDD v1 = _factory.ithVar(1);
+
+    // No crash, correct result.
+    BDD expected = v1.id();
+    BDD result = v0.iteWith(v1, v1);
+    assertEquals(expected, result);
+  }
 }


### PR DESCRIPTION
Add BDD.iteWith() method that consumes both then and else parameters,
following the pattern of existing With methods like andWith, orWith, etc.

This enables more efficient BDD manipulation patterns by avoiding
intermediate BDD allocations. The implementation properly handles edge
cases where parameters may be the same object to avoid double-free.

Tests verify both correctness and proper memory management using
numOutstandingBDDs tracking.

---
Prompt:
```
Can you make a BDD#iteWith function like orAllAndFree? That might be good as a pre-step to this change, making it much more clear. Or iteWith, actually
```

---

**Stack**:
- #9560
- #9559
- #9558
- #9557 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*