### PR TITLE
Driver: remove broken thread timeout mechanism from runBatfish

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -52,8 +52,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   private static final String ARG_MAX_PARSE_TREE_PRINT_LENGTH = "maxparsetreeprintlength";
 
-  private static final String ARG_MAX_RUNTIME_MS = "maxruntime";
-
   private static final String ARG_NO_SHUFFLE = "noshuffle";
 
   private static final String ARG_PRECOMPUTE_AUTOCOMPLETE = "precompute-autocomplete";
@@ -252,10 +250,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getInt(ARG_MAX_PARSE_TREE_PRINT_LENGTH);
   }
 
-  public int getMaxRuntimeMs() {
-    return _config.getInt(ARG_MAX_RUNTIME_MS);
-  }
-
   public boolean getPrecomputeAutocomplete() {
     return _config.getBoolean(ARG_PRECOMPUTE_AUTOCOMPLETE);
   }
@@ -390,7 +384,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_MAX_PARSER_CONTEXT_LINES, 10);
     setDefaultProperty(ARG_MAX_PARSER_CONTEXT_TOKENS, 10);
     setDefaultProperty(ARG_MAX_PARSE_TREE_PRINT_LENGTH, 0);
-    setDefaultProperty(ARG_MAX_RUNTIME_MS, 0);
     setDefaultProperty(ARG_CHECK_BGP_REACHABILITY, true);
     setDefaultProperty(ARG_NO_SHUFFLE, false);
     setDefaultProperty(ARG_PARSE_REUSE, false);
@@ -534,8 +527,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
             + "(<= 0 is treated as no limit)",
         ARGNAME_NUMBER);
 
-    addOption(ARG_MAX_RUNTIME_MS, "maximum time (in ms) to allow a task to run", ARGNAME_NUMBER);
-
     addBooleanOption(ARG_NO_SHUFFLE, "do not shuffle parallel jobs");
 
     addBooleanOption(ARG_PARSE_REUSE, "reuse parse results when appropriate");
@@ -610,6 +601,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
           "gsinputrole",
           "gsremoteas",
           "logtee",
+          "maxruntime",
           "nosimplify",
           "outputenv",
           "parentpid",
@@ -692,7 +684,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getIntOptionValue(ARG_MAX_PARSER_CONTEXT_LINES);
     getIntOptionValue(ARG_MAX_PARSER_CONTEXT_TOKENS);
     getIntOptionValue(ARG_MAX_PARSE_TREE_PRINT_LENGTH);
-    getIntOptionValue(ARG_MAX_RUNTIME_MS);
     getBooleanOptionValue(ARG_PRINT_PARSE_TREES);
     getBooleanOptionValue(ARG_PRINT_PARSE_TREE_LINE_NUMS);
     getStringOptionValue(BfConsts.ARG_QUESTION_NAME);
@@ -768,10 +759,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public void setMaxParseTreePrintLength(int maxParseTreePrintLength) {
     _config.setProperty(ARG_MAX_PARSE_TREE_PRINT_LENGTH, maxParseTreePrintLength);
-  }
-
-  public void setMaxRuntimeMs(int runtimeMs) {
-    _config.setProperty(ARG_MAX_RUNTIME_MS, runtimeMs);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -21,7 +21,6 @@ import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.answers.AnswerStatus;
 import org.glassfish.grizzly.http.server.HttpServer;
 
-@SuppressWarnings("restriction")
 public class Driver {
 
   private static volatile boolean _initialized;
@@ -122,7 +121,6 @@ public class Driver {
     _idle = true;
   }
 
-  @SuppressWarnings("deprecation")
   private static String runBatfish(Settings settings) {
 
     BatfishLogger logger = settings.getLogger();
@@ -138,83 +136,61 @@ public class Driver {
               null,
               null);
 
-      Thread thread =
-          new Thread(
-              () -> {
-                Answer answer = null;
-                NetworkSnapshot snapshot =
-                    new NetworkSnapshot(settings.getContainer(), settings.getTestrig());
-                try {
-                  answer = batfish.run(snapshot);
-                  if (answer.getStatus() == null) {
-                    answer.setStatus(AnswerStatus.SUCCESS);
-                  }
-                } catch (CleanBatfishException e) {
-                  String msg = "FATAL ERROR: " + e.getMessage();
-                  logger.errorf(
-                      "Exception in container:%s, testrig:%s; exception:%s",
-                      snapshot.getNetwork(), snapshot.getSnapshot(), msg);
-                  batfish.setTerminatingExceptionMessage(
-                      e.getClass().getName() + ": " + e.getMessage());
-                  answer = Answer.failureAnswer(msg, null);
-                } catch (QuestionException e) {
-                  String stackTrace = Throwables.getStackTraceAsString(e);
-                  logger.errorf(
-                      "Exception in container:%s, testrig:%s; exception:%s",
-                      snapshot.getNetwork(), snapshot.getSnapshot(), stackTrace);
-                  batfish.setTerminatingExceptionMessage(
-                      e.getClass().getName() + ": " + e.getMessage());
-                  answer = e.getAnswer();
-                  answer.setStatus(AnswerStatus.FAILURE);
-                } catch (BatfishException e) {
-                  String stackTrace = Throwables.getStackTraceAsString(e);
-                  logger.errorf(
-                      "Exception in container:%s, testrig:%s; exception:%s",
-                      snapshot.getNetwork(), snapshot.getSnapshot(), stackTrace);
-                  batfish.setTerminatingExceptionMessage(
-                      e.getClass().getName() + ": " + e.getMessage());
-                  answer = new Answer();
-                  answer.setStatus(AnswerStatus.FAILURE);
-                  answer.addAnswerElement(e.getBatfishStackTrace());
-                } catch (Throwable e) {
-                  String stackTrace = Throwables.getStackTraceAsString(e);
-                  logger.errorf(
-                      "Exception in container:%s, testrig:%s; exception:%s",
-                      snapshot.getNetwork(), snapshot.getSnapshot(), stackTrace);
-                  batfish.setTerminatingExceptionMessage(
-                      e.getClass().getName() + ": " + e.getMessage());
-                  answer = new Answer();
-                  answer.setStatus(AnswerStatus.FAILURE);
-                  answer.addAnswerElement(
-                      new BatfishException("Batfish job failed", e).getBatfishStackTrace());
-                } finally {
-                  try {
-                    if (settings.getTaskId() != null) {
-                      batfish.outputAnswerWithLog(answer);
-                      batfish.outputAnswerMetadata(answer);
-                    }
-                  } catch (IOException e) {
-                    String stackTrace = Throwables.getStackTraceAsString(e);
-                    logger.errorf(
-                        "Exception in network:%s, snapshot:%s; exception:%s",
-                        snapshot.getNetwork(), snapshot.getSnapshot(), stackTrace);
-                    batfish.setTerminatingExceptionMessage(
-                        e.getClass().getName() + ": " + e.getMessage());
-                  }
-                }
-              });
-
-      thread.start();
-      thread.join(settings.getMaxRuntimeMs());
-
-      if (thread.isAlive()) {
-        // this is deprecated but we should be safe since we don't have
-        // locks and such
-        // AF: This doesn't do what you think it does, esp. not in Java 8.
-        // It needs to be replaced. TODO
-        thread.stop();
-        logger.error("Batfish worker took too long. Terminated.");
-        batfish.setTerminatingExceptionMessage("Batfish worker took too long. Terminated.");
+      Answer answer = null;
+      NetworkSnapshot snapshot =
+          new NetworkSnapshot(settings.getContainer(), settings.getTestrig());
+      try {
+        answer = batfish.run(snapshot);
+        if (answer.getStatus() == null) {
+          answer.setStatus(AnswerStatus.SUCCESS);
+        }
+      } catch (CleanBatfishException e) {
+        String msg = "FATAL ERROR: " + e.getMessage();
+        logger.errorf(
+            "Exception in container:%s, testrig:%s; exception:%s",
+            snapshot.getNetwork(), snapshot.getSnapshot(), msg);
+        batfish.setTerminatingExceptionMessage(e.getClass().getName() + ": " + e.getMessage());
+        answer = Answer.failureAnswer(msg, null);
+      } catch (QuestionException e) {
+        String stackTrace = Throwables.getStackTraceAsString(e);
+        logger.errorf(
+            "Exception in container:%s, testrig:%s; exception:%s",
+            snapshot.getNetwork(), snapshot.getSnapshot(), stackTrace);
+        batfish.setTerminatingExceptionMessage(e.getClass().getName() + ": " + e.getMessage());
+        answer = e.getAnswer();
+        answer.setStatus(AnswerStatus.FAILURE);
+      } catch (BatfishException e) {
+        String stackTrace = Throwables.getStackTraceAsString(e);
+        logger.errorf(
+            "Exception in container:%s, testrig:%s; exception:%s",
+            snapshot.getNetwork(), snapshot.getSnapshot(), stackTrace);
+        batfish.setTerminatingExceptionMessage(e.getClass().getName() + ": " + e.getMessage());
+        answer = new Answer();
+        answer.setStatus(AnswerStatus.FAILURE);
+        answer.addAnswerElement(e.getBatfishStackTrace());
+      } catch (Throwable e) {
+        String stackTrace = Throwables.getStackTraceAsString(e);
+        logger.errorf(
+            "Exception in container:%s, testrig:%s; exception:%s",
+            snapshot.getNetwork(), snapshot.getSnapshot(), stackTrace);
+        batfish.setTerminatingExceptionMessage(e.getClass().getName() + ": " + e.getMessage());
+        answer = new Answer();
+        answer.setStatus(AnswerStatus.FAILURE);
+        answer.addAnswerElement(
+            new BatfishException("Batfish job failed", e).getBatfishStackTrace());
+      } finally {
+        try {
+          if (settings.getTaskId() != null) {
+            batfish.outputAnswerWithLog(answer);
+            batfish.outputAnswerMetadata(answer);
+          }
+        } catch (IOException e) {
+          String stackTrace = Throwables.getStackTraceAsString(e);
+          logger.errorf(
+              "Exception in network:%s, snapshot:%s; exception:%s",
+              snapshot.getNetwork(), snapshot.getSnapshot(), stackTrace);
+          batfish.setTerminatingExceptionMessage(e.getClass().getName() + ": " + e.getMessage());
+        }
       }
 
       return batfish.getTerminatingExceptionMessage();


### PR DESCRIPTION
runBatfish() spawned an inner thread solely to support a timeout via
Thread#join(maxRuntimeMs) + Thread#stop(). This was broken:
- maxRuntimeMs defaulted to 0, meaning join() waits forever
- Thread#stop() was deprecated in Java 1.2 and removed in Java 18+
- The code's own comment acknowledged this ("AF: This doesn't do what
you think it does")

The inner thread was unnecessary because runBatfishThroughService()
already runs runBatfish() on its own thread. Remove the thread wrapper
and run the batfish work inline. Deprecate the maxruntime setting.

----

Prompt:
```
Can you analyze the threading logic in Driver and rwwrite whatever
crazy code is there? It seems over engineered, using maybe outdated
work, and using Thread#stop which we know doesn't work. I don't even
know/remember what this code is for.
```