### PR TITLE
finalizeConfiguration: check for undefined ACL references

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclReferencesVerifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclReferencesVerifier.java
@@ -1,0 +1,273 @@
+package org.batfish.datamodel.acl;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.VendorConversionException;
+import org.batfish.datamodel.AclAclLine;
+import org.batfish.datamodel.AclLine;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.transformation.Transformation;
+
+/**
+ * Provides functionality to verify absence of undefined references to ACLs in {@link
+ * PermittedByAcl}, {@link DeniedByAcl}, {@link AclAclLine}, and {@link
+ * org.batfish.datamodel.packet_policy.ApplyFilter}.
+ *
+ * <p>It is the responsibility of conversion code to handle undefined references to vendor-specific
+ * structures. Conversion code must not propagate undefined references to vendor-independent
+ * structures. Thus any such references to vendor-independent structures signify errors in
+ * conversion code, rather than the input configuration text.
+ */
+public final class AclReferencesVerifier {
+
+  /**
+   * Verifies absence of undefined references to ACLs within the input {@code configuration}.
+   *
+   * @throws VendorConversionException if an undefined reference to an ACL is found in {@code
+   *     configuration}.
+   */
+  public static void verify(Configuration configuration) {
+    Set<String> undefinedAclReferences =
+        Sets.difference(
+            collectAclReferences(configuration), configuration.getIpAccessLists().keySet());
+    if (!undefinedAclReferences.isEmpty()) {
+      throw new VendorConversionException(
+          String.format(
+              "Configuration %s has undefined ACL references: %s",
+              configuration.getHostname(), undefinedAclReferences));
+    }
+  }
+
+  @VisibleForTesting
+  @ParametersAreNonnullByDefault
+  static final class CollectAclReferences
+      implements GenericAclLineVisitor<Void>, GenericAclLineMatchExprVisitor<Void> {
+    /**
+     * Returns ACL names referenced by {@link PermittedByAcl}, {@link DeniedByAcl}, {@link
+     * AclAclLine}, and {@link org.batfish.datamodel.packet_policy.ApplyFilter} in {@code c}.
+     */
+    public static Set<String> collect(Configuration c) {
+      ImmutableSet.Builder<String> set = ImmutableSet.builder();
+      CollectAclReferences collector = new CollectAclReferences(set);
+      for (IpAccessList acl : c.getIpAccessLists().values()) {
+        collector.visit(acl);
+      }
+      for (Interface i : c.getAllInterfaces().values()) {
+        collector.visit(i.getIncomingTransformation());
+        collector.visit(i.getOutgoingTransformation());
+      }
+      for (PacketPolicy pp : c.getPacketPolicies().values()) {
+        collector.visit(pp);
+      }
+      return set.build();
+    }
+
+    private final @Nonnull ImmutableSet.Builder<String> _set;
+    private final @Nonnull Set<Object> _visited;
+
+    private CollectAclReferences(ImmutableSet.Builder<String> set) {
+      _set = set;
+      _visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    }
+
+    // Impl below here.
+
+    private void visit(@Nullable Transformation t) {
+      // to avoid stack overflow on large transformations, use a work queue instead of recursion
+      Queue<Transformation> queue = new LinkedList<>();
+      Consumer<Transformation> enqueue =
+          tx -> {
+            if (tx != null && _visited.add(tx)) {
+              queue.add(tx);
+            }
+          };
+      enqueue.accept(t);
+      while (!queue.isEmpty()) {
+        Transformation tx = queue.remove();
+        visit(tx.getGuard());
+        enqueue.accept(tx.getAndThen());
+        enqueue.accept(tx.getOrElse());
+      }
+    }
+
+    private void visit(IpAccessList acl) {
+      if (!_visited.add(acl)) {
+        return;
+      }
+      for (AclLine line : acl.getLines()) {
+        visit(line);
+      }
+    }
+
+    private void visit(PacketPolicy pp) {
+      if (!_visited.add(pp)) {
+        return;
+      }
+      for (org.batfish.datamodel.packet_policy.Statement stmt : pp.getStatements()) {
+        visit(stmt);
+      }
+    }
+
+    private void visit(org.batfish.datamodel.packet_policy.Statement stmt) {
+      if (!_visited.add(stmt)) {
+        return;
+      }
+      if (stmt instanceof org.batfish.datamodel.packet_policy.ApplyFilter) {
+        _set.add(((org.batfish.datamodel.packet_policy.ApplyFilter) stmt).getFilter());
+      } else if (stmt instanceof org.batfish.datamodel.packet_policy.If) {
+        org.batfish.datamodel.packet_policy.If ifStmt =
+            (org.batfish.datamodel.packet_policy.If) stmt;
+        visit(ifStmt.getMatchCondition());
+        ifStmt.getTrueStatements().forEach(this::visit);
+      }
+      // Return and ApplyTransformation don't reference ACLs
+    }
+
+    private void visit(org.batfish.datamodel.packet_policy.BoolExpr expr) {
+      if (!_visited.add(expr)) {
+        return;
+      }
+      if (expr instanceof org.batfish.datamodel.packet_policy.FalseExpr
+          || expr instanceof org.batfish.datamodel.packet_policy.TrueExpr) {
+        // No references
+        return;
+      }
+      if (expr instanceof org.batfish.datamodel.packet_policy.Conjunction) {
+        ((org.batfish.datamodel.packet_policy.Conjunction) expr)
+            .getConjuncts()
+            .forEach(this::visit);
+      } else if (expr instanceof org.batfish.datamodel.packet_policy.PacketMatchExpr) {
+        visit(((org.batfish.datamodel.packet_policy.PacketMatchExpr) expr).getExpr());
+      }
+    }
+
+    @Override
+    public Void visit(AclLineMatchExpr expr) {
+      if (!_visited.add(expr)) {
+        return null;
+      }
+      return GenericAclLineMatchExprVisitor.super.visit(expr);
+    }
+
+    @Override
+    public Void visit(AclLine line) {
+      if (!_visited.add(line)) {
+        return null;
+      }
+      return GenericAclLineVisitor.super.visit(line);
+    }
+
+    @Override
+    public Void visitAndMatchExpr(AndMatchExpr andMatchExpr) {
+      andMatchExpr.getConjuncts().forEach(this::visit);
+      return null;
+    }
+
+    @Override
+    public Void visitDeniedByAcl(DeniedByAcl deniedByAcl) {
+      _set.add(deniedByAcl.getAclName());
+      return null;
+    }
+
+    @Override
+    public Void visitFalseExpr(FalseExpr falseExpr) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchDestinationIp(MatchDestinationIp matchDestinationIp) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchDestinationPort(MatchDestinationPort matchDestinationPort) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchHeaderSpace(MatchHeaderSpace matchHeaderSpace) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchIpProtocol(MatchIpProtocol matchIpProtocol) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchSourceIp(MatchSourceIp matchSourceIp) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchSourcePort(MatchSourcePort matchSourcePort) {
+      return null;
+    }
+
+    @Override
+    public Void visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
+      return null;
+    }
+
+    @Override
+    public Void visitNotMatchExpr(NotMatchExpr notMatchExpr) {
+      visit(notMatchExpr.getOperand());
+      return null;
+    }
+
+    @Override
+    public Void visitOriginatingFromDevice(OriginatingFromDevice originatingFromDevice) {
+      return null;
+    }
+
+    @Override
+    public Void visitOrMatchExpr(OrMatchExpr orMatchExpr) {
+      orMatchExpr.getDisjuncts().forEach(this::visit);
+      return null;
+    }
+
+    @Override
+    public Void visitPermittedByAcl(PermittedByAcl permittedByAcl) {
+      _set.add(permittedByAcl.getAclName());
+      return null;
+    }
+
+    @Override
+    public Void visitTrueExpr(TrueExpr trueExpr) {
+      return null;
+    }
+
+    @Override
+    public Void visitAclAclLine(AclAclLine aclAclLine) {
+      _set.add(aclAclLine.getAclName());
+      return null;
+    }
+
+    @Override
+    public Void visitExprAclLine(ExprAclLine exprAclLine) {
+      visit(exprAclLine.getMatchCondition());
+      return null;
+    }
+  }
+
+  @VisibleForTesting
+  static Set<String> collectAclReferences(Configuration c) {
+    return CollectAclReferences.collect(c);
+  }
+
+  private AclReferencesVerifier() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclReferencesVerifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclReferencesVerifierTest.java
@@ -1,0 +1,132 @@
+package org.batfish.datamodel.acl;
+
+import static org.hamcrest.Matchers.containsString;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.common.VendorConversionException;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Test of {@link AclReferencesVerifier}. */
+public final class AclReferencesVerifierTest {
+
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  @Test
+  public void testUndefinedPermittedByAcl() {
+    Configuration c = new Configuration("testNode", ConfigurationFormat.CISCO_IOS);
+
+    IpAccessList.builder()
+        .setName("acl1")
+        .setOwner(c)
+        .setLines(new ExprAclLine(LineAction.PERMIT, new PermittedByAcl("undefinedAcl"), "line1"))
+        .build();
+
+    _thrown.expect(VendorConversionException.class);
+    _thrown.expectMessage(
+        containsString("Configuration testnode has undefined ACL references: [undefinedAcl]"));
+    AclReferencesVerifier.verify(c);
+  }
+
+  @Test
+  public void testUndefinedDeniedByAcl() {
+    Configuration c = new Configuration("testNode", ConfigurationFormat.CISCO_IOS);
+
+    IpAccessList.builder()
+        .setName("acl1")
+        .setOwner(c)
+        .setLines(new ExprAclLine(LineAction.DENY, new DeniedByAcl("undefinedAcl"), "line1"))
+        .build();
+
+    _thrown.expect(VendorConversionException.class);
+    _thrown.expectMessage(
+        containsString("Configuration testnode has undefined ACL references: [undefinedAcl]"));
+    AclReferencesVerifier.verify(c);
+  }
+
+  @Test
+  public void testUndefinedAclAclLine() {
+    Configuration c = new Configuration("testNode", ConfigurationFormat.CISCO_IOS);
+
+    IpAccessList.builder()
+        .setName("acl1")
+        .setOwner(c)
+        .setLines(new org.batfish.datamodel.AclAclLine("line1", "undefinedAcl"))
+        .build();
+
+    _thrown.expect(VendorConversionException.class);
+    _thrown.expectMessage(
+        containsString("Configuration testnode has undefined ACL references: [undefinedAcl]"));
+    AclReferencesVerifier.verify(c);
+  }
+
+  @Test
+  public void testUndefinedPacketPolicyApplyFilter() {
+    Configuration c = new Configuration("testNode", ConfigurationFormat.CISCO_IOS);
+
+    c.getPacketPolicies()
+        .put(
+            "pp1",
+            new PacketPolicy(
+                "pp1",
+                ImmutableList.of(
+                    new org.batfish.datamodel.packet_policy.ApplyFilter("undefinedAcl")),
+                new org.batfish.datamodel.packet_policy.Return(
+                    org.batfish.datamodel.packet_policy.Drop.instance())));
+
+    _thrown.expect(VendorConversionException.class);
+    _thrown.expectMessage(
+        containsString("Configuration testnode has undefined ACL references: [undefinedAcl]"));
+    AclReferencesVerifier.verify(c);
+  }
+
+  @Test
+  public void testMultipleUndefinedReferences() {
+    Configuration c = new Configuration("testNode", ConfigurationFormat.CISCO_IOS);
+
+    IpAccessList.builder()
+        .setName("acl1")
+        .setOwner(c)
+        .setLines(
+            new ExprAclLine(LineAction.PERMIT, new PermittedByAcl("undefinedAcl1"), "line1"),
+            new ExprAclLine(LineAction.DENY, new DeniedByAcl("undefinedAcl2"), "line2"),
+            new org.batfish.datamodel.AclAclLine("line3", "undefinedAcl3"))
+        .build();
+
+    _thrown.expect(VendorConversionException.class);
+    _thrown.expectMessage(
+        containsString(
+            "Configuration testnode has undefined ACL references: [undefinedAcl1, undefinedAcl2,"
+                + " undefinedAcl3]"));
+    AclReferencesVerifier.verify(c);
+  }
+
+  @Test
+  public void testDefinedReferencesNoError() {
+    Configuration c = new Configuration("testNode", ConfigurationFormat.CISCO_IOS);
+
+    // Create defined ACL
+    IpAccessList.builder()
+        .setName("definedAcl")
+        .setOwner(c)
+        .setLines(new ExprAclLine(LineAction.PERMIT, TrueExpr.INSTANCE, "definedLine"))
+        .build();
+
+    // Create ACL that references the defined ACL
+    IpAccessList.builder()
+        .setName("acl2")
+        .setOwner(c)
+        .setLines(new ExprAclLine(LineAction.PERMIT, new PermittedByAcl("definedAcl"), "line"))
+        .build();
+
+    // Should not throw
+    AclReferencesVerifier.verify(c);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -71,6 +71,7 @@ import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.VrrpGroup;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclReferencesVerifier;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.DeniedByAcl;
 import org.batfish.datamodel.acl.FalseExpr;
@@ -546,6 +547,11 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     c.setInterfaces(
         verifyAndToImmutableMap(
             c.getAllInterfaces(), Interface::getName, w, InterfaceNameComparator.instance()));
+    // TODO(https://github.com/batfish/batfish/issues/9655): Skip ACL reference verification for
+    // ASA; it has known issues with undefined object references.
+    if (c.getConfigurationFormat() != ConfigurationFormat.CISCO_ASA) {
+      AclReferencesVerifier.verify(c);
+    }
     c.setIpAccessLists(verifyAndToImmutableMap(c.getIpAccessLists(), IpAccessList::getName, w));
     c.setIpsecPeerConfigs(toImmutableMap(c.getIpsecPeerConfigs()));
     c.setIpsecPhase2Policies(toImmutableMap(c.getIpsecPhase2Policies()));


### PR DESCRIPTION
Crashes if PermittedByAcl, DeniedByAcl, AclAclLine, or ApplyFilter
(PacketPolicy) references an ACL that doesn't exist in the
configuration. This ensures conversion implementers fix undefined ACL
references rather than allowing them to cause failures during
analysis.

Implemented as AclReferencesVerifier following the pattern of
RoutingPolicyReferencesVerifier and CommunityStructuresVerifier.

Currently skipped for Cisco ASA due to known issues with undefined
object group references (see #9655).

Fixes #1255

---

Prompt:
```
Read https://github.com/batfish/batfish/issues/1255 . I feel like we probably implemneted it, but go look at finalizeConfiguration and see. If not, seems like low-hanging fruit, do it.
```