### PR TITLE
Junos: parse and extract policy-statement then aigp-originate

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -169,6 +169,7 @@ AH: 'ah';
 
 AH_HEADER: 'AH-header';
 AGING_TIMER: 'aging-timer';
+AIGP_ORIGINATE: 'aigp-originate';
 ALARM_WITHOUT_DROP: 'alarm-without-drop';
 
 ALARM_THRESHOLD: 'alarm-threshold';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -521,6 +521,8 @@ popst_accept
    ACCEPT
 ;
 
+popst_aigp_originate: AIGP_ORIGINATE (distance = uint32)?;
+
 popst_as_path_expand
 :
   AS_PATH_EXPAND
@@ -567,6 +569,7 @@ popst_color2
 popst_common
 :
    popst_accept
+   | popst_aigp_originate
    | popst_as_path_expand
    | popst_as_path_prepend
    | popst_bgp_output_queue_priority

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -618,6 +618,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_thenContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_throughContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_uptoContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_acceptContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_aigp_originateContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_as_path_expandContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_as_path_prependContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_bgp_output_queue_priorityContext;
@@ -1121,6 +1122,7 @@ import org.batfish.representation.juniper.PsFroms;
 import org.batfish.representation.juniper.PsTerm;
 import org.batfish.representation.juniper.PsThen;
 import org.batfish.representation.juniper.PsThenAccept;
+import org.batfish.representation.juniper.PsThenAigpOriginate;
 import org.batfish.representation.juniper.PsThenAsPathExpand;
 import org.batfish.representation.juniper.PsThenAsPathExpandAsList;
 import org.batfish.representation.juniper.PsThenAsPathExpandLastAs;
@@ -6265,6 +6267,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitPopst_accept(Popst_acceptContext ctx) {
     addPsThen(PsThenAccept.INSTANCE, ctx);
+  }
+
+  @Override
+  public void exitPopst_aigp_originate(Popst_aigp_originateContext ctx) {
+    todo(ctx);
+    Long distance = ctx.distance != null ? toLong(ctx.distance) : null;
+    addPsThen(new PsThenAigpOriginate(distance), ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAigpOriginate.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAigpOriginate.java
@@ -1,0 +1,49 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/** Represents an unsupported "aigp-originate" action in a {@link PsTerm} */
+@ParametersAreNonnullByDefault
+public final class PsThenAigpOriginate extends PsThen {
+
+  private final @Nullable Long _distance;
+
+  public PsThenAigpOriginate(@Nullable Long distance) {
+    _distance = distance;
+  }
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings warnings) {
+    // AIGP originate is not supported - no-op
+  }
+
+  public @Nullable Long getDistance() {
+    return _distance;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenAigpOriginate)) {
+      return false;
+    }
+    PsThenAigpOriginate that = (PsThenAigpOriginate) o;
+    return Objects.equals(_distance, that._distance);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_distance);
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -472,6 +472,7 @@ import org.batfish.representation.juniper.PsFromExternal;
 import org.batfish.representation.juniper.PsFromLocalPreference;
 import org.batfish.representation.juniper.PsFromTag;
 import org.batfish.representation.juniper.PsTerm;
+import org.batfish.representation.juniper.PsThenAigpOriginate;
 import org.batfish.representation.juniper.PsThenAsPathExpandAsList;
 import org.batfish.representation.juniper.PsThenAsPathExpandLastAs;
 import org.batfish.representation.juniper.PsThenAsPathPrepend;
@@ -4885,6 +4886,16 @@ public final class FlatJuniperGrammarTest {
       assertThat(
           policy.getTerms().get("REMOVE_TUNNEL_ATTR").getThens().getAllThens(),
           contains(PsThenTunnelAttributeRemove.INSTANCE));
+    }
+    {
+      PolicyStatement policy = c.getMasterLogicalSystem().getPolicyStatements().get("AIGP_POLICY");
+      assertThat(policy.getTerms(), hasKeys("WITHOUT_DISTANCE", "WITH_DISTANCE"));
+      assertThat(
+          policy.getTerms().get("WITHOUT_DISTANCE").getThens().getAllThens(),
+          contains(new PsThenAigpOriginate(null)));
+      assertThat(
+          policy.getTerms().get("WITH_DISTANCE").getThens().getAllThens(),
+          contains(new PsThenAigpOriginate(100L)));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenAigpOriginateTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenAigpOriginateTest.java
@@ -1,0 +1,30 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+public class PsThenAigpOriginateTest {
+
+  @Test
+  public void testSerialization() {
+    PsThenAigpOriginate objWithNull = new PsThenAigpOriginate(null);
+    assertThat(SerializationUtils.clone(objWithNull), equalTo(objWithNull));
+
+    PsThenAigpOriginate objWithDistance = new PsThenAigpOriginate(100L);
+    assertThat(SerializationUtils.clone(objWithDistance), equalTo(objWithDistance));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(5)
+        .addEqualityGroup(new PsThenAigpOriginate(null), new PsThenAigpOriginate(null))
+        .addEqualityGroup(new PsThenAigpOriginate(100L), new PsThenAigpOriginate(100L))
+        .addEqualityGroup(new PsThenAigpOriginate(200L))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-then
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-then
@@ -23,3 +23,6 @@ set policy-options policy-statement TAG2_POLICY term TMAX then tag2 4294967295
 #
 set policy-options policy-statement TUNNEL_ATTR_POLICY term SET_TUNNEL_ATTR then tunnel-attribute set TA
 set policy-options policy-statement TUNNEL_ATTR_POLICY term REMOVE_TUNNEL_ATTR then tunnel-attribute remove all
+#
+set policy-options policy-statement AIGP_POLICY term WITHOUT_DISTANCE then aigp-originate
+set policy-options policy-statement AIGP_POLICY term WITH_DISTANCE then aigp-originate 100


### PR DESCRIPTION
Parse and extract 'set policy-options policy-statement <name> term <name> then aigp-originate [distance]' with optional distance parameter (UINT32).

The command is parsed and extracted but not converted to the vendor-independent model, as AIGP (Accumulated IGP Metric) attribute support is not implemented. A warning is issued during extraction.
---
Prompt:
```
Add Juniper grammar support for 'set policy-options policy-statement <name> term <name> then aigp-originate' with optional distance parameter. Docs (https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/aigp-originate-edit-policy-options.html). This should be warned as unsupported and implemented with a no-op PsThen class. Support optional distance parameter (UINT32) as specified in the documentation.
```

---

**Stack**:
- #9619
- #9618
- #9617
- #9616
- #9615 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*