### PR TITLE
Juniper: fix forwarding-table export default action to accept

### DIFF
--- a/docs/conversion/juniper_routing_policy.md
+++ b/docs/conversion/juniper_routing_policy.md
@@ -1,0 +1,21 @@
+# Juniper Routing Policy Conversion
+
+## Default Fall-Through Actions
+
+When wiring a Juniper `policy-statement` to a VI context, always
+consider the **default fall-through action** for that context.
+
+In the VI model, `RoutingPolicy.call()` returns
+`Environment.getDefaultAction()` when a policy falls through without a
+terminal action. The `Environment` defaults to `false` (reject). This is
+correct for contexts where Junos defaults to reject (e.g., OSPF export),
+but wrong for contexts where Junos defaults to accept.
+
+For accept-default contexts, wrap the user's policy in a generated
+policy that sets `SetDefaultActionAccept`. See
+`generatedBgpPeerImportPolicyName` (BGP import) and
+`generatedFibExportPolicyName` (forwarding-table export) for examples.
+
+Junos default actions per context are documented in the Junos routing
+policy manual, Table 4 ("Default Import and Export Policies for
+Protocols").

--- a/docs/data_plane/fib_export_policy.md
+++ b/docs/data_plane/fib_export_policy.md
@@ -31,6 +31,12 @@ per-packet/per-flow distinction has no behavioral effect. Standard route
 attribute mutations (metric, next-hop, etc.) have no effect in this context
 on real Juniper routers.
 
+The default Junos forwarding-table export action is **accept**: routes that
+fall through the policy without a terminal action (accept/reject) are
+installed in the FIB. This is modeled by wrapping the user's policy in a
+generated policy (`~FIB_EXPORT_POLICY:<vrf>~`) that sets the default action
+to accept before calling the user's policy.
+
 ### Vendor-Independent Model
 
 The VI model field is `Vrf.fibExportPolicy` — the name of a `RoutingPolicy`

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -7,6 +7,7 @@ import static org.batfish.datamodel.BumTransportMethod.UNICAST_FLOOD_GROUP;
 import static org.batfish.datamodel.Names.escapeNameIfNeeded;
 import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerImportPolicyName;
+import static org.batfish.datamodel.Names.generatedFibExportPolicyName;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
@@ -4048,7 +4049,21 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (!_c.getRoutingPolicies().containsKey(policyName)) {
       return;
     }
-    _c.getVrfs().get(ri.getName()).setFibExportPolicy(policyName);
+    // Wrap the user's policy in a generated policy that sets the default action to accept. On
+    // Junos, routes not explicitly rejected by the forwarding-table export policy are installed in
+    // the FIB (the default forwarding-table behavior is accept-all).
+    String generatedName = generatedFibExportPolicyName(ri.getName());
+    RoutingPolicy.builder()
+        .setOwner(_c)
+        .setName(generatedName)
+        .addStatement(Statements.SetDefaultActionAccept.toStaticStatement())
+        .addStatement(
+            new If(
+                new CallExpr(policyName),
+                ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
+                ImmutableList.of(Statements.ExitReject.toStaticStatement())))
+        .build();
+    _c.getVrfs().get(ri.getName()).setFibExportPolicy(generatedName);
     warnForwardingTableExportActions(policyName);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -20,6 +20,7 @@ import static org.batfish.datamodel.IpProtocol.OSPF;
 import static org.batfish.datamodel.IpProtocol.UDP;
 import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerImportPolicyName;
+import static org.batfish.datamodel.Names.generatedFibExportPolicyName;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.OriginMechanism.LEARNED;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
@@ -10197,8 +10198,10 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testForwardingTableExport_conversion() {
     Configuration c = parseConfig("forwarding-table-export");
-    // The forwarding-table export policy should be wired to the VRF's fibExportPolicy
-    assertThat(c.getDefaultVrf().getFibExportPolicy(), equalTo("FIB_FILTER"));
+    // The forwarding-table export policy should be wired via a generated wrapper policy
+    assertThat(
+        c.getDefaultVrf().getFibExportPolicy(),
+        equalTo(generatedFibExportPolicyName(DEFAULT_VRF_NAME)));
   }
 
   @Test
@@ -10218,6 +10221,31 @@ public final class FlatJuniperGrammarTest {
     Fib fib = dp.getFibs().get("forwarding-table-export").get(Configuration.DEFAULT_VRF_NAME);
     assertThat(fib.get(Ip.parse("192.168.0.1")), not(empty()));
     assertThat(fib.get(Ip.parse("192.168.1.1")), empty());
+  }
+
+  /**
+   * Test that a forwarding-table export policy with only {@code then load-balance per-packet} (no
+   * explicit accept) allows all routes into the FIB. On Junos, the default forwarding-table export
+   * action is accept, so routes that fall through the policy without a terminal action are
+   * accepted.
+   */
+  @Test
+  public void testForwardingTableExport_defaultAccept() throws IOException {
+    Batfish batfish = getBatfishForConfigurationNames("forwarding-table-export-default-accept");
+    batfish.computeDataPlane(batfish.getSnapshot());
+    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+
+    // Both routes should be in the RIB
+    String hostname = "forwarding-table-export-default-accept";
+    Set<AbstractRoute> routes = dp.getRibs().get(hostname, DEFAULT_VRF_NAME).getRoutes();
+    assertThat(routes, hasItem(hasPrefix(Prefix.parse("192.168.0.0/24"))));
+    assertThat(routes, hasItem(hasPrefix(Prefix.parse("192.168.1.0/24"))));
+
+    // Both routes should also be in the FIB — the policy has no terminal action, so the default
+    // forwarding-table export action (accept) applies.
+    Fib fib = dp.getFibs().get(hostname).get(Configuration.DEFAULT_VRF_NAME);
+    assertThat(fib.get(Ip.parse("192.168.0.1")), not(empty()));
+    assertThat(fib.get(Ip.parse("192.168.1.1")), not(empty()));
   }
 
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/forwarding-table-export-default-accept
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/forwarding-table-export-default-accept
@@ -1,0 +1,16 @@
+#
+set system host-name forwarding-table-export-default-accept
+
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24
+set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+
+set routing-options static route 192.168.0.0/24 next-hop 10.0.0.2
+set routing-options static route 192.168.1.0/24 next-hop 10.0.1.2
+
+# Policy with only load-balance per-packet (no explicit accept or reject).
+# On Junos, routes fall through to the default forwarding-table export action (accept),
+# so all routes should be installed in the FIB.
+set policy-options policy-statement LB_ONLY term ecmp then load-balance per-packet
+
+set routing-options forwarding-table export LB_ONLY

--- a/projects/common/src/main/java/org/batfish/datamodel/Names.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Names.java
@@ -144,6 +144,10 @@ public final class Names {
     return String.format("~OSPF_DEFAULT_ROUTE_GENERATION_POLICY:%s:%s~", vrf, proc);
   }
 
+  public static String generatedFibExportPolicyName(String vrf) {
+    return String.format("~FIB_EXPORT_POLICY:%s~", vrf);
+  }
+
   public static String generatedOspfExportPolicyName(String vrf, String proc) {
     return String.format("~OSPF_EXPORT_POLICY:%s:%s~", vrf, proc);
   }


### PR DESCRIPTION
On Junos, the default forwarding-table export action is accept: routes
that fall through the policy without a terminal action (accept/reject)
are installed in the FIB. Batfish was incorrectly defaulting to reject,
which meant a policy with only `then load-balance per-packet` (no
explicit accept) would reject all routes from the FIB.

Fix by wrapping the user's policy in a generated policy that sets
SetDefaultActionAccept before calling the user's policy, matching the
pattern used for BGP import policies.

----

Prompt:
```
We recently added support for junos forwarding-table export. I learned
that a policy could only have one term with "then load-balance
per-packet" and no accompanying "then accept". It seems that this is
treated as an accept even without an accompanying explicit accept, but
I think if there were an accompanying then reject it would get
rejected.
```

Further investigation of the Junos routing policy manual confirmed that
`load-balance per-packet` is an attribute manipulation action (not a
flow control action), so it does not terminate policy evaluation. The
default forwarding-table export action is accept, meaning routes that
fall through without a terminal action are accepted into the FIB.