### PR TITLE
BgpTopologyUtils: fix session with external peer whose AS matches a confederation member-AS

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD.bazel
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD.bazel
@@ -29,6 +29,7 @@ junit_tests(
         "//projects/batfish/src/test/resources",
         "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-backup-routes",
         "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-best-path-export",
+        "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as",
         "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-local-pref-ebgp",
         "//projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-topology-change",
     ],

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpConfederationExternalMemberAsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpConfederationExternalMemberAsTest.java
@@ -1,0 +1,60 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.graph.ValueGraph;
+import java.io.IOException;
+import org.batfish.datamodel.BgpPeerConfigId;
+import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for https://github.com/batfish/batfish/issues/9877.
+ *
+ * <p>Topology: R1 (AS 65002, external) --- R2 (sub-AS 65001, confed 65000, peers {65002}) --- R3
+ * (sub-AS 65002, confed 65000, peers {65001})
+ *
+ * <p>R1's AS (65002) matches confederation member R3's sub-AS. R2 treats R1 as a confed-eBGP peer
+ * and would send its member-AS (65001) in the OPEN message. R1 expects 65000 (confed ID), causing
+ * an AS mismatch. No session should form between R1 and R2.
+ */
+public final class BgpConfederationExternalMemberAsTest {
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private static boolean isSessionEstablished(Batfish batfish, String hostname, Ip remotePeerIp) {
+    ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpGraph =
+        batfish.getTopologyProvider().getBgpTopology(batfish.getSnapshot()).getGraph();
+    BgpPeerConfigId peerId =
+        new BgpPeerConfigId(hostname, DEFAULT_VRF_NAME, Prefix.create(remotePeerIp, 32), false);
+    return bgpGraph.degree(peerId) > 0;
+  }
+
+  @Test
+  public void testExternalPeerMatchingConfedMemberAs() throws IOException {
+    String snapshotPath = "org/batfish/dataplane/ibdp/bgp-confederation-external-member-as";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder().setConfigurationFiles(snapshotPath, "r1", "r2", "r3").build(),
+            _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+
+    // R1↔R2 session should NOT establish: R1's AS (65002) matches a confederation member-AS,
+    // causing an OPEN message AS mismatch.
+    assertFalse(isSessionEstablished(batfish, "r1", Ip.parse("10.0.12.2")));
+    assertFalse(isSessionEstablished(batfish, "r2", Ip.parse("10.0.12.1")));
+
+    // R2↔R3 session (confed-iBGP within the confederation) should establish normally.
+    assertTrue(isSessionEstablished(batfish, "r2", Ip.parse("10.0.23.3")));
+    assertTrue(isSessionEstablished(batfish, "r3", Ip.parse("10.0.23.2")));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as/BUILD.bazel
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as/BUILD.bazel
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "bgp-confederation-external-member-as",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD.bazel"],
+    ),
+)

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as/configs/r1
@@ -1,0 +1,13 @@
+!
+hostname r1
+!
+interface Ethernet0/1
+ ip address 10.0.12.1 255.255.255.0
+!
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+router bgp 65002
+ neighbor 10.0.12.2 remote-as 65000
+ network 1.1.1.1 mask 255.255.255.255
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as/configs/r2
@@ -1,0 +1,15 @@
+!
+hostname r2
+!
+interface Ethernet0/1
+ ip address 10.0.12.2 255.255.255.0
+!
+interface Ethernet0/2
+ ip address 10.0.23.2 255.255.255.0
+!
+router bgp 65001
+ bgp confederation identifier 65000
+ bgp confederation peers 65002
+ neighbor 10.0.12.1 remote-as 65002
+ neighbor 10.0.23.3 remote-as 65002
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-confederation-external-member-as/configs/r3
@@ -1,0 +1,11 @@
+!
+hostname r3
+!
+interface Ethernet0/1
+ ip address 10.0.23.3 255.255.255.0
+!
+router bgp 65002
+ bgp confederation identifier 65000
+ bgp confederation peers 65001
+ neighbor 10.0.23.2 remote-as 65001
+!

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -400,9 +400,11 @@ public final class BgpSessionProperties {
                 initiatorLocalAs,
                 initiator.getConfederationAsn(),
                 initiator.getRemoteAsns(),
+                null,
                 listenerLocalAs,
                 listener.getConfederationAsn(),
-                listener.getRemoteAsns()));
+                listener.getRemoteAsns(),
+                null));
     return from(
         initiator,
         initiatorLocalIp,

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -282,7 +282,7 @@ public final class BgpTopologyUtils {
                                     // same vrf as initiator
                                     BgpPeerConfig candidate = nc.getBgpPeerConfig(candidateId);
                                     if (!bgpCandidatePassesSanityChecks(
-                                        neighborId, neighbor, candidateId, candidate)) {
+                                        neighborId, neighbor, candidateId, candidate, nc)) {
                                       return Stream.of();
                                     }
                                     assert candidate
@@ -378,9 +378,11 @@ public final class BgpTopologyUtils {
             p1.getLocalAs(),
             p1.getConfederationAsn(),
             p1.getRemoteAsns(),
+            getConfedMembers(id1, networkConfigurations),
             remotePeer.getLocalAs(),
             remotePeer.getConfederationAsn(),
-            remotePeer.getRemoteAsns());
+            remotePeer.getRemoteAsns(),
+            getConfedMembers(id2, networkConfigurations));
     assert asPair != null;
     return Stream.of(
         new BgpEdge(
@@ -446,7 +448,8 @@ public final class BgpTopologyUtils {
       @Nonnull BgpPeerConfigId neighborId,
       @Nonnull BgpActivePeerConfig neighbor,
       @Nonnull BgpPeerConfigId candidateId,
-      @Nullable BgpPeerConfig candidate) {
+      @Nullable BgpPeerConfig candidate,
+      @Nonnull NetworkConfigurations nc) {
     if (neighborId.getHostname().equals(candidateId.getHostname())
         && neighborId.getVrfName().equals(candidateId.getVrfName())) {
       // Do not let the same node/VRF peer with itself.
@@ -456,22 +459,15 @@ public final class BgpTopologyUtils {
     if (candidate == null) {
       return false;
     }
-    return bgpCandidateHasCompatibleAs(neighbor, candidate);
-  }
-
-  /**
-   * Returns if the given candidate BGP peer has a compatible AS configuration to the given active
-   * BGP peer
-   */
-  public static boolean bgpCandidateHasCompatibleAs(
-      BgpPeerConfig neighbor, BgpPeerConfig candidate) {
     return computeAsPair(
             neighbor.getLocalAs(),
             neighbor.getConfederationAsn(),
             neighbor.getRemoteAsns(),
+            getConfedMembers(neighborId, nc),
             candidate.getLocalAs(),
             candidate.getConfederationAsn(),
-            candidate.getRemoteAsns())
+            candidate.getRemoteAsns(),
+            getConfedMembers(candidateId, nc))
         != null;
   }
 
@@ -520,7 +516,16 @@ public final class BgpTopologyUtils {
     }
     BgpPeerConfig candidate = nc.getBgpPeerConfig(candidateId);
     return candidate instanceof BgpUnnumberedPeerConfig
-        && bgpCandidateHasCompatibleAs(neighbor, candidate);
+        && computeAsPair(
+                neighbor.getLocalAs(),
+                neighbor.getConfederationAsn(),
+                neighbor.getRemoteAsns(),
+                getConfedMembers(neighborId, nc),
+                candidate.getLocalAs(),
+                candidate.getConfederationAsn(),
+                candidate.getRemoteAsns(),
+                getConfedMembers(candidateId, nc))
+            != null;
   }
 
   private static final class ReverseFlowAndFirewallSessions {
@@ -665,13 +670,25 @@ public final class BgpTopologyUtils {
                         }));
   }
 
+  /** Returns the confederation members for the BGP process associated with the given peer. */
+  private static @Nullable LongSpace getConfedMembers(
+      BgpPeerConfigId id, NetworkConfigurations nc) {
+    return nc.getVrf(id.getHostname(), id.getVrfName())
+        .map(Vrf::getBgpProcess)
+        .map(BgpProcess::getConfederation)
+        .map(BgpConfederation::getMembers)
+        .orElse(null);
+  }
+
   public static @Nullable AsPair computeAsPair(
       @Nullable Long initiatorLocalAs,
       @Nullable Long initiatorConfed,
       @Nonnull LongSpace initiatorRemoteAsns,
+      @Nullable LongSpace initiatorConfedMembers,
       @Nullable Long listenerLocalAs,
       @Nullable Long listenerConfed,
-      @Nonnull LongSpace listenerRemoteAsns) {
+      @Nonnull LongSpace listenerRemoteAsns,
+      @Nullable LongSpace listenerConfedMembers) {
     if (initiatorLocalAs == null || listenerLocalAs == null) {
       return null; // This is plainly a misconfiguration. No session.
     }
@@ -708,6 +725,12 @@ public final class BgpTopologyUtils {
     }
     // Initiator is inside a confederation, but listener is not
     if (initiatorConfed != null) {
+      // If the listener's local AS is one of the initiator's confederation members, the initiator
+      // would treat this as a confed-eBGP session and send its member-AS in the OPEN message. The
+      // listener expects the confederation ID, so this is an AS mismatch. No session.
+      if (initiatorConfedMembers != null && initiatorConfedMembers.contains(listenerLocalAs)) {
+        return null;
+      }
       // Listener is not in a confederation, so this is across the confederation border if the
       // listener is configured to peer with the initiator's confederation ID. Both peers must
       // agree on the AS numbers: the initiator uses its confederation ID externally, and the
@@ -719,7 +742,13 @@ public final class BgpTopologyUtils {
         return null;
       }
     } else {
-      // Listener is inside a confederation, but initiator is not
+      // Listener is inside a confederation, but initiator is not.
+      // Same check as above in reverse: if the initiator's local AS is in the listener's
+      // confederation members, the listener would treat this as confed-eBGP and send its member-AS.
+      // The initiator expects the confederation ID. AS mismatch, no session.
+      if (listenerConfedMembers != null && listenerConfedMembers.contains(initiatorLocalAs)) {
+        return null;
+      }
       // Similar to above: initiator must be configured to peer with listener's confederation ID
       if (listenerRemoteAsns.contains(initiatorLocalAs)
           && initiatorRemoteAsns.contains(listenerConfed)) {

--- a/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
@@ -436,18 +436,22 @@ public class BgpTopologyUtilsTest {
             initiatorLocalAs,
             initiatorConfed,
             initiatorRemoteAsns,
+            null,
             listenerLocalAs,
             listenerConfed,
-            listenerRemoteAsns),
+            listenerRemoteAsns,
+            null),
         result != null ? equalTo(result) : nullValue());
     assertThat(
         computeAsPair(
             listenerLocalAs,
             listenerConfed,
             listenerRemoteAsns,
+            null,
             initiatorLocalAs,
             initiatorConfed,
-            initiatorRemoteAsns),
+            initiatorRemoteAsns,
+            null),
         result != null ? equalTo(result.reverse()) : nullValue());
   }
 
@@ -726,6 +730,60 @@ public class BgpTopologyUtilsTest {
         null,
         ALL_AS_NUMBERS,
         new AsPair(100, 2000, ConfedSessionType.ACROSS_CONFED_BORDER));
+  }
+
+  /**
+   * Regression test for https://github.com/batfish/batfish/issues/9877.
+   *
+   * <p>When an external peer's AS matches a confederation member-AS, the confederation router would
+   * treat it as a confed-eBGP peer and send its member-AS (not confed ID) in the OPEN message. The
+   * external peer expects the confed ID, causing an AS mismatch. No session should form.
+   */
+  @Test
+  public void testComputeAsPair_confedMemberCollisionWithExternalPeer() {
+    LongSpace confedMembers = LongSpace.builder().including(65001L).including(65002L).build();
+
+    // Initiator is confed peer (R2: localAs=65001, confed=65000, members={65001,65002})
+    // Listener is external (R1: localAs=65002, no confed)
+    // R2 sees R1's AS (65002) in its confed members → treats as confed-eBGP → sends member-AS
+    // R1 expects confed ID (65000) → AS mismatch → no session
+    assertThat(
+        computeAsPair(
+            65001L,
+            65000L,
+            LongSpace.of(65002L),
+            confedMembers,
+            65002L,
+            null,
+            LongSpace.of(65000L),
+            null),
+        nullValue());
+
+    // Reverse direction: R1 as initiator, R2 as listener — same result
+    assertThat(
+        computeAsPair(
+            65002L,
+            null,
+            LongSpace.of(65000L),
+            null,
+            65001L,
+            65000L,
+            LongSpace.of(65002L),
+            confedMembers),
+        nullValue());
+
+    // Sanity check: a non-member external peer (AS 2000) should still work across confed border
+    assertThat(
+        computeAsPair(
+            65001L,
+            65000L,
+            LongSpace.of(2000L),
+            confedMembers,
+            2000L,
+            null,
+            LongSpace.of(65000L),
+            null),
+        equalTo(new AsPair(65000, 2000, ConfedSessionType.ACROSS_CONFED_BORDER)));
   }
 
   @Test


### PR DESCRIPTION
When a non-confederation peer's AS happened to match an AS in the
confederation's member list, `computeAsPair` would allow the session
as ACROSS_CONFED_BORDER. In reality, the confederation router
classifies such a peer as confed-eBGP and sends its member-AS (not
the confederation ID) in the OPEN message. The external peer expects
the confederation ID, causing an AS mismatch that prevents session
establishment.

Add confederation members as a parameter to `computeAsPair` and
reject sessions where the non-confederation peer's AS is in the
confederation peer's member list.

Fixes batfish/batfish#9877

----

Prompt:
```
Read and investigate
https://github.com/batfish/batfish/issues/9877
```
then:
```
Use red/green tdd to fix it
```
then:
```
For head, I don't like that
BgpConfederationExternalMemberAsTest doesn't actually test which
sessions are established but instead indirectly tests via routes.
```

---
**Stack**:
- #9878 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*