### PR TITLE
Resources, StreamDecoder: use InputStream.readAllBytes instead of IOUtils

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Resources.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/Resources.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import javax.annotation.Nonnull;
-import org.apache.commons.io.IOUtils;
 
 /** Utility class for reading resources in the classpath */
 public final class Resources {
@@ -24,7 +23,7 @@ public final class Resources {
     try (InputStream is =
         Thread.currentThread().getContextClassLoader().getResourceAsStream(resourcePath)) {
       checkArgument(is != null, "Error opening resource: '%s'", resourcePath);
-      return IOUtils.toByteArray(is);
+      return is.readAllBytes();
     } catch (IOException e) {
       throw new UncheckedIOException("Could not open resource: '" + resourcePath + "'", e);
     }

--- a/projects/batfish/src/main/java/org/batfish/main/StreamDecoder.java
+++ b/projects/batfish/src/main/java/org/batfish/main/StreamDecoder.java
@@ -9,7 +9,6 @@ import java.io.SequenceInputStream;
 import java.nio.charset.Charset;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.ByteOrderMark;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 
 /** Utility class for decoding streams of unknown charset to strings. */
@@ -24,7 +23,7 @@ final class StreamDecoder {
    */
   static @Nonnull String decodeStreamAndAppendNewline(@Nonnull InputStream inputStream)
       throws IOException {
-    byte[] rawBytes = IOUtils.toByteArray(inputStream);
+    byte[] rawBytes = inputStream.readAllBytes();
     Charset cs = Charset.forName(new CharsetDetector().setText(rawBytes).detect().getName());
     try (Closer closer = Closer.create()) {
       InputStream inputByteStream =
@@ -36,7 +35,7 @@ final class StreamDecoder {
                       inputByteStream,
                       closer.register(bomInputStream(new ByteArrayInputStream("\n".getBytes(cs)))))
                   : inputByteStream);
-      return new String(IOUtils.toByteArray(finalInputStream), cs);
+      return new String(finalInputStream.readAllBytes(), cs);
     }
   }
 


### PR DESCRIPTION
Replaces Apache Commons IOUtils.toByteArray with Java 9+ InputStream.readAllBytes:

1. Resources.readResourceBytes: widely used utility for reading classpath resources
2. StreamDecoder.decodeStreamAndAppendNewline: used for charset detection and config file decoding (2 call sites)

Simplifies code and removes Apache Commons IO dependency from these files.

---

Prompt:
```
Any IOUtils or similar calls we should get rid of?
```