### PR TITLE
Fix NPE in processExternalBgpAdvertisement for null originator IP

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -1951,7 +1951,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
               .setMetric(advert.getMed())
               .setNetwork(advert.getNetwork())
               .setNextHopIp(advert.getNextHopIp())
-              .setOriginatorIp(advert.getOriginatorIp())
+              .setOriginatorIp(firstNonNull(advert.getOriginatorIp(), advert.getSrcIp()))
               .setOriginMechanism(LEARNED)
               .setOriginType(advert.getOriginType())
               .setProtocol(targetProtocol)
@@ -1983,7 +1983,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
               .setMetric(advert.getMed())
               .setNetwork(advert.getNetwork())
               .setNextHopIp(advert.getNextHopIp())
-              .setOriginatorIp(advert.getOriginatorIp())
+              .setOriginatorIp(firstNonNull(advert.getOriginatorIp(), advert.getSrcIp()))
               // Don't know the origin mechanism on the sender, but for us it will be LEARNED
               .setOriginMechanism(LEARNED)
               .setOriginType(advert.getOriginType())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 import java.util.Collections;
@@ -42,7 +43,10 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpAdvertisement;
+import org.batfish.datamodel.BgpAdvertisement.BgpAdvertisementType;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpProcess;
@@ -954,6 +958,53 @@ public class BgpRoutingProcessTest {
 
     // policy application will overwrite the next hop ip
     assertThat(outputRouteBuilder.build().getNextHopIp(), equalTo(neighborIp));
+  }
+
+  /**
+   * Test that external BGP advertisements with null originator IP don't crash. Both the "received"
+   * path (EBGP_RECEIVED) and "sent" path (EBGP_SENT) build Bgpv4Routes that require non-null
+   * originator IP; the code must fall back to srcIp.
+   */
+  @Test
+  public void testProcessExternalBgpAdvertisement_nullOriginatorIp() {
+    Ip srcIp = Ip.parse("1.1.1.1");
+
+    // Add a neighbor to the BGP process so processExternalBgpAdvertisement can find it
+    BgpActivePeerConfig neighbor =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(Ip.parse("1.1.1.2"))
+            .setLocalAs(1L)
+            .setRemoteAs(2L)
+            .setPeerAddress(srcIp)
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
+            .build();
+    _bgpProcess.setNeighbors(ImmutableMap.of(srcIp, neighbor));
+
+    // Before the fix, this threw IllegalArgumentException: Missing originatorIp
+    for (BgpAdvertisementType type :
+        ImmutableList.of(BgpAdvertisementType.EBGP_RECEIVED, BgpAdvertisementType.EBGP_SENT)) {
+      BgpAdvertisement advert =
+          BgpAdvertisement.builder()
+              .setType(type)
+              .setNetwork(Prefix.ZERO)
+              .setNextHopIp(Ip.parse("2.2.2.2"))
+              .setSrcIp(srcIp)
+              .setSrcNode("neighbor")
+              .setSrcVrf(DEFAULT_VRF_NAME)
+              .setDstIp(Ip.parse("1.1.1.2"))
+              .setDstNode("c1")
+              .setDstVrf(DEFAULT_VRF_NAME)
+              .setOriginType(OriginType.EGP)
+              .setSrcProtocol(RoutingProtocol.BGP)
+              .setAsPath(AsPath.empty())
+              .setCommunities(ImmutableSortedSet.of())
+              .setClusterList(ImmutableSortedSet.of())
+              // originatorIp intentionally not set (null)
+              .build();
+
+      // Should not throw; originator IP should fall back to srcIp
+      _routingProcess.processExternalBgpAdvertisement(advert);
+    }
   }
 
   @Test


### PR DESCRIPTION
After BgpAdvertisement.getOriginatorIp() became @Nullable in #9823, external BGP advertisements without an originator IP caused IllegalArgumentException ("Missing originatorIp") when building Bgpv4Routes. Both the EBGP_RECEIVED and EBGP_SENT code paths passed the nullable value directly to the route builder.

Fall back to advert.getSrcIp() when originator IP is null.

----

Prompt:
```
After the Ip.AUTO removal in #9823, processExternalBgpAdvertisement
is crashing:

Caused by: java.lang.IllegalArgumentException: Missing
originatorIp
    at com.google.common.base.Preconditions.checkArgument(
        Preconditions.java:217)
    at org.batfish.datamodel.Bgpv4Route$Builder.build(
        Bgpv4Route.java:41)
    at org.batfish.dataplane.ibdp.BgpRoutingProcess
        .processExternalBgpAdvertisement(
        BgpRoutingProcess.java:1995)

can you figure out the issue and fix it?
```