### PR TITLE
Junos: model advertise-peer-as as EXCEPT_RECEIVED_FROM, not ALWAYS

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -106,11 +106,16 @@ public final class BgpProtocolHelper {
     }
 
     // For eBGP, do not export if AS path contains the peer's AS in a disallowed position
+    AllowRemoteAsOutMode allowRemoteAsOut = af.getAddressFamilyCapabilities().getAllowRemoteAsOut();
     if (localSessionProperties.isEbgp()
         && !allowAsPathOut(
-            route.getAsPath(),
-            localSessionProperties.getRemoteAs(),
-            af.getAddressFamilyCapabilities().getAllowRemoteAsOut())) {
+            route.getAsPath(), localSessionProperties.getRemoteAs(), allowRemoteAsOut)) {
+      return null;
+    }
+    // For EXCEPT_RECEIVED_FROM, also block re-advertisement to the originating peer
+    if (localSessionProperties.isEbgp()
+        && allowRemoteAsOut == AllowRemoteAsOutMode.EXCEPT_RECEIVED_FROM
+        && receivedFromPeer(route.getReceivedFrom(), localSessionProperties.getRemoteIp())) {
       return null;
     }
     // Also do not export if route has NO_EXPORT community and this is a true ebgp session
@@ -233,10 +238,25 @@ public final class BgpProtocolHelper {
       return true;
     }
     return switch (mode) {
-      case ALWAYS -> true;
+      case ALWAYS, EXCEPT_RECEIVED_FROM -> true;
       case NEVER -> asSets.stream().noneMatch(asSet -> asSet.containsAs(peerAs));
       case EXCEPT_FIRST -> !asSets.get(0).containsAs(peerAs);
     };
+  }
+
+  /**
+   * Return {@code true} if the route's {@link ReceivedFrom} indicates it was received from the
+   * given {@code peerIp}. For unnumbered sessions, compares link-local IPs which could
+   * theoretically false-positive across peers with identical link-local addresses.
+   */
+  @VisibleForTesting
+  static boolean receivedFromPeer(ReceivedFrom receivedFrom, Ip peerIp) {
+    if (receivedFrom instanceof ReceivedFromIp receivedFromIp) {
+      return receivedFromIp.getIp().equals(peerIp);
+    } else if (receivedFrom instanceof ReceivedFromInterface receivedFromInterface) {
+      return receivedFromInterface.getLinkLocalIp().equals(peerIp);
+    }
+    return false;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -12,8 +12,8 @@ import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
-import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.EXCEPT_FIRST;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.EXCEPT_RECEIVED_FROM;
 import static org.batfish.datamodel.bgp.LocalOriginationTypeTieBreaker.NO_PREFERENCE;
 import static org.batfish.datamodel.bgp.NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP;
 import static org.batfish.datamodel.routing_policy.statement.Statements.ReturnFalse;
@@ -709,7 +709,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (advertisePeerAs == null) {
         advertisePeerAs = false;
       }
-      ipv4AfSettingsBuilder.setAllowRemoteAsOut(advertisePeerAs ? ALWAYS : EXCEPT_FIRST);
+      ipv4AfSettingsBuilder.setAllowRemoteAsOut(
+          advertisePeerAs ? EXCEPT_RECEIVED_FROM : EXCEPT_FIRST);
       Boolean advertiseExternal = ig.getAdvertiseExternal();
       if (advertiseExternal == null) {
         advertiseExternal = false;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -5,10 +5,12 @@ import static org.batfish.datamodel.Route.UNSET_NEXT_HOP_INTERFACE;
 import static org.batfish.datamodel.Route.UNSET_ROUTE_TAG;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.EXCEPT_FIRST;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.EXCEPT_RECEIVED_FROM;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.NEVER;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.allowAsPathOut;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.convertGeneratedRouteToBgp;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.isReflectable;
+import static org.batfish.dataplane.protocols.BgpProtocolHelper.receivedFromPeer;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRouteOnImport;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRoutePostExport;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,6 +36,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ReceivedFromInterface;
 import org.batfish.datamodel.ReceivedFromIp;
 import org.batfish.datamodel.ReceivedFromSelf;
 import org.batfish.datamodel.RoutingProtocol;
@@ -660,5 +663,32 @@ public class BgpProtocolHelperTest {
     assertFalse(allowAsPathOut(AsPath.ofSingletonAsSets(peerAs), peerAs, EXCEPT_FIRST));
     assertTrue(allowAsPathOut(AsPath.ofSingletonAsSets(2L, peerAs), peerAs, EXCEPT_FIRST));
     assertTrue(allowAsPathOut(AsPath.ofSingletonAsSets(2L), peerAs, EXCEPT_FIRST));
+  }
+
+  @Test
+  public void testAllowAsPathOutExceptReceivedFrom() {
+    long peerAs = 1L;
+    // AS-path filtering is disabled for EXCEPT_RECEIVED_FROM — always allows
+    assertTrue(allowAsPathOut(AsPath.ofSingletonAsSets(peerAs), peerAs, EXCEPT_RECEIVED_FROM));
+    assertTrue(allowAsPathOut(AsPath.ofSingletonAsSets(2L, peerAs), peerAs, EXCEPT_RECEIVED_FROM));
+    assertTrue(allowAsPathOut(AsPath.ofSingletonAsSets(2L), peerAs, EXCEPT_RECEIVED_FROM));
+  }
+
+  @Test
+  public void testReceivedFromPeer() {
+    Ip peerIp = Ip.parse("10.0.0.1");
+    Ip otherIp = Ip.parse("10.0.0.2");
+    Ip linkLocalIp = Ip.parse("169.254.0.1");
+
+    // ReceivedFromIp: matches if IP equals peer IP
+    assertTrue(receivedFromPeer(ReceivedFromIp.of(peerIp), peerIp));
+    assertFalse(receivedFromPeer(ReceivedFromIp.of(otherIp), peerIp));
+
+    // ReceivedFromInterface: matches if link-local IP equals peer IP
+    assertTrue(receivedFromPeer(ReceivedFromInterface.of("eth0", linkLocalIp), linkLocalIp));
+    assertFalse(receivedFromPeer(ReceivedFromInterface.of("eth0", linkLocalIp), peerIp));
+
+    // ReceivedFromSelf: never matches
+    assertFalse(receivedFromPeer(ReceivedFromSelf.instance(), peerIp));
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/AllowRemoteAsOutMode.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/AllowRemoteAsOutMode.java
@@ -7,8 +7,15 @@ package org.batfish.datamodel.bgp;
 public enum AllowRemoteAsOutMode {
   /**
    * Always send, regardless of whether the peer's AS appears in the AS-path of the advertisement.
+   * Disables both AS-path-based and per-peer loop prevention. Only use this when the sending peer
+   * is known to be included in the same-AS group — otherwise use {@link #EXCEPT_RECEIVED_FROM}.
    */
   ALWAYS,
+  /**
+   * Disable AS-path-based loop prevention, but still do not re-advertise a route back to the
+   * specific peer it was received from. This is the Junos {@code advertise-peer-as} behavior.
+   */
+  EXCEPT_RECEIVED_FROM,
   /** Never send if the the peer's AS appears in the AS-path of the advertisement. */
   NEVER,
   /**


### PR DESCRIPTION
Junos `advertise-peer-as` disables AS-path-based loop prevention for
outbound eBGP advertisements but still blocks re-advertisement back
to the specific peer the route was received from. Previously, Batfish
mapped this to AllowRemoteAsOutMode.ALWAYS which has no per-peer
check, causing routes to be incorrectly sent back to originating
peers.

Add a new AllowRemoteAsOutMode.EXCEPT_RECEIVED_FROM that skips
AS-path filtering but checks the route's ReceivedFrom against the
export session's remote peer IP. Map Junos advertise-peer-as to
this new mode.

This is for batfish/lab-validation#44.

----

Prompt:
```
Read up on https://github.com/batfish/lab-validation/issues/44 and
dig into both Batfish and the affected labs. Also note that there
are junos manuals in ./batfish/working/
```