### PR TITLE
Junos: add parsing for remaining protocols mpls top-level options

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -746,9 +746,8 @@ EXP
 ;
 
 EXPEDITED: 'expedited';
-
+EXPLICIT_NULL: 'explicit-null';
 EXPLICIT_PRIORITY: 'explicit-priority';
-
 EXPORT
 :
   'export'
@@ -993,12 +992,10 @@ ICMP: 'icmp';
 
 ICMP_CODE: 'icmp-code' -> pushMode(M_IcmpCodeOrType);
 ICMP_CODE_EXCEPT: 'icmp-code-except' -> pushMode(M_IcmpCodeOrType);
-
+ICMP_TUNNELING: 'icmp-tunneling';
 ICMP_TYPE: 'icmp-type' -> pushMode(M_IcmpCodeOrType);
 ICMP_TYPE_EXCEPT: 'icmp-type-except' -> pushMode(M_IcmpCodeOrType);
-
 ICMP6: 'icmp6';
-
 ICMP6_CODE: 'icmp6-code';
 
 ICMPV6_MALFORMED: 'icmpv6-malformed';
@@ -1238,6 +1235,7 @@ IPSEC_POLICY: 'ipsec-policy' -> pushMode(M_Name);
 IPSEC_VPN: 'ipsec-vpn' -> pushMode(M_Name);
 
 IPV6: 'ipv6';
+IPV6_TUNNELING: 'ipv6-tunneling';
 
 IPV6_EXTENSION_HEADER: 'ipv6-extension-header';
 
@@ -1800,17 +1798,12 @@ LOCAL_PREFERENCE: 'local-preference';
 LOCATION: 'location';
 
 LOG: 'log';
-
+LOG_LSP_HISTORY: 'log-lsp-history';
 LOG_OUT_ON_DISCONNECT: 'log-out-on-disconnect';
-
 LOG_PREFIX: 'log-prefix';
-
 LOG_UPDOWN: 'log-updown';
-
 LOGICAL_SYSTEM: 'logical-system' -> pushMode(M_Name);
-
 LOGICAL_SYSTEMS: 'logical-systems' -> pushMode(M_Name);
-
 LOGIN: 'login';
 
 LONGER: 'longer';
@@ -1970,7 +1963,7 @@ MSTP: 'mstp';
 MTU: 'mtu';
 
 MTU_DISCOVERY: 'mtu-discovery';
-
+MTU_SIGNALING: 'mtu-signaling';
 MULTI_CHASSIS: 'multi-chassis';
 
 MULTICAST: 'multicast';
@@ -2151,6 +2144,7 @@ OFF: 'off';
 
 OFFSET: 'offset';
 OPTIMIZE_ADAPTIVE_TEARDOWN: 'optimize-adaptive-teardown';
+OPTIMIZE_AGGRESSIVE: 'optimize-aggressive';
 OPTIMIZE_HOLD_DEAD_DELAY: 'optimize-hold-dead-delay';
 OPTIMIZE_TIMER: 'optimize-timer';
 OPTIMIZED: 'optimized';
@@ -2204,25 +2198,17 @@ PATH
 ;
 
 PATH_COUNT: 'path-count';
-
+PATH_MTU: 'path-mtu';
 PATH_SELECTION: 'path-selection';
 PATH_SELECTION_MODE: 'path-selection-mode';
 PAYLOAD_PROTOCOL: 'payload-protocol';
-
 PEER_ADDRESS: 'peer-address';
-
 PEER_AS: 'peer-as' -> pushMode(M_BgpAsn);
-
 PEER_UNIT: 'peer-unit';
-
 PER_PACKET: 'per-packet';
-
 PER_UNIT_SCHEDULER: 'per-unit-scheduler';
-
 PERCENT: 'percent';
-
 PERFECT_FORWARD_SECRECY: 'perfect-forward-secrecy';
-
 PERMIT: 'permit';
 
 PERMIT_ALL: 'permit-all';
@@ -2451,6 +2437,7 @@ READ_WRITE: 'read-write';
 READVERTISE: 'readvertise';
 
 RECEIVE: 'receive';
+RECORD: 'record';
 
 RECORD_LIFETIME: 'record-lifetime';
 RECORD_ROUTE_OPTION: 'record-route-option';
@@ -2774,6 +2761,7 @@ SINGLE_CONNECTION: 'single-connection';
 SIP: 'sip';
 
 SMTP: 'smtp';
+SMART_OPTIMIZE_TIMER: 'smart-optimize-timer';
 
 SNMP: 'snmp';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
@@ -33,11 +33,22 @@ p_mpls
    (
        apply
        | mpls_admin_groups
+       | mpls_explicit_null_null
+       | mpls_icmp_tunneling_null
        | mpls_interface
+       | mpls_ipv6_tunneling_null
        | mpls_label_switched_path
+       | mpls_log_lsp_history_null
+       | mpls_log_updown_null
        | mpls_optimize_adaptive_teardown_null
+       | mpls_optimize_aggressive_null
+       | mpls_optimize_timer_null
        | mpls_path
+       | mpls_path_mtu_null
+       | mpls_record_null
+       | mpls_smart_optimize_timer_null
        | mpls_statistics_null
+       | mpls_traffic_engineering_null
        | mpls_traceoptions_null
    )
 ;
@@ -324,14 +335,69 @@ mplslsp_to_null
    TO (ip_address | ipv6_address)
 ;
 
+mpls_explicit_null_null
+:
+   EXPLICIT_NULL null_filler
+;
+
+mpls_icmp_tunneling_null
+:
+   ICMP_TUNNELING null_filler
+;
+
+mpls_ipv6_tunneling_null
+:
+   IPV6_TUNNELING null_filler
+;
+
+mpls_log_lsp_history_null
+:
+   LOG_LSP_HISTORY null_filler
+;
+
+mpls_log_updown_null
+:
+   LOG_UPDOWN null_filler
+;
+
 mpls_optimize_adaptive_teardown_null
 :
    OPTIMIZE_ADAPTIVE_TEARDOWN null_filler
 ;
 
+mpls_optimize_aggressive_null
+:
+   OPTIMIZE_AGGRESSIVE null_filler
+;
+
+mpls_optimize_timer_null
+:
+   OPTIMIZE_TIMER uint32
+;
+
+mpls_path_mtu_null
+:
+   PATH_MTU null_filler
+;
+
+mpls_record_null
+:
+   RECORD null_filler
+;
+
+mpls_smart_optimize_timer_null
+:
+   SMART_OPTIMIZE_TIMER uint32
+;
+
 mpls_statistics_null
 :
    STATISTICS null_filler
+;
+
+mpls_traffic_engineering_null
+:
+   TRAFFIC_ENGINEERING null_filler
 ;
 
 mpls_traceoptions_null

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-mpls
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-mpls
@@ -10,9 +10,19 @@ set interfaces ge-1/0/0 unit 0 family mpls
 set protocols mpls apply-groups GROUP
 set groups GROUP protocols mpls interface ge-1/0/0.0
 #
+set protocols mpls explicit-null
+set protocols mpls icmp-tunneling
+set protocols mpls ipv6-tunneling
+set protocols mpls log-lsp-history
+set protocols mpls log-updown syslog
 set protocols mpls optimize-adaptive-teardown p2p
 set protocols mpls optimize-adaptive-teardown timeout 1800
 set protocols mpls optimize-adaptive-teardown delay 360
+set protocols mpls optimize-aggressive
+set protocols mpls optimize-timer 300
+set protocols mpls path-mtu rsvp mtu-signaling
+set protocols mpls record
+set protocols mpls smart-optimize-timer 100
 #
 set protocols mpls statistics file stats.log
 set protocols mpls statistics file size 10m
@@ -22,6 +32,8 @@ set protocols mpls statistics auto-bandwidth
 set protocols mpls statistics no-transit-statistics
 set protocols mpls statistics traffic-class-statistics
 set protocols mpls statistics transit-statistics-polling
+#
+set protocols mpls traffic-engineering bgp
 #
 set protocols mpls traceoptions file mpls.log
 set protocols mpls traceoptions file size 10m


### PR DESCRIPTION
Adds grammar rules to parse these protocols mpls options:
- explicit-null
- icmp-tunneling
- ipv6-tunneling
- log-lsp-history
- log-updown (and sub-options)
- optimize-aggressive
- optimize-timer
- path-mtu (and sub-options)
- record
- smart-optimize-timer
- traffic-engineering (and sub-options)

All marked as null (not extracted) following the pattern used for
similar diagnostic/logging/optimization features in protocols mpls.

Adds tokens: EXPLICIT_NULL, ICMP_TUNNELING, IPV6_TUNNELING,
LOG_LSP_HISTORY, MTU_SIGNALING, OPTIMIZE_AGGRESSIVE, PATH_MTU,
RECORD, SMART_OPTIMIZE_TIMER.

---
Prompt:
```
Ok let's see if we can finish MPLS:
'set protocols mpls explicit-null',
'set protocols mpls icmp-tunneling',
'set protocols mpls ipv6-tunneling',
'set protocols mpls log-lsp-history',
'set protocols mpls log-updown syslog',
'set protocols mpls optimize-aggressive',
'set protocols mpls optimize-timer 300',
'set protocols mpls path-mtu rsvp mtu-signaling',
'set protocols mpls record',
'set protocols mpls smart-optimize-timer 100',
'set protocols mpls traffic-engineering bgp',
Refer to https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/mpls-edit-protocols-mpls-ex-series.html or https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/record-edit-protocols-mpls.html and links therein. Make sure to add unit tests
```

---

**Stack**:
- #9636
- #9635
- #9633
- #9632
- #9631
- #9630
- #9629 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*