### PR TITLE
Arista: set origin type to incomplete for BGP aggregate routes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -9,6 +9,7 @@ import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.Common.DEFAULT_UNDERSCORE_REPLACEMENT;
 import static org.batfish.datamodel.routing_policy.Common.generateSuppressionPolicy;
 import static org.batfish.datamodel.routing_policy.communities.CommunitySetExprs.toMatchExpr;
+import static org.batfish.datamodel.routing_policy.statement.Statements.ExitAccept;
 import static org.batfish.datamodel.routing_policy.statement.Statements.RemovePrivateAs;
 import static org.batfish.vendor.arista.representation.AristaConfiguration.DEFAULT_VRF_NAME;
 import static org.batfish.vendor.arista.representation.AristaConfiguration.MAX_ADMINISTRATIVE_COST;
@@ -47,6 +48,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
+import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.Vrf;
@@ -79,6 +81,7 @@ import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
+import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType;
 import org.batfish.datamodel.routing_policy.expr.MatchBgpSessionType.Type;
 import org.batfish.datamodel.routing_policy.expr.MatchLocalPreference;
@@ -92,6 +95,7 @@ import org.batfish.datamodel.routing_policy.expr.UnchangedNextHop;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
 import org.batfish.datamodel.routing_policy.statement.SetNextHop;
+import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.vendor.arista.representation.eos.AristaBgpAggregateNetwork;
@@ -219,6 +223,33 @@ final class AristaConversions {
     return true;
   }
 
+  private static @Nonnull String generatedAggregateAttributePolicyName(
+      @Nullable String attributeMap) {
+    return String.format("~BGP_AGGREGATE_ATTRIBUTE_MAP:%s~", attributeMap);
+  }
+
+  /**
+   * Generates a routing policy for Arista BGP aggregate routes that sets vendor-specific defaults
+   * (origin type incomplete) and optionally wraps a user-provided attribute-map.
+   */
+  static @Nonnull String generateAggregateAttributePolicy(
+      @Nullable String attributeMap, Configuration c) {
+    String name = generatedAggregateAttributePolicyName(attributeMap);
+    if (c.getRoutingPolicies().containsKey(name)) {
+      return name;
+    }
+    RoutingPolicy.Builder p = RoutingPolicy.builder().setName(name).setOwner(c);
+    // Arista EOS uses origin type incomplete for aggregate routes.
+    p.addStatement(new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, null)));
+    if (attributeMap != null) {
+      p.addStatement(new If(new CallExpr(attributeMap), ImmutableList.of()));
+    }
+    p.addStatement(ExitAccept.toStaticStatement());
+    RoutingPolicy rp = p.build();
+    c.getRoutingPolicies().put(rp.getName(), rp);
+    return name;
+  }
+
   static @Nonnull BgpAggregate toBgpAggregate(
       Prefix prefix, AristaBgpAggregateNetwork vsAggregate, Configuration c, Warnings w) {
     // TODO: handle advertise-only
@@ -230,12 +261,13 @@ final class AristaConversions {
       w.redFlagf("Ignoring undefined aggregate-address attribute-map %s", attributeMap);
       attributeMap = null;
     }
+    String attributePolicy = generateAggregateAttributePolicy(attributeMap, c);
     return BgpAggregate.of(
         prefix,
         generateSuppressionPolicy(vsAggregate.getSummaryOnlyEffective(), c),
         // TODO: put match-map here
         null,
-        attributeMap);
+        attributePolicy);
   }
 
   static @Nonnull Map<Ip, BgpActivePeerConfig> getNeighbors(

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -1391,18 +1391,22 @@ public class AristaGrammarTest {
                 Prefix.parse("1.2.33.0/24"),
                 SUMMARY_ONLY_SUPPRESSION_POLICY_NAME,
                 null,
-                "ATTR_MAP")));
+                "~BGP_AGGREGATE_ATTRIBUTE_MAP:ATTR_MAP~")));
     assertThat(
         defaultVrfAggs,
         hasEntry(
             Prefix.parse("1.2.44.0/24"),
             BgpAggregate.of(
-                Prefix.parse("1.2.44.0/24"), SUMMARY_ONLY_SUPPRESSION_POLICY_NAME, null, null)));
+                Prefix.parse("1.2.44.0/24"),
+                SUMMARY_ONLY_SUPPRESSION_POLICY_NAME,
+                null,
+                "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~")));
     assertThat(
         defaultVrfAggs,
         hasEntry(
             Prefix.parse("1.2.55.0/24"),
-            BgpAggregate.of(Prefix.parse("1.2.55.0/24"), null, null, null)));
+            BgpAggregate.of(
+                Prefix.parse("1.2.55.0/24"), null, null, "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~")));
 
     // vrf FOO
     Map<Prefix, BgpAggregate> vrfFooAggs = c.getVrfs().get("FOO").getBgpProcess().getAggregates();
@@ -1412,7 +1416,8 @@ public class AristaGrammarTest {
         hasEntry(
             Prefix.parse("5.6.7.0/24"),
             // TODO Support as-set
-            BgpAggregate.of(Prefix.parse("5.6.7.0/24"), null, null, null)));
+            BgpAggregate.of(
+                Prefix.parse("5.6.7.0/24"), null, null, "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~")));
   }
 
   @Test
@@ -1530,7 +1535,7 @@ public class AristaGrammarTest {
             .setNextHop(NextHopDiscard.instance())
             .setOriginatorIp(routerId)
             .setOriginMechanism(OriginMechanism.GENERATED)
-            .setOriginType(OriginType.IGP)
+            .setOriginType(OriginType.INCOMPLETE)
             .setProtocol(RoutingProtocol.AGGREGATE)
             .setReceivedFrom(ReceivedFromSelf.instance()) // indicates local origination
             .setSrcProtocol(RoutingProtocol.AGGREGATE)
@@ -1605,7 +1610,7 @@ public class AristaGrammarTest {
               .setNextHop(NextHopDiscard.instance())
               .setOriginatorIp(Ip.parse("2.2.2.2"))
               .setOriginMechanism(OriginMechanism.GENERATED)
-              .setOriginType(OriginType.IGP)
+              .setOriginType(OriginType.INCOMPLETE)
               .setProtocol(RoutingProtocol.AGGREGATE)
               .setReceivedFrom(ReceivedFromSelf.instance()) // indicates local origination
               .setSrcProtocol(RoutingProtocol.AGGREGATE)


### PR DESCRIPTION
Arista EOS reports origin type incomplete (?) for aggregate-address
routes, but Batfish was using the global default of IGP. Generate a
vendor-specific attribute policy that sets OriginType.INCOMPLETE,
following the same pattern NXOS uses for its vendor-specific aggregate
defaults.

Fixes https://github.com/batfish/lab-validation/issues/141

----

Prompt:
```
Can we try to fix https://github.com/batfish/lab-validation/issues/141
in batfish/, then re-run lab-validation to confirm it worked?
```