### PR TITLE
FRR: Replace stream with for-loop in computeLocalIpForBgpNeighbor

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
@@ -784,24 +784,25 @@ public final class CumulusConversions {
     return source.accept(visitor);
   }
 
-  /** Scan all interfaces, find first that contains given remote IP */
+  /** Scan all interfaces in the given VRF, find first whose subnet contains the given remote IP. */
   @VisibleForTesting
   static @Nullable Ip computeLocalIpForBgpNeighbor(Ip remoteIp, Configuration c, String vrfName) {
     org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
     if (vrf == null) {
       return null;
     }
-    return c.getAllInterfaces(vrf.getName()).values().stream()
-        .flatMap(
-            i ->
-                i.getAllConcreteAddresses().stream()
-                    .filter(
-                        addr ->
-                            addr.getPrefix().containsIp(remoteIp)
-                                && !addr.getIp().equals(remoteIp)))
-        .findFirst()
-        .map(ConcreteInterfaceAddress::getIp)
-        .orElse(null);
+    // Iterate directly to avoid stream allocation and getAllInterfaces(vrfName) map copy per call.
+    for (Interface iface : c.getAllInterfaces().values()) {
+      if (!iface.getVrfName().equals(vrfName)) {
+        continue;
+      }
+      for (ConcreteInterfaceAddress addr : iface.getAllConcreteAddresses()) {
+        if (addr.getPrefix().containsIp(remoteIp) && !addr.getIp().equals(remoteIp)) {
+          return addr.getIp();
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
@@ -1037,24 +1037,25 @@ public final class FrrConversions {
     return source.accept(visitor);
   }
 
-  /** Scan all interfaces, find first that contains given remote IP */
+  /** Scan all interfaces in the given VRF, find first whose subnet contains the given remote IP. */
   @VisibleForTesting
   static @Nullable Ip computeLocalIpForBgpNeighbor(Ip remoteIp, Configuration c, String vrfName) {
     org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
     if (vrf == null) {
       return null;
     }
-    return c.getAllInterfaces(vrf.getName()).values().stream()
-        .flatMap(
-            i ->
-                i.getAllConcreteAddresses().stream()
-                    .filter(
-                        addr ->
-                            addr.getPrefix().containsIp(remoteIp)
-                                && !addr.getIp().equals(remoteIp)))
-        .findFirst()
-        .map(ConcreteInterfaceAddress::getIp)
-        .orElse(null);
+    // Iterate directly to avoid stream allocation and getAllInterfaces(vrfName) map copy per call.
+    for (Interface iface : c.getAllInterfaces().values()) {
+      if (!iface.getVrfName().equals(vrfName)) {
+        continue;
+      }
+      for (ConcreteInterfaceAddress addr : iface.getAllConcreteAddresses()) {
+        if (addr.getPrefix().containsIp(remoteIp) && !addr.getIp().equals(remoteIp)) {
+          return addr.getIp();
+        }
+      }
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
Replace the stream pipeline in computeLocalIpForBgpNeighbor with a
plain for-loop across vendor conversion files (FrrConversions,
CumulusConversions).

The stream version called getAllInterfaces(vrfName), which copies
the interface map on every call, then built a stream pipeline with
flatMap, filter, findFirst, and map. The for-loop iterates
getAllInterfaces() directly and filters by VRF name inline,
avoiding both the map copy and stream/iterator allocations. The
method is called per BGP neighbor during conversion.

---
**Stack**:
- #9886 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*