### PR TITLE
HeaderConstraintsToFlows: generalize TracerouteAnswererHelper to question-independent utility

### DIFF
--- a/docs/question_development/traceroute.md
+++ b/docs/question_development/traceroute.md
@@ -30,7 +30,7 @@ The 2023 SIGCOMM paper discusses how forwarding analysis ("Lesson 4: Faithfully 
 User inputs (startLocation, headers)
         |
         v
-[TracerouteAnswererHelper] -- resolves specifiers, builds Flow objects
+[HeaderConstraintsToFlows] -- resolves specifiers, builds Flow objects
         |
         v
 [TracerouteEngineImpl] -- chunks flows, creates context
@@ -47,7 +47,7 @@ User inputs (startLocation, headers)
 
 ### Flow Construction
 
-The `TracerouteAnswererHelper` converts user inputs into concrete `Flow` objects:
+`HeaderConstraintsToFlows` converts user inputs into concrete `Flow` objects:
 
 1. **Resolve location specifier** to source locations (interfaces or nodes)
 2. **Resolve IP constraints** to concrete source and destination IPs
@@ -103,7 +103,7 @@ Every trace ends with a disposition indicating what happened to the packet. See 
 |-------|----------|---------------|
 | `TracerouteQuestion` | `projects/question/.../traceroute/` | Question parameters: start location, headers, ignoreFilters, maxTraces |
 | `TracerouteAnswerer` | `projects/question/.../traceroute/` | Orchestrates question execution, formats output table |
-| `TracerouteAnswererHelper` | `projects/question/.../traceroute/` | Resolves specifiers, constructs Flow objects from constraints |
+| `HeaderConstraintsToFlows` | `projects/question/.../question/` | Resolves specifiers, constructs Flow objects from constraints |
 | `TracerouteEngine` | `projects/common/.../plugin/` | Interface for computing traces from flows |
 | `TracerouteEngineImpl` | `projects/batfish/.../dataplane/` | Main implementation: chunks flows, builds context, coordinates tracing |
 | `TracerouteEngineImplContext` | `projects/batfish/.../dataplane/traceroute/` | Per-trace-batch context: FIBs, forwarding analysis, sessions, topology |

--- a/projects/allinone/src/test/java/org/batfish/question/HeaderConstraintsToFlowsTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/HeaderConstraintsToFlowsTest.java
@@ -1,4 +1,4 @@
-package org.batfish.question.traceroute;
+package org.batfish.question;
 
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressInterface;
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
@@ -31,8 +32,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
-/** Tests for {@link TracerouteAnswererHelper}. */
-public class TracerouteAnswererHelperTest {
+/** Tests for {@link HeaderConstraintsToFlows}. */
+public class HeaderConstraintsToFlowsTest {
   private IBatfish _batfish;
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
@@ -66,11 +67,12 @@ public class TracerouteAnswererHelperTest {
 
   @Test
   public void testGetFlows_interfaceSource() {
-    TracerouteAnswererHelper helper =
-        new TracerouteAnswererHelper(
+    HeaderConstraintsToFlows helper =
+        new HeaderConstraintsToFlows(
             PacketHeaderConstraints.builder().setDstIp("2.2.2.2").build(),
             NODE1,
-            _batfish.specifierContext(_batfish.getSnapshot()));
+            _batfish.specifierContext(_batfish.getSnapshot()),
+            FlowPreference.TRACEROUTE);
     Set<Flow> flows = helper.getFlows();
 
     String ingressInterface = null;
@@ -95,22 +97,24 @@ public class TracerouteAnswererHelperTest {
 
   @Test
   public void testGetFlows_interfaceLinkSourceNoSourceIp() {
-    TracerouteAnswererHelper helper =
-        new TracerouteAnswererHelper(
+    HeaderConstraintsToFlows helper =
+        new HeaderConstraintsToFlows(
             PacketHeaderConstraints.builder().setDstIp("2.2.2.2").build(),
             "@enter(node1)",
-            _batfish.specifierContext(_batfish.getSnapshot()));
+            _batfish.specifierContext(_batfish.getSnapshot()),
+            FlowPreference.TRACEROUTE);
     thrown.expect(IllegalArgumentException.class);
     helper.getFlows();
   }
 
   @Test
   public void testGetFlows_interfaceLinkSource() {
-    TracerouteAnswererHelper helper =
-        new TracerouteAnswererHelper(
+    HeaderConstraintsToFlows helper =
+        new HeaderConstraintsToFlows(
             PacketHeaderConstraints.builder().setSrcIp("1.1.1.0").setDstIp("2.2.2.2").build(),
             "@enter(node1)",
-            _batfish.specifierContext(_batfish.getSnapshot()));
+            _batfish.specifierContext(_batfish.getSnapshot()),
+            FlowPreference.TRACEROUTE);
 
     Set<Flow> flows = helper.getFlows();
 
@@ -138,11 +142,12 @@ public class TracerouteAnswererHelperTest {
 
   @Test
   public void testGetFlows_dst() {
-    TracerouteAnswererHelper helper =
-        new TracerouteAnswererHelper(
+    HeaderConstraintsToFlows helper =
+        new HeaderConstraintsToFlows(
             PacketHeaderConstraints.builder().setDstIp("node2").build(),
             String.format("%s[%s]", NODE1, LOOPBACK),
-            _batfish.specifierContext(_batfish.getSnapshot()));
+            _batfish.specifierContext(_batfish.getSnapshot()),
+            FlowPreference.TRACEROUTE);
     Set<Flow> flows = helper.getFlows();
     assertThat(
         flows, everyItem(anyOf(hasDstIp(NODE2_FAST_ETHERNET_IP), hasDstIp(NODE2_LOOPBACK_IP))));

--- a/projects/question/src/main/java/org/batfish/question/HeaderConstraintsToFlows.java
+++ b/projects/question/src/main/java/org/batfish/question/HeaderConstraintsToFlows.java
@@ -1,14 +1,13 @@
-package org.batfish.question.traceroute;
+package org.batfish.question;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.SetFlowStartLocation.setStartLocation;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.batfish.common.BatfishException;
-import org.batfish.common.bdd.BDDFlowConstraintGenerator;
+import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Flow;
@@ -32,10 +31,11 @@ import org.batfish.specifier.SpecifierContext;
 import org.batfish.specifier.SpecifierFactories;
 
 /**
- * Helper for {@link TracerouteAnswerer} and {@link BidirectionalTracerouteAnswerer}. Processes
- * question parameters and constructs {@link Flow Flows} for the backend engine.
+ * Converts {@link PacketHeaderConstraints} and a source location specifier into concrete {@link
+ * Flow Flows}. Used by questions that need to construct flows for {@link
+ * org.batfish.common.plugin.TracerouteEngine}.
  */
-public final class TracerouteAnswererHelper {
+public final class HeaderConstraintsToFlows {
   private final PacketHeaderConstraints _packetHeaderConstraints;
   private final String _sourceLocationStr;
   private final SpecifierContext _specifierContext;
@@ -64,10 +64,11 @@ public final class TracerouteAnswererHelper {
         }
       };
 
-  public TracerouteAnswererHelper(
+  public HeaderConstraintsToFlows(
       PacketHeaderConstraints packetHeaderConstraints,
       String sourceLocationStr,
-      SpecifierContext specifierContext) {
+      SpecifierContext specifierContext,
+      FlowPreference flowPreference) {
     _packetHeaderConstraints = packetHeaderConstraints;
     _sourceLocationStr = sourceLocationStr;
     _specifierContext = specifierContext;
@@ -77,20 +78,19 @@ public final class TracerouteAnswererHelper {
     _packetHeaderConstraintToFlowHelper =
         new IpFieldExtractorContext(_srcIpAssignment, _specifierContext);
 
-    _flowBuilder = initFlowBuilder(_packetHeaderConstraints);
+    _flowBuilder = initFlowBuilder(_packetHeaderConstraints, flowPreference);
     setDstIp(_packetHeaderConstraints, _flowBuilder);
   }
 
-  static Flow.Builder initFlowBuilder(PacketHeaderConstraints phc) {
+  static Flow.Builder initFlowBuilder(PacketHeaderConstraints phc, FlowPreference flowPreference) {
     BDDPacket pkt = new BDDPacket();
     return pkt.getFlow(
             PacketHeaderConstraintsUtil.toBDD(
                 pkt, phc, UniverseIpSpace.INSTANCE, UniverseIpSpace.INSTANCE),
-            BDDFlowConstraintGenerator.FlowPreference.TRACEROUTE)
+            flowPreference)
         .orElseThrow(() -> new BatfishException("could not convert header constraints to flow"));
   }
 
-  @VisibleForTesting
   static IpSpaceAssignment initSourceIpAssignment(
       String sourceLocation, String sourceIps, SpecifierContext specifierContext) {
     /* construct specifiers */
@@ -124,9 +124,8 @@ public final class TracerouteAnswererHelper {
     builder.setDstIp(dstIp);
   }
 
-  /** Generate a set of flows to do traceroute */
-  @VisibleForTesting
-  Set<Flow> getFlows() {
+  /** Generate a set of flows from the configured header constraints and source locations. */
+  public Set<Flow> getFlows() {
     Set<Location> srcLocations =
         SpecifierFactories.getLocationSpecifierOrDefault(
                 _sourceLocationStr, AllInterfacesLocationSpecifier.INSTANCE)
@@ -145,7 +144,6 @@ public final class TracerouteAnswererHelper {
     for (Location srcLocation : srcLocations) {
       try {
         Flow.Builder flowBuilder = _flowBuilder;
-        // Extract and source IP from header constraints,
         setSrcIp(_packetHeaderConstraints, srcLocation, flowBuilder);
         setStartLocation(_specifierContext.getConfigs(), flowBuilder, srcLocation);
         setBuilder.add(flowBuilder.build());

--- a/projects/question/src/main/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswerer.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.Answerer;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.datamodel.Flow;
@@ -33,6 +34,7 @@ import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.table.TableMetadata;
+import org.batfish.question.HeaderConstraintsToFlows;
 
 /** {@link Answerer} for {@link BidirectionalTracerouteQuestion}. */
 public class BidirectionalTracerouteAnswerer extends Answerer {
@@ -49,11 +51,12 @@ public class BidirectionalTracerouteAnswerer extends Answerer {
   @Override
   public AnswerElement answer(NetworkSnapshot snapshot) {
     BidirectionalTracerouteQuestion q = (BidirectionalTracerouteQuestion) _question;
-    TracerouteAnswererHelper helper =
-        new TracerouteAnswererHelper(
+    HeaderConstraintsToFlows helper =
+        new HeaderConstraintsToFlows(
             q.getHeaderConstraints(),
             q.getSourceLocationStr(),
-            _batfish.specifierContext(snapshot));
+            _batfish.specifierContext(snapshot),
+            FlowPreference.TRACEROUTE);
     Set<Flow> flows = helper.getFlows();
     TracerouteEngine tracerouteEngine = _batfish.getTracerouteEngine(snapshot);
     return bidirectionalTracerouteAnswerElement(

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.common.Answerer;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.TracePruner;
 import org.batfish.datamodel.Flow;
@@ -24,6 +25,7 @@ import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.table.TableDiff;
 import org.batfish.datamodel.table.TableMetadata;
+import org.batfish.question.HeaderConstraintsToFlows;
 
 /** Produces the answer for {@link TracerouteQuestion} */
 public final class TracerouteAnswerer extends Answerer {
@@ -42,11 +44,12 @@ public final class TracerouteAnswerer extends Answerer {
 
   @VisibleForTesting
   SortedMap<Flow, List<Trace>> getTraces(NetworkSnapshot snapshot, TracerouteQuestion q) {
-    TracerouteAnswererHelper helper =
-        new TracerouteAnswererHelper(
+    HeaderConstraintsToFlows helper =
+        new HeaderConstraintsToFlows(
             q.getHeaderConstraints(),
             q.getSourceLocationStr(),
-            _batfish.specifierContext(snapshot));
+            _batfish.specifierContext(snapshot),
+            FlowPreference.TRACEROUTE);
     Set<Flow> flows = helper.getFlows();
     return _batfish.getTracerouteEngine(snapshot).computeTraces(flows, q.getIgnoreFilters());
   }

--- a/projects/question/src/test/java/org/batfish/question/HeaderConstraintsToFlowsTest.java
+++ b/projects/question/src/test/java/org/batfish/question/HeaderConstraintsToFlowsTest.java
@@ -1,4 +1,4 @@
-package org.batfish.question.traceroute;
+package org.batfish.question;
 
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressInterface;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIngressNode;
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
@@ -38,7 +39,7 @@ import org.batfish.specifier.SpecifierContextImpl;
 import org.batfish.specifier.SpecifierFactories;
 import org.junit.Test;
 
-public class TracerouteAnswererHelperTest {
+public class HeaderConstraintsToFlowsTest {
   @Test
   public void testGetFlows() {
     NetworkFactory nf = new NetworkFactory();
@@ -84,8 +85,9 @@ public class TracerouteAnswererHelperTest {
             new InterfaceLinkLocation(config.getHostname(), inactiveIface.getName())));
 
     // getFlows filters out locations of inactive interfaces
-    TracerouteAnswererHelper helper =
-        new TracerouteAnswererHelper(headerConstraints, sourceLocationStr, ctxt);
+    HeaderConstraintsToFlows helper =
+        new HeaderConstraintsToFlows(
+            headerConstraints, sourceLocationStr, ctxt, FlowPreference.TRACEROUTE);
 
     Set<Flow> flows = helper.getFlows();
     assertThat(
@@ -115,7 +117,8 @@ public class TracerouteAnswererHelperTest {
             .build();
     PacketHeaderConstraints phc =
         PacketHeaderConstraints.builder().setDstIp("8.8.8.8").setApplications("icmp/3/15").build();
-    Set<Flow> flows = new TracerouteAnswererHelper(phc, ".*", ctxt).getFlows();
+    Set<Flow> flows =
+        new HeaderConstraintsToFlows(phc, ".*", ctxt, FlowPreference.TRACEROUTE).getFlows();
     assertThat(flows, contains(allOf(hasIpProtocol(IpProtocol.ICMP))));
   }
 }


### PR DESCRIPTION
Rename and move from the traceroute subpackage to
org.batfish.question, since it is a general utility for converting
PacketHeaderConstraints into concrete Flow objects for any question
that uses TracerouteEngine.

Add a FlowPreference parameter to the constructor (previously
hardcoded to TRACEROUTE) so non-traceroute questions can reuse it.
Make getFlows() public.

----

Prompt:
```
I want to make TracerouteAnswererHelper::getFlows available for
others to use, but it's only visible for testing. Does it make
sense to add as part of the public API? is there a better
abstraction for the role that TracerouteAnswererHelper is filling
-- not a helper for the specific TracerouteAnswerer question, but
in general a tool to help in questions that use TracerouteEngine
to map packet forwarding behavior?
```