### PR TITLE
TransferBDD: fix BDD leak in Conjunction compute

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -361,6 +361,7 @@ public class TransferBDD {
                     r -> {
                       BDD condition = r.getReturnValue().getInputConstraints().and(currBDD);
                       if (condition.isZero()) {
+                        condition.free();
                         return;
                       }
                       TransferResult updated = r.setReturnValueBDD(condition);


### PR DESCRIPTION
Free condition BDD when it is zero (infeasible path). This BDD was
being created but never freed when paths were pruned.

---
Prompt:
```
Let's do more in step 1 [adding assertNoLeaks assertions]
```

Identified leak in Conjunction where condition.isZero() early-returned
without freeing the condition BDD.

---

**Stack**:
- #9560 ⬅
- #9559
- #9558


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*