### PR TITLE
Junos: add parsing for protocols mpls optimize-adaptive-teardown

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -527,6 +527,7 @@ DEFAULT_METRIC: 'default-metric';
 DEFAULT_POLICY: 'default-policy';
 
 DEFAULTS: 'defaults';
+DELAY: 'delay';
 DELEGATE_PROCESSING: 'delegate-processing';
 DELETE
 :
@@ -2149,6 +2150,7 @@ OAM: 'oam';
 OFF: 'off';
 
 OFFSET: 'offset';
+OPTIMIZE_ADAPTIVE_TEARDOWN: 'optimize-adaptive-teardown';
 OPTIMIZE_HOLD_DEAD_DELAY: 'optimize-hold-dead-delay';
 OPTIMIZE_TIMER: 'optimize-timer';
 OPTIMIZED: 'optimized';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
@@ -35,6 +35,7 @@ p_mpls
        | mpls_admin_groups
        | mpls_interface
        | mpls_label_switched_path
+       | mpls_optimize_adaptive_teardown_null
        | mpls_path
        | mpls_statistics_null
        | mpls_traceoptions_null
@@ -321,6 +322,11 @@ mplslspsag_include_any
 mplslsp_to_null
 :
    TO (ip_address | ipv6_address)
+;
+
+mpls_optimize_adaptive_teardown_null
+:
+   OPTIMIZE_ADAPTIVE_TEARDOWN null_filler
 ;
 
 mpls_statistics_null

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-mpls
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-mpls
@@ -10,6 +10,10 @@ set interfaces ge-1/0/0 unit 0 family mpls
 set protocols mpls apply-groups GROUP
 set groups GROUP protocols mpls interface ge-1/0/0.0
 #
+set protocols mpls optimize-adaptive-teardown p2p
+set protocols mpls optimize-adaptive-teardown timeout 1800
+set protocols mpls optimize-adaptive-teardown delay 360
+#
 set protocols mpls statistics file stats.log
 set protocols mpls statistics file size 10m
 set protocols mpls statistics file files 10

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -55917,7 +55917,7 @@
             "                (o_null*",
             "                  SPF_OPTIONS:'spf-options'",
             "                  (null_filler*",
-            "                    UNRECOGNIZED_WORD:'delay'",
+            "                    DELAY:'delay'",
             "                    UINT8:'50'))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",


### PR DESCRIPTION
Adds grammar rules to parse:
- protocols mpls optimize-adaptive-teardown (and sub-options)

Marked as null (not extracted) following the pattern used for similar
diagnostic/logging features in protocols mpls.

Adds OPTIMIZE_ADAPTIVE_TEARDOWN and DELAY tokens to lexer.

---
Prompt:
```
Now add parsing for mpls optimize-adaptive-teardown per https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/optimize-adaptive-teardown-edit-protocols.html and the example config
```

---

**Stack**:
- #9636
- #9635
- #9633
- #9632
- #9631
- #9630
- #9629
- #9628 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*