### PR TITLE
SpecifierContextImpl: lazily compute configs and locationInfo

### DIFF
--- a/projects/common/src/main/java/org/batfish/specifier/SpecifierContextImpl.java
+++ b/projects/common/src/main/java/org/batfish/specifier/SpecifierContextImpl.java
@@ -1,5 +1,7 @@
 package org.batfish.specifier;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
@@ -14,19 +16,20 @@ import org.batfish.role.NodeRoleDimension;
 public class SpecifierContextImpl implements SpecifierContext {
   private final @Nonnull IBatfish _batfish;
 
-  private final @Nonnull Map<String, Configuration> _configs;
+  private final @Nonnull Supplier<Map<String, Configuration>> _configs;
 
-  private final Map<Location, LocationInfo> _locationInfo;
+  private final @Nonnull Supplier<Map<Location, LocationInfo>> _locationInfo;
 
   public SpecifierContextImpl(@Nonnull IBatfish batfish, @Nonnull NetworkSnapshot networkSnapshot) {
     _batfish = batfish;
-    _configs = _batfish.loadConfigurations(networkSnapshot);
-    _locationInfo = ImmutableMap.copyOf(_batfish.getLocationInfo(networkSnapshot));
+    _configs = Suppliers.memoize(() -> batfish.loadConfigurations(networkSnapshot));
+    _locationInfo =
+        Suppliers.memoize(() -> ImmutableMap.copyOf(batfish.getLocationInfo(networkSnapshot)));
   }
 
   @Override
   public @Nonnull Map<String, Configuration> getConfigs() {
-    return _configs;
+    return _configs.get();
   }
 
   @Override
@@ -41,11 +44,11 @@ public class SpecifierContextImpl implements SpecifierContext {
 
   @Override
   public LocationInfo getLocationInfo(Location location) {
-    return _locationInfo.getOrDefault(location, LocationInfo.NOTHING);
+    return _locationInfo.get().getOrDefault(location, LocationInfo.NOTHING);
   }
 
   @Override
   public Map<Location, LocationInfo> getLocationInfo() {
-    return _locationInfo;
+    return _locationInfo.get();
   }
 }


### PR DESCRIPTION
SpecifierContextImpl eagerly computed configs and locationInfo
in its constructor. Questions that never access one or both of
these (e.g., bgpSessionCompatibility never calls
getLocationInfo()) paid the cost unnecessarily.

Use Suppliers.memoize to defer both computations to first access.

---
**Stack**:
- #9879 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*