### PR TITLE
Junos: parse all policy-statement load-balance method variants

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -470,6 +470,7 @@ CONNECTIONS_LIMIT: 'connections-limit';
 CONNECTION_MODE: 'connection-mode';
 
 CONNECTIVITY_FAULT_MANAGEMENT: 'connectivity-fault-management';
+CONSISTENT_HASH: 'consistent-hash';
 CONSOLE: 'console';
 
 CONTACT: 'contact';
@@ -571,6 +572,8 @@ DESTINATION_HOST_UNKNOWN: 'destination-host-unknown';
 DESTINATION_IP: 'destination-ip';
 
 DESTINATION_IP_BASED: 'destination-ip-based';
+
+DESTINATION_IP_ONLY: 'destination-ip-only';
 
 DESTINATION_NAT: 'destination-nat';
 
@@ -2186,7 +2189,9 @@ PAYLOAD_PROTOCOL: 'payload-protocol';
 PEER_ADDRESS: 'peer-address';
 PEER_AS: 'peer-as' -> pushMode(M_BgpAsn);
 PEER_UNIT: 'peer-unit';
+PER_FLOW: 'per-flow';
 PER_PACKET: 'per-packet';
+PER_PREFIX: 'per-prefix';
 PER_UNIT_SCHEDULER: 'per-unit-scheduler';
 PERCENT: 'percent';
 PERFECT_FORWARD_SECRECY: 'perfect-forward-secrecy';
@@ -2342,6 +2347,8 @@ PRIVATE: 'private';
 
 PROBE_IDLE_TUNNEL: 'probe-idle-tunnel';
 PROCESSES: 'processes';
+PROFILE1: 'profile1';
+PROFILE2: 'profile2';
 
 PROPOSAL: 'proposal' -> pushMode(M_Name);
 
@@ -2765,6 +2772,7 @@ SOURCE_HOST_ISOLATED: 'source-host-isolated';
 SOURCE_IDENTITY: 'source-identity' -> pushMode(M_SourceIdentity);
 SOURCE_INTERFACE: 'source-interface' -> pushMode(M_Interface);
 SOURCE_IP_BASED: 'source-ip-based';
+SOURCE_IP_ONLY: 'source-ip-only';
 SOURCE_MAC_ADDRESS: 'source-mac-address' -> pushMode(M_MacAddressAndLength);
 SOURCE_NAT: 'source-nat';
 SOURCE_PORT: 'source-port' -> pushMode(M_Port);
@@ -2855,6 +2863,8 @@ SWAP_SWAP: 'swap-swap';
 SWITCH_OPTIONS: 'switch-options';
 
 SWITCHOVER_ON_ROUTING_CRASH: 'switchover-on-routing-crash';
+
+SYMMETRIC_CONSISTENT_HASH: 'symmetric-consistent-hash';
 
 SYN_ACK_ACK_PROXY: 'syn-ack-ack-proxy';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -798,7 +798,20 @@ popst_next_term
 
 popst_load_balance
 :
-   LOAD_BALANCE PER_PACKET
+   LOAD_BALANCE
+   (
+      ADAPTIVE
+      | CONSISTENT_HASH
+      | DESTINATION_IP_ONLY
+      | PER_FLOW
+      | PER_PACKET
+      | PER_PREFIX
+      | PROFILE1
+      | PROFILE2
+      | RANDOM
+      | SOURCE_IP_ONLY
+      | SYMMETRIC_CONSISTENT_HASH
+   )
 ;
 
 popst_origin

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1196,6 +1196,7 @@ import org.batfish.representation.juniper.PsThenDefaultActionAccept;
 import org.batfish.representation.juniper.PsThenDefaultActionReject;
 import org.batfish.representation.juniper.PsThenExternal;
 import org.batfish.representation.juniper.PsThenLoadBalance;
+import org.batfish.representation.juniper.PsThenLoadBalance.LoadBalanceMethod;
 import org.batfish.representation.juniper.PsThenLocalPreference;
 import org.batfish.representation.juniper.PsThenMetric;
 import org.batfish.representation.juniper.PsThenMetric2;
@@ -6922,7 +6923,32 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitPopst_load_balance(Popst_load_balanceContext ctx) {
-    addPsThen(PsThenLoadBalance.INSTANCE, ctx);
+    LoadBalanceMethod method;
+    if (ctx.ADAPTIVE() != null) {
+      method = LoadBalanceMethod.ADAPTIVE;
+    } else if (ctx.CONSISTENT_HASH() != null) {
+      method = LoadBalanceMethod.CONSISTENT_HASH;
+    } else if (ctx.DESTINATION_IP_ONLY() != null) {
+      method = LoadBalanceMethod.DESTINATION_IP_ONLY;
+    } else if (ctx.PER_FLOW() != null) {
+      method = LoadBalanceMethod.PER_FLOW;
+    } else if (ctx.PER_PACKET() != null) {
+      method = LoadBalanceMethod.PER_PACKET;
+    } else if (ctx.PER_PREFIX() != null) {
+      method = LoadBalanceMethod.PER_PREFIX;
+    } else if (ctx.PROFILE1() != null) {
+      method = LoadBalanceMethod.PROFILE1;
+    } else if (ctx.PROFILE2() != null) {
+      method = LoadBalanceMethod.PROFILE2;
+    } else if (ctx.RANDOM() != null) {
+      method = LoadBalanceMethod.RANDOM;
+    } else if (ctx.SOURCE_IP_ONLY() != null) {
+      method = LoadBalanceMethod.SOURCE_IP_ONLY;
+    } else {
+      assert ctx.SYMMETRIC_CONSISTENT_HASH() != null;
+      method = LoadBalanceMethod.SYMMETRIC_CONSISTENT_HASH;
+    }
+    addPsThen(new PsThenLoadBalance(method), ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLoadBalance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLoadBalance.java
@@ -1,20 +1,41 @@
 package org.batfish.representation.juniper;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
 /**
- * Represents {@code then load-balance per-packet} in a Junos policy-statement. Has no effect on the
+ * Represents {@code then load-balance <method>} in a Junos policy-statement. Has no effect on the
  * VI routing policy (Batfish models all ECMP paths), but is recognized so that forwarding-table
  * export warnings can distinguish it from attribute mutations.
  */
 public final class PsThenLoadBalance extends PsThen {
 
-  public static final PsThenLoadBalance INSTANCE = new PsThenLoadBalance();
+  public enum LoadBalanceMethod {
+    ADAPTIVE,
+    CONSISTENT_HASH,
+    DESTINATION_IP_ONLY,
+    PER_FLOW,
+    PER_PACKET,
+    PER_PREFIX,
+    PROFILE1,
+    PROFILE2,
+    RANDOM,
+    SOURCE_IP_ONLY,
+    SYMMETRIC_CONSISTENT_HASH,
+  }
 
-  private PsThenLoadBalance() {}
+  private final @Nonnull LoadBalanceMethod _method;
+
+  public PsThenLoadBalance(LoadBalanceMethod method) {
+    _method = method;
+  }
+
+  public @Nonnull LoadBalanceMethod getMethod() {
+    return _method;
+  }
 
   @Override
   public void applyTo(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -490,6 +490,7 @@ import org.batfish.representation.juniper.PsFromTag;
 import org.batfish.representation.juniper.PsFromValidationDatabase;
 import org.batfish.representation.juniper.PsProtocol;
 import org.batfish.representation.juniper.PsTerm;
+import org.batfish.representation.juniper.PsThen;
 import org.batfish.representation.juniper.PsThenAigpOriginate;
 import org.batfish.representation.juniper.PsThenAsPathExpandAsList;
 import org.batfish.representation.juniper.PsThenAsPathExpandLastAs;
@@ -497,6 +498,7 @@ import org.batfish.representation.juniper.PsThenAsPathPrepend;
 import org.batfish.representation.juniper.PsThenCommunityAdd;
 import org.batfish.representation.juniper.PsThenCommunitySet;
 import org.batfish.representation.juniper.PsThenLoadBalance;
+import org.batfish.representation.juniper.PsThenLoadBalance.LoadBalanceMethod;
 import org.batfish.representation.juniper.PsThenLocalPreference;
 import org.batfish.representation.juniper.PsThenLocalPreference.Operator;
 import org.batfish.representation.juniper.PsThenMetric;
@@ -10296,6 +10298,37 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         ps.getTerms().get("allow").getThens().getAllThens(),
         hasItem(instanceOf(PsThenLoadBalance.class)));
+  }
+
+  @Test
+  public void testLoadBalanceVariants() {
+    JuniperConfiguration jc = parseJuniperConfig("load-balance-variants");
+    Map<String, LoadBalanceMethod> expected =
+        ImmutableMap.<String, LoadBalanceMethod>builder()
+            .put("LB_ADAPTIVE", LoadBalanceMethod.ADAPTIVE)
+            .put("LB_CONSISTENT_HASH", LoadBalanceMethod.CONSISTENT_HASH)
+            .put("LB_DESTINATION_IP_ONLY", LoadBalanceMethod.DESTINATION_IP_ONLY)
+            .put("LB_PER_FLOW", LoadBalanceMethod.PER_FLOW)
+            .put("LB_PER_PACKET", LoadBalanceMethod.PER_PACKET)
+            .put("LB_PER_PREFIX", LoadBalanceMethod.PER_PREFIX)
+            .put("LB_PROFILE1", LoadBalanceMethod.PROFILE1)
+            .put("LB_PROFILE2", LoadBalanceMethod.PROFILE2)
+            .put("LB_RANDOM", LoadBalanceMethod.RANDOM)
+            .put("LB_SOURCE_IP_ONLY", LoadBalanceMethod.SOURCE_IP_ONLY)
+            .put("LB_SYMMETRIC", LoadBalanceMethod.SYMMETRIC_CONSISTENT_HASH)
+            .build();
+    expected.forEach(
+        (name, method) -> {
+          PolicyStatement ps = jc.getMasterLogicalSystem().getPolicyStatements().get(name);
+          assertThat(name, ps, notNullValue());
+          PsThen then =
+              ps.getDefaultTerm().getThens().getAllThens().stream()
+                  .filter(t -> t instanceof PsThenLoadBalance)
+                  .findFirst()
+                  .orElse(null);
+          assertThat(name, then, notNullValue());
+          assertThat(name, ((PsThenLoadBalance) then).getMethod(), equalTo(method));
+        });
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/load-balance-variants
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/load-balance-variants
@@ -1,0 +1,14 @@
+#
+set system host-name load-balance-variants
+
+set policy-options policy-statement LB_ADAPTIVE then load-balance adaptive
+set policy-options policy-statement LB_CONSISTENT_HASH then load-balance consistent-hash
+set policy-options policy-statement LB_DESTINATION_IP_ONLY then load-balance destination-ip-only
+set policy-options policy-statement LB_PER_FLOW then load-balance per-flow
+set policy-options policy-statement LB_PER_PACKET then load-balance per-packet
+set policy-options policy-statement LB_PER_PREFIX then load-balance per-prefix
+set policy-options policy-statement LB_PROFILE1 then load-balance profile1
+set policy-options policy-statement LB_PROFILE2 then load-balance profile2
+set policy-options policy-statement LB_RANDOM then load-balance random
+set policy-options policy-statement LB_SOURCE_IP_ONLY then load-balance source-ip-only
+set policy-options policy-statement LB_SYMMETRIC then load-balance symmetric-consistent-hash


### PR DESCRIPTION
The grammar only accepted `then load-balance per-packet`. Junos
supports 11 methods: adaptive, consistent-hash, destination-ip-only,
per-flow, per-packet, per-prefix, profile1, profile2, random,
source-ip-only, and symmetric-consistent-hash.

Add lexer tokens for the 8 missing keywords (ADAPTIVE and RANDOM
already existed). Update the grammar rule, extract the specific
method into a new LoadBalanceMethod enum on PsThenLoadBalance, and
remove the old INSTANCE singleton.

----

Prompt:
```
Add parsing support for `set policy-options policy-statement
LOAD-BALANCE then load-balance per-flow`. And look in the manual
in working/ to see if there are other variants after.
```