### PR TITLE
docs: add ACL testing patterns to testing guide

### DIFF
--- a/docs/development/testing_guide.md
+++ b/docs/development/testing_guide.md
@@ -190,6 +190,25 @@ Note that some packages are excluded from coverage instrumentation to prevent cr
 - Use Hamcrest matchers for more readable assertions
 - Create custom matchers for domain-specific assertions
 
+#### Testing ACLs and Filters
+
+Use idiomatic matchers for concise, readable ACL tests:
+
+```java
+// Test filter name
+assertThat(c, hasInterface("eth0", hasIncomingFilter(hasName("my-acl"))));
+
+// Test filter behavior with Flow evaluation
+Flow testFlow = Flow.builder()...build();
+assertThat(c, hasInterface("eth0", hasIncomingFilter(accepts(testFlow, "eth0", c))));
+assertThat(c, hasInterface("eth0", hasIncomingFilter(rejects(testFlow, "eth0", c))));
+```
+
+Key matcher classes (see source for full list):
+- `InterfaceMatchers` - interface properties including `hasIncomingFilter`
+- `IpAccessListMatchers` - ACL properties like `hasName`, `accepts`, `rejects`
+- `DataModelMatchers` - general data model matchers
+
 ## Continuous Integration
 
 Batfish uses GitHub Actions for continuous integration. All tests are run on:


### PR DESCRIPTION
Adds section showing idiomatic Hamcrest matcher patterns for testing
interface filters. Points to matcher classes rather than exhaustively
listing all matchers to keep documentation maintainable.

Examples demonstrate hasInterface + hasIncomingFilter + accepts/rejects
pattern for concise ACL behavior tests.

---

Prompt:
```
review the previous chat log. Are there any documentation updates we should make?
```

Further discussion: testing guide should document matcher patterns that
help write idiomatic tests from the start

---

**Stack**:
- #9653
- #9652 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*