### PR TITLE
Juniper: detect fatal xSTP error for interfaces without ethernet-switching

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -674,6 +674,8 @@ ECHO_REPLY: 'echo-reply';
 
 ECHO_REQUEST: 'echo-request';
 
+EDGE: 'edge';
+
 EGP: 'egp';
 
 EGRESS: 'egress';
@@ -2042,13 +2044,9 @@ NNTP: 'nntp';
 NTALK: 'ntalk';
 
 NO_ACTIVE_BACKBONE: 'no-active-backbone';
-
 NO_ADJACENCY_DOWN_NOTIFICATION: 'no-adjacency-down-notification';
-
 NO_ADVERTISE: 'no-advertise';
-
 NO_ANTI_REPLAY: 'no-anti-replay';
-
 NO_ARP: 'no-arp';
 NO_AUTO_NEGOTIATION: 'no-auto-negotiation';
 NO_CHALLENGE_RESPONSE: 'no-challenge-response';
@@ -2062,50 +2060,29 @@ NO_GATEWAY_COMMUNITY: 'no-gateway-community';
 NO_INSTALL: 'no-install';
 NO_IPV4_ROUTING: 'no-ipv4-routing';
 NO_NAT_TRAVERSAL: 'no-nat-traversal';
-
-
 NO_NEIGHBOR_DOWN_NOTIFICATION: 'no-neighbor-down-notification';
 NO_NEIGHBOR_LEARN: 'no-neighbor-learn';
-
 NO_NEXT_HEADER: 'no-next-header';
-
 NO_NEXTHOP_CHANGE: 'no-nexthop-change';
-
 NO_PASSWORD_AUTHENTICATION: 'no-password-authentication';
-
 NO_PASSWORDS: 'no-passwords';
-
 NO_PEER_LOOP_CHECK: 'no-peer-loop-check';
-
 NO_PING_RECORD_ROUTE: 'no-ping-record-route';
-
 NO_PING_TIME_STAMP: 'no-ping-time-stamp';
-
 NO_PREEMPT: 'no-preempt';
-
 NO_PREPEND_GLOBAL_AS: 'no-prepend-global-as';
-
 NO_PUBLIC_KEYS: 'no-public-keys';
-
 NO_READVERTISE: 'no-readvertise';
-
 NO_REDIRECTS: 'no-redirects';
-
 NO_REDIRECTS_IPV6: 'no-redirects-ipv6';
-
 NO_RESOLVE: 'no-resolve';
-
 NO_RETAIN: 'no-retain';
-
 NO_RFC_1583: 'no-rfc-1583';
+NO_ROOT_PORT: 'no-root-port';
 NO_SELF_PING: 'no-self-ping';
-
 NO_SUMMARIES: 'no-summaries';
-
 NO_TCP_FORWARDING: 'no-tcp-forwarding';
-
 NO_TRANSLATION: 'no-translation';
-
 NO_TRAPS: 'no-traps';
 
 NODE_DEVICE: 'node-device' -> pushMode(M_FabricDevice);

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_protocols.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_protocols.g4
@@ -21,10 +21,13 @@ s_protocols
       | p_null
       | p_ospf
       | p_ospf3
+      | p_rstp
+      | p_stp
+      | p_vstp
    )
 ;
 
- p_null
+p_null
 :
    (
       BFD
@@ -49,13 +52,158 @@ s_protocols
       | PIM
       | ROUTER_ADVERTISEMENT
       | ROUTER_DISCOVERY
-      | RSTP
       | RSVP
       | SFLOW
-      | STP
       | UPLINK_FAILURE_DETECTION
       | VRRP
-      | VSTP
    ) null_filler
+;
+
+p_rstp
+:
+   RSTP prstp_interface
+;
+
+prstp_interface
+:
+   INTERFACE (ALL | id = interface_id | wildcard)
+   (
+      prstpi_edge_null
+      | prstpi_mode_null
+      | prstpi_no_root_port_null
+      | prstpi_priority_null
+   )
+;
+
+prstpi_edge_null
+:
+   EDGE
+;
+
+prstpi_mode_null
+:
+   MODE null_filler
+;
+
+prstpi_no_root_port_null
+:
+   NO_ROOT_PORT
+;
+
+prstpi_priority_null
+:
+   PRIORITY null_filler
+;
+
+p_stp
+:
+   STP pstp_interface
+;
+
+pstp_interface
+:
+   INTERFACE (ALL | id = interface_id | wildcard)
+   (
+      pstpi_edge_null
+      | pstpi_mode_null
+      | pstpi_no_root_port_null
+      | pstpi_priority_null
+   )
+;
+
+pstpi_edge_null
+:
+   EDGE
+;
+
+pstpi_mode_null
+:
+   MODE null_filler
+;
+
+pstpi_no_root_port_null
+:
+   NO_ROOT_PORT
+;
+
+pstpi_priority_null
+:
+   PRIORITY null_filler
+;
+
+p_vstp
+:
+   VSTP
+   (
+      pvstp_vlan
+      | pvstp_interface
+   )
+;
+
+pvstp_vlan
+:
+   VLAN junos_name pvstpv_interface
+;
+
+pvstpv_interface
+:
+   INTERFACE (ALL | id = interface_id | wildcard)
+   (
+      pvstpvi_edge_null
+      | pvstpvi_mode_null
+      | pvstpvi_no_root_port_null
+      | pvstpvi_priority_null
+   )
+;
+
+pvstpvi_edge_null
+:
+   EDGE
+;
+
+pvstpvi_mode_null
+:
+   MODE null_filler
+;
+
+pvstpvi_no_root_port_null
+:
+   NO_ROOT_PORT
+;
+
+pvstpvi_priority_null
+:
+   PRIORITY null_filler
+;
+
+pvstp_interface
+:
+   INTERFACE (ALL | id = interface_id | wildcard)
+   (
+      pvstpi_edge_null
+      | pvstpi_mode_null
+      | pvstpi_no_root_port_null
+      | pvstpi_priority_null
+   )
+;
+
+pvstpi_edge_null
+:
+   EDGE
+;
+
+pvstpi_mode_null
+:
+   MODE null_filler
+;
+
+pvstpi_no_root_port_null
+:
+   NO_ROOT_PORT
+;
+
+pvstpi_priority_null
+:
+   PRIORITY null_filler
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -197,6 +197,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_I
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_INSTANCE_VRF_EXPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_INSTANCE_VRF_IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_OPTIONS_INSTANCE_IMPORT;
+import static org.batfish.representation.juniper.JuniperStructureUsage.RSTP_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SECURITY_POLICY_DEFINITION;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SECURITY_POLICY_MATCH_APPLICATION;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SECURITY_POLICY_TERM_DEFINITION;
@@ -206,12 +207,14 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.SNMP_COMM
 import static org.batfish.representation.juniper.JuniperStructureUsage.SNMP_COMMUNITY_LOGICAL_SYSTEM;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SNMP_COMMUNITY_ROUTING_INSTANCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.STATIC_ROUTE_NEXT_HOP_INTERFACE;
+import static org.batfish.representation.juniper.JuniperStructureUsage.STP_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SWITCH_OPTIONS_VRF_EXPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SWITCH_OPTIONS_VRF_IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SYSLOG_HOST_ROUTING_INSTANCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.TACPLUS_SERVER_ROUTING_INSTANCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.VLAN_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.VLAN_L3_INTERFACE;
+import static org.batfish.representation.juniper.JuniperStructureUsage.VSTP_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.VTEP_SOURCE_INTERFACE;
 import static org.batfish.representation.juniper.Nat.Type.SOURCE;
 import static org.batfish.representation.juniper.RoutingInformationBase.RIB_IPV4_UNICAST;
@@ -695,6 +698,10 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsto_ribContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Port_numberContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Port_rangeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Proposal_set_typeContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Prstp_interfaceContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Pstp_interfaceContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Pvstp_interfaceContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Pvstpv_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.RangeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ri_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ri_named_routing_instanceContext;
@@ -7102,6 +7109,40 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     // only known type is IPIP
     assert ctx.IPIP() != null;
     _currentTunnelAttribute.setType(TunnelAttribute.Type.IPIP);
+  }
+
+  private void recordXstpInterface(Interface_idContext id, JuniperStructureUsage usage) {
+    Interface iface = initRoutingInterface(id);
+    _configuration.referenceStructure(INTERFACE, iface.getName(), usage, getLine(id.getStop()));
+    _currentLogicalSystem.getXstpInterfaceNames().add(iface.getName());
+  }
+
+  @Override
+  public void exitPrstp_interface(Prstp_interfaceContext ctx) {
+    if (ctx.id != null) {
+      recordXstpInterface(ctx.id, RSTP_INTERFACE);
+    }
+  }
+
+  @Override
+  public void exitPstp_interface(Pstp_interfaceContext ctx) {
+    if (ctx.id != null) {
+      recordXstpInterface(ctx.id, STP_INTERFACE);
+    }
+  }
+
+  @Override
+  public void exitPvstpv_interface(Pvstpv_interfaceContext ctx) {
+    if (ctx.id != null) {
+      recordXstpInterface(ctx.id, VSTP_INTERFACE);
+    }
+  }
+
+  @Override
+  public void exitPvstp_interface(Pvstp_interfaceContext ctx) {
+    if (ctx.id != null) {
+      recordXstpInterface(ctx.id, VSTP_INTERFACE);
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3669,6 +3669,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
     // convert interfaces. Before policies because some policies depend on interfaces
     convertInterfaces();
 
+    // validate xSTP interface references have family ethernet-switching
+    validateXstpInterfaces();
+
     // convert conditions to TrackMethod objects
     _masterLogicalSystem
         .getConditions()
@@ -4557,6 +4560,18 @@ public final class JuniperConfiguration extends VendorConfiguration {
       }
     }
     return Optional.empty();
+  }
+
+  private void validateXstpInterfaces() {
+    for (String ifaceName : _masterLogicalSystem.getXstpInterfaceNames()) {
+      Optional<Interface> optIface = getInterfaceOrUnitByName(ifaceName);
+      if (optIface.isEmpty()) {
+        continue;
+      }
+      if (optIface.get().getEthernetSwitching() == null) {
+        _w.fatalRedFlag("XSTP : Interface %s is not enabled for Ethernet Switching", ifaceName);
+      }
+    }
   }
 
   private void convertInterfaces() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -184,8 +184,11 @@ public enum JuniperStructureUsage implements StructureUsage {
   SWITCH_OPTIONS_VRF_IMPORT("switch-options vrf-import"),
   SYSLOG_HOST_ROUTING_INSTANCE("syslog host routing-instance"),
   TACPLUS_SERVER_ROUTING_INSTANCE("tacplus-server routing-instance"),
+  RSTP_INTERFACE("rstp interface"),
+  STP_INTERFACE("stp interface"),
   VLAN_INTERFACE("vlan interface"),
   VLAN_L3_INTERFACE("vlan l3-interface"),
+  VSTP_INTERFACE("vstp interface"),
   VTEP_SOURCE_INTERFACE("routing-instances vtep-source-interface");
 
   private final String _description;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.annotation.Nonnull;
@@ -122,6 +123,8 @@ public class LogicalSystem implements Serializable {
 
   private @Nullable SwitchOptions _switchOptions;
 
+  private final Set<String> _xstpInterfaceNames;
+
   private final Map<String, Zone> _zones;
 
   public LogicalSystem(String name) {
@@ -174,6 +177,7 @@ public class LogicalSystem implements Serializable {
     _namedVlans = new TreeMap<>();
     _vniOptions = new TreeMap<>();
     _switchOptions = new SwitchOptions();
+    _xstpInterfaceNames = new TreeSet<>();
     _zones = new TreeMap<>();
   }
 
@@ -455,6 +459,10 @@ public class LogicalSystem implements Serializable {
 
   public SwitchOptions getSwitchOptions() {
     return _switchOptions;
+  }
+
+  public @Nonnull Set<String> getXstpInterfaceNames() {
+    return _xstpInterfaceNames;
   }
 
   public Map<String, Zone> getZones() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8886,6 +8886,30 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testXstpInterfaceExtraction() {
+    JuniperConfiguration jc = parseJuniperConfig("xstp-interface-validation");
+    Set<String> xstpInterfaces = jc.getMasterLogicalSystem().getXstpInterfaceNames();
+    // Should contain the specific interfaces but not "all"
+    assertThat(xstpInterfaces, containsInAnyOrder("xe-0/0/1.0", "xe-0/0/2.0", "ge-0/0/0.0"));
+  }
+
+  @Test
+  public void testXstpInterfaceValidation() throws IOException {
+    String hostname = "xstp-interface-validation";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // xe-0/0/2.0 does not have family ethernet-switching -- fatal error
+    assertThat(
+        ccae.getWarnings().get(hostname).getFatalRedFlagWarnings(),
+        contains(
+            WarningMatchers.hasText(
+                containsString(
+                    "XSTP : Interface xe-0/0/2.0 is not enabled for Ethernet Switching"))));
+  }
+
+  @Test
   public void testMaximumPrefixes() throws IOException {
     String hostname = "maximum-prefixes";
     Batfish batfish = getBatfishForConfigurationNames(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/xstp-interface-validation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/xstp-interface-validation
@@ -1,0 +1,29 @@
+#
+set system host-name xstp-interface-validation
+#
+# Interface WITH ethernet-switching (valid xSTP reference)
+set interfaces xe-0/0/1 unit 0 family ethernet-switching interface-mode access
+set interfaces xe-0/0/1 unit 0 family ethernet-switching vlan members v100
+#
+# Interface WITHOUT ethernet-switching (invalid xSTP reference - fatal error)
+set interfaces xe-0/0/2 unit 0 family inet address 10.0.0.1/24
+#
+# Interface with ethernet-switching for STP test
+set interfaces ge-0/0/0 unit 0 family ethernet-switching interface-mode access
+#
+set vlans v100 vlan-id 100
+#
+# VSTP: xe-0/0/1 is valid, xe-0/0/2 should produce fatal error
+set protocols vstp vlan v100 interface xe-0/0/1 mode point-to-point
+set protocols vstp vlan v100 interface xe-0/0/2 mode point-to-point
+#
+# RSTP: interface all should NOT produce any error
+set protocols rstp interface all mode point-to-point
+#
+# STP: ge-0/0/0 has ethernet-switching, so should NOT produce error
+set protocols stp interface ge-0/0/0 mode point-to-point
+#
+# Additional interface sub-commands
+set protocols rstp interface ge-0/0/0 edge
+set protocols rstp interface ge-0/0/0 no-root-port
+set protocols stp interface ge-0/0/0 priority 128


### PR DESCRIPTION
On Juniper devices, interfaces referenced in `protocols vstp`,
`protocols rstp`, or `protocols stp` must have
`family ethernet-switching` configured. Without it, the device
rejects the commit with a fatal error:
"XSTP : Interface <name> is not enabled for Ethernet Switching"

Batfish previously silently discarded all xSTP configuration via
the `p_null` grammar rule. This change extracts interface names
from VSTP, RSTP, and STP protocol blocks, starts a minimal grammar, and
validates during conversion that each referenced interface has
`family ethernet-switching`.

----

Prompt:
```
XSTP : Interface xe-0/2/1 is not enabled for Ethernet Switching

This is a fatal error not caught by Batfish today on Juniper
devices. Here's a sample config.

Investigate (using junos manuals in ../batfish/working if needed)
and fix
```