### PR TITLE
client: remove unused interactive mode functionality

### DIFF
--- a/projects/allinone/src/main/java/org/batfish/allinone/AllInOne.java
+++ b/projects/allinone/src/main/java/org/batfish/allinone/AllInOne.java
@@ -47,12 +47,10 @@ public class AllInOne {
 
     String argString =
         String.format(
-            "%s -%s %s -%s %s",
+            "%s -%s %s",
             _settings.getClientArgs(),
             org.batfish.client.config.Settings.ARG_LOG_LEVEL,
-            _settings.getLogLevel(),
-            org.batfish.client.config.Settings.ARG_RUN_MODE,
-            _settings.getRunMode());
+            _settings.getLogLevel());
 
     if (_settings.getLogFile() != null) {
       argString +=

--- a/projects/allinone/src/main/java/org/batfish/allinone/config/Settings.java
+++ b/projects/allinone/src/main/java/org/batfish/allinone/config/Settings.java
@@ -22,7 +22,6 @@ public class Settings extends BaseSettings {
   private static final String ARG_LOG_FILE = "logfile";
   private static final String ARG_LOG_LEVEL = "loglevel";
   private static final String ARG_RUN_CLIENT = "runclient";
-  private static final String ARG_RUN_MODE = org.batfish.client.config.Settings.ARG_RUN_MODE;
   public static final String ARG_SERVICE_NAME = "servicename";
   private static final String ARG_SNAPSHOT_DIR =
       org.batfish.client.config.Settings.ARG_SNAPSHOT_DIR;
@@ -38,7 +37,6 @@ public class Settings extends BaseSettings {
   private String _logFile;
   private String _logLevel;
   private boolean _runClient;
-  private String _runMode;
   private String _serviceName;
   private String _snapshotDir;
   private boolean _tracingEnable;
@@ -98,10 +96,6 @@ public class Settings extends BaseSettings {
     return _runClient;
   }
 
-  public String getRunMode() {
-    return _runMode;
-  }
-
   public String getServiceName() {
     return _serviceName;
   }
@@ -127,7 +121,6 @@ public class Settings extends BaseSettings {
     setDefaultProperty(ARG_CLIENT_ARGS, "");
     setDefaultProperty(ARG_COORDINATOR_ARGS, "");
     setDefaultProperty(ARG_RUN_CLIENT, true);
-    setDefaultProperty(ARG_RUN_MODE, "batch");
     setDefaultProperty(ARG_SERVICE_NAME, "allinone-service");
     setDefaultProperty(ARG_VERSION, false);
   }
@@ -158,8 +151,6 @@ public class Settings extends BaseSettings {
     addOption(ARG_COORDINATOR_ARGS, "arguments for coordinator process", "coordinator_args");
 
     addBooleanOption(ARG_RUN_CLIENT, "whether to run the client");
-
-    addOption(ARG_RUN_MODE, "which mode to run in (batch|interactive)", "run_mode");
 
     addOption(ARG_SERVICE_NAME, "service name", "service_name");
 
@@ -206,7 +197,6 @@ public class Settings extends BaseSettings {
     _clientArgs = getStringOptionValue(ARG_CLIENT_ARGS);
     _coordinatorArgs = getStringOptionValue(ARG_COORDINATOR_ARGS);
     _runClient = getBooleanOptionValue(ARG_RUN_CLIENT);
-    _runMode = getStringOptionValue(ARG_RUN_MODE);
     _serviceName = getStringOptionValue(ARG_SERVICE_NAME);
     _snapshotDir = getStringOptionValue(ARG_SNAPSHOT_DIR);
   }

--- a/projects/client/src/main/java/org/batfish/client/Client.java
+++ b/projects/client/src/main/java/org/batfish/client/Client.java
@@ -733,23 +733,13 @@ public class Client extends AbstractClient implements IClient {
     _bfq = new TreeMap<>();
     _settings = settings;
 
-    switch (_settings.getRunMode()) {
-      case batch:
-        if (_settings.getBatchCommandFile() == null) {
-          System.err.println(
-              "org.batfish.client: Command file not specified while running in batch mode.");
-          System.err.printf("Use '-%s <cmdfile>' for batch mode\n", Settings.ARG_COMMAND_FILE);
-          System.exit(1);
-        }
-        _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile());
-        break;
-      case interactive:
-        System.err.println(
-            "Interactive mode is not supported. Please use pybatfish following the instructions in"
-                + " the README: https://github.com/batfish/batfish/#how-do-i-get-started");
-        System.exit(1);
-        break;
+    if (_settings.getBatchCommandFile() == null) {
+      System.err.println(
+          "org.batfish.client: Command file not specified while running in batch mode.");
+      System.err.printf("Use '-%s <cmdfile>' for batch mode\n", Settings.ARG_COMMAND_FILE);
+      System.exit(1);
     }
+    _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile());
   }
 
   public Client(String[] args) {
@@ -1005,14 +995,6 @@ public class Client extends AbstractClient implements IClient {
     boolean result = pollWorkAndGetAnswer(wItem, outWriter);
 
     return result;
-  }
-
-  private boolean exit(List<String> options, List<String> parameters) {
-    if (!isValidArgument(options, parameters, 0, 0, 0, Command.EXIT)) {
-      return false;
-    }
-    // Exit command is only used in interactive mode, which is no longer supported
-    return true;
   }
 
   private boolean generateDataplane(
@@ -1630,7 +1612,6 @@ public class Client extends AbstractClient implements IClient {
       case SHOW_SNAPSHOT -> showSnapshot(options, parameters);
       case TEST -> test(options, parameters);
       case VALIDATE_TEMPLATE -> validateTemplate(words, outWriter, options, parameters);
-      case EXIT, QUIT -> exit(options, parameters);
     };
   }
 
@@ -1804,18 +1785,7 @@ public class Client extends AbstractClient implements IClient {
       return;
     }
 
-    switch (_settings.getRunMode()) {
-      case batch:
-        runBatchFile();
-        break;
-
-      case interactive:
-        System.err.println(
-            "Interactive mode is not supported. Please use pybatfish following the instructions in"
-                + " the README: https://github.com/batfish/batfish/#how-do-i-get-started");
-        System.exit(1);
-        break;
-    }
+    runBatchFile();
   }
 
   private void runBatchFile() {

--- a/projects/client/src/main/java/org/batfish/client/Command.java
+++ b/projects/client/src/main/java/org/batfish/client/Command.java
@@ -17,7 +17,6 @@ public enum Command {
   DEBUG_PUT("debug-put"),
   DEL_BATFISH_OPTION("del-batfish-option"),
   DEL_NETWORK("del-network"),
-  EXIT("exit"),
   GEN_DP("generate-dataplane"),
   GET("get"),
   GET_POJO_TOPOLOGY("get-pojo-topology"),
@@ -26,7 +25,6 @@ public enum Command {
   INIT_REFERENCE_SNAPSHOT("init-reference-snapshot"),
   INIT_SNAPSHOT("init-snapshot"),
   LOAD_QUESTIONS("load-questions"),
-  QUIT("quit"),
   SET_BATFISH_LOGLEVEL("set-batfish-loglevel"),
   SET_LOGLEVEL("set-loglevel"),
   SET_NETWORK("set-network"),
@@ -100,7 +98,6 @@ public enum Command {
         DEL_BATFISH_OPTION,
         new CommandUsage("<option-key>", "Stop passing this option to Batfish"));
     descs.put(DEL_NETWORK, new CommandUsage("<network-name>", "Delete the specified network"));
-    descs.put(EXIT, new CommandUsage("", "Terminate interactive client session"));
     descs.put(GEN_DP, new CommandUsage("", "Generate dataplane for the current snapshot"));
     descs.put(
         GET,
@@ -130,7 +127,6 @@ public enum Command {
             "Load questions from local directory, -loadremote loads questions from coordinator, "
                 + "if both are specified, questions from local directory overwrite the remote "
                 + "questions"));
-    descs.put(QUIT, new CommandUsage("", "Terminate interactive client session"));
     descs.put(
         SET_BATFISH_LOGLEVEL,
         new CommandUsage(

--- a/projects/client/src/main/java/org/batfish/client/config/Settings.java
+++ b/projects/client/src/main/java/org/batfish/client/config/Settings.java
@@ -7,11 +7,6 @@ import org.batfish.common.CoordConsts;
 
 public class Settings extends BaseSettings {
 
-  public enum RunMode {
-    batch,
-    interactive
-  }
-
   private static final String ARG_API_KEY = "apikey";
   public static final String ARG_BATFISH_LOG_LEVEL = "batfishloglevel";
   public static final String ARG_COMMAND_FILE = "cmdfile";
@@ -21,7 +16,6 @@ public class Settings extends BaseSettings {
   public static final String ARG_LOG_FILE = "logfile";
   public static final String ARG_LOG_LEVEL = "loglevel";
   private static final String ARG_NO_SANITY_CHECK = "nosanitycheck";
-  public static final String ARG_RUN_MODE = "runmode";
   public static final String ARG_SERVICE_NAME = "servicename";
   private static final String ARG_SERVICE_WORK_PORT = "coordinatorworkport";
   private static final String ARG_SERVICE_WORK_V2_PORT = "coordinatorworkv2port";
@@ -38,7 +32,6 @@ public class Settings extends BaseSettings {
   private String _logFile;
   private String _logLevel;
 
-  private RunMode _runMode;
   private boolean _sanityCheck;
   private String _serviceName;
   private String _snapshotDir;
@@ -89,10 +82,6 @@ public class Settings extends BaseSettings {
     return _logLevel;
   }
 
-  public RunMode getRunMode() {
-    return _runMode;
-  }
-
   public boolean getSanityCheck() {
     return _sanityCheck;
   }
@@ -118,7 +107,6 @@ public class Settings extends BaseSettings {
     setDefaultProperty(ARG_LOG_FILE, null);
     setDefaultProperty(ARG_LOG_LEVEL, BatfishLogger.getLogLevelStr(BatfishLogger.LEVEL_OUTPUT));
     setDefaultProperty(ARG_NO_SANITY_CHECK, false);
-    setDefaultProperty(ARG_RUN_MODE, RunMode.batch.toString());
     setDefaultProperty(ARG_SERVICE_NAME, "client-service");
     setDefaultProperty(ARG_SERVICE_WORK_V2_PORT, CoordConsts.SVC_CFG_WORK_V2_PORT);
   }
@@ -142,8 +130,6 @@ public class Settings extends BaseSettings {
 
     addBooleanOption(
         ARG_NO_SANITY_CHECK, "do not check if network, snapshot etc. are set. (helps debugging.)");
-
-    addOption(ARG_RUN_MODE, "which mode to run in (batch|interactive|genquestions)", "run_mode");
 
     addOption(ARG_SERVICE_NAME, "service name", "service_name");
 
@@ -189,7 +175,6 @@ public class Settings extends BaseSettings {
     _containerId = getStringOptionValue(ARG_CONTAINER_ID);
     _logFile = getStringOptionValue(ARG_LOG_FILE);
     _logLevel = getStringOptionValue(ARG_LOG_LEVEL);
-    _runMode = RunMode.valueOf(getStringOptionValue(ARG_RUN_MODE));
     _sanityCheck = !getBooleanOptionValue(ARG_NO_SANITY_CHECK);
     _serviceName = getStringOptionValue(ARG_SERVICE_NAME);
 

--- a/projects/client/src/test/java/org/batfish/client/ClientTest.java
+++ b/projects/client/src/test/java/org/batfish/client/ClientTest.java
@@ -4,7 +4,6 @@ import static org.batfish.client.Command.ADD_BATFISH_OPTION;
 import static org.batfish.client.Command.ANSWER;
 import static org.batfish.client.Command.DEL_BATFISH_OPTION;
 import static org.batfish.client.Command.DEL_NETWORK;
-import static org.batfish.client.Command.EXIT;
 import static org.batfish.client.Command.GEN_DP;
 import static org.batfish.client.Command.GET;
 import static org.batfish.client.Command.HELP;
@@ -210,17 +209,6 @@ public final class ClientTest {
     _thrown.expectMessage(
         equalTo(String.format("A Batfish %s must start with \"/\"", JSON_PATH_REGEX.getName())));
     Client.validateJsonPathRegex("");
-  }
-
-  @Test
-  public void testExitInvalidParas() throws Exception {
-    String[] parameters = new String[] {"parameter1"};
-    testInvalidInput(EXIT, new String[] {}, parameters);
-  }
-
-  @Test
-  public void testExitValidParas() throws Exception {
-    testProcessCommandWithValidInput(EXIT, new String[] {}, "");
   }
 
   @Test


### PR DESCRIPTION
After removing interactive mode in batfish/batfish#9563, there remained several unused components:
- RunMode enum with only batch mode remaining
- EXIT and QUIT commands
- RunMode switches in Client constructor and run()
- RunMode parameter passing in Allinone

Remove these now-unnecessary abstractions and simplify the client to assume batch mode.

---
Prompt:
```
In the recent commit we deleted the interactive mode in client, but we mostly made things crash intead of removing them. Can we now go to delete now-unused functionality? That means commands in client that don't make sense, client runmode if there's only one value, simplifying client and runmode handling in Allinone, etc.
```