### PR TITLE
Configuration: return views from getAllInterfaces(vrf) and getActiveInterfaces(vrf)

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Configuration.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import java.io.Serializable;
 import java.util.Collections;
@@ -630,9 +631,7 @@ public final class Configuration implements Serializable {
    */
   @JsonIgnore
   public Map<String, Interface> getAllInterfaces(@Nonnull String vrf) {
-    return _interfaces.entrySet().stream()
-        .filter(e -> e.getValue().getVrfName().equals(vrf))
-        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+    return Maps.filterValues(_interfaces, i -> i.getVrfName().equals(vrf));
   }
 
   /**
@@ -642,9 +641,7 @@ public final class Configuration implements Serializable {
    */
   @JsonIgnore
   public Map<String, Interface> getActiveInterfaces(@Nonnull String vrf) {
-    return activeInterfaces()
-        .filter(i -> i.getVrfName().equals(vrf))
-        .collect(ImmutableMap.toImmutableMap(Interface::getName, i -> i));
+    return Maps.filterValues(_interfaces, i -> i.getActive() && i.getVrfName().equals(vrf));
   }
 
   @JsonIgnore


### PR DESCRIPTION
Both methods built a new ImmutableMap on every call by streaming
and filtering all interfaces. Replace with Maps.filterValues
views, which avoid the copy and support O(1) get() lookups
against the underlying map.

These methods are called per-BGP-neighbor during vendor
conversion in Cisco IOS, IOS-XR, ASA, Arista, NX-OS, FRR, and
Cumulus. The per-call map copy was the dominant cost; the view
eliminates it for all vendors at once.

----

Prompt:
```
Read HEAD. This seems likely to be a problem in many vendors,
and if it's expensive then we should consider fixing it
everywhere. Is this the right fix or should we actually change
the function to take a list of interfaces, or something else?
```