### PR TITLE
Arista: do not set weight 32768 on locally-originated BGP paths

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
@@ -168,7 +168,6 @@ import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
-import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
@@ -179,7 +178,6 @@ import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
 import org.batfish.datamodel.routing_policy.statement.SetMetric;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
-import org.batfish.datamodel.routing_policy.statement.SetWeight;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
@@ -275,7 +273,6 @@ public final class AristaConfiguration extends VendorConfiguration {
   @VisibleForTesting public static final int DEFAULT_EBGP_ADMIN = 200;
   @VisibleForTesting public static final int DEFAULT_IBGP_ADMIN = 200;
   @VisibleForTesting public static final int DEFAULT_LOCAL_BGP_ADMIN = 200;
-  @VisibleForTesting public static final int DEFAULT_LOCAL_BGP_WEIGHT = 32768;
   static final boolean DEFAULT_VRRP_PREEMPT = true;
 
   static final int DEFAULT_VRRP_PRIORITY = 100;
@@ -896,7 +893,17 @@ public final class AristaConfiguration extends VendorConfiguration {
     // Arista sets local routes' local preference to 0
     // actually, it is unset but treated like 0 in terms of BgpRib comparisons.
     redistributionPolicy.addStatement(new SetLocalPreference(new LiteralLong(0)));
-    redistributionPolicy.addStatement(new SetWeight(new LiteralInt(DEFAULT_LOCAL_BGP_WEIGHT)));
+    // Note: unlike IOS/IOS-XE, Arista EOS does NOT apply weight 32768
+    // to locally-originated BGP paths; the effective weight is 0.
+    // Verified empirically on EOS 4.36 in both multi-agent and ribd
+    // modes: a received path with `neighbor ... weight 10000` wins
+    // over the local path, and the device emits "Not best: Path
+    // weight" as the reason. A route-map on a `network` statement or
+    // aggregate attribute-map can still set weight as usual. See
+    // lab-validation#152 for the repro lab. (Aggregate routes are
+    // still generated with weight 32768 via the shared
+    // BgpProtocolHelper.toBgpv4Route code path; fixing that requires a
+    // vendor-specific override and is left for a follow-up.)
 
     // Arista sets origin type differently depending on source protocol. Redistributed connected
     // routes have origin type IGP and redistributed static routes have origin type incomplete.

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
@@ -39,7 +39,6 @@ import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 import org.batfish.dataplane.ibdp.IncrementalDataPlane;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
-import org.batfish.vendor.arista.representation.AristaConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -107,7 +106,6 @@ public class EvpnType5AristaTest {
             .setSrcProtocol(RoutingProtocol.CONNECTED)
             .setReceivedFrom(ReceivedFromSelf.instance())
             .setOriginatorIp(originatorIp)
-            .setWeight(AristaConfiguration.DEFAULT_LOCAL_BGP_WEIGHT)
             .build();
     assertThat(vrf2BgpRoute, equalTo(expectedVrf2BgpRoute));
 
@@ -132,7 +130,6 @@ public class EvpnType5AristaTest {
             .setReceivedFrom(ReceivedFromSelf.instance())
             .setOriginatorIp(originatorIp)
             .setVni(15004)
-            .setWeight(AristaConfiguration.DEFAULT_LOCAL_BGP_WEIGHT)
             .build();
     assertThat(exportedEvpnRoute, equalTo(expectedEvpnRoute));
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -55,7 +55,6 @@ import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.route.nh.NextHopVtep;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
-import org.batfish.vendor.arista.representation.AristaConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -693,8 +692,7 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
             .setProtocol(RoutingProtocol.BGP)
             .setSrcProtocol(RoutingProtocol.CONNECTED)
             .setReceivedFrom(ReceivedFromSelf.instance())
-            .setVni(exportRouteVni)
-            .setWeight(AristaConfiguration.DEFAULT_LOCAL_BGP_WEIGHT);
+            .setVni(exportRouteVni);
     {
       // Learned EVPN route: Exported route should keep original NH.
       // Whether address family has an NVE IP should not matter.

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -5,6 +5,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.matchers.ParseWarningMatchers.hasComment;
 import static org.batfish.common.matchers.ParseWarningMatchers.hasText;
 import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.datamodel.BgpRoute.DEFAULT_LOCAL_WEIGHT;
 import static org.batfish.datamodel.ConfigurationFormat.ARISTA;
 import static org.batfish.datamodel.Names.bgpNeighborStructureName;
 import static org.batfish.datamodel.Names.generatedBgpPeerEvpnExportPolicyName;
@@ -75,7 +76,6 @@ import static org.batfish.datamodel.transformation.TransformationStep.assignDest
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
 import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
-import static org.batfish.vendor.arista.representation.AristaConfiguration.DEFAULT_LOCAL_BGP_WEIGHT;
 import static org.batfish.vendor.arista.representation.AristaConfiguration.aclLineStructureName;
 import static org.batfish.vendor.arista.representation.AristaStructureType.BGP_LISTEN_RANGE;
 import static org.batfish.vendor.arista.representation.AristaStructureType.BGP_NEIGHBOR;
@@ -907,7 +907,6 @@ public class AristaGrammarTest {
             .setProtocol(RoutingProtocol.BGP)
             .setReceivedFrom(ReceivedFromSelf.instance()) // indicates local origination
             .setSrcProtocol(RoutingProtocol.CONNECTED)
-            .setWeight(DEFAULT_LOCAL_BGP_WEIGHT)
             .build();
     Bgpv4Route bgpRouteVrf1 =
         bgpRouteDefaultVrf.toBuilder()
@@ -1638,13 +1637,16 @@ public class AristaGrammarTest {
             .setProtocol(RoutingProtocol.BGP)
             .setReceivedFrom(ReceivedFromSelf.instance()) // indicates local origination
             .setSrcProtocol(RoutingProtocol.STATIC)
-            .setWeight(DEFAULT_LOCAL_BGP_WEIGHT)
             .setTag(0) // TODO: should redistribute static preserve tag?
             .build();
     Bgpv4Route localRoute2 = localRoute1.toBuilder().setNetwork(staticPrefix2).build();
     Bgpv4Route localRoute3 = localRoute1.toBuilder().setNetwork(staticPrefix3).build();
     Bgpv4Route localRoute4 = localRoute1.toBuilder().setNetwork(staticPrefix4).build();
     Bgpv4Route localRoute5 = localRoute1.toBuilder().setNetwork(staticPrefix5).build();
+    // TODO: aggregate routes still use the shared BgpRoute.DEFAULT_LOCAL_WEIGHT
+    // (32768) via BgpProtocolHelper.toBgpv4Route. Arista actually uses 0, but
+    // fixing that requires a vendor-specific code path in BgpProtocolHelper;
+    // out of scope for the Arista-local-weight fix. See lab-validation#152.
     Bgpv4Route aggRoute1 =
         Bgpv4Route.builder()
             .setNetwork(aggPrefix1)
@@ -1657,7 +1659,7 @@ public class AristaGrammarTest {
             .setProtocol(RoutingProtocol.AGGREGATE)
             .setReceivedFrom(ReceivedFromSelf.instance()) // indicates local origination
             .setSrcProtocol(RoutingProtocol.AGGREGATE)
-            .setWeight(DEFAULT_LOCAL_BGP_WEIGHT)
+            .setWeight(DEFAULT_LOCAL_WEIGHT)
             .build();
     Bgpv4Route aggRoute2 = aggRoute1.toBuilder().setNetwork(aggPrefix2).build();
     Bgpv4Route aggRoute4General = aggRoute1.toBuilder().setNetwork(aggPrefix4General).build();
@@ -1732,7 +1734,7 @@ public class AristaGrammarTest {
               .setProtocol(RoutingProtocol.AGGREGATE)
               .setReceivedFrom(ReceivedFromSelf.instance()) // indicates local origination
               .setSrcProtocol(RoutingProtocol.AGGREGATE)
-              .setWeight(DEFAULT_LOCAL_BGP_WEIGHT)
+              .setWeight(DEFAULT_LOCAL_WEIGHT) // TODO(lab-validation#152): Arista should be 0
               .build();
       Bgpv4Route aggRoute2 = aggRoute1.toBuilder().setNetwork(aggPrefix2).build();
       assertThat(


### PR DESCRIPTION
Unlike IOS/IOS-XE, Arista EOS does NOT apply the industry-common
weight 32768 to locally-originated BGP paths; the effective weight
is 0. Verified empirically on EOS 4.36 in both multi-agent and ribd
modes: with a received path carrying `neighbor ... weight 10000`
and a matching local origin, the received path wins best-path
selection and the device emits "Not best: Path weight" on the local
path. A route-map on a `network` statement or aggregate
attribute-map can still set weight as usual.

Remove the `SetWeight(32768)` statement from the Arista BGP
redistribution policy. Aggregate routes are still generated with
weight 32768 via the shared BgpProtocolHelper.toBgpv4Route code
path; fixing that requires a vendor-specific override and is left
for a follow-up. Test expectations are updated: non-aggregate local
paths no longer assert weight 32768; aggregate paths retain the
32768 expectation with a TODO pointer.

Reproducer lab: batfish/lab-validation snapshot
eos_ceos_bgp_weight_experiment. See
https://github.com/batfish/lab-validation/issues/152 for the
broader Arista local-path attribute divergence (this change fixes
the weight half; local-preference needs further investigation).

----

Prompt:
```
This issue https://github.com/batfish/lab-validation/issues/6
seems to be responsible for a lot of lab issues. Can you dive
into it? Note that there's an EOS manual in ./batfish/working/
```
