### PR TITLE
docs: use getLine() helper for hierarchical configs

### DIFF
--- a/docs/parsing/implementation_guide.md
+++ b/docs/parsing/implementation_guide.md
@@ -190,6 +190,7 @@ For commands that define named objects referenced elsewhere:
 2. Add usage type(s) to vendor's `StructureUsage` enum (name should match command path)
 3. In extractor enter method: Call `defineStructure(type, name, ctx)`
 4. In extractor exit methods: Call `referenceStructure(type, name, usage, line)` at reference sites
+   - For hierarchical configs (Junos, Palo Alto): Use `getLine(token)` helper, not `token.getLine()`
 5. In conversion: Call `markConcreteStructure(type)`
 6. Test with `hasDefinedStructure()`, `hasNumReferrers()`, `hasUndefinedReference()` matchers
 


### PR DESCRIPTION
Document that Junos and Palo Alto require getLine(token) helper instead of
token.getLine() for structure reference tracking due to hierarchical config
preprocessing.

---

**Stack**:
- #9619
- #9618
- #9617
- #9616
- #9615
- #9614
- #9613
- #9612 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*