### PR TITLE
AsSet: distinguish confederation segments in string output

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/AsPath.java
@@ -143,6 +143,8 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
     return _asSets.equals(other._asSets);
   }
 
+  // TODO: Group consecutive confederation singleton AsSets under a single pair of parentheses to
+  //       match standard router output, e.g. "(1 2) 64511" instead of "(1) (2) 64511".
   public String getAsPathString() {
     return StringUtils.join(_asSets, " ");
   }

--- a/projects/common/src/main/java/org/batfish/datamodel/AsSet.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/AsSet.java
@@ -185,6 +185,12 @@ public class AsSet implements Serializable, Comparable<AsSet> {
 
   @Override
   public String toString() {
+    if (_confederation) {
+      if (_value.length == 1) {
+        return "(" + _value[0] + ")";
+      }
+      return "[" + StringUtils.join(_value, ',') + "]";
+    }
     if (_value.length == 1) {
       return Long.toString(_value[0]);
     }

--- a/projects/common/src/test/java/org/batfish/datamodel/AsSetTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/AsSetTest.java
@@ -23,6 +23,12 @@ public class AsSetTest {
 
     // For set of ASNs, should return {asn1,asn2,...lastAsn}
     assertThat(AsSet.of(1, 2, 3).toString(), equalTo("{1,2,3}"));
+
+    // Confederation single ASN should be wrapped in parentheses
+    assertThat(AsSet.confed(1).toString(), equalTo("(1)"));
+
+    // Confederation set should be wrapped in square brackets
+    assertThat(AsSet.confed(1, 2, 3).toString(), equalTo("[1,2,3]"));
   }
 
   @Test


### PR DESCRIPTION
AsSet.toString() now renders confederation segments distinctly:
- AS_CONFED_SEQUENCE: (1) instead of 1
- AS_CONFED_SET: [1,2,3] instead of {1,2,3}

This affects the AS_Path column in bgpRib and routes answers,
which call AsPath.getAsPathString() -> AsSet.toString().

Consecutive confed singletons still render individually, e.g.
"(1) (2) 64511" rather than "(1 2) 64511". Added a TODO on
AsPath.getAsPathString() for that grouping improvement.

Fixes batfish/batfish#9869

----

Prompt:
```
Read https://github.com/batfish/batfish/issues/9869 and evaluate
it. I actually think that this may just be a Pybatfish presentation
issue, that is, I believe that batfish does return this in the API
(AsSet class). batfish is in ./batfish, pybatfish in ./pybatfish.
```

---
**Stack**:
- #9878
- #9874
- #9873
- #9871 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*