### PR TITLE
IOS XR: support chained ingress IPv4 ACLs with 'common' keyword

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -4026,6 +4026,7 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     int line = ctx.start.getLine();
     if (ctx.common_acl != null) {
       String name = toString(ctx.common_acl);
+      _currentInterface.setIncomingFilterCommon(name);
       _configuration.referenceStructure(
           IPV4_ACCESS_LIST, name, INTERFACE_IPV4_ACCESS_GROUP_COMMON, line);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/Interface.java
@@ -134,6 +134,8 @@ public class Interface implements Serializable {
 
   private String _incomingFilter;
 
+  private String _incomingFilterCommon;
+
   private @Nullable Long _isisCost;
 
   private @Nullable IsisInterfaceMode _isisInterfaceMode;
@@ -279,6 +281,10 @@ public class Interface implements Serializable {
     return _incomingFilter;
   }
 
+  public String getIncomingFilterCommon() {
+    return _incomingFilterCommon;
+  }
+
   public Long getIsisCost() {
     return _isisCost;
   }
@@ -415,6 +421,10 @@ public class Interface implements Serializable {
 
   public void setIncomingFilter(String accessListName) {
     _incomingFilter = accessListName;
+  }
+
+  public void setIncomingFilterCommon(String accessListName) {
+    _incomingFilterCommon = accessListName;
   }
 
   public void setIsisCost(Long isisCost) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface-acl-common
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface-acl-common
@@ -1,0 +1,21 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname interface-acl-common
+!
+ipv4 access-list common-acl
+ 10 permit tcp any any eq 22
+ 20 deny tcp host 10.1.1.1 any eq 80
+!
+ipv4 access-list interface-acl
+ 10 permit tcp any any eq 80
+ 20 deny tcp any any eq 443
+!
+interface GigabitEthernet0/0/0/0
+ ipv4 access-group common common-acl interface-acl ingress
+!
+interface GigabitEthernet0/0/0/1
+ ipv4 access-group common common-acl ingress
+!
+interface GigabitEthernet0/0/0/2
+ ipv4 access-group interface-acl ingress
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface-acl-common-abf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/interface-acl-common-abf
@@ -1,0 +1,34 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname interface-acl-common-abf
+!
+ipv4 access-list common-abf
+ 10 permit tcp any host 10.0.1.1 nexthop1 ipv4 10.0.100.1
+ 20 deny tcp any any eq 23
+!
+ipv4 access-list interface-abf
+ 10 permit tcp any host 10.0.2.1 nexthop1 ipv4 10.0.200.1
+ 20 permit tcp any any eq 80
+!
+ipv4 access-list common-no-abf
+ 10 permit tcp any any eq 22
+!
+ipv4 access-list interface-no-abf
+ 10 permit tcp any any eq 443
+!
+! Chained with ABF in common ACL only
+interface GigabitEthernet0/0/0/0
+ ipv4 access-group common common-abf interface-no-abf ingress
+!
+! Chained with ABF in interface ACL only
+interface GigabitEthernet0/0/0/1
+ ipv4 access-group common common-no-abf interface-abf ingress
+!
+! Chained with ABF in both ACLs
+interface GigabitEthernet0/0/0/2
+ ipv4 access-group common common-abf interface-abf ingress
+!
+! Single ACL with ABF (for comparison)
+interface GigabitEthernet0/0/0/3
+ ipv4 access-group interface-abf ingress
+!


### PR DESCRIPTION
Implements support for IOS XR's common ingress ACL feature, which allows
configuring both a common ACL and an interface-specific ACL. The common
ACL is evaluated first, and packets that don't match an explicit action
fall through to the interface-specific ACL.

Grammar already supported parsing the syntax. This change:
- Adds Interface field to store common ACL name for IPv4 ingress
- Updates extraction to populate this field
- Chains ACLs during conversion using AclAclLine for proper fallthrough
- Chains packet policies when ABF is used with chained ACLs
- Adds tests validating extraction, conversion, and semantics

Implementation uses list-based approach to handle 0, 1, or 2+ ACLs cleanly.
Helper functions (`getOrCreateIncomingFilter`, `createChainedPacketPolicy`)
centralize logic and return Optional/objects for simple call sites. The
incomingAclNames list filters by `_ipv4Acls::containsKey` upfront to
eliminate redundant null checks throughout.

IPv6 ACLs are not yet modeled in Batfish, so this implementation is
IPv4-only. The grammar parses IPv6 common ACL syntax but does not extract
or convert it.

ABF (ACL-based forwarding) with common ACLs is supported in IOS XR 7.6.1+
and is now properly modeled by chaining the individual packet policies.

Test coverage includes:
- Extraction tests for all ACL combinations
- Conversion tests validating correct chaining and evaluation order
- Critical ordering test ensures common ACL is evaluated first
- ABF tests confirming packet policy chaining

Resolves https://github.com/batfish/batfish/issues/9398

---

Prompt:
```
Read and implement https://github.com/batfish/batfish/issues/9398
```

Further discussion:
- Verified ABF+common support from IOS XR 7.6.1+ documentation (xrdocs.io)
- Refactored to list-based approach with early filtering by _ipv4Acls::containsKey
- Used idiomatic Hamcrest matchers for tests (hasInterface, accepts/rejects)

---

**Stack**:
- #9653
- #9652
- #9651 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*