### PR TITLE
Ip6Space: parity with IPv4 IpSpace

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractIp6SpaceContainsIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractIp6SpaceContainsIp.java
@@ -14,6 +14,36 @@ public abstract class AbstractIp6SpaceContainsIp implements GenericIp6SpaceVisit
   }
 
   @Override
+  public final Boolean visitAclIp6Space(AclIp6Space aclIp6Space) {
+    for (AclIp6SpaceLine line : aclIp6Space.getLines()) {
+      if (line.getIp6Space().accept(this)) {
+        return line.getAction() == LineAction.PERMIT;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public final Boolean visitEmptyIp6Space(EmptyIp6Space emptyIp6Space) {
+    return false;
+  }
+
+  @Override
+  public final Boolean visitIp6Ip6Space(Ip6Ip6Space ip6Ip6Space) {
+    return _ip6.equals(ip6Ip6Space.getIp6());
+  }
+
+  @Override
+  public final Boolean visitUniverseIp6Space(UniverseIp6Space universeIp6Space) {
+    return true;
+  }
+
+  @Override
+  public final Boolean visitIp6WildcardIp6Space(Ip6WildcardIp6Space ip6WildcardIp6Space) {
+    return ip6WildcardIp6Space.getIp6Wildcard().contains(_ip6);
+  }
+
+  @Override
   public final Boolean visitIp6WildcardSetIp6Space(Ip6WildcardSetIp6Space ip6WildcardSetIp6Space) {
     for (Ip6Wildcard w : ip6WildcardSetIp6Space.getBlockList()) {
       if (w.contains(_ip6)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIp6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIp6Space.java
@@ -1,0 +1,324 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Comparators;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Streams;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.visitors.GenericIp6SpaceVisitor;
+
+/**
+ * An ACL-based {@link Ip6Space}. An IPv6 address is permitted if it is in the space the ACL
+ * represents, or denied if it is not.
+ */
+public class AclIp6Space extends Ip6Space {
+
+  private static final String PROP_LINES = "lines";
+  private final @Nonnull List<AclIp6SpaceLine> _lines;
+  private transient int _hashCode;
+
+  @JsonCreator
+  private AclIp6Space(@JsonProperty(PROP_LINES) @Nullable List<AclIp6SpaceLine> lines) {
+    checkArgument(lines != null, "Missing %s", PROP_LINES);
+    _lines = lines;
+  }
+
+  public static class Builder {
+    private final ImmutableList.Builder<AclIp6SpaceLine> _builderLines;
+    private boolean _full;
+
+    private Builder() {
+      _builderLines = ImmutableList.builder();
+    }
+
+    public Ip6Space build() {
+      List<AclIp6SpaceLine> lines = _builderLines.build();
+      while (!lines.isEmpty() && lines.get(lines.size() - 1).getAction() == LineAction.DENY) {
+        lines = lines.subList(0, lines.size() - 1);
+      }
+      if (lines.isEmpty()) {
+        return EmptyIp6Space.INSTANCE;
+      } else if (lines.size() == 1) {
+        AclIp6SpaceLine line = lines.get(0);
+        assert line.getAction() == LineAction.PERMIT;
+        return line.getIp6Space();
+      }
+      return new AclIp6Space(lines);
+    }
+
+    public Builder then(AclIp6SpaceLine line) {
+      if (_full) {
+        return this;
+      } else if (line.getIp6Space() instanceof EmptyIp6Space) {
+        return this;
+      }
+      _full = line.getIp6Space() instanceof UniverseIp6Space;
+      _builderLines.add(line);
+      return this;
+    }
+
+    public Builder thenAction(LineAction action, Ip6Space space) {
+      return then(AclIp6SpaceLine.builder().setAction(action).setIp6Space(space).build());
+    }
+
+    public Builder thenPermitting(Ip6Space... ip6Spaces) {
+      return thenPermitting(Arrays.stream(ip6Spaces));
+    }
+
+    public Builder thenPermitting(Iterable<Ip6Space> ip6Spaces) {
+      return thenPermitting(Streams.stream(ip6Spaces));
+    }
+
+    public Builder thenPermitting(Stream<Ip6Space> ip6Spaces) {
+      if (_full) {
+        return this;
+      }
+      ip6Spaces.map(AclIp6SpaceLine::permit).forEach(this::then);
+      return this;
+    }
+
+    public Builder thenRejecting(Ip6Space... ip6Spaces) {
+      return thenRejecting(Arrays.stream(ip6Spaces));
+    }
+
+    public Builder thenRejecting(Iterable<Ip6Space> ip6Spaces) {
+      return thenRejecting(Streams.stream(ip6Spaces));
+    }
+
+    private Builder thenRejecting(Stream<Ip6Space> ip6Spaces) {
+      if (_full) {
+        return this;
+      }
+      ip6Spaces.map(AclIp6SpaceLine::reject).forEach(this::then);
+      return this;
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static Ip6Space of(Iterable<AclIp6SpaceLine> lines) {
+    Builder builder = builder();
+    lines.forEach(builder::then);
+    return builder.build();
+  }
+
+  public static Ip6Space of(AclIp6SpaceLine... lines) {
+    return of(Arrays.asList(lines));
+  }
+
+  @Override
+  public Ip6Space complement() {
+    if (_lines.size() == 2
+        && _lines.get(1).getAction() == LineAction.PERMIT
+        && _lines.get(1).getIp6Space() == UniverseIp6Space.INSTANCE) {
+      // This AclIp6Space is a complement already.
+      assert _lines.get(0).getAction() == LineAction.DENY;
+      return _lines.get(0).getIp6Space();
+    }
+    return super.complement();
+  }
+
+  /**
+   * Set-theoretic difference between two Ip6Spaces.<br>
+   * If both arguments are {@code null}, returns {@code null}.<br>
+   * If just {@code ip6Space1} is {@code null}, treat it as {@link UniverseIp6Space}.<br>
+   * If just {@code ip6Space2} is {@code null}, treat it as {@link EmptyIp6Space}.
+   */
+  public static @Nullable Ip6Space difference(
+      @Nullable Ip6Space ip6Space1, @Nullable Ip6Space ip6Space2) {
+    if (ip6Space1 == null && ip6Space2 == null) {
+      return null;
+    } else if (ip6Space2 == null) {
+      return ip6Space1;
+    } else if (EmptyIp6Space.INSTANCE.equals(ip6Space1)) {
+      return EmptyIp6Space.INSTANCE;
+    }
+    return builder()
+        .thenRejecting(ip6Space2)
+        .thenPermitting(firstNonNull(ip6Space1, UniverseIp6Space.INSTANCE))
+        .build();
+  }
+
+  /** Set-theoretic intersection of multiple Ip6Spaces */
+  public static @Nullable Ip6Space intersection(Ip6Space... ip6Spaces) {
+    return intersection(Arrays.spliterator(ip6Spaces));
+  }
+
+  /** Set-theoretic intersection of multiple Ip6Spaces */
+  public static @Nullable Ip6Space intersection(Iterable<Ip6Space> ip6Spaces) {
+    return intersection(ip6Spaces.spliterator());
+  }
+
+  private static @Nullable Ip6Space intersection(Spliterator<Ip6Space> ip6Spaces) {
+    Ip6Space[] nonNullSpaces =
+        StreamSupport.stream(ip6Spaces, false).filter(Objects::nonNull).toArray(Ip6Space[]::new);
+
+    if (nonNullSpaces.length == 0) {
+      // all null
+      return null;
+    }
+
+    Ip6Space[] nonUniverseSpaces =
+        Arrays.stream(nonNullSpaces)
+            .filter(ip6Space -> ip6Space != UniverseIp6Space.INSTANCE)
+            .toArray(Ip6Space[]::new);
+
+    if (nonUniverseSpaces.length == 0) {
+      // all UniverseIp6Space
+      return UniverseIp6Space.INSTANCE;
+    }
+
+    if (nonUniverseSpaces.length == 1) {
+      return nonUniverseSpaces[0];
+    }
+
+    // complement each concrete space.
+    for (int i = 0; i < nonUniverseSpaces.length; i++) {
+      if (nonUniverseSpaces[i] == EmptyIp6Space.INSTANCE) {
+        return EmptyIp6Space.INSTANCE;
+      }
+      nonUniverseSpaces[i] = nonUniverseSpaces[i].complement();
+    }
+
+    return builder()
+        .thenRejecting(nonUniverseSpaces)
+        .thenPermitting(UniverseIp6Space.INSTANCE)
+        .build();
+  }
+
+  public static Builder permitting(Ip6Space... ip6Spaces) {
+    return new Builder().thenPermitting(ip6Spaces);
+  }
+
+  public static Builder permitting(Iterable<Ip6Space> ip6Spaces) {
+    return new Builder().thenPermitting(ip6Spaces);
+  }
+
+  public static Builder permitting(Stream<Ip6Space> ip6Spaces) {
+    return new Builder().thenPermitting(ip6Spaces);
+  }
+
+  public static Builder rejecting(Ip6Space... ip6Spaces) {
+    return new Builder().thenRejecting(ip6Spaces);
+  }
+
+  public static Builder rejecting(Iterable<Ip6Space> ip6Spaces) {
+    return new Builder().thenRejecting(ip6Spaces);
+  }
+
+  /**
+   * Set-theoretic union of multiple {@link Ip6Space IP spaces}.<br>
+   * {@code null} ip6Spaces are ignored. If all arguments are {@code null}, returns {@code null}.
+   */
+  public static @Nullable Ip6Space union(Ip6Space... ip6Spaces) {
+    return union(Arrays.asList(ip6Spaces));
+  }
+
+  /**
+   * When an {@link AclIp6Space} is a pure union (list of only permit lines), flattens it into the
+   * permitted spaces.
+   *
+   * <p>This function makes {@code union(union(a, b), c)} equivalent to {@code union(a, b, c)}.
+   */
+  private static Stream<Ip6Space> flattenAclIp6SpacesForUnion(Ip6Space space) {
+    if (!(space instanceof AclIp6Space)) {
+      return Stream.of(space);
+    }
+    AclIp6Space aclSpace = (AclIp6Space) space;
+    List<AclIp6SpaceLine> lines = aclSpace.getLines();
+    if (lines.stream().allMatch(l -> l.getAction() == LineAction.PERMIT)) {
+      // This is just a big union, flatten it into the list of spaces it unions.
+      return lines.stream().map(AclIp6SpaceLine::getIp6Space);
+    }
+    // Not a pure union, so don't flatten.
+    return Stream.of(aclSpace);
+  }
+
+  /**
+   * Set-theoretic union of multiple {@link Ip6Space IP spaces}.<br>
+   * {@code null} ip6Spaces are ignored. If all arguments are {@code null}, returns {@code null}.
+   */
+  public static @Nullable Ip6Space union(Iterable<Ip6Space> ip6Spaces) {
+    // In one pass, determine if the iterable contains a universe, contains anything, and filter out
+    // null/empty spaces. Have to do this complicated algorithm to properly flatten AclIp6Spaces.
+    boolean[] hasUniverse = new boolean[] {false};
+    boolean[] hasAnything = new boolean[] {false};
+    Ip6Space[] nonEmptySpaces =
+        StreamSupport.stream(ip6Spaces.spliterator(), false)
+            .filter(Objects::nonNull)
+            .flatMap(AclIp6Space::flattenAclIp6SpacesForUnion)
+            .filter(
+                s -> {
+                  hasAnything[0] = true;
+                  if (s instanceof UniverseIp6Space) {
+                    hasUniverse[0] = true;
+                    return false; // can't fully exit from here, but don't include in array
+                  }
+                  return !(s instanceof EmptyIp6Space);
+                })
+            .toArray(Ip6Space[]::new);
+
+    if (hasUniverse[0]) {
+      return UniverseIp6Space.INSTANCE;
+    } else if (!hasAnything[0]) {
+      // no constraint
+      return null;
+    } else if (nonEmptySpaces.length == 0) {
+      return EmptyIp6Space.INSTANCE;
+    } else if (nonEmptySpaces.length == 1) {
+      return nonEmptySpaces[0];
+    }
+    return builder().thenPermitting(nonEmptySpaces).build();
+  }
+
+  @Override
+  public <R> R accept(GenericIp6SpaceVisitor<R> ip6SpaceVisitor) {
+    return ip6SpaceVisitor.visitAclIp6Space(this);
+  }
+
+  @Override
+  protected int compareSameClass(Ip6Space o) {
+    return Comparators.lexicographical(Ordering.<AclIp6SpaceLine>natural())
+        .compare(_lines, ((AclIp6Space) o)._lines);
+  }
+
+  @Override
+  protected boolean exprEquals(Object o) {
+    return _lines.equals(((AclIp6Space) o)._lines);
+  }
+
+  @JsonProperty(PROP_LINES)
+  public @Nonnull List<AclIp6SpaceLine> getLines() {
+    return _lines;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = _hashCode;
+    if (hash == 0) {
+      hash = _lines.hashCode();
+      _hashCode = hash;
+    }
+    return hash;
+  }
+
+  @Override
+  public @Nonnull String toString() {
+    return MoreObjects.toStringHelper(getClass()).add(PROP_LINES, _lines).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIp6SpaceLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIp6SpaceLine.java
@@ -1,0 +1,147 @@
+package org.batfish.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+
+/** A line in an {@link AclIp6Space}. */
+public class AclIp6SpaceLine implements Comparable<AclIp6SpaceLine>, Serializable {
+  // Soft values: let them be garbage collected in times of pressure.
+  // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
+  private static final LoadingCache<Ip6Space, AclIp6SpaceLine> PERMIT_CACHE =
+      Caffeine.newBuilder()
+          .softValues()
+          .maximumSize(1 << 20)
+          .build(s -> new AclIp6SpaceLine(s, LineAction.PERMIT));
+  private static final LoadingCache<Ip6Space, AclIp6SpaceLine> REJECT_CACHE =
+      Caffeine.newBuilder()
+          .softValues()
+          .maximumSize(1 << 20)
+          .build(s -> new AclIp6SpaceLine(s, LineAction.DENY));
+
+  public static class Builder {
+
+    private LineAction _action;
+
+    private Ip6Space _ip6Space;
+
+    private Builder() {
+      _action = LineAction.PERMIT;
+    }
+
+    public AclIp6SpaceLine build() {
+      return create(_ip6Space, _action);
+    }
+
+    public Builder setAction(@Nonnull LineAction action) {
+      _action = action;
+      return this;
+    }
+
+    public Builder setIp6Space(@Nonnull Ip6Space ip6Space) {
+      _ip6Space = ip6Space;
+      return this;
+    }
+  }
+
+  public static final AclIp6SpaceLine DENY_ALL = AclIp6SpaceLine.reject(UniverseIp6Space.INSTANCE);
+
+  public static final AclIp6SpaceLine PERMIT_ALL =
+      AclIp6SpaceLine.permit(UniverseIp6Space.INSTANCE);
+  private static final String PROP_ACTION = "action";
+  private static final String PROP_IP6_SPACE = "ip6Space";
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static AclIp6SpaceLine permit(Ip6Space ip6Space) {
+    return builder().setIp6Space(ip6Space).build();
+  }
+
+  public static AclIp6SpaceLine reject(Ip6Space ip6Space) {
+    return builder().setIp6Space(ip6Space).setAction(LineAction.DENY).build();
+  }
+
+  private final @Nonnull LineAction _action;
+
+  private final @Nonnull Ip6Space _ip6Space;
+
+  @JsonCreator
+  private static AclIp6SpaceLine jsonCreator(
+      @JsonProperty(PROP_IP6_SPACE) @Nonnull Ip6Space ip6Space,
+      @JsonProperty(PROP_ACTION) @Nonnull LineAction action) {
+    return create(ip6Space, action);
+  }
+
+  private static AclIp6SpaceLine create(@Nonnull Ip6Space space, @Nonnull LineAction action) {
+    return action == LineAction.PERMIT ? PERMIT_CACHE.get(space) : REJECT_CACHE.get(space);
+  }
+
+  @VisibleForTesting
+  AclIp6SpaceLine(@Nonnull Ip6Space space, @Nonnull LineAction action) {
+    _ip6Space = space;
+    _action = action;
+  }
+
+  @Override
+  public int compareTo(@Nonnull AclIp6SpaceLine o) {
+    int actionComparison = _action.compareTo(o._action);
+    if (actionComparison != 0) {
+      return actionComparison;
+    }
+    return _ip6Space.compareTo(o._ip6Space);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof AclIp6SpaceLine)) {
+      return false;
+    }
+    AclIp6SpaceLine rhs = (AclIp6SpaceLine) o;
+    return _action == rhs._action && _ip6Space.equals(rhs._ip6Space);
+  }
+
+  @JsonProperty(PROP_ACTION)
+  public @Nonnull LineAction getAction() {
+    return _action;
+  }
+
+  @JsonProperty(PROP_IP6_SPACE)
+  public @Nonnull Ip6Space getIp6Space() {
+    return _ip6Space;
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * _action.ordinal() + _ip6Space.hashCode();
+  }
+
+  public Builder toBuilder() {
+    return builder().setAction(_action).setIp6Space(_ip6Space);
+  }
+
+  @Override
+  public String toString() {
+    ToStringHelper helper = MoreObjects.toStringHelper(getClass());
+    if (_action != LineAction.PERMIT) {
+      helper.add(PROP_ACTION, _action);
+    }
+    helper.add(PROP_IP6_SPACE, _ip6Space);
+    return helper.toString();
+  }
+
+  /** Re-intern after deserialization. */
+  private Object readResolve() throws ObjectStreamException {
+    return create(_ip6Space, _action);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConcreteInterfaceAddress6.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConcreteInterfaceAddress6.java
@@ -45,7 +45,7 @@ public final class ConcreteInterfaceAddress6
         "Invalid network mask %s, must be between 1 and %s",
         networkBits,
         Prefix6.MAX_PREFIX_LENGTH);
-    assert Prefix6.create(ip, networkBits).toIp6Space().containsIp(ip, ImmutableMap.of())
+    assert Prefix6.create(ip, networkBits).toIp6Space().containsIp6(ip, ImmutableMap.of())
         : String.format(
             "ConcreteInterfaceAddress6: IP is not a host IP. ip=%s, networkBits=%d",
             ip, networkBits);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIp6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIp6Space.java
@@ -1,0 +1,58 @@
+package org.batfish.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.visitors.GenericIp6SpaceVisitor;
+
+/** An {@link Ip6Space} that contains no IPv6 addresses. */
+public class EmptyIp6Space extends Ip6Space {
+
+  public static final EmptyIp6Space INSTANCE = new EmptyIp6Space();
+
+  private EmptyIp6Space() {}
+
+  @Override
+  public <R> R accept(GenericIp6SpaceVisitor<R> visitor) {
+    return visitor.visitEmptyIp6Space(this);
+  }
+
+  @Override
+  protected int compareSameClass(Ip6Space o) {
+    return 0;
+  }
+
+  @Override
+  public Ip6Space complement() {
+    return UniverseIp6Space.INSTANCE;
+  }
+
+  @Override
+  protected boolean exprEquals(Object o) {
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().getCanonicalName().hashCode();
+  }
+
+  @Override
+  public @Nonnull String toString() {
+    return "empty";
+  }
+
+  ///////// Ensure that instances are interned.
+
+  @JsonCreator
+  private static EmptyIp6Space jsonCreator() {
+    return INSTANCE;
+  }
+
+  /** Cache after deserialization. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6Ip6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6Ip6Space.java
@@ -1,0 +1,71 @@
+package org.batfish.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.io.ObjectStreamException;
+import java.io.Serial;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.visitors.GenericIp6SpaceVisitor;
+
+/** An {@link Ip6Space} that contains a single IPv6 address. */
+public class Ip6Ip6Space extends Ip6Space {
+  // Soft values: let it be garbage collected in times of pressure.
+  // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
+  private static final LoadingCache<Ip6, Ip6Ip6Space> CACHE =
+      CacheBuilder.newBuilder()
+          .softValues()
+          .maximumSize(1 << 20)
+          .build(CacheLoader.from(Ip6Ip6Space::new));
+  private static final String PROP_IP6 = "ip6";
+
+  private final Ip6 _ip6;
+
+  @JsonCreator
+  static Ip6Ip6Space create(@JsonProperty(PROP_IP6) Ip6 ip6) {
+    return CACHE.getUnchecked(ip6);
+  }
+
+  private Ip6Ip6Space(Ip6 ip6) {
+    _ip6 = ip6;
+  }
+
+  @Override
+  public <R> R accept(GenericIp6SpaceVisitor<R> visitor) {
+    return visitor.visitIp6Ip6Space(this);
+  }
+
+  @Override
+  protected int compareSameClass(Ip6Space o) {
+    return _ip6.compareTo(((Ip6Ip6Space) o)._ip6);
+  }
+
+  @Override
+  protected boolean exprEquals(Object o) {
+    return _ip6.equals(((Ip6Ip6Space) o)._ip6);
+  }
+
+  @JsonProperty(PROP_IP6)
+  public Ip6 getIp6() {
+    return _ip6;
+  }
+
+  @Override
+  public int hashCode() {
+    return _ip6.hashCode();
+  }
+
+  @Override
+  public @Nonnull String toString() {
+    return MoreObjects.toStringHelper(Ip6Ip6Space.class).add(PROP_IP6, _ip6).toString();
+  }
+
+  /** Cache after deserialization. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return CACHE.getUnchecked(_ip6);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6Space.java
@@ -30,6 +30,10 @@ public abstract class Ip6Space implements Comparable<Ip6Space>, Serializable {
   }
 
   /** Return the {@link Ip6Space} of all IPs not in {@code this}. */
+  public Ip6Space complement() {
+    return AclIp6Space.difference(UniverseIp6Space.INSTANCE, this);
+  }
+
   protected abstract int compareSameClass(Ip6Space o);
 
   @Override
@@ -53,8 +57,4 @@ public abstract class Ip6Space implements Comparable<Ip6Space>, Serializable {
 
   @Override
   public abstract @Nonnull String toString();
-
-  public boolean containsIp(Ip6 ip6, Map<String, Ip6Space> namedIp6Spaces) {
-    return accept(new Ip6SpaceContainsIp(ip6, namedIp6Spaces));
-  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6WildcardIp6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6WildcardIp6Space.java
@@ -1,0 +1,70 @@
+package org.batfish.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.io.ObjectStreamException;
+import java.io.Serial;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.visitors.GenericIp6SpaceVisitor;
+
+public class Ip6WildcardIp6Space extends Ip6Space {
+  // Soft values: let it be garbage collected in times of pressure.
+  // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
+  private static final LoadingCache<Ip6Wildcard, Ip6WildcardIp6Space> CACHE =
+      CacheBuilder.newBuilder()
+          .softValues()
+          .maximumSize(1 << 20)
+          .build(CacheLoader.from(Ip6WildcardIp6Space::new));
+  private static final String PROP_IP6_WILDCARD = "ip6Wildcard";
+
+  private final Ip6Wildcard _ip6Wildcard;
+
+  @JsonCreator
+  static Ip6WildcardIp6Space create(@JsonProperty(PROP_IP6_WILDCARD) Ip6Wildcard ip6Wildcard) {
+    return CACHE.getUnchecked(ip6Wildcard);
+  }
+
+  private Ip6WildcardIp6Space(Ip6Wildcard ip6Wildcard) {
+    _ip6Wildcard = ip6Wildcard;
+  }
+
+  @Override
+  public <R> R accept(GenericIp6SpaceVisitor<R> visitor) {
+    return visitor.visitIp6WildcardIp6Space(this);
+  }
+
+  @Override
+  protected int compareSameClass(Ip6Space o) {
+    return _ip6Wildcard.compareTo(((Ip6WildcardIp6Space) o)._ip6Wildcard);
+  }
+
+  @Override
+  protected boolean exprEquals(Object o) {
+    return _ip6Wildcard.equals(((Ip6WildcardIp6Space) o)._ip6Wildcard);
+  }
+
+  @JsonProperty(PROP_IP6_WILDCARD)
+  public Ip6Wildcard getIp6Wildcard() {
+    return _ip6Wildcard;
+  }
+
+  @Override
+  public int hashCode() {
+    return _ip6Wildcard.hashCode();
+  }
+
+  @Override
+  public @Nonnull String toString() {
+    return MoreObjects.toStringHelper(getClass()).add(PROP_IP6_WILDCARD, _ip6Wildcard).toString();
+  }
+
+  /** Cache after deserialization. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return CACHE.getUnchecked(_ip6Wildcard);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6WildcardSetIp6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Ip6WildcardSetIp6Space.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -112,6 +113,7 @@ public class Ip6WildcardSetIp6Space extends Ip6Space {
         && _allowlist.equals(rhs._allowlist);
   }
 
+  @JsonIgnore
   public @Nonnull Set<Ip6Wildcard> getBlockList() {
     return _blocklist;
   }
@@ -121,6 +123,7 @@ public class Ip6WildcardSetIp6Space extends Ip6Space {
     return ImmutableSortedSet.copyOf(_blocklist);
   }
 
+  @JsonIgnore
   public @Nonnull Set<Ip6Wildcard> getAllowList() {
     return _allowlist;
   }
@@ -141,7 +144,7 @@ public class Ip6WildcardSetIp6Space extends Ip6Space {
   }
 
   @Override
-  public String toString() {
+  public @Nonnull String toString() {
     return MoreObjects.toStringHelper(getClass())
         .add(PROP_BLOCKLIST, _blocklist)
         .add(PROP_ALLOWLIST, _allowlist)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixIp6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixIp6Space.java
@@ -6,6 +6,9 @@ import com.google.common.base.MoreObjects;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import java.io.ObjectStreamException;
+import java.io.Serial;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.visitors.GenericIp6SpaceVisitor;
@@ -56,7 +59,13 @@ public class PrefixIp6Space extends Ip6Space {
   }
 
   @Override
-  public String toString() {
+  public @Nonnull String toString() {
     return MoreObjects.toStringHelper(PrefixIp6Space.class).add(PROP_PREFIX, _prefix6).toString();
+  }
+
+  /** Cache after deserialization. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return CACHE.getUnchecked(_prefix6);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UniverseIp6Space.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UniverseIp6Space.java
@@ -1,0 +1,58 @@
+package org.batfish.datamodel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.visitors.GenericIp6SpaceVisitor;
+
+/** An {@link Ip6Space} that contains all IPv6 addresses. */
+public class UniverseIp6Space extends Ip6Space {
+
+  public static final UniverseIp6Space INSTANCE = new UniverseIp6Space();
+
+  private UniverseIp6Space() {}
+
+  @Override
+  public <R> R accept(GenericIp6SpaceVisitor<R> ip6SpaceVisitor) {
+    return ip6SpaceVisitor.visitUniverseIp6Space(this);
+  }
+
+  @Override
+  protected int compareSameClass(Ip6Space o) {
+    return 0;
+  }
+
+  @Override
+  public Ip6Space complement() {
+    return EmptyIp6Space.INSTANCE;
+  }
+
+  @Override
+  protected boolean exprEquals(Object o) {
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().getCanonicalName().hashCode();
+  }
+
+  @Override
+  public @Nonnull String toString() {
+    return "universe";
+  }
+
+  ///////// Ensure that instances are interned.
+
+  @JsonCreator
+  private static UniverseIp6Space jsonCreator() {
+    return INSTANCE;
+  }
+
+  /** Cache after deserialization. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/GenericIp6SpaceVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/GenericIp6SpaceVisitor.java
@@ -1,18 +1,33 @@
 package org.batfish.datamodel.visitors;
 
+import org.batfish.datamodel.AclIp6Space;
+import org.batfish.datamodel.EmptyIp6Space;
+import org.batfish.datamodel.Ip6Ip6Space;
 import org.batfish.datamodel.Ip6Space;
 import org.batfish.datamodel.Ip6SpaceReference;
+import org.batfish.datamodel.Ip6WildcardIp6Space;
 import org.batfish.datamodel.Ip6WildcardSetIp6Space;
 import org.batfish.datamodel.PrefixIp6Space;
+import org.batfish.datamodel.UniverseIp6Space;
 
 public interface GenericIp6SpaceVisitor<R> {
   default R visit(Ip6Space ip6Space) {
     return ip6Space.accept(this);
   }
 
+  R visitAclIp6Space(AclIp6Space aclIp6Space);
+
+  R visitEmptyIp6Space(EmptyIp6Space emptyIp6Space);
+
+  R visitIp6Ip6Space(Ip6Ip6Space ip6Ip6Space);
+
   R visitIp6SpaceReference(Ip6SpaceReference ip6SpaceReference);
 
   R visitPrefixIp6Space(PrefixIp6Space prefixIp6Space);
+
+  R visitUniverseIp6Space(UniverseIp6Space universeIp6Space);
+
+  R visitIp6WildcardIp6Space(Ip6WildcardIp6Space ip6WildcardIp6Space);
 
   R visitIp6WildcardSetIp6Space(Ip6WildcardSetIp6Space ip6WildcardSetIp6Space);
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIp6SpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIp6SpaceTest.java
@@ -1,0 +1,163 @@
+package org.batfish.datamodel;
+
+import static org.batfish.datamodel.AclIp6Space.difference;
+import static org.batfish.datamodel.AclIp6Space.intersection;
+import static org.batfish.datamodel.AclIp6Space.union;
+import static org.batfish.datamodel.matchers.Ip6SpaceMatchers.containsIp6;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class AclIp6SpaceTest {
+  /*
+   * Permit everything in 2001:db8::/32 except for 2001:db8:1::/48.
+   */
+  private static final Ip6Space _aclIp6Space =
+      AclIp6Space.builder()
+          .thenRejecting(Prefix6.parse("2001:db8:1::/48").toIp6Space())
+          .thenPermitting(Prefix6.parse("2001:db8::/32").toIp6Space())
+          .build();
+
+  @Test
+  public void testContainsIp() {
+    assertThat(_aclIp6Space, not(containsIp6(Ip6.parse("2001:db8:1::1"))));
+    assertThat(_aclIp6Space, containsIp6(Ip6.parse("2001:db8:2::1")));
+    assertThat(_aclIp6Space, not(containsIp6(Ip6.parse("2001:db9::1"))));
+  }
+
+  @Test
+  public void testComplement() {
+    Ip6Space notIp6Space = _aclIp6Space.complement();
+    assertThat(notIp6Space, containsIp6(Ip6.parse("2001:db8:1::1")));
+    assertThat(notIp6Space, not(containsIp6(Ip6.parse("2001:db8:2::1"))));
+    assertThat(notIp6Space, containsIp6(Ip6.parse("2001:db9::1")));
+    assertThat(notIp6Space.complement(), equalTo(_aclIp6Space));
+  }
+
+  @Test
+  public void testIntersection() {
+    Ip6Ip6Space ip6Space = Ip6Ip6Space.create(Ip6.parse("2001:db8:2::1"));
+    assertThat(intersection(null, null), nullValue());
+    assertThat(
+        intersection(null, UniverseIp6Space.INSTANCE, null), equalTo(UniverseIp6Space.INSTANCE));
+    assertThat(intersection(ip6Space, null, UniverseIp6Space.INSTANCE), equalTo(ip6Space));
+    assertThat(intersection(EmptyIp6Space.INSTANCE, ip6Space), equalTo(EmptyIp6Space.INSTANCE));
+  }
+
+  @Test
+  public void testUnion() {
+    Ip6Ip6Space ip6Space = Ip6Ip6Space.create(Ip6.parse("2001:db8:2::1"));
+    assertThat(union(null, null), nullValue());
+    assertThat(union(EmptyIp6Space.INSTANCE), equalTo(EmptyIp6Space.INSTANCE));
+    assertThat(union(EmptyIp6Space.INSTANCE, ip6Space), equalTo(ip6Space));
+    assertThat(union(UniverseIp6Space.INSTANCE, ip6Space), equalTo(UniverseIp6Space.INSTANCE));
+    assertThat(union(ip6Space, UniverseIp6Space.INSTANCE), equalTo(UniverseIp6Space.INSTANCE));
+  }
+
+  @Test
+  public void testUnionNested() {
+    Ip6Ip6Space a = Ip6Ip6Space.create(Ip6.parse("2001:db8::1"));
+    Ip6Ip6Space b = Ip6Ip6Space.create(Ip6.parse("2001:db8::2"));
+    Ip6Ip6Space c = Ip6Ip6Space.create(Ip6.parse("2001:db8::3"));
+    assertThat(union(a, b, c), equalTo(union(union(a, b), c)));
+    assertThat(union(a, b, c), equalTo(union(a, union(b, c))));
+  }
+
+  @Test
+  public void testDifference() {
+    Ip6Ip6Space ip6Space = Ip6Ip6Space.create(Ip6.parse("2001:db8::1"));
+
+    // Test null cases
+    assertThat(difference(null, null), nullValue());
+    assertThat(difference(ip6Space, null), equalTo(ip6Space));
+
+    // Test with EmptyIp6Space
+    assertThat(difference(EmptyIp6Space.INSTANCE, ip6Space), equalTo(EmptyIp6Space.INSTANCE));
+    assertThat(difference(ip6Space, EmptyIp6Space.INSTANCE), equalTo(ip6Space));
+
+    // Test with specific IPs
+    Ip6Ip6Space ip1 = Ip6Ip6Space.create(Ip6.parse("2001:db8::1"));
+    Ip6Ip6Space ip2 = Ip6Ip6Space.create(Ip6.parse("2001:db8::2"));
+    Ip6Space diff = difference(ip1, ip2);
+
+    assertThat(diff, containsIp6(Ip6.parse("2001:db8::1")));
+    assertThat(diff, not(containsIp6(Ip6.parse("2001:db8::2"))));
+  }
+
+  @Test
+  public void testStopWhenEmpty() {
+    Ip6Space space =
+        AclIp6Space.builder()
+            .thenPermitting(Prefix6.parse("2001:db8::1/128").toIp6Space())
+            .thenRejecting(UniverseIp6Space.INSTANCE)
+            .thenPermitting(Prefix6.parse("2001:db9::/32").toIp6Space())
+            .build();
+
+    Ip6Space expected =
+        AclIp6Space.builder()
+            .thenPermitting(Prefix6.parse("2001:db8::1/128").toIp6Space())
+            .thenRejecting(UniverseIp6Space.INSTANCE)
+            .build();
+    assertThat(space, equalTo(expected));
+  }
+
+  @Test
+  public void testLineEvaluationOrder() {
+    // Create an ACL that permits 2001:db8::1 but denies 2001:db8::/32
+    Ip6Space space =
+        AclIp6Space.builder()
+            .thenPermitting(Ip6Ip6Space.create(Ip6.parse("2001:db8::1")))
+            .thenRejecting(Prefix6.parse("2001:db8::/32").toIp6Space())
+            .build();
+
+    // The first matching line should determine the result
+    assertThat(space, containsIp6(Ip6.parse("2001:db8::1"))); // First line permits this
+    assertThat(space, not(containsIp6(Ip6.parse("2001:db8::2")))); // Second line denies this
+    assertThat(space, not(containsIp6(Ip6.parse("2001:db9::1")))); // No line matches this
+  }
+
+  @Test
+  public void testOf() {
+    AclIp6SpaceLine line1 = AclIp6SpaceLine.permit(Ip6Ip6Space.create(Ip6.parse("2001:db8::1")));
+    AclIp6SpaceLine line2 = AclIp6SpaceLine.reject(Prefix6.parse("2001:db8::/32").toIp6Space());
+
+    Ip6Space space = AclIp6Space.of(ImmutableList.of(line1, line2));
+
+    assertThat(space, containsIp6(Ip6.parse("2001:db8::1")));
+    assertThat(space, not(containsIp6(Ip6.parse("2001:db8::2"))));
+  }
+
+  @Test
+  public void testSerialization() {
+    Ip6Space original =
+        AclIp6Space.builder()
+            .thenPermitting(Ip6Ip6Space.create(Ip6.parse("2001:db8::1")))
+            .thenRejecting(Prefix6.parse("2001:db8::/32").toIp6Space())
+            .build();
+    assertThat(BatfishObjectMapper.clone(original, Ip6Space.class), equalTo(original));
+    assertThat(SerializationUtils.clone(original), equalTo(original));
+  }
+
+  @Test
+  public void testEquals() {
+    Ip6Ip6Space ip1 = Ip6Ip6Space.create(Ip6.parse("2001:db8::1"));
+    Ip6Ip6Space ip2 = Ip6Ip6Space.create(Ip6.parse("2001:db8::2"));
+    PrefixIp6Space prefix1 = new PrefixIp6Space(Prefix6.parse("2001:db8::/32"));
+
+    new EqualsTester()
+        .addEqualityGroup(
+            AclIp6Space.builder().thenPermitting(ip1).build(),
+            AclIp6Space.builder().thenPermitting(ip1).build())
+        .addEqualityGroup(AclIp6Space.builder().thenPermitting(ip2).build())
+        .addEqualityGroup(AclIp6Space.builder().thenRejecting(ip1).build())
+        .addEqualityGroup(AclIp6Space.builder().thenPermitting(prefix1).thenRejecting(ip1).build())
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EmptyIp6SpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EmptyIp6SpaceTest.java
@@ -1,0 +1,50 @@
+package org.batfish.datamodel;
+
+import static org.batfish.datamodel.matchers.Ip6SpaceMatchers.containsIp6;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class EmptyIp6SpaceTest {
+
+  @Test
+  public void testSingletonBehavior() {
+    assertThat(EmptyIp6Space.INSTANCE, sameInstance(EmptyIp6Space.INSTANCE));
+  }
+
+  @Test
+  public void testInterning() {
+    assertThat(
+        BatfishObjectMapper.clone(EmptyIp6Space.INSTANCE, Ip6Space.class),
+        sameInstance(EmptyIp6Space.INSTANCE));
+    assertThat(
+        SerializationUtils.clone(EmptyIp6Space.INSTANCE), sameInstance(EmptyIp6Space.INSTANCE));
+  }
+
+  @Test
+  public void testComplement() {
+    assertThat(EmptyIp6Space.INSTANCE.complement(), equalTo(UniverseIp6Space.INSTANCE));
+  }
+
+  @Test
+  public void testContainsIp() {
+    // EmptyIp6Space should not contain any IP
+    assertThat(EmptyIp6Space.INSTANCE, not(containsIp6(Ip6.ZERO)));
+    assertThat(EmptyIp6Space.INSTANCE, not(containsIp6(Ip6.MAX)));
+    assertThat(EmptyIp6Space.INSTANCE, not(containsIp6(Ip6.parse("2001:db8::1"))));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(EmptyIp6Space.INSTANCE, EmptyIp6Space.INSTANCE)
+        .addEqualityGroup(UniverseIp6Space.INSTANCE)
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6Ip6SpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6Ip6SpaceTest.java
@@ -1,0 +1,73 @@
+package org.batfish.datamodel;
+
+import static org.batfish.datamodel.matchers.Ip6SpaceMatchers.containsIp6;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class Ip6Ip6SpaceTest {
+
+  @Test
+  public void testContainsIp() {
+    Ip6 ip1 = Ip6.parse("2001:db8::1");
+    Ip6 ip2 = Ip6.parse("2001:db8::2");
+    Ip6Ip6Space ipSpace = Ip6Ip6Space.create(ip1);
+
+    // Should contain only the specific IP it represents
+    assertThat(ipSpace, containsIp6(ip1));
+
+    // Should not contain other IPs
+    assertThat(ipSpace, not(containsIp6(ip2)));
+    assertThat(ipSpace, not(containsIp6(Ip6.ZERO)));
+    assertThat(ipSpace, not(containsIp6(Ip6.MAX)));
+  }
+
+  @Test
+  public void testCaching() {
+    Ip6 ip = Ip6.parse("2001:db8::1");
+    Ip6Ip6Space ipSpace1 = Ip6Ip6Space.create(ip);
+    Ip6Ip6Space ipSpace2 = Ip6Ip6Space.create(ip);
+
+    // Same IP should return the same object (cached)
+    assertThat(ipSpace1, sameInstance(ipSpace2));
+  }
+
+  @Test
+  public void testSerialization() {
+    Ip6Ip6Space original = Ip6Ip6Space.create(Ip6.parse("2001:db8::1"));
+    assertThat(BatfishObjectMapper.clone(original, Ip6Space.class), equalTo(original));
+    assertThat(SerializationUtils.clone(original), equalTo(original));
+  }
+
+  @Test
+  public void testEquals() {
+    Ip6 ip1 = Ip6.parse("2001:db8::1");
+    Ip6 ip2 = Ip6.parse("2001:db8::2");
+
+    new EqualsTester()
+        .addEqualityGroup(Ip6Ip6Space.create(ip1), Ip6Ip6Space.create(ip1))
+        .addEqualityGroup(Ip6Ip6Space.create(ip2))
+        .testEquals();
+  }
+
+  @Test
+  public void testComplement() {
+    Ip6 ip = Ip6.parse("2001:db8::1");
+    Ip6Ip6Space ipSpace = Ip6Ip6Space.create(ip);
+    Ip6Space complement = ipSpace.complement();
+
+    // Complement should not contain the original IP
+    assertThat(complement, not(containsIp6(ip)));
+
+    // Complement should contain other IPs
+    assertThat(complement, containsIp6(Ip6.parse("2001:db8::2")));
+    assertThat(complement, containsIp6(Ip6.ZERO));
+    assertThat(complement, containsIp6(Ip6.MAX));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6SpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6SpaceTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -41,7 +40,7 @@ public class Ip6SpaceTest {
   }
 
   @Test
-  public void testIp6SpaceJacksonSerialization() throws IOException {
+  public void testIp6SpaceJacksonSerialization() {
     for (Ip6Space ip6Space :
         ImmutableList.of(
             Prefix6.parse("1:1:1:1::1/64").toIp6Space(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6WildcardIp6SpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6WildcardIp6SpaceTest.java
@@ -1,0 +1,95 @@
+package org.batfish.datamodel;
+
+import static org.batfish.datamodel.matchers.Ip6SpaceMatchers.containsIp6;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class Ip6WildcardIp6SpaceTest {
+
+  @Test
+  public void testContainsIp() {
+    Ip6 ip1 = Ip6.parse("2001:db8::1");
+    Ip6 ip2 = Ip6.parse("2001:db8::2");
+    Ip6Wildcard wildcard = Ip6Wildcard.parse("2001:db8::1/128");
+    Ip6WildcardIp6Space ipSpace = Ip6WildcardIp6Space.create(wildcard);
+
+    // Should contain only the specific IP in the wildcard
+    assertThat(ipSpace, containsIp6(ip1));
+
+    // Should not contain other IPs
+    assertThat(ipSpace, not(containsIp6(ip2)));
+    assertThat(ipSpace, not(containsIp6(Ip6.ZERO)));
+    assertThat(ipSpace, not(containsIp6(Ip6.MAX)));
+  }
+
+  @Test
+  public void testContainsIpRange() {
+    Ip6 ip1 = Ip6.parse("2001:db8::0");
+    Ip6 ip2 = Ip6.parse("2001:db8::1");
+    Ip6 ip3 = Ip6.parse("2001:db8::2");
+    Ip6 ip4 = Ip6.parse("2001:db8::ffff");
+    Ip6Wildcard wildcard = Ip6Wildcard.parse("2001:db8::/127");
+    Ip6WildcardIp6Space ipSpace = Ip6WildcardIp6Space.create(wildcard);
+
+    // Should contain IPs in the /127 range (2001:db8::0 and 2001:db8::1)
+    assertThat(ipSpace, containsIp6(ip1));
+    assertThat(ipSpace, containsIp6(ip2));
+
+    // Should not contain IPs outside the range
+    assertThat(ipSpace, not(containsIp6(ip3)));
+    assertThat(ipSpace, not(containsIp6(ip4)));
+    assertThat(ipSpace, not(containsIp6(Ip6.ZERO)));
+    assertThat(ipSpace, not(containsIp6(Ip6.MAX)));
+  }
+
+  @Test
+  public void testCaching() {
+    Ip6Wildcard wildcard = Ip6Wildcard.parse("2001:db8::1/128");
+    Ip6WildcardIp6Space ipSpace1 = Ip6WildcardIp6Space.create(wildcard);
+    Ip6WildcardIp6Space ipSpace2 = Ip6WildcardIp6Space.create(wildcard);
+
+    // Same wildcard should return the same object (cached)
+    assertThat(ipSpace1, sameInstance(ipSpace2));
+  }
+
+  @Test
+  public void testSerialization() {
+    Ip6WildcardIp6Space original = Ip6WildcardIp6Space.create(Ip6Wildcard.parse("2001:db8::1/128"));
+    assertThat(BatfishObjectMapper.clone(original, Ip6Space.class), equalTo(original));
+    assertThat(SerializationUtils.clone(original), equalTo(original));
+  }
+
+  @Test
+  public void testEquals() {
+    Ip6Wildcard wildcard1 = Ip6Wildcard.parse("2001:db8::1/128");
+    Ip6Wildcard wildcard2 = Ip6Wildcard.parse("2001:db8::2/128");
+
+    new EqualsTester()
+        .addEqualityGroup(
+            Ip6WildcardIp6Space.create(wildcard1), Ip6WildcardIp6Space.create(wildcard1))
+        .addEqualityGroup(Ip6WildcardIp6Space.create(wildcard2))
+        .testEquals();
+  }
+
+  @Test
+  public void testComplement() {
+    Ip6Wildcard wildcard = Ip6Wildcard.parse("2001:db8::1/128");
+    Ip6WildcardIp6Space ipSpace = Ip6WildcardIp6Space.create(wildcard);
+    Ip6Space complement = ipSpace.complement();
+
+    // Complement should not contain the original IP
+    assertThat(complement, not(containsIp6(Ip6.parse("2001:db8::1"))));
+
+    // Complement should contain other IPs
+    assertThat(complement, containsIp6(Ip6.parse("2001:db8::2")));
+    assertThat(complement, containsIp6(Ip6.ZERO));
+    assertThat(complement, containsIp6(Ip6.MAX));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6WildcardSetIp6SpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Ip6WildcardSetIp6SpaceTest.java
@@ -2,8 +2,12 @@ package org.batfish.datamodel;
 
 import static org.batfish.datamodel.matchers.Ip6SpaceMatchers.containsIp6;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 public class Ip6WildcardSetIp6SpaceTest {
@@ -19,5 +23,34 @@ public class Ip6WildcardSetIp6SpaceTest {
     assertThat(_ip6Space, not(containsIp6(Ip6.parse("1:1:1:1::0"))));
     assertThat(_ip6Space, containsIp6(Ip6.parse("1:1:2:0::0")));
     assertThat(_ip6Space, not(containsIp6(Ip6.parse("1:1:3:0::0"))));
+  }
+
+  @Test
+  public void testSerialization() {
+    Ip6WildcardSetIp6Space original =
+        Ip6WildcardSetIp6Space.builder()
+            .including(Ip6Wildcard.parse("2001:db8::/32"))
+            .excluding(Ip6Wildcard.parse("2001:db8:1::/48"))
+            .build();
+    assertThat(BatfishObjectMapper.clone(original, Ip6Space.class), equalTo(original));
+    assertThat(SerializationUtils.clone(original), equalTo(original));
+  }
+
+  @Test
+  public void testEquals() {
+    Ip6Wildcard wildcard1 = Ip6Wildcard.parse("2001:db8::/32");
+    Ip6Wildcard wildcard2 = Ip6Wildcard.parse("2001:db8:1::/48");
+    Ip6Wildcard wildcard3 = Ip6Wildcard.parse("2001:db8:2::/48");
+
+    new EqualsTester()
+        .addEqualityGroup(
+            Ip6WildcardSetIp6Space.builder().including(wildcard1).build(),
+            Ip6WildcardSetIp6Space.builder().including(wildcard1).build())
+        .addEqualityGroup(Ip6WildcardSetIp6Space.builder().including(wildcard2).build())
+        .addEqualityGroup(
+            Ip6WildcardSetIp6Space.builder().including(wildcard1).excluding(wildcard2).build())
+        .addEqualityGroup(
+            Ip6WildcardSetIp6Space.builder().including(wildcard1).excluding(wildcard3).build())
+        .testEquals();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixIp6SpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PrefixIp6SpaceTest.java
@@ -7,6 +7,8 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import java.util.Optional;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 public class PrefixIp6SpaceTest {
@@ -46,5 +48,12 @@ public class PrefixIp6SpaceTest {
             "fffg:1:1:1::1/64")) {
       assertThat(Prefix6.tryParse(s), equalTo(Optional.empty()));
     }
+  }
+
+  @Test
+  public void testSerialization() {
+    PrefixIp6Space original = new PrefixIp6Space(Prefix6.parse("2001:db8::/32"));
+    assertThat(BatfishObjectMapper.clone(original, Ip6Space.class), equalTo(original));
+    assertThat(SerializationUtils.clone(original), equalTo(original));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/UniverseIp6SpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/UniverseIp6SpaceTest.java
@@ -1,0 +1,52 @@
+package org.batfish.datamodel;
+
+import static org.batfish.datamodel.matchers.Ip6SpaceMatchers.containsIp6;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class UniverseIp6SpaceTest {
+
+  @Test
+  public void testSingletonBehavior() {
+    assertThat(UniverseIp6Space.INSTANCE, sameInstance(UniverseIp6Space.INSTANCE));
+  }
+
+  @Test
+  public void testInterning() {
+    assertThat(
+        BatfishObjectMapper.clone(UniverseIp6Space.INSTANCE, Ip6Space.class),
+        sameInstance(UniverseIp6Space.INSTANCE));
+    assertThat(
+        SerializationUtils.clone(UniverseIp6Space.INSTANCE),
+        sameInstance(UniverseIp6Space.INSTANCE));
+  }
+
+  @Test
+  public void testComplement() {
+    assertThat(UniverseIp6Space.INSTANCE.complement(), equalTo(EmptyIp6Space.INSTANCE));
+  }
+
+  @Test
+  public void testContainsIp() {
+    // UniverseIp6Space should contain all IPs
+    assertThat(UniverseIp6Space.INSTANCE, containsIp6(Ip6.ZERO));
+    assertThat(UniverseIp6Space.INSTANCE, containsIp6(Ip6.MAX));
+    assertThat(UniverseIp6Space.INSTANCE, containsIp6(Ip6.parse("2001:db8::1")));
+    assertThat(UniverseIp6Space.INSTANCE, containsIp6(Ip6.parse("::1")));
+    assertThat(UniverseIp6Space.INSTANCE, containsIp6(Ip6.parse("fe80::1")));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(UniverseIp6Space.INSTANCE, UniverseIp6Space.INSTANCE)
+        .addEqualityGroup(EmptyIp6Space.INSTANCE)
+        .testEquals();
+  }
+}


### PR DESCRIPTION
Implement all seven IPv6 IpSpace variants to match existing IPv4 functionality.

Implementations:
- AclIp6Space: ACL-based IPv6 address space with builder pattern for
constructing permit/reject rules
- AclIp6SpaceLine: Individual ACL entries with permit/reject actions
- EmptyIp6Space: Empty IPv6 address space singleton
- Ip6Ip6Space: Single IPv6 address (consistent with IpIpSpace naming)
- Ip6WildcardIp6Space: IPv6 wildcard-based address ranges
- UniverseIp6Space: Universal IPv6 address space singleton