### PR TITLE
Juniper: parse hop-limit-except and fix spaced sub-ranges

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -918,7 +918,8 @@ HOME_ADDRESS_OPTION: 'home-address-option';
 
 HOP_BY_HOP_HEADER: 'hop-by-hop-header';
 
-HOP_LIMIT: 'hop-limit';
+HOP_LIMIT: 'hop-limit' -> pushMode(M_SubRange);
+HOP_LIMIT_EXCEPT: 'hop-limit-except' -> pushMode(M_SubRange);
 
 HOST_OUTBOUND_TRAFFIC: 'host-outbound-traffic';
 
@@ -5012,6 +5013,7 @@ M_SubRange_DASH: '-' -> type(DASH), mode(M_SubRangeDash);
 M_SubRange_OTHER: F_Alpha F_NonWhitespaceChar* { less(); } -> popMode;
 
 mode M_SubRangeDash;
+M_SubRangeDash_WS: F_WhitespaceChar+ -> skip;
 M_SubRangeDash_NEWLINE: F_Newline -> type(NEWLINE), popMode;
 M_SubRangeDash_UINT8: F_Uint8 -> type(UINT8), popMode;
 M_SubRangeDash_UINT16: F_Uint16 -> type(UINT16), popMode;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
@@ -135,6 +135,7 @@ fft_from
       | fftf_fragment_offset
       | fftf_fragment_offset_except
       | fftf_hop_limit
+      | fftf_hop_limit_except
       | fftf_icmp_code
       | fftf_icmp_code_except
       | fftf_icmp_type
@@ -270,7 +271,12 @@ fragment_offset
 
 fftf_hop_limit
 :
-   HOP_LIMIT uint8
+   HOP_LIMIT uint8_range
+;
+
+fftf_hop_limit_except
+:
+   HOP_LIMIT_EXCEPT uint8_range
 ;
 
 fftf_icmp_code

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
@@ -267,7 +267,7 @@ mplslsp_cross_credibility_cspf_null
 
 mplslsp_hop_limit_null
 :
-   HOP_LIMIT uint32
+   HOP_LIMIT uint8
 ;
 
 mplslsp_optimize_timer_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1022,6 +1022,7 @@ import org.batfish.representation.juniper.FwFromDestinationPrefixList;
 import org.batfish.representation.juniper.FwFromDestinationPrefixListExcept;
 import org.batfish.representation.juniper.FwFromDscp;
 import org.batfish.representation.juniper.FwFromFragmentOffset;
+import org.batfish.representation.juniper.FwFromHopLimit;
 import org.batfish.representation.juniper.FwFromIcmpCode;
 import org.batfish.representation.juniper.FwFromIcmpCodeExcept;
 import org.batfish.representation.juniper.FwFromIcmpType;
@@ -4976,6 +4977,18 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   private @Nonnull Optional<Integer> toInteger(
       ParserRuleContext messageCtx, Fragment_offsetContext ctx) {
     return toIntegerInSpace(messageCtx, ctx, FRAGMENT_OFFSET_RANGE, "fragment offset");
+  }
+
+  @Override
+  public void exitFftf_hop_limit(FlatJuniperParser.Fftf_hop_limitContext ctx) {
+    SubRange range = toSubRange(ctx.uint8_range());
+    _currentFwTerm.getFroms().add(new FwFromHopLimit(range, false));
+  }
+
+  @Override
+  public void exitFftf_hop_limit_except(FlatJuniperParser.Fftf_hop_limit_exceptContext ctx) {
+    SubRange range = toSubRange(ctx.uint8_range());
+    _currentFwTerm.getFroms().add(new FwFromHopLimit(range, true));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromHopLimit.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromHopLimit.java
@@ -1,0 +1,43 @@
+package org.batfish.representation.juniper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.representation.juniper.FwTerm.Field;
+
+/** Class for firewall filter from hop-limit */
+@ParametersAreNonnullByDefault
+public class FwFromHopLimit implements FwFrom {
+
+  private final boolean _except;
+
+  private final @Nonnull SubRange _range;
+
+  public FwFromHopLimit(SubRange range, boolean except) {
+    _range = range;
+    _except = except;
+  }
+
+  public boolean getExcept() {
+    return _except;
+  }
+
+  public @Nonnull SubRange getRange() {
+    return _range;
+  }
+
+  @Override
+  public Field getField() {
+    return _except ? Field.HOP_LIMIT_EXCEPT : Field.HOP_LIMIT;
+  }
+
+  @Override
+  public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
+    // TODO: support hop-limit matching in vendor-independent model
+    return AclLineMatchExprs.FALSE;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwTerm.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwTerm.java
@@ -16,6 +16,8 @@ public final class FwTerm implements Serializable {
     DSCP,
     FRAGMENT_OFFSET,
     FRAGMENT_OFFSET_EXCEPT,
+    HOP_LIMIT,
+    HOP_LIMIT_EXCEPT,
     ICMP_CODE,
     ICMP_CODE_EXCEPT,
     ICMP_TYPE,

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -421,6 +421,7 @@ import org.batfish.representation.juniper.FirewallFilter;
 import org.batfish.representation.juniper.FwFrom;
 import org.batfish.representation.juniper.FwFromDestinationPort;
 import org.batfish.representation.juniper.FwFromFragmentOffset;
+import org.batfish.representation.juniper.FwFromHopLimit;
 import org.batfish.representation.juniper.FwFromIcmpCode;
 import org.batfish.representation.juniper.FwFromIcmpCodeExcept;
 import org.batfish.representation.juniper.FwFromIcmpType;
@@ -9846,6 +9847,81 @@ public final class FlatJuniperGrammarTest {
       assertThat(fromTtl.getRange(), equalTo(new SubRange(100, 200)));
       assertThat(fromTtl.getExcept(), equalTo(true));
       assertFalse(i.hasNext());
+    }
+  }
+
+  @Test
+  public void testFirewallFilterHopLimit() {
+    String hostname = "firewall-filter-hop-limit";
+    JuniperConfiguration vc = parseJuniperConfig(hostname);
+    Map<String, FirewallFilter> filters = vc.getMasterLogicalSystem().getFirewallFilters();
+
+    assertThat(filters, hasKey("FILTER"));
+    ConcreteFirewallFilter filter = (ConcreteFirewallFilter) filters.get("FILTER");
+    assertThat(
+        filter.getTerms().keySet(),
+        containsInAnyOrder("SINGLE", "RANGE", "EXCEPT", "EXCEPT_RANGE"));
+
+    // Single hop-limit value
+    {
+      FwTerm term = filter.getTerms().get("SINGLE");
+      assertThat(term.getFroms(), hasSize(1));
+      FwFromHopLimit from = (FwFromHopLimit) term.getFroms().get(0);
+      assertThat(from.getRange(), equalTo(SubRange.singleton(255)));
+      assertFalse(from.getExcept());
+    }
+
+    // hop-limit range
+    {
+      FwTerm term = filter.getTerms().get("RANGE");
+      assertThat(term.getFroms(), hasSize(1));
+      FwFromHopLimit from = (FwFromHopLimit) term.getFroms().get(0);
+      assertThat(from.getRange(), equalTo(new SubRange(10, 20)));
+      assertFalse(from.getExcept());
+    }
+
+    // hop-limit-except single value
+    {
+      FwTerm term = filter.getTerms().get("EXCEPT");
+      assertThat(term.getFroms(), hasSize(1));
+      FwFromHopLimit from = (FwFromHopLimit) term.getFroms().get(0);
+      assertThat(from.getRange(), equalTo(SubRange.singleton(255)));
+      assertTrue(from.getExcept());
+    }
+
+    // hop-limit-except range
+    {
+      FwTerm term = filter.getTerms().get("EXCEPT_RANGE");
+      assertThat(term.getFroms(), hasSize(1));
+      FwFromHopLimit from = (FwFromHopLimit) term.getFroms().get(0);
+      assertThat(from.getRange(), equalTo(new SubRange(100, 200)));
+      assertTrue(from.getExcept());
+    }
+  }
+
+  @Test
+  public void testFirewallFilterPacketLengthSpacedRange() {
+    String hostname = "firewall-filter-packet-length-spaced-range";
+    JuniperConfiguration vc = parseJuniperConfig(hostname);
+    Map<String, FirewallFilter> filters = vc.getMasterLogicalSystem().getFirewallFilters();
+
+    assertThat(filters, hasKey("FILTER"));
+    ConcreteFirewallFilter filter = (ConcreteFirewallFilter) filters.get("FILTER");
+
+    // Compact range (no spaces around dash)
+    {
+      FwTerm term = filter.getTerms().get("COMPACT");
+      assertThat(term.getFroms(), hasSize(1));
+      FwFromPacketLength from = (FwFromPacketLength) term.getFroms().get(0);
+      assertThat(from.getRange(), equalTo(new SubRange(100, 200)));
+    }
+
+    // Spaced range (spaces around dash)
+    {
+      FwTerm term = filter.getTerms().get("SPACED");
+      assertThat(term.getFroms(), hasSize(1));
+      FwFromPacketLength from = (FwFromPacketLength) term.getFroms().get(0);
+      assertThat(from.getRange(), equalTo(new SubRange(100, 200)));
     }
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filter-hop-limit
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filter-hop-limit
@@ -1,0 +1,14 @@
+#
+set system host-name firewall-filter-hop-limit
+#
+set firewall family inet6 filter FILTER term SINGLE from hop-limit 255
+set firewall family inet6 filter FILTER term SINGLE then accept
+#
+set firewall family inet6 filter FILTER term RANGE from hop-limit 10-20
+set firewall family inet6 filter FILTER term RANGE then accept
+#
+set firewall family inet6 filter FILTER term EXCEPT from hop-limit-except 255
+set firewall family inet6 filter FILTER term EXCEPT then accept
+#
+set firewall family inet6 filter FILTER term EXCEPT_RANGE from hop-limit-except 100-200
+set firewall family inet6 filter FILTER term EXCEPT_RANGE then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filter-packet-length-spaced-range
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filter-packet-length-spaced-range
@@ -1,0 +1,8 @@
+#
+set system host-name firewall-filter-packet-length-spaced-range
+#
+set firewall family inet filter FILTER term COMPACT from packet-length 100-200
+set firewall family inet filter FILTER term COMPACT then accept
+#
+set firewall family inet filter FILTER term SPACED from packet-length 100 - 200
+set firewall family inet filter FILTER term SPACED then accept


### PR DESCRIPTION
Add hop-limit-except support for inet6 firewall filters, with full
extraction into a new FwFromHopLimit class (mirroring FwFromTtl).
Change hop-limit to support ranges (uint8_range) like ttl does.

Fix M_SubRangeDash lexer mode to skip whitespace, allowing spaced
range syntax like `packet-length 100 - 200` (with spaces around
the dash). This was broken for all sub-range tokens.

Also fix MPLS hop-limit grammar from uint32 to uint8: the value is
a TTL (0-255), and M_SubRange mode only produces UINT8/UINT16
tokens.

----

Prompt:
```
Add support for ipv6 filter term 'from hop-limit-except 255'.
Also add support for 'from packet-length 100 - 200'.
```

---

**Stack**:
- #9857
- #9856 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*