### PR TITLE
docs: add structure tracking and extraction best practices

### DIFF
--- a/docs/parsing/parser_rule_conventions.md
+++ b/docs/parsing/parser_rule_conventions.md
@@ -206,6 +206,22 @@ For "interface" vs "ip" commands:
 - Use `ip` for ip commands (already short)
 - Use `ip_acl` for "ip access-list" (more specific than just `ip_a`)
 
+## Handling Prefix Collisions
+
+When a natural prefix is already in use, choose a longer prefix that avoids collisions.
+
+**Example**: In Cisco grammars, `dt_` is used for "depi-tunnel" so "device-tracking" uses `dtr_` instead.
+
+## Inlining Simple Alternatives
+
+Inline simple alternatives instead of creating separate child rules:
+
+**Inline** when alternatives are simple tokens without parameters (enable/disable, true/false).
+
+**Don't inline** when alternatives have different parameters, require different extraction logic, or form a long list (4+ alternatives).
+
+**See**: Cisco_device_tracking.g4 `dtrp_tracking` (inlined) vs `dtrp_limit` (separate child rules).
+
 ## Opportunistic Improvements
 
 While these conventions should be followed for all new grammar rules, existing rules may not always conform to these patterns. When working with existing code:


### PR DESCRIPTION
Extend implementation_guide.md and parser_rule_conventions.md with patterns
from device-tracking policy implementation.

parser_rule_conventions.md:
- Prefix collision handling: use longer prefix when natural choice is taken
- Inlining simple alternatives: when to inline vs create separate child rules

implementation_guide.md:
- Pattern 4: Structure definition and reference tracking workflow
- Assert in else branches: catch new grammar alternatives without updated logic
- @Nullable for config values: distinguish unconfigured from explicit defaults
- Store current objects vs names: avoid repeated lookups in exit methods

All examples simplified to general patterns with references to actual code
rather than verbose copy-paste examples.

---
Prompt:
```
Based on our conversation, what doc updates should we make to parsing,
extraction, reference tracking, grammar conventions, etc.
```

commit-id:32f91e87

---

**Stack**:
- #9619
- #9618
- #9617
- #9616
- #9615
- #9614
- #9613
- #9612
- #9608
- #9605
- #9604 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*