### PR TITLE
IOS: parse access-session port-control interface command

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -4217,6 +4217,8 @@ PORT_CHANNEL: 'port-channel';
 
 PORT_CHANNEL_PROTOCOL: 'port-channel-protocol';
 
+PORT_CONTROL: 'port-control';
+
 PORT_NAME: 'port-name';
 
 PORT_OBJECT: 'port-object';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -6,6 +6,21 @@ options {
    tokenVocab = CiscoLexer;
 }
 
+if_access_session
+:
+  ACCESS_SESSION ifas_port_control_null
+;
+
+ifas_port_control_null
+:
+  PORT_CONTROL
+  (
+    AUTO
+    | FORCE_AUTHORIZED
+    | FORCE_UNAUTHORIZED
+  ) NEWLINE
+;
+
 if_autostate
 :
    NO? AUTOSTATE NEWLINE
@@ -1824,7 +1839,8 @@ s_interface_definition
 
 if_inner
 :
-   if_autostate
+   if_access_session
+   | if_autostate
    | if_bandwidth
    | if_bfd
    | if_channel_group

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -773,6 +773,16 @@ public final class CiscoGrammarTest {
   }
 
   @Test
+  public void testIosAccessSessionPortControl() throws IOException {
+    String hostname = "ios-access-session-port-control";
+    Configuration c = parseConfig(hostname);
+
+    assertThat(c, hasInterface("GigabitEthernet1/0/1", isActive()));
+    assertThat(c, hasInterface("GigabitEthernet1/0/2", isActive()));
+    assertThat(c, hasInterface("GigabitEthernet1/0/3", isActive()));
+  }
+
+  @Test
   public void testIosAclInRouteMap() throws IOException {
     String hostname = "ios-acl-in-routemap";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-access-session-port-control
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-access-session-port-control
@@ -1,0 +1,15 @@
+!
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname ios-access-session-port-control
+!
+!
+interface GigabitEthernet1/0/1
+  access-session port-control auto
+!
+interface GigabitEthernet1/0/2
+  access-session port-control force-authorized
+!
+interface GigabitEthernet1/0/3
+  access-session port-control force-unauthorized
+!

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -43197,7 +43197,7 @@
             "      (template_null*",
             "        ACCESS_SESSION:'access-session'",
             "        (null_rest_of_line*",
-            "          VARIABLE:'port-control'",
+            "          PORT_CONTROL:'port-control'",
             "          AUTO:'auto'",
             "          NEWLINE:'\\n'))",
             "      (template_null*",


### PR DESCRIPTION
Add grammar support for Cisco IOS access-session port-control command with
all three variants.

Grammar:
- Added PORT_CONTROL token to CiscoLexer.g4
- Created if_access_session parent rule for LL(1) compliance
- Created ifas_port_control_null child rule with three variants:
auto, force-authorized, force-unauthorized
- Added to if_inner alternatives in alphabetical order
- Grammar is LL(1): ACCESS_SESSION is first token for immediate rule selection

Implementation:
- Uses _null suffix since command controls interface authentication/security
which does not affect routing or forwarding behavior modeled by Batfish
- No extraction needed - command is silently accepted per documentation

Test:
- Created testIosAccessSessionPortControl with config demonstrating all variants
- Verifies all three command forms parse without warnings

---
Prompt:
```
I want to add idiomatic parsing for the access-session port-control command in Cisco IOS listed here: https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9200/software/release/17-12/command_reference/b_1712_9200_cr/m9_1712_security_ibns_cr.html#wp3145726977 . Does not need to be extracted, should adapt an existing interface parsing test (I assume one exists) for the new flag variants.
```

---

**Stack**:
- #9619
- #9618
- #9617
- #9616
- #9615
- #9614
- #9613
- #9612
- #9608 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*