### PR TITLE
Junos: add built-in classifier, forwarding class, and rewrite-rule support

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -7377,47 +7377,38 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitScosiiu_dscp(Scosiiu_dscpContext ctx) {
-    _configuration.referenceStructure(
-        CLASS_OF_SERVICE_CLASSIFIER,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_DSCP,
-        getLine(ctx.name.getStart()));
+    referenceBuiltIn(
+        ctx.name, CLASS_OF_SERVICE_CLASSIFIER, CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_DSCP);
   }
 
   @Override
   public void exitScosiiu_dscp_ipv6(Scosiiu_dscp_ipv6Context ctx) {
-    _configuration.referenceStructure(
+    referenceBuiltIn(
+        ctx.name,
         CLASS_OF_SERVICE_CLASSIFIER,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_DSCP_IPV6,
-        getLine(ctx.name.getStart()));
+        CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_DSCP_IPV6);
   }
 
   @Override
   public void exitScosiiu_exp(Scosiiu_expContext ctx) {
-    _configuration.referenceStructure(
-        CLASS_OF_SERVICE_CLASSIFIER,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_EXP,
-        getLine(ctx.name.getStart()));
+    referenceBuiltIn(
+        ctx.name, CLASS_OF_SERVICE_CLASSIFIER, CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_EXP);
   }
 
   @Override
   public void exitScosiiu_ieee_802_1(Scosiiu_ieee_802_1Context ctx) {
-    _configuration.referenceStructure(
+    referenceBuiltIn(
+        ctx.name,
         CLASS_OF_SERVICE_CLASSIFIER,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_IEEE_802_1,
-        getLine(ctx.name.getStart()));
+        CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_IEEE_802_1);
   }
 
   @Override
   public void exitScosiiu_inet_precedence(Scosiiu_inet_precedenceContext ctx) {
-    _configuration.referenceStructure(
+    referenceBuiltIn(
+        ctx.name,
         CLASS_OF_SERVICE_CLASSIFIER,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_INET_PRECEDENCE,
-        getLine(ctx.name.getStart()));
+        CLASS_OF_SERVICE_INTERFACES_UNIT_CLASSIFIERS_INET_PRECEDENCE);
   }
 
   @Override
@@ -7431,47 +7422,42 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitScosiiu_dscp_rw(Scosiiu_dscp_rwContext ctx) {
-    _configuration.referenceStructure(
+    referenceBuiltIn(
+        ctx.name,
         CLASS_OF_SERVICE_REWRITE_RULE,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_DSCP,
-        getLine(ctx.name.getStart()));
+        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_DSCP);
   }
 
   @Override
   public void exitScosiiu_dscp_ipv6_rw(Scosiiu_dscp_ipv6_rwContext ctx) {
-    _configuration.referenceStructure(
+    referenceBuiltIn(
+        ctx.name,
         CLASS_OF_SERVICE_REWRITE_RULE,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_DSCP_IPV6,
-        getLine(ctx.name.getStart()));
+        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_DSCP_IPV6);
   }
 
   @Override
   public void exitScosiiu_exp_rw(Scosiiu_exp_rwContext ctx) {
-    _configuration.referenceStructure(
+    referenceBuiltIn(
+        ctx.name,
         CLASS_OF_SERVICE_REWRITE_RULE,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_EXP,
-        getLine(ctx.name.getStart()));
+        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_EXP);
   }
 
   @Override
   public void exitScosiiu_ieee_802_1_rw(Scosiiu_ieee_802_1_rwContext ctx) {
-    _configuration.referenceStructure(
+    referenceBuiltIn(
+        ctx.name,
         CLASS_OF_SERVICE_REWRITE_RULE,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_IEEE_802_1,
-        getLine(ctx.name.getStart()));
+        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_IEEE_802_1);
   }
 
   @Override
   public void exitScosiiu_inet_precedence_rw(Scosiiu_inet_precedence_rwContext ctx) {
-    _configuration.referenceStructure(
+    referenceBuiltIn(
+        ctx.name,
         CLASS_OF_SERVICE_REWRITE_RULE,
-        toString(ctx.name),
-        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_INET_PRECEDENCE,
-        getLine(ctx.name.getStart()));
+        CLASS_OF_SERVICE_INTERFACES_UNIT_REWRITE_RULES_INET_PRECEDENCE);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
@@ -92,12 +92,16 @@ public enum JuniperStructureType implements StructureType {
    */
   public static final ImmutableSetMultimap<JuniperStructureType, String> BUILT_IN_STRUCTURES =
       ImmutableSetMultimap.<JuniperStructureType, String>builder()
+          .put(CLASS_OF_SERVICE_CLASSIFIER, "default")
           .putAll(CLASS_OF_SERVICE_FORWARDING_CLASS, ForwardingClassUtil.builtinNames())
           .putAll(CLASS_OF_SERVICE_DSCP_CODE_POINT_ALIAS, DscpUtil.builtinNames())
           .putAll(CLASS_OF_SERVICE_EXP_CODE_POINT_ALIAS, ExpUtil.builtinNames())
           .putAll(CLASS_OF_SERVICE_IEEE_802_1_CODE_POINT_ALIAS, Ieee8021pUtil.builtinNames())
           .putAll(
               CLASS_OF_SERVICE_INET_PRECEDENCE_CODE_POINT_ALIAS, InetPrecedenceUtil.builtinNames())
+          .put(CLASS_OF_SERVICE_REWRITE_RULE, "default")
+          .put(CLASS_OF_SERVICE_SCHEDULER, "default-be")
+          .put(CLASS_OF_SERVICE_SCHEDULER_MAP, "default")
           .build();
 
   public static final Set<JuniperStructureType> CONCRETE_STRUCTURES =

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1048,6 +1048,83 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testClassOfServiceDefaultClassifier() throws IOException {
+    String hostname = "class-of-service-default-classifier";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Verify built-in "default" classifier doesn't produce undefined reference warnings
+    assertThat(ccae, hasNoUndefinedReferences());
+  }
+
+  @Test
+  public void testClassOfServiceDefaultRewriteRule() throws IOException {
+    String hostname = "class-of-service-default-rewrite-rule";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Verify built-in "default" rewrite-rule doesn't produce undefined reference warnings
+    assertThat(ccae, hasNoUndefinedReferences());
+  }
+
+  @Test
+  public void testClassOfServiceQfxMcastForwardingClass() throws IOException {
+    String hostname = "class-of-service-qfx-mcast-fc";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Verify built-in "mcast" forwarding class doesn't produce undefined reference warnings
+    // Platform-specific: QFX switches (except QFX10000)
+    assertThat(ccae, hasNoUndefinedReferences());
+  }
+
+  @Test
+  public void testClassOfServiceEx4300McastVariants() throws IOException {
+    String hostname = "class-of-service-ex4300-mcast-variants";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Verify built-in mcast-* forwarding class variants don't produce undefined reference warnings
+    // Platform-specific: EX4300 switches
+    assertThat(ccae, hasNoUndefinedReferences());
+  }
+
+  @Test
+  public void testClassOfServiceQfxShortAliases() throws IOException {
+    String hostname = "class-of-service-qfx-short-aliases";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Verify built-in short forwarding class aliases don't produce undefined reference warnings
+    // Platform-specific: QFX switches
+    assertThat(ccae, hasNoUndefinedReferences());
+  }
+
+  @Test
+  public void testClassOfServiceQfxFcoeNoLoss() throws IOException {
+    String hostname = "class-of-service-qfx-fcoe-no-loss";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Verify built-in fcoe and no-loss forwarding classes don't produce undefined reference
+    // warnings
+    // Platform-specific: QFX switches
+    assertThat(ccae, hasNoUndefinedReferences());
+  }
+
+  @Test
   public void testInterfaceMacLimitParsing() {
     parseJuniperConfig("interface-mac-limit");
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/ForwardingClassUtilTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/ForwardingClassUtilTest.java
@@ -25,6 +25,19 @@ public class ForwardingClassUtilTest {
     assertThat(ForwardingClassUtil.isBuiltin("network-control"), equalTo(true));
     assertThat(ForwardingClassUtil.defaultQueueNumber("network-control"), equalTo(Optional.of(3)));
 
+    // Test standard abbreviations
+    assertThat(ForwardingClassUtil.isBuiltin("be"), equalTo(true));
+    assertThat(ForwardingClassUtil.defaultQueueNumber("be"), equalTo(Optional.of(0)));
+
+    assertThat(ForwardingClassUtil.isBuiltin("ef"), equalTo(true));
+    assertThat(ForwardingClassUtil.defaultQueueNumber("ef"), equalTo(Optional.of(1)));
+
+    assertThat(ForwardingClassUtil.isBuiltin("af"), equalTo(true));
+    assertThat(ForwardingClassUtil.defaultQueueNumber("af"), equalTo(Optional.of(2)));
+
+    assertThat(ForwardingClassUtil.isBuiltin("nc"), equalTo(true));
+    assertThat(ForwardingClassUtil.defaultQueueNumber("nc"), equalTo(Optional.of(3)));
+
     // Test custom forwarding classes
     assertThat(ForwardingClassUtil.isBuiltin("custom-class"), equalTo(false));
     assertThat(ForwardingClassUtil.defaultQueueNumber("custom-class"), equalTo(Optional.empty()));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-default-classifier
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-default-classifier
@@ -1,0 +1,7 @@
+set system host-name cos-default-classifier
+# Test that built-in "default" classifier can be imported without explicit definition
+# Reference: classifiers can import the default classifier
+# https://www.juniper.net/documentation/us/en/software/junos/cos-security-devices/topics/ref/statement/import-edit-class-of-service.html
+set class-of-service classifiers dscp CUSTOM-CLASSIFIER import default
+set class-of-service classifiers dscp CUSTOM-CLASSIFIER forwarding-class network-control loss-priority low code-points 110000
+set class-of-service interfaces ae1 unit 0 classifiers dscp default

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-default-rewrite-rule
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-default-rewrite-rule
@@ -1,0 +1,5 @@
+set system host-name cos-default-rewrite-rule
+# Test that built-in "default" rewrite-rule can be used without explicit definition
+# Reference: rewrite-rules can be applied to interfaces
+# https://www.juniper.net/documentation/us/en/software/junos/cos-security-devices/topics/topic-map/cos-qos-rewrite-rules-configuring.html
+set class-of-service interfaces ae1 unit 0 rewrite-rules dscp default

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-ex4300-mcast-variants
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-ex4300-mcast-variants
@@ -1,0 +1,21 @@
+set system host-name cos-ex4300-mcast-variants
+# Test that built-in mcast-* forwarding class variants can be used without explicit definition
+# Platform: EX4300 switches
+# Reference: https://www.juniper.net/documentation/us/en/software/junos/cos-ex/topics/concept/cos-ex-series-forwarding-classes-understanding.html
+# mcast-be/ef/af/nc use same queue numbers as base classes (0/1/2/3)
+set class-of-service classifiers dscp MCAST-VARIANTS forwarding-class mcast-be loss-priority low code-points 000000
+set class-of-service classifiers dscp MCAST-VARIANTS forwarding-class mcast-ef loss-priority low code-points 101110
+set class-of-service classifiers dscp MCAST-VARIANTS forwarding-class mcast-af loss-priority low code-points 001010
+set class-of-service classifiers dscp MCAST-VARIANTS forwarding-class mcast-nc loss-priority low code-points 110000
+set class-of-service scheduler-maps MCAST-MAP forwarding-class mcast-be scheduler SCHED-BE
+set class-of-service scheduler-maps MCAST-MAP forwarding-class mcast-ef scheduler SCHED-EF
+set class-of-service scheduler-maps MCAST-MAP forwarding-class mcast-af scheduler SCHED-AF
+set class-of-service scheduler-maps MCAST-MAP forwarding-class mcast-nc scheduler SCHED-NC
+set class-of-service rewrite-rules dscp MCAST-REWRITE forwarding-class mcast-be loss-priority low code-point 000000
+set class-of-service rewrite-rules dscp MCAST-REWRITE forwarding-class mcast-ef loss-priority low code-point 101110
+set class-of-service rewrite-rules dscp MCAST-REWRITE forwarding-class mcast-af loss-priority low code-point 001010
+set class-of-service rewrite-rules dscp MCAST-REWRITE forwarding-class mcast-nc loss-priority low code-point 110000
+set class-of-service schedulers SCHED-BE transmit-rate percent 40
+set class-of-service schedulers SCHED-EF transmit-rate percent 20
+set class-of-service schedulers SCHED-AF transmit-rate percent 30
+set class-of-service schedulers SCHED-NC transmit-rate percent 10

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-qfx-fcoe-no-loss
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-qfx-fcoe-no-loss
@@ -1,0 +1,13 @@
+set system host-name cos-qfx-fcoe-no-loss
+# Test that built-in fcoe and no-loss forwarding classes can be used without explicit definition
+# Platform: QFX switches
+# Reference: https://www.juniper.net/documentation/us/en/software/junos/traffic-mgmt-qfx/topics/example/forwarding-classes-cos-configuring.html
+# fcoe: Fibre Channel over Ethernet, no-loss: lossless traffic (platform-specific queue assignments)
+set class-of-service classifiers dscp SPECIAL-FC forwarding-class fcoe loss-priority low code-points 011000
+set class-of-service classifiers dscp SPECIAL-FC forwarding-class no-loss loss-priority low code-points 100000
+set class-of-service scheduler-maps SPECIAL-MAP forwarding-class fcoe scheduler SCHED-FCOE
+set class-of-service scheduler-maps SPECIAL-MAP forwarding-class no-loss scheduler SCHED-NO-LOSS
+set class-of-service rewrite-rules dscp SPECIAL-REWRITE forwarding-class fcoe loss-priority low code-point 011000
+set class-of-service rewrite-rules dscp SPECIAL-REWRITE forwarding-class no-loss loss-priority low code-point 100000
+set class-of-service schedulers SCHED-FCOE transmit-rate percent 30
+set class-of-service schedulers SCHED-NO-LOSS transmit-rate percent 70

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-qfx-mcast-fc
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-qfx-mcast-fc
@@ -1,0 +1,12 @@
+set system host-name cos-qfx-mcast-fc
+# Test that built-in "mcast" forwarding class can be used without explicit definition
+# Platform: QFX switches (except QFX10000)
+# Reference: https://www.juniper.net/documentation/us/en/software/junos/traffic-mgmt-qfx/topics/example/forwarding-classes-cos-configuring.html
+# mcast is the default multidestination forwarding class on QFX (queue 8)
+set class-of-service classifiers dscp MCAST-CLASSIFIER forwarding-class mcast loss-priority low code-points 000000
+set class-of-service scheduler-maps MCAST-MAP forwarding-class mcast scheduler SCHED-MCAST
+set class-of-service rewrite-rules dscp MCAST-REWRITE forwarding-class mcast loss-priority low code-point 000000
+set class-of-service host-outbound-traffic forwarding-class mcast
+set class-of-service interfaces ae1 forwarding-class mcast
+set class-of-service interfaces ae1 unit 0 forwarding-class mcast
+set class-of-service schedulers SCHED-MCAST transmit-rate percent 10

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-qfx-short-aliases
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-qfx-short-aliases
@@ -1,0 +1,20 @@
+set system host-name cos-qfx-short-aliases
+# Test that built-in short forwarding class aliases can be used without explicit definition
+# Platform: QFX switches
+# Reference: https://www.juniper.net/documentation/us/en/software/junos/traffic-mgmt-qfx/topics/example/forwarding-classes-cos-configuring.html
+# be (queue 0), be1 (queue 1), nc (queue 7)
+set class-of-service classifiers dscp SHORT-ALIASES forwarding-class be loss-priority low code-points 000000
+set class-of-service classifiers dscp SHORT-ALIASES forwarding-class be1 loss-priority low code-points 001000
+set class-of-service classifiers dscp SHORT-ALIASES forwarding-class nc loss-priority low code-points 110000
+set class-of-service scheduler-maps SHORT-MAP forwarding-class be scheduler SCHED-BE
+set class-of-service scheduler-maps SHORT-MAP forwarding-class be1 scheduler SCHED-BE1
+set class-of-service scheduler-maps SHORT-MAP forwarding-class nc scheduler SCHED-NC
+set class-of-service rewrite-rules dscp SHORT-REWRITE forwarding-class be loss-priority low code-point 000000
+set class-of-service rewrite-rules dscp SHORT-REWRITE forwarding-class be1 loss-priority low code-point 001000
+set class-of-service rewrite-rules dscp SHORT-REWRITE forwarding-class nc loss-priority low code-point 110000
+set class-of-service host-outbound-traffic forwarding-class be
+set class-of-service interfaces ae1 forwarding-class nc
+set class-of-service interfaces ae1 unit 0 forwarding-class be1
+set class-of-service schedulers SCHED-BE transmit-rate percent 50
+set class-of-service schedulers SCHED-BE1 transmit-rate percent 20
+set class-of-service schedulers SCHED-NC transmit-rate percent 30


### PR DESCRIPTION
Add platform-specific built-in forwarding classes and "default"
classifier/rewrite-rule/scheduler structures that can be referenced without
explicit definition.

ForwardingClassUtil adds: mcast (QFX queue 8), mcast-* variants (EX4300),
be/be1/nc short aliases (QFX), fcoe/no-loss (QFX platform-specific). Add
TODO about chassis-aware queue assignments.

JuniperStructureType.BUILT_IN_STRUCTURES adds "default" for classifiers
and rewrite-rules.

ConfigurationBuilder: migrate 10 reference methods to use referenceBuiltIn()
for automatic line-0 definition creation.

Add per-chassis test configs with documentation links and tests verifying
no undefined references.
---
Prompt:
```
Read the most recent commit for context. Then add the following built-ins:
1. class-of-service classifier default
2. class-of-service forwarding-class mcast
3. class-of-service rewrite-rule default
```

---

**Stack**:
- #9636
- #9635
- #9633
- #9632 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*