### PR TITLE
Cancel previous pre-commit runs on PR updates

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,10 @@ on:
     - cron: "0 12 * * *" # Daily at 5am Seattle time (12 UTC)
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   get_date:
     name: ":clock: Get Date"


### PR DESCRIPTION
Add concurrency control to automatically cancel in-progress workflow
runs when new commits are pushed to a pull request. This reduces
unnecessary CI resource usage by stopping outdated runs.

Uses github.head_ref (PR branch name) to group runs per PR, with
fallback to github.run_id for non-PR events (pushes to master,
scheduled runs, manual dispatches).

---

Prompt:
```
Read https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-using-concurrency-and-the-default-behavior . I want to correctly cancel previous runs only for updates to an existing pull request. How should I do this?
```