### PR TITLE
Cisco ASA: fix undefined object group references

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -547,11 +547,7 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     c.setInterfaces(
         verifyAndToImmutableMap(
             c.getAllInterfaces(), Interface::getName, w, InterfaceNameComparator.instance()));
-    // TODO(https://github.com/batfish/batfish/issues/9655): Skip ACL reference verification for
-    // ASA; it has known issues with undefined object references.
-    if (c.getConfigurationFormat() != ConfigurationFormat.CISCO_ASA) {
-      AclReferencesVerifier.verify(c);
-    }
+    AclReferencesVerifier.verify(c);
     c.setIpAccessLists(verifyAndToImmutableMap(c.getIpAccessLists(), IpAccessList::getName, w));
     c.setIpsecPeerConfigs(toImmutableMap(c.getIpsecPeerConfigs()));
     c.setIpsecPhase2Policies(toImmutableMap(c.getIpsecPhase2Policies()));

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AccessListServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AccessListServiceSpecifier.java
@@ -8,5 +8,6 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
 public interface AccessListServiceSpecifier extends Serializable {
 
   @Nonnull
-  AclLineMatchExpr toAclLineMatchExpr(Map<String, ObjectGroup> objectGroups);
+  AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ObjectGroup> objectGroups, Map<String, ServiceObject> serviceObjects);
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -2771,14 +2771,16 @@ public final class AsaConfiguration extends VendorConfiguration {
         c.getRouteFilterLists().put(rfList.getName(), rfList);
       }
       c.getIpAccessLists()
-          .put(saList.getName(), toIpAccessList(saList.toExtendedAccessList(), _objectGroups));
+          .put(
+              saList.getName(),
+              toIpAccessList(saList.toExtendedAccessList(), _objectGroups, _serviceObjects));
     }
     for (ExtendedAccessList eaList : _extendedAccessLists.values()) {
       if (isAclUsedForRouting(eaList.getName())) {
         RouteFilterList rfList = AsaConversions.toRouteFilterList(eaList, _filename);
         c.getRouteFilterLists().put(rfList.getName(), rfList);
       }
-      IpAccessList ipaList = toIpAccessList(eaList, _objectGroups);
+      IpAccessList ipaList = toIpAccessList(eaList, _objectGroups, _serviceObjects);
       c.getIpAccessLists().put(ipaList.getName(), ipaList);
     }
 
@@ -2842,13 +2844,17 @@ public final class AsaConfiguration extends VendorConfiguration {
     _icmpTypeObjectGroups.forEach(
         (name, icmpTypeObjectGroups) ->
             c.getIpAccessLists()
-                .put(computeIcmpObjectGroupAclName(name), toIpAccessList(icmpTypeObjectGroups)));
+                .put(
+                    computeIcmpObjectGroupAclName(name),
+                    toIpAccessList(icmpTypeObjectGroups, _icmpTypeObjectGroups)));
 
     // convert each ProtocolObjectGroup to IpAccessList
     _protocolObjectGroups.forEach(
         (name, protocolObjectGroup) ->
             c.getIpAccessLists()
-                .put(computeProtocolObjectGroupAclName(name), toIpAccessList(protocolObjectGroup)));
+                .put(
+                    computeProtocolObjectGroupAclName(name),
+                    toIpAccessList(protocolObjectGroup, _protocolObjectGroups)));
 
     // convert each ServiceObject and ServiceObjectGroup to IpAccessList
     _serviceObjectGroups.forEach(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeGroupReferenceLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeGroupReferenceLine.java
@@ -2,7 +2,9 @@ package org.batfish.representation.cisco_asa;
 
 import static org.batfish.representation.cisco_asa.AsaConfiguration.computeIcmpObjectGroupAclName;
 
+import java.util.Map;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.PermittedByAcl;
 
 public class IcmpTypeGroupReferenceLine implements IcmpTypeObjectGroupLine {
@@ -18,7 +20,11 @@ public class IcmpTypeGroupReferenceLine implements IcmpTypeObjectGroupLine {
   }
 
   @Override
-  public AclLineMatchExpr toAclLineMatchExpr() {
+  public AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, IcmpTypeObjectGroup> icmpTypeObjectGroups) {
+    if (!icmpTypeObjectGroups.containsKey(_name)) {
+      return AclLineMatchExprs.FALSE;
+    }
     return new PermittedByAcl(computeIcmpObjectGroupAclName(_name));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeGroupTypeLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeGroupTypeLine.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.cisco_asa;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Map;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.SubRange;
@@ -20,7 +21,8 @@ public class IcmpTypeGroupTypeLine implements IcmpTypeObjectGroupLine {
   }
 
   @Override
-  public AclLineMatchExpr toAclLineMatchExpr() {
+  public AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, IcmpTypeObjectGroup> icmpTypeObjectGroups) {
     return new MatchHeaderSpace(
         HeaderSpace.builder()
             .setIpProtocols(IpProtocol.ICMP)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeObjectGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeObjectGroup.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import com.google.common.collect.ImmutableSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 
 public class IcmpTypeObjectGroup extends ObjectGroup {
@@ -20,10 +21,11 @@ public class IcmpTypeObjectGroup extends ObjectGroup {
     return _lines;
   }
 
-  public AclLineMatchExpr toAclLineMatchExpr() {
+  public AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, IcmpTypeObjectGroup> icmpTypeObjectGroups) {
     return or(
         _lines.stream()
-            .map(IcmpTypeObjectGroupLine::toAclLineMatchExpr)
+            .map(line -> line.toAclLineMatchExpr(icmpTypeObjectGroups))
             .collect(ImmutableSet.toImmutableSet()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeObjectGroupLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/IcmpTypeObjectGroupLine.java
@@ -1,8 +1,9 @@
 package org.batfish.representation.cisco_asa;
 
 import java.io.Serializable;
+import java.util.Map;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 
 public interface IcmpTypeObjectGroupLine extends Serializable {
-  AclLineMatchExpr toAclLineMatchExpr();
+  AclLineMatchExpr toAclLineMatchExpr(Map<String, IcmpTypeObjectGroup> icmpTypeObjectGroups);
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolObjectGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolObjectGroup.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import com.google.common.collect.ImmutableSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 
 public class ProtocolObjectGroup extends ObjectGroup {
@@ -20,10 +21,11 @@ public class ProtocolObjectGroup extends ObjectGroup {
     return _lines;
   }
 
-  public AclLineMatchExpr toAclLineMatchExpr() {
+  public AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ProtocolObjectGroup> protocolObjectGroups) {
     return or(
         _lines.stream()
-            .map(ProtocolObjectGroupLine::toAclLineMatchExpr)
+            .map(line -> line.toAclLineMatchExpr(protocolObjectGroups))
             .collect(ImmutableSet.toImmutableSet()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolObjectGroupLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolObjectGroupLine.java
@@ -1,8 +1,9 @@
 package org.batfish.representation.cisco_asa;
 
 import java.io.Serializable;
+import java.util.Map;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 
 public interface ProtocolObjectGroupLine extends Serializable {
-  AclLineMatchExpr toAclLineMatchExpr();
+  AclLineMatchExpr toAclLineMatchExpr(Map<String, ProtocolObjectGroup> protocolObjectGroups);
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolObjectGroupProtocolLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolObjectGroupProtocolLine.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.cisco_asa;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.HeaderSpace;
@@ -22,7 +23,8 @@ public class ProtocolObjectGroupProtocolLine implements ProtocolObjectGroupLine 
   }
 
   @Override
-  public AclLineMatchExpr toAclLineMatchExpr() {
+  public AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ProtocolObjectGroup> protocolObjectGroups) {
     if (_protocol == null) {
       return TrueExpr.INSTANCE;
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolObjectGroupReferenceLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolObjectGroupReferenceLine.java
@@ -2,8 +2,10 @@ package org.batfish.representation.cisco_asa;
 
 import static org.batfish.representation.cisco_asa.AsaConfiguration.computeProtocolObjectGroupAclName;
 
+import java.util.Map;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.PermittedByAcl;
 
 public class ProtocolObjectGroupReferenceLine implements ProtocolObjectGroupLine {
@@ -19,7 +21,11 @@ public class ProtocolObjectGroupReferenceLine implements ProtocolObjectGroupLine
   }
 
   @Override
-  public AclLineMatchExpr toAclLineMatchExpr() {
+  public AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ProtocolObjectGroup> protocolObjectGroups) {
+    if (!protocolObjectGroups.containsKey(_name)) {
+      return AclLineMatchExprs.FALSE;
+    }
     return new PermittedByAcl(computeProtocolObjectGroupAclName(_name));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolOrServiceObjectGroupServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ProtocolOrServiceObjectGroupServiceSpecifier.java
@@ -15,7 +15,8 @@ public class ProtocolOrServiceObjectGroupServiceSpecifier implements AccessListS
   }
 
   @Override
-  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(Map<String, ObjectGroup> objectGroups) {
+  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ObjectGroup> objectGroups, Map<String, ServiceObject> serviceObjects) {
     ObjectGroup objectGroup = objectGroups.get(_name);
     String aclName;
     if (objectGroup instanceof ProtocolObjectGroup) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ServiceObjectServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/ServiceObjectServiceSpecifier.java
@@ -3,6 +3,7 @@ package org.batfish.representation.cisco_asa;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.PermittedByAcl;
 
 public class ServiceObjectServiceSpecifier implements AccessListServiceSpecifier {
@@ -14,7 +15,11 @@ public class ServiceObjectServiceSpecifier implements AccessListServiceSpecifier
   }
 
   @Override
-  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(Map<String, ObjectGroup> objectGroups) {
+  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ObjectGroup> objectGroups, Map<String, ServiceObject> serviceObjects) {
+    if (!serviceObjects.containsKey(_name)) {
+      return AclLineMatchExprs.FALSE;
+    }
     String aclName = AsaConfiguration.computeServiceObjectAclName(_name);
     return new PermittedByAcl(aclName, String.format("Match service object: '%s'", _name));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/SimpleExtendedAccessListServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/SimpleExtendedAccessListServiceSpecifier.java
@@ -111,7 +111,8 @@ public class SimpleExtendedAccessListServiceSpecifier implements AccessListServi
   }
 
   @Override
-  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(Map<String, ObjectGroup> objectGroups) {
+  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ObjectGroup> objectGroups, Map<String, ServiceObject> serviceObjects) {
     return new MatchHeaderSpace(
         HeaderSpace.builder()
             .setDscps(_dscps)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/StandardAccessListServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/StandardAccessListServiceSpecifier.java
@@ -29,7 +29,8 @@ public class StandardAccessListServiceSpecifier implements AccessListServiceSpec
   }
 
   @Override
-  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(Map<String, ObjectGroup> objectGroups) {
+  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ObjectGroup> objectGroups, Map<String, ServiceObject> serviceObjects) {
     return new MatchHeaderSpace(HeaderSpace.builder().setDscps(_dscps).setEcns(_ecns).build());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/UnimplementedAccessListServiceSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/UnimplementedAccessListServiceSpecifier.java
@@ -15,7 +15,8 @@ public final class UnimplementedAccessListServiceSpecifier implements AccessList
       new UnimplementedAccessListServiceSpecifier();
 
   @Override
-  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(Map<String, ObjectGroup> objectGroups) {
+  public @Nonnull AclLineMatchExpr toAclLineMatchExpr(
+      Map<String, ObjectGroup> objectGroups, Map<String, ServiceObject> serviceObjects) {
     return FalseExpr.INSTANCE;
   }
 


### PR DESCRIPTION
Update protocol and ICMP type object group conversion to check if
referenced groups exist before creating PermittedByAcl references.
Returns AclLineMatchExprs.FALSE when undefined references are found.

Updates:
- ProtocolObjectGroupReferenceLine: check protocol object groups map
- IcmpTypeGroupReferenceLine: check ICMP type object groups map
- ServiceObjectServiceSpecifier: check service objects map
- ServiceObjectReferenceServiceObjectGroupLine: already had the fix

All toAclLineMatchExpr methods now receive the appropriate maps to
enable existence checking, following the pattern established by
ServiceObjectGroupLine implementations.

Remove the skip for AclReferencesVerifier for CISCO_ASA configurations
now that the underlying issue has been fixed.

Fixes #9655

---

Prompt:
```
Read and implement https://github.com/batfish/batfish/issues/9655
```