### PR TITLE
Arista: support BGP interface neighbors (unnumbered peering)

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaLexer.g4
@@ -6355,6 +6355,11 @@ M_Interface_IPV4
    'IPv4' -> type ( IPV4 )
 ;
 
+M_Interface_PEER_GROUP
+:
+   'peer-group' -> type ( PEER_GROUP ) , mode ( M_NEIGHBOR )
+;
+
 M_Interface_POINT_TO_POINT
 :
    'point-to-point' -> type ( POINT_TO_POINT ) , popMode
@@ -6592,6 +6597,11 @@ M_NEIGHBOR_PASSIVE
 M_NEIGHBOR_SRC_IP
 :
    'src-ip' -> type ( SRC_IP ) , popMode
+;
+
+M_NEIGHBOR_INTERFACE
+:
+   'interface' -> type ( INTERFACE ) , mode ( M_Interface )
 ;
 
 M_NEIGHBOR_NEWLINE

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/Arista_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/Arista_bgp.g4
@@ -1666,9 +1666,39 @@ eos_rbi_neighbor
   (
     eos_rbi_neighbor4
     | eos_rbi_neighbor6
+    | eos_rbi_neighbor_interface
     // Definition of a peer group
     | eos_rbi_peer_group
   )
+;
+
+eos_rbi_neighbor_interface
+:
+  INTERFACE irange = eos_bgp_iface_range
+  PEER_GROUP pg = variable
+  (
+    PEER_FILTER pf = variable
+    | REMOTE_AS asn = bgp_asn
+  )? NEWLINE
+;
+
+// Interface range as Arista's running-config emits it for `neighbor
+// interface`: the prefix appears once and subsequent comma-separated entries
+// elide it (Et1/1,2/1,3/1 = Ethernet1/1, Ethernet2/1, Ethernet3/1).
+eos_bgp_iface_range
+:
+  prefix = M_Interface_PREFIX entries += eos_bgp_iface_tail
+  (COMMA entries += eos_bgp_iface_tail)*
+;
+
+eos_bgp_iface_tail
+:
+  path = eos_bgp_iface_path sr = subrange
+;
+
+eos_bgp_iface_path
+:
+  (dec (FORWARD_SLASH | PERIOD))*
 ;
 
 eos_rbi_neighbor4
@@ -1969,6 +1999,7 @@ eos_rbi_no
     | eos_rbino_ipv6
     | eos_rbino_monitoring
     | eos_rbino_neighbor
+    | eos_rbino_neighbor_interface
     | eos_rbino_redistribute
     | eos_rbino_router_id
     | eos_rbino_shutdown
@@ -2329,6 +2360,11 @@ eos_rbino_mrr_post_policy
 eos_rbino_mrr_pre_policy
 :
   PRE_POLICY NEWLINE
+;
+
+eos_rbino_neighbor_interface
+:
+  NEIGHBOR INTERFACE irange = eos_bgp_iface_range NEWLINE
 ;
 
 eos_rbino_neighbor

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -56,6 +56,8 @@ import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_
 import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_INBOUND_ROUTE_MAP;
 import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_LISTEN_RANGE_PEER_FILTER;
 import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_LISTEN_RANGE_SELF_REF;
+import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_NEIGHBOR_INTERFACE_PEER_FILTER;
+import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_NEIGHBOR_INTERFACE_PEER_GROUP;
 import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_NEIGHBOR_PEER_GROUP;
 import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_NEIGHBOR_SELF_REF;
 import static org.batfish.vendor.arista.representation.AristaStructureUsage.BGP_NETWORK_ORIGINATION_ROUTE_MAP;
@@ -381,6 +383,8 @@ import org.batfish.vendor.arista.grammar.AristaParser.Eos_as_rangeContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_as_range_listContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_bandwidth_specifierContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_bgp_communityContext;
+import org.batfish.vendor.arista.grammar.AristaParser.Eos_bgp_iface_rangeContext;
+import org.batfish.vendor.arista.grammar.AristaParser.Eos_bgp_iface_tailContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_mlag_domainContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_mlag_local_interfaceContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_mlag_peer_linkContext;
@@ -476,6 +480,7 @@ import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbi_distanceContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbi_maximum_pathsContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbi_neighbor4Context;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbi_neighbor6Context;
+import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbi_neighbor_interfaceContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbi_network4Context;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbi_network6Context;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbi_peer_groupContext;
@@ -536,6 +541,7 @@ import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbino_bgp_default_ipv4
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbino_bgp_next_hop_unchangedContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbino_default_metricContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbino_neighborContext;
+import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbino_neighbor_interfaceContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbino_neighbor_neighborContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbino_router_idContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Eos_rbino_shutdownContext;
@@ -974,6 +980,7 @@ import org.batfish.vendor.arista.representation.eos.AristaBgpAggregateNetwork;
 import org.batfish.vendor.arista.representation.eos.AristaBgpBestpathTieBreaker;
 import org.batfish.vendor.arista.representation.eos.AristaBgpDefaultOriginate;
 import org.batfish.vendor.arista.representation.eos.AristaBgpHasPeerGroup;
+import org.batfish.vendor.arista.representation.eos.AristaBgpInterfaceNeighbor;
 import org.batfish.vendor.arista.representation.eos.AristaBgpNeighbor;
 import org.batfish.vendor.arista.representation.eos.AristaBgpNeighbor.RemovePrivateAsMode;
 import org.batfish.vendor.arista.representation.eos.AristaBgpNeighborAddressFamily;
@@ -2852,6 +2859,72 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   public void exitEos_rbi_neighbor6(Eos_rbi_neighbor6Context ctx) {
     _currentAristaBgpNeighbor = null;
     _currentAristaBgpNeighborAddressFamily = null;
+  }
+
+  @Override
+  public void exitEos_rbi_neighbor_interface(Eos_rbi_neighbor_interfaceContext ctx) {
+    List<String> ifaceNames = expandBgpIfaceRange(ctx.irange, ctx);
+    String peerGroup = ctx.pg.getText();
+    String peerFilter = ctx.pf != null ? ctx.pf.getText() : null;
+    Long remoteAs = ctx.asn != null ? toAsNum(ctx.asn) : null;
+    for (String ifaceName : ifaceNames) {
+      AristaBgpInterfaceNeighbor n = _currentAristaBgpVrf.getOrCreateInterfaceNeighbor(ifaceName);
+      n.setPeerGroup(peerGroup);
+      if (peerFilter != null) {
+        n.setPeerFilter(peerFilter);
+      }
+      if (remoteAs != null) {
+        n.setRemoteAs(remoteAs);
+      }
+      String structName = bgpNeighborStructureName(ifaceName, _currentAristaBgpVrf.getName());
+      _configuration.defineStructure(BGP_NEIGHBOR, structName, ctx);
+      _configuration.referenceStructure(
+          BGP_NEIGHBOR, structName, BGP_NEIGHBOR_SELF_REF, ctx.getStart().getLine());
+    }
+    _configuration.referenceStructure(
+        BGP_PEER_GROUP, peerGroup, BGP_NEIGHBOR_INTERFACE_PEER_GROUP, ctx.pg.getStart().getLine());
+    if (peerFilter != null) {
+      _configuration.referenceStructure(
+          PEER_FILTER, peerFilter, BGP_NEIGHBOR_INTERFACE_PEER_FILTER, ctx.pf.getStart().getLine());
+    }
+  }
+
+  /**
+   * Expands a {@code neighbor interface} range to canonical interface names. The prefix (e.g.
+   * {@code Et}) appears once; each comma-separated entry is a bare numeric path with optional
+   * trailing dash-range ({@code Et1/1,2/1,3-4} = Ethernet1/1, Ethernet2/1, Ethernet3, Ethernet4).
+   */
+  private @Nonnull List<String> expandBgpIfaceRange(
+      Eos_bgp_iface_rangeContext range, ParserRuleContext ctx) {
+    String canonicalPrefix;
+    try {
+      canonicalPrefix = AristaConfiguration.getCanonicalInterfaceNamePrefix(range.prefix.getText());
+    } catch (BatfishException e) {
+      warn(ctx, "Unrecognized interface name: " + e.getMessage());
+      return ImmutableList.of();
+    }
+    final int maxRange = 1000;
+    List<String> ifaceNames = new ArrayList<>();
+    for (Eos_bgp_iface_tailContext entry : range.entries) {
+      String base = canonicalPrefix + entry.path.getText();
+      SubRange sr = toSubRange(entry.sr);
+      if (sr.getEnd() - sr.getStart() > maxRange) {
+        warn(
+            ctx,
+            String.format(
+                "Interface range %s%s exceeds %d entries; ignoring.", base, sr, maxRange));
+        continue;
+      }
+      sr.asStream().forEach(i -> ifaceNames.add(base + i));
+    }
+    return ifaceNames;
+  }
+
+  @Override
+  public void exitEos_rbino_neighbor_interface(Eos_rbino_neighbor_interfaceContext ctx) {
+    for (String ifaceName : expandBgpIfaceRange(ctx.irange, ctx)) {
+      _currentAristaBgpVrf.removeInterfaceNeighbor(ifaceName);
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
@@ -97,6 +97,7 @@ import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpTieBreaker;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Bgpv4ToEvpnVrfLeakConfig;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -1091,6 +1092,19 @@ public final class AristaConfiguration extends VendorConfiguration {
             _peerFilters,
             _w);
     newBgpProcess.setPassiveNeighbors(ImmutableSortedMap.copyOf(passiveNeighbors));
+
+    Map<String, BgpUnnumberedPeerConfig> interfaceNeighbors =
+        AristaConversions.getInterfaceNeighbors(
+            c,
+            v,
+            newBgpProcess,
+            bgpGlobal,
+            bgpVrf,
+            _eosVxlan,
+            vxlanSourceInterfaceIp,
+            _peerFilters,
+            _w);
+    newBgpProcess.setInterfaceNeighbors(ImmutableSortedMap.copyOf(interfaceNeighbors));
 
     return newBgpProcess;
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.GeneratedRoute;
@@ -101,6 +102,7 @@ import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.vendor.arista.representation.eos.AristaBgpAggregateNetwork;
 import org.batfish.vendor.arista.representation.eos.AristaBgpDefaultOriginate;
 import org.batfish.vendor.arista.representation.eos.AristaBgpHasPeerGroup;
+import org.batfish.vendor.arista.representation.eos.AristaBgpInterfaceNeighbor;
 import org.batfish.vendor.arista.representation.eos.AristaBgpNeighbor;
 import org.batfish.vendor.arista.representation.eos.AristaBgpNeighbor.RemovePrivateAsMode;
 import org.batfish.vendor.arista.representation.eos.AristaBgpNeighborAddressFamily;
@@ -223,6 +225,33 @@ final class AristaConversions {
     return true;
   }
 
+  /**
+   * Checks that the neighbor is not shutdown and at least one of the address families is activated
+   */
+  private static boolean isActive(
+      String name, AristaBgpVrf vrf, AristaBgpInterfaceNeighbor neighbor, Warnings w) {
+    if (firstNonNull(neighbor.getShutdown(), Boolean.FALSE)) {
+      return false;
+    }
+
+    // No active address family that we support.
+    boolean v4 =
+        Optional.ofNullable(vrf.getV4UnicastAf())
+            .map(af -> af.getInterfaceNeighbor(neighbor.getInterfaceName()))
+            .map(AristaBgpNeighborAddressFamily::getActivate)
+            .orElse(Boolean.FALSE);
+    boolean evpn =
+        Optional.ofNullable(vrf.getEvpnAf())
+            .map(af -> af.getInterfaceNeighbor(neighbor.getInterfaceName()))
+            .map(AristaBgpNeighborAddressFamily::getActivate)
+            .orElse(Boolean.FALSE);
+    if (!v4 && !evpn) {
+      w.redFlag("No supported address-family configured for " + name);
+      return false;
+    }
+    return true;
+  }
+
   private static @Nonnull String generatedAggregateAttributePolicyName(
       @Nullable String attributeMap) {
     return String.format("~BGP_AGGREGATE_ATTRIBUTE_MAP:%s~", attributeMap);
@@ -303,6 +332,51 @@ final class AristaConversions {
                             warnings)));
   }
 
+  /** Placeholder local IP for unnumbered peers, mirroring FRR/Cumulus convention. */
+  private static final Ip ARISTA_BGP_UNNUMBERED_IP = Ip.parse("169.254.0.1");
+
+  static @Nonnull Map<String, BgpUnnumberedPeerConfig> getInterfaceNeighbors(
+      Configuration c,
+      Vrf vrf,
+      BgpProcess proc,
+      AristaBgpProcess bgpConfig,
+      AristaBgpVrf bgpVrf,
+      @Nullable AristaEosVxlan vxlan,
+      @Nullable Ip vxlanSourceInterfaceIp,
+      Map<String, AristaBgpPeerFilter> peerFilters,
+      Warnings warnings) {
+    return bgpVrf.getInterfaceNeighbors().entrySet().stream()
+        .peek(e -> e.getValue().inherit(bgpConfig, bgpVrf, warnings))
+        .filter(e -> interfaceExists(c, e.getKey(), warnings))
+        .filter(e -> isActive(getTextDesc(e.getKey(), vrf), bgpVrf, e.getValue(), warnings))
+        .collect(
+            ImmutableMap.toImmutableMap(
+                Entry::getKey,
+                e ->
+                    (BgpUnnumberedPeerConfig)
+                        AristaConversions.toBgpNeighbor(
+                            c,
+                            vrf,
+                            proc,
+                            null,
+                            bgpConfig,
+                            bgpVrf,
+                            e.getValue(),
+                            false,
+                            vxlan,
+                            vxlanSourceInterfaceIp,
+                            peerFilters,
+                            warnings)));
+  }
+
+  private static boolean interfaceExists(Configuration c, String ifaceName, Warnings w) {
+    if (c.getAllInterfaces().containsKey(ifaceName)) {
+      return true;
+    }
+    w.redFlagf("BGP interface neighbor %s refers to a non-existent interface", ifaceName);
+    return false;
+  }
+
   static @Nonnull Map<Prefix, BgpPassivePeerConfig> getPassiveNeighbors(
       Configuration c,
       Vrf vrf,
@@ -377,10 +451,24 @@ final class AristaConversions {
   @VisibleForTesting
   static @Nonnull LongSpace getAsnSpace(
       AristaBgpV4DynamicNeighbor neighbor, Map<String, AristaBgpPeerFilter> peerFilters) {
-    if (neighbor.getRemoteAs() != null) {
-      return LongSpace.of(neighbor.getRemoteAs());
-    } else if (neighbor.getPeerFilter() != null) {
-      AristaBgpPeerFilter peerFilter = peerFilters.get(neighbor.getPeerFilter());
+    return getAsnSpace(neighbor.getRemoteAs(), neighbor.getPeerFilter(), peerFilters);
+  }
+
+  /** Compute the remote AS space for a BGP unnumbered neighbor */
+  @VisibleForTesting
+  static @Nonnull LongSpace getAsnSpace(
+      AristaBgpInterfaceNeighbor neighbor, Map<String, AristaBgpPeerFilter> peerFilters) {
+    return getAsnSpace(neighbor.getRemoteAs(), neighbor.getPeerFilter(), peerFilters);
+  }
+
+  private static @Nonnull LongSpace getAsnSpace(
+      @Nullable Long remoteAs,
+      @Nullable String peerFilterName,
+      Map<String, AristaBgpPeerFilter> peerFilters) {
+    if (remoteAs != null) {
+      return LongSpace.of(remoteAs);
+    } else if (peerFilterName != null) {
+      AristaBgpPeerFilter peerFilter = peerFilters.get(peerFilterName);
       if (peerFilter == null) {
         // If the filter does not exist, accept any ASN:
         // http://www.arista.com/en/um-eos/eos-section-33-2-configuring-bgp#ww1319501
@@ -396,7 +484,7 @@ final class AristaConversions {
       Configuration c,
       Vrf vrf,
       BgpProcess proc,
-      Prefix prefix,
+      @Nullable Prefix prefix,
       AristaBgpProcess bgpConfig,
       AristaBgpVrf vrfConfig,
       AristaBgpNeighbor neighbor,
@@ -405,11 +493,22 @@ final class AristaConversions {
       @Nullable Ip vxlanSourceInterfaceIp,
       Map<String, AristaBgpPeerFilter> peerFilters,
       Warnings warnings) {
-    // We should be converting only concrete (active or dynamic) neighbors
+    // We should be converting only concrete (active, dynamic, or interface) neighbors
     assert neighbor instanceof AristaBgpHasPeerGroup;
 
     BgpPeerConfig.Builder<?, ?> newNeighborBuilder;
-    if (dynamic) {
+    if (neighbor instanceof AristaBgpInterfaceNeighbor) {
+      AristaBgpInterfaceNeighbor unnumbered = (AristaBgpInterfaceNeighbor) neighbor;
+      LongSpace remoteAsns = getAsnSpace(unnumbered, peerFilters);
+      if (remoteAsns.isEmpty()) {
+        warnings.redFlagf(
+            "No acceptable remote-as for %s", getTextDesc(unnumbered.getInterfaceName(), vrf));
+      }
+      newNeighborBuilder =
+          BgpUnnumberedPeerConfig.builder()
+              .setRemoteAsns(remoteAsns)
+              .setPeerInterface(unnumbered.getInterfaceName());
+    } else if (dynamic) {
       assert neighbor instanceof AristaBgpV4DynamicNeighbor;
       LongSpace remoteAsns = getAsnSpace((AristaBgpV4DynamicNeighbor) neighbor, peerFilters);
       if (remoteAsns.isEmpty()) {
@@ -421,6 +520,7 @@ final class AristaConversions {
           BgpPassivePeerConfig.builder().setRemoteAsns(remoteAsns).setPeerPrefix(prefix);
     } else {
       assert neighbor instanceof AristaBgpV4Neighbor;
+      assert prefix != null;
       LongSpace remoteAsns =
           Optional.ofNullable(neighbor.getRemoteAs()).map(LongSpace::of).orElse(LongSpace.EMPTY);
       if (remoteAsns.isEmpty()) {
@@ -458,9 +558,18 @@ final class AristaConversions {
       newNeighborBuilder.setLocalAs(bgpConfig.getAsn());
     }
 
-    newNeighborBuilder.setLocalIp(
-        computeUpdateSource(
-            vrf.getName(), c.getAllInterfaces(vrf.getName()), prefix, neighbor, dynamic, warnings));
+    if (neighbor instanceof AristaBgpInterfaceNeighbor) {
+      newNeighborBuilder.setLocalIp(ARISTA_BGP_UNNUMBERED_IP);
+    } else {
+      newNeighborBuilder.setLocalIp(
+          computeUpdateSource(
+              vrf.getName(),
+              c.getAllInterfaces(vrf.getName()),
+              prefix,
+              neighbor,
+              dynamic,
+              warnings));
+    }
 
     @Nullable AristaBgpVrfIpv4UnicastAddressFamily af4 = vrfConfig.getV4UnicastAf();
     @Nullable AristaBgpNeighborAddressFamily naf4;
@@ -470,12 +579,24 @@ final class AristaConversions {
       naf4 =
           af4 == null ? null : af4.getNeighbor(((AristaBgpV4DynamicNeighbor) neighbor).getRange());
     } else {
-      throw new IllegalStateException("Unsupported type of BGP neighbor");
+      assert neighbor instanceof AristaBgpInterfaceNeighbor;
+      naf4 =
+          af4 == null
+              ? null
+              : af4.getInterfaceNeighbor(
+                  ((AristaBgpInterfaceNeighbor) neighbor).getInterfaceName());
     }
     Ipv4UnicastAddressFamily.Builder ipv4FamilyBuilder = Ipv4UnicastAddressFamily.builder();
     boolean v4Enabled = naf4 != null && firstNonNull(naf4.getActivate(), Boolean.FALSE);
 
-    String peerStrRepr = dynamic ? prefix.toString() : prefix.getStartIp().toString();
+    String peerStrRepr;
+    if (neighbor instanceof AristaBgpInterfaceNeighbor) {
+      peerStrRepr = ((AristaBgpInterfaceNeighbor) neighbor).getInterfaceName();
+    } else if (dynamic) {
+      peerStrRepr = prefix.toString();
+    } else {
+      peerStrRepr = prefix.getStartIp().toString();
+    }
     if (v4Enabled) {
       ipv4FamilyBuilder.setAddressFamilyCapabilities(
           AddressFamilyCapabilities.builder()
@@ -646,11 +767,18 @@ final class AristaConversions {
     @Nullable AristaBgpNeighborAddressFamily nEvpn;
     if (neighbor instanceof AristaBgpV4Neighbor) {
       nEvpn = evpnAf == null ? null : evpnAf.getNeighbor(((AristaBgpV4Neighbor) neighbor).getIp());
-    } else {
+    } else if (neighbor instanceof AristaBgpV4DynamicNeighbor) {
       nEvpn =
           evpnAf == null
               ? null
               : evpnAf.getNeighbor(((AristaBgpV4DynamicNeighbor) neighbor).getRange());
+    } else {
+      assert neighbor instanceof AristaBgpInterfaceNeighbor;
+      nEvpn =
+          evpnAf == null
+              ? null
+              : evpnAf.getInterfaceNeighbor(
+                  ((AristaBgpInterfaceNeighbor) neighbor).getInterfaceName());
     }
     boolean evpnEnabled = nEvpn != null && firstNonNull(nEvpn.getActivate(), Boolean.FALSE);
     if (evpnEnabled) {
@@ -749,15 +877,7 @@ final class AristaConversions {
       }
       evpnFamilyBuilder.setL3Vnis(l3vnis.build());
       // Peer-specific export policy for EVPN
-      String neighborKey;
-      if (neighbor instanceof AristaBgpV4Neighbor) {
-        neighborKey = ((AristaBgpV4Neighbor) neighbor).getIp().toString();
-      } else if (neighbor instanceof AristaBgpV4DynamicNeighbor) {
-        neighborKey = ((AristaBgpV4DynamicNeighbor) neighbor).getRange().toString();
-      } else {
-        throw new IllegalStateException("Unsupported type of BGP neighbor");
-      }
-      String policyName = generatedBgpPeerEvpnExportPolicyName(vrfConfig.getName(), neighborKey);
+      String policyName = generatedBgpPeerEvpnExportPolicyName(vrfConfig.getName(), peerStrRepr);
 
       // TODO: handle other modifiers (next-hop-self, etc.) and export route map
       Builder<Statement> exportStatementsBuilder = ImmutableList.builder();
@@ -814,6 +934,10 @@ final class AristaConversions {
 
   private static String getTextDesc(Ip ip, Vrf v) {
     return String.format("BGP neighbor %s in vrf %s", ip.toString(), v.getName());
+  }
+
+  private static String getTextDesc(String interfaceName, Vrf v) {
+    return String.format("BGP neighbor interface %s in vrf %s", interfaceName, v.getName());
   }
 
   private static String getTextDesc(Prefix prefix, Vrf v) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaStructureUsage.java
@@ -15,6 +15,8 @@ public enum AristaStructureUsage implements StructureUsage {
   BGP_NEIGHBOR_DISTRIBUTE_LIST_ACCESS6_LIST_IN("bgp neighbor distribute-list ipv6 access-list in"),
   BGP_NEIGHBOR_DISTRIBUTE_LIST_ACCESS6_LIST_OUT(
       "bgp neighbor distribute-list ipv6 access-list out"),
+  BGP_NEIGHBOR_INTERFACE_PEER_FILTER("bgp neighbor interface peer-filter"),
+  BGP_NEIGHBOR_INTERFACE_PEER_GROUP("bgp neighbor interface peer-group"),
   BGP_NEIGHBOR_PEER_GROUP("bgp neighbor peer-group"),
   BGP_NEIGHBOR_SELF_REF("bgp neighbor self ref"),
   BGP_NETWORK_ORIGINATION_ROUTE_MAP("bgp ipv4 network statement route-map"),

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpInterfaceNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpInterfaceNeighbor.java
@@ -1,0 +1,74 @@
+package org.batfish.vendor.arista.representation.eos;
+
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.Warnings;
+
+/** Config for BGP unnumbered neighbors (created using "neighbor interface ... peer-group") */
+public class AristaBgpInterfaceNeighbor extends AristaBgpNeighbor implements AristaBgpHasPeerGroup {
+  private final @Nonnull String _interfaceName;
+  private @Nullable String _peerFilter;
+  private @Nullable String _peerGroup;
+
+  public AristaBgpInterfaceNeighbor(@Nonnull String interfaceName) {
+    _interfaceName = interfaceName;
+  }
+
+  public @Nonnull String getInterfaceName() {
+    return _interfaceName;
+  }
+
+  public @Nullable String getPeerFilter() {
+    return _peerFilter;
+  }
+
+  public AristaBgpInterfaceNeighbor setPeerFilter(@Nullable String peerFilter) {
+    _peerFilter = peerFilter;
+    return this;
+  }
+
+  @Override
+  public @Nullable String getPeerGroup() {
+    return _peerGroup;
+  }
+
+  @Override
+  public void setPeerGroup(@Nullable String peerGroup) {
+    _peerGroup = peerGroup;
+  }
+
+  @Override
+  public void inherit(AristaBgpProcess bgpGlobal, AristaBgpVrf bgpVrf, Warnings w) {
+    Optional<String> pgName = Optional.ofNullable(_peerGroup);
+    Optional<AristaBgpPeerGroupNeighbor> pgn = pgName.map(bgpGlobal::getPeerGroup);
+    // Inherit the overall (non-address-family) specific settings.
+    pgn.ifPresent(this::inheritFrom);
+
+    /////////////////////////////////////////////////////
+    //// Inherit for each address family separately. ////
+    /////////////////////////////////////////////////////
+
+    // V4
+    AristaBgpVrfIpv4UnicastAddressFamily v4 = bgpVrf.getV4UnicastAf();
+    if (v4 != null) {
+      AristaBgpNeighborAddressFamily neighbor = v4.getOrCreateInterfaceNeighbor(_interfaceName);
+      neighbor.inheritFrom(getGenericAddressFamily());
+      pgName.map(v4::getPeerGroup).ifPresent(neighbor::inheritFrom);
+      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
+      // If not yet set, activate based on the vrf setting for v4 unicast.
+      if (neighbor.getActivate() == null) {
+        neighbor.setActivate(bgpVrf.getDefaultIpv4Unicast());
+      }
+    }
+
+    // EVPN
+    AristaBgpVrfEvpnAddressFamily evpn = bgpVrf.getEvpnAf();
+    if (evpn != null) {
+      AristaBgpNeighborAddressFamily neighbor = evpn.getOrCreateInterfaceNeighbor(_interfaceName);
+      neighbor.inheritFrom(getGenericAddressFamily());
+      pgName.map(evpn::getPeerGroup).ifPresent(neighbor::inheritFrom);
+      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpVrf.java
@@ -53,6 +53,7 @@ public final class AristaBgpVrf implements Serializable {
   private final @Nonnull Map<Prefix6, AristaBgpAggregateNetwork> _v6aggregates;
   private final @Nonnull Map<Ip, AristaBgpV4Neighbor> _v4neighbors;
   private final @Nonnull Map<Prefix, AristaBgpV4DynamicNeighbor> _v4DynamicNeighbors;
+  private final @Nonnull Map<String, AristaBgpInterfaceNeighbor> _interfaceNeighbors;
 
   private @Nullable AristaBgpVrfEvpnAddressFamily _evpnAf;
 
@@ -81,6 +82,7 @@ public final class AristaBgpVrf implements Serializable {
     _v6aggregates = new HashMap<>(0);
     _v4DynamicNeighbors = new HashMap<>(0);
     _v4neighbors = new HashMap<>(0);
+    _interfaceNeighbors = new HashMap<>(0);
     _redistributionPolicies = new EnumMap<>(AristaRedistributeType.class);
   }
 
@@ -374,6 +376,18 @@ public final class AristaBgpVrf implements Serializable {
 
   public @Nonnull AristaBgpV4DynamicNeighbor getOrCreateV4DynamicNeighbor(Prefix prefix) {
     return _v4DynamicNeighbors.computeIfAbsent(prefix, AristaBgpV4DynamicNeighbor::new);
+  }
+
+  public @Nonnull Map<String, AristaBgpInterfaceNeighbor> getInterfaceNeighbors() {
+    return _interfaceNeighbors;
+  }
+
+  public @Nonnull AristaBgpInterfaceNeighbor getOrCreateInterfaceNeighbor(String ifaceName) {
+    return _interfaceNeighbors.computeIfAbsent(ifaceName, AristaBgpInterfaceNeighbor::new);
+  }
+
+  public void removeInterfaceNeighbor(String ifaceName) {
+    _interfaceNeighbors.remove(ifaceName);
   }
 
   public @Nonnull Map<Ip, AristaBgpV4Neighbor> getV4neighbors() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpVrfAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpVrfAddressFamily.java
@@ -14,6 +14,7 @@ import org.batfish.datamodel.Prefix;
  */
 public abstract class AristaBgpVrfAddressFamily implements Serializable {
   protected @Nullable AristaBgpAdditionalPathsConfig _additionalPaths;
+  private final @Nonnull Map<String, AristaBgpNeighborAddressFamily> _interfaceNeighbors;
   private final @Nonnull Map<String, AristaBgpNeighborAddressFamily> _peerGroups;
   private final @Nonnull Map<Ip, AristaBgpNeighborAddressFamily> _v4Neighbors;
   private final @Nonnull Map<Prefix, AristaBgpNeighborAddressFamily> _v4DynamicNeighbors;
@@ -21,6 +22,7 @@ public abstract class AristaBgpVrfAddressFamily implements Serializable {
   protected @Nullable Boolean _nextHopUnchanged;
 
   public AristaBgpVrfAddressFamily() {
+    _interfaceNeighbors = new HashMap<>();
     _peerGroups = new HashMap<>();
     _v4DynamicNeighbors = new HashMap<>();
     _v4Neighbors = new HashMap<>();
@@ -76,5 +78,15 @@ public abstract class AristaBgpVrfAddressFamily implements Serializable {
 
   public @Nonnull AristaBgpNeighborAddressFamily getOrCreatePeerGroup(String peerGroup) {
     return _peerGroups.computeIfAbsent(peerGroup, n -> new AristaBgpNeighborAddressFamily());
+  }
+
+  public @Nullable AristaBgpNeighborAddressFamily getInterfaceNeighbor(String interfaceName) {
+    return _interfaceNeighbors.get(interfaceName);
+  }
+
+  public @Nonnull AristaBgpNeighborAddressFamily getOrCreateInterfaceNeighbor(
+      String interfaceName) {
+    return _interfaceNeighbors.computeIfAbsent(
+        interfaceName, n -> new AristaBgpNeighborAddressFamily());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -79,6 +79,7 @@ import static org.batfish.vendor.arista.representation.AristaConfiguration.DEFAU
 import static org.batfish.vendor.arista.representation.AristaConfiguration.aclLineStructureName;
 import static org.batfish.vendor.arista.representation.AristaStructureType.BGP_LISTEN_RANGE;
 import static org.batfish.vendor.arista.representation.AristaStructureType.BGP_NEIGHBOR;
+import static org.batfish.vendor.arista.representation.AristaStructureType.BGP_PEER_GROUP;
 import static org.batfish.vendor.arista.representation.AristaStructureType.INTERFACE;
 import static org.batfish.vendor.arista.representation.AristaStructureType.MAC_ACCESS_LIST;
 import static org.batfish.vendor.arista.representation.AristaStructureType.POLICY_MAP;
@@ -153,6 +154,7 @@ import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.BgpTieBreaker;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Bgpv4Route.Builder;
 import org.batfish.datamodel.BumTransportMethod;
@@ -509,6 +511,94 @@ public class AristaGrammarTest {
       assertTrue(vrf.getShutdown());
       assertThat(vrf.getRouterId(), nullValue());
     }
+  }
+
+  @Test
+  public void testBgpNeighborInterfaceExtraction() {
+    AristaConfiguration config = parseVendorConfig("arista_bgp_neighbor_interface");
+    AristaBgpVrf vrf = config.getAristaBgp().getDefaultVrf();
+    // Et99 was removed by `no neighbor interface`; Et2-3,Et5 expands the comma-separated range
+    assertThat(
+        vrf.getInterfaceNeighbors().keySet(),
+        containsInAnyOrder(
+            "Ethernet1",
+            "Ethernet2",
+            "Ethernet3",
+            "Ethernet5",
+            "Ethernet6",
+            "Ethernet8",
+            "Ethernet9",
+            "Ethernet3/1/1",
+            "Ethernet4/1/1",
+            "Ethernet5/1/1",
+            "Ethernet100"));
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet1").getPeerGroup(), equalTo("LEAVES"));
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet1").getPeerFilter(), equalTo("PF_LEAVES"));
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet1").getRemoteAs(), nullValue());
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet2").getPeerGroup(), equalTo("LEAVES"));
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet2").getPeerFilter(), nullValue());
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet2").getRemoteAs(), equalTo(65999L));
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet3").getRemoteAs(), equalTo(65999L));
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet5").getRemoteAs(), equalTo(65999L));
+    // elided-prefix comma list: prefix carries forward
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet4/1/1").getRemoteAs(), equalTo(65999L));
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet5/1/1").getPeerGroup(), equalTo("LEAVES"));
+    assertThat(vrf.getInterfaceNeighbors().get("Ethernet6").getPeerGroup(), equalTo("SHUT"));
+
+    AristaBgpVrf tenant = config.getAristaBgp().getVrfs().get("TENANT");
+    assertThat(tenant.getInterfaceNeighbors().keySet(), containsInAnyOrder("Ethernet10"));
+  }
+
+  @Test
+  public void testBgpNeighborInterfaceConversion() {
+    Configuration c = parseConfig("arista_bgp_neighbor_interface");
+    Map<String, BgpUnnumberedPeerConfig> neighbors =
+        c.getDefaultVrf().getBgpProcess().getInterfaceNeighbors();
+    // Dropped: Et6 (inherits shutdown from SHUT), Et99 (removed by `no`),
+    // Et100 (non-existent interface), Et9 (peer-group ISOLATED has no active AF
+    // under `no bgp default ipv4-unicast`).
+    assertThat(
+        neighbors.keySet(),
+        containsInAnyOrder(
+            "Ethernet1",
+            "Ethernet2",
+            "Ethernet3",
+            "Ethernet5",
+            "Ethernet8",
+            "Ethernet3/1/1",
+            "Ethernet4/1/1",
+            "Ethernet5/1/1"));
+    BgpUnnumberedPeerConfig et1 = neighbors.get("Ethernet1");
+    assertThat(et1.getPeerInterface(), equalTo("Ethernet1"));
+    assertThat(et1.getLocalAs(), equalTo(65001L));
+    assertThat(et1.getRemoteAsns(), equalTo(LongSpace.of(Range.closed(65100L, 65199L))));
+    assertThat(et1.getGroup(), equalTo("LEAVES"));
+    // `no bgp default ipv4-unicast` means v4 AF is null
+    assertThat(et1.getIpv4UnicastAddressFamily(), nullValue());
+    // EVPN inherited from peer-group LEAVES activate, send-community inherited too
+    assertThat(et1.getEvpnAddressFamily(), notNullValue());
+    assertThat(
+        et1.getEvpnAddressFamily().getAddressFamilyCapabilities().getSendCommunity(),
+        equalTo(true));
+    BgpUnnumberedPeerConfig et2 = neighbors.get("Ethernet2");
+    assertThat(et2.getRemoteAsns(), equalTo(LongSpace.of(65999L)));
+    // Et8 has no remote-as and no peer-filter
+    assertThat(neighbors.get("Ethernet8").getRemoteAsns(), equalTo(LongSpace.EMPTY));
+
+    Map<String, BgpUnnumberedPeerConfig> tenantNeighbors =
+        c.getVrfs().get("TENANT").getBgpProcess().getInterfaceNeighbors();
+    assertThat(tenantNeighbors.keySet(), containsInAnyOrder("Ethernet10"));
+  }
+
+  @Test
+  public void testBgpNeighborInterfaceReferences() throws IOException {
+    String hostname = "arista_bgp_neighbor_interface";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    assertThat(ccae, hasNumReferrers(filename, BGP_PEER_GROUP, "LEAVES", 10));
+    assertThat(ccae, hasNumReferrers(filename, BGP_PEER_GROUP, "SHUT", 1));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_neighbor_interface
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_neighbor_interface
@@ -1,0 +1,80 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_bgp_neighbor_interface
+!
+peer-filter PF_LEAVES
+   10 match as-range 65100-65199 result accept
+!
+interface Ethernet1
+   no switchport
+   ipv6 enable
+!
+interface Ethernet2
+   no switchport
+   ipv6 enable
+!
+interface Ethernet3
+   no switchport
+   ipv6 enable
+!
+interface Ethernet5
+   no switchport
+   ipv6 enable
+!
+interface Ethernet6
+   no switchport
+   ipv6 enable
+!
+interface Ethernet8
+   no switchport
+   ipv6 enable
+!
+interface Ethernet3/1/1
+   no switchport
+   ipv6 enable
+!
+interface Ethernet4/1/1
+   no switchport
+   ipv6 enable
+!
+interface Ethernet5/1/1
+   no switchport
+   ipv6 enable
+!
+vrf instance TENANT
+!
+interface Ethernet9
+   no switchport
+   ipv6 enable
+!
+interface Ethernet10
+   no switchport
+   vrf TENANT
+   ipv6 enable
+!
+router bgp 65001
+   router-id 10.0.0.1
+   no bgp default ipv4-unicast
+   neighbor LEAVES peer group
+   neighbor LEAVES send-community
+   neighbor SHUT peer group
+   neighbor SHUT shutdown
+   neighbor ISOLATED peer group
+   neighbor interface Et1 peer-group LEAVES peer-filter PF_LEAVES
+   neighbor interface Et2-3,5 peer-group LEAVES remote-as 65999
+   neighbor interface Et6 peer-group SHUT remote-as 65999
+   neighbor interface Et8 peer-group LEAVES
+   neighbor interface Et3/1/1,4/1/1,5/1/1 peer-group LEAVES remote-as 65999
+   neighbor interface Et9 peer-group ISOLATED remote-as 65999
+   ! Following lines are deliberate-warning cases (bad prefix, range bound), not show-run output:
+   neighbor interface Xy1 peer-group LEAVES remote-as 65999
+   neighbor interface Et200-2000 peer-group LEAVES remote-as 65999
+   neighbor interface Et99 peer-group LEAVES remote-as 65999
+   no neighbor interface Et99
+   neighbor interface Et100 peer-group LEAVES remote-as 65999
+   address-family evpn
+      neighbor LEAVES activate
+   vrf TENANT
+      neighbor interface Et10 peer-group LEAVES remote-as 65999
+!
+end


### PR DESCRIPTION
Adds parsing and conversion for the Arista `neighbor interface <range> peer-group <pg> [peer-filter <pf> | remote-as <asn>]` syntax to `BgpUnnumberedPeerConfig` — the same vendor-independent model FRR/Cumulus already uses — so `bgpSessionStatus` reports ESTABLISHED for Arista RFC 5549 interface-based unnumbered fabrics given a `layer1_topology.json`.

Related to #2926. This covers the `neighbor interface` form of Arista RFC 5549 peering; explicit-IPv6-address neighbors and the `next-hop address-family ipv6` knobs are not addressed here.

**Lexer/parser:** new `M_NEIGHBOR_INTERFACE` and `M_Interface_PEER_GROUP`/`M_Interface_PEER` mode transitions; `eos_rbi_neighbor_interface` (comma-separated ranges) and the `no` form.

**Representation/conversion:** `AristaBgpInterfaceNeighbor` mirrors `AristaBgpV4DynamicNeighbor`; `toBgpNeighbor` gains an interface branch alongside active/dynamic so clusterId, ebgpMultihop, enforce-first-as, route-map policies, EVPN, and send-community flow through the existing common path. EVPN export policy naming switches to `peerStrRepr` (behavior-preserving for existing neighbor types).

**Tests:** comma ranges, range expansion, slashed interface names, peer-group inherit, VRF-scoped neighbors, `no` form, two-word `peer group`, non-existent-interface warning, EVPN AF, and `BGP_PEER_GROUP` referrer counts.