### PR TITLE
Juniper: support `forwarding-context` for BGP sessions

### DIFF
--- a/docs/question_development/bgpSessionStatus.md
+++ b/docs/question_development/bgpSessionStatus.md
@@ -132,6 +132,7 @@ This catches issues like:
 |--------|------|-------------|
 | `Node` | Node | The node where this session is configured |
 | `VRF` | String | The VRF containing the BGP process |
+| `Session_VRF` | String | The VRF in which the BGP TCP session takes place, if different from VRF |
 | `Local_AS` | Long | The local AS number |
 | `Local_Interface` | Interface | Local interface (unnumbered peers only) |
 | `Local_IP` | IP | The local IP address |

--- a/projects/allinone/src/test/java/org/batfish/e2e/bgp/forwardingcontext/BUILD.bazel
+++ b/projects/allinone/src/test/java/org/batfish/e2e/bgp/forwardingcontext/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:private"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob(["*Test.java"]),
+    resources = [
+        "//projects/allinone/src/test/resources/org/batfish/e2e/bgp/forwardingcontext",
+    ],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/common",
+        "//projects/common/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/question",
+        "@maven//:com_google_guava_guava",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/allinone/src/test/java/org/batfish/e2e/bgp/forwardingcontext/BgpForwardingContextTest.java
+++ b/projects/allinone/src/test/java/org/batfish/e2e/bgp/forwardingcontext/BgpForwardingContextTest.java
@@ -1,0 +1,112 @@
+package org.batfish.e2e.bgp.forwardingcontext;
+
+import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.questions.BgpSessionStatus;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.batfish.question.bgpsessionstatus.BgpSessionCompatibilityAnswerer;
+import org.batfish.question.bgpsessionstatus.BgpSessionCompatibilityQuestion;
+import org.batfish.question.bgpsessionstatus.BgpSessionStatusAnswerer;
+import org.batfish.question.bgpsessionstatus.BgpSessionStatusQuestion;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end test for Junos {@code forwarding-context master}. Two routers each have a BGP session
+ * configured in a non-default VRF (MY-VRF) but sourced from the default VRF via forwarding-context.
+ * The local IPs (loopbacks) are in the default VRF. Without forwarding-context support, these
+ * sessions would be reported as INVALID_LOCAL_IP.
+ */
+public class BgpForwardingContextTest {
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private static final String PREFIX = "org/batfish/e2e/bgp/forwardingcontext";
+
+  private Batfish getBatfish() throws IOException {
+    return BatfishTestUtils.getBatfishFromTestrigText(
+        TestrigText.builder().setConfigurationFiles(PREFIX, "r1", "r2").build(), _folder);
+  }
+
+  /** Sessions should be compatible (UNIQUE_MATCH), not INVALID_LOCAL_IP. */
+  @Test
+  public void testSessionCompatibility() throws IOException {
+    Batfish batfish = getBatfish();
+    NetworkSnapshot snapshot = batfish.getSnapshot();
+    batfish.loadConfigurations(snapshot);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            new BgpSessionCompatibilityAnswerer(new BgpSessionCompatibilityQuestion(), batfish)
+                .answer(snapshot);
+
+    // Both sessions (r1->r2 and r2->r1) should be UNIQUE_MATCH, not INVALID_LOCAL_IP
+    assertThat(
+        answer.getRowsList(),
+        everyItem(hasColumn("Configured_Status", "UNIQUE_MATCH", Schema.STRING)));
+    assertThat(
+        answer.getRowsList(),
+        not(hasItem(hasColumn("Configured_Status", "INVALID_LOCAL_IP", Schema.STRING))));
+
+    // Session_VRF column should show "default" (the session VRF)
+    assertThat(answer.getRowsList(), everyItem(hasColumn("Session_VRF", "default", Schema.STRING)));
+  }
+
+  /** Sessions should establish (reachable through default VRF). */
+  @Test
+  public void testSessionEstablishment() throws IOException {
+    Batfish batfish = getBatfish();
+    NetworkSnapshot snapshot = batfish.getSnapshot();
+    batfish.loadConfigurations(snapshot);
+    batfish.computeDataPlane(snapshot);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            new BgpSessionStatusAnswerer(new BgpSessionStatusQuestion(), batfish).answer(snapshot);
+
+    // Both sessions should be ESTABLISHED
+    assertThat(
+        answer.getRowsList(),
+        everyItem(
+            hasColumn(
+                "Established_Status", BgpSessionStatus.ESTABLISHED.toString(), Schema.STRING)));
+  }
+
+  /** Peers in the default VRF should not have sessionVrf set. */
+  @Test
+  public void testDefaultVrfPeersNoSessionVrf() throws IOException {
+    Batfish batfish = getBatfish();
+    NetworkSnapshot snapshot = batfish.getSnapshot();
+    var configs = batfish.loadConfigurations(snapshot);
+
+    // Default VRF should have no BGP process (BGP is only in MY-VRF)
+    assertThat(configs.get("r1").getDefaultVrf().getBgpProcess(), nullValue());
+    assertThat(configs.get("r2").getDefaultVrf().getBgpProcess(), nullValue());
+
+    // MY-VRF peers should have sessionVrf = "default"
+    assertThat(
+        configs
+            .get("r1")
+            .getVrfs()
+            .get("MY-VRF")
+            .getBgpProcess()
+            .getActiveNeighbors()
+            .values()
+            .iterator()
+            .next()
+            .getSessionVrf(),
+        equalTo("default"));
+  }
+}

--- a/projects/allinone/src/test/resources/org/batfish/e2e/bgp/forwardingcontext/BUILD.bazel
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/bgp/forwardingcontext/BUILD.bazel
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "forwardingcontext",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD.bazel"],
+    ),
+)

--- a/projects/allinone/src/test/resources/org/batfish/e2e/bgp/forwardingcontext/configs/r1
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/bgp/forwardingcontext/configs/r1
@@ -1,0 +1,20 @@
+#
+set system host-name r1
+#
+# Loopback in default VRF with BGP local-address
+set interfaces lo0 unit 0 family inet address 10.0.0.1/32
+#
+# Direct link to r2 in default VRF (for reachability)
+set interfaces ge-0/0/0 unit 0 family inet address 10.1.0.0/31
+#
+# Static route to r2's loopback
+set routing-options static route 10.0.0.2/32 next-hop 10.1.0.1
+set routing-options autonomous-system 1
+#
+# BGP session in VRF, sourced from default VRF via forwarding-context
+set routing-instances MY-VRF instance-type vrf
+set routing-instances MY-VRF route-distinguisher 1:1
+set routing-instances MY-VRF protocols bgp forwarding-context master
+set routing-instances MY-VRF protocols bgp group PEERS type internal
+set routing-instances MY-VRF protocols bgp group PEERS local-address 10.0.0.1
+set routing-instances MY-VRF protocols bgp group PEERS neighbor 10.0.0.2

--- a/projects/allinone/src/test/resources/org/batfish/e2e/bgp/forwardingcontext/configs/r2
+++ b/projects/allinone/src/test/resources/org/batfish/e2e/bgp/forwardingcontext/configs/r2
@@ -1,0 +1,20 @@
+#
+set system host-name r2
+#
+# Loopback in default VRF with BGP local-address
+set interfaces lo0 unit 0 family inet address 10.0.0.2/32
+#
+# Direct link to r1 in default VRF (for reachability)
+set interfaces ge-0/0/0 unit 0 family inet address 10.1.0.1/31
+#
+# Static route to r1's loopback
+set routing-options static route 10.0.0.1/32 next-hop 10.1.0.0
+set routing-options autonomous-system 1
+#
+# BGP session in VRF, sourced from default VRF via forwarding-context
+set routing-instances MY-VRF instance-type vrf
+set routing-instances MY-VRF route-distinguisher 2:2
+set routing-instances MY-VRF protocols bgp forwarding-context master
+set routing-instances MY-VRF protocols bgp group PEERS type internal
+set routing-instances MY-VRF protocols bgp group PEERS local-address 10.0.0.2
+set routing-instances MY-VRF protocols bgp group PEERS neighbor 10.0.0.1

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -111,6 +111,7 @@ b_common
    | b_enforce_first_as
    | b_export
    | b_family
+   | b_forwarding_context
    | b_import
    | b_keep
    | b_local_address
@@ -664,7 +665,6 @@ p_bgp
       | b_disable
       | b_drop_path_attributes
       | b_enable
-      | b_forwarding_context_null
       | b_group
       | b_neighbor
       | b_output_queue_priority
@@ -674,4 +674,4 @@ p_bgp
 // Protocol-wide config only
 b_advertise_from_main_vpn_tables_null: ADVERTISE_FROM_MAIN_VPN_TABLES;
 b_bgp_error_tolerance_null: BGP_ERROR_TOLERANCE;
-b_forwarding_context_null: FORWARDING_CONTEXT name = junos_name;
+b_forwarding_context: FORWARDING_CONTEXT name = junos_name;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -327,6 +327,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_drop_path_attributesC
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_enableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_enforce_first_asContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_exportContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_forwarding_contextContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_groupContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_importContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_keepContext;
@@ -4774,6 +4775,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitB_enforce_first_as(B_enforce_first_asContext ctx) {
     _currentBgpGroup.setEnforceFirstAs(true);
+  }
+
+  @Override
+  public void exitB_forwarding_context(B_forwarding_contextContext ctx) {
+    _currentBgpGroup.setForwardingContext(toString(ctx.name));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
@@ -37,6 +37,7 @@ public class BgpGroup implements Serializable {
   private Boolean _enforceFirstAs;
   private @Nullable Boolean _evpnAf;
   private final List<String> _exportPolicies;
+  private @Nullable String _forwardingContext;
   protected String _groupName;
   private final List<String> _importPolicies;
   protected transient boolean _inherited;
@@ -103,6 +104,9 @@ public class BgpGroup implements Serializable {
       }
       if (_evpnAf == null) {
         _evpnAf = _parent._evpnAf;
+      }
+      if (_forwardingContext == null) {
+        _forwardingContext = _parent._forwardingContext;
       }
       if (_ebgpMultihop == null) {
         _ebgpMultihop = _parent._ebgpMultihop;
@@ -225,6 +229,14 @@ public class BgpGroup implements Serializable {
 
   public void setEvpnAf(@Nullable Boolean evpnAf) {
     _evpnAf = evpnAf;
+  }
+
+  public @Nullable String getForwardingContext() {
+    return _forwardingContext;
+  }
+
+  public void setForwardingContext(@Nullable String forwardingContext) {
+    _forwardingContext = forwardingContext;
   }
 
   public final List<String> getExportPolicies() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -861,6 +861,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
       // inherit update-source
       neighbor.setLocalIp(ig.getLocalAddress());
+      // forwarding-context: resolve the VRF from which the BGP TCP session is sourced
+      String forwardingContext = ig.getForwardingContext();
+      if (forwardingContext != null) {
+        neighbor.setSessionVrf(
+            forwardingContext.equals(DEFAULT_ROUTING_INSTANCE_NAME)
+                ? Configuration.DEFAULT_VRF_NAME
+                : forwardingContext);
+      }
       neighbor.setBgpProcess(proc);
       neighbor.setIpv4UnicastAddressFamily(
           ipv4AfBuilder.setAddressFamilyCapabilities(ipv4AfSettingsBuilder.build()).build());

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1358,6 +1358,47 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testBgpForwardingContext() {
+    // Test extraction: forwarding-context at protocol level and group level
+    JuniperConfiguration jc = parseJuniperConfig("bgp-forwarding-context");
+    RoutingInstance vrf1 = jc.getMasterLogicalSystem().getRoutingInstances().get("VRF1");
+    assertThat(vrf1.getMasterBgpGroup().getForwardingContext(), equalTo("master"));
+
+    RoutingInstance vrf2 = jc.getMasterLogicalSystem().getRoutingInstances().get("VRF2");
+    // forwarding-context at group level should be inherited by neighbors
+    IpBgpGroup neighbor = vrf2.getIpBgpGroups().get(Prefix.parse("10.0.0.3/32"));
+    assertThat(neighbor, notNullValue());
+    neighbor.cascadeInheritance();
+    assertThat(neighbor.getForwardingContext(), equalTo("master"));
+  }
+
+  @Test
+  public void testBgpForwardingContextConversion() {
+    // Test VI conversion: forwarding-context master → sessionVrf = "default"
+    Configuration c = parseConfig("bgp-forwarding-context");
+
+    // VRF1 peer (protocol-level forwarding-context)
+    BgpActivePeerConfig vrf1Peer =
+        c.getVrfs().get("VRF1").getBgpProcess().getActiveNeighbors().get(Ip.parse("10.0.0.2"));
+    assertThat(vrf1Peer, notNullValue());
+    assertThat(vrf1Peer.getSessionVrf(), equalTo(Configuration.DEFAULT_VRF_NAME));
+
+    // VRF2 peer (group-level forwarding-context)
+    BgpActivePeerConfig vrf2Peer =
+        c.getVrfs().get("VRF2").getBgpProcess().getActiveNeighbors().get(Ip.parse("10.0.0.3"));
+    assertThat(vrf2Peer, notNullValue());
+    assertThat(vrf2Peer.getSessionVrf(), equalTo(Configuration.DEFAULT_VRF_NAME));
+
+    // Default VRF peers should not have sessionVrf set
+    BgpProcess defaultProc = c.getDefaultVrf().getBgpProcess();
+    if (defaultProc != null) {
+      for (BgpActivePeerConfig peer : defaultProc.getActiveNeighbors().values()) {
+        assertThat(peer.getSessionVrf(), nullValue());
+      }
+    }
+  }
+
+  @Test
   public void testBgpDropPathAttributes() {
     JuniperConfiguration c = parseJuniperConfig("bgp-drop-path-attributes");
     BgpGroup master = c.getMasterLogicalSystem().getDefaultRoutingInstance().getMasterBgpGroup();

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-forwarding-context
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-forwarding-context
@@ -1,0 +1,17 @@
+#
+set system host-name bgp-forwarding-context
+#
+set interfaces lo0 unit 0 family inet address 10.0.0.1/32
+set routing-options autonomous-system 1
+#
+set routing-instances VRF1 instance-type vrf
+set routing-instances VRF1 protocols bgp forwarding-context master
+set routing-instances VRF1 protocols bgp group G type internal
+set routing-instances VRF1 protocols bgp group G local-address 10.0.0.1
+set routing-instances VRF1 protocols bgp group G neighbor 10.0.0.2
+#
+set routing-instances VRF2 instance-type vrf
+set routing-instances VRF2 protocols bgp group H type internal
+set routing-instances VRF2 protocols bgp group H forwarding-context master
+set routing-instances VRF2 protocols bgp group H local-address 10.0.0.1
+set routing-instances VRF2 protocols bgp group H neighbor 10.0.0.3

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
@@ -41,7 +41,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
       @JsonProperty(PROP_IPV4_UNICAST_ADDRESS_FAMILY) @Nullable
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
-      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport) {
+      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport,
+      @JsonProperty(PROP_SESSION_VRF) @Nullable String sessionVrf) {
     return new BgpActivePeerConfig(
         appliedRibGroup,
         authenticationSettings,
@@ -60,7 +61,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
         firstNonNull(remoteAsns, LongSpace.EMPTY),
         ipv4UnicastAddressFamily,
         evpnAddressFamily,
-        replaceNonLocalAsesOnExport);
+        replaceNonLocalAsesOnExport,
+        sessionVrf);
   }
 
   private BgpActivePeerConfig(
@@ -81,7 +83,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
       @Nullable LongSpace remoteAsns,
       Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @Nullable EvpnAddressFamily evpnAddressFamily,
-      boolean replaceNonLocalAsesOnExport) {
+      boolean replaceNonLocalAsesOnExport,
+      @Nullable String sessionVrf) {
     super(
         appliedRibGroup,
         authenticationSettings,
@@ -99,7 +102,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
         remoteAsns,
         ipv4UnicastAddressFamily,
         evpnAddressFamily,
-        replaceNonLocalAsesOnExport);
+        replaceNonLocalAsesOnExport,
+        sessionVrf);
     _peerAddress = peerAddress;
   }
 
@@ -169,7 +173,8 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
               _remoteAsns,
               _ipv4UnicastAddressFamily,
               _evpnAddressFamily,
-              _replaceNonLocalAsesOnExport);
+              _replaceNonLocalAsesOnExport,
+              _sessionVrf);
       if (_bgpProcess != null && _peerAddress != null) {
         _bgpProcess.getActiveNeighbors().put(_peerAddress, bgpPeerConfig);
       }

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
@@ -43,7 +43,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
       @JsonProperty(PROP_IPV4_UNICAST_ADDRESS_FAMILY) @Nullable
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
-      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport) {
+      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport,
+      @JsonProperty(PROP_SESSION_VRF) @Nullable String sessionVrf) {
     return new BgpPassivePeerConfig(
         appliedRibGroup,
         authenticationSettings,
@@ -62,7 +63,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
         firstNonNull(remoteAsns, LongSpace.EMPTY),
         ipv4UnicastAddressFamily,
         evpnAddressFamily,
-        replaceNonLocalAsesOnExport);
+        replaceNonLocalAsesOnExport,
+        sessionVrf);
   }
 
   private BgpPassivePeerConfig(
@@ -83,7 +85,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
       @Nullable LongSpace remoteAsns,
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @Nullable EvpnAddressFamily evpnAddressFamily,
-      boolean replaceNonLocalAsesOnExport) {
+      boolean replaceNonLocalAsesOnExport,
+      @Nullable String sessionVrf) {
     super(
         appliedRibGroup,
         authenticationSettings,
@@ -101,7 +104,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
         remoteAsns,
         ipv4UnicastAddressFamily,
         evpnAddressFamily,
-        replaceNonLocalAsesOnExport);
+        replaceNonLocalAsesOnExport,
+        sessionVrf);
     _peerPrefix = peerPrefix;
   }
 
@@ -161,7 +165,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
               _remoteAsns,
               _ipv4UnicastAddressFamily,
               _evpnAddressFamily,
-              _replaceNonLocalAsesOnExport);
+              _replaceNonLocalAsesOnExport,
+              _sessionVrf);
       if (_bgpProcess != null) {
         _bgpProcess.getPassiveNeighbors().put(_peerPrefix, bgpPeerConfig);
       }

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -45,6 +45,7 @@ public abstract class BgpPeerConfig implements Serializable {
   static final String PROP_EVPN_ADDRESS_FAMILY = "evpnAddressFamily";
 
   static final String PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT = "replaceNonLocalAsesOnExport";
+  static final String PROP_SESSION_VRF = "sessionVrf";
 
   private final @Nullable RibGroup _appliedRibGroup;
   private final @Nullable BgpAuthenticationSettings _authenticationSettings;
@@ -94,6 +95,15 @@ public abstract class BgpPeerConfig implements Serializable {
 
   private final boolean _replaceNonLocalAsesOnExport;
 
+  /**
+   * The VRF from which this peer's BGP TCP session is sourced, if different from the VRF in which
+   * the peer is configured. When {@code null}, the session is sourced from the peer's own VRF.
+   *
+   * <p>For example, Junos {@code forwarding-context master} causes a BGP session in a VRF to source
+   * its TCP connection from the default routing instance.
+   */
+  private final @Nullable String _sessionVrf;
+
   protected BgpPeerConfig(
       @Nullable RibGroup appliedRibGroup,
       @Nullable BgpAuthenticationSettings authenticationSettings,
@@ -111,7 +121,8 @@ public abstract class BgpPeerConfig implements Serializable {
       @Nullable LongSpace remoteAsns,
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @Nullable EvpnAddressFamily evpnAddressFamily,
-      boolean replaceNonLocalAsesOnExport) {
+      boolean replaceNonLocalAsesOnExport,
+      @Nullable String sessionVrf) {
     _appliedRibGroup = appliedRibGroup;
     _authenticationSettings = authenticationSettings;
     _checkLocalIpOnAccept = firstNonNull(checkLocalIpOnAccept, true);
@@ -129,6 +140,7 @@ public abstract class BgpPeerConfig implements Serializable {
     _ipv4UnicastAddressFamily = ipv4UnicastAddressFamily;
     _evpnAddressFamily = evpnAddressFamily;
     _replaceNonLocalAsesOnExport = replaceNonLocalAsesOnExport;
+    _sessionVrf = sessionVrf;
   }
 
   /** Return the {@link RibGroup} applied to this config */
@@ -281,6 +293,15 @@ public abstract class BgpPeerConfig implements Serializable {
     return _replaceNonLocalAsesOnExport;
   }
 
+  /**
+   * The VRF in which this peer's BGP TCP session takes place, if different from the VRF in which
+   * the peer is configured. When {@code null}, the session uses the peer's own VRF.
+   */
+  @JsonProperty(PROP_SESSION_VRF)
+  public @Nullable String getSessionVrf() {
+    return _sessionVrf;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -306,7 +327,8 @@ public abstract class BgpPeerConfig implements Serializable {
         && _remoteAsns.equals(that._remoteAsns)
         && Objects.equals(_ipv4UnicastAddressFamily, that._ipv4UnicastAddressFamily)
         && Objects.equals(_evpnAddressFamily, that._evpnAddressFamily)
-        && _replaceNonLocalAsesOnExport == that._replaceNonLocalAsesOnExport;
+        && _replaceNonLocalAsesOnExport == that._replaceNonLocalAsesOnExport
+        && Objects.equals(_sessionVrf, that._sessionVrf);
   }
 
   @Override
@@ -328,7 +350,8 @@ public abstract class BgpPeerConfig implements Serializable {
         _remoteAsns,
         _ipv4UnicastAddressFamily,
         _evpnAddressFamily,
-        _replaceNonLocalAsesOnExport);
+        _replaceNonLocalAsesOnExport,
+        _sessionVrf);
   }
 
   @Override
@@ -351,6 +374,7 @@ public abstract class BgpPeerConfig implements Serializable {
         .add("_ipv4UnicastAddressFamily", _ipv4UnicastAddressFamily)
         .add("_evpnAddressFamily", _evpnAddressFamily)
         .add("_replaceNonLocalAsesOnExport", _replaceNonLocalAsesOnExport)
+        .add("_sessionVrf", _sessionVrf)
         .toString();
   }
 
@@ -377,6 +401,7 @@ public abstract class BgpPeerConfig implements Serializable {
     protected @Nullable String _hostname;
 
     protected boolean _replaceNonLocalAsesOnExport;
+    protected @Nullable String _sessionVrf;
 
     protected Builder() {
       _remoteAsns = LongSpace.EMPTY;
@@ -493,6 +518,11 @@ public abstract class BgpPeerConfig implements Serializable {
 
     public S setReplaceNonLocalAsesOnExport(boolean replaceNonLocalAsesOnExport) {
       _replaceNonLocalAsesOnExport = replaceNonLocalAsesOnExport;
+      return getThis();
+    }
+
+    public S setSessionVrf(@Nullable String sessionVrf) {
+      _sessionVrf = sessionVrf;
       return getThis();
     }
   }

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpUnnumberedPeerConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpUnnumberedPeerConfig.java
@@ -50,7 +50,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
               _remoteAsns,
               _ipv4UnicastAddressFamily,
               _evpnAddressFamily,
-              _replaceNonLocalAsesOnExport);
+              _replaceNonLocalAsesOnExport,
+              _sessionVrf);
       if (_bgpProcess != null) {
         _bgpProcess.getInterfaceNeighbors().put(_peerInterface, bgpPeerConfig);
       }
@@ -94,7 +95,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
       @JsonProperty(PROP_IPV4_UNICAST_ADDRESS_FAMILY) @Nullable
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
-      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport) {
+      @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport,
+      @JsonProperty(PROP_SESSION_VRF) @Nullable String sessionVrf) {
     checkArgument(peerInterface != null, "Missing %s", PROP_PEER_INTERFACE);
     return new BgpUnnumberedPeerConfig(
         appliedRibGroup,
@@ -113,7 +115,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
         firstNonNull(remoteAsns, LongSpace.EMPTY),
         ipv4UnicastAddressFamily,
         evpnAddressFamily,
-        replaceNonLocalAsesOnExport);
+        replaceNonLocalAsesOnExport,
+        sessionVrf);
   }
 
   private final @Nonnull String _peerInterface;
@@ -135,7 +138,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
       @Nullable LongSpace remoteAsns,
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @Nullable EvpnAddressFamily evpnAddressFamily,
-      boolean replaceNonLocalAsesOnExport) {
+      boolean replaceNonLocalAsesOnExport,
+      @Nullable String sessionVrf) {
     super(
         appliedRibGroup,
         authenticationSettings,
@@ -153,7 +157,8 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
         remoteAsns,
         ipv4UnicastAddressFamily,
         evpnAddressFamily,
-        replaceNonLocalAsesOnExport);
+        replaceNonLocalAsesOnExport,
+        sessionVrf);
     _peerInterface = peerInterface;
   }
 

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.bgp;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.MoreObjects;
@@ -152,9 +153,20 @@ public final class BgpTopologyUtils {
             localIpsBuilder.put(neighborId, config.getLocalIp());
           } else {
             // No explicitly configured local IP. Check for dynamically resolvable local IPs.
-            localIpsBuilder.putAll(
-                neighborId,
-                vrf.getSourceIpInference().getPotentialSourceIps(peerAddress, fib, node));
+            // If sessionVrf is set, resolve from that VRF's FIB instead.
+            String sourceVrfName = firstNonNull(config.getSessionVrf(), vrfName);
+            Vrf sourceVrf = sourceVrfName.equals(vrfName) ? vrf : node.getVrfs().get(sourceVrfName);
+            Fib sourceFib =
+                sourceVrfName.equals(vrfName)
+                    ? fib
+                    : fibs.getOrDefault(hostname, ImmutableMap.of()).get(sourceVrfName);
+            if (sourceVrf != null && sourceFib != null) {
+              localIpsBuilder.putAll(
+                  neighborId,
+                  sourceVrf
+                      .getSourceIpInference()
+                      .getPotentialSourceIps(peerAddress, sourceFib, node));
+            }
           }
         }
         // Dynamic peers: map of prefix to BgpPassivePeerConfig
@@ -185,9 +197,16 @@ public final class BgpTopologyUtils {
         // Unnumbered configs only form sessions with each other
         continue;
       }
-      Multimap<String, BgpPeerConfigId> vrf =
+      Multimap<String, BgpPeerConfigId> hostReceivers =
           receivers.computeIfAbsent(peer.getHostname(), name -> LinkedListMultimap.create());
-      vrf.put(peer.getVrfName(), peer);
+      // Register under sessionVrf if set (the VRF where the TCP session lives), otherwise
+      // the peer's own VRF.
+      BgpPeerConfig peerConfig = networkConfigurations.getBgpPeerConfig(peer);
+      String receiverVrf =
+          peerConfig != null
+              ? firstNonNull(peerConfig.getSessionVrf(), peer.getVrfName())
+              : peer.getVrfName();
+      hostReceivers.put(receiverVrf, peer);
     }
     SetMultimap<BgpPeerConfigId, Ip> localIps = localIpsBuilder.build();
 
@@ -409,9 +428,10 @@ public final class BgpTopologyUtils {
     }
 
     Ip localIp = config.getLocalIp();
+    String sourceVrf = firstNonNull(config.getSessionVrf(), vrfName);
     return localIp == null
         || (ipOwners.containsKey(localIp)
-            && ipOwners.get(localIp).getOrDefault(hostname, ImmutableSet.of()).contains(vrfName));
+            && ipOwners.get(localIp).getOrDefault(hostname, ImmutableSet.of()).contains(sourceVrf));
   }
 
   /**
@@ -566,7 +586,7 @@ public final class BgpTopologyUtils {
             .setIpProtocol(IpProtocol.TCP)
             .setTcpFlagsSyn(true)
             .setIngressNode(initiatorId.getHostname())
-            .setIngressVrf(initiatorId.getVrfName())
+            .setIngressVrf(firstNonNull(initiator.getSessionVrf(), initiatorId.getVrfName()))
             .setSrcIp(initiatorLocalIp)
             .setDstIp(initiator.getPeerAddress())
             .setSrcPort(NamedPort.EPHEMERAL_LOWEST.number())
@@ -596,8 +616,10 @@ public final class BgpTopologyUtils {
               Flow reverseFlow = traceAndReverseFlow.getReverseFlow();
               assert traceAndReverseFlow.getReverseFlow() != null; // success implies return flow
               assert reverseFlow.getIngressVrf() != null; // accepted
+              String listenerSessionVrf =
+                  firstNonNull(listener.getSessionVrf(), listenerId.getVrfName());
               if (!reverseFlow.getIngressNode().equals(listenerId.getHostname())
-                  || !reverseFlow.getIngressVrf().equals(listenerId.getVrfName())) {
+                  || !reverseFlow.getIngressVrf().equals(listenerSessionVrf)) {
                 // This trace is success at the wrong device or in the wrong VRF.
                 return false;
               } else if (listener.getCheckLocalIpOnAccept() && listener.getLocalIp() != null) {

--- a/projects/common/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
@@ -52,6 +52,7 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
   public static final String IMPORT_POLICY = "Import_Policy";
   public static final String EXPORT_POLICY = "Export_Policy";
   public static final String SEND_COMMUNITY = "Send_Community";
+  public static final String SESSION_VRF = "Session_VRF";
 
   /**
    * Some properties are reported by address family, and some peers don't have all address families
@@ -149,6 +150,12 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
               DESCRIPTION,
               new PropertyDescriptor<>(
                   BgpPeerConfig::getDescription, Schema.STRING, "Configured peer description"))
+          .put(
+              SESSION_VRF,
+              new PropertyDescriptor<>(
+                  BgpPeerConfig::getSessionVrf,
+                  Schema.STRING,
+                  "The VRF in which the BGP TCP session takes place, if different from VRF"))
           .build();
 
   /** Returns the property descriptor for {@code property} */

--- a/projects/common/src/test/java/org/batfish/datamodel/BgpUnnumberedPeerConfigTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/BgpUnnumberedPeerConfigTest.java
@@ -90,6 +90,7 @@ public final class BgpUnnumberedPeerConfigTest {
             builder.setEvpnAddressFamily(
                 EvpnAddressFamily.builder().setPropagateUnmatched(true).build()))
         .addEqualityGroup(builder.setReplaceNonLocalAsesOnExport(true).build())
+        .addEqualityGroup(builder.setSessionVrf("default").build())
         .testEquals();
   }
 
@@ -124,6 +125,7 @@ public final class BgpUnnumberedPeerConfigTest {
             .setLocalIp(Ip.FIRST_CLASS_A_PRIVATE_IP)
             .setPeerInterface("eth0")
             .setRemoteAsns(LongSpace.of(11L))
+            .setSessionVrf("default")
             .build();
 
     assertThat(
@@ -163,6 +165,7 @@ public final class BgpUnnumberedPeerConfigTest {
             .setLocalIp(Ip.FIRST_CLASS_A_PRIVATE_IP)
             .setPeerInterface("eth0")
             .setRemoteAsns(LongSpace.of(11L))
+            .setSessionVrf("default")
             .build();
 
     assertThat(SerializationUtils.clone(bgpUnnumberedPeerConfig), equalTo(bgpUnnumberedPeerConfig));

--- a/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
@@ -94,6 +94,48 @@ public class BgpTopologyUtilsTest {
     _node3BgpProcess.setInterfaceNeighbors(ImmutableSortedMap.of());
   }
 
+  /**
+   * A peer in a non-default VRF with sessionVrf="default" and local IP owned by the default VRF
+   * should pass sanity checks and appear in the topology.
+   */
+  @Test
+  public void testInitTopologySessionVrf() {
+    // Peer on node1 in VRF "myVrf" with local IP 1.1.1.1 (owned by default VRF).
+    // sessionVrf is set to "default", so sanity check should pass.
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+
+    BgpActivePeerConfig peer1 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip1)
+            .setLocalAs(1L)
+            .setPeerAddress(ip2)
+            .setRemoteAs(2L)
+            .setSessionVrf(DEFAULT_VRF_NAME)
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder()
+                    .setAddressFamilyCapabilities(AddressFamilyCapabilities.builder().build())
+                    .build())
+            .build();
+
+    // Add peer to node1's default VRF BGP process (for simplicity; the key point is that
+    // the ipOwners map has ip1 in DEFAULT_VRF_NAME, not "myVrf")
+    _node1BgpProcess.setNeighbors(ImmutableSortedMap.of(ip2, peer1));
+
+    // ip1 is in the default VRF, not in "myVrf"
+    Map<Ip, Map<String, Set<String>>> ipOwners =
+        ImmutableMap.of(
+            ip1,
+            ImmutableMap.of(NODE1, ImmutableSet.of(DEFAULT_VRF_NAME)),
+            ip2,
+            ImmutableMap.of(NODE2, ImmutableSet.of(DEFAULT_VRF_NAME)));
+
+    // With keepInvalid=false, peer should still appear (sessionVrf makes it valid)
+    ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
+        initBgpTopology(_configs, ipOwners, false, null).getGraph();
+    assertThat(bgpTopology.nodes(), hasSize(1));
+  }
+
   @Test
   public void testInitTopologyRemotePrefixNotMatchingLocalIp() {
     // Peer 1 on node1 with IP 1.1.1.1 is active, set up to peer with 2.2.2.2

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
@@ -12,6 +12,7 @@ import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.PEER_GROU
 import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.REMOTE_AS;
 import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.ROUTE_REFLECTOR_CLIENT;
 import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.SEND_COMMUNITY;
+import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.SESSION_VRF;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -61,6 +62,7 @@ public class BgpPeerConfigurationAnswerer extends Answerer {
       ImmutableList.of(
           COL_NODE,
           COL_VRF,
+          SESSION_VRF,
           LOCAL_AS,
           LOCAL_IP,
           COL_LOCAL_INTERFACE,

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtils.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtils.java
@@ -1,5 +1,7 @@
 package org.batfish.question.bgpsessionstatus;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -40,6 +42,7 @@ public final class BgpSessionAnswererUtils {
   public static final String COL_REMOTE_NODE = "Remote_Node";
   public static final String COL_REMOTE_INTERFACE = "Remote_Interface";
   public static final String COL_REMOTE_IP = "Remote_IP";
+  public static final String COL_SESSION_VRF = "Session_VRF";
   public static final String COL_SESSION_TYPE = "Session_Type";
   public static final String COL_VRF = "VRF";
 
@@ -63,10 +66,11 @@ public final class BgpSessionAnswererUtils {
     Ip localIp = activePeerConfig.getLocalIp();
     Ip remoteIp = activePeerConfig.getPeerAddress();
 
+    String sourceVrf = firstNonNull(activePeerConfig.getSessionVrf(), peerId.getVrfName());
     if (!ipVrfOwners
         .getOrDefault(localIp, ImmutableMap.of())
         .getOrDefault(peerId.getHostname(), ImmutableSet.of())
-        .contains(peerId.getVrfName())) {
+        .contains(sourceVrf)) {
       return ConfiguredSessionStatus.INVALID_LOCAL_IP;
     } else if (!ipVrfOwners.containsKey(remoteIp)) {
       return ConfiguredSessionStatus.UNKNOWN_REMOTE;

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
@@ -15,6 +15,7 @@ import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_REMOTE_IP;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_REMOTE_NODE;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_SESSION_TYPE;
+import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_SESSION_VRF;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_VRF;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.getConfiguredStatus;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.getLocallyBrokenStatus;
@@ -71,6 +72,12 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
               COL_NODE, Schema.NODE, "The node where this session is configured", true, false),
           new ColumnMetadata(
               COL_VRF, Schema.STRING, "The VRF in which this session is configured", true, false),
+          new ColumnMetadata(
+              COL_SESSION_VRF,
+              Schema.STRING,
+              "The VRF in which this session's TCP connection takes place, if different from VRF",
+              false,
+              false),
           new ColumnMetadata(
               COL_LOCAL_AS, Schema.LONG, "The local AS of the session", false, false),
           new ColumnMetadata(
@@ -203,6 +210,7 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
         .put(COL_REMOTE_NODE, remoteNode)
         .put(COL_REMOTE_INTERFACE, null)
         .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, activePeer.getPeerAddress()))
+        .put(COL_SESSION_VRF, activePeer.getSessionVrf())
         .put(COL_SESSION_TYPE, getSessionType(activePeer))
         .put(COL_VRF, activeId.getVrfName())
         .build();
@@ -230,6 +238,7 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
             .put(
                 COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, passivePeer.getPeerPrefix()))
             .put(COL_ADDRESS_FAMILIES, ImmutableSet.of())
+            .put(COL_SESSION_VRF, passivePeer.getSessionVrf())
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, passiveId.getVrfName());
 
@@ -307,6 +316,7 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
         .put(COL_REMOTE_INTERFACE, remoteInterface)
         .put(COL_REMOTE_IP, null)
         .put(COL_ADDRESS_FAMILIES, addressFamilies)
+        .put(COL_SESSION_VRF, unnumPeer.getSessionVrf())
         .put(COL_SESSION_TYPE, getSessionType(unnumPeer))
         .put(COL_VRF, unnumId.getVrfName())
         .build();

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -16,6 +16,7 @@ import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_REMOTE_IP;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_REMOTE_NODE;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_SESSION_TYPE;
+import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_SESSION_VRF;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_VRF;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.getConfiguredStatus;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.getLocallyBrokenStatus;
@@ -74,6 +75,12 @@ public class BgpSessionStatusAnswerer extends Answerer {
               COL_NODE, Schema.NODE, "The node where this session is configured", true, false),
           new ColumnMetadata(
               COL_VRF, Schema.STRING, "The VRF in which this session is configured", true, false),
+          new ColumnMetadata(
+              COL_SESSION_VRF,
+              Schema.STRING,
+              "The VRF in which this session's TCP connection takes place, if different from VRF",
+              false,
+              false),
           new ColumnMetadata(
               COL_LOCAL_AS, Schema.LONG, "The local AS of the session", false, false),
           new ColumnMetadata(
@@ -240,6 +247,7 @@ public class BgpSessionStatusAnswerer extends Answerer {
         .put(COL_REMOTE_NODE, remoteNode)
         .put(COL_REMOTE_INTERFACE, null)
         .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, remoteIp))
+        .put(COL_SESSION_VRF, activePeer.getSessionVrf())
         .put(COL_SESSION_TYPE, getSessionType(activePeer))
         .put(COL_VRF, activeId.getVrfName())
         .build();
@@ -300,6 +308,7 @@ public class BgpSessionStatusAnswerer extends Answerer {
             .put(COL_REMOTE_AS, passivePeer.getRemoteAsns().toString())
             .put(
                 COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, passivePeer.getPeerPrefix()))
+            .put(COL_SESSION_VRF, passivePeer.getSessionVrf())
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, passiveId.getVrfName());
 
@@ -407,6 +416,7 @@ public class BgpSessionStatusAnswerer extends Answerer {
         .put(COL_REMOTE_NODE, remoteNode)
         .put(COL_REMOTE_INTERFACE, remoteInterface)
         .put(COL_REMOTE_IP, null)
+        .put(COL_SESSION_VRF, unnumPeer.getSessionVrf())
         .put(COL_SESSION_TYPE, getSessionType(unnumPeer))
         .put(COL_VRF, unnumId.getVrfName())
         .build();

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswererTest.java
@@ -12,6 +12,7 @@ import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.PEER_GROU
 import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.REMOTE_AS;
 import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.ROUTE_REFLECTOR_CLIENT;
 import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.SEND_COMMUNITY;
+import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.SESSION_VRF;
 import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_LOCAL_INTERFACE;
 import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_NODE;
 import static org.batfish.question.bgpproperties.BgpPeerConfigurationAnswerer.COL_REMOTE_IP;
@@ -67,6 +68,7 @@ public final class BgpPeerConfigurationAnswererTest {
             .setConfederation(1L)
             .setDescription("desc1")
             .setGroup("g1")
+            .setSessionVrf("otherVrf")
             .setIpv4UnicastAddressFamily(
                 Ipv4UnicastAddressFamily.builder()
                     .setImportPolicySources(ImmutableSortedSet.of("p1"))
@@ -160,6 +162,7 @@ public final class BgpPeerConfigurationAnswererTest {
             .put(getColumnName(IMPORT_POLICY), ImmutableSet.of("p1"))
             .put(getColumnName(EXPORT_POLICY), ImmutableSet.of("p2"))
             .put(getColumnName(SEND_COMMUNITY), false)
+            .put(getColumnName(SESSION_VRF), "otherVrf")
             .build());
     expected.add(
         Row.builder()
@@ -181,6 +184,7 @@ public final class BgpPeerConfigurationAnswererTest {
             .put(getColumnName(IMPORT_POLICY), ImmutableSet.of("p3"))
             .put(getColumnName(EXPORT_POLICY), ImmutableSet.of("p4"))
             .put(getColumnName(SEND_COMMUNITY), false)
+            .put(getColumnName(SESSION_VRF), null)
             .build());
     expected.add(
         Row.builder()
@@ -200,6 +204,7 @@ public final class BgpPeerConfigurationAnswererTest {
             .put(getColumnName(IMPORT_POLICY), ImmutableSet.of("p5"))
             .put(getColumnName(EXPORT_POLICY), ImmutableSet.of("p6"))
             .put(getColumnName(SEND_COMMUNITY), false)
+            .put(getColumnName(SESSION_VRF), null)
             .build());
 
     assertThat(rows, equalTo(expected));

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtilsTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtilsTest.java
@@ -6,8 +6,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
+import java.util.Map;
+import java.util.Set;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -162,6 +166,78 @@ public final class BgpSessionAnswererUtilsTest {
             .setRemoteAsns(LongSpace.EMPTY)
             .build();
     assertThat(getLocallyBrokenStatus(peer), equalTo(ConfiguredSessionStatus.NO_REMOTE_AS));
+  }
+
+  /** Local IP is in the default VRF, peer is in a non-default VRF with sessionVrf set. */
+  @Test
+  public void testSessionVrfPreventsInvalidLocalIp() {
+    Ip localIp = Ip.parse("1.1.1.1");
+    Ip remoteIp = Ip.parse("2.2.2.2");
+
+    // Peer is in "myVrf" but sessionVrf is "default" (where localIp actually lives)
+    BgpPeerConfigId peerId = new BgpPeerConfigId("c1", "myVrf", remoteIp.toPrefix(), false);
+    BgpActivePeerConfig peer =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(localIp)
+            .setPeerAddress(remoteIp)
+            .setLocalAs(1L)
+            .setRemoteAs(2L)
+            .setSessionVrf("default")
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
+            .build();
+
+    // localIp is owned by the default VRF, not myVrf
+    Map<Ip, Map<String, Set<String>>> ipVrfOwners =
+        ImmutableMap.of(
+            localIp,
+            ImmutableMap.of("c1", ImmutableSet.of("default")),
+            remoteIp,
+            ImmutableMap.of("c2", ImmutableSet.of("default")));
+
+    MutableValueGraph<BgpPeerConfigId, BgpSessionProperties> topology =
+        ValueGraphBuilder.directed().allowsSelfLoops(false).build();
+    topology.addNode(peerId);
+
+    // Without sessionVrf, this would be INVALID_LOCAL_IP (localIp not in "myVrf").
+    // With sessionVrf="default", it should pass the local IP check.
+    ConfiguredSessionStatus status =
+        getConfiguredStatus(
+            peerId, peer, BgpSessionProperties.SessionType.IBGP, ipVrfOwners, topology);
+    assertThat(status, equalTo(ConfiguredSessionStatus.HALF_OPEN));
+  }
+
+  /** Without sessionVrf, a local IP in a different VRF should produce INVALID_LOCAL_IP. */
+  @Test
+  public void testInvalidLocalIpWithoutSessionVrf() {
+    Ip localIp = Ip.parse("1.1.1.1");
+    Ip remoteIp = Ip.parse("2.2.2.2");
+
+    // Peer is in "myVrf", no sessionVrf set, localIp is in "default"
+    BgpPeerConfigId peerId = new BgpPeerConfigId("c1", "myVrf", remoteIp.toPrefix(), false);
+    BgpActivePeerConfig peer =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(localIp)
+            .setPeerAddress(remoteIp)
+            .setLocalAs(1L)
+            .setRemoteAs(2L)
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
+            .build();
+
+    Map<Ip, Map<String, Set<String>>> ipVrfOwners =
+        ImmutableMap.of(
+            localIp,
+            ImmutableMap.of("c1", ImmutableSet.of("default")),
+            remoteIp,
+            ImmutableMap.of("c2", ImmutableSet.of("default")));
+
+    MutableValueGraph<BgpPeerConfigId, BgpSessionProperties> topology =
+        ValueGraphBuilder.directed().allowsSelfLoops(false).build();
+    topology.addNode(peerId);
+
+    ConfiguredSessionStatus status =
+        getConfiguredStatus(
+            peerId, peer, BgpSessionProperties.SessionType.IBGP, ipVrfOwners, topology);
+    assertThat(status, equalTo(ConfiguredSessionStatus.INVALID_LOCAL_IP));
   }
 
   @Test

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
@@ -11,6 +11,7 @@ import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_REMOTE_IP;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_REMOTE_NODE;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_SESSION_TYPE;
+import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_SESSION_VRF;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_VRF;
 import static org.batfish.question.bgpsessionstatus.BgpSessionCompatibilityAnswerer.COLUMN_METADATA;
 import static org.batfish.question.bgpsessionstatus.BgpSessionCompatibilityAnswerer.COL_CONFIGURED_STATUS;
@@ -123,6 +124,7 @@ public class BgpSessionCompatibilityAnswererTest {
             .put(COL_REMOTE_NODE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, remoteIp))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP)
             .put(COL_VRF, "vrf1")
             .build();
@@ -181,6 +183,7 @@ public class BgpSessionCompatibilityAnswererTest {
             .put(COL_REMOTE_NODE, new Node("c2"))
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, remoteIp))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP)
             .put(COL_VRF, "vrf1")
             .build();
@@ -213,6 +216,7 @@ public class BgpSessionCompatibilityAnswererTest {
             .put(COL_REMOTE_NODE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, remotePrefix))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, "vrf1")
             .build();
@@ -251,6 +255,7 @@ public class BgpSessionCompatibilityAnswererTest {
             .put(COL_REMOTE_NODE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, remotePrefix))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, "vrf1")
             .build();
@@ -318,6 +323,7 @@ public class BgpSessionCompatibilityAnswererTest {
             .put(COL_ADDRESS_FAMILIES, ImmutableSet.of(Type.IPV4_UNICAST))
             .put(COL_LOCAL_IP, localIp)
             .put(COL_NODE, new Node("c1"))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP)
             .put(COL_VRF, "vrf1")
             .put(COL_CONFIGURED_STATUS, ConfiguredSessionStatus.DYNAMIC_MATCH)
@@ -362,6 +368,7 @@ public class BgpSessionCompatibilityAnswererTest {
             .put(COL_REMOTE_NODE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, null)
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, "vrf1")
             .build();
@@ -412,6 +419,7 @@ public class BgpSessionCompatibilityAnswererTest {
             .put(COL_REMOTE_NODE, new Node("c2"))
             .put(COL_REMOTE_INTERFACE, NodeInterfacePair.of("c2", "iface2"))
             .put(COL_REMOTE_IP, null)
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_UNNUMBERED)
             .put(COL_VRF, "vrf1")
             .build();
@@ -453,6 +461,7 @@ public class BgpSessionCompatibilityAnswererTest {
             .put(COL_CONFIGURED_STATUS, ConfiguredSessionStatus.UNIQUE_MATCH)
             .put(COL_LOCAL_INTERFACE, null)
             .put(COL_REMOTE_INTERFACE, null)
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP)
             .put(COL_ADDRESS_FAMILIES, ImmutableSet.of(Type.IPV4_UNICAST));
     Row row1To2 =

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswererTest.java
@@ -13,6 +13,7 @@ import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_REMOTE_IP;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_REMOTE_NODE;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_SESSION_TYPE;
+import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_SESSION_VRF;
 import static org.batfish.question.bgpsessionstatus.BgpSessionAnswererUtils.COL_VRF;
 import static org.batfish.question.bgpsessionstatus.BgpSessionCompatibilityAnswererTest.createConfigurations;
 import static org.batfish.question.bgpsessionstatus.BgpSessionStatusAnswerer.COLUMN_METADATA;
@@ -123,6 +124,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_REMOTE_NODE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, remoteIp))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP)
             .put(COL_VRF, "vrf1")
             .build();
@@ -189,6 +191,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_REMOTE_NODE, new Node("c2"))
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, remoteIp))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP)
             .put(COL_VRF, "vrf1");
     assertThat(row, equalTo(expected.build()));
@@ -215,6 +218,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_REMOTE_NODE, new Node("c1"))
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, localIp))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP)
             .put(COL_VRF, "vrf2")
             .build();
@@ -251,6 +255,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_REMOTE_NODE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, remotePrefix))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, "vrf1")
             .build();
@@ -289,6 +294,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_REMOTE_NODE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, remotePrefix))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, "vrf1")
             .build();
@@ -324,6 +330,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_REMOTE_NODE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_REMOTE_IP, null)
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, "vrf1")
             .build();
@@ -373,6 +380,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_REMOTE_NODE, new Node("c2"))
             .put(COL_REMOTE_INTERFACE, NodeInterfacePair.of("c2", "iface2"))
             .put(COL_REMOTE_IP, null)
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_UNNUMBERED)
             .put(COL_VRF, "vrf1")
             .build();
@@ -468,6 +476,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_LOCAL_AS, 1L)
             .put(COL_LOCAL_IP, localIp)
             .put(COL_NODE, new Node("c1"))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP)
             .put(COL_VRF, "vrf1")
             .put(COL_LOCAL_INTERFACE, null)
@@ -613,6 +622,7 @@ public class BgpSessionStatusAnswererTest {
             .put(COL_LOCAL_INTERFACE, null)
             .put(COL_REMOTE_INTERFACE, null)
             .put(COL_ADDRESS_FAMILIES, ImmutableSet.of(Type.IPV4_UNICAST))
+            .put(COL_SESSION_VRF, null)
             .put(COL_SESSION_TYPE, SessionType.EBGP_SINGLEHOP);
     Row row1To2 =
         expectedRowBuilder

--- a/tests/basic/bgpSessionStatus.ref
+++ b/tests/basic/bgpSessionStatus.ref
@@ -18,6 +18,13 @@
           "schema" : "String"
         },
         {
+          "description" : "The VRF in which this session's TCP connection takes place, if different from VRF",
+          "isKey" : false,
+          "isValue" : false,
+          "name" : "Session_VRF",
+          "schema" : "String"
+        },
+        {
           "description" : "The local AS of the session",
           "isKey" : false,
           "isValue" : false,
@@ -113,6 +120,7 @@
           "schema" : "Ip",
           "value" : "10.23.21.3"
         },
+        "Session_VRF" : null,
         "Session_Type" : "EBGP_SINGLEHOP",
         "VRF" : "default"
       }


### PR DESCRIPTION
Extract the Junos `forwarding-context` BGP setting instead of
discarding it. When configured (e.g., `forwarding-context master`),
the BGP TCP session takes place in a different routing instance than
the VRF where the BGP peer is configured. This causes Batfish to
look up the local-address in the wrong VRF, reporting INVALID_LOCAL_IP.

Add a `sessionVrf` field to the VI model `BgpPeerConfig` that, when
set, overrides which VRF is used for the BGP TCP session. Update the
local IP validation, FIB-based local IP inference, BGP topology
receiver matching, and traceroute-based session establishment checks
in `BgpTopologyUtils` and `BgpSessionAnswererUtils` to use this
field. Add a `Session_VRF` column to the bgpSessionCompatibility,
bgpSessionStatus, and bgpPeerConfiguration questions.

Grammar: move `forwarding-context` from protocol-level only to
`b_common` so it works at protocol, group, and neighbor levels
(matching Junos hierarchy).

----

Prompt:
```
Support Junos `forwarding-context` for BGP sessions. Look in the
juniper manuals for more information on the `forwarding-context`
command. Think about how to implement this in Batfish. Do we need
to change the VI model to add an optional vrf to BGP peer
configuration? Can we already handle this by allowing update-source
to be in a different vrf from the bgp peering and doing that?
Consider multiple designs and present an analysis for how to move
forward.
```

---
**Stack**:
- #9878
- #9874 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*