### PR TITLE
Juniper: implement forwarding-table export (FIB export policy)

### DIFF
--- a/docs/data_plane/README.md
+++ b/docs/data_plane/README.md
@@ -635,6 +635,8 @@ fib = bf.get_fib(nodes="router1")
 - [Symbolic Engine](../symbolic_engine/README.md): BDD-based analysis using data plane
 - [Post-processing](../post_processing/README.md): Pre-processing before data plane
 - [Architecture](../architecture/README.md): Overall system architecture
+- [BGP Table-Map](table_map.md): Filtering BGP routes before main RIB installation
+- [FIB Export Policy](fib_export_policy.md): Filtering routes before FIB installation
 
 ---
 

--- a/docs/data_plane/fib_export_policy.md
+++ b/docs/data_plane/fib_export_policy.md
@@ -1,0 +1,91 @@
+# FIB Export Policy
+
+## Overview
+
+A FIB export policy filters routes exported from the main RIB into the FIB.
+This applies to all routes regardless of source protocol.
+
+- **Denied routes**: remain in the main RIB (visible for protocol
+  advertisements and redistribution) but are excluded from the FIB
+  (not used for packet forwarding).
+- **Permitted routes**: installed in the FIB normally.
+
+This differs from [BGP table-map](table_map.md), which filters at the
+protocol-RIB-to-main-RIB boundary using `nonRouting`. FIB export operates
+one level later — routes are in the main RIB but excluded from forwarding.
+
+```
+Protocol RIBs  --[table-map]--> Main RIB --[FIB export policy]--> FIB
+                 (nonRouting)               (nonForwarding)
+```
+
+### Vendor Support
+
+| Vendor | Syntax | Status in Batfish |
+|--------|--------|-------------------|
+| Juniper | `routing-options forwarding-table export <policy>` | Implemented (deny/permit) |
+
+On Juniper, this policy also supports `then load-balance per-packet` for
+ECMP selection. Batfish models all ECMP paths regardless, so the
+per-packet/per-flow distinction has no behavioral effect. Standard route
+attribute mutations (metric, next-hop, etc.) have no effect in this context
+on real Juniper routers.
+
+### Vendor-Independent Model
+
+The VI model field is `Vrf.fibExportPolicy` — the name of a `RoutingPolicy`
+to evaluate on each route during FIB construction.
+
+### Data Plane
+
+In `VirtualRouter.computeFib()`, if a FIB export policy is configured, it is
+passed to `FibImpl` as a predicate. During FIB construction, each main RIB
+route is evaluated against the policy. Denied routes are excluded from the
+FIB.
+
+Note: because the policy is applied at FIB construction time rather than at
+main RIB insertion time, the `nonForwarding` flag on route objects in the
+main RIB does not reflect FIB export policy denials. A route denied by the
+FIB export policy will have `nonForwarding=false` in the main RIB but will
+still be absent from the FIB. If we later need `nonForwarding` to be
+authoritative on main RIB routes (e.g., for a routes question column), the
+implementation should be changed to stamp the flag on routes as they enter
+the main RIB instead.
+
+---
+
+## Juniper Implementation
+
+### Syntax
+
+```
+routing-options {
+    forwarding-table {
+        export <policy-name>;
+    }
+}
+```
+
+### Pipeline
+
+```
+Config           "forwarding-table export FIB_FILTER"
+    |
+Parsing          FlatJuniper_routing_instances.g4: rof_export rule
+    |
+Extraction       ConfigurationBuilder.exitRof_export()
+                 -> RoutingInstance._forwardingTableExportPolicy
+    |
+Conversion       JuniperConfiguration.convertForwardingTableExport()
+                 -> Vrf.fibExportPolicy
+```
+
+### Key Files
+
+| Layer | File | What |
+|-------|------|------|
+| VS model | `representation/juniper/RoutingInstance.java` | `_forwardingTableExportPolicy` field |
+| Extraction | `grammar/flatjuniper/ConfigurationBuilder.java` | `exitRof_export()` |
+| Conversion | `representation/juniper/JuniperConfiguration.java` | `convertForwardingTableExport()` |
+| Data plane | `dataplane/ibdp/VirtualRouter.java` | `computeFib()` |
+| FIB | `datamodel/FibImpl.java` | `fibExportFilter` parameter |

--- a/docs/data_plane/table_map.md
+++ b/docs/data_plane/table_map.md
@@ -11,6 +11,10 @@ into the main RIB. This controls which BGP routes are used for forwarding.
   vendor, the router may also modify route attributes (e.g., metric,
   next-hop) before installation; Batfish does not yet model this.
 
+Table-map uses the `nonRouting` flag to exclude denied routes from the main
+RIB. See also [FIB export policy](fib_export_policy.md), which filters at
+the RIB-to-FIB boundary using `nonForwarding`.
+
 ### Vendor Support
 
 | Vendor | Syntax | Status in Batfish |
@@ -18,27 +22,11 @@ into the main RIB. This controls which BGP routes are used for forwarding.
 | FRR | `table-map <route-map>` | Implemented (deny/permit) |
 | Cisco NX-OS | `table-map <route-map> [filter]` | Parsed, not converted |
 | Cisco IOS/IOS-XR | `table-map <route-map>` | Recognized, ignored |
-| Juniper | No direct equivalent | N/A |
 
 ### Vendor-Independent Model
 
 The VI model field is `BgpProcess.tableMapPolicy` — the name of a
 `RoutingPolicy` to evaluate on each BGP route during the unstage step.
-
-### Relation to `nonRouting` and `nonForwarding`
-
-Batfish has two independent flags for controlling route installation:
-
-- **`nonRouting`**: Route is excluded from the main RIB entirely. Used by
-  table-map deny, redistributed routes (to prevent re-export), and protocol
-  computation internals.
-- **`nonForwarding`**: Route is in the main RIB but excluded from the FIB
-  (not used for longest-prefix-match forwarding). Used by Juniper
-  `no-install` on static routes.
-
-Table-map uses `nonRouting`. There is no interference with the resolvability
-enforcer: `nonRouting` is checked first as the outermost gate in
-`Rib.mergeRouteGetDelta()`, before any resolvability logic runs.
 
 ### Data Plane
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -603,7 +603,7 @@ popst_common
    | popst_next_hop
    | popst_next_policy
    | popst_next_term
-   | popst_null
+   | popst_load_balance
    | popst_origin
    | popst_preference
    | popst_priority
@@ -796,9 +796,9 @@ popst_next_term
    NEXT TERM
 ;
 
-popst_null
+popst_load_balance
 :
-   LOAD_BALANCE null_filler
+   LOAD_BALANCE PER_PACKET
 ;
 
 popst_origin

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -711,7 +711,17 @@ public final class VirtualRouter {
   /** Compute the FIB from the main RIB */
   public void computeFib() {
     _fib = null; // free the old one.
-    _fib = new FibImpl(_mainRib, _resolutionRestriction);
+    String fibExportPolicyName = _vrf.getFibExportPolicy();
+    if (fibExportPolicyName == null) {
+      _fib = new FibImpl(_mainRib, _resolutionRestriction);
+    } else {
+      RoutingPolicy fibExportPolicy = _c.getRoutingPolicies().get(fibExportPolicyName);
+      _fib =
+          new FibImpl(
+              _mainRib,
+              _resolutionRestriction,
+              fibExportPolicy == null ? r -> true : fibExportPolicy::processReadOnly);
+    }
   }
 
   void initBgpAggregateRoutes() {

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -649,6 +649,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_community_setCont
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_default_action_acceptContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_default_action_rejectContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_externalContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_load_balanceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_local_preferenceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_multipath_resolveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_next_policyContext;
@@ -1166,6 +1167,7 @@ import org.batfish.representation.juniper.PsThenCommunitySet;
 import org.batfish.representation.juniper.PsThenDefaultActionAccept;
 import org.batfish.representation.juniper.PsThenDefaultActionReject;
 import org.batfish.representation.juniper.PsThenExternal;
+import org.batfish.representation.juniper.PsThenLoadBalance;
 import org.batfish.representation.juniper.PsThenLocalPreference;
 import org.batfish.representation.juniper.PsThenMetric;
 import org.batfish.representation.juniper.PsThenMetric2;
@@ -6715,6 +6717,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
+  public void exitPopst_load_balance(Popst_load_balanceContext ctx) {
+    addPsThen(PsThenLoadBalance.INSTANCE, ctx);
+  }
+
+  @Override
   public void exitPopst_multipath_resolve(Popst_multipath_resolveContext ctx) {
     todo(ctx);
   }
@@ -7008,7 +7015,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
         .getDefaultRoutingInstance()
         .setForwardingTableExportPolicy(
             toComplexPolicyStatement(ctx.expr, FORWARDING_TABLE_EXPORT_POLICY));
-    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3890,6 +3890,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
             .ifPresent(ip -> vrf.setSourceIpInference(UseConstantIp.create(ip)));
       }
       convertResolution(ri);
+      convertForwardingTableExport(ri);
     }
 
     // static nats
@@ -4037,6 +4038,52 @@ public final class JuniperConfiguration extends VendorConfiguration {
                     ImmutableList.of(ReturnFalse.toStaticStatement()))))
         .build();
     _c.getVrfs().get(ri.getName()).setResolutionPolicy(policyName);
+  }
+
+  private void convertForwardingTableExport(RoutingInstance ri) {
+    String policyName = ri.getForwardingTableExportPolicy();
+    if (policyName == null) {
+      return;
+    }
+    if (!_c.getRoutingPolicies().containsKey(policyName)) {
+      return;
+    }
+    _c.getVrfs().get(ri.getName()).setFibExportPolicy(policyName);
+    warnForwardingTableExportActions(policyName);
+  }
+
+  /**
+   * Emit warnings for policy actions that have no effect in the forwarding-table export context. On
+   * Junos, only accept/reject and load-balance/source-class are meaningful; all other attribute
+   * mutations (metric, next-hop, community, etc.) are no-ops.
+   */
+  private void warnForwardingTableExportActions(String policyName) {
+    PolicyStatement ps = _masterLogicalSystem.getPolicyStatements().get(policyName);
+    if (ps == null) {
+      return;
+    }
+    for (PsTerm term : ps.getTerms().values()) {
+      warnForwardingTableExportTermActions(policyName, term);
+    }
+    warnForwardingTableExportTermActions(policyName, ps.getDefaultTerm());
+  }
+
+  private void warnForwardingTableExportTermActions(String policyName, PsTerm term) {
+    for (PsThen then : term.getThens().getAllThens()) {
+      if (then instanceof PsThenAccept
+          || then instanceof PsThenReject
+          || then instanceof PsThenDefaultActionAccept
+          || then instanceof PsThenDefaultActionReject
+          || then instanceof PsThenNextPolicy
+          || then instanceof PsThenLoadBalance) {
+        // Control flow or forwarding-table-specific actions — no warning.
+        continue;
+      }
+      _w.riskyRedFlag(
+          "forwarding-table export %s term %s: %s has no effect"
+              + " (only accept/reject affects forwarding-table export)",
+          policyName, term.getName(), then.getClass().getSimpleName());
+    }
   }
 
   private void convertFirewallFiltersToIpAccessLists() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLoadBalance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLoadBalance.java
@@ -1,0 +1,27 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * Represents {@code then load-balance per-packet} in a Junos policy-statement. Has no effect on the
+ * VI routing policy (Batfish models all ECMP paths), but is recognized so that forwarding-table
+ * export warnings can distinguish it from attribute mutations.
+ */
+public final class PsThenLoadBalance extends PsThen {
+
+  public static final PsThenLoadBalance INSTANCE = new PsThenLoadBalance();
+
+  private PsThenLoadBalance() {}
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings warnings) {
+    // No-op: Batfish models all ECMP paths regardless of per-packet/per-flow selection.
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -486,4 +486,33 @@ public final class FibImplTest {
     Set<AbstractRoute> fibRoutesEth2 = getTopLevelRoutesByInterface(fib, "Eth2");
     assertThat(fibRoutesEth2, contains(restrictionViolatingRoute));
   }
+
+  @Test
+  public void testFibExportFilter() {
+    Rib rib = new Rib();
+
+    StaticRoute allowedRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setNextHopInterface("Eth1")
+            .setAdministrativeCost(1)
+            .build();
+    StaticRoute deniedRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("2.2.2.0/24"))
+            .setNextHopInterface("Eth1")
+            .setAdministrativeCost(1)
+            .build();
+
+    rib.mergeRoute(annotateRoute(allowedRoute));
+    rib.mergeRoute(annotateRoute(deniedRoute));
+
+    // FIB export filter that only permits 1.1.1.0/24
+    Fib fib =
+        new FibImpl(rib, alwaysTrue(), r -> r.getNetwork().equals(Prefix.parse("1.1.1.0/24")));
+
+    Set<AbstractRoute> fibRoutes = getTopLevelRoutesByInterface(fib, "Eth1");
+    assertThat(fibRoutes, hasItem(hasPrefix(Prefix.parse("1.1.1.0/24"))));
+    assertThat(fibRoutes, not(hasItem(hasPrefix(Prefix.parse("2.2.2.0/24")))));
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -281,6 +281,7 @@ import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Flow;
@@ -488,6 +489,7 @@ import org.batfish.representation.juniper.PsThenAsPathExpandLastAs;
 import org.batfish.representation.juniper.PsThenAsPathPrepend;
 import org.batfish.representation.juniper.PsThenCommunityAdd;
 import org.batfish.representation.juniper.PsThenCommunitySet;
+import org.batfish.representation.juniper.PsThenLoadBalance;
 import org.batfish.representation.juniper.PsThenLocalPreference;
 import org.batfish.representation.juniper.PsThenLocalPreference.Operator;
 import org.batfish.representation.juniper.PsThenMetric;
@@ -10175,6 +10177,47 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         vc.getWarnings().getParseWarnings(),
         hasItem(hasComment("This feature is not currently supported")));
+  }
+
+  @Test
+  public void testForwardingTableExport_extraction() {
+    JuniperConfiguration jc = parseJuniperConfig("forwarding-table-export");
+    // Policy is stored on the routing instance
+    assertThat(
+        jc.getMasterLogicalSystem().getDefaultRoutingInstance().getForwardingTableExportPolicy(),
+        equalTo("FIB_FILTER"));
+    // The "allow" term has load-balance per-packet and accept
+    PolicyStatement ps = jc.getMasterLogicalSystem().getPolicyStatements().get("FIB_FILTER");
+    assertThat(ps.getTerms(), hasKey("allow"));
+    assertThat(
+        ps.getTerms().get("allow").getThens().getAllThens(),
+        hasItem(instanceOf(PsThenLoadBalance.class)));
+  }
+
+  @Test
+  public void testForwardingTableExport_conversion() {
+    Configuration c = parseConfig("forwarding-table-export");
+    // The forwarding-table export policy should be wired to the VRF's fibExportPolicy
+    assertThat(c.getDefaultVrf().getFibExportPolicy(), equalTo("FIB_FILTER"));
+  }
+
+  @Test
+  public void testForwardingTableExport_dataPlane() throws IOException {
+    Batfish batfish = getBatfishForConfigurationNames("forwarding-table-export");
+    batfish.computeDataPlane(batfish.getSnapshot());
+    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+
+    // Both routes should be in the RIB
+    Set<AbstractRoute> routes =
+        dp.getRibs().get("forwarding-table-export", DEFAULT_VRF_NAME).getRoutes();
+    assertThat(routes, hasItem(hasPrefix(Prefix.parse("192.168.0.0/24"))));
+    assertThat(routes, hasItem(hasPrefix(Prefix.parse("192.168.1.0/24"))));
+
+    // Only 192.168.0.0/24 should be in the FIB (permitted by the policy);
+    // 192.168.1.0/24 should be rejected by the policy and excluded from FIB.
+    Fib fib = dp.getFibs().get("forwarding-table-export").get(Configuration.DEFAULT_VRF_NAME);
+    assertThat(fib.get(Ip.parse("192.168.0.1")), not(empty()));
+    assertThat(fib.get(Ip.parse("192.168.1.1")), empty());
   }
 
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/forwarding-table-export
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/forwarding-table-export
@@ -1,0 +1,16 @@
+#
+set system host-name forwarding-table-export
+
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24
+set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+
+set routing-options static route 192.168.0.0/24 next-hop 10.0.0.2
+set routing-options static route 192.168.1.0/24 next-hop 10.0.1.2
+
+set policy-options policy-statement FIB_FILTER term allow from route-filter 192.168.0.0/24 exact
+set policy-options policy-statement FIB_FILTER term allow then load-balance per-packet
+set policy-options policy-statement FIB_FILTER term allow then accept
+set policy-options policy-statement FIB_FILTER term deny then reject
+
+set routing-options forwarding-table export FIB_FILTER

--- a/projects/common/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -94,10 +95,22 @@ public final class FibImpl implements Fib {
 
   public <R extends AbstractRouteDecorator> FibImpl(
       GenericRib<R> rib, ResolutionRestriction<R> restriction) {
+    this(rib, restriction, r -> true);
+  }
+
+  /**
+   * @param fibExportFilter additional predicate applied to routes before FIB installation. Routes
+   *     for which this returns {@code false} are excluded from the FIB (equivalent to {@code
+   *     nonForwarding}).
+   */
+  public <R extends AbstractRouteDecorator> FibImpl(
+      GenericRib<R> rib,
+      ResolutionRestriction<R> restriction,
+      Predicate<AbstractRoute> fibExportFilter) {
     _root = new PrefixTrieMultiMap<>();
     rib.getRoutes().stream()
         .map(AbstractRouteDecorator::getAbstractRoute)
-        .filter(r -> !r.getNonForwarding())
+        .filter(r -> !r.getNonForwarding() && fibExportFilter.test(r))
         .forEach(r -> _root.putAll(r.getNetwork(), resolveRoute(rib, r, restriction)));
     initSuppliers();
   }

--- a/projects/common/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Vrf.java
@@ -97,6 +97,7 @@ public class Vrf extends ComparableStructure<String> {
   private static final String PROP_KERNEL_ROUTES = "kernelRoutes";
   private static final String PROP_OSPF_PROCESS = "ospfProcess";
   private static final String PROP_OSPF_PROCESSES = "ospfProcesses";
+  private static final String PROP_FIB_EXPORT_POLICY = "fibExportPolicy";
   private static final String PROP_RESOLUTION_POLICY = "resolutionPolicy";
   private static final String PROP_RIP_PROCESS = "ripProcess";
   private static final String PROP_STATIC_ROUTES = "staticRoutes";
@@ -114,6 +115,7 @@ public class Vrf extends ComparableStructure<String> {
   private BgpProcess _bgpProcess;
   private String _description;
   private FirewallSessionVrfInfo _firewallSessionVrfInfo;
+  private @Nullable String _fibExportPolicy;
   private NavigableSet<GeneratedRoute> _generatedRoutes;
   private SortedMap<Long, EigrpProcess> _eigrpProcesses;
   private IsisProcess _isisProcess;
@@ -363,6 +365,21 @@ public class Vrf extends ComparableStructure<String> {
             .putAll(_ospfProcesses)
             .put(ospfProcess.getProcessId(), ospfProcess)
             .build();
+  }
+
+  /**
+   * Name of a {@link org.batfish.datamodel.routing_policy.RoutingPolicy} applied to routes exported
+   * from the main RIB into the FIB. Denied routes remain in the RIB but are not used for forwarding
+   * ({@code nonForwarding=true}).
+   */
+  @JsonProperty(PROP_FIB_EXPORT_POLICY)
+  public @Nullable String getFibExportPolicy() {
+    return _fibExportPolicy;
+  }
+
+  @JsonProperty(PROP_FIB_EXPORT_POLICY)
+  public void setFibExportPolicy(@Nullable String fibExportPolicy) {
+    _fibExportPolicy = fibExportPolicy;
   }
 
   @JsonProperty(PROP_RESOLUTION_POLICY)

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -2444,10 +2444,9 @@
             "                (pops_then*",
             "                  THEN:'then'",
             "                  (popst_common*",
-            "                    (popst_null*",
+            "                    (popst_load_balance",
             "                      LOAD_BALANCE:'load-balance'",
-            "                      (null_filler*",
-            "                        PER_PACKET:'per-packet'))))))))))",
+            "                      PER_PACKET:'per-packet')))))))))",
             "    NEWLINE:'\\n\\n')",
             "  EOF:<EOF>)"
           ]
@@ -6165,12 +6164,6 @@
               "Line" : 47,
               "Parser_Context" : "[sesot_land seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "land"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 104,
-              "Parser_Context" : "[rof_export ro_forwarding_table s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "export loadbal"
             }
           ]
         },

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1115,13 +1115,6 @@
       },
       {
         "Filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
-        "Line" : 112,
-        "Text" : "export lbpp",
-        "Parser_Context" : "[rof_export ro_forwarding_table s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
         "Line" : 201,
         "Text" : "vtep-source-interface lo0.0",
         "Parser_Context" : "[ri_vtep_source_interface ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
@@ -1577,10 +1570,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 219 results",
+      "notes" : "Found 218 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 219
+      "numResults" : 218
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -41326,10 +41326,9 @@
             "                  (pops_then*",
             "                    THEN:'then'",
             "                    (popst_common*",
-            "                      (popst_null*",
+            "                      (popst_load_balance",
             "                        LOAD_BALANCE:'load-balance'",
-            "                        (null_filler*",
-            "                          PER_PACKET:'per-packet')))))))))))",
+            "                        PER_PACKET:'per-packet'))))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",
             "    SET:'set'",
@@ -71243,12 +71242,6 @@
         },
         "configs/gh-2658-juniper-vrf-import-export.cfg" : {
           "Parse warnings" : [
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 112,
-              "Parser_Context" : "[rof_export ro_forwarding_table s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "export lbpp"
-            },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 201,


### PR DESCRIPTION
Add support for Junos `routing-options forwarding-table export` which
filters routes exported from the main RIB into the FIB. Denied routes
remain in the RIB (visible to protocols, redistribution, BGP
advertisement) but are excluded from the FIB (not used for forwarding).

VI model: add `Vrf.fibExportPolicy` field (name of a RoutingPolicy).
Data plane: `FibImpl` accepts an optional export filter predicate,
evaluated at FIB construction time. `VirtualRouter.computeFib()` passes
the resolved policy to `FibImpl`.

Juniper conversion: wire `RoutingInstance._forwardingTableExportPolicy`
to `Vrf.fibExportPolicy`, remove `todo(ctx)` from the parser.

----

Prompt:
```
In a recent commit, we added `FRR table-map` as an export filter from
BGP to main-RIB that results in routes being routing or not. Refresh
what we did in the VS and VI models for that.

Now read about junos forwarding-export policies (feel free to refer to
junos manuals in working/). How should we add support for those to
Batfish, both Junos and generic, powerful VI support?
```