### PR TITLE
Junos: apply autostate to VNI-backed VLANs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2168,12 +2168,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (vxlan.getVniId() == null) {
         continue;
       }
-      // Exclude VNI VLANs from normalVlanRange so their IRB interfaces are not deactivated by
-      // autostate (these VLANs carry VXLAN overlay traffic and may have no physical members).
-      if (vxlan.getVlanId() != null) {
-        _c.setNormalVlanRange(
-            _c.getNormalVlanRange().difference(IntegerSpace.of(vxlan.getVlanId())));
-      }
       if (vxlan.getVlanId() == null) {
         continue;
       }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/JuniperIrbTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/JuniperIrbTest.java
@@ -1,17 +1,26 @@
 package org.batfish.grammar.flatjuniper;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.Resources.readResourceBytes;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.runtime.SnapshotRuntimeData;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -49,5 +58,59 @@ public final class JuniperIrbTest {
     Configuration c = parseConfig("irb-deactivate");
     assertThat(c, hasInterface("irb.2", isActive()));
     assertThat(c, hasInterface("irb.5", isActive(false)));
+  }
+
+  /**
+   * VNI VLANs without trunk port members should have their IRB interfaces deactivated by autostate,
+   * regardless of whether the VLAN has a VXLAN VNI. When runtime data reports the trunk port as
+   * line-down, the IRB that depended on it should also be deactivated.
+   */
+  @Test
+  public void testIrbVxlanAutostate() throws IOException {
+    String hostname = "irb-vxlan-autostate";
+
+    // Without runtime data: VLAN100 has a trunk member (xe-0/0/0), VLAN200 does not.
+    // irb.100 should be active, irb.200 should be deactivated by autostate.
+    Configuration c = parseConfig(hostname);
+    assertThat(c, hasInterface("irb.100", isActive()));
+    assertThat(c, hasInterface("irb.200", isActive(false)));
+
+    // With runtime data reporting xe-0/0/0 (physical) as line-down: the bind dependency
+    // deactivates xe-0/0/0.0, leaving VLAN100 with zero active members. Both IRBs should be
+    // deactivated by autostate.
+    SnapshotRuntimeData lineDown =
+        SnapshotRuntimeData.builder()
+            .setInterfacesLineDown(ImmutableList.of(NodeInterfacePair.of(hostname, "xe-0/0/0")))
+            .build();
+    Configuration cLineDown = parseConfigWithRuntimeData(hostname, lineDown);
+    assertThat(cLineDown, hasInterface("irb.100", isActive(false)));
+    assertThat(cLineDown, hasInterface("irb.200", isActive(false)));
+
+    // With runtime data reporting xe-0/0/0 as line-up: irb.100 stays active, irb.200 still
+    // deactivated (no trunk member regardless of runtime data).
+    SnapshotRuntimeData lineUp =
+        SnapshotRuntimeData.builder()
+            .setInterfacesLineUp(ImmutableList.of(NodeInterfacePair.of(hostname, "xe-0/0/0")))
+            .build();
+    Configuration cLineUp = parseConfigWithRuntimeData(hostname, lineUp);
+    assertThat(cLineUp, hasInterface("irb.100", isActive()));
+    assertThat(cLineUp, hasInterface("irb.200", isActive(false)));
+  }
+
+  private Configuration parseConfigWithRuntimeData(String hostname, SnapshotRuntimeData runtimeData)
+      throws IOException {
+    String resourcePath = TESTCONFIGS_PREFIX + hostname;
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationBytes(
+                    ImmutableSortedMap.of(
+                        new File(resourcePath).getName(), readResourceBytes(resourcePath)))
+                .setRuntimeDataBytes(BatfishObjectMapper.writeString(runtimeData).getBytes(UTF_8))
+                .build(),
+            _folder);
+    Map<String, Configuration> configs = batfish.loadConfigurations(batfish.getSnapshot());
+    assertThat(configs, hasKey(hostname.toLowerCase()));
+    return configs.get(hostname.toLowerCase());
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/irb-vxlan-autostate
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/irb-vxlan-autostate
@@ -1,0 +1,23 @@
+#
+set system host-name irb-vxlan-autostate
+
+set interfaces lo0 unit 0 family inet address 10.0.0.1/32
+
+# Trunk port is a member of VLAN100 only
+set interfaces xe-0/0/0 unit 0 family ethernet-switching interface-mode trunk
+set interfaces xe-0/0/0 unit 0 family ethernet-switching vlan members VLAN100
+
+# IRB interfaces for two VLANs
+set interfaces irb unit 100 family inet address 172.16.100.1/24
+set interfaces irb unit 200 family inet address 172.16.200.1/24
+
+# Both VLANs have VNI IDs (VXLAN overlay)
+set vlans VLAN100 vlan-id 100
+set vlans VLAN100 l3-interface irb.100
+set vlans VLAN100 vxlan vni 10100
+
+set vlans VLAN200 vlan-id 200
+set vlans VLAN200 l3-interface irb.200
+set vlans VLAN200 vxlan vni 10200
+
+set switch-options vtep-source-interface lo0.0


### PR DESCRIPTION
Previously, VLANs with a VXLAN VNI were excluded from autostate
(normalVlanRange), keeping their IRB interfaces active even when no
switchport was assigned to the VLAN. This was added in #9843 under the
assumption that VXLAN overlay traffic would provide connectivity without
local physical members.

In practice, if the underlay links are down (e.g., in a containerlab
environment), the IRBs should be deactivated — the real device marks
them as hardware-down and does not install connected routes. Removing
the exclusion lets autostate deactivate these IRBs, matching on-device
behavior when runtime data reflects the actual link state.

This fixes a regression from batfish/batfish#9843.

Prompt:
```
Let's make the batfish change first. Ideally, some test will fail
from this change and we can confirm that test was testing the wrong
behavior.
```