### PR TITLE
Junos: add parsing for interface family inet6 sampling

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -374,6 +374,7 @@ if_inet
       | ifi_no_redirects
       | ifi_null
       | ifi_rpf_check
+      | ifi_sampling_null
       | ifi_tcp_mss
    )
 ;
@@ -387,6 +388,7 @@ if_inet6
       | ifi6_destination_udp_port
       | ifi6_filter
       | ifi6_mtu
+      | ifi6_sampling_null
    )
 ;
 
@@ -414,6 +416,11 @@ ifi6_filter: FILTER ifi6f_input;
 ifi6f_input: INPUT name = junos_name;
 
 ifi6_mtu: i_mtu;
+
+ifi6_sampling_null
+:
+   SAMPLING null_filler
+;
 
 if_iso
 :
@@ -542,10 +549,14 @@ ifi_null
    (
       DHCP
       | POLICER
-      | SAMPLING
       | SERVICE
       | TARGETED_BROADCAST
    ) null_filler
+;
+
+ifi_sampling_null
+:
+   SAMPLING null_filler
 ;
 
 ifi_rpf_check

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3655,6 +3655,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfaceSampling() {
+    // Sampling is parsed but ignored; verify parsing succeeds for both family inet and inet6
+    parseConfig("interface-sampling");
+  }
+
+  @Test
   public void testInterfaceOspfNetworkType() {
     String hostname = "ospf-interface-network-type";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-sampling
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-sampling
@@ -1,0 +1,8 @@
+#
+set system host-name interface-sampling
+#
+set interfaces xe-0/0/0 unit 0 family inet sampling input
+set interfaces xe-0/0/1 unit 0 family inet6 sampling input
+#
+set groups SAMPLING-GROUP interfaces <xe-*> unit <*> family inet6 sampling input
+#


### PR DESCRIPTION
Add parsing support for the 'sampling' command under both 'family inet' and 'family inet6' interface configurations.

Grammar additions:
- Add ifi6_sampling_null rule for family inet6 sampling
- Add ifi_sampling_null rule for family inet (extracted from ifi_null)
- Update if_inet6 to include ifi6_sampling_null
- Update if_inet to include ifi_sampling_null
- Remove SAMPLING from ifi_null to avoid duplication

Test additions:
- Add testInterfaceSampling test verifying parsing succeeds
- Add interface-sampling test config with direct and groups-based configurations

The sampling command is parsed but ignored (sent to null_filler), which is appropriate since Batfish does not model sampling behavior.
---
Prompt:
```
Figure out what to change to support this command on Junos: 'set groups SAMPLING-GROUP interfaces <xe-*> unit <*> family inet6 sampling input'. Use juniper docs or manuals as a reference; feel free to search the internet or their website.
```

---

**Stack**:
- #9619
- #9618
- #9617
- #9616
- #9615
- #9614 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*