### PR TITLE
BOMInputStream: migrate from deprecated constructor to builder API

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/StreamDecoder.java
+++ b/projects/batfish/src/main/java/org/batfish/main/StreamDecoder.java
@@ -31,14 +31,17 @@ final class StreamDecoder {
     }
   }
 
-  private static @Nonnull BOMInputStream bomInputStream(@Nonnull InputStream inputStream) {
-    return new BOMInputStream(
-        inputStream,
-        ByteOrderMark.UTF_8,
-        ByteOrderMark.UTF_16BE,
-        ByteOrderMark.UTF_16LE,
-        ByteOrderMark.UTF_32BE,
-        ByteOrderMark.UTF_32LE);
+  private static @Nonnull BOMInputStream bomInputStream(@Nonnull InputStream inputStream)
+      throws IOException {
+    return BOMInputStream.builder()
+        .setInputStream(inputStream)
+        .setByteOrderMarks(
+            ByteOrderMark.UTF_8,
+            ByteOrderMark.UTF_16BE,
+            ByteOrderMark.UTF_16LE,
+            ByteOrderMark.UTF_32BE,
+            ByteOrderMark.UTF_32LE)
+        .get();
   }
 
   private StreamDecoder() {}

--- a/tools/benchmarks/BenchmarkStreamDecoder.java
+++ b/tools/benchmarks/BenchmarkStreamDecoder.java
@@ -99,13 +99,15 @@ public class BenchmarkStreamDecoder {
     }
   }
 
-  private static BOMInputStream bomInputStream(InputStream inputStream) {
-    return new BOMInputStream(
-        inputStream,
-        ByteOrderMark.UTF_8,
-        ByteOrderMark.UTF_16BE,
-        ByteOrderMark.UTF_16LE,
-        ByteOrderMark.UTF_32BE,
-        ByteOrderMark.UTF_32LE);
+  private static BOMInputStream bomInputStream(InputStream inputStream) throws IOException {
+    return BOMInputStream.builder()
+        .setInputStream(inputStream)
+        .setByteOrderMarks(
+            ByteOrderMark.UTF_8,
+            ByteOrderMark.UTF_16BE,
+            ByteOrderMark.UTF_16LE,
+            ByteOrderMark.UTF_32BE,
+            ByteOrderMark.UTF_32LE)
+        .get();
   }
 }


### PR DESCRIPTION
The deprecated BOMInputStream varargs constructor now throws IOException
in commons-io 2.21.0, causing compilation failures. Use the builder API
(BOMInputStream.builder()) which is the recommended replacement.

----

Prompt:
```
https://github.com/batfish/batfish/actions/runs/24835593475/job/72731602753?pr=9899
fails to compile against new commons-io - because we are using a
deprecated method [...] and in the new version they added an exception
to it.
```