### PR TITLE
Junos: add built-in forwarding class support for class-of-service

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -986,6 +986,7 @@ import org.batfish.representation.juniper.EvpnEncapsulation;
 import org.batfish.representation.juniper.ExpUtil;
 import org.batfish.representation.juniper.Family;
 import org.batfish.representation.juniper.FirewallFilter;
+import org.batfish.representation.juniper.ForwardingClassUtil;
 import org.batfish.representation.juniper.FwFrom;
 import org.batfish.representation.juniper.FwFromAddress;
 import org.batfish.representation.juniper.FwFromApplicationOrApplicationSet;
@@ -7534,128 +7535,183 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitScosii_forwarding_class(Scosii_forwarding_classContext ctx) {
+    String fcName = toString(ctx.name);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.name),
+        fcName,
         CLASS_OF_SERVICE_INTERFACES_FORWARDING_CLASS,
         getLine(ctx.name.getStart()));
   }
 
   @Override
   public void exitScosiiu_forwarding_class(Scosiiu_forwarding_classContext ctx) {
+    String fcName = toString(ctx.name);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.name),
+        fcName,
         CLASS_OF_SERVICE_INTERFACES_UNIT_FORWARDING_CLASS,
         getLine(ctx.name.getStart()));
   }
 
   @Override
   public void exitScoshob_forwarding_class(Scoshob_forwarding_classContext ctx) {
+    String fcName = toString(ctx.name);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.name),
+        fcName,
         CLASS_OF_SERVICE_HOST_OUTBOUND_TRAFFIC_FORWARDING_CLASS,
         getLine(ctx.name.getStart()));
   }
 
   @Override
   public void exitScoscld_forwarding_class(Scoscld_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_CLASSIFIERS_DSCP_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScoscld6_forwarding_class(Scoscld6_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IPV6_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScoscle_forwarding_class(Scoscle_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_CLASSIFIERS_EXP_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScoscli_forwarding_class(Scoscli_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_CLASSIFIERS_IEEE_802_1_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScosclip_forwarding_class(Scosclip_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_CLASSIFIERS_INET_PRECEDENCE_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScosrrd_forwarding_class(Scosrrd_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_REWRITE_RULES_DSCP_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScosrrd6_forwarding_class(Scosrrd6_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_REWRITE_RULES_DSCP_IPV6_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScosrre_forwarding_class(Scosrre_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_REWRITE_RULES_EXP_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScosrri_forwarding_class(Scosrri_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScosrrip_forwarding_class(Scosrrip_forwarding_classContext ctx) {
+    String fcName = toString(ctx.fc);
+    if (ForwardingClassUtil.isBuiltin(fcName)) {
+      return;
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
+        fcName,
         CLASS_OF_SERVICE_REWRITE_RULES_INET_PRECEDENCE_FORWARDING_CLASS,
         getLine(ctx.fc.getStart()));
   }
 
   @Override
   public void exitScossm_forwarding_class(Scossm_forwarding_classContext ctx) {
-    _configuration.referenceStructure(
-        CLASS_OF_SERVICE_FORWARDING_CLASS,
-        toString(ctx.fc),
-        CLASS_OF_SERVICE_SCHEDULER_MAPS_FORWARDING_CLASS,
-        getLine(ctx.fc.getStart()));
+    String fcName = toString(ctx.fc);
+    if (!ForwardingClassUtil.isBuiltin(fcName)) {
+      _configuration.referenceStructure(
+          CLASS_OF_SERVICE_FORWARDING_CLASS,
+          fcName,
+          CLASS_OF_SERVICE_SCHEDULER_MAPS_FORWARDING_CLASS,
+          getLine(ctx.fc.getStart()));
+    }
     _configuration.referenceStructure(
         CLASS_OF_SERVICE_SCHEDULER,
         toString(ctx.sched),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ForwardingClassUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ForwardingClassUtil.java
@@ -1,0 +1,42 @@
+package org.batfish.representation.juniper;
+
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * A helper class for forwarding class related functionality. Provides information about built-in
+ * forwarding classes.
+ */
+@ParametersAreNonnullByDefault
+public final class ForwardingClassUtil {
+
+  /**
+   * Returns the default queue number for built-in forwarding classes.
+   *
+   * <p>Juniper Networks devices have eight queues built into hardware. By default, four queues are
+   * assigned to four built-in forwarding classes. Queue numbers 4-7 have no default assignments.
+   */
+  // Built-in forwarding classes and default queue assignments are from
+  // https://www.juniper.net/documentation/us/en/software/junos/cos-security-devices/topics/concept/cos-qos-forwarding-classes-overview.html
+  // Table 12: Default Forwarding Class Queue Assignments
+  private static final Map<String, Integer> DEFAULT_QUEUE_ASSIGNMENTS =
+      Map.of(
+          "best-effort", 0,
+          "expedited-forwarding", 1,
+          "assured-forwarding", 2,
+          "network-control", 3);
+
+  /** Returns the default queue number for a built-in forwarding class name. */
+  public static @Nonnull Optional<Integer> defaultQueueNumber(String forwardingClassName) {
+    return Optional.ofNullable(DEFAULT_QUEUE_ASSIGNMENTS.get(forwardingClassName));
+  }
+
+  /** Returns true if the given name is a built-in forwarding class. */
+  public static boolean isBuiltin(String forwardingClassName) {
+    return DEFAULT_QUEUE_ASSIGNMENTS.containsKey(forwardingClassName);
+  }
+
+  private ForwardingClassUtil() {}
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -176,6 +176,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.BGP_GROUP;
 import static org.batfish.representation.juniper.JuniperStructureType.BGP_NEIGHBOR;
 import static org.batfish.representation.juniper.JuniperStructureType.BRIDGE_DOMAIN;
 import static org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_DSCP_CODE_POINT_ALIAS;
+import static org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_FORWARDING_CLASS;
 import static org.batfish.representation.juniper.JuniperStructureType.COMMUNITY;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER_TERM;
@@ -1015,6 +1016,35 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testClassOfServiceComprehensive() {
     parseJuniperConfig("class-of-service-comprehensive");
+  }
+
+  @Test
+  public void testClassOfServiceBuiltinForwardingClasses() throws IOException {
+    String hostname = "class-of-service-builtin-forwarding-classes";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Verify built-in forwarding classes don't produce undefined reference warnings when used
+    // without explicit definition
+    assertThat(
+        ccae,
+        not(hasUndefinedReference(filename, CLASS_OF_SERVICE_FORWARDING_CLASS, "best-effort")));
+    assertThat(
+        ccae,
+        not(
+            hasUndefinedReference(
+                filename, CLASS_OF_SERVICE_FORWARDING_CLASS, "expedited-forwarding")));
+    assertThat(
+        ccae,
+        not(
+            hasUndefinedReference(
+                filename, CLASS_OF_SERVICE_FORWARDING_CLASS, "assured-forwarding")));
+    assertThat(
+        ccae,
+        not(hasUndefinedReference(filename, CLASS_OF_SERVICE_FORWARDING_CLASS, "network-control")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/ForwardingClassUtilTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/ForwardingClassUtilTest.java
@@ -1,0 +1,35 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Optional;
+import org.junit.Test;
+
+public class ForwardingClassUtilTest {
+
+  @Test
+  public void testBuiltinForwardingClasses() {
+    // Test all built-in forwarding classes
+    assertThat(ForwardingClassUtil.isBuiltin("best-effort"), equalTo(true));
+    assertThat(ForwardingClassUtil.defaultQueueNumber("best-effort"), equalTo(Optional.of(0)));
+
+    assertThat(ForwardingClassUtil.isBuiltin("expedited-forwarding"), equalTo(true));
+    assertThat(
+        ForwardingClassUtil.defaultQueueNumber("expedited-forwarding"), equalTo(Optional.of(1)));
+
+    assertThat(ForwardingClassUtil.isBuiltin("assured-forwarding"), equalTo(true));
+    assertThat(
+        ForwardingClassUtil.defaultQueueNumber("assured-forwarding"), equalTo(Optional.of(2)));
+
+    assertThat(ForwardingClassUtil.isBuiltin("network-control"), equalTo(true));
+    assertThat(ForwardingClassUtil.defaultQueueNumber("network-control"), equalTo(Optional.of(3)));
+
+    // Test custom forwarding classes
+    assertThat(ForwardingClassUtil.isBuiltin("custom-class"), equalTo(false));
+    assertThat(ForwardingClassUtil.defaultQueueNumber("custom-class"), equalTo(Optional.empty()));
+
+    assertThat(ForwardingClassUtil.isBuiltin("FC-CLASS1"), equalTo(false));
+    assertThat(ForwardingClassUtil.defaultQueueNumber("FC-CLASS1"), equalTo(Optional.empty()));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-builtin-forwarding-classes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-builtin-forwarding-classes
@@ -1,0 +1,31 @@
+set system host-name cos-builtin-fc
+# Test that built-in forwarding classes can be used without explicit definition
+set class-of-service classifiers dscp BUILTIN-CLASSIFIER forwarding-class best-effort loss-priority low code-points 000000
+set class-of-service classifiers dscp BUILTIN-CLASSIFIER forwarding-class expedited-forwarding loss-priority low code-points 101110
+set class-of-service classifiers dscp BUILTIN-CLASSIFIER forwarding-class assured-forwarding loss-priority low code-points 001010
+set class-of-service classifiers dscp BUILTIN-CLASSIFIER forwarding-class network-control loss-priority low code-points 110000
+# Test in scheduler-maps
+set class-of-service scheduler-maps BUILTIN-MAP forwarding-class best-effort scheduler SCHED-BE
+set class-of-service scheduler-maps BUILTIN-MAP forwarding-class expedited-forwarding scheduler SCHED-EF
+set class-of-service scheduler-maps BUILTIN-MAP forwarding-class assured-forwarding scheduler SCHED-AF
+set class-of-service scheduler-maps BUILTIN-MAP forwarding-class network-control scheduler SCHED-NC
+# Test in rewrite-rules
+set class-of-service rewrite-rules dscp BUILTIN-REWRITE forwarding-class best-effort loss-priority low code-point 000000
+set class-of-service rewrite-rules dscp BUILTIN-REWRITE forwarding-class expedited-forwarding loss-priority low code-point 101110
+set class-of-service rewrite-rules dscp BUILTIN-REWRITE forwarding-class assured-forwarding loss-priority low code-point 001010
+set class-of-service rewrite-rules dscp BUILTIN-REWRITE forwarding-class network-control loss-priority low code-point 110000
+# Test in host-outbound-traffic
+set class-of-service host-outbound-traffic forwarding-class best-effort
+# Test on interfaces
+set class-of-service interfaces ae1 forwarding-class expedited-forwarding
+set class-of-service interfaces ae1 unit 0 forwarding-class assured-forwarding
+# Define schedulers
+set class-of-service schedulers SCHED-BE transmit-rate percent 40
+set class-of-service schedulers SCHED-EF transmit-rate percent 20
+set class-of-service schedulers SCHED-AF transmit-rate percent 30
+set class-of-service schedulers SCHED-NC transmit-rate percent 10
+# Test that explicit definition also works (remapping to different queues)
+set class-of-service forwarding-classes class best-effort queue-num 0
+set class-of-service forwarding-classes class expedited-forwarding queue-num 1
+set class-of-service forwarding-classes class assured-forwarding queue-num 2
+set class-of-service forwarding-classes class network-control queue-num 3


### PR DESCRIPTION
Junos devices have four built-in forwarding classes available by default:
best-effort (queue 0), expedited-forwarding (queue 1), assured-forwarding
(queue 2), and network-control (queue 3). These can be used without
explicit definition.

Add ForwardingClassUtil providing isBuiltin() and defaultQueueNumber()
methods for the four built-in forwarding classes, following the pattern
of DscpUtil, ExpUtil, etc.

Update ConfigurationBuilder reference tracking to skip adding references
for built-in forwarding classes, preventing false undefined reference
warnings. Modified 14 exit methods across classifiers, rewrite-rules,
scheduler-maps, host-outbound-traffic, and interfaces.

Add test config exercising built-in forwarding classes in all contexts
(classifiers, scheduler-maps, rewrite-rules, host-outbound-traffic,
interfaces, and explicit definitions). Add test verifying no undefined
reference warnings are generated for built-in forwarding classes.
---
Prompt:
```
In recent commits we implemented class-of-service parsing for Junos, using the pdf and configs in working/class-of-service/ as a guide. (361825e68689abb1c7d630fe6cd85d24b15b3031). We added support for built-in code points (DSCP, EXP, etc). Are there any built-in classes of service? If so, we need to add those and flesh out tests.
```

---

**Stack**:
- #9636
- #9635
- #9633
- #9632
- #9631
- #9630 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*