### PR TITLE
RouteFilterList: make immutable; fix O(N^2) addLine; delete dead code

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1960,13 +1960,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
       Map<Prefix, OspfAreaSummary> summaries = e1.getValue();
       OspfArea.Builder area = areas.get(areaLong);
       String summaryFilterName = "~OSPF_SUMMARY_FILTER:" + vrfName + ":" + areaLong + "~";
-      RouteFilterList summaryFilter = new RouteFilterList(summaryFilterName);
-      c.getRouteFilterLists().put(summaryFilterName, summaryFilter);
       if (area == null) {
         area = OspfArea.builder().setNumber(areaLong);
         areas.put(areaLong, area);
       }
       area.setSummaryFilter(summaryFilterName);
+      ImmutableList.Builder<RouteFilterLine> summaryLines = ImmutableList.builder();
       for (Entry<Prefix, OspfAreaSummary> e2 : summaries.entrySet()) {
         Prefix prefix = e2.getKey();
         OspfAreaSummary summary = e2.getValue();
@@ -1975,18 +1974,20 @@ public final class CiscoConfiguration extends VendorConfiguration {
             summary.isAdvertised()
                 ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
                 : prefixLength;
-        summaryFilter.addLine(
+        summaryLines.add(
             new RouteFilterLine(
                 LineAction.DENY,
                 IpWildcard.create(prefix),
                 new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
       }
       area.addSummaries(ImmutableSortedMap.copyOf(summaries));
-      summaryFilter.addLine(
+      summaryLines.add(
           new RouteFilterLine(
               LineAction.PERMIT,
               IpWildcard.create(Prefix.ZERO),
               new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
+      c.getRouteFilterLists()
+          .put(summaryFilterName, new RouteFilterList(summaryFilterName, summaryLines.build()));
     }
     newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -2216,13 +2216,12 @@ public final class AsaConfiguration extends VendorConfiguration {
       Map<Prefix, OspfAreaSummary> summaries = e1.getValue();
       OspfArea.Builder area = areas.get(areaLong);
       String summaryFilterName = "~OSPF_SUMMARY_FILTER:" + vrfName + ":" + areaLong + "~";
-      RouteFilterList summaryFilter = new RouteFilterList(summaryFilterName);
-      c.getRouteFilterLists().put(summaryFilterName, summaryFilter);
       if (area == null) {
         area = OspfArea.builder().setNumber(areaLong);
         areas.put(areaLong, area);
       }
       area.setSummaryFilter(summaryFilterName);
+      ImmutableList.Builder<RouteFilterLine> summaryLines = ImmutableList.builder();
       for (Entry<Prefix, OspfAreaSummary> e2 : summaries.entrySet()) {
         Prefix prefix = e2.getKey();
         OspfAreaSummary summary = e2.getValue();
@@ -2231,18 +2230,20 @@ public final class AsaConfiguration extends VendorConfiguration {
             summary.isAdvertised()
                 ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
                 : prefixLength;
-        summaryFilter.addLine(
+        summaryLines.add(
             new RouteFilterLine(
                 LineAction.DENY,
                 IpWildcard.create(prefix),
                 new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
       }
       area.addSummaries(ImmutableSortedMap.copyOf(summaries));
-      summaryFilter.addLine(
+      summaryLines.add(
           new RouteFilterLine(
               LineAction.PERMIT,
               IpWildcard.create(Prefix.ZERO),
               new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
+      c.getRouteFilterLists()
+          .put(summaryFilterName, new RouteFilterList(summaryFilterName, summaryLines.build()));
     }
     newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -1657,9 +1657,8 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
       // Populate VI area summaries and create summary filter
       if (!area.getSummaries().isEmpty()) {
         String summaryFilterName = "~OSPF_SUMMARY_FILTER:" + vrfName + ":" + areaNum + "~";
-        RouteFilterList summaryFilter = new RouteFilterList(summaryFilterName);
-        c.getRouteFilterLists().put(summaryFilterName, summaryFilter);
         viAreaBuilder.setSummaryFilter(summaryFilterName);
+        ImmutableList.Builder<RouteFilterLine> summaryLines = ImmutableList.builder();
         for (Entry<Prefix, OspfAreaSummary> e : area.getSummaries().entrySet()) {
           Prefix prefix = e.getKey();
           OspfAreaSummary summary = e.getValue();
@@ -1668,18 +1667,20 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
               summary.isAdvertised()
                   ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
                   : prefixLength;
-          summaryFilter.addLine(
+          summaryLines.add(
               new RouteFilterLine(
                   LineAction.DENY,
                   IpWildcard.create(prefix),
                   new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
         }
         viAreaBuilder.addSummaries(ImmutableSortedMap.copyOf(area.getSummaries()));
-        summaryFilter.addLine(
+        summaryLines.add(
             new RouteFilterLine(
                 LineAction.PERMIT,
                 IpWildcard.create(Prefix.ZERO),
                 new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
+        c.getRouteFilterLists()
+            .put(summaryFilterName, new RouteFilterList(summaryFilterName, summaryLines.build()));
       }
 
       areas.put(areaNum, viAreaBuilder.build());

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
@@ -265,14 +265,13 @@ public final class CumulusConversions {
       return null;
     }
     // Create a RouteFilterList that matches any network longer than a prefix marked summary only.
-    RouteFilterList matchLonger =
-        new RouteFilterList(computeMatchSuppressedSummaryOnlyPolicyName(vrfName));
+    String name = computeMatchSuppressedSummaryOnlyPolicyName(vrfName);
+    ImmutableList.Builder<RouteFilterLine> lines = ImmutableList.builder();
     prefixesToSuppress.forEachRemaining(
-        p ->
-            matchLonger.addLine(
-                new RouteFilterLine(LineAction.PERMIT, PrefixRange.moreSpecificThan(p))));
+        p -> lines.add(new RouteFilterLine(LineAction.PERMIT, PrefixRange.moreSpecificThan(p))));
+    RouteFilterList matchLonger = new RouteFilterList(name, lines.build());
     // Bookkeeping: record that we created this RouteFilterList to match longer networks.
-    c.getRouteFilterLists().put(matchLonger.getName(), matchLonger);
+    c.getRouteFilterLists().put(name, matchLonger);
 
     return new If(
         "Suppress more specific networks for summary-only aggregate-address networks",
@@ -1454,13 +1453,11 @@ public final class CumulusConversions {
 
   @VisibleForTesting
   static @Nonnull RouteFilterList toRouteFilterList(IpPrefixList ipPrefixList) {
-    String name = ipPrefixList.getName();
-    RouteFilterList rfl = new RouteFilterList(name);
-    rfl.setLines(
+    return new RouteFilterList(
+        ipPrefixList.getName(),
         ipPrefixList.getLines().values().stream()
             .map(CumulusConversions::toRouteFilterLine)
             .collect(ImmutableList.toImmutableList()));
-    return rfl;
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
@@ -402,14 +402,13 @@ public final class FrrConversions {
       return null;
     }
     // Create a RouteFilterList that matches any network longer than a prefix marked summary only.
-    RouteFilterList matchLonger =
-        new RouteFilterList(computeMatchSuppressedSummaryOnlyPolicyName(vrfName));
+    String name = computeMatchSuppressedSummaryOnlyPolicyName(vrfName);
+    ImmutableList.Builder<RouteFilterLine> lines = ImmutableList.builder();
     prefixesToSuppress.forEachRemaining(
-        p ->
-            matchLonger.addLine(
-                new RouteFilterLine(LineAction.PERMIT, PrefixRange.moreSpecificThan(p))));
+        p -> lines.add(new RouteFilterLine(LineAction.PERMIT, PrefixRange.moreSpecificThan(p))));
+    RouteFilterList matchLonger = new RouteFilterList(name, lines.build());
     // Bookkeeping: record that we created this RouteFilterList to match longer networks.
-    c.getRouteFilterLists().put(matchLonger.getName(), matchLonger);
+    c.getRouteFilterLists().put(name, matchLonger);
 
     return new If(
         "Suppress more specific networks for summary-only aggregate-address networks",

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1438,9 +1438,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
             e -> {
               String summaryFilterName =
                   "~OSPF_SUMMARY_FILTER:" + vrfName + ":" + e.getValue().getName() + "~";
-              RouteFilterList summaryFilter = new RouteFilterList(summaryFilterName);
-              _c.getRouteFilterLists().put(summaryFilterName, summaryFilter);
-              return toOspfAreaBuilder(e.getValue(), summaryFilter);
+              return toOspfAreaBuilder(e.getValue(), summaryFilterName);
             });
     // place interfaces into areas
     for (Entry<String, Interface> e : routingInstance.getInterfaces().entrySet()) {
@@ -1562,7 +1560,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private org.batfish.datamodel.ospf.OspfArea.Builder toOspfAreaBuilder(
-      OspfArea area, RouteFilterList summaryFilter) {
+      OspfArea area, String summaryFilterName) {
     org.batfish.datamodel.ospf.OspfArea.Builder newAreaBuilder =
         org.batfish.datamodel.ospf.OspfArea.builder();
     newAreaBuilder.setNumber(area.getName());
@@ -1574,6 +1572,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
     newAreaBuilder.setMetricOfDefaultRoute(area.getMetricOfDefaultRoute());
 
     // Add summary filters for each area summary
+    ImmutableList.Builder<org.batfish.datamodel.RouteFilterLine> summaryLines =
+        ImmutableList.builder();
     for (Entry<Prefix, OspfAreaSummary> e2 : area.getSummaries().entrySet()) {
       Prefix prefix = e2.getKey();
       OspfAreaSummary summary = e2.getValue();
@@ -1582,18 +1582,20 @@ public final class JuniperConfiguration extends VendorConfiguration {
           summary.isAdvertised()
               ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
               : prefixLength;
-      summaryFilter.addLine(
+      summaryLines.add(
           new org.batfish.datamodel.RouteFilterLine(
               LineAction.DENY,
               IpWildcard.create(prefix),
               new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
     }
-    summaryFilter.addLine(
+    summaryLines.add(
         new org.batfish.datamodel.RouteFilterLine(
             LineAction.PERMIT,
             IpWildcard.create(Prefix.ZERO),
             new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
-    newAreaBuilder.setSummaryFilter(summaryFilter.getName());
+    RouteFilterList summaryFilter = new RouteFilterList(summaryFilterName, summaryLines.build());
+    _c.getRouteFilterLists().put(summaryFilterName, summaryFilter);
+    newAreaBuilder.setSummaryFilter(summaryFilterName);
     return newAreaBuilder;
   }
 
@@ -1791,12 +1793,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
     String rflName = computeContributorRouteFilterListName(prefix);
     MatchPrefixSet isContributingRoute =
         new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(rflName));
-    RouteFilterList rfList = new RouteFilterList(rflName);
-    rfList.addLine(
-        new org.batfish.datamodel.RouteFilterLine(
-            LineAction.PERMIT,
-            prefix,
-            new SubRange(prefix.getPrefixLength() + 1, Prefix.MAX_PREFIX_LENGTH)));
+    RouteFilterList rfList =
+        new RouteFilterList(
+            rflName,
+            ImmutableList.of(
+                new org.batfish.datamodel.RouteFilterLine(
+                    LineAction.PERMIT,
+                    prefix,
+                    new SubRange(prefix.getPrefixLength() + 1, Prefix.MAX_PREFIX_LENGTH))));
     _c.getRouteFilterLists().put(rflName, rfList);
 
     // contributor check that exits for non-contributing routes
@@ -3174,8 +3178,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
             }
             if (!line.getThens().isEmpty()) {
               String lineListName = name + "_ACTION_LINE_" + actionLineCounter;
-              RouteFilterList lineSpecificList = new RouteFilterList(lineListName);
-              ((Route4FilterLine) line).applyTo(lineSpecificList);
+              RouteFilterList lineSpecificList =
+                  new RouteFilterList(lineListName, ((Route4FilterLine) line).toRouteFilterLines());
               actionLineCounter++;
               _c.getRouteFilterLists().put(lineListName, lineSpecificList);
               If lineSpecificIfStatement = new If();
@@ -3649,12 +3653,13 @@ public final class JuniperConfiguration extends VendorConfiguration {
       String name = e.getKey();
       RouteFilter rf = e.getValue();
       if (rf.getIpv4()) {
-        RouteFilterList rfl = new RouteFilterList(name);
-        for (RouteFilterLine line : rf.getLines()) {
-          if (line instanceof Route4FilterLine && line.getThens().isEmpty()) {
-            ((Route4FilterLine) line).applyTo(rfl);
-          }
-        }
+        RouteFilterList rfl =
+            new RouteFilterList(
+                name,
+                rf.getLines().stream()
+                    .filter(line -> line instanceof Route4FilterLine && line.getThens().isEmpty())
+                    .flatMap(line -> ((Route4FilterLine) line).toRouteFilterLines().stream())
+                    .collect(ImmutableList.toImmutableList()));
         _c.getRouteFilterLists().put(name, rfl);
       }
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterLonger.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.juniper;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Warnings;
@@ -48,8 +49,7 @@ public final class PsFromPrefixListFilterLonger extends PsFrom {
 
     RouteFilterList longerList = c.getRouteFilterLists().get(name(_prefixList));
     if (longerList == null) {
-      longerList = new RouteFilterList(name(_prefixList));
-      c.getRouteFilterLists().put(longerList.getName(), longerList);
+      ImmutableList.Builder<RouteFilterLine> lines = ImmutableList.builder();
       for (Prefix prefix : pl.getPrefixes()) {
         if (prefix.getPrefixLength() == Prefix.MAX_PREFIX_LENGTH) {
           // Skip this prefix; there may be others in the prefix-list.
@@ -57,8 +57,10 @@ public final class PsFromPrefixListFilterLonger extends PsFrom {
         }
         SubRange longerLineRange =
             new SubRange(prefix.getPrefixLength() + 1, Prefix.MAX_PREFIX_LENGTH);
-        longerList.addLine(new RouteFilterLine(LineAction.PERMIT, prefix, longerLineRange));
+        lines.add(new RouteFilterLine(LineAction.PERMIT, prefix, longerLineRange));
       }
+      longerList = new RouteFilterList(name(_prefixList), lines.build());
+      c.getRouteFilterLists().put(longerList.getName(), longerList);
     }
     return new MatchPrefixSet(
         DestinationNetwork.instance(), new NamedPrefixSet(longerList.getName()));

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterOrLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromPrefixListFilterOrLonger.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.juniper;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Warnings;
@@ -49,15 +50,14 @@ public final class PsFromPrefixListFilterOrLonger extends PsFrom {
     String orLongerListName = name(_prefixList);
     RouteFilterList orLongerList = c.getRouteFilterLists().get(orLongerListName);
     if (orLongerList == null) {
-      orLongerList = new RouteFilterList(orLongerListName);
-      c.getRouteFilterLists().put(orLongerList.getName(), orLongerList);
+      ImmutableList.Builder<RouteFilterLine> lines = ImmutableList.builder();
       for (Prefix prefix : pl.getPrefixes()) {
         SubRange orLongerLineRange =
             new SubRange(prefix.getPrefixLength(), Prefix.MAX_PREFIX_LENGTH);
-        RouteFilterLine orLongerLine =
-            new RouteFilterLine(LineAction.PERMIT, prefix, orLongerLineRange);
-        orLongerList.addLine(orLongerLine);
+        lines.add(new RouteFilterLine(LineAction.PERMIT, prefix, orLongerLineRange));
       }
+      orLongerList = new RouteFilterList(orLongerListName, lines.build());
+      c.getRouteFilterLists().put(orLongerList.getName(), orLongerList);
     }
     return new MatchPrefixSet(
         DestinationNetwork.instance(), new NamedPrefixSet(orLongerList.getName()));

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLine.java
@@ -1,7 +1,7 @@
 package org.batfish.representation.juniper;
 
+import java.util.List;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.RouteFilterList;
 
 public abstract class Route4FilterLine extends RouteFilterLine {
 
@@ -11,5 +11,8 @@ public abstract class Route4FilterLine extends RouteFilterLine {
     _prefix = prefix;
   }
 
-  public abstract void applyTo(RouteFilterList rfl);
+  /**
+   * Returns the vendor-independent {@link org.batfish.datamodel.RouteFilterLine}s for this line.
+   */
+  public abstract List<org.batfish.datamodel.RouteFilterLine> toRouteFilterLines();
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineAddressMask.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineAddressMask.java
@@ -1,11 +1,12 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import java.util.Objects;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.SubRange;
 
 /** Representation of a route-filter with a IPv4 prefix and an address mask */
@@ -19,15 +20,14 @@ public final class Route4FilterLineAddressMask extends Route4FilterLine {
   }
 
   @Override
-  public void applyTo(RouteFilterList rfl) {
+  public List<org.batfish.datamodel.RouteFilterLine> toRouteFilterLines() {
     int prefixLength = _prefix.getPrefixLength();
-    org.batfish.datamodel.RouteFilterLine line =
+    return ImmutableList.of(
         new org.batfish.datamodel.RouteFilterLine(
             LineAction.PERMIT,
             IpWildcard.ipWithWildcardMask(
                 Prefix.create(_prefix.getStartIp(), prefixLength).getStartIp(), _addressMask),
-            SubRange.singleton(prefixLength));
-    rfl.addLine(line);
+            SubRange.singleton(prefixLength)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineExact.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineExact.java
@@ -1,8 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.SubRange;
 
 public final class Route4FilterLineExact extends Route4FilterLine {
@@ -12,12 +13,11 @@ public final class Route4FilterLineExact extends Route4FilterLine {
   }
 
   @Override
-  public void applyTo(RouteFilterList rfl) {
+  public List<org.batfish.datamodel.RouteFilterLine> toRouteFilterLines() {
     int prefixLength = _prefix.getPrefixLength();
-    org.batfish.datamodel.RouteFilterLine line =
+    return ImmutableList.of(
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.PERMIT, _prefix, SubRange.singleton(prefixLength));
-    rfl.addLine(line);
+            LineAction.PERMIT, _prefix, SubRange.singleton(prefixLength)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLengthRange.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLengthRange.java
@@ -1,8 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.SubRange;
 
 public final class Route4FilterLineLengthRange extends Route4FilterLine {
@@ -18,11 +19,10 @@ public final class Route4FilterLineLengthRange extends Route4FilterLine {
   }
 
   @Override
-  public void applyTo(RouteFilterList rfl) {
-    org.batfish.datamodel.RouteFilterLine line =
+  public List<org.batfish.datamodel.RouteFilterLine> toRouteFilterLines() {
+    return ImmutableList.of(
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.PERMIT, _prefix, new SubRange(_minPrefixLength, _maxPrefixLength));
-    rfl.addLine(line);
+            LineAction.PERMIT, _prefix, new SubRange(_minPrefixLength, _maxPrefixLength)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineLonger.java
@@ -1,10 +1,11 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixRange;
-import org.batfish.datamodel.RouteFilterList;
 
 public class Route4FilterLineLonger extends Route4FilterLine {
 
@@ -13,15 +14,14 @@ public class Route4FilterLineLonger extends Route4FilterLine {
   }
 
   @Override
-  public void applyTo(RouteFilterList rfl) {
+  public List<org.batfish.datamodel.RouteFilterLine> toRouteFilterLines() {
     int prefixLength = _prefix.getPrefixLength();
     if (prefixLength >= 32) {
       throw new BatfishException("Route filter prefix length cannot be 'longer' than 32");
     }
-    org.batfish.datamodel.RouteFilterLine line =
+    return ImmutableList.of(
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.PERMIT, PrefixRange.moreSpecificThan(_prefix));
-    rfl.addLine(line);
+            LineAction.PERMIT, PrefixRange.moreSpecificThan(_prefix)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineOrLonger.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineOrLonger.java
@@ -1,8 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.SubRange;
 
 public class Route4FilterLineOrLonger extends Route4FilterLine {
@@ -12,12 +13,11 @@ public class Route4FilterLineOrLonger extends Route4FilterLine {
   }
 
   @Override
-  public void applyTo(RouteFilterList rfl) {
+  public List<org.batfish.datamodel.RouteFilterLine> toRouteFilterLines() {
     int prefixLength = _prefix.getPrefixLength();
-    org.batfish.datamodel.RouteFilterLine line =
+    return ImmutableList.of(
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.PERMIT, _prefix, new SubRange(prefixLength, Prefix.MAX_PREFIX_LENGTH));
-    rfl.addLine(line);
+            LineAction.PERMIT, _prefix, new SubRange(prefixLength, Prefix.MAX_PREFIX_LENGTH)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineThrough.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineThrough.java
@@ -1,9 +1,10 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.SubRange;
 
 public final class Route4FilterLineThrough extends Route4FilterLine {
@@ -16,17 +17,18 @@ public final class Route4FilterLineThrough extends Route4FilterLine {
   }
 
   @Override
-  public void applyTo(RouteFilterList rfl) {
+  public List<org.batfish.datamodel.RouteFilterLine> toRouteFilterLines() {
     int low = _prefix.getPrefixLength();
     int high = _throughPrefix.getPrefixLength();
     Ip startIp = _throughPrefix.getStartIp();
+    ImmutableList.Builder<org.batfish.datamodel.RouteFilterLine> lines = ImmutableList.builder();
     for (int i = low; i <= high; i++) {
       Prefix currentPrefix = Prefix.create(startIp, i);
-      org.batfish.datamodel.RouteFilterLine line =
+      lines.add(
           new org.batfish.datamodel.RouteFilterLine(
-              LineAction.PERMIT, currentPrefix, SubRange.singleton(i));
-      rfl.addLine(line);
+              LineAction.PERMIT, currentPrefix, SubRange.singleton(i)));
     }
+    return lines.build();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineUpTo.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineUpTo.java
@@ -1,8 +1,9 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.SubRange;
 
 public final class Route4FilterLineUpTo extends Route4FilterLine {
@@ -15,12 +16,11 @@ public final class Route4FilterLineUpTo extends Route4FilterLine {
   }
 
   @Override
-  public void applyTo(RouteFilterList rfl) {
+  public List<org.batfish.datamodel.RouteFilterLine> toRouteFilterLines() {
     int prefixLength = _prefix.getPrefixLength();
-    org.batfish.datamodel.RouteFilterLine line =
+    return ImmutableList.of(
         new org.batfish.datamodel.RouteFilterLine(
-            LineAction.PERMIT, _prefix, new SubRange(prefixLength, _maxPrefixLength));
-    rfl.addLine(line);
+            LineAction.PERMIT, _prefix, new SubRange(prefixLength, _maxPrefixLength)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -306,14 +306,11 @@ public class VyosConfiguration extends VendorConfiguration {
   }
 
   private RouteFilterList toRouteFilterList(PrefixList prefixList) {
-    String name = prefixList.getName();
-    RouteFilterList newList = new RouteFilterList(name);
-    List<RouteFilterLine> newLines =
+    return new RouteFilterList(
+        prefixList.getName(),
         prefixList.getRules().values().stream()
             .map(l -> new RouteFilterLine(l.getAction(), l.getPrefix(), l.getLengthRange()))
-            .collect(ImmutableList.toImmutableList());
-    newList.setLines(newLines);
-    return newList;
+            .collect(ImmutableList.toImmutableList()));
   }
 
   private RoutingPolicy toRoutingPolicy(RouteMap routeMap) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
@@ -1631,13 +1631,12 @@ public final class AristaConfiguration extends VendorConfiguration {
       Map<Prefix, OspfAreaSummary> summaries = e1.getValue();
       OspfArea.Builder area = areas.get(areaLong);
       String summaryFilterName = "~OSPF_SUMMARY_FILTER:" + vrfName + ":" + areaLong + "~";
-      RouteFilterList summaryFilter = new RouteFilterList(summaryFilterName);
-      c.getRouteFilterLists().put(summaryFilterName, summaryFilter);
       if (area == null) {
         area = OspfArea.builder().setNumber(areaLong);
         areas.put(areaLong, area);
       }
       area.setSummaryFilter(summaryFilterName);
+      ImmutableList.Builder<RouteFilterLine> summaryLines = ImmutableList.builder();
       for (Entry<Prefix, OspfAreaSummary> e2 : summaries.entrySet()) {
         Prefix prefix = e2.getKey();
         OspfAreaSummary summary = e2.getValue();
@@ -1646,18 +1645,20 @@ public final class AristaConfiguration extends VendorConfiguration {
             summary.isAdvertised()
                 ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
                 : prefixLength;
-        summaryFilter.addLine(
+        summaryLines.add(
             new RouteFilterLine(
                 LineAction.DENY,
                 IpWildcard.create(prefix),
                 new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
       }
       area.addSummaries(ImmutableSortedMap.copyOf(summaries));
-      summaryFilter.addLine(
+      summaryLines.add(
           new RouteFilterLine(
               LineAction.PERMIT,
               IpWildcard.create(Prefix.ZERO),
               new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
+      c.getRouteFilterLists()
+          .put(summaryFilterName, new RouteFilterList(summaryFilterName, summaryLines.build()));
     }
     newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -238,10 +238,13 @@ public class OspfTest {
 
     Configuration c2 = cb.setHostname(C2_NAME).build();
     if (summaryR1L0Behavior != null) {
-      RouteFilterList rfl = new RouteFilterList(C1_L0_SUMMARY_FILTER_NAME);
-      rfl.addLine(
-          new RouteFilterLine(LineAction.DENY, PrefixRange.moreSpecificThan(C1_L0_SUMMARY_PREFIX)));
-      rfl.addLine(RouteFilterLine.PERMIT_ALL);
+      RouteFilterList rfl =
+          new RouteFilterList(
+              C1_L0_SUMMARY_FILTER_NAME,
+              ImmutableList.of(
+                  new RouteFilterLine(
+                      LineAction.DENY, PrefixRange.moreSpecificThan(C1_L0_SUMMARY_PREFIX)),
+                  RouteFilterLine.PERMIT_ALL));
       c2.getRouteFilterLists().put(C1_L0_SUMMARY_FILTER_NAME, rfl);
     }
     Vrf v2 = vb.setOwner(c2).build();

--- a/projects/common/src/main/java/org/batfish/datamodel/RouteFilterList.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/RouteFilterList.java
@@ -16,10 +16,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.BatfishException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.vendor.VendorStructureId;
 
@@ -34,7 +32,7 @@ public class RouteFilterList implements Serializable {
 
   private final Supplier<Set<Prefix>> _deniedCache;
 
-  private @Nonnull List<RouteFilterLine> _lines;
+  private final @Nonnull ImmutableList<RouteFilterLine> _lines;
 
   private final @Nullable String _name;
 
@@ -58,7 +56,7 @@ public class RouteFilterList implements Serializable {
     return new RouteFilterList(name, firstNonNull(lines, ImmutableList.of()), vendorStructureId);
   }
 
-  /** Create and empty route filter list (with no lines) */
+  /** Create an empty route filter list (with no lines) */
   public RouteFilterList(@Nullable String name) {
     this(name, ImmutableList.of());
   }
@@ -74,12 +72,8 @@ public class RouteFilterList implements Serializable {
     _name = name;
     _deniedCache = Suppliers.memoize(new CacheSupplier());
     _permittedCache = Suppliers.memoize(new CacheSupplier());
-    _lines = lines;
+    _lines = ImmutableList.copyOf(lines);
     _vendorStructureId = vendorStructureId;
-  }
-
-  public void addLine(RouteFilterLine r) {
-    _lines = ImmutableList.<RouteFilterLine>builder().addAll(_lines).add(r).build();
   }
 
   @Override
@@ -145,37 +139,12 @@ public class RouteFilterList implements Serializable {
   }
 
   /**
-   * Returns the set of {@link IpWildcard ips} that match this filter list.
-   *
-   * @throws BatfishException if any line in this {@link RouteFilterList} does not have an {@link
-   *     LineAction#PERMIT} when matching.
-   */
-  @JsonIgnore
-  public List<IpWildcard> getMatchingIps() {
-    return getLines().stream()
-        .map(
-            rfLine -> {
-              if (rfLine.getAction() != LineAction.PERMIT) {
-                throw new BatfishException(
-                    "Expected accept action for routerfilterlist from juniper");
-              } else {
-                return rfLine.getIpWildcard();
-              }
-            })
-        .collect(Collectors.toList());
-  }
-
-  /** Set the list of lines against which to match a route's prefix. */
-  public void setLines(@Nonnull List<RouteFilterLine> lines) {
-    _lines = lines;
-  }
-
-  /**
    * Returns a JSON string that represents the definition of this object, ignoring any irrelevant
    * fields.
    *
    * <p>Can be used for JSON-based comparison in questions line compareSameName.
    */
+  @JsonIgnore
   public String definitionJson() {
     try {
       return BatfishObjectMapper.writePrettyString(_lines);

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/Common.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/Common.java
@@ -112,14 +112,13 @@ public final class Common {
       return null;
     }
     // Create a RouteFilterList that matches any network longer than a prefix marked summary only.
-    RouteFilterList matchLonger =
-        new RouteFilterList("~MATCH_SUPPRESSED_SUMMARY_ONLY:" + vrfName + "~");
+    String name = "~MATCH_SUPPRESSED_SUMMARY_ONLY:" + vrfName + "~";
+    ImmutableList.Builder<RouteFilterLine> lines = ImmutableList.builder();
     prefixesToSuppress.forEachRemaining(
-        p ->
-            matchLonger.addLine(
-                new RouteFilterLine(LineAction.PERMIT, PrefixRange.moreSpecificThan(p))));
+        p -> lines.add(new RouteFilterLine(LineAction.PERMIT, PrefixRange.moreSpecificThan(p))));
+    RouteFilterList matchLonger = new RouteFilterList(name, lines.build());
     // Bookkeeping: record that we created this RouteFilterList to match longer networks.
-    c.getRouteFilterLists().put(matchLonger.getName(), matchLonger);
+    c.getRouteFilterLists().put(name, matchLonger);
 
     return new If(
         "Suppress more specific networks for summary-only aggregate-address networks",


### PR DESCRIPTION
RouteFilterList._lines was in a broken half-mutable state: addLine()
rebuilt the entire ImmutableList on every call (O(N) per call, O(N^2)
in loops), caches were never invalidated on mutation, and setLines()
accepted any list with no immutability guarantee.

- Make _lines final ImmutableList, set once at construction
- Remove addLine() and setLines() mutation methods
- Remove getMatchingIps() which had zero callers
- Change Route4FilterLine.applyTo(RouteFilterList) to
toRouteFilterLines() returning a List
- Update all 21 call sites across Juniper, Cisco, CiscoXR, ASA,
Arista, FRR, Cumulus, VyOS, and Common to build lines first then
pass to constructor

----

Prompt:
```
Make a comprehensive look at RouteFilterList. I have many questions:

1. Why does it take IpWildcard instead of Prefix? The semantics it
has seem to apply specifically to prefixes.
2. Can we delete unused code (getMatchingIps)?

Most importantly:

3. What are the semantics in terms of immutability or not, especially
of the _lines. I have some evidence that VI conversion is causing
O(N^2) work in the addLine function which is dumb. Should we rewrite
it as an immutable class with a builder, or just make folks pass in
the lines, or let it be mutable during construction but change it to
immutable in finalizeConfiguration?
```