### PR TITLE
LargeCommunity: add @JsonValue for correct JSON serialization

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/community/LargeCommunity.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/community/LargeCommunity.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.bgp.community;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Optional;
@@ -119,6 +120,7 @@ public final class LargeCommunity extends Community {
     return Objects.hash(_globalAdministrator, _localData1, _localData2);
   }
 
+  @JsonValue
   @Override
   public @Nonnull String toString() {
     if (_str == null) {

--- a/projects/common/src/test/java/org/batfish/datamodel/bgp/community/LargeCommunityTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/bgp/community/LargeCommunityTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertFalse;
 import com.google.common.testing.EqualsTester;
 import java.math.BigInteger;
 import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -36,7 +37,13 @@ public class LargeCommunityTest {
   @Test
   public void testJsonSerialization() {
     LargeCommunity lc = LargeCommunity.of(1L, 2L, 3L);
-    assertThat(SerializationUtils.clone(lc), equalTo(lc));
+    assertThat(BatfishObjectMapper.clone(lc, LargeCommunity.class), equalTo(lc));
+  }
+
+  @Test
+  public void testJsonSerializationAsCommunity() {
+    LargeCommunity lc = LargeCommunity.of(1L, 2L, 3L);
+    assertThat(BatfishObjectMapper.clone(lc, Community.class), equalTo(lc));
   }
 
   @Test


### PR DESCRIPTION
LargeCommunity was missing the @JsonValue annotation on toString(),
unlike StandardCommunity and ExtendedCommunity. Without it, Jackson
serialized LargeCommunity as a JSON object with field names instead
of its string representation, causing deserialization failures (e.g.,
viModel question returning HTTP 400).

Also fix testJsonSerialization which was testing Java serialization
instead of JSON round-trip, and add a test for round-tripping through
the Community base class.

----

Prompt:
```
go in ../batfish and fix the large community issue
[Batfish viModel question fails to deserialize LargeCommunity —
batfish/lab-validation#160]
```