### PR TITLE
Junos: add parsing support for switch-options interface-mac-limit

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -601,6 +601,8 @@ DOMAIN_NAME: 'domain-name' -> pushMode(M_Name);
 
 DOMAIN_SEARCH: 'domain-search';
 DOMAIN_TYPE: 'domain-type';
+DROP: 'drop';
+DROP_AND_LOG: 'drop-and-log';
 DROP_PATH_ATTRIBUTES: 'drop-path-attributes';
 
 DROP_PROFILES: 'drop-profiles' -> pushMode(M_Name);
@@ -1087,6 +1089,7 @@ INTERFACE
    'interface' -> pushMode ( M_Interface )
 ;
 
+INTERFACE_MAC_LIMIT: 'interface-mac-limit';
 INTERFACE_MODE: 'interface-mode';
 
 INTERFACE_RANGE: 'interface-range' -> pushMode(M_Name);
@@ -2087,6 +2090,7 @@ OVERRIDES: 'overrides';
 P2MP: 'p2mp';
 P2MP_OVER_LAN: 'p2mp-over-lan';
 P2P: 'p2p';
+PACKET_ACTION: 'packet-action';
 PACKET_LENGTH: 'packet-length' -> pushMode(M_SubRange);
 PACKET_LENGTH_EXCEPT: 'packet-length-except' -> pushMode(M_SubRange);
 
@@ -2643,7 +2647,7 @@ SHARED_IKE_ID: 'shared-ike-id';
 SHIM6_HEADER: 'shim6-header';
 
 SHORTCUTS: 'shortcuts';
-
+SHUTDOWN: 'shutdown';
 SIGNALING: 'signaling';
 
 SIMPLE: 'simple';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_switch_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_switch_options.g4
@@ -10,7 +10,8 @@ s_switch_options
 :
   SWITCH_OPTIONS
     (
-      so_vtep_source_interface
+      so_interface
+      | so_vtep_source_interface
       | so_route_distinguisher
       | so_vrf_target
       | so_vrf_export
@@ -41,4 +42,38 @@ so_vrf_export
 so_vrf_import
 :
   VRF_IMPORT null_filler
+;
+
+so_interface
+:
+  INTERFACE interface_id
+  (
+    soi_interface_mac_limit
+  )
+;
+
+soi_interface_mac_limit
+:
+  INTERFACE_MAC_LIMIT
+  (
+    soiiml_limit_null
+    | soiiml_packet_action_null
+  )
+;
+
+soiiml_limit_null
+:
+  uint16
+;
+
+soiiml_packet_action_null
+:
+  PACKET_ACTION
+  (
+    DROP
+    | DROP_AND_LOG
+    | LOG
+    | NONE
+    | SHUTDOWN
+  )
 ;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1012,6 +1012,11 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfaceMacLimitParsing() {
+    parseJuniperConfig("interface-mac-limit");
+  }
+
+  @Test
   public void testL2Topology() throws IOException {
     /*
     L1:

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-mac-limit
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-mac-limit
@@ -1,0 +1,21 @@
+# RANCID-CONTENT-TYPE: juniper
+set system host-name interface-mac-limit
+#
+# Test interface-mac-limit with limit value
+set switch-options interface ge-0/0/24.0 interface-mac-limit 5
+#
+# Test interface-mac-limit with packet-action shutdown
+set switch-options interface ge-0/0/24.0 interface-mac-limit packet-action shutdown
+#
+# Test interface-mac-limit with all packet-action values
+set switch-options interface ge-0/0/25.0 interface-mac-limit 10
+set switch-options interface ge-0/0/25.0 interface-mac-limit packet-action drop
+#
+set switch-options interface ge-0/0/26.0 interface-mac-limit 15
+set switch-options interface ge-0/0/26.0 interface-mac-limit packet-action drop-and-log
+#
+set switch-options interface ge-0/0/27.0 interface-mac-limit 20
+set switch-options interface ge-0/0/27.0 interface-mac-limit packet-action log
+#
+set switch-options interface ge-0/0/28.0 interface-mac-limit 25
+set switch-options interface ge-0/0/28.0 interface-mac-limit packet-action none


### PR DESCRIPTION
Add parsing support for Juniper switch-options interface-mac-limit
configuration, including the limit value and packet-action options
(drop, drop-and-log, log, none, shutdown).

This change adds grammar rules to parse both hierarchical and
set-style configurations:
- set switch-options interface <iface> interface-mac-limit <limit>
- set switch-options interface <iface> interface-mac-limit packet-action <action>

Parsing is implemented using _null suffix rules as this configuration
does not affect the Batfish data model (MAC learning is not modeled).

---
Prompt:
```
Add Juniper parsing support for

    interface ge-0/0/0.0 {
        interface-mac-limit {
            5;
            packet-action shutdown;
        }
    }

set switch-options interface ge-0/0/24.0 interface-mac-limit 5
set switch-options interface ge-0/0/24.0 interface-mac-limit packet-action shutdown

The docs for this are https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/interface-mac-limit-edit-bridge-domains-edit-switch-options.html

Read the general parsing and specific juniper docs/, and add a parsing "don't crash" test.
```

commit-id:24734f36

---

**Stack**:
- #9582
- #9581
- #9580 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*