### PR TITLE
FileBasedStorage: use Files.readString instead of Guava ByteStreams

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
-import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
 import com.google.common.io.MoreFiles;
 import com.google.errorprone.annotations.MustBeClosed;
@@ -36,6 +35,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -1226,10 +1226,11 @@ public class FileBasedStorage implements StorageProvider {
    */
   private @Nonnull String readFileToString(Path file, Charset charset) throws IOException {
     Path sanitizedFile = validatePath(file);
-    try (InputStream in = new FileInputStream(sanitizedFile.toFile())) {
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-      ByteStreams.copy(in, out);
-      return new String(out.toByteArray(), charset);
+    try {
+      return Files.readString(sanitizedFile, charset);
+    } catch (NoSuchFileException e) {
+      // Convert to FileNotFoundException to maintain API contract
+      throw new FileNotFoundException(sanitizedFile.toString());
     }
   }
 


### PR DESCRIPTION
Simplifies readFileToString implementation by using Java 11+ Files.readString instead of manually reading FileInputStream through Guava ByteStreams into ByteArrayOutputStream.

Maintains backward compatibility by converting NoSuchFileException to FileNotFoundException to preserve existing API contract.

---

Prompt:
```
A series of PRs to Spark (https://github.com/apache/spark/pull/51751) and (https://github.com/apache/spark/pull/51881) and linked PRs seem to indicate that Java 9+ have dramatically improved file performance over guava ioutils, etc implementations. Is this true, and if so should we adopt any of these? Review the github discussions (use github CLI tool) in addition to any other searches online or knowledge base you have.
```

---

**Stack**:
- #9646
- #9645
- #9644 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*