### PR TITLE
VXLAN-aware autostate: activate IRBs when L2 VNI tunnels come up

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -37,6 +37,7 @@ import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.batfish.common.BdpOscillationException;
@@ -56,10 +57,16 @@ import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.InactiveReason;
+import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IsisRoute;
 import org.batfish.datamodel.NetworkConfigurations;
+import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.IncrementalBdpAnswerElement;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.eigrp.EigrpTopology;
@@ -75,6 +82,8 @@ import org.batfish.datamodel.tracking.TrackMethodReference;
 import org.batfish.datamodel.tracking.TrackReachability;
 import org.batfish.datamodel.tracking.TrackRoute;
 import org.batfish.datamodel.tracking.TrackTrue;
+import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.VxlanNode;
 import org.batfish.datamodel.vxlan.VxlanTopology;
 import org.batfish.dataplane.TracerouteEngineImpl;
 import org.batfish.dataplane.ibdp.DataplaneTrackEvaluator.DataPlaneTrackMethodEvaluatorProvider;
@@ -257,6 +266,129 @@ final class IncrementalBdpEngine {
         .build();
   }
 
+  /**
+   * Update autostate for VLAN interfaces based on VXLAN L2 VNI edge changes. When a VLAN gains an
+   * active L2 VNI edge (remote VTEP reachable), its IRB should be active even without physical
+   * switchport members. When L2 VNI edges disappear and the VLAN has no physical members, the IRB
+   * should be deactivated.
+   *
+   * @return the set of hostnames whose interface status changed (empty if no changes)
+   */
+  @VisibleForTesting
+  static Set<String> updateVxlanAutostate(
+      VxlanTopology oldVxlanTopology,
+      VxlanTopology newVxlanTopology,
+      Map<String, Configuration> configurations) {
+    // Collect (hostname, VNI) pairs that have L2 VNI edges in each topology
+    Set<VxlanNode> oldNodes = nodesWithLayer2VniEdges(oldVxlanTopology);
+    Set<VxlanNode> newNodes = nodesWithLayer2VniEdges(newVxlanTopology);
+
+    Set<VxlanNode> gained = Sets.difference(newNodes, oldNodes);
+    Set<VxlanNode> lost = Sets.difference(oldNodes, newNodes);
+    if (gained.isEmpty() && lost.isEmpty()) {
+      return ImmutableSet.of();
+    }
+
+    NetworkConfigurations nc = NetworkConfigurations.of(configurations);
+    ImmutableSet.Builder<String> affectedHostnames = ImmutableSet.builder();
+
+    // Activate IRBs for VLANs that gained VXLAN connectivity
+    for (VxlanNode node : gained) {
+      Interface iface = findVlanInterfaceForVni(node, nc);
+      if (iface != null
+          && !iface.getActive()
+          && iface.getInactiveReason() == InactiveReason.AUTOSTATE_FAILURE) {
+        iface.reactivateForAutostate();
+        affectedHostnames.add(node.getHostname());
+      }
+    }
+
+    // Deactivate IRBs for VLANs that lost VXLAN connectivity (if no physical members)
+    for (VxlanNode node : lost) {
+      Interface iface = findVlanInterfaceForVni(node, nc);
+      if (iface != null && iface.getActive() && iface.getAutoState()) {
+        Configuration c = configurations.get(node.getHostname());
+        int vlanNumber = iface.getVlan();
+        if (c.getNormalVlanRange().contains(vlanNumber)
+            && countPhysicalVlanMembers(c, vlanNumber) == 0) {
+          iface.deactivate(InactiveReason.AUTOSTATE_FAILURE);
+          affectedHostnames.add(node.getHostname());
+        }
+      }
+    }
+
+    return affectedHostnames.build();
+  }
+
+  /** Collect the set of VxlanNodes that participate in at least one L2 VNI edge. */
+  private static Set<VxlanNode> nodesWithLayer2VniEdges(VxlanTopology topology) {
+    ImmutableSet.Builder<VxlanNode> nodes = ImmutableSet.builder();
+    topology
+        .getLayer2VniEdges()
+        .forEach(
+            edge -> {
+              nodes.add(edge.nodeU());
+              nodes.add(edge.nodeV());
+            });
+    return nodes.build();
+  }
+
+  /**
+   * Find the VLAN interface associated with a given VxlanNode's L2 VNI. Returns null if the VNI or
+   * VLAN interface cannot be resolved.
+   */
+  private static @Nullable Interface findVlanInterfaceForVni(
+      VxlanNode node, NetworkConfigurations nc) {
+    Optional<Layer2Vni> vniOpt =
+        nc.getVniSettings(node.getHostname(), node.getVni(), Vrf::getLayer2Vnis);
+    if (vniOpt.isEmpty()) {
+      return null;
+    }
+    int vlanNumber = vniOpt.get().getVlan();
+    Optional<Configuration> cOpt = nc.get(node.getHostname());
+    if (cOpt.isEmpty()) {
+      return null;
+    }
+    // Find the VLAN interface for this VLAN number
+    return cOpt.get().getAllInterfaces().values().stream()
+        .filter(
+            iface ->
+                iface.getInterfaceType() == InterfaceType.VLAN
+                    && Integer.valueOf(vlanNumber).equals(iface.getVlan()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Count active physical switchport members for a given VLAN on a device. This mirrors the
+   * member-counting logic in {@link org.batfish.main.Batfish#disableUnusableVlanInterfaces}.
+   */
+  private static int countPhysicalVlanMembers(Configuration c, int vlanNumber) {
+    int count = 0;
+    for (Interface iface : c.getActiveInterfaces().values()) {
+      if (iface.getInterfaceType() == InterfaceType.VLAN) {
+        continue;
+      }
+      if (iface.getSwitchportMode() == SwitchportMode.TRUNK) {
+        IntegerSpace allowed = iface.getAllowedVlans();
+        if (allowed.isEmpty() || allowed.contains(vlanNumber)) {
+          count++;
+          continue;
+        }
+        Integer nativeVlan = iface.getNativeVlan();
+        if (nativeVlan != null && nativeVlan == vlanNumber) {
+          count++;
+        }
+      } else if (iface.getSwitchportMode() == SwitchportMode.ACCESS) {
+        Integer accessVlan = iface.getAccessVlan();
+        if (accessVlan != null && accessVlan == vlanNumber) {
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
   /** Helper method used to sample the change in tracks across iterations. */
   @VisibleForTesting
   static <T> @Nonnull Optional<String> compareTracks(
@@ -402,6 +534,19 @@ final class IncrementalBdpEngine {
               networkConfigurations,
               currentIpOwners.getIpVrfOwners());
 
+      // Activate/deactivate IRBs based on L2 VNI edge changes (VXLAN-aware autostate)
+      Set<String> autostateAffectedHostnames =
+          updateVxlanAutostate(
+              currentTopologyContext.getVxlanTopology(),
+              nextTopologyContext.getVxlanTopology(),
+              configurations);
+      if (!autostateAffectedHostnames.isEmpty()) {
+        // Recompute connected routes only for VRFs on affected nodes
+        vrs.parallelStream()
+            .filter(vr -> autostateAffectedHostnames.contains(vr.getHostname()))
+            .forEach(VirtualRouter::updateConnectedAndLocalRoutesForAutostateChange);
+      }
+
       Table<String, TrackReachability, Boolean> nextTrackReachabilityResults =
           nextTrackReachabilityResults(
               currentDataplane,
@@ -434,6 +579,10 @@ final class IncrementalBdpEngine {
       if (!currentIpOwners.equals(nextIpOwners)) {
         converged = false;
         LOGGER.info("IP ownership changed in this iteration");
+      }
+      if (!autostateAffectedHostnames.isEmpty()) {
+        converged = false;
+        LOGGER.info("VXLAN autostate changed interface status in this iteration");
       }
       currentTopologyContext = nextTopologyContext;
       currentTrackReachabilityResults = nextTrackReachabilityResults;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -775,6 +775,33 @@ public final class VirtualRouter {
         .forEach(r -> _connectedRib.mergeRoute(annotateRoute(r)));
   }
 
+  /**
+   * Recompute connected and local routes, applying deltas to the main RIB. Called when VXLAN-aware
+   * autostate changes interface status during topology iteration.
+   */
+  void updateConnectedAndLocalRoutesForAutostateChange() {
+    // Withdraw old connected routes from main RIB
+    for (AnnotatedRoute<ConnectedRoute> route : _connectedRib.getRoutes()) {
+      _mainRibRouteDeltaBuilder.from(
+          _mainRib.removeRouteGetDelta(
+              new AnnotatedRoute<>(route.getRoute(), route.getSourceVrf())));
+    }
+    // Withdraw old local routes from main RIB
+    for (AnnotatedRoute<LocalRoute> route : _localRib.getRoutes()) {
+      _mainRibRouteDeltaBuilder.from(
+          _mainRib.removeRouteGetDelta(
+              new AnnotatedRoute<>(route.getRoute(), route.getSourceVrf())));
+    }
+    // Rebuild connected and local RIBs from current active interfaces
+    _connectedRib = new ConnectedRib();
+    initConnectedRib();
+    _localRib = new LocalRib();
+    initLocalRib();
+    // Add new routes to main RIB
+    _mainRibRouteDeltaBuilder.from(importRib(_mainRib, _connectedRib));
+    _mainRibRouteDeltaBuilder.from(importRib(_mainRib, _localRib));
+  }
+
   /** Generate connected routes for a given active interface. */
   private static @Nonnull Stream<ConnectedRoute> generateConnectedRoutes(@Nonnull Interface iface) {
     assert iface.getActive();

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
@@ -3901,7 +3901,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     convertStaticRoutes();
     computeImplicitOspfAreas();
     convertOspfProcesses();
-    convertVlans();
     convertNves();
     convertBgp();
     convertEigrp();
@@ -3909,16 +3908,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     markStructures();
     return _c;
-  }
-
-  private void convertVlans() {
-    _vlans.forEach(
-        (vlanId, vlan) -> {
-          if (vlan.getVni() != null) {
-            // Ensure IRB stays up even if it has no associated switchports
-            _c.setNormalVlanRange(_c.getNormalVlanRange().difference(IntegerSpace.of(vlanId)));
-          }
-        });
   }
 
   private void makeLeakConfigs() {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
@@ -31,6 +31,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
@@ -197,6 +198,197 @@ public class EvpnTest {
     assertThat(
         dp.getLayer2Vnis().column(DEFAULT_VRF_NAME),
         hasEntry(equalTo("n2"), contains(hasBumTransportIps(contains(Ip.parse("1.111.111.111"))))));
+  }
+
+  /**
+   * Build a 2-node network with L2 VNIs and VLAN interfaces that have no physical switchport
+   * members. VTEP source IPs are on loopbacks, reachable via direct link. VLAN interfaces should be
+   * deactivated by autostate pre-dataplane, then reactivated when VXLAN tunnels come up.
+   */
+  private static SortedMap<String, Configuration> twoNodeNetworkWithVlanInterfaces() {
+    NetworkFactory nf = new NetworkFactory();
+
+    // -- Node 1 --
+    Configuration c1 =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("n1")
+            .build();
+    policyName = "EXPORT_ALL";
+    RoutingPolicy.builder()
+        .setOwner(c1)
+        .setName(policyName)
+        .addStatement(Statements.ReturnTrue.toStaticStatement())
+        .build();
+    Ip loopback1 = Ip.parse("10.0.0.1");
+    Ip loopback2 = Ip.parse("10.0.0.2");
+    Ip link1 = Ip.parse("10.1.0.1");
+    Ip link2 = Ip.parse("10.1.0.2");
+
+    Vrf vrf1 = nf.vrfBuilder().setOwner(c1).setName(DEFAULT_VRF_NAME).build();
+    BgpProcess bgp1 = BgpProcess.testBgpProcess(loopback1);
+    vrf1.setBgpProcess(bgp1);
+    // Loopback (VTEP source)
+    nf.interfaceBuilder()
+        .setOwner(c1)
+        .setVrf(vrf1)
+        .setName("Loopback0")
+        .setAddress(ConcreteInterfaceAddress.create(loopback1, 32))
+        .build();
+    // Physical link to n2
+    nf.interfaceBuilder()
+        .setOwner(c1)
+        .setVrf(vrf1)
+        .setName("Ethernet1")
+        .setAddress(ConcreteInterfaceAddress.create(link1, 30))
+        .build();
+    // VLAN interface — no switchport members, autostate enabled
+    nf.interfaceBuilder()
+        .setOwner(c1)
+        .setVrf(vrf1)
+        .setName("Vlan100")
+        .setType(InterfaceType.VLAN)
+        .setVlan(100)
+        .setAutoState(true)
+        .setAddress(ConcreteInterfaceAddress.parse("172.16.100.1/24"))
+        .build();
+    // L2 VNI for VLAN 100
+    int vni = 10100;
+    vrf1.setLayer2Vnis(
+        ImmutableSet.of(
+            Layer2Vni.testBuilder()
+                .setVni(vni)
+                .setVlan(100)
+                .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+                .setSourceAddress(loopback1)
+                .build()));
+    Layer2VniConfig vniConfig1 =
+        Layer2VniConfig.builder()
+            .setVni(vni)
+            .setVrf(DEFAULT_VRF_NAME)
+            .setRouteDistinguisher(RouteDistinguisher.from(bgp1.getRouterId(), 1))
+            .setRouteTarget(ExtendedCommunity.target(65500, vni))
+            .build();
+    nf.bgpNeighborBuilder()
+        .setPeerAddress(loopback2)
+        .setRemoteAs(2L)
+        .setLocalIp(loopback1)
+        .setLocalAs(1L)
+        .setBgpProcess(bgp1)
+        .setEvpnAddressFamily(
+            EvpnAddressFamily.builder()
+                .setL2Vnis(ImmutableSet.of(vniConfig1))
+                .setL3Vnis(ImmutableSet.of())
+                .setPropagateUnmatched(true)
+                .setAddressFamilyCapabilities(
+                    AddressFamilyCapabilities.builder()
+                        .setSendCommunity(true)
+                        .setSendExtendedCommunity(true)
+                        .build())
+                .setExportPolicy(policyName)
+                .build())
+        .setIpv4UnicastAddressFamily(
+            Ipv4UnicastAddressFamily.builder().setExportPolicy(policyName).build())
+        .build();
+
+    // -- Node 2 --
+    Configuration c2 =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("n2")
+            .build();
+    RoutingPolicy.builder()
+        .setOwner(c2)
+        .setName(policyName)
+        .addStatement(Statements.ReturnTrue.toStaticStatement())
+        .build();
+    Vrf vrf2 = nf.vrfBuilder().setOwner(c2).setName(DEFAULT_VRF_NAME).build();
+    BgpProcess bgp2 = BgpProcess.testBgpProcess(loopback2);
+    vrf2.setBgpProcess(bgp2);
+    nf.interfaceBuilder()
+        .setOwner(c2)
+        .setVrf(vrf2)
+        .setName("Loopback0")
+        .setAddress(ConcreteInterfaceAddress.create(loopback2, 32))
+        .build();
+    nf.interfaceBuilder()
+        .setOwner(c2)
+        .setVrf(vrf2)
+        .setName("Ethernet1")
+        .setAddress(ConcreteInterfaceAddress.create(link2, 30))
+        .build();
+    nf.interfaceBuilder()
+        .setOwner(c2)
+        .setVrf(vrf2)
+        .setName("Vlan100")
+        .setType(InterfaceType.VLAN)
+        .setVlan(100)
+        .setAutoState(true)
+        .setAddress(ConcreteInterfaceAddress.parse("172.16.100.2/24"))
+        .build();
+    vrf2.setLayer2Vnis(
+        ImmutableSet.of(
+            Layer2Vni.testBuilder()
+                .setVni(vni)
+                .setVlan(100)
+                .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+                .setSourceAddress(loopback2)
+                .build()));
+    Layer2VniConfig vniConfig2 =
+        Layer2VniConfig.builder()
+            .setVni(vni)
+            .setVrf(DEFAULT_VRF_NAME)
+            .setRouteDistinguisher(RouteDistinguisher.from(bgp2.getRouterId(), 2))
+            .setRouteTarget(ExtendedCommunity.target(65500, vni))
+            .build();
+    nf.bgpNeighborBuilder()
+        .setPeerAddress(loopback1)
+        .setRemoteAs(1L)
+        .setLocalIp(loopback2)
+        .setLocalAs(2L)
+        .setBgpProcess(bgp2)
+        .setEvpnAddressFamily(
+            EvpnAddressFamily.builder()
+                .setL2Vnis(ImmutableSet.of(vniConfig2))
+                .setL3Vnis(ImmutableSet.of())
+                .setPropagateUnmatched(true)
+                .setAddressFamilyCapabilities(
+                    AddressFamilyCapabilities.builder()
+                        .setSendCommunity(true)
+                        .setSendExtendedCommunity(true)
+                        .build())
+                .setExportPolicy(policyName)
+                .build())
+        .setIpv4UnicastAddressFamily(
+            Ipv4UnicastAddressFamily.builder().setExportPolicy(policyName).build())
+        .build();
+
+    return ImmutableSortedMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
+  }
+
+  @Test
+  public void testVxlanAutostateReactivatesIrb() throws IOException {
+    SortedMap<String, Configuration> configs = twoNodeNetworkWithVlanInterfaces();
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+
+    // After dataplane computation, VXLAN tunnels should be up and IRBs reactivated.
+    // Check that Vlan100 on both nodes is active.
+    Configuration n1 = configs.get("n1");
+    Configuration n2 = configs.get("n2");
+    assertThat(n1.getAllInterfaces().get("Vlan100").getActive(), equalTo(true));
+    assertThat(n2.getAllInterfaces().get("Vlan100").getActive(), equalTo(true));
+
+    // Connected routes for the IRB subnets should be in the main RIBs
+    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
+        dp.getRibsForTesting();
+    assertThat(
+        ribs.get("n1").get(DEFAULT_VRF_NAME).getUnannotatedRoutes(),
+        hasItem(hasPrefix(Prefix.parse("172.16.100.0/24"))));
+    assertThat(
+        ribs.get("n2").get(DEFAULT_VRF_NAME).getUnannotatedRoutes(),
+        hasItem(hasPrefix(Prefix.parse("172.16.100.0/24"))));
   }
 
   @Test(expected = AssertionError.class) // xfail this until NX-OS supports type 5 routes

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalBdpEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalBdpEngineTest.java
@@ -27,6 +27,8 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -37,12 +39,16 @@ import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.HmmRoute;
+import org.batfish.datamodel.InactiveReason;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.KernelRoute;
 import org.batfish.datamodel.OriginMechanism;
@@ -51,6 +57,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.ReceivedFromIp;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.TestInterface;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.VrrpGroup;
@@ -61,6 +68,11 @@ import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.tracking.DecrementPriority;
 import org.batfish.datamodel.tracking.PreDataPlaneTrackMethodEvaluator;
 import org.batfish.datamodel.tracking.TrackRoute;
+import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.datamodel.vxlan.Vni;
+import org.batfish.datamodel.vxlan.VniLayer;
+import org.batfish.datamodel.vxlan.VxlanNode;
+import org.batfish.datamodel.vxlan.VxlanTopology;
 import org.batfish.dataplane.rib.Bgpv4Rib;
 import org.batfish.dataplane.rib.Rib;
 import org.junit.Test;
@@ -543,6 +555,159 @@ public final class IncrementalBdpEngineTest {
     assertThat(
         dp.getRibsForTesting().get("r2").get(DEFAULT_VRF_NAME).getRoutes(kernelRoutePrefix),
         empty());
+  }
+
+  // ---- updateVxlanAutostate tests ----
+
+  /** Helper to build a VxlanTopology with the given L2 VNI edges. */
+  private static VxlanTopology buildL2VxlanTopology(VxlanNode... nodesInPairs) {
+    MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
+    for (int i = 0; i < nodesInPairs.length; i += 2) {
+      graph.putEdge(nodesInPairs[i], nodesInPairs[i + 1]);
+    }
+    return new VxlanTopology(graph);
+  }
+
+  /**
+   * Helper to build a Configuration with a VLAN interface (optionally autostate-deactivated) and an
+   * L2 VNI for the VLAN.
+   */
+  private static Configuration buildVxlanConfig(
+      String hostname, int vlanNumber, int vni, boolean autostateDeactivated) {
+    Configuration c =
+        Configuration.builder().setHostname(hostname).setConfigurationFormat(CISCO_IOS).build();
+    Vrf vrf = Vrf.builder().setOwner(c).setName(DEFAULT_VRF_NAME).build();
+    Interface vlanIface =
+        Interface.builder()
+            .setOwner(c)
+            .setVrf(vrf)
+            .setName("Vlan" + vlanNumber)
+            .setType(InterfaceType.VLAN)
+            .setVlan(vlanNumber)
+            .setAutoState(true)
+            .setAddress(ConcreteInterfaceAddress.parse("172.16." + vlanNumber + ".1/24"))
+            .build();
+    if (autostateDeactivated) {
+      vlanIface.deactivate(InactiveReason.AUTOSTATE_FAILURE);
+    }
+    vrf.addLayer2Vni(
+        Layer2Vni.builder()
+            .setVni(vni)
+            .setVlan(vlanNumber)
+            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+            .setUdpPort(Vni.DEFAULT_UDP_PORT)
+            .setSrcVrf(DEFAULT_VRF_NAME)
+            .build());
+    return c;
+  }
+
+  @Test
+  public void testUpdateVxlanAutostate_gainedEdgeReactivatesIrb() {
+    Configuration c = buildVxlanConfig("leaf1", 100, 10100, true);
+    VxlanNode leaf1 = new VxlanNode("leaf1", 10100, VniLayer.LAYER_2);
+    VxlanNode leaf2 = new VxlanNode("leaf2", 10100, VniLayer.LAYER_2);
+
+    Set<String> affected =
+        IncrementalBdpEngine.updateVxlanAutostate(
+            VxlanTopology.EMPTY, buildL2VxlanTopology(leaf1, leaf2), ImmutableMap.of("leaf1", c));
+    assertThat(affected, equalTo(ImmutableSet.of("leaf1")));
+    assertTrue(c.getAllInterfaces().get("Vlan100").getActive());
+  }
+
+  @Test
+  public void testUpdateVxlanAutostate_gainedEdgeAlreadyActive() {
+    Configuration c = buildVxlanConfig("leaf1", 100, 10100, false);
+    VxlanNode leaf1 = new VxlanNode("leaf1", 10100, VniLayer.LAYER_2);
+    VxlanNode leaf2 = new VxlanNode("leaf2", 10100, VniLayer.LAYER_2);
+
+    Set<String> affected =
+        IncrementalBdpEngine.updateVxlanAutostate(
+            VxlanTopology.EMPTY, buildL2VxlanTopology(leaf1, leaf2), ImmutableMap.of("leaf1", c));
+    assertThat(affected, empty());
+    assertTrue(c.getAllInterfaces().get("Vlan100").getActive());
+  }
+
+  @Test
+  public void testUpdateVxlanAutostate_gainedEdgeAdminDown() {
+    Configuration c =
+        Configuration.builder().setHostname("leaf1").setConfigurationFormat(CISCO_IOS).build();
+    Vrf vrf = Vrf.builder().setOwner(c).setName(DEFAULT_VRF_NAME).build();
+    Interface.builder()
+        .setOwner(c)
+        .setVrf(vrf)
+        .setName("Vlan100")
+        .setType(InterfaceType.VLAN)
+        .setVlan(100)
+        .setAutoState(true)
+        .setAdminUp(false)
+        .setAddress(ConcreteInterfaceAddress.parse("172.16.100.1/24"))
+        .build();
+    vrf.addLayer2Vni(
+        Layer2Vni.builder()
+            .setVni(10100)
+            .setVlan(100)
+            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+            .setUdpPort(Vni.DEFAULT_UDP_PORT)
+            .setSrcVrf(DEFAULT_VRF_NAME)
+            .build());
+
+    VxlanNode leaf1 = new VxlanNode("leaf1", 10100, VniLayer.LAYER_2);
+    VxlanNode leaf2 = new VxlanNode("leaf2", 10100, VniLayer.LAYER_2);
+
+    Set<String> affected =
+        IncrementalBdpEngine.updateVxlanAutostate(
+            VxlanTopology.EMPTY, buildL2VxlanTopology(leaf1, leaf2), ImmutableMap.of("leaf1", c));
+    assertThat(affected, empty());
+    assertFalse(c.getAllInterfaces().get("Vlan100").getActive());
+  }
+
+  @Test
+  public void testUpdateVxlanAutostate_lostEdgeDeactivatesIrb() {
+    Configuration c = buildVxlanConfig("leaf1", 100, 10100, false);
+    VxlanNode leaf1 = new VxlanNode("leaf1", 10100, VniLayer.LAYER_2);
+    VxlanNode leaf2 = new VxlanNode("leaf2", 10100, VniLayer.LAYER_2);
+
+    Set<String> affected =
+        IncrementalBdpEngine.updateVxlanAutostate(
+            buildL2VxlanTopology(leaf1, leaf2), VxlanTopology.EMPTY, ImmutableMap.of("leaf1", c));
+    assertThat(affected, equalTo(ImmutableSet.of("leaf1")));
+    assertFalse(c.getAllInterfaces().get("Vlan100").getActive());
+  }
+
+  @Test
+  public void testUpdateVxlanAutostate_lostEdgeWithPhysicalMembers() {
+    Configuration c = buildVxlanConfig("leaf1", 100, 10100, false);
+    // Add a trunk port member for VLAN 100
+    Vrf vrf = c.getVrfs().get(DEFAULT_VRF_NAME);
+    Interface.builder()
+        .setOwner(c)
+        .setVrf(vrf)
+        .setName("Ethernet1")
+        .setType(InterfaceType.PHYSICAL)
+        .setSwitchportMode(SwitchportMode.TRUNK)
+        .setAllowedVlans(IntegerSpace.of(100))
+        .build();
+
+    VxlanNode leaf1 = new VxlanNode("leaf1", 10100, VniLayer.LAYER_2);
+    VxlanNode leaf2 = new VxlanNode("leaf2", 10100, VniLayer.LAYER_2);
+
+    Set<String> affected =
+        IncrementalBdpEngine.updateVxlanAutostate(
+            buildL2VxlanTopology(leaf1, leaf2), VxlanTopology.EMPTY, ImmutableMap.of("leaf1", c));
+    assertThat(affected, empty());
+    assertTrue(c.getAllInterfaces().get("Vlan100").getActive());
+  }
+
+  @Test
+  public void testUpdateVxlanAutostate_noChanges() {
+    Configuration c = buildVxlanConfig("leaf1", 100, 10100, false);
+    VxlanNode leaf1 = new VxlanNode("leaf1", 10100, VniLayer.LAYER_2);
+    VxlanNode leaf2 = new VxlanNode("leaf2", 10100, VniLayer.LAYER_2);
+    VxlanTopology topo = buildL2VxlanTopology(leaf1, leaf2);
+
+    Set<String> affected =
+        IncrementalBdpEngine.updateVxlanAutostate(topo, topo, ImmutableMap.of("leaf1", c));
+    assertThat(affected, empty());
   }
 
   private static class TestIpOwners extends IpOwnersBaseImpl {

--- a/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
@@ -5525,11 +5525,11 @@ public final class CiscoNxosGrammarTest {
             hasSourceAddress(nullValue()),
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
             hasVni(20001)));
-    // Make sure Vlan3 and Vlan7 are up after post-processing. While they have no associated
-    // switchports and are in autostate, they should stay up since they are associated with
-    // vn-segments.
-    assertThat(c, hasInterface("Vlan3", isActive()));
-    assertThat(c, hasInterface("Vlan7", isActive()));
+    // Vlan3 and Vlan7 have VNI associations but no switchport members, so autostate deactivates
+    // them during single-config parsing. They would be reactivated during topology iteration when
+    // VXLAN tunnels come up (see IncrementalBdpEngine.updateVxlanAutostate).
+    assertThat(c, hasInterface("Vlan3", isActive(false)));
+    assertThat(c, hasInterface("Vlan7", isActive(false)));
 
     assertThat(c, hasDefaultVrf(hasLayer2Vnis(hasKey(30001))));
     assertThat(

--- a/projects/common/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Interface.java
@@ -1968,6 +1968,25 @@ public final class Interface extends ComparableStructure<String> {
     }
   }
 
+  /**
+   * Reactivate this interface after it was deactivated by autostate (no active VLAN members).
+   *
+   * <p>Callers must verify preconditions before calling: the interface must be inactive with {@link
+   * InactiveReason#AUTOSTATE_FAILURE}.
+   *
+   * @throws IllegalStateException if this interface is active or was deactivated for a different
+   *     reason.
+   */
+  public void reactivateForAutostate() {
+    checkState(!_active, "Cannot reactivate an active interface");
+    checkState(
+        _inactiveReason == InactiveReason.AUTOSTATE_FAILURE,
+        "Can only reactivate AUTOSTATE_FAILURE interfaces, not %s",
+        _inactiveReason);
+    _active = true;
+    _inactiveReason = null;
+  }
+
   /** Helper to get an IpAccessList object given its name. */
   private @Nullable IpAccessList getIpAccessList(@Nullable String name) {
     return _owner == null || name == null

--- a/projects/common/src/test/java/org/batfish/datamodel/InterfaceTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/InterfaceTest.java
@@ -202,6 +202,33 @@ public class InterfaceTest {
   }
 
   @Test
+  public void testReactivateForAutostate() {
+    Interface i = TestInterface.builder().setName("foo").setType(LOGICAL).build();
+    i.deactivate(InactiveReason.AUTOSTATE_FAILURE);
+    assertThat(i, allOf(isActive(false), hasInactiveReason(InactiveReason.AUTOSTATE_FAILURE)));
+
+    i.reactivateForAutostate();
+    assertThat(i, allOf(isActive(), hasInactiveReason(nullValue())));
+  }
+
+  @Test
+  public void testReactivateForAutostateAlreadyActive() {
+    Interface i = TestInterface.builder().setName("foo").setType(LOGICAL).build();
+    _thrown.expect(IllegalStateException.class);
+    _thrown.expectMessage("Cannot reactivate an active interface");
+    i.reactivateForAutostate();
+  }
+
+  @Test
+  public void testReactivateForAutostateWrongReason() {
+    Interface i = TestInterface.builder().setName("foo").setType(PHYSICAL).build();
+    i.deactivate(PARENT_DOWN);
+    _thrown.expect(IllegalStateException.class);
+    _thrown.expectMessage("AUTOSTATE_FAILURE");
+    i.reactivateForAutostate();
+  }
+
+  @Test
   public void testAdminDown() {
     // admin down
     Interface i = TestInterface.builder().setName("foo").setType(PHYSICAL).build();


### PR DESCRIPTION
Previously, VLAN interfaces (IRBs) with no physical switchport
members were permanently deactivated by autostate during
pre-dataplane post-processing. VXLAN tunnels are established later
during topology iteration, but there was no feedback path to
reactivate IRBs once remote VTEPs became reachable. NX-OS worked
around this by excluding VNI-backed VLANs from autostate entirely,
which was wrong when the underlay was down (the same issue fixed
for Juniper in #9898).

This change makes autostate VXLAN-aware during topology iteration.
When L2 VNI edges change, affected VLAN interfaces are re-evaluated:
- Gained edge + AUTOSTATE_FAILURE IRB → reactivate
- Lost edge + zero physical members → deactivate

Connected and local routes are recomputed via delta when interface
status changes, so newly-active IRBs contribute routes to the RIBs.

Also removes the NX-OS normalVlanRange exclusion workaround, which
is no longer needed.

Prompt:
```
Read https://github.com/batfish/lab-validation/issues/125 and
d255adc5c2f337783496161aa92834aa81dd38db
(batfish/batfish#9898). I think that code, also used in other
vendors, is a misguided attempt to work around the fact that we
don't dynamically bring IRBs up and down during
TopologyIteration based on the presence of VTEPs. Do your
analysis and see if you agree? If so, how should we fix?
```