### PR TITLE
AbstractRoute: store admin and tag as int for memory savings

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -38,10 +38,13 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
   static final String PROP_TAG = "tag";
 
   protected final @Nonnull Prefix _network;
-  protected final long _admin;
+  // Stored as unsigned 32-bit int for memory savings. Use getAdministrativeCost() to read.
+  private final int _admin;
   private final boolean _nonRouting;
   private final boolean _nonForwarding;
-  protected final long _tag;
+  private final boolean _hasTag;
+  // Stored as unsigned 32-bit int for memory savings. Use getTag() to read.
+  private final int _tag;
   protected @Nonnull NextHop _nextHop = NextHopDiscard.instance();
 
   /** Helper to check admin distance validity. */
@@ -58,11 +61,17 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
       @Nullable Prefix network, long admin, long tag, boolean nonRouting, boolean nonForwarding) {
     checkArgument(network != null, "Cannot create a route without a %s", PROP_NETWORK);
     checkAdmin(admin, 0);
+    checkArgument(
+        tag == Route.UNSET_ROUTE_TAG || (tag >= 0 && tag <= MAX_TAG),
+        "Invalid tag %s is not UNSET or in [0,%s]",
+        tag,
+        MAX_TAG);
     _network = network;
-    _admin = admin;
+    _admin = (int) admin;
     _nonForwarding = nonForwarding;
     _nonRouting = nonRouting;
-    _tag = tag;
+    _hasTag = tag != Route.UNSET_ROUTE_TAG;
+    _tag = (int) tag;
   }
 
   @Override
@@ -78,7 +87,7 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
   }
 
   public final long getAdministrativeCost() {
-    return _admin;
+    return Integer.toUnsignedLong(_admin);
   }
 
   @JsonIgnore
@@ -139,7 +148,7 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
   /** Return the route's tag or {@link Route#UNSET_ROUTE_TAG} if no tag is present */
   @JsonProperty(PROP_TAG)
   public final long getTag() {
-    return _tag;
+    return _hasTag ? Integer.toUnsignedLong(_tag) : Route.UNSET_ROUTE_TAG;
   }
 
   @Override

--- a/projects/common/src/main/java/org/batfish/datamodel/Bgpv4Route.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Bgpv4Route.java
@@ -194,7 +194,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
         .setReceivedFrom(_receivedFrom)
         .setReceivedFromRouteReflectorClient(_attributes._receivedFromRouteReflectorClient)
         .setSrcProtocol(_attributes.getSrcProtocol())
-        .setTag(_tag)
+        .setTag(getTag())
         .setTunnelEncapsulationAttribute(_attributes._tunnelEncapsulationAttribute)
         .setWeight(_attributes._weight);
   }
@@ -215,8 +215,8 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
         && _attributes.equals(other._attributes)
         && _receivedFrom.equals(other._receivedFrom)
         // Things above this line are more likely to cause false earlier.
-        && _admin == other._admin
-        && _tag == other._tag
+        && getAdministrativeCost() == other.getAdministrativeCost()
+        && getTag() == other.getTag()
         && getNonRouting() == other.getNonRouting()
         && getNonForwarding() == other.getNonForwarding();
   }
@@ -225,7 +225,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
   public int hashCode() {
     int h = _hashCode;
     if (h == 0) {
-      h = Long.hashCode(_admin);
+      h = Long.hashCode(getAdministrativeCost());
       h = h * 31 + _attributes.hashCode();
       h = h * 31 + _receivedFrom.hashCode();
       h = h * 31 + _network.hashCode();
@@ -233,7 +233,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
       h = h * 31 + (_pathId != null ? _pathId : 0);
       h = h * 31 + Boolean.hashCode(getNonForwarding());
       h = h * 31 + Boolean.hashCode(getNonRouting());
-      h = h * 31 + Long.hashCode(_tag);
+      h = h * 31 + Long.hashCode(getTag());
 
       _hashCode = h;
     }
@@ -245,8 +245,8 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
     return MoreObjects.toStringHelper(this)
         .omitNullValues()
         .add("_network", _network)
-        .add("_admin", _admin)
-        .add("_tag", _tag)
+        .add("_admin", getAdministrativeCost())
+        .add("_tag", getTag())
         .add("_asPath", _attributes._asPath)
         .add("_clusterList", _attributes._clusterList)
         .add("_communities", _attributes._communities)

--- a/projects/common/src/main/java/org/batfish/datamodel/ConnectedRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/ConnectedRoute.java
@@ -24,7 +24,7 @@ public final class ConnectedRoute extends AbstractRoute {
       @JsonProperty(PROP_NETWORK) @Nullable Prefix network,
       @JsonProperty(PROP_NEXT_HOP_INTERFACE) @Nullable String nextHopInterface,
       @JsonProperty(PROP_NEXT_HOP_IP) @Nullable String nextHopIp,
-      @JsonProperty(PROP_ADMINISTRATIVE_COST) int adminCost,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) long adminCost,
       @JsonProperty(PROP_TAG) long tag) {
     checkArgument(network != null, "Cannot create connected route: missing %s", PROP_NETWORK);
     return new ConnectedRoute(
@@ -46,9 +46,9 @@ public final class ConnectedRoute extends AbstractRoute {
         + "_network="
         + _network
         + ", _admin="
-        + _admin
+        + getAdministrativeCost()
         + ", _tag="
-        + _tag
+        + getTag()
         + '}';
   }
 
@@ -96,11 +96,11 @@ public final class ConnectedRoute extends AbstractRoute {
   public Builder toBuilder() {
     return builder()
         .setNetwork(getNetwork())
-        .setAdmin(_admin)
+        .setAdmin(getAdministrativeCost())
         .setNextHop(_nextHop)
         .setNonRouting(getNonRouting())
         .setNonForwarding(getNonForwarding())
-        .setTag(_tag);
+        .setTag(getTag());
   }
 
   @Override
@@ -112,15 +112,16 @@ public final class ConnectedRoute extends AbstractRoute {
     }
     ConnectedRoute rhs = (ConnectedRoute) o;
     return _network.equals(rhs._network)
-        && _admin == rhs._admin
+        && getAdministrativeCost() == rhs.getAdministrativeCost()
         && getNonRouting() == rhs.getNonRouting()
         && getNonForwarding() == rhs.getNonForwarding()
         && _nextHop.equals(rhs._nextHop)
-        && _tag == rhs._tag;
+        && getTag() == rhs.getTag();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_network, _admin, getNonRouting(), getNonForwarding(), _nextHop, _tag);
+    return Objects.hash(
+        _network, getAdministrativeCost(), getNonRouting(), getNonForwarding(), _nextHop, getTag());
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
@@ -153,14 +153,14 @@ public class EigrpExternalRoute extends EigrpRoute {
       return false;
     }
     EigrpExternalRoute rhs = (EigrpExternalRoute) obj;
-    return _admin == rhs._admin
+    return getAdministrativeCost() == rhs.getAdministrativeCost()
         && Objects.equals(_destinationAsn, rhs._destinationAsn)
         && _metric.equals(rhs._metric)
         && _metricVersion == rhs._metricVersion
         && _network.equals(rhs._network)
         && _nextHop.equals(rhs._nextHop)
         && _processAsn == rhs._processAsn
-        && _tag == rhs._tag
+        && getTag() == rhs.getTag()
         && getNonForwarding() == rhs.getNonForwarding()
         && getNonRouting() == rhs.getNonRouting();
   }
@@ -170,8 +170,8 @@ public class EigrpExternalRoute extends EigrpRoute {
     return hash(
         _network,
         _nextHop,
-        _admin,
-        _tag,
+        getAdministrativeCost(),
+        getTag(),
         getNonForwarding(),
         getNonRouting(),
         _destinationAsn,

--- a/projects/common/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
@@ -134,11 +134,11 @@ public class EigrpInternalRoute extends EigrpRoute {
       return false;
     }
     EigrpInternalRoute rhs = (EigrpInternalRoute) obj;
-    return _admin == rhs._admin
+    return getAdministrativeCost() == rhs.getAdministrativeCost()
         // Skip #getMetric() since it is derived from EigrpMetric _metric
         && _network.equals(rhs._network)
         && _nextHop.equals(rhs._nextHop)
-        && _tag == rhs._tag
+        && getTag() == rhs.getTag()
         && _processAsn == rhs._processAsn
         && _metric.equals(rhs._metric)
         && _metricVersion == rhs._metricVersion
@@ -149,10 +149,10 @@ public class EigrpInternalRoute extends EigrpRoute {
   @Override
   public final int hashCode() {
     return Objects.hash(
-        _admin,
+        getAdministrativeCost(),
         _network,
         _nextHop,
-        _tag,
+        getTag(),
         _processAsn,
         _metric,
         _metricVersion,

--- a/projects/common/src/main/java/org/batfish/datamodel/EigrpRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EigrpRoute.java
@@ -16,7 +16,6 @@ public abstract class EigrpRoute extends AbstractRoute {
   static final String PROP_EIGRP_METRIC_VERSION = "eigrp-metric-version";
   static final String PROP_PROCESS_ASN = "process-asn";
 
-  protected final long _admin;
   protected final @Nonnull EigrpMetric _metric;
   protected final @Nonnull EigrpMetricVersion _metricVersion;
 
@@ -34,7 +33,6 @@ public abstract class EigrpRoute extends AbstractRoute {
       boolean nonForwarding,
       boolean nonRouting) {
     super(network, admin, tag, nonRouting, nonForwarding);
-    _admin = admin;
     _metric = metric;
     _metricVersion = metricVersion;
     _nextHop = nextHop;

--- a/projects/common/src/main/java/org/batfish/datamodel/EvpnType2Route.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EvpnType2Route.java
@@ -227,7 +227,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
         .setRouteDistinguisher(_routeDistinguisher)
         .setVni(_vni)
         .setSrcProtocol(_attributes.getSrcProtocol())
-        .setTag(_tag)
+        .setTag(getTag())
         .setTunnelEncapsulationAttribute(_attributes._tunnelEncapsulationAttribute)
         .setWeight(_attributes._weight);
   }
@@ -251,7 +251,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
         && Objects.equals(_pathId, other._pathId)
         && Objects.equals(_routeDistinguisher, other._routeDistinguisher)
         && _vni == other._vni
-        && _tag == other._tag;
+        && getTag() == other.getTag();
   }
 
   @Override
@@ -267,7 +267,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
       h = h * 31 + Objects.hashCode(_pathId);
       h = h * 31 + _routeDistinguisher.hashCode();
       h = h * 31 + Integer.hashCode(_vni);
-      h = h * 31 + Long.hashCode(_tag);
+      h = h * 31 + Long.hashCode(getTag());
 
       _hashCode = h;
     }

--- a/projects/common/src/main/java/org/batfish/datamodel/EvpnType3Route.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EvpnType3Route.java
@@ -204,7 +204,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
         .setReceivedFromRouteReflectorClient(_attributes._receivedFromRouteReflectorClient)
         .setRouteDistinguisher(_routeDistinguisher)
         .setSrcProtocol(_attributes.getSrcProtocol())
-        .setTag(_tag)
+        .setTag(getTag())
         .setTunnelEncapsulationAttribute(_attributes._tunnelEncapsulationAttribute)
         .setVni(_vni)
         .setVniIp(_vniIp)
@@ -228,7 +228,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
         && Objects.equals(_pathId, other._pathId)
         && Objects.equals(_routeDistinguisher, other._routeDistinguisher)
         && _vni == other._vni
-        && _tag == other._tag
+        && getTag() == other.getTag()
         && Objects.equals(_vniIp, other._vniIp);
   }
 
@@ -243,7 +243,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
       h = h * 31 + Objects.hashCode(_pathId);
       h = h * 31 + _routeDistinguisher.hashCode();
       h = h * 31 + Integer.hashCode(_vni);
-      h = h * 31 + Long.hashCode(_tag);
+      h = h * 31 + Long.hashCode(getTag());
       h = h * 31 + _vniIp.hashCode();
 
       _hashCode = h;

--- a/projects/common/src/main/java/org/batfish/datamodel/EvpnType5Route.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EvpnType5Route.java
@@ -179,7 +179,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         .setReceivedFromRouteReflectorClient(_attributes._receivedFromRouteReflectorClient)
         .setRouteDistinguisher(_routeDistinguisher)
         .setSrcProtocol(_attributes.getSrcProtocol())
-        .setTag(_tag)
+        .setTag(getTag())
         .setTunnelEncapsulationAttribute(_attributes._tunnelEncapsulationAttribute)
         .setVni(_vni)
         .setWeight(_attributes._weight);
@@ -202,7 +202,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         && Objects.equals(_pathId, other._pathId)
         && Objects.equals(_routeDistinguisher, other._routeDistinguisher)
         && _vni == other._vni
-        && _tag == other._tag;
+        && getTag() == other.getTag();
   }
 
   @Override
@@ -216,7 +216,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
       h = h * 31 + Objects.hashCode(_pathId);
       h = h * 31 + _routeDistinguisher.hashCode();
       h = h * 31 + Integer.hashCode(_vni);
-      h = h * 31 + Long.hashCode(_tag);
+      h = h * 31 + Long.hashCode(getTag());
 
       _hashCode = h;
     }
@@ -246,7 +246,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
             PROP_RECEIVED_FROM_ROUTE_REFLECTOR_CLIENT,
             _attributes._receivedFromRouteReflectorClient)
         .add(PROP_SRC_PROTOCOL, _attributes._srcProtocol)
-        .add(PROP_TAG, _tag)
+        .add(PROP_TAG, getTag())
         .add(PROP_TUNNEL_ENCAPSULATION_ATTRIBUTE, _attributes._tunnelEncapsulationAttribute)
         .add(PROP_WEIGHT, _attributes._weight)
         .toString();

--- a/projects/common/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -409,12 +409,12 @@ public final class GeneratedRoute extends AbstractRoute
     GeneratedRoute that = (GeneratedRoute) o;
     return (_hashCode == that._hashCode || _hashCode == 0 || that._hashCode == 0)
         && _network.equals(that._network)
-        && _admin == that._admin
+        && getAdministrativeCost() == that.getAdministrativeCost()
         && getNonRouting() == that.getNonRouting()
         && getNonForwarding() == that.getNonForwarding()
         && _discard == that._discard
         && _metric == that._metric
-        && _tag == that._tag
+        && getTag() == that.getTag()
         && _asPath.equals(that._asPath)
         && Objects.equals(_attributePolicy, that._attributePolicy)
         && _communities.equals(that._communities)
@@ -432,10 +432,10 @@ public final class GeneratedRoute extends AbstractRoute
       h =
           Objects.hash(
               _network,
-              _admin,
+              getAdministrativeCost(),
               getNonRouting(),
               getNonForwarding(),
-              _tag,
+              getTag(),
               _asPath,
               _attributePolicy,
               _communities,

--- a/projects/common/src/main/java/org/batfish/datamodel/HmmRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/HmmRoute.java
@@ -105,7 +105,11 @@ public final class HmmRoute extends AbstractRoute {
 
   @Override
   public Builder toBuilder() {
-    return builder().setNetwork(_network).setNextHop(_nextHop).setAdmin(_admin).setTag(_tag);
+    return builder()
+        .setNetwork(_network)
+        .setNextHop(_nextHop)
+        .setAdmin(getAdministrativeCost())
+        .setTag(getTag());
   }
 
   @Override
@@ -120,18 +124,18 @@ public final class HmmRoute extends AbstractRoute {
     return (_hashCode == that._hashCode || _hashCode == 0 || that._hashCode == 0)
         && _nextHop.equals(that._nextHop)
         && _network.equals(that._network)
-        && _tag == that._tag
-        && _admin == that._admin;
+        && getTag() == that.getTag()
+        && getAdministrativeCost() == that.getAdministrativeCost();
   }
 
   @Override
   public int hashCode() {
     int h = _hashCode;
     if (h == 0) {
-      h = Long.hashCode(_admin);
+      h = Long.hashCode(getAdministrativeCost());
       h = h * 31 + _network.hashCode();
       h = h * 31 + _nextHop.hashCode();
-      h = h * 31 + Long.hashCode(_tag);
+      h = h * 31 + Long.hashCode(getTag());
 
       _hashCode = h;
     }

--- a/projects/common/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -238,7 +238,7 @@ public class IsisRoute extends AbstractRoute {
   @Override
   public Builder toBuilder() {
     return new Builder()
-        .setAdmin(_admin)
+        .setAdmin(getAdministrativeCost())
         .setArea(_area)
         .setAttach(_attach)
         .setDown(_down)
@@ -251,7 +251,7 @@ public class IsisRoute extends AbstractRoute {
         .setOverload(_overload)
         .setProtocol(_protocol)
         .setSystemId(_systemId)
-        .setTag(_tag);
+        .setTag(getTag());
   }
 
   @Override
@@ -263,7 +263,7 @@ public class IsisRoute extends AbstractRoute {
       return false;
     }
     IsisRoute rhs = (IsisRoute) o;
-    return _admin == rhs._admin
+    return getAdministrativeCost() == rhs.getAdministrativeCost()
         && _area.equals(rhs._area)
         && _attach == rhs._attach
         && _down == rhs._down
@@ -276,13 +276,13 @@ public class IsisRoute extends AbstractRoute {
         && _overload == rhs._overload
         && _protocol == rhs._protocol
         && _systemId.equals(rhs._systemId)
-        && _tag == rhs._tag;
+        && getTag() == rhs.getTag();
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        _admin,
+        getAdministrativeCost(),
         _area,
         _attach,
         _down,
@@ -295,6 +295,6 @@ public class IsisRoute extends AbstractRoute {
         _overload,
         _protocol.ordinal(),
         _systemId,
-        _tag);
+        getTag());
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/KernelRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/KernelRoute.java
@@ -68,7 +68,7 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
   @SuppressWarnings("unused")
   private static @Nonnull KernelRoute create(
       @JsonProperty(PROP_NETWORK) @Nullable Prefix network,
-      @JsonProperty(PROP_ADMINISTRATIVE_COST) int adminCost,
+      @JsonProperty(PROP_ADMINISTRATIVE_COST) long adminCost,
       @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
       @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_REQUIRED_OWNED_IP) @Nullable Ip requiredOwnedIp,
@@ -124,14 +124,14 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
     }
     KernelRoute rhs = (KernelRoute) o;
     return _network.equals(rhs._network)
-        && _tag == rhs._tag
+        && getTag() == rhs.getTag()
         && Objects.equals(_requiredOwnedIp, rhs._requiredOwnedIp)
         && getNonForwarding() == rhs.getNonForwarding();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_network, _tag, _requiredOwnedIp, getNonForwarding());
+    return Objects.hash(_network, getTag(), _requiredOwnedIp, getNonForwarding());
   }
 
   @Override
@@ -139,7 +139,7 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
     return toStringHelper(this)
         .omitNullValues()
         .add("_network", _network)
-        .add("_tag", _tag)
+        .add("_tag", getTag())
         .add("_requiredOwnedIp", _requiredOwnedIp)
         .add("_nonForwarding", getNonForwarding())
         .toString();

--- a/projects/common/src/main/java/org/batfish/datamodel/LocalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/LocalRoute.java
@@ -108,12 +108,12 @@ public final class LocalRoute extends AbstractRoute {
   public AbstractRouteBuilder<Builder, LocalRoute> toBuilder() {
     return builder()
         .setNetwork(_network)
-        .setAdmin(_admin)
+        .setAdmin(getAdministrativeCost())
         .setNonRouting(getNonRouting())
         .setNonForwarding(getNonForwarding())
         .setNextHop(_nextHop)
         .setSourcePrefixLength(_sourcePrefixLength)
-        .setTag(_tag);
+        .setTag(getTag());
   }
 
   /////// Keep #toBuilder, #equals, and #hashCode in sync ////////
@@ -127,17 +127,23 @@ public final class LocalRoute extends AbstractRoute {
     }
     LocalRoute rhs = (LocalRoute) o;
     return _network.equals(rhs._network)
-        && _admin == rhs._admin
+        && getAdministrativeCost() == rhs.getAdministrativeCost()
         && getNonRouting() == rhs.getNonRouting()
         && getNonForwarding() == rhs.getNonForwarding()
         && _nextHop.equals(rhs._nextHop)
         && _sourcePrefixLength == rhs._sourcePrefixLength
-        && _tag == rhs._tag;
+        && getTag() == rhs.getTag();
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        _network, _admin, getNonRouting(), getNonForwarding(), _nextHop, _sourcePrefixLength, _tag);
+        _network,
+        getAdministrativeCost(),
+        getNonRouting(),
+        getNonForwarding(),
+        _nextHop,
+        _sourcePrefixLength,
+        getTag());
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
@@ -196,12 +196,12 @@ public abstract class OspfExternalRoute extends OspfRoute {
     return (_hashCode == that._hashCode || _hashCode == 0 || that._hashCode == 0)
         // AbstractRoute properties
         && _network.equals(that._network)
-        && _admin == that._admin
+        && getAdministrativeCost() == that.getAdministrativeCost()
         && getNonRouting() == that.getNonRouting()
         && getNonForwarding() == that.getNonForwarding()
         && _metric == that._metric
         && _nextHop.equals(that._nextHop)
-        && _tag == that._tag
+        && getTag() == that.getTag()
         // OspfRoute properties
         && _area == that._area
         // OspfExternalRoute properties
@@ -216,12 +216,12 @@ public abstract class OspfExternalRoute extends OspfRoute {
     if (h == 0) {
       // AbstractRoute Properties
       h = _network.hashCode();
-      h = 31 * h + Long.hashCode(_admin);
+      h = 31 * h + Long.hashCode(getAdministrativeCost());
       h = 31 * h + Long.hashCode(_metric);
       h = 31 * h + _nextHop.hashCode();
       h = 31 * h + Boolean.hashCode(getNonRouting());
       h = 31 * h + Boolean.hashCode(getNonForwarding());
-      h = 31 * h + Long.hashCode(_tag);
+      h = 31 * h + Long.hashCode(getTag());
       // OspfRoute properties
       h = 31 * h + Long.hashCode(_area);
       // OspfExternalRoute properties

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
@@ -123,7 +123,7 @@ public final class OspfInterAreaRoute extends OspfInternalRoute {
         .setMetric(getMetric())
         .setNonForwarding(getNonForwarding())
         .setNonRouting(getNonRouting())
-        .setTag(_tag)
+        .setTag(getTag())
         // OspfInterAreaRoute properties
         .setArea(getArea());
   }
@@ -137,13 +137,13 @@ public final class OspfInterAreaRoute extends OspfInternalRoute {
     }
     OspfInterAreaRoute other = (OspfInterAreaRoute) o;
     return _network.equals(other._network)
-        && _admin == other._admin
+        && getAdministrativeCost() == other.getAdministrativeCost()
         && getNonRouting() == other.getNonRouting()
         && getNonForwarding() == other.getNonForwarding()
         && _area == other._area
         && _metric == other._metric
         && _nextHop.equals(other._nextHop)
-        && _tag == other._tag;
+        && getTag() == other.getTag();
   }
 
   @Override
@@ -151,13 +151,13 @@ public final class OspfInterAreaRoute extends OspfInternalRoute {
     int h = _hashCode;
     if (h == 0) {
       h = _network.hashCode();
-      h = 31 * h + Long.hashCode(_admin);
+      h = 31 * h + Long.hashCode(getAdministrativeCost());
       h = 31 * h + Long.hashCode(_area);
       h = 31 * h + Long.hashCode(_metric);
       h = 31 * h + _nextHop.hashCode();
       h = 31 * h + Boolean.hashCode(getNonForwarding());
       h = 31 * h + Boolean.hashCode(getNonRouting());
-      h = 31 * h + Long.hashCode(_tag);
+      h = 31 * h + Long.hashCode(getTag());
       _hashCode = h;
     }
     return h;

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfInternalSummaryRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfInternalSummaryRoute.java
@@ -82,9 +82,9 @@ public class OspfInternalSummaryRoute extends OspfInternalRoute {
         // AbstractRoute properties
         .setNetwork(getNetwork())
         .setNextHop(NextHopDiscard.instance())
-        .setAdmin(_admin)
+        .setAdmin(getAdministrativeCost())
         .setMetric(_metric)
-        .setTag(_tag)
+        .setTag(getTag())
         // OspfInternalSummaryRoute properties
         .setArea(getArea());
   }
@@ -98,10 +98,10 @@ public class OspfInternalSummaryRoute extends OspfInternalRoute {
     }
     OspfInternalSummaryRoute other = (OspfInternalSummaryRoute) o;
     return _network.equals(other._network)
-        && _admin == other._admin
+        && getAdministrativeCost() == other.getAdministrativeCost()
         && _area == other._area
         && _metric == other._metric
-        && _tag == other._tag;
+        && getTag() == other.getTag();
   }
 
   @Override
@@ -109,10 +109,10 @@ public class OspfInternalSummaryRoute extends OspfInternalRoute {
     int h = _hashCode;
     if (h == 0) {
       h = _network.hashCode();
-      h = 31 * h + Long.hashCode(_admin);
+      h = 31 * h + Long.hashCode(getAdministrativeCost());
       h = 31 * h + Long.hashCode(_area);
       h = 31 * h + Long.hashCode(_metric);
-      h = 31 * h + Long.hashCode(_tag);
+      h = 31 * h + Long.hashCode(getTag());
 
       _hashCode = h;
     }

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
@@ -104,11 +104,11 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
         // AbstractRoute properties
         .setNetwork(getNetwork())
         .setNextHop(_nextHop)
-        .setAdmin(_admin)
+        .setAdmin(getAdministrativeCost())
         .setMetric(_metric)
         .setNonForwarding(getNonForwarding())
         .setNonRouting(getNonRouting())
-        .setTag(_tag)
+        .setTag(getTag())
         // OspfIntraAreaRoute properties
         .setArea(getArea());
   }
@@ -122,13 +122,13 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
     }
     OspfIntraAreaRoute other = (OspfIntraAreaRoute) o;
     return _network.equals(other._network)
-        && _admin == other._admin
+        && getAdministrativeCost() == other.getAdministrativeCost()
         && _area == other._area
         && getNonRouting() == other.getNonRouting()
         && getNonForwarding() == other.getNonForwarding()
         && _metric == other._metric
         && _nextHop.equals(other._nextHop)
-        && _tag == other._tag;
+        && getTag() == other.getTag();
   }
 
   @Override
@@ -136,13 +136,13 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
     int h = _hashCode;
     if (h == 0) {
       h = _network.hashCode();
-      h = 31 * h + Long.hashCode(_admin);
+      h = 31 * h + Long.hashCode(getAdministrativeCost());
       h = 31 * h + Long.hashCode(_area);
       h = 31 * h + Long.hashCode(_metric);
       h = 31 * h + _nextHop.hashCode();
       h = 31 * h + Boolean.hashCode(getNonForwarding());
       h = 31 * h + Boolean.hashCode(getNonRouting());
-      h = 31 * h + Long.hashCode(_tag);
+      h = 31 * h + Long.hashCode(getTag());
 
       _hashCode = h;
     }

--- a/projects/common/src/main/java/org/batfish/datamodel/RipInternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/RipInternalRoute.java
@@ -90,17 +90,23 @@ public class RipInternalRoute extends RipRoute {
     }
     RipRoute other = (RipRoute) o;
     return _network.equals(other._network)
-        && _admin == other._admin
+        && getAdministrativeCost() == other.getAdministrativeCost()
         && _metric == other._metric
         && _nextHop.equals(other._nextHop)
         && getNonForwarding() == other.getNonForwarding()
         && getNonRouting() == other.getNonRouting()
-        && _tag == other._tag;
+        && getTag() == other.getTag();
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        _network, _admin, _metric, _nextHop, getNonForwarding(), getNonRouting(), _tag);
+        _network,
+        getAdministrativeCost(),
+        _metric,
+        _nextHop,
+        getNonForwarding(),
+        getNonRouting(),
+        getTag());
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -198,7 +198,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
         .setNetwork(getNetwork())
         .setNextHop(_nextHop)
         .setMetric(_metric)
-        .setTag(_tag)
+        .setTag(getTag())
         .setAdmin(getAdministrativeCost())
         .setNonRouting(getNonRouting())
         .setNonForwarding(getNonForwarding())
@@ -216,12 +216,12 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
     StaticRoute rhs = (StaticRoute) o;
     return (_hashCode == rhs._hashCode || _hashCode == 0 || rhs._hashCode == 0)
         && _network.equals(rhs._network)
-        && _admin == rhs._admin
+        && getAdministrativeCost() == rhs.getAdministrativeCost()
         && getNonForwarding() == rhs.getNonForwarding()
         && getNonRouting() == rhs.getNonRouting()
         && _metric == rhs._metric
         && _nextHop.equals(rhs._nextHop)
-        && _tag == rhs._tag
+        && getTag() == rhs.getTag()
         && _recursive == rhs._recursive
         && Objects.equals(_track, rhs._track);
   }
@@ -233,12 +233,12 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       h =
           Objects.hash(
               _network,
-              _admin,
+              getAdministrativeCost(),
               getNonForwarding(),
               getNonRouting(),
               _metric,
               _nextHop,
-              _tag,
+              getTag(),
               _recursive,
               _track);
       _hashCode = h;
@@ -252,10 +252,10 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
         .omitNullValues()
         .add(PROP_NETWORK, _network)
         .add("nextHop", _nextHop)
-        .add(PROP_ADMINISTRATIVE_COST, _admin)
+        .add(PROP_ADMINISTRATIVE_COST, getAdministrativeCost())
         .add(PROP_METRIC, _metric)
         .add("recursive", _recursive)
-        .add(PROP_TAG, _tag)
+        .add(PROP_TAG, getTag())
         .add(PROP_TRACK, _track)
         .toString();
   }

--- a/projects/common/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
@@ -50,5 +52,60 @@ public class ConnectedRouteTest {
         .addEqualityGroup(new ConnectedRoute(Prefix.parse("1.1.2.0/24"), "Ethernet1", 123, 5L))
         .addEqualityGroup(new Object())
         .testEquals();
+  }
+
+  /** admin and tag are stored as unsigned 32-bit ints. Test boundary values round-trip. */
+  @Test
+  public void testUnsignedAdminAndTagRoundTrip() {
+    // MAX values (0xFFFFFFFF as unsigned int)
+    ConnectedRoute maxRoute =
+        new ConnectedRoute(
+            Prefix.parse("1.0.0.0/8"),
+            "Ethernet0",
+            AbstractRoute.MAX_ADMIN_DISTANCE,
+            AbstractRoute.MAX_TAG);
+    assertThat(maxRoute.getAdministrativeCost(), equalTo(AbstractRoute.MAX_ADMIN_DISTANCE));
+    assertThat(maxRoute.getTag(), equalTo(AbstractRoute.MAX_TAG));
+
+    // toBuilder round-trip preserves MAX values
+    assertThat(maxRoute.toBuilder().build(), equalTo(maxRoute));
+
+    // JSON round-trip preserves MAX values
+    assertThat(BatfishObjectMapper.clone(maxRoute, ConnectedRoute.class), equalTo(maxRoute));
+
+    // Java serialization round-trip preserves MAX values
+    assertThat(SerializationUtils.clone(maxRoute), equalTo(maxRoute));
+
+    // Large unsigned values (> Integer.MAX_VALUE but < MAX)
+    long largeAdmin = 0x80000000L; // 2147483648
+    long largeTag = 0xFFFFFFFEL; // 4294967294
+    ConnectedRoute largeRoute =
+        new ConnectedRoute(Prefix.parse("2.0.0.0/8"), "Ethernet0", largeAdmin, largeTag);
+    assertThat(largeRoute.getAdministrativeCost(), equalTo(largeAdmin));
+    assertThat(largeRoute.getTag(), equalTo(largeTag));
+    assertThat(largeRoute.toBuilder().build(), equalTo(largeRoute));
+  }
+
+  /** MAX_TAG and UNSET_ROUTE_TAG must be distinguishable despite both mapping to int -1. */
+  @Test
+  public void testMaxTagNotEqualToUnsetTag() {
+    ConnectedRoute withMaxTag =
+        new ConnectedRoute(Prefix.parse("1.0.0.0/8"), "Ethernet0", 0, AbstractRoute.MAX_TAG);
+    ConnectedRoute withUnsetTag = new ConnectedRoute(Prefix.parse("1.0.0.0/8"), "Ethernet0", 0);
+
+    assertThat(withMaxTag.getTag(), equalTo(AbstractRoute.MAX_TAG));
+    assertThat(withUnsetTag.getTag(), equalTo(Route.UNSET_ROUTE_TAG));
+    assertThat(
+        "MAX_TAG and UNSET_ROUTE_TAG must be distinguishable",
+        withMaxTag,
+        not(equalTo(withUnsetTag)));
+  }
+
+  /** Tags outside the valid u32 range should be rejected. */
+  @Test
+  public void testRejectsOutOfRangeTag() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new ConnectedRoute(Prefix.parse("1.0.0.0/8"), "Ethernet0", 0, 1L << 32));
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -211,7 +211,7 @@ public class RoutesAnswererUtilTest {
             .setArea(1L)
             .setAdvertiser("n2")
             .setOspfMetricType(OspfMetricType.E2)
-            .setTag(2L << 35)
+            .setTag(2L << 30)
             .build();
     FinalMainRib rib = FinalMainRib.of(route);
 
@@ -232,7 +232,7 @@ public class RoutesAnswererUtilTest {
                 hasColumn(COL_NEXT_HOP_IP, Ip.parse("1.1.1.2"), Schema.IP),
                 hasColumn(COL_NEXT_HOP_INTERFACE, "e0", Schema.STRING),
                 hasColumn(COL_PROTOCOL, "ospfE2", Schema.STRING),
-                hasColumn(COL_TAG, equalTo(2L << 35), Schema.LONG),
+                hasColumn(COL_TAG, equalTo(2L << 30), Schema.LONG),
                 hasColumn(COL_ADMIN_DISTANCE, equalTo(10), Schema.INTEGER),
                 hasColumn(COL_METRIC, equalTo(2L << 34), Schema.LONG))));
   }


### PR DESCRIPTION
Change _admin and _tag from long to int in AbstractRoute, treating
them as unsigned 32-bit values. This shrinks every route instance by
8 bytes (e.g., Bgpv4Route 80 -> 72 bytes, measured with JOL). A new
_hasTag boolean distinguishes UNSET_ROUTE_TAG (-1L) from MAX_TAG
(0xFFFFFFFFL), which both map to int -1. The boolean fits in
alignment padding so costs no additional memory.

Both fields are now private. Subclasses use getAdministrativeCost()
and getTag() for all access, eliminating the risk of accidental
sign-extension when passing the raw int to a long parameter.

Also: remove redundant EigrpRoute._admin that shadowed the base
class field, fix ConnectedRoute/KernelRoute JsonCreators that used
int instead of long for admin, add tag range validation in the
constructor, and fix a test that used a 37-bit tag value.

----

Prompt:
```
The most recent commit used JOL analysis to shrink Ip in memory
representation by adding a bit of complexity internal to that
class (ints as UnsignedInts, etc.).

Look at Prefix and all variants of AbstractRoute to see if there
are similar opportunities
```

---
**Stack**:
- #9840
- #9839
- #9838
- #9837 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*