### PR TITLE
Junos: refactor built-in structure reference tracking

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/DscpUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/DscpUtil.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.DscpType;
@@ -11,58 +14,44 @@ import org.batfish.datamodel.DscpType;
 @ParametersAreNonnullByDefault
 public final class DscpUtil {
 
-  /** Returns the default value for builtin DSCP aliases. */
+  /** Built-in DSCP aliases and their default values. */
   // Aliases and values are from
   // https://www.juniper.net/documentation/us/en/software/junos/cos-security-devices/topics/concept/cos-default-value-alias-security.html
+  private static final Map<String, Integer> DEFAULT_VALUES =
+      ImmutableMap.<String, Integer>builder()
+          .put("ef", DscpType.EF.number())
+          .put("af11", DscpType.AF11.number())
+          .put("af12", DscpType.AF12.number())
+          .put("af13", DscpType.AF13.number())
+          .put("af21", DscpType.AF21.number())
+          .put("af22", DscpType.AF22.number())
+          .put("af23", DscpType.AF23.number())
+          .put("af31", DscpType.AF31.number())
+          .put("af32", DscpType.AF32.number())
+          .put("af33", DscpType.AF33.number())
+          .put("af41", DscpType.AF41.number())
+          .put("af42", DscpType.AF42.number())
+          .put("af43", DscpType.AF43.number())
+          .put("be", DscpType.DEFAULT.number())
+          .put("cs1", DscpType.CS1.number())
+          .put("cs2", DscpType.CS2.number())
+          .put("cs3", DscpType.CS3.number())
+          .put("cs4", DscpType.CS4.number())
+          .put("cs5", DscpType.CS5.number())
+          .put("nc1", DscpType.CS6.number())
+          .put("cs6", DscpType.CS6.number())
+          .put("nc2", DscpType.CS7.number())
+          .put("cs7", DscpType.CS7.number())
+          .build();
+
+  /** Returns the default value for builtin DSCP aliases. */
   public static @Nonnull Optional<Integer> defaultValue(String alias) {
-    switch (alias) {
-      case "ef":
-        return Optional.of(DscpType.EF.number());
-      case "af11":
-        return Optional.of(DscpType.AF11.number());
-      case "af12":
-        return Optional.of(DscpType.AF12.number());
-      case "af13":
-        return Optional.of(DscpType.AF13.number());
-      case "af21":
-        return Optional.of(DscpType.AF21.number());
-      case "af22":
-        return Optional.of(DscpType.AF22.number());
-      case "af23":
-        return Optional.of(DscpType.AF23.number());
-      case "af31":
-        return Optional.of(DscpType.AF31.number());
-      case "af32":
-        return Optional.of(DscpType.AF32.number());
-      case "af33":
-        return Optional.of(DscpType.AF33.number());
-      case "af41":
-        return Optional.of(DscpType.AF41.number());
-      case "af42":
-        return Optional.of(DscpType.AF42.number());
-      case "af43":
-        return Optional.of(DscpType.AF43.number());
-      case "be":
-        return Optional.of(DscpType.DEFAULT.number());
-      case "cs1":
-        return Optional.of(DscpType.CS1.number());
-      case "cs2":
-        return Optional.of(DscpType.CS2.number());
-      case "cs3":
-        return Optional.of(DscpType.CS3.number());
-      case "cs4":
-        return Optional.of(DscpType.CS4.number());
-      case "cs5":
-        return Optional.of(DscpType.CS5.number());
-      case "nc1":
-      case "cs6":
-        return Optional.of(DscpType.CS6.number());
-      case "nc2":
-      case "cs7":
-        return Optional.of(DscpType.CS7.number());
-      default:
-        return Optional.empty();
-    }
+    return Optional.ofNullable(DEFAULT_VALUES.get(alias));
+  }
+
+  /** Returns the set of built-in DSCP alias names. */
+  public static @Nonnull Set<String> builtinNames() {
+    return DEFAULT_VALUES.keySet();
   }
 
   private DscpUtil() {}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ExpUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ExpUtil.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -11,33 +14,32 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public final class ExpUtil {
 
-  /** Returns the default value for builtin MPLS EXP aliases. */
+  /** Built-in MPLS EXP aliases and their default values. */
   // Aliases and values are from
   // https://www.juniper.net/documentation/us/en/software/junos/cos-security-devices/topics/concept/cos-default-value-alias-security.html
   // Table 40: Standard CoS Aliases and Bit Values
+  private static final Map<String, Integer> DEFAULT_VALUES =
+      ImmutableMap.<String, Integer>builder()
+          .put("be", 0)
+          .put("be1", 1)
+          .put("ef", 2)
+          .put("ef1", 3)
+          .put("af11", 4)
+          .put("af12", 5)
+          .put("nc1", 6)
+          .put("cs6", 6)
+          .put("nc2", 7)
+          .put("cs7", 7)
+          .build();
+
+  /** Returns the default value for builtin MPLS EXP aliases. */
   public static @Nonnull Optional<Integer> defaultValue(String alias) {
-    switch (alias) {
-      case "be":
-        return Optional.of(0);
-      case "be1":
-        return Optional.of(1);
-      case "ef":
-        return Optional.of(2);
-      case "ef1":
-        return Optional.of(3);
-      case "af11":
-        return Optional.of(4);
-      case "af12":
-        return Optional.of(5);
-      case "nc1":
-      case "cs6":
-        return Optional.of(6);
-      case "nc2":
-      case "cs7":
-        return Optional.of(7);
-      default:
-        return Optional.empty();
-    }
+    return Optional.ofNullable(DEFAULT_VALUES.get(alias));
+  }
+
+  /** Returns the set of built-in MPLS EXP alias names. */
+  public static @Nonnull Set<String> builtinNames() {
+    return DEFAULT_VALUES.keySet();
   }
 
   private ExpUtil() {}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ForwardingClassUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ForwardingClassUtil.java
@@ -2,6 +2,7 @@ package org.batfish.representation.juniper;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -36,6 +37,11 @@ public final class ForwardingClassUtil {
   /** Returns true if the given name is a built-in forwarding class. */
   public static boolean isBuiltin(String forwardingClassName) {
     return DEFAULT_QUEUE_ASSIGNMENTS.containsKey(forwardingClassName);
+  }
+
+  /** Returns the set of built-in forwarding class names. */
+  public static @Nonnull Set<String> builtinNames() {
+    return DEFAULT_QUEUE_ASSIGNMENTS.keySet();
   }
 
   private ForwardingClassUtil() {}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Ieee8021pUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Ieee8021pUtil.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -11,33 +14,32 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public final class Ieee8021pUtil {
 
-  /** Returns the default value for builtin IEEE 802.1p aliases. */
+  /** Built-in IEEE 802.1p aliases and their default values. */
   // Aliases and values are from
   // https://www.juniper.net/documentation/us/en/software/junos/cos-security-devices/topics/concept/cos-default-value-alias-security.html
   // Table 40: Standard CoS Aliases and Bit Values
+  private static final Map<String, Integer> DEFAULT_VALUES =
+      ImmutableMap.<String, Integer>builder()
+          .put("be", 0)
+          .put("be1", 1)
+          .put("ef", 2)
+          .put("ef1", 3)
+          .put("af11", 4)
+          .put("af12", 5)
+          .put("nc1", 6)
+          .put("cs6", 6)
+          .put("nc2", 7)
+          .put("cs7", 7)
+          .build();
+
+  /** Returns the default value for builtin IEEE 802.1p aliases. */
   public static @Nonnull Optional<Integer> defaultValue(String alias) {
-    switch (alias) {
-      case "be":
-        return Optional.of(0);
-      case "be1":
-        return Optional.of(1);
-      case "ef":
-        return Optional.of(2);
-      case "ef1":
-        return Optional.of(3);
-      case "af11":
-        return Optional.of(4);
-      case "af12":
-        return Optional.of(5);
-      case "nc1":
-      case "cs6":
-        return Optional.of(6);
-      case "nc2":
-      case "cs7":
-        return Optional.of(7);
-      default:
-        return Optional.empty();
-    }
+    return Optional.ofNullable(DEFAULT_VALUES.get(alias));
+  }
+
+  /** Returns the set of built-in IEEE 802.1p alias names. */
+  public static @Nonnull Set<String> builtinNames() {
+    return DEFAULT_VALUES.keySet();
   }
 
   private Ieee8021pUtil() {}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/InetPrecedenceUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/InetPrecedenceUtil.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -11,33 +14,32 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public final class InetPrecedenceUtil {
 
-  /** Returns the default value for builtin IP Precedence aliases. */
+  /** Built-in IP Precedence aliases and their default values. */
   // Aliases and values are from
   // https://www.juniper.net/documentation/us/en/software/junos/cos-security-devices/topics/concept/cos-default-value-alias-security.html
   // Table 40: Standard CoS Aliases and Bit Values
+  private static final Map<String, Integer> DEFAULT_VALUES =
+      ImmutableMap.<String, Integer>builder()
+          .put("be", 0)
+          .put("be1", 1)
+          .put("ef", 2)
+          .put("ef1", 3)
+          .put("af11", 4)
+          .put("af12", 5)
+          .put("nc1", 6)
+          .put("cs6", 6)
+          .put("nc2", 7)
+          .put("cs7", 7)
+          .build();
+
+  /** Returns the default value for builtin IP Precedence aliases. */
   public static @Nonnull Optional<Integer> defaultValue(String alias) {
-    switch (alias) {
-      case "be":
-        return Optional.of(0);
-      case "be1":
-        return Optional.of(1);
-      case "ef":
-        return Optional.of(2);
-      case "ef1":
-        return Optional.of(3);
-      case "af11":
-        return Optional.of(4);
-      case "af12":
-        return Optional.of(5);
-      case "nc1":
-      case "cs6":
-        return Optional.of(6);
-      case "nc2":
-      case "cs7":
-        return Optional.of(7);
-      default:
-        return Optional.empty();
-    }
+    return Optional.ofNullable(DEFAULT_VALUES.get(alias));
+  }
+
+  /** Returns the set of built-in IP Precedence alias names. */
+  public static @Nonnull Set<String> builtinNames() {
+    return DEFAULT_VALUES.keySet();
   }
 
   private InetPrecedenceUtil() {}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
@@ -2,6 +2,7 @@ package org.batfish.representation.juniper;
 
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import java.util.Set;
@@ -83,6 +84,20 @@ public enum JuniperStructureType implements StructureType {
       ImmutableListMultimap.<JuniperStructureType, JuniperStructureType>builder()
           .putAll(APPLICATION_OR_APPLICATION_SET, APPLICATION, APPLICATION_SET)
           .putAll(SNMP_CLIENT_LIST_OR_PREFIX_LIST, SNMP_CLIENT_LIST, PREFIX_LIST)
+          .build();
+
+  /**
+   * Built-in structures that don't appear in configurations but can be referenced. Maps structure
+   * types to their built-in names.
+   */
+  public static final ImmutableSetMultimap<JuniperStructureType, String> BUILT_IN_STRUCTURES =
+      ImmutableSetMultimap.<JuniperStructureType, String>builder()
+          .putAll(CLASS_OF_SERVICE_FORWARDING_CLASS, ForwardingClassUtil.builtinNames())
+          .putAll(CLASS_OF_SERVICE_DSCP_CODE_POINT_ALIAS, DscpUtil.builtinNames())
+          .putAll(CLASS_OF_SERVICE_EXP_CODE_POINT_ALIAS, ExpUtil.builtinNames())
+          .putAll(CLASS_OF_SERVICE_IEEE_802_1_CODE_POINT_ALIAS, Ieee8021pUtil.builtinNames())
+          .putAll(
+              CLASS_OF_SERVICE_INET_PRECEDENCE_CODE_POINT_ALIAS, InetPrecedenceUtil.builtinNames())
           .build();
 
   public static final Set<JuniperStructureType> CONCRETE_STRUCTURES =


### PR DESCRIPTION
Replace verbose "if is builtin and not defined, then skip reference"
pattern with centralized referenceBuiltIn() helper method. Previous
pattern required checking each builtin individually and was repeated
across 23 exit methods, making it error-prone and verbose.

Changes:

Add JuniperStructureType.BUILT_IN_STRUCTURES multimap mapping structure
types to their built-in names. Populated from util class builtinNames()
methods to maintain single source of truth.

Add ConfigurationBuilder.referenceBuiltIn() helper that references a
structure and automatically creates line-0 definitions for built-ins.
Line 0 is a convention for definitions not appearing in text, preventing
undefined reference warnings. Takes Junos_nameContext for type safety.

Update util classes to expose builtinNames() methods:
- ForwardingClassUtil: expose DEFAULT_QUEUE_ASSIGNMENTS keySet
- DscpUtil: convert switch to DEFAULT_VALUES map, expose keySet
- ExpUtil: convert switch to DEFAULT_VALUES map, expose keySet
- Ieee8021pUtil: convert switch to DEFAULT_VALUES map, expose keySet
- InetPrecedenceUtil: convert switch to DEFAULT_VALUES map, expose keySet

Migrate 23 reference sites to use referenceBuiltIn():
- 12 forwarding class references (classifiers, rewrite-rules,
scheduler-maps, host-outbound-traffic, interfaces)
- 6 DSCP alias references (classifiers, rewrite-rules, firewall filters)
- 2 EXP alias references (classifiers, rewrite-rules)
- 2 IEEE 802.1p alias references (classifiers, rewrite-rules)
- 2 INET precedence alias references (classifiers, rewrite-rules)

Remove now-unused imports: ForwardingClassUtil, DscpUtil, ExpUtil,
Ieee8021pUtil, InetPrecedenceUtil from ConfigurationBuilder.

Benefits: simpler code (3 lines vs 8), single source of truth for
built-in names, eliminates TODOs about ordering issues with overrides.
---
Prompt:
```
In the last few commits to Juniper (class-of-service related), we have this pattern for built-in structures where do this painfiul check: "if is builtin and not defined, then don't reference otherwise reference". It requires us to be religious about using it, it makes the code verbose, etc. I'd like to change this pattern as follows:

1. Let's keep a Multimap of structure types that can have a built-in that doesn't appear in configs, and all the names of them.
2. Let's add a helper method `referenceBuiltIn(name token, USAGE TYPE)` that does 2 things: a) create the reference for the name and line of the name token, and b) if it is the name of a built-in default (appears in the multimpa), add a defition at line 0. Line 0 is a convention for definitions that don't appear in the text that helps them not show up as undefined.
3. Let's migrate all reference types with this pattern to the new helper.

if something about this doesn't make sense, ask me rather than making things up.
```

---

**Stack**:
- #9636
- #9635
- #9633
- #9632
- #9631 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*