### PR TITLE
Group async-profiler packages in bazel-steward config

### DIFF
--- a/.bazel-steward.yaml
+++ b/.bazel-steward.yaml
@@ -24,6 +24,8 @@ pull-requests:
     group-id: mockito
   - dependencies: "org.parboiled:*"
     group-id: parboiled
+  - dependencies: "tools.profiler:*"
+    group-id: async-profiler
   - limits:
       max-open: 5
 


### PR DESCRIPTION
----

Prompt:
```
Fix the bazel-steward config to consider all the async-profiler
packages as part of the same group. We do it for other things, like
jackson and jersey
```