### PR TITLE
BGP: reset local preference and weight in post-export

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -85,8 +85,6 @@ public final class BgpProtocolHelper {
     builder.setProtocol(outgoingProtocol);
     builder.setSrcProtocol(routeProtocol);
 
-    // Clear a bunch of non-transitive attributes
-    builder.setWeight(0);
     if (!(route instanceof EvpnRoute<?, ?>)) {
       // These attributes are constants for EVPN routes and cannot be set
       builder.setNonRouting(false);
@@ -187,12 +185,6 @@ public final class BgpProtocolHelper {
     if (!localSessionProperties.advertiseUnchangedMed() && !routeOriginatedLocally) {
       builder.setMetric(0);
     }
-
-    // Local preference: only transitive for iBGP or within a confederation
-    builder.setLocalPreference(
-        localSessionProperties.advertiseUnchangedLocalPref()
-            ? route.getLocalPreference()
-            : DEFAULT_LOCAL_PREFERENCE);
 
     return builder;
   }
@@ -419,6 +411,7 @@ public final class BgpProtocolHelper {
     transformBgpRoutePostExport(
         routeBuilder,
         ourSessionProperties.isEbgp(),
+        ourSessionProperties.advertiseUnchangedLocalPref(),
         af.getAddressFamilyCapabilities().getSendCommunity(),
         af.getAddressFamilyCapabilities().getSendExtendedCommunity(),
         ourSessionProperties.getConfedSessionType(),
@@ -438,6 +431,8 @@ public final class BgpProtocolHelper {
    *
    * @param routeBuilder Builder for the output (exported) route
    * @param isEbgp true for ebgp sessions
+   * @param advertiseUnchangedLocalPref whether to preserve local preference (true for iBGP and eBGP
+   *     within a confederation)
    * @param sendStandardCommunities whether to send standard communities to the neighbor
    * @param sendExtendedCommunities whether to send extended communities to the neighbor
    * @param confedSessionType type of confederation session, if any
@@ -452,6 +447,7 @@ public final class BgpProtocolHelper {
       void transformBgpRoutePostExport(
           B routeBuilder,
           boolean isEbgp,
+          boolean advertiseUnchangedLocalPref,
           boolean sendStandardCommunities,
           boolean sendExtendedCommunities,
           ConfedSessionType confedSessionType,
@@ -493,6 +489,15 @@ public final class BgpProtocolHelper {
       }
 
       routeBuilder.setAsPath(routeAsPath);
+    }
+
+    // Weight is non-transitive and not carried in BGP UPDATE messages.
+    routeBuilder.setWeight(0);
+
+    // Local preference is non-transitive: clear for eBGP sessions outside a confederation (after
+    // export policy may have set it). Within a confederation, local-pref is preserved.
+    if (!advertiseUnchangedLocalPref) {
+      routeBuilder.setLocalPreference(DEFAULT_LOCAL_PREFERENCE);
     }
 
     // Tags are non-transitive

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD.bazel
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD.bazel
@@ -29,6 +29,7 @@ junit_tests(
         "//projects/batfish/src/test/resources",
         "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-backup-routes",
         "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export",
+        "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-local-pref-ebgp",
         "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-topology-change",
     ],
     runtime_deps = [

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpLocalPrefEbgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpLocalPrefEbgpTest.java
@@ -1,0 +1,57 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.datamodel.BgpRoute.DEFAULT_LOCAL_PREFERENCE;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasLocalPreference;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+
+import java.io.IOException;
+import java.util.Set;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Prefix;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Test that local preference set by an export route-map is not propagated across EBGP sessions.
+ * Local preference is non-transitive and should always be reset to the default on the receiving
+ * side.
+ *
+ * <p>Regression test for https://github.com/batfish/batfish/issues/9262
+ */
+public final class BgpLocalPrefEbgpTest {
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  /**
+   * R1 (AS 400) advertises 100.0.0.0/8 to R2 (AS 512) with an outbound route-map that sets
+   * local-preference to 50. R2 should install the route with the default local-preference of 100.
+   */
+  @Test
+  public void testEbgpLocalPreferenceReset() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/bgp-local-pref-ebgp";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder().setConfigurationFiles(snapshotPath, "r1", "r2").build(), _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dataplane =
+        (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+
+    Set<Bgpv4Route> bgpRoutesOnR2 =
+        dataplane.getBgpRoutes().get("r2", Configuration.DEFAULT_VRF_NAME);
+
+    assertThat(
+        bgpRoutesOnR2,
+        contains(
+            allOf(
+                hasPrefix(Prefix.parse("100.0.0.0/8")),
+                hasLocalPreference(DEFAULT_LOCAL_PREFERENCE))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -261,13 +261,24 @@ public class BgpProtocolHelperTest {
   public void testTransformPostExportClearTag() {
     Builder builder = _baseBgpRouteBuilder.setTag(MAX_TAG);
     transformBgpRoutePostExport(
-        builder, true, false, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
+        builder,
+        true,
+        true,
+        false,
+        false,
+        ConfedSessionType.NO_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
     assertThat("Tag is cleared", builder.getTag(), equalTo(UNSET_ROUTE_TAG));
 
     builder.setTag(MAX_TAG);
     transformBgpRoutePostExport(
         builder,
         false,
+        true,
         false,
         false,
         ConfedSessionType.NO_CONFED,
@@ -287,13 +298,33 @@ public class BgpProtocolHelperTest {
     // Nothing sent
     Builder builder = _baseBgpRouteBuilder.setCommunities(mixedComms).build().toBuilder();
     transformBgpRoutePostExport(
-        builder, true, false, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
+        builder,
+        true,
+        true,
+        false,
+        false,
+        ConfedSessionType.NO_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
     assertThat("Communities cleared", builder.getCommunities(), equalTo(CommunitySet.empty()));
 
     // only standard sent
     builder = _baseBgpRouteBuilder.setCommunities(mixedComms).build().toBuilder();
     transformBgpRoutePostExport(
-        builder, true, true, false, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
+        builder,
+        true,
+        true,
+        true,
+        false,
+        ConfedSessionType.NO_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
     assertThat(
         "Only standard communities",
         builder.getCommunities().getCommunities(),
@@ -302,7 +333,17 @@ public class BgpProtocolHelperTest {
     // only extended sent
     builder = _baseBgpRouteBuilder.setCommunities(mixedComms).build().toBuilder();
     transformBgpRoutePostExport(
-        builder, true, false, true, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
+        builder,
+        true,
+        true,
+        false,
+        true,
+        ConfedSessionType.NO_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
     assertThat(
         "Only extended communities",
         builder.getCommunities().getCommunities(),
@@ -311,7 +352,17 @@ public class BgpProtocolHelperTest {
     // both sent
     builder = _baseBgpRouteBuilder.setCommunities(mixedComms).build().toBuilder();
     transformBgpRoutePostExport(
-        builder, true, true, true, ConfedSessionType.NO_CONFED, 1, DEST_IP, Ip.ZERO, null, false);
+        builder,
+        true,
+        true,
+        true,
+        true,
+        ConfedSessionType.NO_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
     assertThat("All communities", builder.getCommunities(), equalTo(mixedComms));
   }
 
@@ -322,6 +373,7 @@ public class BgpProtocolHelperTest {
     _baseBgpRouteBuilder.setAsPath(baseAsPath);
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
+        true,
         true,
         false,
         false,
@@ -346,6 +398,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         true,
+        true,
         false,
         false,
         ConfedSessionType.ACROSS_CONFED_BORDER,
@@ -364,6 +417,7 @@ public class BgpProtocolHelperTest {
     _baseBgpRouteBuilder.setAsPath(baseAsPath);
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
+        true,
         true,
         false,
         false,
@@ -388,6 +442,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         false,
+        true,
         false,
         false,
         ConfedSessionType.NO_CONFED,
@@ -404,6 +459,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         false,
+        true,
         false,
         false,
         ConfedSessionType.WITHIN_CONFED,
@@ -424,6 +480,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         true,
+        true,
         false,
         false,
         ConfedSessionType.NO_CONFED,
@@ -438,6 +495,7 @@ public class BgpProtocolHelperTest {
     _baseBgpRouteBuilder.setNextHopIp(null);
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
+        true,
         true,
         false,
         false,
@@ -454,6 +512,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         true,
+        true,
         false,
         false,
         ConfedSessionType.WITHIN_CONFED,
@@ -469,6 +528,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         false,
+        true,
         false,
         false,
         ConfedSessionType.NO_CONFED,
@@ -484,6 +544,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         false,
+        true,
         false,
         false,
         ConfedSessionType.WITHIN_CONFED,
@@ -498,6 +559,7 @@ public class BgpProtocolHelperTest {
     _baseBgpRouteBuilder.setNextHopIp(null);
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
+        true,
         true,
         false,
         false,
@@ -514,6 +576,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         false,
+        true,
         false,
         false,
         ConfedSessionType.NO_CONFED,
@@ -529,6 +592,7 @@ public class BgpProtocolHelperTest {
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder,
         false,
+        true,
         false,
         false,
         ConfedSessionType.WITHIN_CONFED,

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -25,6 +25,7 @@ import org.batfish.datamodel.AsSet;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Bgpv4Route.Builder;
@@ -203,6 +204,7 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
     transformBgpRoutePostExport(
         routeBuilder,
         _sessionProperties.isEbgp(),
+        _sessionProperties.advertiseUnchangedLocalPref(),
         _fromNeighbor
             .getIpv4UnicastAddressFamily()
             .getAddressFamilyCapabilities()
@@ -504,20 +506,23 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
     assertThat(transformedBgpRoute.getMetric(), equalTo(1000L));
   }
 
-  /** Test that weight is cleared before exporting for both IBGP and EBGP. */
+  /** Test that weight is cleared in post-export for both IBGP and EBGP. */
   @Test
-  public void testWeightIsClearedBeforeExport() {
-    Bgpv4Route bgpv4Route = _baseBgpRouteBuilder.setWeight(19).build();
-
-    // IBGP
-    setUpPeers(true);
-    Bgpv4Route.Builder transformedBgpRoute = runTransformBgpRoutePreExport(bgpv4Route);
-    assertThat(transformedBgpRoute.getWeight(), equalTo(0));
+  public void testWeightIsClearedPostExport() {
+    int nonZeroWeight = 19;
 
     // EBGP
     setUpPeers(false);
-    transformedBgpRoute = runTransformBgpRoutePreExport(bgpv4Route);
-    assertThat(transformedBgpRoute.getWeight(), equalTo(0));
+    Builder routeBuilder =
+        Bgpv4Route.testBuilder().setWeight(nonZeroWeight).setNetwork(DEST_NETWORK);
+    runTransformBgpRoutePostExport(routeBuilder);
+    assertThat(routeBuilder.getWeight(), equalTo(0));
+
+    // IBGP
+    setUpPeers(true);
+    routeBuilder = Bgpv4Route.testBuilder().setWeight(nonZeroWeight).setNetwork(DEST_NETWORK);
+    runTransformBgpRoutePostExport(routeBuilder);
+    assertThat(routeBuilder.getWeight(), equalTo(0));
   }
 
   @Test
@@ -572,12 +577,87 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
     assertThat(runTransformBgpRoutePreExport(bgpRoute).getMetric(), equalTo(metric));
   }
 
+  /**
+   * Test that local preference is reset to default in post-export for eBGP sessions, even if the
+   * export policy set it to a non-default value. Local preference is non-transitive and should not
+   * be propagated across eBGP session boundaries.
+   */
+  @Test
+  public void testLocalPreferenceClearedPostExportForEbgp() {
+    long nonDefaultLocalPref = 50;
+    Builder routeBuilder =
+        Bgpv4Route.testBuilder().setLocalPreference(nonDefaultLocalPref).setNetwork(DEST_NETWORK);
+
+    // eBGP: local preference should be reset to default
+    transformBgpRoutePostExport(
+        routeBuilder,
+        true,
+        false,
+        false,
+        false,
+        ConfedSessionType.NO_CONFED,
+        1,
+        Ip.parse("1.1.1.1"),
+        Ip.ZERO,
+        null,
+        false);
+    assertThat(routeBuilder.getLocalPreference(), equalTo(BgpRoute.DEFAULT_LOCAL_PREFERENCE));
+  }
+
+  /**
+   * Test that local preference is preserved in post-export for iBGP sessions and eBGP sessions
+   * within a confederation.
+   */
+  @Test
+  public void testLocalPreferencePreservedPostExportForIbgpAndConfed() {
+    long nonDefaultLocalPref = 50;
+
+    // iBGP: local preference should be preserved
+    {
+      Builder routeBuilder =
+          Bgpv4Route.testBuilder().setLocalPreference(nonDefaultLocalPref).setNetwork(DEST_NETWORK);
+      transformBgpRoutePostExport(
+          routeBuilder,
+          false,
+          true,
+          false,
+          false,
+          ConfedSessionType.NO_CONFED,
+          1,
+          Ip.parse("1.1.1.1"),
+          Ip.parse("1.1.1.1"),
+          null,
+          false);
+      assertThat(routeBuilder.getLocalPreference(), equalTo(nonDefaultLocalPref));
+    }
+
+    // eBGP within confederation: local preference should be preserved
+    {
+      Builder routeBuilder =
+          Bgpv4Route.testBuilder().setLocalPreference(nonDefaultLocalPref).setNetwork(DEST_NETWORK);
+      transformBgpRoutePostExport(
+          routeBuilder,
+          true,
+          true,
+          false,
+          false,
+          ConfedSessionType.WITHIN_CONFED,
+          1,
+          Ip.parse("1.1.1.1"),
+          Ip.parse("1.1.1.1"),
+          null,
+          false);
+      assertThat(routeBuilder.getLocalPreference(), equalTo(nonDefaultLocalPref));
+    }
+  }
+
   @Test
   public void testAggregateProtocolIsCleared() {
     Builder routeBuilder = Bgpv4Route.testBuilder().setProtocol(RoutingProtocol.AGGREGATE);
     transformBgpRoutePostExport(
         routeBuilder,
         true,
+        false,
         false,
         false,
         ConfedSessionType.NO_CONFED,

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-local-pref-ebgp/BUILD.bazel
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-local-pref-ebgp/BUILD.bazel
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "bgp-local-pref-ebgp",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD.bazel"],
+    ),
+)

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-local-pref-ebgp/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-local-pref-ebgp/configs/r1
@@ -1,0 +1,17 @@
+!
+hostname r1
+!
+interface Ethernet0/1
+ ip address 3.0.0.3 255.0.0.0
+!
+interface Ethernet0/2
+ ip address 100.0.0.1 255.0.0.0
+!
+route-map RM1 permit 10
+ set local-preference 50
+!
+router bgp 400
+ network 100.0.0.0
+ neighbor 3.0.0.2 remote-as 512
+ neighbor 3.0.0.2 route-map RM1 out
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-local-pref-ebgp/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-local-pref-ebgp/configs/r2
@@ -1,0 +1,9 @@
+!
+hostname r2
+!
+interface Ethernet0/1
+ ip address 3.0.0.2 255.0.0.0
+!
+router bgp 512
+ neighbor 3.0.0.3 remote-as 400
+!


### PR DESCRIPTION
Local preference and weight are non-transitive BGP attributes that
should not be propagated to peers. Previously, both were cleared in
transformBgpRoutePreExport, before the export policy ran. If the
export policy set either attribute (e.g., via `set local-preference`
or `set weight`), the value would persist into the exported route.

For local preference, this meant an EBGP peer would install a route
with the sender's local-pref instead of the default (100).

Move both resets to transformBgpRoutePostExport so they run after
the export policy. Local-pref is preserved for IBGP and
within-confederation sessions via an `advertiseUnchangedLocalPref`
parameter. Weight is always cleared since it is never carried in
BGP UPDATE messages.

Fixes https://github.com/batfish/batfish/issues/9262

----

Prompt:
```
Fix https://github.com/batfish/batfish/issues/9262
```