### PR TITLE
Junos: add parsing for protocols mpls statistics and traceoptions

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2871,6 +2871,8 @@ STATION_ADDRESS: 'station-address';
 
 STATION_PORT: 'station-port';
 
+STATISTICS: 'statistics';
+
 STATISTICS_TIMEOUT: 'statistics-timeout';
 
 STATS_CACHE_LIFETIME: 'stats-cache-lifetime';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
@@ -36,6 +36,8 @@ p_mpls
        | mpls_interface
        | mpls_label_switched_path
        | mpls_path
+       | mpls_statistics_null
+       | mpls_traceoptions_null
    )
 ;
 
@@ -319,4 +321,14 @@ mplslspsag_include_any
 mplslsp_to_null
 :
    TO (ip_address | ipv6_address)
+;
+
+mpls_statistics_null
+:
+   STATISTICS null_filler
+;
+
+mpls_traceoptions_null
+:
+   TRACEOPTIONS null_filler
 ;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-mpls
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-mpls
@@ -10,3 +10,20 @@ set interfaces ge-1/0/0 unit 0 family mpls
 set protocols mpls apply-groups GROUP
 set groups GROUP protocols mpls interface ge-1/0/0.0
 #
+set protocols mpls statistics file stats.log
+set protocols mpls statistics file size 10m
+set protocols mpls statistics file files 10
+set protocols mpls statistics interval 300
+set protocols mpls statistics auto-bandwidth
+set protocols mpls statistics no-transit-statistics
+set protocols mpls statistics traffic-class-statistics
+set protocols mpls statistics transit-statistics-polling
+#
+set protocols mpls traceoptions file mpls.log
+set protocols mpls traceoptions file size 10m
+set protocols mpls traceoptions file files 10
+set protocols mpls traceoptions flag lsp-history
+set protocols mpls traceoptions flag state
+set protocols mpls traceoptions flag error
+set protocols mpls traceoptions flag all
+#


### PR DESCRIPTION
Adds grammar rules to parse:
- protocols mpls statistics (and sub-options)
- protocols mpls traceoptions (and sub-options)

Both are marked as null (not extracted) following the pattern used
for traceoptions in other Junos protocols (bgp, ospf, isis).

Adds STATISTICS token to lexer. TRACEOPTIONS token already existed.

---
Prompt:
```
Let's add junos grammar for mpls statistics (https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/statistics-edit-protocols-mpls.html) and traceoptions (https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/traceoptions-edit-protocols-mpls.html). Mark them as null or extract them as predicted. Ground in the sample config in working/class-of-services/ (anonymizing constants and names).
```

---

**Stack**:
- #9619
- #9618
- #9617 ⬅
- #9616
- #9615


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*