### PR TITLE
Add Dependabot configuration for Bazel and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  # Bazel infrastructure dependencies (rules_java, bazel_skylib, etc.)
+  # Note: Beta only updates bazel_dep() declarations, not Maven artifacts
+  - package-ecosystem: "bazel"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Enable Dependabot beta support for:
- Bazel infrastructure (rules_java, bazel_skylib, etc.)
- GitHub Actions workflows

Weekly schedule with 5 PR limit to avoid overwhelming CI.

Note: Beta only updates bazel_dep() declarations, not Maven artifacts
in maven.install(), which still require manual updates.

---
Prompt:
```
Based on our github test repo success, I'd liek to proceed with a minimal dependabot file for Batfish. As simple as possible while being useful.
```