### PR TITLE
Junos: support metric2 add/subtract parsing

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -587,7 +587,6 @@ popst_common
    | popst_local_preference
    | popst_metric
    | popst_metric2
-   | popst_metric2_expression
    | popst_multipath_resolve
    | popst_next_hop
    | popst_next_policy
@@ -696,12 +695,34 @@ popstm_value
 
 popst_metric2
 :
-   METRIC2 metric2 = dec
+   METRIC2
+   (
+      popstm2_add
+      | popstm2_expression
+      | popstm2_subtract
+      | popstm2_value
+      | apply_groups
+   )
 ;
 
-popst_metric2_expression
+popstm2_add
 :
-   METRIC2 EXPRESSION metric_expression
+   ADD metric2 = uint32
+;
+
+popstm2_expression
+:
+   EXPRESSION metric_expression
+;
+
+popstm2_subtract
+:
+   SUBTRACT metric2 = uint32
+;
+
+popstm2_value
+:
+   metric2 = uint32
 ;
 
 popst_multipath_resolve

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -651,6 +651,10 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_preferenceContext
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_rejectContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_tag2Context;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_tagContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstm2_addContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstm2_expressionContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstm2_subtractContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstm2_valueContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstm_addContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstm_expressionContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popstm_igpContext;
@@ -1151,6 +1155,7 @@ import org.batfish.representation.juniper.PsThenDefaultActionReject;
 import org.batfish.representation.juniper.PsThenExternal;
 import org.batfish.representation.juniper.PsThenLocalPreference;
 import org.batfish.representation.juniper.PsThenMetric;
+import org.batfish.representation.juniper.PsThenMetric2;
 import org.batfish.representation.juniper.PsThenNextHopDiscard;
 import org.batfish.representation.juniper.PsThenNextHopIp;
 import org.batfish.representation.juniper.PsThenNextHopPeerAddress;
@@ -6554,6 +6559,33 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void exitPopstm_value(Popstm_valueContext ctx) {
     long metric = toLong(ctx.metric);
     addPsThen(new PsThenMetric(metric, PsThenMetric.Operator.SET), ctx);
+  }
+
+  @Override
+  public void exitPopstm2_add(Popstm2_addContext ctx) {
+    long metric2 = toLong(ctx.metric2);
+    addPsThen(new PsThenMetric2(metric2, PsThenMetric2.Operator.ADD), ctx);
+    todo(ctx); // TODO: implement metric2 in VI model
+  }
+
+  @Override
+  public void exitPopstm2_expression(Popstm2_expressionContext ctx) {
+    // TODO: implement metric2 expression
+    todo(ctx);
+  }
+
+  @Override
+  public void exitPopstm2_subtract(Popstm2_subtractContext ctx) {
+    long metric2 = toLong(ctx.metric2);
+    addPsThen(new PsThenMetric2(metric2, PsThenMetric2.Operator.SUBTRACT), ctx);
+    todo(ctx); // TODO: implement metric2 in VI model
+  }
+
+  @Override
+  public void exitPopstm2_value(Popstm2_valueContext ctx) {
+    long metric2 = toLong(ctx.metric2);
+    addPsThen(new PsThenMetric2(metric2, PsThenMetric2.Operator.SET), ctx);
+    todo(ctx); // TODO: implement metric2 in VI model
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenMetric2.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenMetric2.java
@@ -1,0 +1,69 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * Represents the action in Juniper's routing policy(policy statement) which sets the metric2 for a
+ * matched route
+ */
+@ParametersAreNonnullByDefault
+public final class PsThenMetric2 extends PsThen {
+
+  public enum Operator {
+    /** Increment the metric2, clipping at 4,294,967,295. */
+    ADD,
+    /** Decrement the metric2, clipping at 0. */
+    SUBTRACT,
+    /** Set the metric2 to the given value. */
+    SET,
+  }
+
+  private final long _metric2;
+  private final @Nonnull Operator _op;
+
+  public PsThenMetric2(long metric2, Operator op) {
+    _metric2 = metric2;
+    _op = op;
+  }
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings warnings) {
+    // TODO: implement metric2 in VI model
+    // Metric2 is the IGP metric for BGP routes when next hop loops through another router
+    // VI model only supports single metric field, needs additional modeling
+  }
+
+  public long getMetric2() {
+    return _metric2;
+  }
+
+  public @Nonnull Operator getOp() {
+    return _op;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenMetric2)) {
+      return false;
+    }
+    PsThenMetric2 that = (PsThenMetric2) o;
+    return _metric2 == that._metric2 && _op == that._op;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_metric2, _op.ordinal());
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -485,6 +485,7 @@ import org.batfish.representation.juniper.PsThenCommunitySet;
 import org.batfish.representation.juniper.PsThenLocalPreference;
 import org.batfish.representation.juniper.PsThenLocalPreference.Operator;
 import org.batfish.representation.juniper.PsThenMetric;
+import org.batfish.representation.juniper.PsThenMetric2;
 import org.batfish.representation.juniper.PsThenPreference;
 import org.batfish.representation.juniper.PsThenTag;
 import org.batfish.representation.juniper.PsThenTunnelAttributeRemove;
@@ -3843,6 +3844,47 @@ public final class FlatJuniperGrammarTest {
     assertThat(setSub.getMetric(), instanceOf(DecrementMetric.class));
     DecrementMetric dec = (DecrementMetric) setSub.getMetric();
     assertThat(dec.getSubtrahend(), equalTo(30L));
+  }
+
+  @Test
+  public void testPsMetric2AddSubtractExtraction() {
+    JuniperConfiguration c = parseJuniperConfig("metric2-add-subtract");
+    Map<String, PolicyStatement> policies = c.getMasterLogicalSystem().getPolicyStatements();
+
+    // Test literal metric2
+    PolicyStatement ps1 = policies.get("PS1");
+    assertThat(ps1.getTerms().get("T1").getThens().getAllThens(), hasSize(1));
+    assertThat(
+        getOnlyElement(ps1.getTerms().get("T1").getThens().getAllThens()),
+        equalTo(new PsThenMetric2(100, PsThenMetric2.Operator.SET)));
+
+    // Test metric2 add
+    PolicyStatement ps2 = policies.get("PS2");
+    assertThat(ps2.getTerms().get("T1").getThens().getAllThens(), hasSize(1));
+    assertThat(
+        getOnlyElement(ps2.getTerms().get("T1").getThens().getAllThens()),
+        equalTo(new PsThenMetric2(50, PsThenMetric2.Operator.ADD)));
+
+    // Test metric2 subtract
+    PolicyStatement ps3 = policies.get("PS3");
+    assertThat(ps3.getTerms().get("T1").getThens().getAllThens(), hasSize(1));
+    assertThat(
+        getOnlyElement(ps3.getTerms().get("T1").getThens().getAllThens()),
+        equalTo(new PsThenMetric2(30, PsThenMetric2.Operator.SUBTRACT)));
+
+    // Test large metric2 add (near uint32 max)
+    PolicyStatement ps4 = policies.get("PS4");
+    assertThat(ps4.getTerms().get("T1").getThens().getAllThens(), hasSize(1));
+    assertThat(
+        getOnlyElement(ps4.getTerms().get("T1").getThens().getAllThens()),
+        equalTo(new PsThenMetric2(4294967200L, PsThenMetric2.Operator.ADD)));
+
+    // Test large metric2 subtract
+    PolicyStatement ps5 = policies.get("PS5");
+    assertThat(ps5.getTerms().get("T1").getThens().getAllThens(), hasSize(1));
+    assertThat(
+        getOnlyElement(ps5.getTerms().get("T1").getThens().getAllThens()),
+        equalTo(new PsThenMetric2(4294967200L, PsThenMetric2.Operator.SUBTRACT)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenMetric2Test.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenMetric2Test.java
@@ -1,0 +1,49 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+import com.google.common.testing.EqualsTester;
+import java.util.LinkedList;
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.representation.juniper.PsThenMetric2.Operator;
+import org.junit.Test;
+
+public class PsThenMetric2Test {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(5L)
+        .addEqualityGroup(new PsThenMetric2(1, Operator.SET), new PsThenMetric2(1, Operator.SET))
+        .addEqualityGroup(new PsThenMetric2(2, Operator.SET))
+        .addEqualityGroup(new PsThenMetric2(1, Operator.ADD))
+        .addEqualityGroup(new PsThenMetric2(1, Operator.SUBTRACT))
+        .testEquals();
+  }
+
+  List<Statement> getStatements(PsThenMetric2 p) {
+    List<Statement> statements = new LinkedList<>();
+    JuniperConfiguration fakeVsConfig = new JuniperConfiguration();
+    fakeVsConfig.setHostname("c");
+    Configuration fakeConfig =
+        Configuration.builder()
+            .setHostname("c")
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .build();
+    p.applyTo(statements, fakeVsConfig, fakeConfig, new Warnings());
+    return statements;
+  }
+
+  @Test
+  public void testConversion() {
+    // No VI model support for metric2 yet
+    // applyTo() is a no-op with TODO comment
+    assertThat(getStatements(new PsThenMetric2(1, Operator.SET)), empty());
+    assertThat(getStatements(new PsThenMetric2(2, Operator.SUBTRACT)), empty());
+    assertThat(getStatements(new PsThenMetric2(3, Operator.ADD)), empty());
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/metric2-add-subtract
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/metric2-add-subtract
@@ -1,0 +1,16 @@
+set system host-name metric2-add-subtract
+
+set policy-options policy-statement PS1 term T1 from protocol bgp
+set policy-options policy-statement PS1 term T1 then metric2 100
+
+set policy-options policy-statement PS2 term T1 from protocol bgp
+set policy-options policy-statement PS2 term T1 then metric2 add 50
+
+set policy-options policy-statement PS3 term T1 from protocol bgp
+set policy-options policy-statement PS3 term T1 then metric2 subtract 30
+
+set policy-options policy-statement PS4 term T1 from protocol bgp
+set policy-options policy-statement PS4 term T1 then metric2 add 4294967200
+
+set policy-options policy-statement PS5 term T1 from protocol bgp
+set policy-options policy-statement PS5 term T1 then metric2 subtract 4294967200


### PR DESCRIPTION
Add parsing and extraction for `set policy-options policy-statement PS term TERM then metric2 add/subtract <m>`. Refactor metric2 grammar to use subrules per token for LL(1) compliance, matching the pattern used for metric operators. VI model conversion is TODO since metric2 (IGP metric for BGP routes with recursive next hops) is not currently modeled.

Changes:
- Consolidate popst_metric2 rule with subrules: popstm2_add, popstm2_expression, popstm2_subtract, popstm2_value
- Remove popst_metric2_expression from popst_common
- Add apply_groups alternative at popst_metric2 level
- Change metric2 value type from dec to uint32 for full Junos range (0-4,294,967,295)
- Create PsThenMetric2 with Operator enum (ADD/SUBTRACT/SET), matching PsThenMetric pattern
- Update ConfigurationBuilder with separate exitPopstm2_* methods for each subrule
- PsThenMetric2.applyTo() is TODO - VI model lacks metric2 field
- Add extraction tests for metric2 add/subtract parsing into PsThenMetric2
- Add unit tests in PsThenMetric2Test for equals/hashCode (conversion test verifies no-op)

---

Prompt:
```
I pushed!

Now let's do metric2, just like metric. Ground it in the CLI text, again
```

Further discussion:
- Confirmed metric2 add/subtract support from working/junos-routing-policy.pdf line 4965
- VI model doesn't support metric2 (IGP metric), so conversion is left as TODO

---

**Stack**:
- #9767
- #9768
- #9695
- #9694
- #9667
- #9666 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*