### PR TITLE
Flatten, Annotate: support files as well as directories

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Flatten.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Flatten.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import javax.annotation.Nonnull;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
 import org.batfish.common.Warnings;
@@ -25,7 +26,7 @@ import org.batfish.job.FlattenVendorConfigurationJob;
 public final class Flatten {
 
   public static void main(String[] args) throws IOException {
-    checkArgument(args.length == 2, "Expected arguments: <input_dir> <output_dir>");
+    checkArgument(args.length == 2, "Expected arguments: <input_path> <output_path>");
     Path inputPath = Paths.get(args[0]);
     Path outputPath = Paths.get(args[1]);
 
@@ -42,25 +43,52 @@ public final class Flatten {
     flatten(inputPath, outputPath, settings);
   }
 
-  private static void flatten(Path inputPath, Path outputPath, Settings settings)
+  /**
+   * Flatten configs in snapshot stored at {@code inputPath}, and dump to {@code outputPath}.
+   *
+   * <p>Handles both file and directory inputs:
+   *
+   * <ul>
+   *   <li>If {@code inputPath} is a regular file, flattens that file directly and writes to {@code
+   *       outputPath} as a file.
+   *   <li>Otherwise, treats {@code inputPath} as a snapshot directory and flattens all files in its
+   *       configs subdirectory into {@code outputPath}'s configs subdirectory.
+   * </ul>
+   */
+  private static void flatten(@Nonnull Path inputPath, @Nonnull Path outputPath, Settings settings)
       throws IOException {
     BatfishLogger logger = settings.getLogger();
-    logger.info("\n*** READING FILES TO FLATTEN ***\n");
-    Map<Path, String> configurationData =
-        readAllFiles(inputPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR), logger);
+
+    Map<Path, String> inputConfigurationData;
+    Path outputConfigDir;
+    if (Files.isRegularFile(inputPath)) {
+      logger.info("\n*** READING INPUT FILE ***\n");
+      logger.debugf("Reading: \"%s\"\n", inputPath);
+      inputConfigurationData = Map.of(inputPath, Files.readString(inputPath));
+      if (outputPath.getParent() != null) {
+        Files.createDirectories(outputPath.getParent());
+      }
+      outputConfigDir = null;
+    } else {
+      logger.info("\n*** READING FILES TO FLATTEN ***\n");
+      inputConfigurationData =
+          readAllFiles(inputPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR), logger);
+      outputConfigDir = outputPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR);
+      Files.createDirectories(outputConfigDir);
+    }
 
     Map<Path, String> outputConfigurationData = new TreeMap<>();
-    Path outputConfigDir = outputPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR);
-    Files.createDirectories(outputConfigDir);
     logger.info("\n*** FLATTENING TEST RIG ***\n");
     logger.resetTimer();
     List<FlattenVendorConfigurationJob> jobs = new ArrayList<>();
-    for (Entry<Path, String> configFile : configurationData.entrySet()) {
+    for (Entry<Path, String> configFile : inputConfigurationData.entrySet()) {
       Path inputFile = configFile.getKey();
       String fileText = configFile.getValue();
       Warnings warnings = forLogger(logger);
-      String name = inputFile.getFileName().toString();
-      Path outputFile = outputConfigDir.resolve(name);
+      Path outputFile =
+          outputConfigDir == null
+              ? outputPath
+              : outputConfigDir.resolve(inputFile.getFileName().toString());
       FlattenVendorConfigurationJob job =
           new FlattenVendorConfigurationJob(settings, fileText, inputFile, outputFile, warnings);
       jobs.add(job);

--- a/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
+++ b/projects/batfish/src/main/java/org/batfish/main/annotate/Annotate.java
@@ -38,7 +38,7 @@ import org.batfish.main.preprocess.Preprocessor;
 public final class Annotate {
 
   public static void main(String[] args) throws IOException {
-    checkArgument(args.length == 2, "Expected arguments: <input_dir> <output_dir>");
+    checkArgument(args.length == 2, "Expected arguments: <input_path> <output_path>");
     Path inputPath = Paths.get(args[0]);
     Path outputPath = Paths.get(args[1]);
 
@@ -55,13 +55,45 @@ public final class Annotate {
     annotate(inputPath, outputPath, settings);
   }
 
+  /**
+   * Annotate configs at {@code inputPath}, dumping results to {@code outputPath}.
+   *
+   * <p>Handles both file and directory inputs:
+   *
+   * <ul>
+   *   <li>If {@code inputPath} is a regular file, annotates that file directly and writes to {@code
+   *       outputPath} as a file.
+   *   <li>Otherwise, treats {@code inputPath} as a snapshot directory and annotates all files in
+   *       its configs subdirectory into {@code outputPath}'s configs subdirectory.
+   * </ul>
+   */
   private static void annotate(Path inputPath, Path outputPath, Settings settings)
       throws IOException {
-    // Stream through all files in inputPath, annotate each, and write to outputPath without
-    // loading all files into memory.
-    Path inputConfigsPath = inputPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR);
-    Path outputConfigsPath = outputPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR);
-    annotateStreaming(inputConfigsPath, outputConfigsPath, settings);
+    if (Files.isRegularFile(inputPath)) {
+      annotateSingleFile(inputPath, outputPath, settings);
+    } else {
+      Path inputConfigsPath = inputPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR);
+      Path outputConfigsPath = outputPath.resolve(BfConsts.RELPATH_CONFIGURATIONS_DIR);
+      annotateStreaming(inputConfigsPath, outputConfigsPath, settings);
+    }
+  }
+
+  private static void annotateSingleFile(Path inputFile, Path outputFile, Settings settings)
+      throws IOException {
+    LOGGER.debug("Reading: {}", inputFile);
+    String inputText = Files.readString(inputFile, UTF_8);
+    if (!inputText.endsWith("\n")) {
+      inputText = inputText + "\n";
+    }
+    String annotatedText = annotateText(inputFile, inputText, settings);
+    if (annotatedText == null) {
+      return;
+    }
+    if (outputFile.getParent() != null) {
+      Files.createDirectories(outputFile.getParent());
+    }
+    MoreFiles.asCharSink(outputFile, UTF_8).write(annotatedText);
+    LOGGER.debug("Written: {}", outputFile);
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/main/FlattenTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/FlattenTest.java
@@ -82,4 +82,27 @@ public final class FlattenTest {
   public void testMultipleTags() throws IOException {
     assertInputOutputPair("multiple_tags", "multiple_tags_flattened");
   }
+
+  /**
+   * Assert that running flatten on {@code inputFilename} as a direct file input (not a snapshot
+   * directory) produces the content of {@code outputFilename}.
+   */
+  private void assertValidFileProcessing(String inputFilename, String outputFilename)
+      throws IOException {
+    Path root = _folder.getRoot().toPath();
+    Path inputFile = root.resolve("input_file");
+    Path outputFile = root.resolve("output_file");
+    writeFile(
+        inputFile, readResource(String.format("%s/%s", TESTCONFIGS_PATH, inputFilename), UTF_8));
+    main(new String[] {inputFile.toString(), outputFile.toString()});
+
+    assertThat(
+        readFile(outputFile),
+        equalTo(readResource(String.format("%s/%s", TESTCONFIGS_PATH, outputFilename), UTF_8)));
+  }
+
+  @Test
+  public void testFileBasedProcessing() throws IOException {
+    assertValidFileProcessing("hierarchical", "flat");
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/main/annotate/AnnotateTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/annotate/AnnotateTest.java
@@ -56,4 +56,27 @@ public final class AnnotateTest {
   public void testHierarchical() throws IOException {
     assertValidPair("annotate-hierarchical-before", "annotate-hierarchical-after");
   }
+
+  /**
+   * Assert that running annotate on {@code before} as a direct file input (not a snapshot
+   * directory) produces the content of {@code after}.
+   */
+  private void assertValidFileProcessing(String prefix, String before, String after)
+      throws IOException {
+    Path root = _folder.getRoot().toPath();
+    Path inputFile = root.resolve("input_file");
+    Path outputFile = root.resolve("output_file");
+    writeFile(inputFile, readResource(String.format("%s%s", prefix, before), UTF_8));
+    main(new String[] {inputFile.toString(), outputFile.toString()});
+
+    assertThat(
+        CommonUtil.readFile(outputFile).trim(),
+        equalTo(readResource(String.format("%s%s", prefix, after), UTF_8).trim()));
+  }
+
+  @Test
+  public void testFileBasedProcessing() throws IOException {
+    assertValidFileProcessing(
+        TESTCONFIGS_PREFIX, "annotate-hierarchical-before", "annotate-hierarchical-after");
+  }
 }


### PR DESCRIPTION
Bring both tools in line with Preprocess: if the input is a regular
file, flatten/annotate it directly and write the result to the given
output path; otherwise, treat the input as a snapshot directory as
before. Usage strings updated to <input_path> <output_path>. Adds
file-based tests mirroring PreprocessTest.

----

Prompt:
```
Only one of //tools:{preprocess,flatten,annotate} gracefully takes in
a file or a directory. Fix the other two? Also make sure they
properly use relative links from pwd, etc.
```