### PR TITLE
Junos: rename firewall grammar f_null to f_service_filter_null

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
@@ -9,8 +9,8 @@ options {
 f_common
 :
    f_filter
-   | f_null
    | f_policer
+   | f_service_filter_null
 ;
 
 f_family
@@ -43,11 +43,6 @@ f_filter
       | ff_interface_specific
       | ff_term
    )
-;
-
-f_null
-:
-   SERVICE_FILTER null_filler
 ;
 
 f_policer
@@ -89,6 +84,11 @@ fp_then
 fpt_discard
 :
    DISCARD
+;
+
+f_service_filter_null
+:
+   SERVICE_FILTER null_filler
 ;
 
 ff_interface_specific


### PR DESCRIPTION
Rename f_null to f_service_filter_null for clarity since it now only
handles SERVICE_FILTER (POLICER was extracted to f_policer). Move rule
definition after f_policer rules for better organization.

---
Prompt:
```
Let's do a small change and rename f_null (which now is only SERVICE_FILTER?) to f_service_filter_null?
```