### PR TITLE
Arista: do not set local-preference 0 on locally-originated BGP paths

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
@@ -174,7 +174,6 @@ import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.statement.If;
-import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
 import org.batfish.datamodel.routing_policy.statement.SetMetric;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
@@ -890,20 +889,18 @@ public final class AristaConfiguration extends VendorConfiguration {
     RoutingPolicy.Builder redistributionPolicy =
         RoutingPolicy.builder().setOwner(c).setName(redistPolicyName);
 
-    // Arista sets local routes' local preference to 0
-    // actually, it is unset but treated like 0 in terms of BgpRib comparisons.
-    redistributionPolicy.addStatement(new SetLocalPreference(new LiteralLong(0)));
-    // Note: unlike IOS/IOS-XE, Arista EOS does NOT apply weight 32768
-    // to locally-originated BGP paths; the effective weight is 0.
-    // Verified empirically on EOS 4.36 in both multi-agent and ribd
-    // modes: a received path with `neighbor ... weight 10000` wins
-    // over the local path, and the device emits "Not best: Path
-    // weight" as the reason. A route-map on a `network` statement or
-    // aggregate attribute-map can still set weight as usual. See
-    // lab-validation#152 for the repro lab. (Aggregate routes are
-    // still generated with weight 32768 via the shared
-    // BgpProtocolHelper.toBgpv4Route code path; fixing that requires a
-    // vendor-specific override and is left for a follow-up.)
+    // Note: Arista EOS locally-originated BGP paths use standard BGP
+    // defaults for both weight (0) and local-preference (100).
+    // Unlike IOS/IOS-XE, Arista does NOT set weight 32768 on local
+    // paths. And unlike what the previous code assumed, local-pref
+    // is not 0 — it is the standard default 100 (verified empirically
+    // on EOS 4.36 in both multi-agent and ribd by forcing best-path
+    // tiebreaks at each step; see lab-validation#152). We therefore
+    // set neither attribute here; the BGP pipeline's defaults suffice.
+    // A route-map on a `network` statement or `redistribute` can
+    // still override as usual. (Aggregate routes are still generated
+    // with weight 32768 via the shared BgpProtocolHelper.toBgpv4Route
+    // code path; fixing that is left for a follow-up.)
 
     // Arista sets origin type differently depending on source protocol. Redistributed connected
     // routes have origin type IGP and redistributed static routes have origin type incomplete.

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
@@ -548,9 +549,12 @@ final class AristaConversions {
                     new MatchBgpSessionType(Type.IBGP),
                     // The route being exported is not learned.
                     new Not(new MatchSourceProtocol(RoutingProtocol.BGP, RoutingProtocol.IBGP)),
-                    // The route being exported has the unset default local preference of 0 (since
-                    // we can't yet model unset explicitly)
-                    new MatchLocalPreference(IntComparator.EQ, new LiteralLong(0)))),
+                    // The route being exported has the default local preference (since
+                    // we can't yet model unset explicitly). Locally-originated routes
+                    // inherit the BGP default (100) from the pipeline when no explicit
+                    // SetLocalPreference is applied in the redistribution policy.
+                    new MatchLocalPreference(
+                        IntComparator.EQ, new LiteralLong(BgpRoute.DEFAULT_LOCAL_PREFERENCE)))),
             ImmutableList.of(
                 new SetLocalPreference(
                     new LiteralLong(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5AristaTest.java
@@ -20,6 +20,7 @@ import java.util.SortedMap;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.EvpnRoute;
@@ -106,6 +107,7 @@ public class EvpnType5AristaTest {
             .setSrcProtocol(RoutingProtocol.CONNECTED)
             .setReceivedFrom(ReceivedFromSelf.instance())
             .setOriginatorIp(originatorIp)
+            .setLocalPreference(BgpRoute.DEFAULT_LOCAL_PREFERENCE)
             .build();
     assertThat(vrf2BgpRoute, equalTo(expectedVrf2BgpRoute));
 
@@ -130,6 +132,7 @@ public class EvpnType5AristaTest {
             .setReceivedFrom(ReceivedFromSelf.instance())
             .setOriginatorIp(originatorIp)
             .setVni(15004)
+            .setLocalPreference(BgpRoute.DEFAULT_LOCAL_PREFERENCE)
             .build();
     assertThat(exportedEvpnRoute, equalTo(expectedEvpnRoute));
   }

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -5,6 +5,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.matchers.ParseWarningMatchers.hasComment;
 import static org.batfish.common.matchers.ParseWarningMatchers.hasText;
 import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.datamodel.BgpRoute.DEFAULT_LOCAL_PREFERENCE;
 import static org.batfish.datamodel.BgpRoute.DEFAULT_LOCAL_WEIGHT;
 import static org.batfish.datamodel.ConfigurationFormat.ARISTA;
 import static org.batfish.datamodel.Names.bgpNeighborStructureName;
@@ -899,7 +900,7 @@ public class AristaGrammarTest {
             .setNetwork(connectedPrefix)
             .setNonRouting(true)
             .setAdmin(bgpAdmin)
-            .setLocalPreference(0)
+            .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
             .setNextHop(NextHopDiscard.instance())
             .setOriginType(OriginType.IGP)
             .setOriginMechanism(OriginMechanism.REDISTRIBUTE)
@@ -1629,7 +1630,7 @@ public class AristaGrammarTest {
             .setNetwork(staticPrefix1)
             .setNonRouting(true)
             .setAdmin(localAdmin)
-            .setLocalPreference(0)
+            .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
             .setNextHop(NextHopDiscard.instance())
             .setOriginatorIp(routerId)
             .setOriginMechanism(OriginMechanism.REDISTRIBUTE)


### PR DESCRIPTION
The previous commit (#9913) fixed the weight of locally-originated
Arista BGP paths from 32768 to 0. But the redistribution policy also
set local-preference to 0, overriding the standard BGP default of
100. Empirical testing on EOS 4.36 showed that locally-originated
paths use the default local-preference of 100: a received path with
`set local-preference 50` loses, and one with `set local-preference
150` wins. See lab-validation#152 for the reproducer lab.

Removing the explicit SetLocalPreference(0) also required updating
the `export-localpref` guard in AristaConversions, which previously
checked for LP==0 as a proxy for "unset default" — now it checks
for LP==DEFAULT_LOCAL_PREFERENCE (100) since that is the new
effective default for locally-originated routes.

Without this fix, the weight-only change in #9913 caused a
regression in eos_private_asn: on DuplicatePrivate (which has
`allowas-in 3`), the locally-originated route for
`192.168.123.8/32` had weight=0 and LP=0. The eBGP peer
(R-PublicASN100) sent the route back, and the received copy arrived
with LP=100 (default eBGP import). Since weight tied (both 0) and
LP 100 > 0, the received route replaced the local route as
best-path. But the received route failed the export filter
(not ReceivedFromSelf), causing a withdrawal that removed the
route from the entire network. With LP=100 on the locally-
originated route, LP ties and the "prefer locally originated" step
keeps the local route as best-path, preventing the oscillation.

----

Prompt:
```
So we did a deep analysis and concluded that the issue was LP --
not being set on the local route, but being set on the re-received
route. Why did we have to undo the LP 100 stuff?
```