### PR TITLE
AWS IPSec: fix VPN connection parsing when TunnelOptions is incomplete

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpsecTunnel.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpsecTunnel.java
@@ -140,19 +140,24 @@ final class IpsecTunnel implements Serializable {
             Utils.textOfFirstXmlElementWithTag(ipsecElement, AwsVpcEntity.XML_KEY_LIFETIME)));
     builder.setIpsecMode(
         Utils.textOfFirstXmlElementWithTag(ipsecElement, AwsVpcEntity.XML_KEY_MODE));
-    if (ipsecTunnel != null) {
-      // AWS configs give the subnet address, they will always use the first host.
-      assert ipsecTunnel.getPhase1IntegrityAlgorithm() != null;
+    // Use TunnelOptions crypto settings if available, otherwise fall back to
+    // permissive defaults. Some snapshots have TunnelOptions with only
+    // OutsideIpAddress/PreSharedKey but no crypto algorithms.
+    boolean hasCryptoOptions =
+        ipsecTunnel != null
+            && ipsecTunnel.getPhase1IntegrityAlgorithm() != null
+            && ipsecTunnel.getPhase1EncryptionAlgorithm() != null
+            && ipsecTunnel.getPhase1DHGroupNumbers() != null
+            && ipsecTunnel.getPhase2IntegrityAlgorithm() != null
+            && ipsecTunnel.getPhase2EncryptionAlgorithm() != null
+            && ipsecTunnel.getPhase2DHGroupNumbers() != null;
+
+    if (hasCryptoOptions) {
       builder.setIkeAuthProtocol(ipsecTunnel.getPhase1IntegrityAlgorithm());
-      assert ipsecTunnel.getPhase1EncryptionAlgorithm() != null;
       builder.setIkeEncryptionProtocol(ipsecTunnel.getPhase1EncryptionAlgorithm());
-      assert ipsecTunnel.getPhase1DHGroupNumbers() != null;
       builder.setIkePerfectForwardSecrecy(ipsecTunnel.getPhase1DHGroupNumbers());
-      assert ipsecTunnel.getPhase2IntegrityAlgorithm() != null;
       builder.setIpsecAuthProtocol(ipsecTunnel.getPhase2IntegrityAlgorithm());
-      assert ipsecTunnel.getPhase2EncryptionAlgorithm() != null;
       builder.setIpsecEncryptionProtocol(ipsecTunnel.getPhase2EncryptionAlgorithm());
-      assert ipsecTunnel.getPhase2DHGroupNumbers() != null;
       builder.setIpsecPerfectForwardSecrecy(ipsecTunnel.getPhase2DHGroupNumbers());
     } else {
       builder.setIkeAuthProtocol(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -806,7 +806,6 @@ final class VpnConnection implements AwsVpcEntity, Serializable {
         @JsonProperty(JSON_KEY_PHASE2_LIFETIME_SECONDS) @Nullable Integer phase2LifetimeSeconds) {
       checkArgument(outsideIpAddress != null, "OutsideIpAddress cannot be null");
       checkArgument(presharedKey != null, "PreSharedKey cannot be null");
-      checkArgument(tunnelInsideCidr != null, "TunnelInsideCidr cannot be null");
       return new TunnelOptions(
           ikeVersions,
           firstNonNull(


### PR DESCRIPTION
Two bugs in VPN connection handling introduced by PR #9381:

1. TunnelInsideCidr was required to be non-null in TunnelOptions
deserialization, but real AWS snapshots from older API versions only
have OutsideIpAddress and PreSharedKey. The inside addresses are
already available in the CustomerGatewayConfiguration XML, so this
field is supplementary. Remove the assertion.

2. When TunnelOptions is present but Phase1/Phase2 crypto algorithms
are null, use permissive defaults instead of asserting non-null.

Without these fixes, VPN connections fail to parse entirely, causing
missing IPSec tunnels, missing BGP sessions, and missing routes.

Fixes: batfish/lab-validation#74

----

Prompt:
```
work on https://github.com/batfish/lab-validation/issues/74
```