### PR TITLE
ComparePeerGroupPolicies: fix package names

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswerer.java
@@ -1,4 +1,4 @@
-package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesPlugin.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesPlugin.java
@@ -1,4 +1,4 @@
-package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
 
 import com.google.auto.service.AutoService;
 import org.batfish.common.Answerer;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesQuestion.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesQuestion.java
@@ -1,4 +1,4 @@
-package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
 
 import org.batfish.datamodel.questions.Question;
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
@@ -1,4 +1,4 @@
-package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
 
 import java.util.HashSet;
 import java.util.Map;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/RoutingPolicyContextDiff.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/RoutingPolicyContextDiff.java
@@ -1,4 +1,4 @@
-package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Comparators;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticCompare.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticCompare.java
@@ -1,4 +1,4 @@
-package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticDifference.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticDifference.java
@@ -1,4 +1,4 @@
-package projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies;
+package org.batfish.minesweeper.question.comparepeergrouppolicies;
 
 import static org.batfish.question.TracingHintsStripper.TRACING_HINTS_STRIPPER;
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
@@ -79,8 +79,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.ComparePeerGroupPoliciesAnswerer;
-import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.ComparePeerGroupPoliciesQuestion;
 
 public class ComparePeerGroupPoliciesAnswererTest {
   @Rule public TemporaryFolder _tempFolder = new TemporaryFolder();

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/RoutingPolicyContextDiffTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/RoutingPolicyContextDiffTest.java
@@ -36,7 +36,6 @@ import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.junit.Before;
 import org.junit.Test;
-import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.RoutingPolicyContextDiff;
 
 public class RoutingPolicyContextDiffTest {
   private static final String HOSTNAME = "hostname";

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticCompareTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticCompareTest.java
@@ -29,7 +29,6 @@ import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.junit.Before;
 import org.junit.Test;
-import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.SyntacticCompare;
 
 public class SyntacticCompareTest {
   private static final String HOSTNAME = "hostname";

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticDifferenceTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/SyntacticDifferenceTest.java
@@ -26,8 +26,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.RoutingPolicyContextDiff;
-import projects.minesweeper.src.main.java.org.batfish.minesweeper.question.comparepeergrouppolicies.SyntacticDifference;
 
 public class SyntacticDifferenceTest {
   @Rule public TemporaryFolder _tempFolder = new TemporaryFolder();


### PR DESCRIPTION
The 7 main source files had the erroneous package
`projects.minesweeper.src.main.java.org.batfish.minesweeper...`
instead of `org.batfish.minesweeper...`. Also fix corresponding
imports in 4 test files.

----

Prompt:
```
Fix the package names on the comparepeergrouppolicies question
```