### PR TITLE
Junos: add parsing for class-of-service scheduler options

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -357,23 +357,16 @@ BLOCK_FRAG: 'block-frag';
 BMP: 'bmp';
 
 BOOT_SERVER: 'boot-server';
-
 BOOTP: 'bootp';
-
 BOOTP_SUPPORT: 'bootp-support';
-
 BOOTPC: 'bootpc';
-
 BOOTPS: 'bootps';
-
+BOTH: 'both';
 BRIDGE: 'bridge';
-
 BRIDGE_DOMAINS: 'bridge-domains' -> pushMode(M_Name);
-
 BROADCAST_CLIENT: 'broadcast-client';
-
+BUFFER_DYNAMIC_THRESHOLD: 'buffer-dynamic-threshold';
 BUFFER_SIZE: 'buffer-size';
-
 BUNDLE: 'bundle';
 
 C: 'c';
@@ -624,9 +617,9 @@ DOMAIN_TYPE: 'domain-type';
 DROP: 'drop';
 DROP_AND_LOG: 'drop-and-log';
 DROP_PATH_ATTRIBUTES: 'drop-path-attributes' -> pushMode(M_SubRange);
-
+DROP_PROFILE: 'drop-profile' -> pushMode(M_Name);
+DROP_PROFILE_MAP: 'drop-profile-map';
 DROP_PROFILES: 'drop-profiles' -> pushMode(M_Name);
-
 DSA_SIGNATURES: 'dsa-signatures';
 
 DSCP
@@ -722,17 +715,12 @@ EVENT_OPTIONS: 'event-options';
 EVPN: 'evpn';
 
 EXACT: 'exact';
-
 EXCEPT: 'except';
-
+EXCESS_RATE: 'excess-rate';
 EXCLUDE: 'exclude';
-
 EXCLUDE_NON_ELIGIBLE: 'exclude-non-eligible';
-
 EXCLUDE_NON_FEASIBLE: 'exclude-non-feasible';
-
 EXEC: 'exec';
-
 EXP
 :
   'exp'
@@ -744,7 +732,6 @@ EXP
     }
   }
 ;
-
 EXPEDITED: 'expedited';
 EXPLICIT_NULL: 'explicit-null';
 EXPLICIT_PRIORITY: 'explicit-priority';
@@ -758,31 +745,20 @@ EXPORT
     }
   }
 ;
-
 EXPORT_RIB: 'export-rib' -> pushMode(M_Name);
-
 EXPRESSION: 'expression';
-
 EXTENDED_NEXTHOP_TUNNEL: 'extended-nexthop-tunnel';
 EXTENDED_VNI_LIST: 'extended-vni-list' -> pushMode(M_ExtendedVniList);
-
 EXTENSIBLE_SUBSCRIBER: 'extensible-subscriber';
-
 EXTENSION_SERVICE: 'extension-service';
-
 EXTERNAL: 'external';
-
 EXTERNAL_INTERFACE
 :
    'external-interface' -> pushMode ( M_Interface )
 ;
-
 EXTERNAL_PREFERENCE: 'external-preference';
-
 EXTERNAL_ROUTER_ID: 'external-router-id';
-
 EXTENSION_HEADER: 'extension-header';
-
 EXTENSIONS: 'extensions';
 
 FABRIC: 'fabric';
@@ -2739,25 +2715,17 @@ SFLOW: 'sflow';
 SFM_DPD_OPTION: 'SFM-DPD-option';
 
 SHA_256: 'sha-256';
-
 SHA_384: 'sha-384';
-
 SHA1: 'sha1';
-
+SHAPING_RATE: 'shaping-rate';
 SHARED_BUFFER: 'shared-buffer';
-
 SHARED_IKE_ID: 'shared-ike-id';
-
 SHIM6_HEADER: 'shim6-header';
-
 SHORTCUTS: 'shortcuts';
 SHUTDOWN: 'shutdown';
 SIGNALING: 'signaling';
-
 SIMPLE: 'simple';
-
 SINGLE_CONNECTION: 'single-connection';
-
 SIP: 'sip';
 
 SMTP: 'smtp';
@@ -2874,13 +2842,10 @@ STORM_CONTROL_PROFILES: 'storm-control-profiles';
 STP: 'stp';
 
 STREAM_ID: 'stream-id';
-
 STREAM_OPTION: 'stream-option';
-
+STRICT_HIGH: 'strict-high';
 STRICT_SOURCE_ROUTE: 'strict-source-route';
-
 STRICT_SOURCE_ROUTE_OPTION: 'strict-source-route-option';
-
 STRUCTURED_DATA: 'structured-data';
 
 STUB: 'stub';
@@ -2946,36 +2911,24 @@ TARGETED_BROADCAST: 'targeted-broadcast';
 TARGETS: 'targets';
 
 TCP: 'tcp';
-
 TCP_ESTABLISHED: 'tcp-established';
-
 TCP_FLAGS
 :
    'tcp-flags' -> pushMode ( M_TcpFlags )
 ;
-
 TCP_FORWARDING: 'tcp-forwarding';
-
 TCP_INITIAL: 'tcp-initial';
-
 TCP_MSS: 'tcp-mss';
-
 TCP_NO_FLAG: 'tcp-no-flag';
-
 TCP_RST: 'tcp-rst';
-
 TCP_SWEEP: 'tcp-sweep';
 
 TE_METRIC: 'te-metric';
-
-TEARDOWN: 'teardown';
-
 TEAR_DROP: 'tear-drop';
-
-TEREDO: 'teredo';
-
+TEARDOWN: 'teardown';
 TELNET: 'telnet';
-
+TEMPORAL: 'temporal' -> pushMode(M_Bandwidth);
+TEREDO: 'teredo';
 TERM: 'term' -> pushMode(M_Name);
 
 TFTP: 'tftp';
@@ -2983,60 +2936,35 @@ TFTP: 'tftp';
 TFTP_SERVER: 'tftp-server';
 
 THEN: 'then';
-
 THREEDES_CBC: '3des-cbc';
-
 THRESHOLD: 'threshold';
-
 THROUGH: 'through';
 
-TIME_FORMAT: 'time-format';
-
 TIME_EXCEEDED: 'time-exceeded';
-
+TIME_FORMAT: 'time-format';
 TIME_ZONE: 'time-zone' -> pushMode(M_RestOfLine);
-
 TIMED: 'timed';
-
 TIMEOUT: 'timeout';
-
 TIMESTAMP: 'timestamp';
-
 TIMESTAMP_OPTION: 'timestamp-option';
-
 TIMESTAMP_REPLY: 'timestamp-reply';
 
 TO: 'to';
-
-TOLERANCE: 'tolerance';
 TO_ZONE: 'to-zone' -> pushMode(M_Zone);
-
+TOLERANCE: 'tolerance';
 TRACE: 'trace';
-
 TRACE_OPTIONS: 'trace-options';
-
 TRACEOPTIONS: 'traceoptions';
-
 TRACEROUTE: 'traceroute';
-
 TRACK: 'track';
-
 TRAFFIC_CONTROL_PROFILES: 'traffic-control-profiles' -> pushMode(M_Name);
-
 TRAFFIC_ENGINEERING: 'traffic-engineering';
-
 TRANSLATION_TABLE: 'translation-table';
-
-TRANSMIT_RATE: 'transmit-rate';
-
-TRAP_DESTINATIONS: 'trap-destinations';
-
+TRANSMIT_RATE: 'transmit-rate' -> pushMode(M_TransmitRate);
 TRAP: 'trap';
-
+TRAP_DESTINATIONS: 'trap-destinations';
 TRAP_GROUP: 'trap-group' -> pushMode(M_Name);
-
 TRAP_OPTIONS: 'trap-options';
-
 TRAPS: 'traps';
 
 TRI_COLOR: 'tri-color';
@@ -4359,6 +4287,53 @@ M_Bandwidth_NEWLINE
 ;
 
 M_Bandwidth_WS
+:
+   F_WhitespaceChar+ -> channel ( HIDDEN )
+;
+
+mode M_TransmitRate;
+
+M_TransmitRate_DEC
+:
+  F_Digit+ -> type ( DEC )
+;
+
+M_TransmitRate_C
+:
+  'c' -> type ( C ) , popMode
+;
+
+M_TransmitRate_G
+:
+  'g' -> type ( G ) , popMode
+;
+
+M_TransmitRate_K
+:
+  'k' -> type ( K ) , popMode
+;
+
+M_TransmitRate_M
+:
+  'm' -> type ( M ) , popMode
+;
+
+M_TransmitRate_PERCENT
+:
+  'percent' -> type ( PERCENT )
+;
+
+M_TransmitRate_REMAINDER
+:
+  'remainder' -> type ( REMAINDER )
+;
+
+M_TransmitRate_NEWLINE
+:
+  F_NewlineChar+ -> type ( NEWLINE ) , popMode
+;
+
+M_TransmitRate_WS
 :
    F_WhitespaceChar+ -> channel ( HIDDEN )
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
@@ -598,10 +598,19 @@ scos_schedulers
 :
     SCHEDULERS name = junos_name
     (
-        scoss_buffer_size
+        scoss_buffer_dynamic_threshold
+        | scoss_buffer_size
+        | scoss_drop_profile_map
+        | scoss_excess_rate
         | scoss_priority
+        | scoss_shaping_rate
         | scoss_transmit_rate
     )
+;
+
+scoss_buffer_dynamic_threshold
+:
+    BUFFER_DYNAMIC_THRESHOLD value = dec
 ;
 
 scoss_buffer_size
@@ -610,6 +619,7 @@ scoss_buffer_size
     (
         scossb_percent
         | scossb_remainder
+        | scossb_temporal
     )
 ;
 
@@ -623,6 +633,11 @@ scossb_remainder
     REMAINDER
 ;
 
+scossb_temporal
+:
+    TEMPORAL size = bandwidth
+;
+
 scoss_priority
 :
     PRIORITY
@@ -631,6 +646,7 @@ scoss_priority
         | LOW
         | MEDIUM_HIGH
         | MEDIUM_LOW
+        | STRICT_HIGH
     )
 ;
 
@@ -638,9 +654,15 @@ scoss_transmit_rate
 :
     TRANSMIT_RATE
     (
-        scosst_percent
+        scosst_explicit
+        | scosst_percent
         | scosst_remainder
     )
+;
+
+scosst_explicit
+:
+    rate = bandwidth
 ;
 
 scosst_percent
@@ -651,6 +673,33 @@ scosst_percent
 scosst_remainder
 :
     REMAINDER (num = dec)?
+;
+
+scoss_drop_profile_map
+:
+    DROP_PROFILE_MAP LOSS_PRIORITY priority = scoss_dpm_loss_priority_value PROTOCOL protocol = scoss_dpm_protocol_value DROP_PROFILE name = junos_name
+;
+
+scoss_dpm_loss_priority_value
+:
+    ANY
+    | scos_loss_priority_value
+;
+
+scoss_dpm_protocol_value
+:
+    ANY
+    | BOTH
+;
+
+scoss_excess_rate
+:
+    EXCESS_RATE PERCENT num = dec
+;
+
+scoss_shaping_rate
+:
+    SHAPING_RATE PERCENT num = dec
 ;
 
 scos_null

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
@@ -56,3 +56,11 @@ set class-of-service schedulers SCHED1 buffer-size percent 15
 set class-of-service schedulers SCHED1 priority high
 set class-of-service schedulers SCHED2 buffer-size remainder
 set class-of-service schedulers SCHED2 transmit-rate remainder
+set class-of-service schedulers SCHED3 buffer-size temporal 4m
+set class-of-service schedulers SCHED3 transmit-rate 20m
+set class-of-service schedulers SCHED3 priority strict-high
+set class-of-service schedulers SCHED3 drop-profile-map loss-priority low protocol any drop-profile LOW-PROF
+set class-of-service schedulers SCHED3 drop-profile-map loss-priority high protocol any drop-profile HIGH-PROF
+set class-of-service schedulers SCHED4 excess-rate percent 40
+set class-of-service schedulers SCHED5 shaping-rate percent 10
+set class-of-service schedulers SCHED6 buffer-dynamic-threshold 10


### PR DESCRIPTION
Add parsing support for additional class-of-service scheduler options:
buffer-size temporal, buffer-dynamic-threshold, transmit-rate explicit
bandwidth, priority strict-high, drop-profile-map, excess-rate, and
shaping-rate.

Grammar additions:
- Schedulers: buffer-size temporal with bandwidth values,
buffer-dynamic-threshold with integer value (0-10), transmit-rate with
explicit bandwidth (e.g., 20m, 100k), priority strict-high,
drop-profile-map with loss-priority and protocol, excess-rate percent,
shaping-rate percent

Lexer tokens added (8): BUFFER_DYNAMIC_THRESHOLD, DROP_PROFILE,
DROP_PROFILE_MAP, EXCESS_RATE, SHAPING_RATE, STRICT_HIGH, TEMPORAL,
BOTH

Lexer mode added:
- M_TransmitRate: specialized mode for transmit-rate that accepts
explicit bandwidth values (number with c/k/m/g suffix) or percent/remainder
keywords. Separated from M_Bandwidth mode which only accepts numeric
bandwidth values (used by bandwidth and temporal keywords).

Test coverage: Extended class-of-service-comprehensive test config with
examples of all new scheduler options.
---
Prompt:
```
We recently added support for Juniper class-of-service parsing using resources in working/class-of-service including a manual and test configs. Review recent commits for more info. I'm finding false positives for missing schedulers because we are missing key parsing rules: set class-of-service schedulers SCHEDULERS buffer-dynamic-threshold 10
or
set class-of-service schedulers FOOBAR transmit-rate 19m
.
Can you look at the sample configs (there are more now) and the book and improve the grammar?
```

---

**Stack**:
- #9636
- #9635
- #9633 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*