### PR TITLE
Ip: store as int instead of long for memory savings

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/Ip.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Ip.java
@@ -19,7 +19,7 @@ public class Ip implements Comparable<Ip>, Serializable {
 
   // Soft values: let it be garbage collected in times of pressure.
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
-  //   (8 bytes seems smallest possible entry (long), would be 8 MiB total).
+  //   (4 bytes seems smallest possible entry (int), would be 4 MiB total).
   private static final LoadingCache<Ip, Ip> CACHE =
       CacheBuilder.newBuilder().softValues().maximumSize(1 << 20).build(CacheLoader.from(x -> x));
 
@@ -38,27 +38,33 @@ public class Ip implements Comparable<Ip>, Serializable {
   public static final Ip ZERO = create(0L);
 
   /**
-   * See {@link #getBitAtPosition(long, int)}. Equivalent to {@code getBitAtPosition(ip.asLong(),
-   * position)}
-   */
-  public static boolean getBitAtPosition(Ip ip, int position) {
-    return getBitAtPosition(ip.asLong(), position);
-  }
-
-  /**
    * Return the boolean value of a bit at the given position.
    *
-   * @param bits the representation of an IP address as a long
+   * @param bits the representation of an IP address as an int (unsigned 32-bit value)
    * @param position bit position (0 means most significant, 31 least significant)
-   * @return a boolean representation of the bit value
    */
-  public static boolean getBitAtPosition(long bits, int position) {
+  public static boolean getBitAtPosition(int bits, int position) {
     checkArgument(
         position >= 0 && position < Prefix.MAX_PREFIX_LENGTH, "Invalid bit position %s", position);
     return (bits & (1 << (Prefix.MAX_PREFIX_LENGTH - 1 - position))) != 0;
   }
 
-  private static long ipStrToLong(String addr) {
+  /**
+   * Return the boolean value of a bit at the given position.
+   *
+   * @param bits the representation of an IP address as a long (unsigned 32-bit value)
+   * @param position bit position (0 means most significant, 31 least significant)
+   */
+  public static boolean getBitAtPosition(long bits, int position) {
+    return getBitAtPosition((int) bits, position);
+  }
+
+  /** Return the boolean value of the bit at the given position (0 = most significant). */
+  public boolean getBitAtPosition(int position) {
+    return getBitAtPosition(_ip, position);
+  }
+
+  private static int ipStrToInt(String addr) {
     String[] addrArray = addr.split("\\.");
     if (addrArray.length != 4) {
       if (addr.startsWith("INVALID_IP") || addr.startsWith("AUTO/NONE")) {
@@ -67,16 +73,16 @@ public class Ip implements Comparable<Ip>, Serializable {
           String[] longStrParts = tail[1].split("l");
           if (longStrParts.length == 2) {
             String longStr = longStrParts[0];
-            return Long.parseLong(longStr);
+            return (int) Long.parseLong(longStr);
           }
         }
       }
       throw new IllegalArgumentException("Invalid IPv4 address: " + addr);
     }
-    long num = 0;
+    int num = 0;
     try {
       for (int i = 0; i < 4; i++) {
-        long segment = Long.parseLong(addrArray[i]);
+        int segment = Integer.parseInt(addrArray[i]);
         checkArgument(
             0 <= segment && segment <= 255,
             "Invalid IPv4 address: %s. %s is an invalid octet",
@@ -91,19 +97,19 @@ public class Ip implements Comparable<Ip>, Serializable {
   }
 
   /**
-   * Return a {@code long} that represents the {@code /numBits} network mask in a IPv4 subnet.
+   * Return an {@code int} that represents the {@code /numBits} network mask in a IPv4 subnet.
    *
-   * <p>For example, for {@code numBits = 8}, should return {@code 0xFF000000L} representing a mask
+   * <p>For example, for {@code numBits = 8}, should return {@code 0xFF000000} representing a mask
    * of the top 8 bits.
    */
   // Visible for testing only.
-  static long numSubnetBitsToSubnetLong(int numBits) {
-    return ~(0xFFFFFFFFL >> numBits) & 0xFFFFFFFFL;
+  static int numSubnetBitsToSubnetInt(int numBits) {
+    // Shifts are mod 32 in Java, so -1 >>> 32 is a no-op. Handle 32 explicitly.
+    return numBits == Prefix.MAX_PREFIX_LENGTH ? -1 : ~(-1 >>> numBits);
   }
 
   public static Ip numSubnetBitsToSubnetMask(int numBits) {
-    long mask = numSubnetBitsToSubnetLong(numBits);
-    return create(mask);
+    return create(numSubnetBitsToSubnetInt(numBits));
   }
 
   /**
@@ -118,30 +124,36 @@ public class Ip implements Comparable<Ip>, Serializable {
     }
   }
 
-  private final long _ip;
+  private final int _ip;
 
-  private Ip(long ipAsLong) {
-    _ip = ipAsLong;
+  private Ip(int ipAsInt) {
+    _ip = ipAsInt;
   }
 
   @JsonCreator
   public static Ip parse(String ipAsString) {
-    return create(ipStrToLong(ipAsString));
+    return create(ipStrToInt(ipAsString));
   }
 
+  /** Create an {@link Ip} from the unsigned 32-bit representation stored in a {@code long}. */
   public static Ip create(long ipAsLong) {
     checkArgument(ipAsLong >= 0L && ipAsLong <= 0xFFFFFFFFL, "Invalid IP value: %s", ipAsLong);
-    Ip ip = new Ip(ipAsLong);
+    return create((int) ipAsLong);
+  }
+
+  /** Create an {@link Ip} from the unsigned 32-bit representation stored in an {@code int}. */
+  public static Ip create(int ipAsInt) {
+    Ip ip = new Ip(ipAsInt);
     return CACHE.getUnchecked(ip);
   }
 
   public long asLong() {
-    return _ip;
+    return Integer.toUnsignedLong(_ip);
   }
 
   @Override
   public int compareTo(Ip rhs) {
-    return Long.compare(_ip, rhs._ip);
+    return Integer.compareUnsigned(_ip, rhs._ip);
   }
 
   @Override
@@ -156,13 +168,14 @@ public class Ip implements Comparable<Ip>, Serializable {
   }
 
   public Ip getClassMask() {
-    long firstOctet = _ip >> 24;
+    // Use unsigned right shift to get first octet as unsigned value.
+    int firstOctet = _ip >>> 24;
     if (firstOctet <= 127) {
-      return create(0xFF000000L);
+      return create(0xFF000000);
     } else if (firstOctet <= 191) {
-      return create(0XFFFF0000L);
+      return create(0xFFFF0000);
     } else if (firstOctet <= 223) {
-      return create(0xFFFFFF00L);
+      return create(0xFFFFFF00);
     } else {
       throw new IllegalArgumentException("Cannot compute classmask");
     }
@@ -173,7 +186,7 @@ public class Ip implements Comparable<Ip>, Serializable {
    * -1} if the class does not have a defined subnet size, e.g. the experimental subnet.
    */
   public int getClassNetworkSize() {
-    long firstOctet = _ip >> 24;
+    int firstOctet = _ip >>> 24;
     if (firstOctet <= 127) {
       return 8;
     } else if (firstOctet <= 191) {
@@ -186,7 +199,7 @@ public class Ip implements Comparable<Ip>, Serializable {
   }
 
   public Ip getNetworkAddress(int subnetBits) {
-    long masked = _ip & numSubnetBitsToSubnetLong(subnetBits);
+    int masked = _ip & numSubnetBitsToSubnetInt(subnetBits);
     if (masked == _ip) {
       return this;
     }
@@ -195,21 +208,15 @@ public class Ip implements Comparable<Ip>, Serializable {
 
   @Override
   public int hashCode() {
-    return Long.hashCode(_ip);
+    return _ip;
   }
 
   public Ip inverted() {
-    long invertedLong = (~_ip) & 0xFFFFFFFFL;
-    return create(invertedLong);
+    return create(~_ip);
   }
 
   public int numSubnetBits() {
-    int numTrailingZeros = Long.numberOfTrailingZeros(_ip);
-    if (numTrailingZeros > Prefix.MAX_PREFIX_LENGTH) {
-      return 0;
-    } else {
-      return Prefix.MAX_PREFIX_LENGTH - numTrailingZeros;
-    }
+    return Prefix.MAX_PREFIX_LENGTH - Integer.numberOfTrailingZeros(_ip);
   }
 
   /**
@@ -217,8 +224,7 @@ public class Ip implements Comparable<Ip>, Serializable {
    * are considered valid 1s-leading netmasks.
    */
   public boolean isValidNetmask1sLeading() {
-    int numTrailingZeros = Math.min(Long.numberOfTrailingZeros(_ip), Prefix.MAX_PREFIX_LENGTH);
-    return _ip >> numTrailingZeros == Ip.MAX.asLong() >> numTrailingZeros;
+    return (_ip | (_ip - 1)) == -1;
   }
 
   public @Nonnull IpIpSpace toIpSpace() {
@@ -228,11 +234,11 @@ public class Ip implements Comparable<Ip>, Serializable {
   @Override
   @JsonValue
   public String toString() {
-    return ((_ip >> 24) & 0xFF)
+    return ((_ip >>> 24) & 0xFF)
         + "."
-        + ((_ip >> 16) & 0xFF)
+        + ((_ip >>> 16) & 0xFF)
         + "."
-        + ((_ip >> 8) & 0xFF)
+        + ((_ip >>> 8) & 0xFF)
         + "."
         + (_ip & 0xFF);
   }

--- a/projects/common/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Prefix.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Ordering;
-import com.google.common.primitives.UnsignedInts;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
@@ -276,7 +275,7 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
 
     @Serial
     private Object readResolve() throws ObjectStreamException {
-      return CACHE.get(new Prefix(Ip.create(UnsignedInts.toLong(_ip)), _length));
+      return CACHE.get(new Prefix(Ip.create(_ip), _length));
     }
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -60,7 +60,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
      * the newNode.
      */
     if (newPrefix.containsPrefix(oldPrefix)) {
-      boolean currentBit = Ip.getBitAtPosition(oldPrefix.getStartIp(), newPrefix.getPrefixLength());
+      boolean currentBit = oldPrefix.getStartIp().getBitAtPosition(newPrefix.getPrefixLength());
       if (currentBit) {
         newNode._right = oldNode;
       } else {
@@ -75,7 +75,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     Prefix lcp = longestCommonPrefix(newPrefix, oldPrefix);
     Node<T> parent = new Node<>(lcp);
 
-    boolean newNodeRight = Ip.getBitAtPosition(newPrefix.getStartIp(), lcp.getPrefixLength());
+    boolean newNodeRight = newPrefix.getStartIp().getBitAtPosition(lcp.getPrefixLength());
     if (newNodeRight) {
       parent.setRight(newNode);
       parent.setLeft(oldNode);
@@ -90,14 +90,14 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
   static boolean legalLeftChildPrefix(Prefix parentPrefix, Prefix childPrefix) {
     return parentPrefix.containsPrefix(childPrefix)
         && parentPrefix.getPrefixLength() < childPrefix.getPrefixLength()
-        && !Ip.getBitAtPosition(childPrefix.getStartIp(), parentPrefix.getPrefixLength());
+        && !childPrefix.getStartIp().getBitAtPosition(parentPrefix.getPrefixLength());
   }
 
   @VisibleForTesting
   static boolean legalRightChildPrefix(Prefix parentPrefix, Prefix childPrefix) {
     return parentPrefix.containsPrefix(childPrefix)
         && parentPrefix.getPrefixLength() < childPrefix.getPrefixLength()
-        && Ip.getBitAtPosition(childPrefix.getStartIp(), parentPrefix.getPrefixLength());
+        && childPrefix.getStartIp().getBitAtPosition(parentPrefix.getPrefixLength());
   }
 
   /**
@@ -129,8 +129,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
 
     private @Nonnull Node<T> createChild(Prefix prefix) {
       assert _prefix.containsPrefix(prefix);
-      boolean currentBit =
-          Ip.getBitAtPosition(prefix.getStartIp().asLong(), _prefix.getPrefixLength());
+      boolean currentBit = prefix.getStartIp().getBitAtPosition(_prefix.getPrefixLength());
 
       Node<T> node = new Node<>(prefix);
       if (currentBit) {
@@ -221,7 +220,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
       if (_prefix.getPrefixLength() == Prefix.MAX_PREFIX_LENGTH) {
         return null;
       }
-      Node<T> child = Ip.getBitAtPosition(ip.asLong(), _prefix.getPrefixLength()) ? _right : _left;
+      Node<T> child = ip.getBitAtPosition(_prefix.getPrefixLength()) ? _right : _left;
       return child == null || !child._prefix.containsPrefix(ip, prefixLength) ? null : child;
     }
 

--- a/projects/common/src/test/java/org/batfish/datamodel/IpTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/IpTest.java
@@ -22,13 +22,13 @@ public class IpTest {
   @Rule public ExpectedException _thrown = ExpectedException.none();
 
   @Test
-  public void numSubnetBitsToSubnetLong() {
+  public void testNumSubnetBitsToSubnetInt() {
     // Test the boundaries (0 and 32) as well as a representative sample of intermediate values.
-    assertThat(Ip.numSubnetBitsToSubnetLong(0), equalTo(0L));
-    assertThat(Ip.numSubnetBitsToSubnetLong(4), equalTo(0xF0000000L));
-    assertThat(Ip.numSubnetBitsToSubnetLong(17), equalTo(0xFFFF8000L));
-    assertThat(Ip.numSubnetBitsToSubnetLong(31), equalTo(0xFFFFFFFEL));
-    assertThat(Ip.numSubnetBitsToSubnetLong(32), equalTo(0xFFFFFFFFL));
+    assertThat(Ip.numSubnetBitsToSubnetInt(0), equalTo(0));
+    assertThat(Ip.numSubnetBitsToSubnetInt(4), equalTo(0xF0000000));
+    assertThat(Ip.numSubnetBitsToSubnetInt(17), equalTo(0xFFFF8000));
+    assertThat(Ip.numSubnetBitsToSubnetInt(31), equalTo(0xFFFFFFFE));
+    assertThat(Ip.numSubnetBitsToSubnetInt(32), equalTo(0xFFFFFFFF));
   }
 
   @Test


### PR DESCRIPTION
Change Ip's internal representation from long to int, treating it
as an unsigned 32-bit value. This shrinks each Ip instance from 24
to 16 bytes (33% reduction) by fitting the int into the alignment
padding gap after the compressed class pointer.

Public API is preserved: create(long) and asLong() still work via
Integer.toUnsignedLong/compareUnsigned. Added create(int) overload
and getBitAtPosition(int) member method. Simplified several methods
that no longer need long masking (inverted, isValidNetmask1sLeading,
numSubnetBits, hashCode). Migrated PrefixTrieMultiMap to use new
member getBitAtPosition. Simplified Prefix.SerializedForm to use
Ip.create(int) directly.

----

Prompt:
```
Suppose I changed Ip to store an int instead of a long, but then
treated it like an unsigned int in all places we have to
(comparator, etc). I think guava has helpers for this if not other
places. Would that save memory (use //tools/jol)? How would it
impact performance?
```

---
**Stack**:
- #9840
- #9839
- #9838
- #9837
- #9836 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*