### PR TITLE
CommonUtil, UnzipUtility: use Files API instead of FileOutputStream

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CommonUtil.java
@@ -6,9 +6,7 @@ import static org.batfish.common.util.Resources.readResource;
 import com.google.common.hash.Hashing;
 import com.ibm.icu.text.CharsetDetector;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -205,9 +203,8 @@ public class CommonUtil {
   }
 
   public static void writeFile(Path outputPath, String output) {
-    try (FileOutputStream fs = new FileOutputStream(outputPath.toFile());
-        OutputStreamWriter os = new OutputStreamWriter(fs, UTF_8)) {
-      os.write(output);
+    try {
+      Files.writeString(outputPath, output, UTF_8);
     } catch (FileNotFoundException e) {
       throw new BatfishException("Failed to write file (file not found): " + outputPath, e);
     } catch (IOException e) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
@@ -2,13 +2,13 @@ package org.batfish.common.util;
 
 import static com.google.common.io.MoreFiles.createParentDirectories;
 
-import com.google.common.io.ByteStreams;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
@@ -27,8 +27,8 @@ public final class UnzipUtility {
    * @param filePath The path to write the output file
    */
   private static void extractFile(ZipInputStream zipIn, Path filePath) {
-    try (FileOutputStream fos = new FileOutputStream(filePath.toFile())) {
-      ByteStreams.copy(zipIn, fos);
+    try {
+      Files.copy(zipIn, filePath, StandardCopyOption.REPLACE_EXISTING);
     } catch (IOException e) {
       throw new BatfishException("Error unzipping to output file: '" + filePath + "'", e);
     }


### PR DESCRIPTION
Modernizes two utilities to use java.nio.file.Files API:

1. CommonUtil.writeFile: use Files.writeString instead of FileOutputStream + OutputStreamWriter pattern (38 call sites benefit)

2. UnzipUtility.extractFile: use Files.copy instead of Guava ByteStreams.copy

Simplifies code and reduces dependency on older I/O patterns and Guava utilities.

---

Prompt:
```
Can we check elsewhere in the project we should be using Files API?
```

---

**Stack**:
- #9646
- #9645 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*