### PR TITLE
Arista: consolidate concrete BGP neighbors into a shared base class

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -2890,6 +2890,13 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   }
 
   /**
+   * Upper bound on the size of a single {@code neighbor interface} range entry. A typical Arista
+   * chassis has far fewer physical interfaces than this; any range that exceeds it is almost
+   * certainly a typo or misuse of the syntax.
+   */
+  private static final int BGP_IFACE_RANGE_MAX = 1000;
+
+  /**
    * Expands a {@code neighbor interface} range to canonical interface names. The prefix (e.g.
    * {@code Et}) appears once; each comma-separated entry is a bare numeric path with optional
    * trailing dash-range ({@code Et1/1,2/1,3-4} = Ethernet1/1, Ethernet2/1, Ethernet3, Ethernet4).
@@ -2903,16 +2910,16 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
       warn(ctx, "Unrecognized interface name: " + e.getMessage());
       return ImmutableList.of();
     }
-    final int maxRange = 1000;
     List<String> ifaceNames = new ArrayList<>();
     for (Eos_bgp_iface_tailContext entry : range.entries) {
       String base = canonicalPrefix + entry.path.getText();
       SubRange sr = toSubRange(entry.sr);
-      if (sr.getEnd() - sr.getStart() > maxRange) {
+      if (sr.getEnd() - sr.getStart() > BGP_IFACE_RANGE_MAX) {
         warn(
             ctx,
             String.format(
-                "Interface range %s%s exceeds %d entries; ignoring.", base, sr, maxRange));
+                "Interface range %s%s exceeds %d entries; skipping this range.",
+                base, sr, BGP_IFACE_RANGE_MAX));
         continue;
       }
       sr.asStream().forEach(i -> ifaceNames.add(base + i));

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -100,8 +100,8 @@ import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.vendor.arista.representation.eos.AristaBgpAggregateNetwork;
+import org.batfish.vendor.arista.representation.eos.AristaBgpConcreteNeighbor;
 import org.batfish.vendor.arista.representation.eos.AristaBgpDefaultOriginate;
-import org.batfish.vendor.arista.representation.eos.AristaBgpHasPeerGroup;
 import org.batfish.vendor.arista.representation.eos.AristaBgpInterfaceNeighbor;
 import org.batfish.vendor.arista.representation.eos.AristaBgpNeighbor;
 import org.batfish.vendor.arista.representation.eos.AristaBgpNeighbor.RemovePrivateAsMode;
@@ -171,87 +171,6 @@ final class AristaConversions {
     return highestIp.get();
   }
 
-  /**
-   * Checks that the neighbor is not shutdown and at least one of the address families is activated
-   */
-  private static boolean isActive(
-      String name, AristaBgpVrf vrf, AristaBgpV4Neighbor neighbor, Warnings w) {
-    if (firstNonNull(neighbor.getShutdown(), Boolean.FALSE)) {
-      return false;
-    }
-
-    // No active address family that we support.
-    boolean v4 =
-        Optional.ofNullable(vrf.getV4UnicastAf())
-            .map(af -> af.getNeighbor(neighbor.getIp()))
-            .map(AristaBgpNeighborAddressFamily::getActivate)
-            .orElse(Boolean.FALSE);
-    boolean evpn =
-        Optional.ofNullable(vrf.getEvpnAf())
-            .map(af -> af.getNeighbor(neighbor.getIp()))
-            .map(AristaBgpNeighborAddressFamily::getActivate)
-            .orElse(Boolean.FALSE);
-    if (!v4 && !evpn) {
-      w.redFlag("No supported address-family configured for " + name);
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Checks that the neighbor is not shutdown and at least one of the address families is activated
-   */
-  private static boolean isActive(
-      String name, AristaBgpVrf vrf, AristaBgpV4DynamicNeighbor neighbor, Warnings w) {
-    if (firstNonNull(neighbor.getShutdown(), Boolean.FALSE)) {
-      return false;
-    }
-
-    // No active address family that we support.
-    boolean v4 =
-        Optional.ofNullable(vrf.getV4UnicastAf())
-            .map(af -> af.getNeighbor(neighbor.getRange()))
-            .map(AristaBgpNeighborAddressFamily::getActivate)
-            .orElse(Boolean.FALSE);
-    boolean evpn =
-        Optional.ofNullable(vrf.getEvpnAf())
-            .map(af -> af.getNeighbor(neighbor.getRange()))
-            .map(AristaBgpNeighborAddressFamily::getActivate)
-            .orElse(Boolean.FALSE);
-    if (!v4 && !evpn) {
-      w.redFlag("No supported address-family configured for " + name);
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Checks that the neighbor is not shutdown and at least one of the address families is activated
-   */
-  private static boolean isActive(
-      String name, AristaBgpVrf vrf, AristaBgpInterfaceNeighbor neighbor, Warnings w) {
-    if (firstNonNull(neighbor.getShutdown(), Boolean.FALSE)) {
-      return false;
-    }
-
-    // No active address family that we support.
-    boolean v4 =
-        Optional.ofNullable(vrf.getV4UnicastAf())
-            .map(af -> af.getInterfaceNeighbor(neighbor.getInterfaceName()))
-            .map(AristaBgpNeighborAddressFamily::getActivate)
-            .orElse(Boolean.FALSE);
-    boolean evpn =
-        Optional.ofNullable(vrf.getEvpnAf())
-            .map(af -> af.getInterfaceNeighbor(neighbor.getInterfaceName()))
-            .map(AristaBgpNeighborAddressFamily::getActivate)
-            .orElse(Boolean.FALSE);
-    if (!v4 && !evpn) {
-      w.redFlag("No supported address-family configured for " + name);
-      return false;
-    }
-    return true;
-  }
-
   private static @Nonnull String generatedAggregateAttributePolicyName(
       @Nullable String attributeMap) {
     return String.format("~BGP_AGGREGATE_ATTRIBUTE_MAP:%s~", attributeMap);
@@ -308,10 +227,9 @@ final class AristaConversions {
       @Nullable AristaEosVxlan vxlan,
       @Nullable Ip vxlanSourceInterfaceIp,
       Warnings warnings) {
-
+    bgpVrf.getV4neighbors().values().forEach(n -> n.inherit(bgpConfig, bgpVrf, warnings));
     return bgpVrf.getV4neighbors().entrySet().stream()
-        .peek(e -> e.getValue().inherit(bgpConfig, bgpVrf, warnings))
-        .filter(e -> isActive(getTextDesc(e.getKey(), vrf), bgpVrf, e.getValue(), warnings))
+        .filter(e -> e.getValue().isActive(vrf, bgpVrf, warnings))
         .collect(
             ImmutableMap.toImmutableMap(
                 Entry::getKey,
@@ -345,10 +263,10 @@ final class AristaConversions {
       @Nullable Ip vxlanSourceInterfaceIp,
       Map<String, AristaBgpPeerFilter> peerFilters,
       Warnings warnings) {
+    bgpVrf.getInterfaceNeighbors().values().forEach(n -> n.inherit(bgpConfig, bgpVrf, warnings));
     return bgpVrf.getInterfaceNeighbors().entrySet().stream()
-        .peek(e -> e.getValue().inherit(bgpConfig, bgpVrf, warnings))
         .filter(e -> interfaceExists(c, e.getKey(), warnings))
-        .filter(e -> isActive(getTextDesc(e.getKey(), vrf), bgpVrf, e.getValue(), warnings))
+        .filter(e -> e.getValue().isActive(vrf, bgpVrf, warnings))
         .collect(
             ImmutableMap.toImmutableMap(
                 Entry::getKey,
@@ -387,9 +305,9 @@ final class AristaConversions {
       @Nullable Ip vxlanSourceInterfaceIp,
       Map<String, AristaBgpPeerFilter> peerFilters,
       Warnings warnings) {
+    bgpVrf.getV4DynamicNeighbors().values().forEach(n -> n.inherit(bgpConfig, bgpVrf, warnings));
     return bgpVrf.getV4DynamicNeighbors().entrySet().stream()
-        .peek(e -> e.getValue().inherit(bgpConfig, bgpVrf, warnings))
-        .filter(e -> isActive(getTextDesc(e.getKey(), vrf), bgpVrf, e.getValue(), warnings))
+        .filter(e -> e.getValue().isActive(vrf, bgpVrf, warnings))
         .collect(
             ImmutableMap.toImmutableMap(
                 Entry::getKey,
@@ -487,22 +405,20 @@ final class AristaConversions {
       @Nullable Prefix prefix,
       AristaBgpProcess bgpConfig,
       AristaBgpVrf vrfConfig,
-      AristaBgpNeighbor neighbor,
+      AristaBgpConcreteNeighbor neighbor,
       boolean dynamic,
       @Nullable AristaEosVxlan vxlan,
       @Nullable Ip vxlanSourceInterfaceIp,
       Map<String, AristaBgpPeerFilter> peerFilters,
       Warnings warnings) {
-    // We should be converting only concrete (active, dynamic, or interface) neighbors
-    assert neighbor instanceof AristaBgpHasPeerGroup;
+    String peerStrRepr = neighbor.getPeerString();
 
     BgpPeerConfig.Builder<?, ?> newNeighborBuilder;
     if (neighbor instanceof AristaBgpInterfaceNeighbor) {
       AristaBgpInterfaceNeighbor unnumbered = (AristaBgpInterfaceNeighbor) neighbor;
       LongSpace remoteAsns = getAsnSpace(unnumbered, peerFilters);
       if (remoteAsns.isEmpty()) {
-        warnings.redFlagf(
-            "No acceptable remote-as for %s", getTextDesc(unnumbered.getInterfaceName(), vrf));
+        warnings.redFlagf("No acceptable remote-as for %s", neighbor.getTextDesc(vrf));
       }
       newNeighborBuilder =
           BgpUnnumberedPeerConfig.builder()
@@ -512,9 +428,7 @@ final class AristaConversions {
       assert neighbor instanceof AristaBgpV4DynamicNeighbor;
       LongSpace remoteAsns = getAsnSpace((AristaBgpV4DynamicNeighbor) neighbor, peerFilters);
       if (remoteAsns.isEmpty()) {
-        warnings.redFlagf(
-            "No acceptable remote-as for %s",
-            getTextDesc(((AristaBgpV4DynamicNeighbor) neighbor).getRange(), vrf));
+        warnings.redFlagf("No acceptable remote-as for %s", neighbor.getTextDesc(vrf));
       }
       newNeighborBuilder =
           BgpPassivePeerConfig.builder().setRemoteAsns(remoteAsns).setPeerPrefix(prefix);
@@ -524,9 +438,7 @@ final class AristaConversions {
       LongSpace remoteAsns =
           Optional.ofNullable(neighbor.getRemoteAs()).map(LongSpace::of).orElse(LongSpace.EMPTY);
       if (remoteAsns.isEmpty()) {
-        warnings.redFlagf(
-            "No remote-as configured for %s",
-            getTextDesc(((AristaBgpV4Neighbor) neighbor).getIp(), vrf));
+        warnings.redFlagf("No remote-as configured for %s", neighbor.getTextDesc(vrf));
       }
       newNeighborBuilder =
           BgpActivePeerConfig.builder()
@@ -546,8 +458,8 @@ final class AristaConversions {
             neighbor.getEnforceFirstAs(),
             firstNonNull(vrfConfig.getEnforceFirstAs(), Boolean.TRUE)));
 
-    if (((AristaBgpHasPeerGroup) neighbor).getPeerGroup() != null) {
-      newNeighborBuilder.setGroup(((AristaBgpHasPeerGroup) neighbor).getPeerGroup());
+    if (neighbor.getPeerGroup() != null) {
+      newNeighborBuilder.setGroup(neighbor.getPeerGroup());
     }
 
     if (neighbor.getLocalAs() != null) {
@@ -572,31 +484,10 @@ final class AristaConversions {
     }
 
     @Nullable AristaBgpVrfIpv4UnicastAddressFamily af4 = vrfConfig.getV4UnicastAf();
-    @Nullable AristaBgpNeighborAddressFamily naf4;
-    if (neighbor instanceof AristaBgpV4Neighbor) {
-      naf4 = af4 == null ? null : af4.getNeighbor(((AristaBgpV4Neighbor) neighbor).getIp());
-    } else if (neighbor instanceof AristaBgpV4DynamicNeighbor) {
-      naf4 =
-          af4 == null ? null : af4.getNeighbor(((AristaBgpV4DynamicNeighbor) neighbor).getRange());
-    } else {
-      assert neighbor instanceof AristaBgpInterfaceNeighbor;
-      naf4 =
-          af4 == null
-              ? null
-              : af4.getInterfaceNeighbor(
-                  ((AristaBgpInterfaceNeighbor) neighbor).getInterfaceName());
-    }
+    @Nullable
+    AristaBgpNeighborAddressFamily naf4 = af4 == null ? null : neighbor.getAfSettings(af4);
     Ipv4UnicastAddressFamily.Builder ipv4FamilyBuilder = Ipv4UnicastAddressFamily.builder();
     boolean v4Enabled = naf4 != null && firstNonNull(naf4.getActivate(), Boolean.FALSE);
-
-    String peerStrRepr;
-    if (neighbor instanceof AristaBgpInterfaceNeighbor) {
-      peerStrRepr = ((AristaBgpInterfaceNeighbor) neighbor).getInterfaceName();
-    } else if (dynamic) {
-      peerStrRepr = prefix.toString();
-    } else {
-      peerStrRepr = prefix.getStartIp().toString();
-    }
     if (v4Enabled) {
       ipv4FamilyBuilder.setAddressFamilyCapabilities(
           AddressFamilyCapabilities.builder()
@@ -764,22 +655,8 @@ final class AristaConversions {
     }
 
     @Nullable AristaBgpVrfEvpnAddressFamily evpnAf = vrfConfig.getEvpnAf();
-    @Nullable AristaBgpNeighborAddressFamily nEvpn;
-    if (neighbor instanceof AristaBgpV4Neighbor) {
-      nEvpn = evpnAf == null ? null : evpnAf.getNeighbor(((AristaBgpV4Neighbor) neighbor).getIp());
-    } else if (neighbor instanceof AristaBgpV4DynamicNeighbor) {
-      nEvpn =
-          evpnAf == null
-              ? null
-              : evpnAf.getNeighbor(((AristaBgpV4DynamicNeighbor) neighbor).getRange());
-    } else {
-      assert neighbor instanceof AristaBgpInterfaceNeighbor;
-      nEvpn =
-          evpnAf == null
-              ? null
-              : evpnAf.getInterfaceNeighbor(
-                  ((AristaBgpInterfaceNeighbor) neighbor).getInterfaceName());
-    }
+    @Nullable
+    AristaBgpNeighborAddressFamily nEvpn = evpnAf == null ? null : neighbor.getAfSettings(evpnAf);
     boolean evpnEnabled = nEvpn != null && firstNonNull(nEvpn.getActivate(), Boolean.FALSE);
     if (evpnEnabled) {
       EvpnAddressFamily.Builder evpnFamilyBuilder = EvpnAddressFamily.builder();
@@ -930,18 +807,6 @@ final class AristaConversions {
     return c.getVrfs().values().stream()
         .filter(vrf -> c.getAllInterfaces(vrf.getName()).containsKey(String.format("Vlan%d", vlan)))
         .findFirst();
-  }
-
-  private static String getTextDesc(Ip ip, Vrf v) {
-    return String.format("BGP neighbor %s in vrf %s", ip.toString(), v.getName());
-  }
-
-  private static String getTextDesc(String interfaceName, Vrf v) {
-    return String.format("BGP neighbor interface %s in vrf %s", interfaceName, v.getName());
-  }
-
-  private static String getTextDesc(Prefix prefix, Vrf v) {
-    return String.format("BGP neighbor %s in vrf %s", prefix.toString(), v.getName());
   }
 
   static @Nonnull CommunitySetMatchExpr toCommunitySetMatchExpr(

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpConcreteNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpConcreteNeighbor.java
@@ -1,0 +1,100 @@
+package org.batfish.vendor.arista.representation.eos;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Vrf;
+
+/**
+ * Base class for concrete (non-peer-group) Arista BGP neighbors, keyed by IP, prefix, or interface.
+ *
+ * <p>Subclasses supply the per-address-family settings lookup keyed by their specific identifier;
+ * this class provides the common peer-group/address-family inheritance and activity checks.
+ */
+public abstract class AristaBgpConcreteNeighbor extends AristaBgpNeighbor
+    implements AristaBgpHasPeerGroup {
+  private @Nullable String _peerGroup;
+
+  @Override
+  public @Nullable String getPeerGroup() {
+    return _peerGroup;
+  }
+
+  @Override
+  public void setPeerGroup(@Nullable String peerGroup) {
+    _peerGroup = peerGroup;
+  }
+
+  /** String representation of this peer, used to name generated policies and in warnings. */
+  public abstract @Nonnull String getPeerString();
+
+  /** Human-readable description for warnings, e.g., {@code "BGP neighbor 1.2.3.4 in vrf V"}. */
+  public @Nonnull String getTextDesc(Vrf v) {
+    return String.format("BGP neighbor %s in vrf %s", getPeerString(), v.getName());
+  }
+
+  /** Returns this peer's per-AF settings, or {@code null} if none are configured. */
+  public abstract @Nullable AristaBgpNeighborAddressFamily getAfSettings(
+      AristaBgpVrfAddressFamily af);
+
+  /** Returns or creates this peer's per-AF settings. */
+  protected abstract @Nonnull AristaBgpNeighborAddressFamily getOrCreateAfSettings(
+      AristaBgpVrfAddressFamily af);
+
+  @Override
+  public void inherit(AristaBgpProcess bgpGlobal, AristaBgpVrf bgpVrf, Warnings w) {
+    Optional<String> pgName = Optional.ofNullable(_peerGroup);
+    Optional<AristaBgpPeerGroupNeighbor> pgn = pgName.map(bgpGlobal::getPeerGroup);
+    // Inherit the overall (non-address-family) specific settings.
+    pgn.ifPresent(this::inheritFrom);
+
+    // Inherit for each address family separately.
+    AristaBgpVrfIpv4UnicastAddressFamily v4 = bgpVrf.getV4UnicastAf();
+    if (v4 != null) {
+      AristaBgpNeighborAddressFamily neighbor = getOrCreateAfSettings(v4);
+      neighbor.inheritFrom(getGenericAddressFamily());
+      pgName.map(v4::getPeerGroup).ifPresent(neighbor::inheritFrom);
+      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
+      // If not yet set, activate based on the vrf setting for v4 unicast.
+      if (neighbor.getActivate() == null) {
+        neighbor.setActivate(bgpVrf.getDefaultIpv4Unicast());
+      }
+    }
+
+    AristaBgpVrfEvpnAddressFamily evpn = bgpVrf.getEvpnAf();
+    if (evpn != null) {
+      AristaBgpNeighborAddressFamily neighbor = getOrCreateAfSettings(evpn);
+      neighbor.inheritFrom(getGenericAddressFamily());
+      pgName.map(evpn::getPeerGroup).ifPresent(neighbor::inheritFrom);
+      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
+    }
+  }
+
+  /**
+   * Checks that this neighbor is not shutdown and at least one supported address family is
+   * activated. Emits a red-flag warning if no supported AF is active.
+   */
+  public boolean isActive(Vrf vrf, AristaBgpVrf bgpVrf, Warnings w) {
+    if (firstNonNull(getShutdown(), Boolean.FALSE)) {
+      return false;
+    }
+    boolean v4 =
+        Optional.ofNullable(bgpVrf.getV4UnicastAf())
+            .map(this::getAfSettings)
+            .map(AristaBgpNeighborAddressFamily::getActivate)
+            .orElse(Boolean.FALSE);
+    boolean evpn =
+        Optional.ofNullable(bgpVrf.getEvpnAf())
+            .map(this::getAfSettings)
+            .map(AristaBgpNeighborAddressFamily::getActivate)
+            .orElse(Boolean.FALSE);
+    if (!v4 && !evpn) {
+      w.redFlag("No supported address-family configured for " + getTextDesc(vrf));
+      return false;
+    }
+    return true;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpInterfaceNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpInterfaceNeighbor.java
@@ -1,15 +1,13 @@
 package org.batfish.vendor.arista.representation.eos;
 
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.Warnings;
+import org.batfish.datamodel.Vrf;
 
 /** Config for BGP unnumbered neighbors (created using "neighbor interface ... peer-group") */
-public class AristaBgpInterfaceNeighbor extends AristaBgpNeighbor implements AristaBgpHasPeerGroup {
+public class AristaBgpInterfaceNeighbor extends AristaBgpConcreteNeighbor {
   private final @Nonnull String _interfaceName;
   private @Nullable String _peerFilter;
-  private @Nullable String _peerGroup;
 
   public AristaBgpInterfaceNeighbor(@Nonnull String interfaceName) {
     _interfaceName = interfaceName;
@@ -29,46 +27,23 @@ public class AristaBgpInterfaceNeighbor extends AristaBgpNeighbor implements Ari
   }
 
   @Override
-  public @Nullable String getPeerGroup() {
-    return _peerGroup;
+  public @Nonnull String getPeerString() {
+    return _interfaceName;
   }
 
   @Override
-  public void setPeerGroup(@Nullable String peerGroup) {
-    _peerGroup = peerGroup;
+  public @Nonnull String getTextDesc(Vrf v) {
+    return String.format("BGP neighbor interface %s in vrf %s", _interfaceName, v.getName());
   }
 
   @Override
-  public void inherit(AristaBgpProcess bgpGlobal, AristaBgpVrf bgpVrf, Warnings w) {
-    Optional<String> pgName = Optional.ofNullable(_peerGroup);
-    Optional<AristaBgpPeerGroupNeighbor> pgn = pgName.map(bgpGlobal::getPeerGroup);
-    // Inherit the overall (non-address-family) specific settings.
-    pgn.ifPresent(this::inheritFrom);
+  public @Nullable AristaBgpNeighborAddressFamily getAfSettings(AristaBgpVrfAddressFamily af) {
+    return af.getInterfaceNeighbor(_interfaceName);
+  }
 
-    /////////////////////////////////////////////////////
-    //// Inherit for each address family separately. ////
-    /////////////////////////////////////////////////////
-
-    // V4
-    AristaBgpVrfIpv4UnicastAddressFamily v4 = bgpVrf.getV4UnicastAf();
-    if (v4 != null) {
-      AristaBgpNeighborAddressFamily neighbor = v4.getOrCreateInterfaceNeighbor(_interfaceName);
-      neighbor.inheritFrom(getGenericAddressFamily());
-      pgName.map(v4::getPeerGroup).ifPresent(neighbor::inheritFrom);
-      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
-      // If not yet set, activate based on the vrf setting for v4 unicast.
-      if (neighbor.getActivate() == null) {
-        neighbor.setActivate(bgpVrf.getDefaultIpv4Unicast());
-      }
-    }
-
-    // EVPN
-    AristaBgpVrfEvpnAddressFamily evpn = bgpVrf.getEvpnAf();
-    if (evpn != null) {
-      AristaBgpNeighborAddressFamily neighbor = evpn.getOrCreateInterfaceNeighbor(_interfaceName);
-      neighbor.inheritFrom(getGenericAddressFamily());
-      pgName.map(evpn::getPeerGroup).ifPresent(neighbor::inheritFrom);
-      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
-    }
+  @Override
+  protected @Nonnull AristaBgpNeighborAddressFamily getOrCreateAfSettings(
+      AristaBgpVrfAddressFamily af) {
+    return af.getOrCreateInterfaceNeighbor(_interfaceName);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpV4DynamicNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpV4DynamicNeighbor.java
@@ -1,16 +1,13 @@
 package org.batfish.vendor.arista.representation.eos;
 
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.Warnings;
 import org.batfish.datamodel.Prefix;
 
 /** Config for dynamic BGP neighbors (created using "bgp listen range") */
-public class AristaBgpV4DynamicNeighbor extends AristaBgpNeighbor implements AristaBgpHasPeerGroup {
+public class AristaBgpV4DynamicNeighbor extends AristaBgpConcreteNeighbor {
   private final @Nonnull Prefix _range;
   private @Nullable String _peerFilter;
-  private @Nullable String _peerGroup;
 
   public AristaBgpV4DynamicNeighbor(@Nonnull Prefix range) {
     _range = range;
@@ -30,46 +27,18 @@ public class AristaBgpV4DynamicNeighbor extends AristaBgpNeighbor implements Ari
   }
 
   @Override
-  public @Nullable String getPeerGroup() {
-    return _peerGroup;
+  public @Nonnull String getPeerString() {
+    return _range.toString();
   }
 
   @Override
-  public void setPeerGroup(@Nullable String peerGroup) {
-    _peerGroup = peerGroup;
+  public @Nullable AristaBgpNeighborAddressFamily getAfSettings(AristaBgpVrfAddressFamily af) {
+    return af.getNeighbor(_range);
   }
 
   @Override
-  public void inherit(AristaBgpProcess bgpGlobal, AristaBgpVrf bgpVrf, Warnings w) {
-    Optional<String> pgName = Optional.ofNullable(_peerGroup);
-    Optional<AristaBgpPeerGroupNeighbor> pgn = pgName.map(bgpGlobal::getPeerGroup);
-    // Inherit the overall (non-address-family) specific settings.
-    pgn.ifPresent(this::inheritFrom);
-
-    /////////////////////////////////////////////////////
-    //// Inherit for each address family separately. ////
-    /////////////////////////////////////////////////////
-
-    // V4
-    AristaBgpVrfIpv4UnicastAddressFamily v4 = bgpVrf.getV4UnicastAf();
-    if (v4 != null) {
-      AristaBgpNeighborAddressFamily neighbor = v4.getOrCreateNeighbor(_range);
-      neighbor.inheritFrom(getGenericAddressFamily());
-      pgName.map(v4::getPeerGroup).ifPresent(neighbor::inheritFrom);
-      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
-      // If not yet set, activate based on the vrf setting for v4 unicast.
-      if (neighbor.getActivate() == null) {
-        neighbor.setActivate(bgpVrf.getDefaultIpv4Unicast());
-      }
-    }
-
-    // EVPN
-    AristaBgpVrfEvpnAddressFamily evpn = bgpVrf.getEvpnAf();
-    if (evpn != null) {
-      AristaBgpNeighborAddressFamily neighbor = evpn.getOrCreateNeighbor(_range);
-      neighbor.inheritFrom(getGenericAddressFamily());
-      pgName.map(evpn::getPeerGroup).ifPresent(neighbor::inheritFrom);
-      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
-    }
+  protected @Nonnull AristaBgpNeighborAddressFamily getOrCreateAfSettings(
+      AristaBgpVrfAddressFamily af) {
+    return af.getOrCreateNeighbor(_range);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpV4Neighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpV4Neighbor.java
@@ -1,15 +1,12 @@
 package org.batfish.vendor.arista.representation.eos;
 
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.Warnings;
 import org.batfish.datamodel.Ip;
 
 /** IPv4 BGP neighbor */
-public final class AristaBgpV4Neighbor extends AristaBgpNeighbor implements AristaBgpHasPeerGroup {
+public final class AristaBgpV4Neighbor extends AristaBgpConcreteNeighbor {
   private final @Nonnull Ip _ip;
-  private @Nullable String _peerGroup;
 
   public AristaBgpV4Neighbor(@Nonnull Ip ip) {
     _ip = ip;
@@ -20,46 +17,18 @@ public final class AristaBgpV4Neighbor extends AristaBgpNeighbor implements Aris
   }
 
   @Override
-  public @Nullable String getPeerGroup() {
-    return _peerGroup;
+  public @Nonnull String getPeerString() {
+    return _ip.toString();
   }
 
   @Override
-  public void setPeerGroup(@Nullable String peerGroup) {
-    _peerGroup = peerGroup;
+  public @Nullable AristaBgpNeighborAddressFamily getAfSettings(AristaBgpVrfAddressFamily af) {
+    return af.getNeighbor(_ip);
   }
 
   @Override
-  public void inherit(AristaBgpProcess bgpGlobal, AristaBgpVrf bgpVrf, Warnings w) {
-    Optional<String> pgName = Optional.ofNullable(_peerGroup);
-    Optional<AristaBgpPeerGroupNeighbor> pgn = pgName.map(bgpGlobal::getPeerGroup);
-    // Inherit the overall (non-address-family) specific settings.
-    pgn.ifPresent(this::inheritFrom);
-
-    /////////////////////////////////////////////////////
-    //// Inherit for each address family separately. ////
-    /////////////////////////////////////////////////////
-
-    // V4
-    AristaBgpVrfIpv4UnicastAddressFamily v4 = bgpVrf.getV4UnicastAf();
-    if (v4 != null) {
-      AristaBgpNeighborAddressFamily neighbor = v4.getOrCreateNeighbor(_ip);
-      neighbor.inheritFrom(getGenericAddressFamily());
-      pgName.map(v4::getPeerGroup).ifPresent(neighbor::inheritFrom);
-      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
-      // If not yet set, activate based on the vrf setting for v4 unicast.
-      if (neighbor.getActivate() == null) {
-        neighbor.setActivate(bgpVrf.getDefaultIpv4Unicast());
-      }
-    }
-
-    // EVPN
-    AristaBgpVrfEvpnAddressFamily evpn = bgpVrf.getEvpnAf();
-    if (evpn != null) {
-      AristaBgpNeighborAddressFamily neighbor = evpn.getOrCreateNeighbor(_ip);
-      neighbor.inheritFrom(getGenericAddressFamily());
-      pgName.map(evpn::getPeerGroup).ifPresent(neighbor::inheritFrom);
-      pgn.map(AristaBgpPeerGroupNeighbor::getGenericAddressFamily).ifPresent(neighbor::inheritFrom);
-    }
+  protected @Nonnull AristaBgpNeighborAddressFamily getOrCreateAfSettings(
+      AristaBgpVrfAddressFamily af) {
+    return af.getOrCreateNeighbor(_ip);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpV6Neighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpV6Neighbor.java
@@ -1,15 +1,12 @@
 package org.batfish.vendor.arista.representation.eos;
 
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.common.Warnings;
 import org.batfish.datamodel.Ip6;
 
-/** IPv4 BGP neighbor */
-public final class AristaBgpV6Neighbor extends AristaBgpNeighbor implements AristaBgpHasPeerGroup {
+/** IPv6 BGP neighbor. Not yet converted to the vendor-independent model. */
+public final class AristaBgpV6Neighbor extends AristaBgpConcreteNeighbor {
   private final @Nonnull Ip6 _ip;
-  private @Nullable String _peerGroup;
 
   public AristaBgpV6Neighbor(@Nonnull Ip6 ip) {
     _ip = ip;
@@ -20,26 +17,20 @@ public final class AristaBgpV6Neighbor extends AristaBgpNeighbor implements Aris
   }
 
   @Override
-  public @Nullable String getPeerGroup() {
-    return _peerGroup;
+  public @Nonnull String getPeerString() {
+    return _ip.toString();
+  }
+
+  // TODO: wire up IPv6 address-family settings. For now, return null/a throwaway AF so the
+  // shared inherit() logic is a no-op for V6 neighbors.
+  @Override
+  public @Nullable AristaBgpNeighborAddressFamily getAfSettings(AristaBgpVrfAddressFamily af) {
+    return null;
   }
 
   @Override
-  public void setPeerGroup(@Nullable String peerGroup) {
-    _peerGroup = peerGroup;
-  }
-
-  @Override
-  public void inherit(AristaBgpProcess bgpGlobal, AristaBgpVrf bgpVrf, Warnings w) {
-    Optional<String> pgName = Optional.ofNullable(_peerGroup);
-    Optional<AristaBgpPeerGroupNeighbor> pgn = pgName.map(bgpGlobal::getPeerGroup);
-    // Inherit the overall (non-address-family) specific settings.
-    pgn.ifPresent(this::inheritFrom);
-
-    /////////////////////////////////////////////////////
-    //// Inherit for each address family separately. ////
-    /////////////////////////////////////////////////////
-
-    // TODO: flesh out
+  protected @Nonnull AristaBgpNeighborAddressFamily getOrCreateAfSettings(
+      AristaBgpVrfAddressFamily af) {
+    return new AristaBgpNeighborAddressFamily();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -517,7 +517,8 @@ public class AristaGrammarTest {
   public void testBgpNeighborInterfaceExtraction() {
     AristaConfiguration config = parseVendorConfig("arista_bgp_neighbor_interface");
     AristaBgpVrf vrf = config.getAristaBgp().getDefaultVrf();
-    // Et99 was removed by `no neighbor interface`; Et2-3,Et5 expands the comma-separated range
+    // Et99 was removed by `no neighbor interface`; Et50-51 added then removed by range;
+    // Et2-3,Et5 expands the comma-separated range.
     assertThat(
         vrf.getInterfaceNeighbors().keySet(),
         containsInAnyOrder(
@@ -547,11 +548,24 @@ public class AristaGrammarTest {
 
     AristaBgpVrf tenant = config.getAristaBgp().getVrfs().get("TENANT");
     assertThat(tenant.getInterfaceNeighbors().keySet(), containsInAnyOrder("Ethernet10"));
+
+    // Parse-time warnings for bad prefix (`Xy1`) and too-large range (`Et200-2000`).
+    assertThat(
+        config.getWarnings().getParseWarnings(),
+        hasItems(
+            hasComment("Unrecognized interface name: Invalid interface name prefix: 'Xy'"),
+            hasComment(
+                "Interface range Ethernet[200,2000] exceeds 1000 entries; skipping this"
+                    + " range.")));
   }
 
   @Test
-  public void testBgpNeighborInterfaceConversion() {
-    Configuration c = parseConfig("arista_bgp_neighbor_interface");
+  public void testBgpNeighborInterfaceConversion() throws IOException {
+    String hostname = "arista_bgp_neighbor_interface";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    Configuration c = parseConfig(hostname);
     Map<String, BgpUnnumberedPeerConfig> neighbors =
         c.getDefaultVrf().getBgpProcess().getInterfaceNeighbors();
     // Dropped: Et6 (inherits shutdown from SHUT), Et99 (removed by `no`),
@@ -588,6 +602,20 @@ public class AristaGrammarTest {
     Map<String, BgpUnnumberedPeerConfig> tenantNeighbors =
         c.getVrfs().get("TENANT").getBgpProcess().getInterfaceNeighbors();
     assertThat(tenantNeighbors.keySet(), containsInAnyOrder("Ethernet10"));
+
+    // Conversion-time warnings: non-existent interface (Et100) and no acceptable remote-as (Et8).
+    assertThat(
+        ccae,
+        hasRedFlagWarning(
+            hostname,
+            containsString(
+                "BGP interface neighbor Ethernet100 refers to a non-existent interface")));
+    assertThat(
+        ccae,
+        hasRedFlagWarning(
+            hostname,
+            containsString(
+                "No acceptable remote-as for BGP neighbor interface Ethernet8 in vrf default")));
   }
 
   @Test
@@ -597,7 +625,7 @@ public class AristaGrammarTest {
     Batfish batfish = getBatfishForConfigurationNames(hostname);
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
-    assertThat(ccae, hasNumReferrers(filename, BGP_PEER_GROUP, "LEAVES", 10));
+    assertThat(ccae, hasNumReferrers(filename, BGP_PEER_GROUP, "LEAVES", 11));
     assertThat(ccae, hasNumReferrers(filename, BGP_PEER_GROUP, "SHUT", 1));
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_neighbor_interface
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_neighbor_interface
@@ -71,6 +71,9 @@ router bgp 65001
    neighbor interface Et200-2000 peer-group LEAVES remote-as 65999
    neighbor interface Et99 peer-group LEAVES remote-as 65999
    no neighbor interface Et99
+   ! Removal by range: Et50-51 added, then both removed in one statement.
+   neighbor interface Et50-51 peer-group LEAVES remote-as 65999
+   no neighbor interface Et50-51
    neighbor interface Et100 peer-group LEAVES remote-as 65999
    address-family evpn
       neighbor LEAVES activate


### PR DESCRIPTION
Introduce AristaBgpConcreteNeighbor as the common parent of V4,
V4Dynamic, Interface, and V6 neighbors (but not peer-group neighbors).
It holds _peerGroup, provides the shared inherit() and isActive()
implementations, and declares abstract getPeerString() /
getAfSettings() / getOrCreateAfSettings() hooks that each subclass
fills in with its identifier (Ip, Prefix, interface name).

This removes three copies of inherit(), three copies of isActive(),
and three getTextDesc overloads. In AristaConversions.toBgpNeighbor
it also collapses the three-way instanceof ladders that picked naf4,
nEvpn, and peerStrRepr into single polymorphic calls.

Also:
- Replace Stream.peek(...) side effects with explicit forEach before
the stream pipeline, matching Javadoc guidance on peek.
- Lift the 1000-entry range cap out of expandBgpIfaceRange into a
named constant with a comment; clarify the skip warning message.
- Add deliberate-warning assertions for the existing Xy1,
Et200-2000, and Et100 test cases, plus coverage for
`no neighbor interface` with a range.

V6 neighbors inherit the base class with stub AF hooks; no converter
iterates them today.

----

Prompt:
```
Read HEAD, an external submission. What review would you have given
in terms of idiomatic Batfish contibutions and clean maintainable
code?
```

Followups in conversation: fix review items 2 (warning assertions),
3 (range-removal test coverage), 4 (dedup inherit + unify peer-string
accessor), 5 (peek to forEach), 7 (magic number), 8 (move isActive
to the class); also make V6 extend the new base class with stubs.