### PR TITLE
Junos: parse and extract BGP group local-preference

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -115,6 +115,7 @@ b_common
    | b_keep
    | b_local_address
    | b_local_as
+   | b_local_preference
    | b_multihop
    | b_multipath
    | b_no_client_reflect
@@ -214,6 +215,11 @@ b_local_address
 b_local_as
 :
    LOCAL_AS bl_number? bl_common*
+;
+
+b_local_preference
+:
+   LOCAL_PREFERENCE localpref = uint32
 ;
 
 b_multihop

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -321,6 +321,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_groupContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_importContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_keepContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_local_addressContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_local_preferenceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_multihopContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_multipathContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_neighborContext;
@@ -4691,6 +4692,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void exitB_preference(B_preferenceContext ctx) {
     int preference = toInt(ctx.pref);
     _currentBgpGroup.setPreference(preference);
+  }
+
+  @Override
+  public void exitB_local_preference(B_local_preferenceContext ctx) {
+    long localPreference = toLong(ctx.localpref);
+    _currentBgpGroup.setLocalPreference(localPreference);
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
@@ -43,6 +43,7 @@ public class BgpGroup implements Serializable {
   private @Nullable BgpKeepType _keep;
   private Ip _localAddress;
   private Long _localAs;
+  private @Nullable Long _localPreference;
   private Integer _loops;
   private Boolean _multipath;
   private Boolean _multipathMultipleAs;
@@ -116,6 +117,9 @@ public class BgpGroup implements Serializable {
       }
       if (_localAs == null) {
         _localAs = _parent._localAs;
+      }
+      if (_localPreference == null) {
+        _localPreference = _parent._localPreference;
       }
       if (_loops == null) {
         _loops = _parent._loops;
@@ -265,6 +269,22 @@ public class BgpGroup implements Serializable {
 
   public void setPreference(@Nullable Integer preference) {
     _preference = preference;
+  }
+
+  /**
+   * Local preference value to set on routes advertised to this group/neighbor. Distinct from
+   * preference (admin distance) and from local-preference manipulated via routing policy.
+   *
+   * @see <a
+   *     href="https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/ref/statement/local-preference-edit-protocols-bgp.html">local-preference
+   *     (Protocols BGP)</a>
+   */
+  public @Nullable Long getLocalPreference() {
+    return _localPreference;
+  }
+
+  public void setLocalPreference(@Nullable Long localPreference) {
+    _localPreference = localPreference;
   }
 
   public Boolean getRemovePrivate() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -9724,5 +9724,27 @@ public final class FlatJuniperGrammarTest {
         equalTo(4000));
   }
 
+  @Test
+  public void testBgpLocalPreference() {
+    JuniperConfiguration config = parseJuniperConfig("bgp-local-preference");
+    Map<String, NamedBgpGroup> groups =
+        config.getMasterLogicalSystem().getDefaultRoutingInstance().getNamedBgpGroups();
+    BgpGroup master =
+        config.getMasterLogicalSystem().getDefaultRoutingInstance().getMasterBgpGroup();
+
+    // Process-level local-preference
+    assertThat(master.getLocalPreference(), equalTo(50L));
+
+    // Group with override
+    BgpGroup groupOverride = groups.get("TEST-GROUP");
+    assertThat(groupOverride.getLocalPreference(), equalTo(100L));
+
+    // Group that inherits from process level
+    BgpGroup groupInherit = groups.get("TEST-GROUP-INHERIT");
+    assertThat(groupInherit.getLocalPreference(), nullValue());
+    groupInherit.cascadeInheritance();
+    assertThat(groupInherit.getLocalPreference(), equalTo(50L));
+  }
+
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-local-preference
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-local-preference
@@ -1,0 +1,14 @@
+#
+set system host-name bgp-local-preference
+#
+set routing-options router-id 1.1.1.1
+set routing-options autonomous-system 1
+# Process-level default
+set protocols bgp local-preference 50
+# Group-level override
+set protocols bgp group TEST-GROUP type internal
+set protocols bgp group TEST-GROUP local-preference 100
+set protocols bgp group TEST-GROUP neighbor 1.1.1.2
+# Group that inherits from process level
+set protocols bgp group TEST-GROUP-INHERIT type internal
+set protocols bgp group TEST-GROUP-INHERIT neighbor 1.1.1.3


### PR DESCRIPTION
Adds support for configuring local-preference value on routes advertised
to a BGP group or neighbor. This is distinct from preference (admin
distance) and from local-preference manipulation via routing policy.

---

Prompt:
```
Why is `set protocols bgp group <group-name> local-preference 100` unrecognized and/or unimplemented? I'd think this is supported. Read any Junos manuals in working/* for what it does.
```

---

**Stack**:
- #9767
- #9768
- #9695
- #9694
- #9667 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*