### PR TITLE
Route subclasses: store metric, area, and processAsn as int

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
@@ -159,7 +159,7 @@ public class EigrpExternalRoute extends EigrpRoute {
         && _metricVersion == rhs._metricVersion
         && _network.equals(rhs._network)
         && _nextHop.equals(rhs._nextHop)
-        && _processAsn == rhs._processAsn
+        && getProcessAsn() == rhs.getProcessAsn()
         && getTag() == rhs.getTag()
         && getNonForwarding() == rhs.getNonForwarding()
         && getNonRouting() == rhs.getNonRouting();
@@ -177,7 +177,7 @@ public class EigrpExternalRoute extends EigrpRoute {
         _destinationAsn,
         _metric,
         _metricVersion,
-        _processAsn);
+        getProcessAsn());
   }
 
   @Override
@@ -185,7 +185,7 @@ public class EigrpExternalRoute extends EigrpRoute {
     return MoreObjects.toStringHelper(this)
         .add(PROP_NETWORK, _network)
         .add(PROP_NEXT_HOP_IP, _nextHop)
-        .add(PROP_PROCESS_ASN, _processAsn)
+        .add(PROP_PROCESS_ASN, getProcessAsn())
         .toString();
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
@@ -139,7 +139,7 @@ public class EigrpInternalRoute extends EigrpRoute {
         && _network.equals(rhs._network)
         && _nextHop.equals(rhs._nextHop)
         && getTag() == rhs.getTag()
-        && _processAsn == rhs._processAsn
+        && getProcessAsn() == rhs.getProcessAsn()
         && _metric.equals(rhs._metric)
         && _metricVersion == rhs._metricVersion
         && getNonForwarding() == rhs.getNonForwarding()
@@ -153,7 +153,7 @@ public class EigrpInternalRoute extends EigrpRoute {
         _network,
         _nextHop,
         getTag(),
-        _processAsn,
+        getProcessAsn(),
         _metric,
         _metricVersion,
         getNonForwarding(),
@@ -165,7 +165,7 @@ public class EigrpInternalRoute extends EigrpRoute {
     return MoreObjects.toStringHelper(this)
         .add(PROP_NETWORK, _network)
         .add(PROP_NEXT_HOP_IP, _nextHop)
-        .add(PROP_PROCESS_ASN, _processAsn)
+        .add(PROP_PROCESS_ASN, getProcessAsn())
         .toString();
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/EigrpRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EigrpRoute.java
@@ -19,8 +19,8 @@ public abstract class EigrpRoute extends AbstractRoute {
   protected final @Nonnull EigrpMetric _metric;
   protected final @Nonnull EigrpMetricVersion _metricVersion;
 
-  /** AS number of the EIGRP process that installed this route in the RIB */
-  final long _processAsn;
+  // Stored as unsigned 32-bit int for memory savings. Use getProcessAsn() to read.
+  private final int _processAsn;
 
   EigrpRoute(
       long admin,
@@ -36,7 +36,7 @@ public abstract class EigrpRoute extends AbstractRoute {
     _metric = metric;
     _metricVersion = metricVersion;
     _nextHop = nextHop;
-    _processAsn = processAsn;
+    _processAsn = (int) processAsn;
   }
 
   @JsonIgnore
@@ -61,7 +61,7 @@ public abstract class EigrpRoute extends AbstractRoute {
 
   @JsonProperty(PROP_PROCESS_ASN)
   public long getProcessAsn() {
-    return _processAsn;
+    return Integer.toUnsignedLong(_processAsn);
   }
 
   @Override

--- a/projects/common/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -185,7 +185,8 @@ public final class GeneratedRoute extends AbstractRoute
   private final boolean _discard;
   private final @Nullable String _generationPolicy;
   private final long _localPreference;
-  private final long _metric;
+  // Stored as unsigned 32-bit int for memory savings. Use getMetric() to read.
+  private final int _metric;
   private final @Nonnull OriginType _originType;
   private final int _weight;
 
@@ -255,7 +256,7 @@ public final class GeneratedRoute extends AbstractRoute
     _discard = discard;
     _generationPolicy = generationPolicy;
     _generationPolicySources = ImmutableSortedSet.of();
-    _metric = metric;
+    _metric = (int) metric;
     _localPreference = localPreference;
     _nextHop = nextHop;
     _originType = originType;
@@ -318,7 +319,7 @@ public final class GeneratedRoute extends AbstractRoute
   @JsonProperty(PROP_METRIC)
   @Override
   public long getMetric() {
-    return _metric;
+    return Integer.toUnsignedLong(_metric);
   }
 
   @JsonProperty(PROP_ORIGIN_TYPE)
@@ -413,7 +414,7 @@ public final class GeneratedRoute extends AbstractRoute
         && getNonRouting() == that.getNonRouting()
         && getNonForwarding() == that.getNonForwarding()
         && _discard == that._discard
-        && _metric == that._metric
+        && getMetric() == that.getMetric()
         && getTag() == that.getTag()
         && _asPath.equals(that._asPath)
         && Objects.equals(_attributePolicy, that._attributePolicy)
@@ -441,7 +442,7 @@ public final class GeneratedRoute extends AbstractRoute
               _communities,
               _discard,
               _generationPolicy,
-              _metric,
+              getMetric(),
               _nextHop,
               _localPreference,
               _originType.ordinal(),

--- a/projects/common/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -145,7 +145,8 @@ public class IsisRoute extends AbstractRoute {
 
   private final IsisLevel _level;
 
-  private final long _metric;
+  // Stored as unsigned 32-bit int for memory savings. Use getMetric() to read.
+  private final int _metric;
 
   private final boolean _overload;
 
@@ -173,7 +174,7 @@ public class IsisRoute extends AbstractRoute {
     _attach = attach;
     _down = down;
     _level = level;
-    _metric = metric;
+    _metric = (int) metric;
     _nextHop = nextHop;
     _overload = overload;
     _protocol = protocol;
@@ -212,7 +213,7 @@ public class IsisRoute extends AbstractRoute {
   @JsonProperty(PROP_METRIC)
   @Override
   public @Nonnull long getMetric() {
-    return _metric;
+    return Integer.toUnsignedLong(_metric);
   }
 
   /** Overload bit indicates this route came through an overloaded interface level. */
@@ -243,7 +244,7 @@ public class IsisRoute extends AbstractRoute {
         .setAttach(_attach)
         .setDown(_down)
         .setLevel(_level)
-        .setMetric(_metric)
+        .setMetric(getMetric())
         .setNetwork(_network)
         .setNextHop(_nextHop)
         .setNonForwarding(getNonForwarding())
@@ -268,7 +269,7 @@ public class IsisRoute extends AbstractRoute {
         && _attach == rhs._attach
         && _down == rhs._down
         && _level == rhs._level
-        && _metric == rhs._metric
+        && getMetric() == rhs.getMetric()
         && _network.equals(rhs._network)
         && _nextHop.equals(rhs._nextHop)
         && getNonForwarding() == rhs.getNonForwarding()
@@ -287,7 +288,7 @@ public class IsisRoute extends AbstractRoute {
         _attach,
         _down,
         _level.ordinal(),
-        _metric,
+        getMetric(),
         _network,
         _nextHop,
         getNonForwarding(),

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
@@ -114,8 +114,10 @@ public abstract class OspfExternalRoute extends OspfRoute {
   protected static final String PROP_LSA_METRIC = "lsaMetric";
 
   private final @Nonnull String _advertiser;
-  private final long _costToAdvertiser;
-  private final long _lsaMetric;
+  // Stored as unsigned 32-bit int for memory savings. Use getCostToAdvertiser() to read.
+  private final int _costToAdvertiser;
+  // Stored as unsigned 32-bit int for memory savings. Use getLsaMetric() to read.
+  private final int _lsaMetric;
   private transient int _hashCode;
 
   public static @Nonnull Builder builder() {
@@ -136,8 +138,8 @@ public abstract class OspfExternalRoute extends OspfRoute {
       boolean nonRouting) {
     super(prefix, nextHop, admin, metric, area, tag, nonRouting, nonForwarding);
     _advertiser = advertiser;
-    _costToAdvertiser = costToAdvertiser;
-    _lsaMetric = lsaMetric;
+    _costToAdvertiser = (int) costToAdvertiser;
+    _lsaMetric = (int) lsaMetric;
   }
 
   @JsonProperty(PROP_ADVERTISER)
@@ -147,12 +149,12 @@ public abstract class OspfExternalRoute extends OspfRoute {
 
   @JsonProperty(PROP_COST_TO_ADVERTISER)
   public long getCostToAdvertiser() {
-    return _costToAdvertiser;
+    return Integer.toUnsignedLong(_costToAdvertiser);
   }
 
   @JsonProperty(PROP_LSA_METRIC)
   public long getLsaMetric() {
-    return _lsaMetric;
+    return Integer.toUnsignedLong(_lsaMetric);
   }
 
   @JsonIgnore
@@ -199,11 +201,11 @@ public abstract class OspfExternalRoute extends OspfRoute {
         && getAdministrativeCost() == that.getAdministrativeCost()
         && getNonRouting() == that.getNonRouting()
         && getNonForwarding() == that.getNonForwarding()
-        && _metric == that._metric
+        && getMetric() == that.getMetric()
         && _nextHop.equals(that._nextHop)
         && getTag() == that.getTag()
         // OspfRoute properties
-        && _area == that._area
+        && getArea() == that.getArea()
         // OspfExternalRoute properties
         && getCostToAdvertiser() == that.getCostToAdvertiser()
         && getLsaMetric() == that.getLsaMetric()
@@ -217,17 +219,17 @@ public abstract class OspfExternalRoute extends OspfRoute {
       // AbstractRoute Properties
       h = _network.hashCode();
       h = 31 * h + Long.hashCode(getAdministrativeCost());
-      h = 31 * h + Long.hashCode(_metric);
+      h = 31 * h + Long.hashCode(getMetric());
       h = 31 * h + _nextHop.hashCode();
       h = 31 * h + Boolean.hashCode(getNonRouting());
       h = 31 * h + Boolean.hashCode(getNonForwarding());
       h = 31 * h + Long.hashCode(getTag());
       // OspfRoute properties
-      h = 31 * h + Long.hashCode(_area);
+      h = 31 * h + Long.hashCode(getArea());
       // OspfExternalRoute properties
       h = 31 * h + _advertiser.hashCode();
-      h = 31 * h + Long.hashCode(_costToAdvertiser);
-      h = 31 * h + Long.hashCode(_lsaMetric);
+      h = 31 * h + Long.hashCode(getCostToAdvertiser());
+      h = 31 * h + Long.hashCode(getLsaMetric());
 
       _hashCode = h;
     }

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
@@ -140,8 +140,8 @@ public final class OspfInterAreaRoute extends OspfInternalRoute {
         && getAdministrativeCost() == other.getAdministrativeCost()
         && getNonRouting() == other.getNonRouting()
         && getNonForwarding() == other.getNonForwarding()
-        && _area == other._area
-        && _metric == other._metric
+        && getArea() == other.getArea()
+        && getMetric() == other.getMetric()
         && _nextHop.equals(other._nextHop)
         && getTag() == other.getTag();
   }
@@ -152,8 +152,8 @@ public final class OspfInterAreaRoute extends OspfInternalRoute {
     if (h == 0) {
       h = _network.hashCode();
       h = 31 * h + Long.hashCode(getAdministrativeCost());
-      h = 31 * h + Long.hashCode(_area);
-      h = 31 * h + Long.hashCode(_metric);
+      h = 31 * h + Long.hashCode(getArea());
+      h = 31 * h + Long.hashCode(getMetric());
       h = 31 * h + _nextHop.hashCode();
       h = 31 * h + Boolean.hashCode(getNonForwarding());
       h = 31 * h + Boolean.hashCode(getNonRouting());

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfInternalSummaryRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfInternalSummaryRoute.java
@@ -83,7 +83,7 @@ public class OspfInternalSummaryRoute extends OspfInternalRoute {
         .setNetwork(getNetwork())
         .setNextHop(NextHopDiscard.instance())
         .setAdmin(getAdministrativeCost())
-        .setMetric(_metric)
+        .setMetric(getMetric())
         .setTag(getTag())
         // OspfInternalSummaryRoute properties
         .setArea(getArea());
@@ -99,8 +99,8 @@ public class OspfInternalSummaryRoute extends OspfInternalRoute {
     OspfInternalSummaryRoute other = (OspfInternalSummaryRoute) o;
     return _network.equals(other._network)
         && getAdministrativeCost() == other.getAdministrativeCost()
-        && _area == other._area
-        && _metric == other._metric
+        && getArea() == other.getArea()
+        && getMetric() == other.getMetric()
         && getTag() == other.getTag();
   }
 
@@ -110,8 +110,8 @@ public class OspfInternalSummaryRoute extends OspfInternalRoute {
     if (h == 0) {
       h = _network.hashCode();
       h = 31 * h + Long.hashCode(getAdministrativeCost());
-      h = 31 * h + Long.hashCode(_area);
-      h = 31 * h + Long.hashCode(_metric);
+      h = 31 * h + Long.hashCode(getArea());
+      h = 31 * h + Long.hashCode(getMetric());
       h = 31 * h + Long.hashCode(getTag());
 
       _hashCode = h;

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
@@ -105,7 +105,7 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
         .setNetwork(getNetwork())
         .setNextHop(_nextHop)
         .setAdmin(getAdministrativeCost())
-        .setMetric(_metric)
+        .setMetric(getMetric())
         .setNonForwarding(getNonForwarding())
         .setNonRouting(getNonRouting())
         .setTag(getTag())
@@ -123,10 +123,10 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
     OspfIntraAreaRoute other = (OspfIntraAreaRoute) o;
     return _network.equals(other._network)
         && getAdministrativeCost() == other.getAdministrativeCost()
-        && _area == other._area
+        && getArea() == other.getArea()
         && getNonRouting() == other.getNonRouting()
         && getNonForwarding() == other.getNonForwarding()
-        && _metric == other._metric
+        && getMetric() == other.getMetric()
         && _nextHop.equals(other._nextHop)
         && getTag() == other.getTag();
   }
@@ -137,8 +137,8 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
     if (h == 0) {
       h = _network.hashCode();
       h = 31 * h + Long.hashCode(getAdministrativeCost());
-      h = 31 * h + Long.hashCode(_area);
-      h = 31 * h + Long.hashCode(_metric);
+      h = 31 * h + Long.hashCode(getArea());
+      h = 31 * h + Long.hashCode(getMetric());
       h = 31 * h + _nextHop.hashCode();
       h = 31 * h + Boolean.hashCode(getNonForwarding());
       h = 31 * h + Boolean.hashCode(getNonRouting());

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfRoute.java
@@ -15,12 +15,14 @@ import org.batfish.datamodel.route.nh.NextHopIp;
 public abstract class OspfRoute extends AbstractRoute {
 
   /** Indicate that this route has no defined area (e.g., external routes) */
-  public static final long NO_AREA = -1L;
+  public static final long NO_AREA = 0xFFFFFFFFL;
 
   protected static final String PROP_AREA = "area";
 
-  protected final long _area;
-  protected final long _metric;
+  // Stored as unsigned 32-bit int for memory savings. Use getArea() to read.
+  private final int _area;
+  // Stored as unsigned 32-bit int for memory savings. Use getMetric() to read.
+  private final int _metric;
 
   protected OspfRoute(
       Prefix network,
@@ -38,22 +40,22 @@ public abstract class OspfRoute extends AbstractRoute {
     checkArgument(
         !(nextHop instanceof NextHopInterface) || ((NextHopInterface) nextHop).getIp() != null,
         "OSPF routes with next-hop interface must have next-hop IP.");
-    _metric = metric;
+    _metric = (int) metric;
     _nextHop = nextHop;
-    _area = area;
+    _area = (int) area;
   }
 
   /** The route's area number */
   @JsonProperty(PROP_AREA)
   public long getArea() {
-    return _area;
+    return Integer.toUnsignedLong(_area);
   }
 
   @Override
   @JsonIgnore(false)
   @JsonProperty(PROP_METRIC)
   public final @Nonnull long getMetric() {
-    return _metric;
+    return Integer.toUnsignedLong(_metric);
   }
 
   @Override

--- a/projects/common/src/main/java/org/batfish/datamodel/RipInternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/RipInternalRoute.java
@@ -91,7 +91,7 @@ public class RipInternalRoute extends RipRoute {
     RipRoute other = (RipRoute) o;
     return _network.equals(other._network)
         && getAdministrativeCost() == other.getAdministrativeCost()
-        && _metric == other._metric
+        && getMetric() == other.getMetric()
         && _nextHop.equals(other._nextHop)
         && getNonForwarding() == other.getNonForwarding()
         && getNonRouting() == other.getNonRouting()
@@ -103,7 +103,7 @@ public class RipInternalRoute extends RipRoute {
     return Objects.hash(
         _network,
         getAdministrativeCost(),
-        _metric,
+        getMetric(),
         _nextHop,
         getNonForwarding(),
         getNonRouting(),

--- a/projects/common/src/main/java/org/batfish/datamodel/RipRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/RipRoute.java
@@ -13,7 +13,8 @@ public abstract class RipRoute extends AbstractRoute {
   /** Maximum allowable route metric in RIP */
   public static final long MAX_ROUTE_METRIC = 16;
 
-  protected final long _metric;
+  // Stored as unsigned 32-bit int for memory savings. Use getMetric() to read.
+  private final int _metric;
 
   protected RipRoute(Prefix network, NextHop nextHop, long admin, long metric, long tag) {
     super(network, admin, tag, false, false);
@@ -22,7 +23,7 @@ public abstract class RipRoute extends AbstractRoute {
         "Invalid RIP route metric %s. Must be between 0 and %s",
         metric,
         MAX_ROUTE_METRIC);
-    _metric = metric;
+    _metric = (int) metric;
     _nextHop = nextHop;
   }
 
@@ -30,6 +31,6 @@ public abstract class RipRoute extends AbstractRoute {
   @JsonProperty(PROP_METRIC)
   @Override
   public final long getMetric() {
-    return _metric;
+    return Integer.toUnsignedLong(_metric);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -33,7 +33,8 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
   private static final String PROP_NEXT_VRF = "nextVrf";
   private static final String PROP_TRACK = "track";
 
-  private final long _metric;
+  // Stored as unsigned 32-bit int for memory savings. Use getMetric() to read.
+  private final int _metric;
   private final boolean _recursive;
   private final @Nullable String _track;
 
@@ -74,7 +75,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       boolean recursive,
       @Nullable String track) {
     super(network, administrativeCost, tag, nonRouting, nonForwarding);
-    _metric = metric;
+    _metric = (int) metric;
     _nextHop = nextHop;
     _recursive = recursive;
     _track = track;
@@ -84,7 +85,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
   @JsonIgnore(false)
   @JsonProperty(PROP_METRIC)
   public long getMetric() {
-    return _metric;
+    return Integer.toUnsignedLong(_metric);
   }
 
   /** Jackson use only */
@@ -197,7 +198,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
     return builder()
         .setNetwork(getNetwork())
         .setNextHop(_nextHop)
-        .setMetric(_metric)
+        .setMetric(getMetric())
         .setTag(getTag())
         .setAdmin(getAdministrativeCost())
         .setNonRouting(getNonRouting())
@@ -219,7 +220,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
         && getAdministrativeCost() == rhs.getAdministrativeCost()
         && getNonForwarding() == rhs.getNonForwarding()
         && getNonRouting() == rhs.getNonRouting()
-        && _metric == rhs._metric
+        && getMetric() == rhs.getMetric()
         && _nextHop.equals(rhs._nextHop)
         && getTag() == rhs.getTag()
         && _recursive == rhs._recursive
@@ -236,7 +237,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
               getAdministrativeCost(),
               getNonForwarding(),
               getNonRouting(),
-              _metric,
+              getMetric(),
               _nextHop,
               getTag(),
               _recursive,
@@ -253,7 +254,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
         .add(PROP_NETWORK, _network)
         .add("nextHop", _nextHop)
         .add(PROP_ADMINISTRATIVE_COST, getAdministrativeCost())
-        .add(PROP_METRIC, _metric)
+        .add(PROP_METRIC, getMetric())
         .add("recursive", _recursive)
         .add(PROP_TAG, getTag())
         .add(PROP_TRACK, _track)

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -205,7 +205,7 @@ public class RoutesAnswererUtilTest {
             .setNetwork(Prefix.parse("1.1.1.0/24"))
             .setNextHop(NextHopInterface.of("e0", Ip.parse("1.1.1.2")))
             .setAdmin(10)
-            .setMetric(2L << 34)
+            .setMetric(2L << 30)
             .setLsaMetric(2)
             .setCostToAdvertiser(2)
             .setArea(1L)
@@ -234,7 +234,7 @@ public class RoutesAnswererUtilTest {
                 hasColumn(COL_PROTOCOL, "ospfE2", Schema.STRING),
                 hasColumn(COL_TAG, equalTo(2L << 30), Schema.LONG),
                 hasColumn(COL_ADMIN_DISTANCE, equalTo(10), Schema.INTEGER),
-                hasColumn(COL_METRIC, equalTo(2L << 34), Schema.LONG))));
+                hasColumn(COL_METRIC, equalTo(2L << 30), Schema.LONG))));
   }
 
   @Test


### PR DESCRIPTION
Convert remaining long fields to unsigned 32-bit int across route
subclasses: OSPF _area/_metric/_costToAdvertiser/_lsaMetric, ISIS
_metric, EIGRP _processAsn, Static _metric, RIP _metric, and
Generated _metric. All fields are now private with unsigned getters.

JOL measurements (with -XX:-UseCompressedOops):
OspfIntraAreaRoute: 64 -> 56 bytes
IsisRoute:          88 -> 80 bytes
StaticRoute:        64 -> 56 bytes
EigrpInternalRoute: 64 -> 64 bytes (padding absorbed savings)
RipInternalRoute:   48 -> 48 bytes (padding absorbed savings)

Also changed OspfRoute.NO_AREA from -1L to 0xFFFFFFFFL. Unlike
UNSET_ROUTE_TAG (which uses a _hasTag boolean to distinguish from
MAX_TAG), NO_AREA simply conflates with area 0xFFFFFFFF — an area
ID that is never used in practice.

----

Prompt:
```
Convert remaining long metric/area/processAsn fields across OSPF,
ISIS, EIGRP, Static, RIP, and Generated route classes to unsigned
32-bit int, following the same pattern as AbstractRoute._admin/_tag.
```

---
**Stack**:
- #9840
- #9839 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*