### PR TITLE
BgpRoute: store pathId as int with 0 sentinel for null

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -496,7 +496,8 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
   static final String PROP_WEIGHT = "weight";
 
   protected final @Nonnull BgpRouteAttributes _attributes;
-  protected final @Nullable Integer _pathId;
+  // Stored as int with 0 meaning null (path IDs start at 1). Use getPathId() to read.
+  private final int _pathId;
 
   protected final @Nonnull ReceivedFrom _receivedFrom;
 
@@ -513,7 +514,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
     super(network, admin, tag, nonRouting, nonForwarding);
     _attributes = attributes;
     _nextHop = nextHop;
-    _pathId = pathId;
+    _pathId = pathId == null ? 0 : pathId;
     _receivedFrom = receivedFrom;
   }
 
@@ -588,7 +589,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
    */
   @JsonProperty(PROP_PATH_ID)
   public @Nullable Integer getPathId() {
-    return _pathId;
+    return _pathId == 0 ? null : _pathId;
   }
 
   @JsonIgnore(false)

--- a/projects/common/src/main/java/org/batfish/datamodel/Bgpv4Route.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Bgpv4Route.java
@@ -65,7 +65,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
           _receivedFrom,
           getNetwork(),
           _nextHop,
-          _pathId,
+          getPathId(),
           getAdmin(),
           getTag(),
           getNonForwarding(),
@@ -189,7 +189,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
         .setOriginatorIp(_attributes._originatorIp)
         .setOriginMechanism(_attributes.getOriginMechanism())
         .setOriginType(_attributes.getOriginType())
-        .setPathId(_pathId)
+        .setPathId(getPathId())
         .setProtocol(_attributes.getProtocol())
         .setReceivedFrom(_receivedFrom)
         .setReceivedFromRouteReflectorClient(_attributes._receivedFromRouteReflectorClient)
@@ -211,7 +211,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
     return (_hashCode == other._hashCode || _hashCode == 0 || other._hashCode == 0)
         && _network.equals(other._network)
         && _nextHop.equals(other._nextHop)
-        && Objects.equals(_pathId, other._pathId)
+        && Objects.equals(getPathId(), other.getPathId())
         && _attributes.equals(other._attributes)
         && _receivedFrom.equals(other._receivedFrom)
         // Things above this line are more likely to cause false earlier.
@@ -230,7 +230,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
       h = h * 31 + _receivedFrom.hashCode();
       h = h * 31 + _network.hashCode();
       h = h * 31 + _nextHop.hashCode();
-      h = h * 31 + (_pathId != null ? _pathId : 0);
+      h = h * 31 + (getPathId() != null ? getPathId() : 0);
       h = h * 31 + Boolean.hashCode(getNonForwarding());
       h = h * 31 + Boolean.hashCode(getNonRouting());
       h = h * 31 + Long.hashCode(getTag());
@@ -256,7 +256,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
         .add("_originatorIp", _attributes._originatorIp)
         .add("_originMechanism", _attributes._originMechanism)
         .add("_originType", _attributes._originType)
-        .add("_pathId", _pathId)
+        .add("getPathId()", getPathId())
         .add("_protocol", _attributes._protocol)
         .add("_receivedFrom", _receivedFrom)
         .add("_receivedFromRouteReflectorClient", _attributes._receivedFromRouteReflectorClient)

--- a/projects/common/src/main/java/org/batfish/datamodel/EvpnType2Route.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EvpnType2Route.java
@@ -72,7 +72,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
           _macAddress,
           _routeDistinguisher,
           _vni,
-          _pathId,
+          getPathId(),
           getTag());
     }
 
@@ -220,7 +220,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
         .setOriginatorIp(_attributes._originatorIp)
         .setOriginMechanism(_attributes.getOriginMechanism())
         .setOriginType(_attributes.getOriginType())
-        .setPathId(_pathId)
+        .setPathId(getPathId())
         .setProtocol(_attributes.getProtocol())
         .setReceivedFrom(_receivedFrom)
         .setReceivedFromRouteReflectorClient(_attributes._receivedFromRouteReflectorClient)
@@ -248,7 +248,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
         && _receivedFrom.equals(other._receivedFrom)
         && Objects.equals(_macAddress, other._macAddress)
         && Objects.equals(_nextHop, other._nextHop)
-        && Objects.equals(_pathId, other._pathId)
+        && Objects.equals(getPathId(), other.getPathId())
         && Objects.equals(_routeDistinguisher, other._routeDistinguisher)
         && _vni == other._vni
         && getTag() == other.getTag();
@@ -264,7 +264,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
       h = h * 31 + Objects.hashCode(_macAddress);
       h = h * 31 + _network.hashCode();
       h = h * 31 + _nextHop.hashCode();
-      h = h * 31 + Objects.hashCode(_pathId);
+      h = h * 31 + Objects.hashCode(getPathId());
       h = h * 31 + _routeDistinguisher.hashCode();
       h = h * 31 + Integer.hashCode(_vni);
       h = h * 31 + Long.hashCode(getTag());

--- a/projects/common/src/main/java/org/batfish/datamodel/EvpnType3Route.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EvpnType3Route.java
@@ -69,7 +69,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
           _nextHop,
           _routeDistinguisher,
           _vni,
-          _pathId,
+          getPathId(),
           getTag(),
           _vniIp);
     }
@@ -198,7 +198,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
         .setOriginatorIp(_attributes._originatorIp)
         .setOriginMechanism(_attributes.getOriginMechanism())
         .setOriginType(_attributes.getOriginType())
-        .setPathId(_pathId)
+        .setPathId(getPathId())
         .setProtocol(_attributes.getProtocol())
         .setReceivedFrom(_receivedFrom)
         .setReceivedFromRouteReflectorClient(_attributes._receivedFromRouteReflectorClient)
@@ -225,7 +225,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
         && _attributes.equals(other._attributes)
         && _receivedFrom.equals(other._receivedFrom)
         && Objects.equals(_nextHop, other._nextHop)
-        && Objects.equals(_pathId, other._pathId)
+        && Objects.equals(getPathId(), other.getPathId())
         && Objects.equals(_routeDistinguisher, other._routeDistinguisher)
         && _vni == other._vni
         && getTag() == other.getTag()
@@ -240,7 +240,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
       h = h * 31 + _receivedFrom.hashCode();
       h = h * 31 + _network.hashCode();
       h = h * 31 + _nextHop.hashCode();
-      h = h * 31 + Objects.hashCode(_pathId);
+      h = h * 31 + Objects.hashCode(getPathId());
       h = h * 31 + _routeDistinguisher.hashCode();
       h = h * 31 + Integer.hashCode(_vni);
       h = h * 31 + Long.hashCode(getTag());

--- a/projects/common/src/main/java/org/batfish/datamodel/EvpnType5Route.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EvpnType5Route.java
@@ -68,7 +68,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
           _nextHop,
           _routeDistinguisher,
           _vni,
-          _pathId,
+          getPathId(),
           getTag());
     }
 
@@ -173,7 +173,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         .setOriginatorIp(_attributes._originatorIp)
         .setOriginMechanism(_attributes.getOriginMechanism())
         .setOriginType(_attributes.getOriginType())
-        .setPathId(_pathId)
+        .setPathId(getPathId())
         .setProtocol(_attributes.getProtocol())
         .setReceivedFrom(_receivedFrom)
         .setReceivedFromRouteReflectorClient(_attributes._receivedFromRouteReflectorClient)
@@ -199,7 +199,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         && _attributes.equals(other._attributes)
         && _receivedFrom.equals(other._receivedFrom)
         && Objects.equals(_nextHop, other._nextHop)
-        && Objects.equals(_pathId, other._pathId)
+        && Objects.equals(getPathId(), other.getPathId())
         && Objects.equals(_routeDistinguisher, other._routeDistinguisher)
         && _vni == other._vni
         && getTag() == other.getTag();
@@ -213,7 +213,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
       h = h * 31 + _receivedFrom.hashCode();
       h = h * 31 + _network.hashCode();
       h = h * 31 + _nextHop.hashCode();
-      h = h * 31 + Objects.hashCode(_pathId);
+      h = h * 31 + Objects.hashCode(getPathId());
       h = h * 31 + _routeDistinguisher.hashCode();
       h = h * 31 + Integer.hashCode(_vni);
       h = h * 31 + Long.hashCode(getTag());
@@ -239,7 +239,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         .add(PROP_ORIGINATOR_IP, _attributes._originatorIp)
         .add(PROP_ORIGIN_MECHANISM, _attributes._originMechanism)
         .add(PROP_ORIGIN_TYPE, _attributes._originType)
-        .add(PROP_PATH_ID, _pathId)
+        .add(PROP_PATH_ID, getPathId())
         .add(PROP_PROTOCOL, _attributes._protocol)
         .add(PROP_RECEIVED_FROM, _receivedFrom)
         .add(


### PR DESCRIPTION
Replace the boxed @Nullable Integer _pathId with a primitive int,
using 0 as the sentinel for null (path IDs are generated starting
at 1, so 0 is never a valid value). This eliminates both the 8-byte
object reference and the ~16-byte Integer object per route.

JOL: Bgpv4Route shrinks from 72 to 64 bytes. The int slots into
alignment padding that was previously wasted, achieving zero padding
loss (1 byte internal only).

The public API (getPathId() returning @Nullable Integer) is
preserved; the getter boxes on return only when non-null.

----

Prompt:
```
Convert BgpRoute's boxed @Nullable Integer _pathId to a primitive
int with 0 as sentinel for null, eliminating the object reference
and Integer allocation per route.
```

---
**Stack**:
- #9840 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*