### PR TITLE
Junos: add parsing and extraction for firewall filter from ttl

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2970,11 +2970,10 @@ TRUNK: 'trunk';
 
 TRUST: 'trust';
 
-TTL: 'ttl';
-
+TTL: 'ttl' -> pushMode(M_SubRange);
 TTL_EQ_ZERO_DURING_REASSEMBLY: 'ttl-eq-zero-during-reassembly';
-
 TTL_EQ_ZERO_DURING_TRANSIT: 'ttl-eq-zero-during-transit';
+TTL_EXCEPT: 'ttl-except' -> pushMode(M_SubRange);
 
 TUNNEL: 'tunnel';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
@@ -151,6 +151,8 @@ fft_from
       | fftf_tcp_established
       | fftf_tcp_flags
       | fftf_tcp_initial
+      | fftf_ttl
+      | fftf_ttl_except
       | fftf_vlan
    )
 ;
@@ -410,6 +412,16 @@ fftf_tcp_flags
 fftf_tcp_initial
 :
    TCP_INITIAL
+;
+
+fftf_ttl
+:
+   TTL uint8_range
+;
+
+fftf_ttl_except
+:
+   TTL_EXCEPT uint8_range
 ;
 
 fftf_vlan

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -398,6 +398,8 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_source_prefix_list
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_tcp_establishedContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_tcp_flagsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_tcp_initialContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_ttlContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_ttl_exceptContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftfa_address_mask_prefixContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftt_acceptContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftt_decapsulateContext;
@@ -1024,6 +1026,7 @@ import org.batfish.representation.juniper.FwFromSourcePort;
 import org.batfish.representation.juniper.FwFromSourcePrefixList;
 import org.batfish.representation.juniper.FwFromSourcePrefixListExcept;
 import org.batfish.representation.juniper.FwFromTcpFlags;
+import org.batfish.representation.juniper.FwFromTtl;
 import org.batfish.representation.juniper.FwTerm;
 import org.batfish.representation.juniper.FwThenAccept;
 import org.batfish.representation.juniper.FwThenDiscard;
@@ -5186,6 +5189,20 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitFftf_tcp_initial(Fftf_tcp_initialContext ctx) {
     _currentFwTerm.getFroms().add(FwFromTcpFlags.TCP_INITIAL);
+  }
+
+  @Override
+  public void exitFftf_ttl(Fftf_ttlContext ctx) {
+    SubRange range = toSubRange(ctx.uint8_range());
+    FwFrom from = new FwFromTtl(range, false);
+    _currentFwTerm.getFroms().add(from);
+  }
+
+  @Override
+  public void exitFftf_ttl_except(Fftf_ttl_exceptContext ctx) {
+    SubRange range = toSubRange(ctx.uint8_range());
+    FwFrom from = new FwFromTtl(range, true);
+    _currentFwTerm.getFroms().add(from);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromTtl.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromTtl.java
@@ -1,0 +1,43 @@
+package org.batfish.representation.juniper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.representation.juniper.FwTerm.Field;
+
+/** Class for firewall filter from ttl */
+@ParametersAreNonnullByDefault
+public class FwFromTtl implements FwFrom {
+
+  private final boolean _except;
+
+  private final @Nonnull SubRange _range;
+
+  public FwFromTtl(SubRange range, boolean except) {
+    _range = range;
+    _except = except;
+  }
+
+  public boolean getExcept() {
+    return _except;
+  }
+
+  public @Nonnull SubRange getRange() {
+    return _range;
+  }
+
+  @Override
+  public Field getField() {
+    return _except ? Field.TTL_EXCEPT : Field.TTL;
+  }
+
+  @Override
+  public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
+    // TODO: support TTL matching in vendor-independent model
+    return AclLineMatchExprs.FALSE;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwTerm.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwTerm.java
@@ -29,7 +29,9 @@ public final class FwTerm implements Serializable {
     SOURCE_EXCEPT,
     SOURCE_INTERFACE,
     SOURCE_PORT,
-    TCP_FLAG
+    TCP_FLAG,
+    TTL,
+    TTL_EXCEPT
   }
 
   private final List<FwFromApplicationSetMember> _fromApplicationSetMembers;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3061,6 +3061,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                     case ICMP_TYPE_EXCEPT:
                     case PACKET_LENGTH_EXCEPT:
                     case SOURCE_EXCEPT:
+                    case TTL_EXCEPT:
                       // FOO_EXCEPT is already compiled to a list of (Not(MatchFoo),
                       // so combining them needs an AND.
                       return and(inner);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filter-ttl
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filter-ttl
@@ -1,0 +1,11 @@
+#
+set system host-name firewall-filter-ttl
+#
+set firewall family inet filter FILTER term SINGLE from ttl 64
+set firewall family inet filter FILTER term SINGLE then accept
+#
+set firewall family inet filter FILTER term RANGE from ttl 10-20
+set firewall family inet filter FILTER term RANGE then accept
+#
+set firewall family inet filter FILTER term EXCEPT from ttl-except 100-200
+set firewall family inet filter FILTER term EXCEPT then accept


### PR DESCRIPTION
Add support for Junos firewall filter TTL match conditions:
- Parse `set firewall family inet filter <FILTER> term <TERM> from ttl <value>` where value is a single TTL (0-255) or range (e.g., 10-20)
- Parse `set firewall family inet filter <FILTER> term <TERM> from ttl-except <value>`
- Extract TTL value/range into FwFromTtl vendor-specific class using SubRange with except flag
- Add FwFromTtl.TTL and FwFromTtl.TTL_EXCEPT field types for tracking
- Push M_SubRange lexer mode after TTL/TTL_EXCEPT keywords to properly tokenize ranges
- Conversion returns FALSE with TODO as TTL is not yet supported in vendor-independent HeaderSpace model

---

Prompt:
```
Let's add support for Junos `set firewall family inet filter FILTER term TERM from ttl <ttl>` where ttl is a valid ttl number. You may find useful information in the Junos CLI reference in working/.
```

Further discussion:
- Extended to support TTL ranges (e.g., `from ttl 10-20`) using uint8_range and SubRange
- Added support for `from ttl-except` following the pattern of other except conditions