### PR TITLE
Add missing readResolve() to Serializable singletons and cached classes

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/FibNullRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/FibNullRoute.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import org.batfish.datamodel.visitors.FibActionVisitor;
 
 /** A {@link FibAction} that discards a packet. */
@@ -22,5 +24,11 @@ public final class FibNullRoute implements FibAction {
   @Override
   public <T> T accept(FibActionVisitor<T> visitor) {
     return visitor.visitFibNullRoute(this);
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/InferFromFib.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/InferFromFib.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel;
 
 import com.google.common.collect.ImmutableSet;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -21,6 +23,12 @@ public final class InferFromFib extends SourceIpInference {
   }
 
   private InferFromFib() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 
   /**
    * Returns the potential source IPs of a packet with the given {@code dstIp} originating on the

--- a/projects/common/src/main/java/org/batfish/datamodel/Ip6.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Ip6.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.net.InetAddresses;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.net.Inet4Address;
@@ -170,5 +172,11 @@ public class Ip6 implements Comparable<Ip6>, Serializable {
   /** Private constructor, use {@link #create} instead */
   private Ip6(BigInteger ip6AsBigInteger) {
     _ip6 = ip6AsBigInteger;
+  }
+
+  /** Cache after deserialization. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return CACHE.get(_ip6);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/Prefix6.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Prefix6.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Optional;
@@ -148,5 +150,11 @@ public class Prefix6 implements Comparable<Prefix6>, Serializable {
         prefixLength);
     _address = network.getNetworkAddress(prefixLength);
     _prefixLength = prefixLength;
+  }
+
+  /** Cache after deserialization. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return CACHE.get(this);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/acl/FalseExpr.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/acl/FalseExpr.java
@@ -3,6 +3,8 @@ package org.batfish.datamodel.acl;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -63,5 +65,11 @@ public class FalseExpr extends AclLineMatchExpr {
   private static @Nonnull FalseExpr jsonCreator(
       @JsonProperty(PROP_TRACE_ELEMENT) @Nullable TraceElement traceElement) {
     return new FalseExpr(traceElement);
+  }
+
+  /** Deserialize to singleton instance when possible. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return _traceElement == null ? INSTANCE : this;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/acl/OriginatingFromDevice.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/acl/OriginatingFromDevice.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.acl;
 
 import com.google.common.base.MoreObjects;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 
 /**
  * Match condition that holds when flow originated from this device rather than being received on
@@ -32,5 +34,11 @@ public class OriginatingFromDevice extends AclLineMatchExpr {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(getClass()).toString();
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/acl/TrueExpr.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/acl/TrueExpr.java
@@ -3,6 +3,8 @@ package org.batfish.datamodel.acl;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -62,5 +64,11 @@ public class TrueExpr extends AclLineMatchExpr {
   private static @Nonnull TrueExpr jsonCreator(
       @JsonProperty(PROP_TRACE_ELEMENT) @Nullable TraceElement traceElement) {
     return new TrueExpr(traceElement);
+  }
+
+  /** Deserialize to singleton instance when possible. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return _traceElement == null ? INSTANCE : this;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/packet_policy/Drop.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/packet_policy/Drop.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.packet_policy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.base.MoreObjects;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -36,5 +38,11 @@ public final class Drop implements Action {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).toString();
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/packet_policy/FalseExpr.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/packet_policy/FalseExpr.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.packet_policy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nullable;
 
 /** The boolean false identity */
@@ -27,5 +29,11 @@ public final class FalseExpr implements BoolExpr {
   @Override
   public <T> T accept(BoolExprVisitor<T> tBoolExprVisitor) {
     return tBoolExprVisitor.visitFalseExpr(this);
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrf.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrf.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.packet_policy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.base.MoreObjects;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nullable;
 
 /** Represents VRF of the ingress interface, resolved at the time of policy evaluation */
@@ -33,5 +35,11 @@ public final class IngressInterfaceVrf implements VrfExpr {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(IngressInterfaceVrf.class).toString();
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/packet_policy/TrueExpr.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/packet_policy/TrueExpr.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.packet_policy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nullable;
 
 /** True boolean identity */
@@ -27,5 +29,11 @@ public final class TrueExpr implements BoolExpr {
   @Override
   public <T> T accept(BoolExprVisitor<T> tBoolExprVisitor) {
     return tBoolExprVisitor.visitTrueExpr(this);
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/route/nh/NextHopDiscard.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/route/nh/NextHopDiscard.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.route.nh;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -40,4 +42,10 @@ public final class NextHopDiscard implements NextHop {
   private static final NextHopDiscard INSTANCE = new NextHopDiscard();
 
   private NextHopDiscard() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/as_path/InputAsPath.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/as_path/InputAsPath.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.as_path;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -33,4 +35,10 @@ public final class InputAsPath extends AsPathExpr {
   private static final InputAsPath INSTANCE = new InputAsPath();
 
   private InputAsPath() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/AllExtendedCommunities.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/AllExtendedCommunities.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.communities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 
 /**
@@ -35,4 +37,10 @@ public final class AllExtendedCommunities extends CommunityMatchExpr {
   }
 
   private AllExtendedCommunities() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/AllLargeCommunities.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/AllLargeCommunities.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.communities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 
 /** Matches a {@link org.batfish.datamodel.bgp.community.Community} iff it is a large community. */
@@ -33,4 +35,10 @@ public final class AllLargeCommunities extends CommunityMatchExpr {
   }
 
   private AllLargeCommunities() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/AllStandardCommunities.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/AllStandardCommunities.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.communities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 
 /**
@@ -35,4 +37,10 @@ public final class AllStandardCommunities extends CommunityMatchExpr {
   }
 
   private AllStandardCommunities() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/ColonSeparatedRendering.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/ColonSeparatedRendering.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.communities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -45,4 +47,10 @@ public final class ColonSeparatedRendering implements CommunityRendering {
   }
 
   private ColonSeparatedRendering() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/InputCommunities.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/InputCommunities.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.routing_policy.communities;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -35,4 +37,10 @@ public final class InputCommunities extends CommunitySetExpr {
   }
 
   private static final InputCommunities INSTANCE = new InputCommunities();
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/IntegerValueRendering.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/IntegerValueRendering.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.communities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -37,4 +39,10 @@ public final class IntegerValueRendering implements CommunityRendering {
   }
 
   private IntegerValueRendering() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunities.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunities.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.communities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 
 /**
@@ -37,4 +39,10 @@ public final class RouteTargetExtendedCommunities extends CommunityMatchExpr {
   }
 
   private RouteTargetExtendedCommunities() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/SiteOfOriginExtendedCommunities.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/SiteOfOriginExtendedCommunities.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.communities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 
 /**
@@ -37,4 +39,10 @@ public final class SiteOfOriginExtendedCommunities extends CommunityMatchExpr {
   }
 
   private SiteOfOriginExtendedCommunities() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/VpnDistinguisherExtendedCommunities.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/VpnDistinguisherExtendedCommunities.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.communities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 
 /**
@@ -37,4 +39,10 @@ public final class VpnDistinguisherExtendedCommunities extends CommunityMatchExp
   }
 
   private VpnDistinguisherExtendedCommunities() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/AutoAs.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/AutoAs.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.List;
 import java.util.Optional;
 import java.util.SortedSet;
@@ -73,5 +75,11 @@ public final class AutoAs extends AsExpr {
   @Override
   public int hashCode() {
     return 0xb21f9d07; // randomly generated
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/DestinationNetwork.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/DestinationNetwork.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment;
 
@@ -29,5 +31,11 @@ public final class DestinationNetwork extends PrefixExpr {
   @Override
   public int hashCode() {
     return System.identityHashCode(this);
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/LastAs.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/LastAs.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.List;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -55,5 +57,11 @@ public final class LastAs extends AsExpr {
   @Override
   public int hashCode() {
     return 0x207D97F5; // randomly generated
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/LocalAs.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/LocalAs.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -39,5 +41,11 @@ public final class LocalAs extends AsExpr {
   @Override
   public String toString() {
     return LocalAs.class.getSimpleName();
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/NextHopIp.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/NextHopIp.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.routing_policy.expr;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -28,5 +30,11 @@ public final class NextHopIp extends IpExpr {
   @Override
   public int hashCode() {
     return System.identityHashCode(this);
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/RemoteAs.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/RemoteAs.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -39,5 +41,11 @@ public final class RemoteAs extends AsExpr {
   @Override
   public String toString() {
     return RemoteAs.class.getSimpleName();
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassful.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassful.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.routing_policy.Environment;
@@ -50,5 +52,11 @@ public final class RouteIsClassful extends BooleanExpr {
   @Override
   public int hashCode() {
     return 0;
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/statement/RemoveTunnelEncapsulationAttribute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/statement/RemoveTunnelEncapsulationAttribute.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.statement;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -56,5 +58,11 @@ public final class RemoveTunnelEncapsulationAttribute extends Statement {
   @Override
   public String toString() {
     return RemoveTunnelEncapsulationAttribute.class.getSimpleName();
+  }
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/statement/ReplaceAsesInAsSequence.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/statement/ReplaceAsesInAsSequence.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
@@ -85,6 +87,12 @@ public final class ReplaceAsesInAsSequence extends Statement {
     }
 
     private static final AnyAs INSTANCE = new AnyAs();
+
+    /** Deserialize to singleton instance. */
+    @Serial
+    private Object readResolve() throws ObjectStreamException {
+      return INSTANCE;
+    }
   }
 
   public static @Nonnull AsSequenceExpr anyAs() {
@@ -180,6 +188,12 @@ public final class ReplaceAsesInAsSequence extends Statement {
 
     private static final @Nonnull LocalAsOrConfedIfNeighborNotInConfed INSTANCE =
         new LocalAsOrConfedIfNeighborNotInConfed();
+
+    /** Deserialize to singleton instance. */
+    @Serial
+    private Object readResolve() throws ObjectStreamException {
+      return INSTANCE;
+    }
   }
 
   public ReplaceAsesInAsSequence(

--- a/projects/common/src/main/java/org/batfish/datamodel/vendor_family/f5_bigip/ManagementIp.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/vendor_family/f5_bigip/ManagementIp.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.vendor_family.f5_bigip;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -23,4 +25,10 @@ public class ManagementIp implements UnicastAddressIp {
   }
 
   private ManagementIp() {}
+
+  /** Deserialize to singleton instance. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return INSTANCE;
+  }
 }


### PR DESCRIPTION
Many Serializable classes with INSTANCE singletons or LoadingCache
interning lacked readResolve(), causing deserialization to bypass
the cache or create duplicate singleton instances. Add readResolve()
to all 33 such classes across the datamodel package, following the
existing pattern used by Ip, Prefix, EmptyIpSpace, etc.

For cache-interned classes (Ip6, Prefix6), readResolve re-interns
through the cache. For pure singletons, it returns INSTANCE. For
acl FalseExpr/TrueExpr which have a parameterized variant, it
conditionally returns INSTANCE only when traceElement is null.

----

Prompt:
```
I would expect that every serializable singleton or cached object
has special handling for serialization to ensure that it comes back
out as cached/singleton. Look for classes that have properties like
INSTANCE or Guava Cache or Caffeine Cache. Audit this package for
all such classes and tell me the state of all of them in a table.
[Then: Fix all 36 issues reported]
```