### PR TITLE
Juniper: parse family inet6 filter input-list and output-list

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -411,9 +411,7 @@ ifi6a_primary: PRIMARY;
 
 ifi6_destination_udp_port: DESTINATION_UDP_PORT port_number;
 
-ifi6_filter: FILTER ifi6f_input;
-
-ifi6f_input: INPUT name = junos_name;
+ifi6_filter: filter;
 
 ifi6_mtu: i_mtu;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -458,9 +458,9 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_port_modeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_vlanContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6_destination_udp_portContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6_filterContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6a_preferredContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6a_primaryContext;
-import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi6f_inputContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi_destination_udp_portContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifi_filterContext;
@@ -5678,10 +5678,34 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
-  public void exitIfi6f_input(Ifi6f_inputContext ctx) {
-    String name = toString(ctx.name);
+  public void exitIfi6_filter(Ifi6_filterContext ctx) {
+    FilterContext filter = ctx.filter();
+    if (filter.direction() == null) {
+      return;
+    }
+    String name = toString(filter.name);
+    JuniperStructureUsage usage = INTERFACE_FILTER;
+    if (filter.direction() != null) {
+      DirectionContext direction = filter.direction();
+      if (direction.INPUT() != null) {
+        _currentInterfaceOrRange.setIncomingFilter6(name);
+        usage = INTERFACE_INCOMING_FILTER;
+      } else if (direction.INPUT_LIST() != null) {
+        _currentInterfaceOrRange.addIncomingFilterList6(name);
+        usage = INTERFACE_INCOMING_FILTER_LIST;
+      } else if (direction.OUTPUT() != null) {
+        _currentInterfaceOrRange.setOutgoingFilter6(name);
+        usage = INTERFACE_OUTGOING_FILTER;
+      } else if (direction.OUTPUT_LIST() != null) {
+        _currentInterfaceOrRange.addOutgoingFilterList6(name);
+        usage = INTERFACE_OUTGOING_FILTER_LIST;
+      } else {
+        // Should be unreachable.
+        warn(ctx, "Unhandled filter direction");
+      }
+    }
     _configuration.referenceStructure(
-        FIREWALL_INET6_FILTER, name, INTERFACE_FILTER, getLine(ctx.name.start));
+        FIREWALL_INET6_FILTER, name, usage, getLine(filter.name.getStart()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -159,6 +159,8 @@ public class Interface implements Serializable {
   private @Nullable EthernetSwitching _ethernetSwitching;
   private @Nullable String _incomingFilter;
   private @Nullable List<String> _incomingFilterList;
+  private @Nullable String _incomingFilter6;
+  private @Nullable List<String> _incomingFilterList6;
   private transient boolean _inherited;
   private @Nullable IsisInterfaceSettings _isisSettings;
   private IsoAddress _isoAddress;
@@ -168,6 +170,8 @@ public class Interface implements Serializable {
   private @Nullable OspfInterfaceSettings _ospfSettings;
   private @Nullable String _outgoingFilter;
   private @Nullable List<String> _outgoingFilterList;
+  private @Nullable String _outgoingFilter6;
+  private @Nullable List<String> _outgoingFilterList6;
   private Interface _parent;
   private InterfaceAddress _preferredAddress;
   private @Nullable ConcreteInterfaceAddress6 _preferredAddress6;
@@ -248,6 +252,14 @@ public class Interface implements Serializable {
     return _incomingFilterList;
   }
 
+  public @Nullable String getIncomingFilter6() {
+    return _incomingFilter6;
+  }
+
+  public @Nullable List<String> getIncomingFilterList6() {
+    return _incomingFilterList6;
+  }
+
   public @Nullable IsisInterfaceSettings getIsisSettings() {
     return _isisSettings;
   }
@@ -290,6 +302,14 @@ public class Interface implements Serializable {
 
   public @Nullable List<String> getOutgoingFilterList() {
     return _outgoingFilterList;
+  }
+
+  public @Nullable String getOutgoingFilter6() {
+    return _outgoingFilter6;
+  }
+
+  public @Nullable List<String> getOutgoingFilterList6() {
+    return _outgoingFilterList6;
   }
 
   public Interface getParent() {
@@ -459,6 +479,19 @@ public class Interface implements Serializable {
     _incomingFilterList.add(accessListName);
   }
 
+  public void setIncomingFilter6(@Nullable String accessListName) {
+    _incomingFilter6 = accessListName;
+    _incomingFilterList6 = null;
+  }
+
+  public void addIncomingFilterList6(@Nonnull String accessListName) {
+    _incomingFilter6 = null;
+    if (_incomingFilterList6 == null) {
+      _incomingFilterList6 = new LinkedList<>();
+    }
+    _incomingFilterList6.add(accessListName);
+  }
+
   public void setIsoAddress(IsoAddress address) {
     _isoAddress = address;
   }
@@ -486,6 +519,19 @@ public class Interface implements Serializable {
       _outgoingFilterList = new LinkedList<>();
     }
     _outgoingFilterList.add(accessListName);
+  }
+
+  public void setOutgoingFilter6(@Nullable String accessListName) {
+    _outgoingFilter6 = accessListName;
+    _outgoingFilterList6 = null;
+  }
+
+  public void addOutgoingFilterList6(@Nonnull String accessListName) {
+    _outgoingFilter6 = null;
+    if (_outgoingFilterList6 == null) {
+      _outgoingFilterList6 = new LinkedList<>();
+    }
+    _outgoingFilterList6.add(accessListName);
   }
 
   public void setParent(Interface parent) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2292,7 +2292,7 @@ public final class FlatJuniperGrammarTest {
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
 
     /* Confirm filter usage is tracked properly */
-    assertThat(ccae, hasNumReferrers(filename, FIREWALL_FILTER, "FILTER1", 3));
+    assertThat(ccae, hasNumReferrers(filename, FIREWALL_FILTER, "FILTER1", 4));
     assertThat(ccae, hasNumReferrers(filename, FIREWALL_FILTER, "FILTER2", 4));
     assertThat(ccae, hasNumReferrers(filename, FIREWALL_FILTER, "FILTER_UNUSED", 0));
 
@@ -2365,6 +2365,59 @@ public final class FlatJuniperGrammarTest {
       assertThat(iface.getIncomingFilterList(), contains("FILTER1", "FILTER2"));
       assertThat(iface.getOutgoingFilter(), nullValue());
       assertThat(iface.getOutgoingFilterList(), contains("FILTER2", "FILTER1"));
+    }
+    // inet6 filter input
+    {
+      String parentName = "xe-0/0/4";
+      String unitName = parentName + ".0";
+      assertThat(ifaces, hasKey(parentName));
+      org.batfish.representation.juniper.Interface parent = ifaces.get(parentName);
+      assertThat(parent.getUnits(), hasKey(unitName));
+      org.batfish.representation.juniper.Interface iface = parent.getUnits().get(unitName);
+      assertThat(iface.getIncomingFilter6(), equalTo("FILTER6_1"));
+      assertThat(iface.getIncomingFilterList6(), nullValue());
+      assertThat(iface.getOutgoingFilter6(), nullValue());
+      assertThat(iface.getOutgoingFilterList6(), nullValue());
+    }
+    // inet6 filter input-list and output-list
+    {
+      String parentName = "xe-0/0/5";
+      String unitName = parentName + ".0";
+      assertThat(ifaces, hasKey(parentName));
+      org.batfish.representation.juniper.Interface parent = ifaces.get(parentName);
+      assertThat(parent.getUnits(), hasKey(unitName));
+      org.batfish.representation.juniper.Interface iface = parent.getUnits().get(unitName);
+      assertThat(iface.getIncomingFilter6(), nullValue());
+      assertThat(iface.getIncomingFilterList6(), contains("FILTER6_1", "FILTER6_2"));
+      assertThat(iface.getOutgoingFilter6(), nullValue());
+      assertThat(iface.getOutgoingFilterList6(), contains("FILTER6_2", "FILTER6_1"));
+    }
+    // inet6 input-list then input: input wins, clears list
+    {
+      String parentName = "xe-0/0/6";
+      String unitName = parentName + ".0";
+      org.batfish.representation.juniper.Interface iface =
+          ifaces.get(parentName).getUnits().get(unitName);
+      assertThat(iface.getIncomingFilter6(), equalTo("FILTER6_2"));
+      assertThat(iface.getIncomingFilterList6(), nullValue());
+    }
+    // inet6 input then input-list: input-list wins, clears single
+    {
+      String parentName = "xe-0/0/7";
+      String unitName = parentName + ".0";
+      org.batfish.representation.juniper.Interface iface =
+          ifaces.get(parentName).getUnits().get(unitName);
+      assertThat(iface.getIncomingFilter6(), nullValue());
+      assertThat(iface.getIncomingFilterList6(), contains("FILTER6_2"));
+    }
+    // inet and inet6 are independent
+    {
+      String parentName = "xe-0/0/8";
+      String unitName = parentName + ".0";
+      org.batfish.representation.juniper.Interface iface =
+          ifaces.get(parentName).getUnits().get(unitName);
+      assertThat(iface.getIncomingFilter(), equalTo("FILTER1"));
+      assertThat(iface.getIncomingFilter6(), equalTo("FILTER6_1"));
     }
 
     // filter definitions

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filters
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filters
@@ -49,5 +49,31 @@ set firewall filter PARSING term PACKET_LENGTH from packet-length 100-200
 set firewall filter PARSING term PACKET_LENGTH from packet-length-except 70
 set firewall filter PARSING term PACKET_LENGTH from packet-length-except 80-90
 #
+#
+set firewall family inet6 filter FILTER6_1 term TERM from next-header tcp
+set firewall family inet6 filter FILTER6_1 term TERM then accept
+set firewall family inet6 filter FILTER6_2 term TERM from next-header udp
+set firewall family inet6 filter FILTER6_2 term TERM then accept
+set interfaces xe-0/0/4 unit 0 family inet6 address 2001:db8::1/64
+set interfaces xe-0/0/4 unit 0 family inet6 filter input FILTER6_1
+set interfaces xe-0/0/5 unit 0 family inet6 address 2001:db8::2/64
+set interfaces xe-0/0/5 unit 0 family inet6 filter input-list FILTER6_1
+set interfaces xe-0/0/5 unit 0 family inet6 filter input-list FILTER6_2
+set interfaces xe-0/0/5 unit 0 family inet6 filter output-list FILTER6_2
+set interfaces xe-0/0/5 unit 0 family inet6 filter output-list FILTER6_1
+# inet6 input-list then input: input wins, clears list
+set interfaces xe-0/0/6 unit 0 family inet6 address 2001:db8::3/64
+set interfaces xe-0/0/6 unit 0 family inet6 filter input-list FILTER6_1
+set interfaces xe-0/0/6 unit 0 family inet6 filter input FILTER6_2
+# inet6 input then input-list: input-list wins, clears single
+set interfaces xe-0/0/7 unit 0 family inet6 address 2001:db8::4/64
+set interfaces xe-0/0/7 unit 0 family inet6 filter input FILTER6_1
+set interfaces xe-0/0/7 unit 0 family inet6 filter input-list FILTER6_2
+# inet and inet6 are independent
+set interfaces xe-0/0/8 unit 0 family inet address 5.2.3.4/24
+set interfaces xe-0/0/8 unit 0 family inet filter input FILTER1
+set interfaces xe-0/0/8 unit 0 family inet6 address 2001:db8::5/64
+set interfaces xe-0/0/8 unit 0 family inet6 filter input FILTER6_1
+#
 set firewall family inet filter FILTER term IPV6 from protocol ipv6
 set firewall family inet filter FILTER term DECAPSULATE-GRE then decapsulate gre

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -52637,12 +52637,14 @@
             "                    FAMILY:'family'",
             "                    (if_inet6*",
             "                      INET6:'inet6'",
-            "                      (ifi6_filter*",
-            "                        FILTER:'filter'",
-            "                        (ifi6f_input",
-            "                          INPUT:'input'  <== mode:M_Filter",
-            "                          name = (junos_name*",
-            "                            NAME:'blah6'  <== mode:M_Filter))))))))))))",
+            "                      (ifi6_filter",
+            "                        (filter*",
+            "                          FILTER:'filter'",
+            "                          (direction*",
+            "                            INPUT:'input'  <== mode:M_Filter)",
+            "                          name = (filter_name*",
+            "                            (junos_name*",
+            "                              NAME:'blah6'  <== mode:M_Filter)))))))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",
             "    SET:'set'",
@@ -82537,7 +82539,7 @@
         "configs/juniper_firewall" : {
           "firewall family inet6 filter" : {
             "blah6" : {
-              "interface firewall filter" : [
+              "interface firewall filter input" : [
                 47
               ]
             }


### PR DESCRIPTION
The Juniper flat parser only recognized `family inet6 filter input`.
Reuse the generic `filter` rule (which supports input, input-list,
output, output-list) for inet6, matching how inet already works.

Add separate inet6 filter fields to Interface to avoid overwriting
inet filter assignments. Extraction-only; no VI model conversion yet.

----

Prompt:
```
Look at the ipv6 filter-list apply groups that is not recognized.
Fix it and add a test.
```

---

**Stack**:
- #9857
- #9856
- #9855 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*