### PR TITLE
Add batfish-code-runner CLI tool

### DIFF
--- a/projects/batfish-code-runner/BUILD.bazel
+++ b/projects/batfish-code-runner/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "coderunner",
+    srcs = glob(["src/main/java/**/*.java"]),
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_apache_commons_commons_text",
+    ],
+)
+
+java_binary(
+    name = "cli",
+    main_class = "org.batfish.coderunner.CLI",
+    runtime_deps = [":coderunner"],
+)

--- a/projects/batfish-code-runner/README.md
+++ b/projects/batfish-code-runner/README.md
@@ -1,0 +1,39 @@
+# Batfish Code Runner
+
+CLI tool to run user-provided Java code against parsed Batfish configurations.
+
+## Usage
+
+```bash
+bazel run //projects/batfish-code-runner:cli -- <snapshot-dir> <code-file>
+```
+
+## Function Signature
+
+User code must implement:
+```java
+String func(Configuration viConfig, VendorConfiguration vendorConfig, String originalText, String processedText)
+```
+
+## Output
+
+CSV with columns: `hostname,result`
+
+## Example
+
+```java
+import org.batfish.coderunner.BatfishCodeRunner.BatfishFunction;
+import org.batfish.datamodel.Configuration;
+import org.batfish.vendor.VendorConfiguration;
+
+public class Example implements BatfishFunction {
+  @Override
+  public String apply(
+      Configuration viConfig,
+      VendorConfiguration vendorConfig,
+      String originalText,
+      String processedText) {
+    return viConfig.getHostname() + " has " + viConfig.getAllInterfaces().size() + " interfaces";
+  }
+}
+```

--- a/projects/batfish-code-runner/src/main/java/org/batfish/coderunner/BatfishCodeRunner.java
+++ b/projects/batfish-code-runner/src/main/java/org/batfish/coderunner/BatfishCodeRunner.java
@@ -1,0 +1,35 @@
+package org.batfish.coderunner;
+
+import org.batfish.datamodel.Configuration;
+import org.batfish.vendor.VendorConfiguration;
+
+public class BatfishCodeRunner {
+  private final RuntimeCompiler compiler;
+
+  public BatfishCodeRunner() {
+    this.compiler = new RuntimeCompiler();
+  }
+
+  public String runCode(
+      Configuration viConfig,
+      VendorConfiguration vendorConfig,
+      String originalText,
+      String processedText,
+      String code)
+      throws Exception {
+    Class<?> compiledClass = compiler.compile(code);
+    Object instance = compiledClass.getDeclaredConstructor().newInstance();
+    @SuppressWarnings("unchecked")
+    BatfishFunction function = (BatfishFunction) instance;
+    return function.apply(viConfig, vendorConfig, originalText, processedText);
+  }
+
+  @FunctionalInterface
+  public interface BatfishFunction {
+    String apply(
+        Configuration viConfig,
+        VendorConfiguration vendorConfig,
+        String originalText,
+        String processedText);
+  }
+}

--- a/projects/batfish-code-runner/src/main/java/org/batfish/coderunner/CLI.java
+++ b/projects/batfish-code-runner/src/main/java/org/batfish/coderunner/CLI.java
@@ -1,0 +1,156 @@
+package org.batfish.coderunner;
+
+import static org.batfish.main.Batfish.flatten;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
+import org.batfish.config.Settings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.grammar.BatfishParseException;
+import org.batfish.grammar.VendorConfigurationFormatDetector;
+import org.batfish.job.ParseVendorConfigurationJob;
+import org.batfish.job.ParseVendorConfigurationResult;
+import org.batfish.vendor.VendorConfiguration;
+
+public class CLI {
+  public static void main(String[] args) {
+    if (args.length != 2) {
+      System.err.println("Usage: <snapshot-dir> <code-file>");
+      System.exit(1);
+    }
+
+    String snapshotDir = args[0];
+    String codeFile = args[1];
+
+    try {
+      String code = Files.readString(Paths.get(codeFile));
+      Map<String, DeviceData> devices = parseSnapshot(snapshotDir);
+      BatfishCodeRunner runner = new BatfishCodeRunner();
+
+      System.out.println("hostname,result");
+      for (Map.Entry<String, DeviceData> entry : devices.entrySet()) {
+        String hostname = entry.getKey();
+        DeviceData data = entry.getValue();
+        try {
+          String result =
+              runner.runCode(
+                  data.viConfig, data.vendorConfig, data.originalText, data.processedText, code);
+          System.out.println(escapeCsv(hostname) + "," + escapeCsv(result));
+        } catch (Exception e) {
+          System.err.println("Error processing " + hostname + ": " + e.getMessage());
+        }
+      }
+    } catch (Exception e) {
+      System.err.println("Error: " + e.getMessage());
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+
+  private static String escapeCsv(String value) {
+    if (value == null) {
+      return "";
+    }
+    if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+      return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+    return value;
+  }
+
+  private static Map<String, DeviceData> parseSnapshot(String snapshotDir) throws IOException {
+    Path configsDir = Paths.get(snapshotDir, "configs");
+    if (!Files.isDirectory(configsDir)) {
+      throw new IllegalArgumentException("No configs directory found in snapshot");
+    }
+
+    Settings settings = new Settings(new String[] {});
+    BatfishLogger logger = new BatfishLogger("output", false);
+    settings.setLogger(logger);
+
+    Map<String, DeviceData> devices = new TreeMap<>();
+
+    try (Stream<Path> paths = Files.list(configsDir)) {
+      paths
+          .filter(Files::isRegularFile)
+          .forEach(
+              path -> {
+                try {
+                  String filename = path.toString();
+                  String originalText = Files.readString(path);
+
+                  Warnings warnings = new Warnings(true, true, true);
+                  ConfigurationFormat format =
+                      VendorConfigurationFormatDetector.identifyConfigurationFormat(originalText);
+
+                  String processedText = originalText;
+                  if (format == ConfigurationFormat.JUNIPER
+                      || format == ConfigurationFormat.PALO_ALTO_NESTED
+                      || format == ConfigurationFormat.VYOS) {
+                    try {
+                      processedText =
+                          flatten(originalText, logger, settings, warnings, format, "")
+                              .getFlattenedConfigurationText();
+                    } catch (BatfishParseException e) {
+                      processedText = originalText;
+                    }
+                  }
+
+                  ParseVendorConfigurationJob job =
+                      new ParseVendorConfigurationJob(
+                          settings,
+                          null,
+                          ImmutableMap.of(filename, originalText),
+                          Warnings.Settings.fromLogger(logger),
+                          format,
+                          null);
+                  ParseVendorConfigurationResult result = job.call();
+
+                  if (result.getVendorConfiguration() != null) {
+                    VendorConfiguration vc = result.getVendorConfiguration();
+                    vc.setWarnings(warnings);
+                    List<Configuration> viConfigs = vc.toVendorIndependentConfigurations();
+                    if (!viConfigs.isEmpty()) {
+                      Configuration viConfig = viConfigs.get(0);
+                      devices.put(
+                          viConfig.getHostname(),
+                          new DeviceData(viConfig, vc, originalText, processedText));
+                    }
+                  }
+                } catch (Exception e) {
+                  System.err.println(
+                      "Failed to parse " + path.getFileName() + ": " + e.getMessage());
+                }
+              });
+    }
+
+    return devices;
+  }
+
+  private static class DeviceData {
+    final Configuration viConfig;
+    final VendorConfiguration vendorConfig;
+    final String originalText;
+    final String processedText;
+
+    DeviceData(
+        Configuration viConfig,
+        VendorConfiguration vendorConfig,
+        String originalText,
+        String processedText) {
+      this.viConfig = viConfig;
+      this.vendorConfig = vendorConfig;
+      this.originalText = originalText;
+      this.processedText = processedText;
+    }
+  }
+}

--- a/projects/batfish-code-runner/src/main/java/org/batfish/coderunner/RuntimeCompiler.java
+++ b/projects/batfish-code-runner/src/main/java/org/batfish/coderunner/RuntimeCompiler.java
@@ -1,0 +1,111 @@
+package org.batfish.coderunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Collections;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+class RuntimeCompiler {
+  private final JavaCompiler compiler;
+
+  public RuntimeCompiler() {
+    this.compiler = ToolProvider.getSystemJavaCompiler();
+    if (compiler == null) {
+      throw new IllegalStateException(
+          "Java compiler not available. Ensure you're running with a JDK.");
+    }
+  }
+
+  public Class<?> compile(String sourceCode) throws Exception {
+    String className = extractClassName(sourceCode);
+    JavaFileObject sourceFile = new StringSourceJavaFileObject(className, sourceCode);
+    InMemoryClassFileManager fileManager =
+        new InMemoryClassFileManager(compiler.getStandardFileManager(null, null, null));
+    JavaCompiler.CompilationTask task =
+        compiler.getTask(
+            null, fileManager, null, null, null, Collections.singletonList(sourceFile));
+    if (!task.call()) {
+      throw new RuntimeException("Compilation failed");
+    }
+    byte[] bytecode = fileManager.getCompiledBytes(className);
+    return new ByteClassLoader().defineClass(className, bytecode);
+  }
+
+  private String extractClassName(String sourceCode) {
+    java.util.regex.Pattern p = java.util.regex.Pattern.compile("(?:public\\s+)?class\\s+(\\w+)");
+    java.util.regex.Matcher m = p.matcher(sourceCode);
+    if (m.find()) {
+      return m.group(1);
+    }
+    throw new IllegalArgumentException("Could not extract class name");
+  }
+
+  private static class StringSourceJavaFileObject extends SimpleJavaFileObject {
+    private final String code;
+
+    StringSourceJavaFileObject(String className, String code) {
+      super(
+          URI.create("string:///" + className.replace('.', '/') + Kind.SOURCE.extension),
+          Kind.SOURCE);
+      this.code = code;
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      return code;
+    }
+  }
+
+  private static class ByteJavaFileObject extends SimpleJavaFileObject {
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    ByteJavaFileObject(String className) {
+      super(
+          URI.create("bytes:///" + className.replace('.', '/') + Kind.CLASS.extension), Kind.CLASS);
+    }
+
+    @Override
+    public OutputStream openOutputStream() {
+      return outputStream;
+    }
+
+    byte[] getBytes() {
+      return outputStream.toByteArray();
+    }
+  }
+
+  private static class InMemoryClassFileManager extends ForwardingJavaFileManager<JavaFileManager> {
+    private ByteJavaFileObject compiledClass;
+
+    InMemoryClassFileManager(JavaFileManager fileManager) {
+      super(fileManager);
+    }
+
+    @Override
+    public JavaFileObject getJavaFileForOutput(
+        Location location, String className, JavaFileObject.Kind kind, FileObject sibling) {
+      compiledClass = new ByteJavaFileObject(className);
+      return compiledClass;
+    }
+
+    byte[] getCompiledBytes(String className) {
+      if (compiledClass == null) {
+        throw new IllegalStateException("No compiled class available");
+      }
+      return compiledClass.getBytes();
+    }
+  }
+
+  private static class ByteClassLoader extends ClassLoader {
+    Class<?> defineClass(String name, byte[] bytes) {
+      return defineClass(name, bytes, 0, bytes.length);
+    }
+  }
+}


### PR DESCRIPTION
Add a CLI utility that runs user-provided Java code against parsed
Batfish configurations. The tool:
- Parses a snapshot directory and loads all device configurations
- Compiles user code at runtime using Java Compiler API
- Executes code with signature: String func(Configuration, VendorConfiguration, String originalText, String processedText)
- Outputs CSV with hostname and function return value

The tool provides access to both vendor-independent (Configuration) and
vendor-specific (VendorConfiguration) representations, plus original and
preprocessed configuration text for vendors like Junos where flattening
is significant.

---
Prompt:
```
Read ~/github/java-code-runner. I want to make a similar CLI util for Batfish where the provided code has signature "String func(Configuration, VendorConfiguration, String originalText, String processedText)". The CLI will take as argument a Batfish snapshot directory. It will parse and load the snapshot, keeping for each device the original input text and the processed text (in the case of vendors like Junos where preprocessing is an important step). Then it will take the user's code and run it on each file. The output of the CLI will be a CSV with hostname,functon-return-value. (the CSV will be properly encoded/escaped).
```

---

**Stack**:
- #9637 ⬅
- #9636
- #9635
- #9633
- #9632
- #9631
- #9630
- #9629
- #9628
- #9627


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*