### PR TITLE
Junos: add vrf-export, route-distinguisher-id support

### DIFF
--- a/docs/evpn_vxlan/README.md
+++ b/docs/evpn_vxlan/README.md
@@ -5,9 +5,13 @@ route leaking, route target communities, import/export policies, and Layer 3
 VXLAN forwarding through VTEP tunnels. This article demonstrates these
 capabilities using a Juniper ERB (Edge-Routed Bridging) fabric.
 
-## Example Network
+## Example Network Walkthrough
 
-The demonstration network is a four-node Juniper EVPN-VXLAN fabric. It redistributes a CE route (192.168.99.0/24) into the overlay as an EVPN Type 5 route.
+The demonstration network is a four-node Juniper EVPN-VXLAN fabric (see [example network configs](../../projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-evpn-type5-route-test/configs/)).
+
+The example network establishes an EVPN fabric with VTEP interfaces. It redistributes a CE route (192.168.99.0/24) into the overlay as an EVPN Type 5 route.
+
+Batfish can show trace routes for traffic entering irb.100 towards the CE route, crossing the underlay network through the VTEP tunnel, and exiting out through the CE device. It can also show the forwarding tables for all VRFs and EVPN RIBs on all devices.
 
 ```
                 ┌─────────┐
@@ -219,9 +223,9 @@ confirming the ip-prefix-routes import policy was evaluated.
 
 ## VRF Export and Route Filtering
 
-The `vrf-export` policy controls which routes from a tenant VRF are
-redistributed into the EVPN overlay. This is useful for blocking specific
-prefixes or attaching communities during export.
+The `vrf-export` policy can filter routes from a tenant VRF before they are
+redistributed into the EVPN overlay - useful for blocking specific
+prefixes. It can also add new extended community values to exported routes.
 
 In the test fabric, router1 has:
 
@@ -260,26 +264,18 @@ After data plane computation:
 - EVPN routes for connected prefixes like `172.16.100.0/24` carry the
   `gateway-community` (`target:65000:99`) set by the vrf-export policy
 
-This demonstrates that Batfish correctly evaluates `vrf-export` during route
-redistribution into the EVPN overlay.
-
 ---
 
 ## Self-Import Loop Prevention
 
-A subtle issue arises when a VRF contains routes learned via eBGP (admin
-distance 170). When the VRF exports these routes as EVPN Type 5 and the same
-device's VRF attempts to re-import them, the EVPN route (also admin distance
-170) could replace the original, triggering a withdrawal loop.
+A subtle issue arises for the eBGP-learned `192.168.99.0/24` in router1's TENANT-A.
+If a VRF contains routes learned via eBGP, those routes have admin distance 170.
+When the VRF exports EVPN Type 5 routes, they enter the device EVPN RIB and become
+candidates for re-import into the same VRF. EVPN routes also have admin distance
+170 and can replace the original if re-imported, triggering a withdrawal loop.
 
-Batfish prevents this by filtering EVPN routes whose route distinguisher matches
-the importing VRF's own RD during cross-VRF import. In the test fabric,
-router1's TENANT-A uses RD `172.16.0.100:10000`. When its own EVPN Type 5
-routes appear in the default-VRF EVPN RIB, they are not re-imported into
-TENANT-A because the RDs match.
-
-This ensures the eBGP-learned `192.168.99.0/24` in router1's TENANT-A remains
-stable — matching the behavior observed on live Junos devices.
+Batfish avoids this EVPN type 5 route re-import issue by refusing to import EVPN routes
+whose route distinguisher matches the importing VRF's own RD.
 
 ---
 
@@ -325,7 +321,7 @@ Key details visible in the trace:
 - **`Forwarded into VXLAN tunnel`**: The FORWARDED step on node1-1 shows the
   VNI and remote VTEP IP. This is how Batfish represents a packet entering the
   VXLAN overlay.
-- **`nve~50000`**: The virtual tunnel interface name encodes the L3 VNI. The
+- **`nve~50000`**: The virtual tunnel interface name reflects the L3 VNI. The
   packet exits the source VTEP on this interface and arrives at the remote VTEP
   on the same interface name.
 - **VRF context**: The packet enters node1-1 in VRF TENANT-A and exits the
@@ -334,11 +330,6 @@ Key details visible in the trace:
 - **Route used**: The forwarding step references the iBGP route to
   `192.168.99.0/24` with `nextHop: vtep` — confirming the EVPN-imported route
   drives the forwarding decision.
-
-In production networks with multiple VRFs, different VNIs are used for different
-tenants. A trace in VRF "Lab-DMZ" might use VNI 2005, while VRF "Lab" uses VNI
-2000 — each tunnel carrying traffic for a separate routing domain across the
-shared underlay.
 
 ---
 

--- a/docs/evpn_vxlan/README.md
+++ b/docs/evpn_vxlan/README.md
@@ -1,0 +1,404 @@
+# EVPN-VXLAN Support in Batfish
+
+Batfish models EVPN-VXLAN fabrics — including EVPN Type 5 IP prefix routes, VRF
+route leaking, route target communities, import/export policies, and Layer 3
+VXLAN forwarding through VTEP tunnels. This article demonstrates these
+capabilities using a Juniper ERB (Edge-Routed Bridging) fabric.
+
+## Example Network
+
+The demonstration network is a four-node Juniper EVPN-VXLAN fabric. It redistributes a CE route (192.168.99.0/24) into the overlay as an EVPN Type 5 route.
+
+```
+                ┌─────────┐
+                │  edge1  │   AS 65200
+                │ (CE)    │   192.168.99.0/24
+                └────┬────┘
+                     │  eBGP (TENANT-A VRF)
+                ┌────┴────┐
+                │ router1 │   AS 65100 / 65000 (overlay)
+                │ (PE/GW) │   VTEP: 172.16.0.100
+                └────┬────┘
+                     │  eBGP underlay + iBGP overlay
+                ┌────┴────┐
+                │ node2-1 │   AS 65011 / 65000 (overlay)
+                │ (Spine) │   Route Reflector
+                └────┬────┘
+                     │  eBGP underlay + iBGP overlay
+                ┌────┴────┐
+                │ node1-1 │   AS 65001 / 65000 (overlay)
+                │ (Leaf)  │   VTEP: 172.16.0.1
+                └─────────┘
+```
+
+- **edge1** is a CE device advertising `192.168.99.0/24` via eBGP into
+  router1's TENANT-A VRF.
+- **router1** is a PE/gateway that receives the eBGP route and redistributes
+  tenant VRF prefixes as EVPN Type 5 routes into the overlay.
+- **node2-1** is a spine acting as an iBGP EVPN route reflector.
+- **node1-1** is a leaf that imports EVPN Type 5 routes into its TENANT-A VRF.
+
+Both router1 and node1-1 have IRB interfaces in TENANT-A (irb.100, irb.200) and
+TENANT-B (irb.300, irb.400), with VLANs mapped to VNIs for Layer 2 VXLAN.
+
+---
+
+## EVPN Type 5 Route Propagation
+
+An EVPN Type 5 (IP Prefix) route carries a Layer 3 VRF prefix across the VXLAN
+overlay. In the fabric above, the flow is:
+
+1. **edge1** advertises `192.168.99.0/24` via eBGP to router1's TENANT-A VRF.
+2. **router1** redistributes the prefix into EVPN as a Type 5 route, tagging it
+   with route target `target:65000:10000` and route distinguisher
+   `172.16.0.100:10000`.
+3. **node2-1** (the route reflector) receives and reflects the EVPN route.
+4. **node1-1** imports the EVPN route into its TENANT-A VRF.
+
+After computing the data plane, the EVPN RIB on node2-1 contains the Type 5
+route:
+
+```
+Node:    node2-1
+VRF:     default (EVPN RIB)
+Prefix:  192.168.99.0/24
+Type:    EVPN Type 5
+```
+
+And node1-1's TENANT-A main RIB contains the imported prefix:
+
+```
+Node:    node1-1
+VRF:     TENANT-A
+Prefix:  192.168.99.0/24
+Protocol: iBGP
+Admin:   170
+```
+
+The route appears in node1-1's VRF as an iBGP route with admin distance 170,
+which is the standard distance for routes learned via EVPN Type 5 import. This
+matches what you would see on a live Junos device under
+`show route table TENANT-A.inet.0`.
+
+---
+
+## VRF Routing Instance Configuration
+
+Each VTEP configures tenant VRFs as Junos routing instances with
+`instance-type vrf`. The key EVPN-specific settings are under `protocols evpn
+ip-prefix-routes`:
+
+```
+routing-instances {
+    TENANT-A {
+        instance-type vrf;
+        protocols {
+            evpn {
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation vxlan;
+                    vni 50000;
+                }
+            }
+        }
+        route-distinguisher 172.16.0.100:10000;
+        vrf-target target:65000:10000;
+    }
+}
+```
+
+Batfish requires the `vni`, `advertise`, and `encapsulation` fields to create
+the IP-VRF. If any are missing, a warning is raised and the VRF is not
+configured for EVPN leaking. The `vni` here (50000) is the Layer 3 VNI used for
+VXLAN encapsulation on the symmetric IRB data plane — distinct from the per-VLAN
+Layer 2 VNIs (like 10100 for VLAN100) used for bridged traffic.
+
+The `vtep-source-interface` under `switch-options` identifies the loopback whose
+IP becomes the VTEP address for tunnel endpoints:
+
+```
+switch-options {
+    vtep-source-interface lo0.0;
+}
+```
+
+---
+
+## Route Targets and Import/Export Policies
+
+Route targets control which VRFs exchange routes. The simplest form uses
+`vrf-target`, which sets both the import and export community:
+
+```
+vrf-target target:65000:10000;
+```
+
+When a route is exported from this VRF, it is tagged with `target:65000:10000`.
+When importing, only EVPN routes carrying a matching route target are accepted.
+
+### Separate Import and Export Targets
+
+Import and export targets can be set independently:
+
+```
+vrf-target import target:65000:10000;
+vrf-target export target:65000:20000;
+```
+
+### Explicit Import/Export Policies
+
+For finer-grained control, `vrf-import` and `vrf-export` policies can be used
+alongside or instead of simple RT matching:
+
+```
+routing-instances {
+    TENANT-A {
+        vrf-import TENANT-A-import;
+        vrf-export TENANT-A-export;
+    }
+}
+```
+
+When `vrf-import` is set, it replaces simple RT-based import filtering — the
+policy itself must match on the route target community to accept routes. This
+lets a single VRF import from multiple tenants:
+
+```
+policy-statement TENANT-A-import {
+    term from-tenant-a {
+        from community TENANT-A-RT;    /* target:65000:10000 */
+        then accept;
+    }
+    term from-tenant-b {
+        from community TENANT-B-RT;    /* target:65000:20000 */
+        then accept;
+    }
+    term default {
+        then reject;
+    }
+}
+```
+
+### IP-Prefix-Routes Import/Export Policies
+
+The `ip-prefix-routes` block can also carry its own import and export policies:
+
+```
+protocols {
+    evpn {
+        ip-prefix-routes {
+            import TENANT-A-ipr-import;
+            vni 50000;
+            advertise direct-nexthop;
+            encapsulation vxlan;
+        }
+    }
+}
+```
+
+When both `vrf-import` and `ip-prefix-routes import` are present, they are
+evaluated conjunctively — a route must pass both policies to be accepted. The
+ip-prefix-routes import policy can set route attributes like tags:
+
+```
+policy-statement TENANT-A-ipr-import {
+    term 1 {
+        then {
+            tag 999;
+            accept;
+        }
+    }
+}
+```
+
+In this testrig, node1-1 has this policy. After data plane computation,
+the imported 192.168.99.0/24 route in node1-1's TENANT-A VRF carries `tag 999`,
+confirming the ip-prefix-routes import policy was evaluated.
+
+---
+
+## VRF Export and Route Filtering
+
+The `vrf-export` policy controls which routes from a tenant VRF are
+redistributed into the EVPN overlay. This is useful for blocking specific
+prefixes or attaching communities during export.
+
+In the test fabric, router1 has:
+
+```
+vrf-export TENANT-A-vrf-export-redist;
+```
+
+This policy rejects `10.10.10.0/24` (a static route in the VRF) and attaches a
+`gateway-community` to all other routes:
+
+```
+policy-statement TENANT-A-vrf-export-redist {
+    term reject-blocked {
+        from {
+            route-filter 10.10.10.0/24 exact;
+        }
+        then reject;
+    }
+    term accept-rest {
+        then {
+            community add gateway-community;
+            accept;
+        }
+    }
+}
+```
+
+After data plane computation:
+
+- `10.10.10.0/24` **is present** in router1's TENANT-A VRF (it's a
+  local static route)
+- `10.10.10.0/24` **is absent** from node1-1's TENANT-A VRF (the
+  vrf-export policy rejected it)
+- `192.168.99.0/24` **is present** in node1-1's TENANT-A VRF (the
+  vrf-export policy accepted it)
+- EVPN routes for connected prefixes like `172.16.100.0/24` carry the
+  `gateway-community` (`target:65000:99`) set by the vrf-export policy
+
+This demonstrates that Batfish correctly evaluates `vrf-export` during route
+redistribution into the EVPN overlay.
+
+---
+
+## Self-Import Loop Prevention
+
+A subtle issue arises when a VRF contains routes learned via eBGP (admin
+distance 170). When the VRF exports these routes as EVPN Type 5 and the same
+device's VRF attempts to re-import them, the EVPN route (also admin distance
+170) could replace the original, triggering a withdrawal loop.
+
+Batfish prevents this by filtering EVPN routes whose route distinguisher matches
+the importing VRF's own RD during cross-VRF import. In the test fabric,
+router1's TENANT-A uses RD `172.16.0.100:10000`. When its own EVPN Type 5
+routes appear in the default-VRF EVPN RIB, they are not re-imported into
+TENANT-A because the RDs match.
+
+This ensures the eBGP-learned `192.168.99.0/24` in router1's TENANT-A remains
+stable — matching the behavior observed on live Junos devices.
+
+---
+
+## Traceroute Through VXLAN Tunnels
+
+Batfish traceroute models the Layer 3 forwarding path through VXLAN tunnels.
+When a route's next hop is a remote VTEP, the trace shows the packet being
+forwarded into a VXLAN tunnel with the L3 VNI and remote VTEP IP.
+
+A traceroute from node1-1 (irb.100 in TENANT-A) to edge1's network:
+
+```python
+bf.q.traceroute(
+    startLocation="@enter(node1-1[irb.100])",
+    headers=HeaderConstraints(
+        srcIps="172.16.100.10",
+        dstIps="192.168.99.10"
+    )
+).answer()
+```
+
+The trace hops are:
+
+```
+Hop 1: node1-1
+  RECEIVED    on irb.100 (VRF: TENANT-A)
+  FORWARDED   into VXLAN tunnel with VNI: 50000 and VTEP: 172.16.0.100
+  TRANSMITTED on nve~50000
+
+Hop 2: router1
+  RECEIVED    on nve~50000 (VRF: TENANT-A)
+  FORWARDED   out ge-0/0/3.0 with resolved next-hop IP: 10.99.0.1
+  TRANSMITTED on ge-0/0/3.0
+
+Hop 3: edge1
+  RECEIVED    on ge-0/0/1.0
+  FORWARDED   out ge-0/0/2.0
+  DELIVERED_TO_SUBNET via ge-0/0/2.0
+```
+
+Key details visible in the trace:
+
+- **`Forwarded into VXLAN tunnel`**: The FORWARDED step on node1-1 shows the
+  VNI and remote VTEP IP. This is how Batfish represents a packet entering the
+  VXLAN overlay.
+- **`nve~50000`**: The virtual tunnel interface name encodes the L3 VNI. The
+  packet exits the source VTEP on this interface and arrives at the remote VTEP
+  on the same interface name.
+- **VRF context**: The packet enters node1-1 in VRF TENANT-A and exits the
+  tunnel at router1 still in VRF TENANT-A — the L3 VNI maps the tunnel to the
+  correct tenant VRF on both sides.
+- **Route used**: The forwarding step references the iBGP route to
+  `192.168.99.0/24` with `nextHop: vtep` — confirming the EVPN-imported route
+  drives the forwarding decision.
+
+In production networks with multiple VRFs, different VNIs are used for different
+tenants. A trace in VRF "Lab-DMZ" might use VNI 2005, while VRF "Lab" uses VNI
+2000 — each tunnel carrying traffic for a separate routing domain across the
+shared underlay.
+
+---
+
+## Batfish Questions
+
+### Routes
+
+Use `bf.q.routes()` to inspect the main RIB of each VRF. The EVPN Type 5
+imported routes appear alongside connected and static routes:
+
+```python
+bf.q.routes().answer()
+```
+
+| Node    | VRF      | Network            | Protocol  | Admin | Next Hop              |
+|---------|----------|--------------------|-----------|-------|-----------------------|
+| node1-1 | TENANT-A | 172.16.100.0/24    | connected | 0     | irb.100               |
+| node1-1 | TENANT-A | 172.16.200.0/24    | connected | 0     | irb.200               |
+| node1-1 | TENANT-A | 192.168.99.0/24    | ibgp      | 170   | vni 50000 vtep 172.16.0.100 |
+| router1 | TENANT-A | 192.168.99.0/24    | bgp       | 170   | 10.99.0.1 (ge-0/0/3.0)|
+| router1 | TENANT-A | 10.10.10.0/24      | static    | 5     | discard               |
+
+The EVPN-imported route on node1-1 has a VTEP next hop — the packet will be
+VXLAN-encapsulated to reach it. The same prefix on router1 uses a normal IP next
+hop since it was learned via eBGP from edge1.
+
+### EVPN RIB
+
+Use `bf.q.evpnRib()` to inspect the EVPN RIB separately. This shows Type 5
+routes with their route distinguisher, route targets, and originator:
+
+```python
+bf.q.evpnRib().answer()
+```
+
+| Node    | VRF     | Prefix          | RD                   | Route Targets        |
+|---------|---------|-----------------|----------------------|----------------------|
+| node2-1 | default | 192.168.99.0/24 | 172.16.0.100:10000   | target:65000:10000   |
+| node1-1 | default | 192.168.99.0/24 | 172.16.0.100:10000   | target:65000:10000   |
+
+---
+
+## Junos Configuration Reference
+
+The following Junos configuration constructs are supported for EVPN-VXLAN:
+
+| Configuration                                                     | Purpose                                      |
+|-------------------------------------------------------------------|----------------------------------------------|
+| `routing-instances <name> instance-type vrf`                      | Defines a tenant VRF                         |
+| `routing-instances <name> route-distinguisher`                    | RD for EVPN route identification             |
+| `routing-instances <name> vrf-target`                             | Sets import and export route target          |
+| `routing-instances <name> vrf-target import`                      | Sets import RT only                          |
+| `routing-instances <name> vrf-target export`                      | Sets export RT only                          |
+| `routing-instances <name> vrf-import`                             | Explicit import policy (replaces RT matching)|
+| `routing-instances <name> vrf-export`                             | Explicit export/redistribution policy        |
+| `routing-instances <name> protocols evpn ip-prefix-routes vni`    | L3 VNI for Type 5 encapsulation              |
+| `routing-instances <name> protocols evpn ip-prefix-routes advertise` | Enables prefix advertisement              |
+| `routing-instances <name> protocols evpn ip-prefix-routes encapsulation` | VXLAN encapsulation type              |
+| `routing-instances <name> protocols evpn ip-prefix-routes import` | Per-IPR import policy                        |
+| `routing-instances <name> protocols evpn ip-prefix-routes export` | Per-IPR export policy                        |
+| `switch-options vtep-source-interface`                            | Loopback for VTEP source IP                  |
+| `vlans <name> vxlan vni`                                          | Maps VLAN to L2 VNI                          |
+| `protocols bgp group <name> family evpn signaling`                | Enables EVPN address family on BGP peers     |

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3062,7 +3062,7 @@ VPN_MONITOR: 'vpn-monitor';
 
 VRF: 'vrf';
 
-VRF_EXPORT: 'vrf-export' -> pushMode(M_Name);
+VRF_EXPORT: 'vrf-export' -> pushMode(M_NameList);
 
 VRF_IMPORT: 'vrf-import' -> pushMode(M_Name);
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -89,7 +89,7 @@ ri_snmp
 
 ri_vrf_export
 :
-   VRF_EXPORT name = junos_name
+   VRF_EXPORT junos_name_list
 ;
 
 ri_vrf_import

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -7167,10 +7167,12 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitRi_vrf_export(Ri_vrf_exportContext ctx) {
-    String name = toString(ctx.name);
-    _configuration.referenceStructure(
-        POLICY_STATEMENT, name, ROUTING_INSTANCE_VRF_EXPORT, getLine(ctx.name.getStart()));
-    _currentRoutingInstance.setVrfExportPolicy(name);
+    for (Junos_nameContext nameCtx : ctx.junos_name_list().junos_name()) {
+      String name = toString(nameCtx);
+      _configuration.referenceStructure(
+          POLICY_STATEMENT, name, ROUTING_INSTANCE_VRF_EXPORT, getLine(nameCtx.getStart()));
+      _currentRoutingInstance.addVrfExportPolicy(name);
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -7217,7 +7217,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void exitRo_route_distinguisher_id(Ro_route_distinguisher_idContext ctx) {
     Ip rdId = Ip.parse(ctx.addr.getText());
     _currentRoutingInstance.setRouteDistinguisherId(rdId);
-    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -7170,7 +7170,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     String name = toString(ctx.name);
     _configuration.referenceStructure(
         POLICY_STATEMENT, name, ROUTING_INSTANCE_VRF_EXPORT, getLine(ctx.name.getStart()));
-    todo(ctx);
+    _currentRoutingInstance.setVrfExportPolicy(name);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -4164,16 +4164,50 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
         // Create redistribution policy on tenant VRF
         String redistPolicyName = generatedEvpnIprRedistPolicyName(riName);
-        if (ipr.getExportPolicy() != null
-            && _c.getRoutingPolicies().containsKey(ipr.getExportPolicy())) {
-          // Use the configured export policy
+        String vrfExport = ri.getVrfExportPolicy();
+        String iprExport = ipr.getExportPolicy();
+        if (vrfExport != null && _c.getRoutingPolicies().containsKey(vrfExport)) {
+          if (iprExport != null && _c.getRoutingPolicies().containsKey(iprExport)) {
+            // Both vrf-export and ipr export: chain them (vrf-export first, then ipr export)
+            RoutingPolicy redistPolicy =
+                RoutingPolicy.builder()
+                    .setOwner(_c)
+                    .setName(redistPolicyName)
+                    .addStatement(
+                        new If(
+                            new CallExpr(vrfExport),
+                            ImmutableList.of(),
+                            ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
+                    .addStatement(
+                        new If(
+                            new CallExpr(iprExport),
+                            ImmutableList.of(Statements.ReturnTrue.toStaticStatement()),
+                            ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
+                    .build();
+            _c.getRoutingPolicies().put(redistPolicyName, redistPolicy);
+          } else {
+            // Only vrf-export
+            RoutingPolicy redistPolicy =
+                RoutingPolicy.builder()
+                    .setOwner(_c)
+                    .setName(redistPolicyName)
+                    .addStatement(
+                        new If(
+                            new CallExpr(vrfExport),
+                            ImmutableList.of(Statements.ReturnTrue.toStaticStatement())))
+                    .addStatement(Statements.ReturnFalse.toStaticStatement())
+                    .build();
+            _c.getRoutingPolicies().put(redistPolicyName, redistPolicy);
+          }
+        } else if (iprExport != null && _c.getRoutingPolicies().containsKey(iprExport)) {
+          // Only ipr export
           RoutingPolicy redistPolicy =
               RoutingPolicy.builder()
                   .setOwner(_c)
                   .setName(redistPolicyName)
                   .addStatement(
                       new If(
-                          new CallExpr(ipr.getExportPolicy()),
+                          new CallExpr(iprExport),
                           ImmutableList.of(Statements.ReturnTrue.toStaticStatement())))
                   .addStatement(Statements.ReturnFalse.toStaticStatement())
                   .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -4190,42 +4190,41 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
         // Create redistribution policy on tenant VRF
         String redistPolicyName = generatedEvpnIprRedistPolicyName(riName);
-        String vrfExport = ri.getVrfExportPolicy();
+        // Collect all constituent export policies (vrf-export policies first, then ipr export)
+        List<String> constituentPolicies = new ArrayList<>();
+        for (String vrfExport : ri.getVrfExportPolicies()) {
+          if (!_c.getRoutingPolicies().containsKey(vrfExport)) {
+            _w.redFlagf(
+                "Ignoring vrf-export policy %s in routing-instance %s: policy not defined",
+                vrfExport, riName);
+            continue;
+          }
+          constituentPolicies.add(vrfExport);
+        }
         String iprExport = ipr.getExportPolicy();
-        boolean hasVrfExport = vrfExport != null && _c.getRoutingPolicies().containsKey(vrfExport);
-        boolean hasIprExport = iprExport != null && _c.getRoutingPolicies().containsKey(iprExport);
-        if (hasVrfExport && hasIprExport) {
-          // Both vrf-export and ipr export: chain them (vrf-export first, then ipr export)
-          RoutingPolicy redistPolicy =
-              RoutingPolicy.builder()
-                  .setOwner(_c)
-                  .setName(redistPolicyName)
-                  .addStatement(
-                      new If(
-                          new CallExpr(vrfExport),
-                          ImmutableList.of(),
-                          ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
-                  .addStatement(
-                      new If(
-                          new CallExpr(iprExport),
-                          ImmutableList.of(Statements.ReturnTrue.toStaticStatement()),
-                          ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
-                  .build();
-          _c.getRoutingPolicies().put(redistPolicyName, redistPolicy);
-        } else if (hasVrfExport || hasIprExport) {
-          // Single policy (either vrf-export or ipr export)
-          String exportPolicy = hasVrfExport ? vrfExport : iprExport;
-          RoutingPolicy redistPolicy =
-              RoutingPolicy.builder()
-                  .setOwner(_c)
-                  .setName(redistPolicyName)
-                  .addStatement(
-                      new If(
-                          new CallExpr(exportPolicy),
-                          ImmutableList.of(Statements.ReturnTrue.toStaticStatement())))
-                  .addStatement(Statements.ReturnFalse.toStaticStatement())
-                  .build();
-          _c.getRoutingPolicies().put(redistPolicyName, redistPolicy);
+        if (iprExport != null) {
+          if (!_c.getRoutingPolicies().containsKey(iprExport)) {
+            _w.redFlagf(
+                "Ignoring ip-prefix-routes export policy %s in routing-instance %s:"
+                    + " policy not defined",
+                iprExport, riName);
+          } else {
+            constituentPolicies.add(iprExport);
+          }
+        }
+        if (!constituentPolicies.isEmpty()) {
+          // Evaluate all constituent export policies; stop early on reject
+          RoutingPolicy.Builder builder =
+              RoutingPolicy.builder().setOwner(_c).setName(redistPolicyName);
+          for (String policy : constituentPolicies) {
+            builder.addStatement(
+                new If(
+                    new CallExpr(policy),
+                    ImmutableList.of(),
+                    ImmutableList.of(Statements.ReturnFalse.toStaticStatement())));
+          }
+          builder.addStatement(Statements.ReturnTrue.toStaticStatement());
+          _c.getRoutingPolicies().put(redistPolicyName, builder.build());
         } else {
           // Default: redistribute connected and static
           RoutingPolicy redistPolicy =

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3785,6 +3785,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
     _c.setDefaultCrossZoneAction(_masterLogicalSystem.getDefaultCrossZoneAction());
     _c.setDefaultInboundAction(_masterLogicalSystem.getDefaultInboundAction());
 
+    // convert route distinguishers: if routing-options route-distinguisher-id is set,
+    // auto-generate RDs for routing-instances missing an explicit route-distinguisher
+    convertRouteDistinguishers();
+
     for (Entry<String, RoutingInstance> e : _masterLogicalSystem.getRoutingInstances().entrySet()) {
       String riName = e.getKey();
       RoutingInstance ri = e.getValue();
@@ -4040,6 +4044,28 @@ public final class JuniperConfiguration extends VendorConfiguration {
         _c.setNormalVlanRange(_c.getNormalVlanRange().difference(IntegerSpace.of(vlan)));
       }
     }.visit(vlanId);
+  }
+
+  /**
+   * If {@code routing-options route-distinguisher-id} is set, auto-generate a unique Type 1 Route
+   * Distinguisher for each routing-instance that does not already have an explicit
+   * route-distinguisher configured. The generated RD uses the route-distinguisher-id IP as the
+   * administrator subfield and the 1-based index of the routing-instance (in iteration order) as
+   * the assigned-number subfield.
+   */
+  @VisibleForTesting
+  void convertRouteDistinguishers() {
+    Ip rdId = _masterLogicalSystem.getDefaultRoutingInstance().getRouteDistinguisherId();
+    if (rdId == null) {
+      return;
+    }
+    int index = 1;
+    for (RoutingInstance ri : _masterLogicalSystem.getRoutingInstances().values()) {
+      if (ri.getRouteDistinguisher() == null) {
+        ri.setRouteDistinguisher(RouteDistinguisher.from(rdId, index));
+      }
+      index++;
+    }
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -4192,48 +4192,36 @@ public final class JuniperConfiguration extends VendorConfiguration {
         String redistPolicyName = generatedEvpnIprRedistPolicyName(riName);
         String vrfExport = ri.getVrfExportPolicy();
         String iprExport = ipr.getExportPolicy();
-        if (vrfExport != null && _c.getRoutingPolicies().containsKey(vrfExport)) {
-          if (iprExport != null && _c.getRoutingPolicies().containsKey(iprExport)) {
-            // Both vrf-export and ipr export: chain them (vrf-export first, then ipr export)
-            RoutingPolicy redistPolicy =
-                RoutingPolicy.builder()
-                    .setOwner(_c)
-                    .setName(redistPolicyName)
-                    .addStatement(
-                        new If(
-                            new CallExpr(vrfExport),
-                            ImmutableList.of(),
-                            ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
-                    .addStatement(
-                        new If(
-                            new CallExpr(iprExport),
-                            ImmutableList.of(Statements.ReturnTrue.toStaticStatement()),
-                            ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
-                    .build();
-            _c.getRoutingPolicies().put(redistPolicyName, redistPolicy);
-          } else {
-            // Only vrf-export
-            RoutingPolicy redistPolicy =
-                RoutingPolicy.builder()
-                    .setOwner(_c)
-                    .setName(redistPolicyName)
-                    .addStatement(
-                        new If(
-                            new CallExpr(vrfExport),
-                            ImmutableList.of(Statements.ReturnTrue.toStaticStatement())))
-                    .addStatement(Statements.ReturnFalse.toStaticStatement())
-                    .build();
-            _c.getRoutingPolicies().put(redistPolicyName, redistPolicy);
-          }
-        } else if (iprExport != null && _c.getRoutingPolicies().containsKey(iprExport)) {
-          // Only ipr export
+        boolean hasVrfExport = vrfExport != null && _c.getRoutingPolicies().containsKey(vrfExport);
+        boolean hasIprExport = iprExport != null && _c.getRoutingPolicies().containsKey(iprExport);
+        if (hasVrfExport && hasIprExport) {
+          // Both vrf-export and ipr export: chain them (vrf-export first, then ipr export)
           RoutingPolicy redistPolicy =
               RoutingPolicy.builder()
                   .setOwner(_c)
                   .setName(redistPolicyName)
                   .addStatement(
                       new If(
+                          new CallExpr(vrfExport),
+                          ImmutableList.of(),
+                          ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
+                  .addStatement(
+                      new If(
                           new CallExpr(iprExport),
+                          ImmutableList.of(Statements.ReturnTrue.toStaticStatement()),
+                          ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
+                  .build();
+          _c.getRoutingPolicies().put(redistPolicyName, redistPolicy);
+        } else if (hasVrfExport || hasIprExport) {
+          // Single policy (either vrf-export or ipr export)
+          String exportPolicy = hasVrfExport ? vrfExport : iprExport;
+          RoutingPolicy redistPolicy =
+              RoutingPolicy.builder()
+                  .setOwner(_c)
+                  .setName(redistPolicyName)
+                  .addStatement(
+                      new If(
+                          new CallExpr(exportPolicy),
                           ImmutableList.of(Statements.ReturnTrue.toStaticStatement())))
                   .addStatement(Statements.ReturnFalse.toStaticStatement())
                   .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -69,6 +69,7 @@ public class RoutingInstance implements Serializable {
   private @Nullable ExtendedCommunity _vrfTargetImport;
   private @Nullable ExtendedCommunity _vrfTargetExport;
   private @Nullable String _vrfImportPolicy;
+  private @Nullable String _vrfExportPolicy;
 
   public RoutingInstance(@Nonnull String name) {
     _aggregateRouteDefaults = initAggregateRouteDefaults();
@@ -437,5 +438,13 @@ public class RoutingInstance implements Serializable {
 
   public void setVrfImportPolicy(@Nullable String vrfImportPolicy) {
     _vrfImportPolicy = vrfImportPolicy;
+  }
+
+  public @Nullable String getVrfExportPolicy() {
+    return _vrfExportPolicy;
+  }
+
+  public void setVrfExportPolicy(@Nullable String vrfExportPolicy) {
+    _vrfExportPolicy = vrfExportPolicy;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -69,7 +70,7 @@ public class RoutingInstance implements Serializable {
   private @Nullable ExtendedCommunity _vrfTargetImport;
   private @Nullable ExtendedCommunity _vrfTargetExport;
   private @Nullable String _vrfImportPolicy;
-  private @Nullable String _vrfExportPolicy;
+  private final @Nonnull List<String> _vrfExportPolicies;
 
   public RoutingInstance(@Nonnull String name) {
     _aggregateRouteDefaults = initAggregateRouteDefaults();
@@ -80,6 +81,7 @@ public class RoutingInstance implements Serializable {
     _generatedRouteDefaults = initGeneratedRouteDefaults();
     _isisSettings = new IsisSettings();
     _instanceImports = new LinkedList<>();
+    _vrfExportPolicies = new ArrayList<>();
     _interfaces = new TreeMap<>();
     _ipBgpGroups = new TreeMap<>();
     _masterBgpGroup = new BgpGroup();
@@ -440,11 +442,11 @@ public class RoutingInstance implements Serializable {
     _vrfImportPolicy = vrfImportPolicy;
   }
 
-  public @Nullable String getVrfExportPolicy() {
-    return _vrfExportPolicy;
+  public @Nonnull List<String> getVrfExportPolicies() {
+    return _vrfExportPolicies;
   }
 
-  public void setVrfExportPolicy(@Nullable String vrfExportPolicy) {
-    _vrfExportPolicy = vrfExportPolicy;
+  public void addVrfExportPolicy(@Nonnull String vrfExportPolicy) {
+    _vrfExportPolicies.add(vrfExportPolicy);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5JuniperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5JuniperTest.java
@@ -32,6 +32,7 @@ import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.dataplane.ibdp.IncrementalDataPlane;
 import org.batfish.main.Batfish;
@@ -182,5 +183,64 @@ public class EvpnType5JuniperTest {
 
     // We expect the Originator ID to match router1's router ID (172.16.0.100).
     assertThat(originatorIp, org.hamcrest.Matchers.equalTo(Ip.parse("172.16.0.100")));
+  }
+
+  /**
+   * Tests that the vrf-export policy on router1's TENANT-A is actually called. Router1 has a static
+   * route 10.10.10.0/24 in TENANT-A and a vrf-export policy (TENANT-A-vrf-export-redist) that
+   * rejects that prefix but accepts all other routes with 'community add gateway-community'.
+   * Without vrf-export support, the default redistribution would export connected+static routes,
+   * causing 10.10.10.0/24 to appear in node1-1's TENANT-A RIB via EVPN. With vrf-export, the route
+   * is blocked and accepted routes get the gateway-community (target:65000:99) attached.
+   */
+  @Test
+  public void testEvpnType5VrfExportFiltering() throws IOException {
+    Batfish batfish = loadTestrigAndComputeDataPlane();
+    NetworkSnapshot snapshot = batfish.getSnapshot();
+
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(snapshot);
+    Prefix blockedPrefix = Prefix.parse("10.10.10.0/24");
+
+    Map<String, java.util.SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
+        dp.getRibsForTesting();
+
+    // Verify 10.10.10.0/24 IS present in router1's TENANT-A (local static route)
+    GenericRib<AnnotatedRoute<AbstractRoute>> router1Rib = ribs.get("router1").get("TENANT-A");
+    assertThat(router1Rib.getRoutes(), hasItem(hasPrefix(blockedPrefix)));
+
+    // Verify 10.10.10.0/24 is NOT present in node1-1's TENANT-A
+    // (vrf-export rejected it, so it was never redistributed into EVPN)
+    GenericRib<AnnotatedRoute<AbstractRoute>> node1Rib = ribs.get("node1-1").get("TENANT-A");
+    for (AnnotatedRoute<AbstractRoute> route : node1Rib.getRoutes()) {
+      assertNotEquals(
+          "Route 10.10.10.0/24 should be blocked by vrf-export policy",
+          blockedPrefix,
+          route.getNetwork());
+    }
+
+    // Verify 192.168.99.0/24 STILL propagates (vrf-export accepts it)
+    Prefix allowedPrefix = Prefix.parse("192.168.99.0/24");
+    assertThat(node1Rib.getRoutes(), hasItem(hasPrefix(allowedPrefix)));
+
+    // NOTE: The vrf-export policy includes 'community add gateway-community' in its accept-rest
+    // term, but Batfish currently wraps the vrf-export policy as a boolean CallExpr filter
+    // (accept/reject only). Route attribute modifications like 'community add' are NOT evaluated
+    // by the redistribution policy. This assertion documents that current limitation.
+    Table<String, String, Set<EvpnRoute<?, ?>>> evpnRoutes = dp.getEvpnRoutes();
+    Set<EvpnRoute<?, ?>> node2EvpnRoutes =
+        evpnRoutes.get("node2-1", org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME);
+    ExtendedCommunity gatewayCommunity = ExtendedCommunity.target(65000, 99);
+    boolean foundRouteWithGatewayCommunity = false;
+    for (EvpnRoute<?, ?> route : node2EvpnRoutes) {
+      if (route.getNetwork().equals(allowedPrefix)
+          && route.getCommunities().getCommunities().contains(gatewayCommunity)) {
+        foundRouteWithGatewayCommunity = true;
+      }
+    }
+    // TODO: When redistribution policy attribute modification is supported, change to assertTrue
+    assertFalse(
+        "community-add in vrf-export is not currently evaluated (attribute modification unsupported"
+            + " in redistribution CallExpr filter)",
+        foundRouteWithGatewayCommunity);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5JuniperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5JuniperTest.java
@@ -222,25 +222,24 @@ public class EvpnType5JuniperTest {
     Prefix allowedPrefix = Prefix.parse("192.168.99.0/24");
     assertThat(node1Rib.getRoutes(), hasItem(hasPrefix(allowedPrefix)));
 
-    // NOTE: The vrf-export policy includes 'community add gateway-community' in its accept-rest
-    // term, but Batfish currently wraps the vrf-export policy as a boolean CallExpr filter
-    // (accept/reject only). Route attribute modifications like 'community add' are NOT evaluated
-    // by the redistribution policy. This assertion documents that current limitation.
+    // Verify the vrf-export policy's 'community add gateway-community' action is evaluated:
+    // Connected routes from router1's TENANT-A (e.g. 172.16.100.0/24 from irb.100) go through
+    // the vrf-export redistribution policy and should carry gateway-community (target:65000:99).
     Table<String, String, Set<EvpnRoute<?, ?>>> evpnRoutes = dp.getEvpnRoutes();
     Set<EvpnRoute<?, ?>> node2EvpnRoutes =
         evpnRoutes.get("node2-1", org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME);
     ExtendedCommunity gatewayCommunity = ExtendedCommunity.target(65000, 99);
+    Prefix connectedPrefix = Prefix.parse("172.16.100.0/24");
     boolean foundRouteWithGatewayCommunity = false;
     for (EvpnRoute<?, ?> route : node2EvpnRoutes) {
-      if (route.getNetwork().equals(allowedPrefix)
+      if (route.getNetwork().equals(connectedPrefix)
           && route.getCommunities().getCommunities().contains(gatewayCommunity)) {
         foundRouteWithGatewayCommunity = true;
       }
     }
-    // TODO: When redistribution policy attribute modification is supported, change to assertTrue
-    assertFalse(
-        "community-add in vrf-export is not currently evaluated (attribute modification unsupported"
-            + " in redistribution CallExpr filter)",
+    assertTrue(
+        "EVPN Type 5 route for 172.16.100.0/24 should carry gateway-community (target:65000:99)"
+            + " set by vrf-export policy",
         foundRouteWithGatewayCommunity);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -10447,5 +10447,19 @@ public final class FlatJuniperGrammarTest {
     assertThat(fib.get(Ip.parse("192.168.1.1")), not(empty()));
   }
 
+  @Test
+  public void testRouteDistinguisherIdAutoGeneration() {
+    Configuration c = parseConfig("route-distinguisher-id-auto");
+    Ip rdId = Ip.parse("10.0.0.1");
+
+    // VRF1 has no explicit RD; should get auto-generated Type 1 RD with index 1
+    Vrf vrf1 = c.getVrfs().get("VRF1");
+    assertThat(vrf1.getRouteDistinguisher(), equalTo(RouteDistinguisher.from(rdId, 1)));
+
+    // VRF2 has explicit RD 99:99; should keep it
+    Vrf vrf2 = c.getVrfs().get("VRF2");
+    assertThat(vrf2.getRouteDistinguisher(), equalTo(RouteDistinguisher.parse("10.0.0.2:99")));
+  }
+
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8175,7 +8175,8 @@ public final class FlatJuniperGrammarTest {
     assertThat(ipPrefixRoutes.getVni(), equalTo(1011));
     assertThat(ipPrefixRoutes.getImportPolicy(), equalTo("FOO-vrf-import"));
     assertThat(ipPrefixRoutes.getExportPolicy(), equalTo("FOO-vrf-export"));
-    assertThat(ri.getVrfExportPolicy(), equalTo("FOO-ri-export"));
+    assertThat(
+        ri.getVrfExportPolicies(), equalTo(ImmutableList.of("FOO-ri-export", "FOO-ri-export2")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -8167,17 +8167,15 @@ public final class FlatJuniperGrammarTest {
   public void testRoutingInstancesEvpnIpPrefixRoutesExtraction() {
     JuniperConfiguration juniperConfiguration =
         parseJuniperConfig("routing-instance-vrf-evpn-ip-prefix-routes");
-    EvpnIpPrefixRoutes ipPrefixRoutes =
-        juniperConfiguration
-            .getMasterLogicalSystem()
-            .getRoutingInstances()
-            .get("FOO")
-            .getEvpnIpPrefixRoutes();
+    RoutingInstance ri =
+        juniperConfiguration.getMasterLogicalSystem().getRoutingInstances().get("FOO");
+    EvpnIpPrefixRoutes ipPrefixRoutes = ri.getEvpnIpPrefixRoutes();
     assertThat(ipPrefixRoutes.getAdvertise(), equalTo(EvpnIpPrefixRoutesAdvertise.DIRECT_NEXTHOP));
     assertThat(ipPrefixRoutes.getEncapsulation(), equalTo(EvpnEncapsulation.VXLAN));
     assertThat(ipPrefixRoutes.getVni(), equalTo(1011));
     assertThat(ipPrefixRoutes.getImportPolicy(), equalTo("FOO-vrf-import"));
     assertThat(ipPrefixRoutes.getExportPolicy(), equalTo("FOO-vrf-export"));
+    assertThat(ri.getVrfExportPolicy(), equalTo("FOO-ri-export"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -82,6 +82,7 @@ import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.dataplane.rib.RibId;
 import org.batfish.datamodel.isis.IsisLevel;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetTag;
 import org.batfish.datamodel.routing_policy.statement.Statement;
@@ -1216,6 +1217,143 @@ public class JuniperConfigurationTest {
     String importPolicyName =
         tenantVrf.getVrfLeakConfig().getEvpnToBgpv4VrfLeakConfigs().get(0).getImportPolicy();
     assertThat(importPolicyName, equalTo("vrf-import-policy"));
+  }
+
+  @Test
+  public void testConvertEvpnVrfLeaking_VrfExportOnly() {
+    JuniperConfiguration config = createConfig();
+    config._c.setVrfs(
+        ImmutableMap.of(
+            Configuration.DEFAULT_VRF_NAME,
+            new Vrf(Configuration.DEFAULT_VRF_NAME),
+            "tenant",
+            new Vrf("tenant")));
+
+    RoutingInstance defaultRi = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
+    defaultRi.setRouterId(Ip.parse("1.1.1.1"));
+    defaultRi.setAs(65000L);
+    RoutingInstance tenantRi = new RoutingInstance("tenant");
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setVni(100);
+    tenantRi
+        .getOrCreateEvpnIpPrefixRoutes()
+        .setAdvertise(EvpnIpPrefixRoutesAdvertise.DIRECT_NEXTHOP);
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setEncapsulation(EvpnEncapsulation.VXLAN);
+    tenantRi.setRouteDistinguisher(RouteDistinguisher.from(1L, 1L));
+    tenantRi.setVrfTargetExport(ExtendedCommunity.target(1, 1));
+    tenantRi.setVrfTargetImport(ExtendedCommunity.target(1, 1));
+
+    tenantRi.setVrfExportPolicy("vrf-export-policy");
+    // Register the policy so containsKey check passes
+    config
+        ._c
+        .getRoutingPolicies()
+        .put(
+            "vrf-export-policy",
+            RoutingPolicy.builder().setOwner(config._c).setName("vrf-export-policy").build());
+
+    config
+        .getMasterLogicalSystem()
+        .getRoutingInstances()
+        .put(Configuration.DEFAULT_VRF_NAME, defaultRi);
+    config.getMasterLogicalSystem().setDefaultRoutingInstance(defaultRi);
+    config.getMasterLogicalSystem().getRoutingInstances().put("tenant", tenantRi);
+
+    config.convertEvpnVrfLeaking();
+
+    Vrf tenantVrf = config._c.getVrfs().get("tenant");
+    assertNotNull(tenantVrf.getBgpProcess());
+    String redistPolicyName = tenantVrf.getBgpProcess().getRedistributionPolicy();
+    org.batfish.datamodel.routing_policy.RoutingPolicy redistPolicy =
+        config._c.getRoutingPolicies().get(redistPolicyName);
+    assertNotNull(redistPolicy);
+
+    // Expecting: If(call vrf-export-policy -> return true), then return false
+    assertThat(redistPolicy.getStatements(), hasSize(2));
+    org.batfish.datamodel.routing_policy.statement.If firstIf =
+        (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(0);
+    assertThat(
+        firstIf.getGuard(), instanceOf(org.batfish.datamodel.routing_policy.expr.CallExpr.class));
+    assertThat(
+        ((org.batfish.datamodel.routing_policy.expr.CallExpr) firstIf.getGuard())
+            .getCalledPolicyName(),
+        equalTo("vrf-export-policy"));
+  }
+
+  @Test
+  public void testConvertEvpnVrfLeaking_BothExportPolicies() {
+    JuniperConfiguration config = createConfig();
+    config._c.setVrfs(
+        ImmutableMap.of(
+            Configuration.DEFAULT_VRF_NAME,
+            new Vrf(Configuration.DEFAULT_VRF_NAME),
+            "tenant",
+            new Vrf("tenant")));
+
+    RoutingInstance defaultRi = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
+    defaultRi.setRouterId(Ip.parse("1.1.1.1"));
+    defaultRi.setAs(65000L);
+    RoutingInstance tenantRi = new RoutingInstance("tenant");
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setVni(100);
+    tenantRi
+        .getOrCreateEvpnIpPrefixRoutes()
+        .setAdvertise(EvpnIpPrefixRoutesAdvertise.DIRECT_NEXTHOP);
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setEncapsulation(EvpnEncapsulation.VXLAN);
+    tenantRi.setRouteDistinguisher(RouteDistinguisher.from(1L, 1L));
+    tenantRi.setVrfTargetExport(ExtendedCommunity.target(1, 1));
+    tenantRi.setVrfTargetImport(ExtendedCommunity.target(1, 1));
+
+    tenantRi.setVrfExportPolicy("vrf-export-policy");
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setExportPolicy("ipr-export-policy");
+    // Register both policies so containsKey checks pass
+    config
+        ._c
+        .getRoutingPolicies()
+        .put(
+            "vrf-export-policy",
+            RoutingPolicy.builder().setOwner(config._c).setName("vrf-export-policy").build());
+    config
+        ._c
+        .getRoutingPolicies()
+        .put(
+            "ipr-export-policy",
+            RoutingPolicy.builder().setOwner(config._c).setName("ipr-export-policy").build());
+
+    config
+        .getMasterLogicalSystem()
+        .getRoutingInstances()
+        .put(Configuration.DEFAULT_VRF_NAME, defaultRi);
+    config.getMasterLogicalSystem().setDefaultRoutingInstance(defaultRi);
+    config.getMasterLogicalSystem().getRoutingInstances().put("tenant", tenantRi);
+
+    config.convertEvpnVrfLeaking();
+
+    Vrf tenantVrf = config._c.getVrfs().get("tenant");
+    assertNotNull(tenantVrf.getBgpProcess());
+    String redistPolicyName = tenantVrf.getBgpProcess().getRedistributionPolicy();
+    org.batfish.datamodel.routing_policy.RoutingPolicy redistPolicy =
+        config._c.getRoutingPolicies().get(redistPolicyName);
+    assertNotNull(redistPolicy);
+
+    // Expecting two if statements that chain the export policies
+    assertThat(redistPolicy.getStatements(), hasSize(2));
+    org.batfish.datamodel.routing_policy.statement.If firstIf =
+        (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(0);
+    org.batfish.datamodel.routing_policy.statement.If secondIf =
+        (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(1);
+
+    assertThat(
+        firstIf.getGuard(), instanceOf(org.batfish.datamodel.routing_policy.expr.CallExpr.class));
+    assertThat(
+        ((org.batfish.datamodel.routing_policy.expr.CallExpr) firstIf.getGuard())
+            .getCalledPolicyName(),
+        equalTo("vrf-export-policy"));
+
+    assertThat(
+        secondIf.getGuard(), instanceOf(org.batfish.datamodel.routing_policy.expr.CallExpr.class));
+    assertThat(
+        ((org.batfish.datamodel.routing_policy.expr.CallExpr) secondIf.getGuard())
+            .getCalledPolicyName(),
+        equalTo("ipr-export-policy"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -1473,4 +1473,61 @@ public class JuniperConfigurationTest {
           contains(new Warning(testCase.getValue(), TAG_PEDANTIC)));
     }
   }
+
+  @Test
+  public void testConvertRouteDistinguishers_NoRdId() {
+    JuniperConfiguration config = createConfig();
+    RoutingInstance defaultRi = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
+    config.getMasterLogicalSystem().setDefaultRoutingInstance(defaultRi);
+
+    RoutingInstance ri1 = new RoutingInstance("VRF1");
+    config.getMasterLogicalSystem().getRoutingInstances().put("VRF1", ri1);
+
+    // No route-distinguisher-id set, so convertRouteDistinguishers should be a no-op
+    config.convertRouteDistinguishers();
+
+    assertThat(ri1.getRouteDistinguisher(), nullValue());
+  }
+
+  @Test
+  public void testConvertRouteDistinguishers_AutoGeneratesRds() {
+    JuniperConfiguration config = createConfig();
+    RoutingInstance defaultRi = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
+    Ip rdId = Ip.parse("10.0.0.1");
+    defaultRi.setRouteDistinguisherId(rdId);
+    config.getMasterLogicalSystem().setDefaultRoutingInstance(defaultRi);
+
+    RoutingInstance ri1 = new RoutingInstance("VRF1");
+    RoutingInstance ri2 = new RoutingInstance("VRF2");
+    config.getMasterLogicalSystem().getRoutingInstances().put("VRF1", ri1);
+    config.getMasterLogicalSystem().getRoutingInstances().put("VRF2", ri2);
+
+    config.convertRouteDistinguishers();
+
+    assertThat(ri1.getRouteDistinguisher(), equalTo(RouteDistinguisher.from(rdId, 1)));
+    assertThat(ri2.getRouteDistinguisher(), equalTo(RouteDistinguisher.from(rdId, 2)));
+  }
+
+  @Test
+  public void testConvertRouteDistinguishers_SkipsExplicitRd() {
+    JuniperConfiguration config = createConfig();
+    RoutingInstance defaultRi = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
+    Ip rdId = Ip.parse("10.0.0.1");
+    defaultRi.setRouteDistinguisherId(rdId);
+    config.getMasterLogicalSystem().setDefaultRoutingInstance(defaultRi);
+
+    RoutingInstance ri1 = new RoutingInstance("VRF1");
+    RouteDistinguisher explicitRd = RouteDistinguisher.from(Ip.parse("10.0.0.2"), 99);
+    ri1.setRouteDistinguisher(explicitRd);
+    RoutingInstance ri2 = new RoutingInstance("VRF2");
+    config.getMasterLogicalSystem().getRoutingInstances().put("VRF1", ri1);
+    config.getMasterLogicalSystem().getRoutingInstances().put("VRF2", ri2);
+
+    config.convertRouteDistinguishers();
+
+    // ri1 already has an explicit RD, should not be overwritten
+    assertThat(ri1.getRouteDistinguisher(), equalTo(explicitRd));
+    // ri2 should get an auto-generated RD (index 2)
+    assertThat(ri2.getRouteDistinguisher(), equalTo(RouteDistinguisher.from(rdId, 2)));
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -35,6 +35,7 @@ import static org.batfish.representation.juniper.NatPacketLocation.routingInstan
 import static org.batfish.representation.juniper.NatPacketLocation.zoneLocation;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -1242,7 +1243,7 @@ public class JuniperConfigurationTest {
     tenantRi.setVrfTargetExport(ExtendedCommunity.target(1, 1));
     tenantRi.setVrfTargetImport(ExtendedCommunity.target(1, 1));
 
-    tenantRi.setVrfExportPolicy("vrf-export-policy");
+    tenantRi.addVrfExportPolicy("vrf-export-policy");
     // Register the policy so containsKey check passes
     config
         ._c
@@ -1267,7 +1268,7 @@ public class JuniperConfigurationTest {
         config._c.getRoutingPolicies().get(redistPolicyName);
     assertNotNull(redistPolicy);
 
-    // Expecting: If(call vrf-export-policy -> return true), then return false
+    // Expecting: If(call vrf-export-policy, [], [ReturnFalse]), then ReturnTrue
     assertThat(redistPolicy.getStatements(), hasSize(2));
     org.batfish.datamodel.routing_policy.statement.If firstIf =
         (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(0);
@@ -1277,6 +1278,8 @@ public class JuniperConfigurationTest {
         ((org.batfish.datamodel.routing_policy.expr.CallExpr) firstIf.getGuard())
             .getCalledPolicyName(),
         equalTo("vrf-export-policy"));
+    assertThat(firstIf.getTrueStatements(), empty());
+    assertThat(firstIf.getFalseStatements(), hasSize(1));
   }
 
   @Test
@@ -1302,7 +1305,7 @@ public class JuniperConfigurationTest {
     tenantRi.setVrfTargetExport(ExtendedCommunity.target(1, 1));
     tenantRi.setVrfTargetImport(ExtendedCommunity.target(1, 1));
 
-    tenantRi.setVrfExportPolicy("vrf-export-policy");
+    tenantRi.addVrfExportPolicy("vrf-export-policy");
     tenantRi.getOrCreateEvpnIpPrefixRoutes().setExportPolicy("ipr-export-policy");
     // Register both policies so containsKey checks pass
     config
@@ -1334,26 +1337,165 @@ public class JuniperConfigurationTest {
         config._c.getRoutingPolicies().get(redistPolicyName);
     assertNotNull(redistPolicy);
 
-    // Expecting two if statements that chain the export policies
-    assertThat(redistPolicy.getStatements(), hasSize(2));
+    // Expecting: gate(vrf-export-policy), gate(ipr-export-policy), ReturnTrue
+    assertThat(redistPolicy.getStatements(), hasSize(3));
     org.batfish.datamodel.routing_policy.statement.If firstIf =
         (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(0);
     org.batfish.datamodel.routing_policy.statement.If secondIf =
         (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(1);
 
     assertThat(
-        firstIf.getGuard(), instanceOf(org.batfish.datamodel.routing_policy.expr.CallExpr.class));
-    assertThat(
         ((org.batfish.datamodel.routing_policy.expr.CallExpr) firstIf.getGuard())
             .getCalledPolicyName(),
         equalTo("vrf-export-policy"));
+    assertThat(firstIf.getTrueStatements(), empty());
 
-    assertThat(
-        secondIf.getGuard(), instanceOf(org.batfish.datamodel.routing_policy.expr.CallExpr.class));
     assertThat(
         ((org.batfish.datamodel.routing_policy.expr.CallExpr) secondIf.getGuard())
             .getCalledPolicyName(),
         equalTo("ipr-export-policy"));
+    assertThat(secondIf.getTrueStatements(), empty());
+  }
+
+  @Test
+  public void testConvertEvpnVrfLeaking_MultipleVrfExportPolicies() {
+    JuniperConfiguration config = createConfig();
+    config._c.setVrfs(
+        ImmutableMap.of(
+            Configuration.DEFAULT_VRF_NAME,
+            new Vrf(Configuration.DEFAULT_VRF_NAME),
+            "tenant",
+            new Vrf("tenant")));
+
+    RoutingInstance defaultRi = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
+    defaultRi.setRouterId(Ip.parse("1.1.1.1"));
+    defaultRi.setAs(65000L);
+    RoutingInstance tenantRi = new RoutingInstance("tenant");
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setVni(100);
+    tenantRi
+        .getOrCreateEvpnIpPrefixRoutes()
+        .setAdvertise(EvpnIpPrefixRoutesAdvertise.DIRECT_NEXTHOP);
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setEncapsulation(EvpnEncapsulation.VXLAN);
+    tenantRi.setRouteDistinguisher(RouteDistinguisher.from(1L, 1L));
+    tenantRi.setVrfTargetExport(ExtendedCommunity.target(1, 1));
+    tenantRi.setVrfTargetImport(ExtendedCommunity.target(1, 1));
+
+    tenantRi.addVrfExportPolicy("vrf-export-policy1");
+    tenantRi.addVrfExportPolicy("vrf-export-policy2");
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setExportPolicy("ipr-export-policy");
+    // Register all policies so containsKey checks pass
+    config
+        ._c
+        .getRoutingPolicies()
+        .put(
+            "vrf-export-policy1",
+            RoutingPolicy.builder().setOwner(config._c).setName("vrf-export-policy1").build());
+    config
+        ._c
+        .getRoutingPolicies()
+        .put(
+            "vrf-export-policy2",
+            RoutingPolicy.builder().setOwner(config._c).setName("vrf-export-policy2").build());
+    config
+        ._c
+        .getRoutingPolicies()
+        .put(
+            "ipr-export-policy",
+            RoutingPolicy.builder().setOwner(config._c).setName("ipr-export-policy").build());
+
+    config
+        .getMasterLogicalSystem()
+        .getRoutingInstances()
+        .put(Configuration.DEFAULT_VRF_NAME, defaultRi);
+    config.getMasterLogicalSystem().setDefaultRoutingInstance(defaultRi);
+    config.getMasterLogicalSystem().getRoutingInstances().put("tenant", tenantRi);
+
+    config.convertEvpnVrfLeaking();
+
+    Vrf tenantVrf = config._c.getVrfs().get("tenant");
+    assertNotNull(tenantVrf.getBgpProcess());
+    String redistPolicyName = tenantVrf.getBgpProcess().getRedistributionPolicy();
+    org.batfish.datamodel.routing_policy.RoutingPolicy redistPolicy =
+        config._c.getRoutingPolicies().get(redistPolicyName);
+    assertNotNull(redistPolicy);
+
+    // Expecting: gate(vrf1), gate(vrf2), gate(ipr), ReturnTrue
+    assertThat(redistPolicy.getStatements(), hasSize(4));
+    org.batfish.datamodel.routing_policy.statement.If firstIf =
+        (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(0);
+    org.batfish.datamodel.routing_policy.statement.If secondIf =
+        (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(1);
+    org.batfish.datamodel.routing_policy.statement.If thirdIf =
+        (org.batfish.datamodel.routing_policy.statement.If) redistPolicy.getStatements().get(2);
+
+    assertThat(
+        ((org.batfish.datamodel.routing_policy.expr.CallExpr) firstIf.getGuard())
+            .getCalledPolicyName(),
+        equalTo("vrf-export-policy1"));
+    assertThat(firstIf.getTrueStatements(), empty());
+
+    assertThat(
+        ((org.batfish.datamodel.routing_policy.expr.CallExpr) secondIf.getGuard())
+            .getCalledPolicyName(),
+        equalTo("vrf-export-policy2"));
+    assertThat(secondIf.getTrueStatements(), empty());
+
+    assertThat(
+        ((org.batfish.datamodel.routing_policy.expr.CallExpr) thirdIf.getGuard())
+            .getCalledPolicyName(),
+        equalTo("ipr-export-policy"));
+    assertThat(thirdIf.getTrueStatements(), empty());
+  }
+
+  @Test
+  public void testConvertEvpnVrfLeaking_MissingExportPolicy() {
+    JuniperConfiguration config = createConfig();
+    config.setWarnings(new org.batfish.common.Warnings(true, true, true));
+    config._c.setVrfs(
+        ImmutableMap.of(
+            Configuration.DEFAULT_VRF_NAME,
+            new Vrf(Configuration.DEFAULT_VRF_NAME),
+            "tenant",
+            new Vrf("tenant")));
+
+    RoutingInstance defaultRi = new RoutingInstance(Configuration.DEFAULT_VRF_NAME);
+    defaultRi.setRouterId(Ip.parse("1.1.1.1"));
+    defaultRi.setAs(65000L);
+    RoutingInstance tenantRi = new RoutingInstance("tenant");
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setVni(100);
+    tenantRi
+        .getOrCreateEvpnIpPrefixRoutes()
+        .setAdvertise(EvpnIpPrefixRoutesAdvertise.DIRECT_NEXTHOP);
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setEncapsulation(EvpnEncapsulation.VXLAN);
+    tenantRi.setRouteDistinguisher(RouteDistinguisher.from(1L, 1L));
+    tenantRi.setVrfTargetExport(ExtendedCommunity.target(1, 1));
+    tenantRi.setVrfTargetImport(ExtendedCommunity.target(1, 1));
+
+    // Add named policies that are NOT registered in _c.getRoutingPolicies()
+    tenantRi.addVrfExportPolicy("missing-vrf-export");
+    tenantRi.getOrCreateEvpnIpPrefixRoutes().setExportPolicy("missing-ipr-export");
+
+    config
+        .getMasterLogicalSystem()
+        .getRoutingInstances()
+        .put(Configuration.DEFAULT_VRF_NAME, defaultRi);
+    config.getMasterLogicalSystem().setDefaultRoutingInstance(defaultRi);
+    config.getMasterLogicalSystem().getRoutingInstances().put("tenant", tenantRi);
+
+    config.convertEvpnVrfLeaking();
+
+    // Verify warnings
+    assertThat(
+        config.getWarnings().getRedFlagWarnings(),
+        org.hamcrest.Matchers.containsInAnyOrder(
+            new org.batfish.common.Warning(
+                "Ignoring vrf-export policy missing-vrf-export in routing-instance tenant: policy"
+                    + " not defined",
+                "MISCELLANEOUS"),
+            new org.batfish.common.Warning(
+                "Ignoring ip-prefix-routes export policy missing-ipr-export in routing-instance"
+                    + " tenant: policy not defined",
+                "MISCELLANEOUS")));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-evpn-type5-route-test/configs/router1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-evpn-type5-route-test/configs/router1
@@ -100,6 +100,20 @@ policy-options {
             }
         }
     }
+    policy-statement TENANT-A-vrf-export-redist {
+        term reject-blocked {
+            from {
+                route-filter 10.10.10.0/24 exact;
+            }
+            then reject;
+        }
+        term accept-rest {
+            then {
+                community add gateway-community;
+                accept;
+            }
+        }
+    }
     policy-statement TENANT-A-import {
         term evpn {
             from community TENANT-A-community;
@@ -233,6 +247,9 @@ routing-instances {
         routing-options {
             multipath;
             auto-export;
+            static {
+                route 10.10.10.0/24 discard;
+            }
         }
         protocols {
             bgp {
@@ -265,6 +282,7 @@ routing-instances {
         interface irb.200;
         route-distinguisher 172.16.0.100:10000;
         vrf-target target:65000:10000;
+        vrf-export TENANT-A-vrf-export-redist;
         vrf-table-label;
     }
     TENANT-B {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/route-distinguisher-id-auto
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/route-distinguisher-id-auto
@@ -1,0 +1,12 @@
+set system host-name route-distinguisher-id-auto
+set routing-options route-distinguisher-id 10.0.0.1
+set routing-options autonomous-system 65001
+set routing-options router-id 10.0.0.1
+
+set interfaces lo0 unit 0 family inet address 10.0.0.1/32
+
+set routing-instances VRF1 instance-type vrf
+set routing-instances VRF1 interface lo0.0
+
+set routing-instances VRF2 instance-type vrf
+set routing-instances VRF2 route-distinguisher 10.0.0.2:99

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/routing-instance-vrf-evpn-ip-prefix-routes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/routing-instance-vrf-evpn-ip-prefix-routes
@@ -8,4 +8,6 @@ set routing-instances FOO protocols evpn ip-prefix-routes vni 1011
 set routing-instances FOO protocols evpn ip-prefix-routes import FOO-vrf-import
 set routing-instances FOO protocols evpn ip-prefix-routes export FOO-vrf-export
 set routing-instances FOO vrf-export FOO-ri-export
+set routing-instances FOO vrf-export FOO-ri-export2
 set policy-options policy-statement FOO-ri-export then accept
+set policy-options policy-statement FOO-ri-export2 then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/routing-instance-vrf-evpn-ip-prefix-routes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/routing-instance-vrf-evpn-ip-prefix-routes
@@ -7,3 +7,5 @@ set routing-instances FOO protocols evpn ip-prefix-routes encapsulation vxlan
 set routing-instances FOO protocols evpn ip-prefix-routes vni 1011
 set routing-instances FOO protocols evpn ip-prefix-routes import FOO-vrf-import
 set routing-instances FOO protocols evpn ip-prefix-routes export FOO-vrf-export
+set routing-instances FOO vrf-export FOO-ri-export
+set policy-options policy-statement FOO-ri-export then accept

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1115,13 +1115,6 @@
       },
       {
         "Filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
-        "Line" : 109,
-        "Text" : "route-distinguisher-id 192.168.1.2",
-        "Parser_Context" : "[ro_route_distinguisher_id s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
         "Line" : 201,
         "Text" : "vtep-source-interface lo0.0",
         "Parser_Context" : "[ri_vtep_source_interface ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
@@ -1542,10 +1535,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 214 results",
+      "notes" : "Found 213 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 214
+      "numResults" : 213
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71481,12 +71481,6 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 109,
-              "Parser_Context" : "[ro_route_distinguisher_id s_routing_options s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "route-distinguisher-id 192.168.1.2"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
               "Line" : 201,
               "Parser_Context" : "[ri_vtep_source_interface ri_named_routing_instance s_routing_instances s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "vtep-source-interface lo0.0"


### PR DESCRIPTION
Follow-up PR to #9843: adding vrf-export and route-distinguisher-id support in Junos, plus a short README in docs/evpn_vxlan/ .

### route-distinguisher-id

https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/route-distinguisher-id-edit-routing-options.html

If `route-distinguisher` is not specified for a routing-instance and `[routing-options route-distinguisher-id]` is configured, JunOS will automatically generate a route distinguisher value for the routing instance as a Type 1 RD based on `route-distinguisher-id`. A locally unique number is created for in the Assigned Number subfield - I used the Batfish internal index value of the routing-instance here absent any better information about the real Junos number selection strategy.

### vrf-export

https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/vrf-export-edit-routing-instances-vp.html

`[routing-instances <name> vrf-export <policy-names>]` specifies one or more export policies on this VRF, all of which are evaluated against exported EVPN routes, and . If `ip-prefix-routes export <policy-name>` is also configured it is added to the list of export policies.

### Known issues

Per Junos docs, I'm under the impression that policies specified with `ip-prefix-routes export` and `ip-prefix-routes import` should apply only to Type 5 EPVN routes while policies specified with `vrf-export` and `vrf-import` apply to all EVPN route types. However, the current implementation applies the ip-prefix-routes policies to all routes.