### PR TITLE
Arista: support `ip address unnumbered` with new UnnumberedAddress type

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaLexer.g4
@@ -4695,6 +4695,11 @@ UPDATE_SOURCE
    'update-source' -> pushMode ( M_Interface )
 ;
 
+UNNUMBERED
+:
+   'unnumbered' -> pushMode ( M_Interface )
+;
+
 UPLINK_FAILURE_DETECTION: 'uplink-failure-detection';
 
 UPLINKFAST: 'uplinkfast';

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/Legacy_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/Legacy_interface.g4
@@ -315,7 +315,7 @@ ifip_address_eos
   (
     ifip_address_address_eos
     | ifip_address_dhcp_eos
-    // | ifip_address_unnumbered_eos
+    | ifip_address_unnumbered_eos
     | ifip_address_virtual_eos
   )
 ;
@@ -328,6 +328,11 @@ ifip_address_address_eos
 ifip_address_dhcp_eos
 :
    DHCP NEWLINE
+;
+
+ifip_address_unnumbered_eos
+:
+  UNNUMBERED iname = interface_name NEWLINE
 ;
 
 ifip_address_virtual_eos

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -646,6 +646,7 @@ import org.batfish.vendor.arista.grammar.AristaParser.Ifigmphp_access_listContex
 import org.batfish.vendor.arista.grammar.AristaParser.Ifigmpsg_aclContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Ifip_access_group_eosContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Ifip_address_address_eosContext;
+import org.batfish.vendor.arista.grammar.AristaParser.Ifip_address_unnumbered_eosContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Ifip_address_virtual_eosContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Ifip_proxy_arp_eosContext;
 import org.batfish.vendor.arista.grammar.AristaParser.Ifipm_boundary_eosContext;
@@ -5158,6 +5159,24 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
           } else {
             i.setAddress(addr);
           }
+        });
+  }
+
+  @Override
+  public void exitIfip_address_unnumbered_eos(Ifip_address_unnumbered_eosContext ctx) {
+    String sourceInterface = toInterfaceName(ctx.iname);
+    _configuration.referenceStructure(
+        INTERFACE,
+        sourceInterface,
+        AristaStructureUsage.INTERFACE_IP_ADDRESS_UNNUMBERED,
+        ctx.iname.getStart().getLine());
+    _currentInterfaces.forEach(
+        i -> {
+          if (i.getSwitchport()) {
+            warn(ctx, String.format("Ignoring IP address for switchport %s", i.getName()));
+            return;
+          }
+          i.setUnnumberedSourceInterface(sourceInterface);
         });
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
@@ -141,6 +141,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportEncapsulationType;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.TunnelConfiguration;
+import org.batfish.datamodel.UnnumberedAddress;
 import org.batfish.datamodel.VrfLeakConfig;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
@@ -148,6 +149,7 @@ import org.batfish.datamodel.bgp.BgpConfederation;
 import org.batfish.datamodel.isis.IsisInterfaceLevelSettings;
 import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisInterfaceSettings;
+import org.batfish.datamodel.ospf.OspfAddresses;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
@@ -1338,6 +1340,19 @@ public final class AristaConfiguration extends VendorConfiguration {
           }
           newIface.setAutoState(iface.getAutoState());
         }
+        // Resolve unnumbered interface address from source interface.
+        if (iface.getUnnumberedSourceInterface() != null && iface.getAddress() == null) {
+          Interface sourceIface = _interfaces.get(iface.getUnnumberedSourceInterface());
+          if (sourceIface != null && sourceIface.getAddress() != null) {
+            UnnumberedAddress unnumbered =
+                UnnumberedAddress.of(
+                    iface.getUnnumberedSourceInterface(), sourceIface.getAddress().getIp());
+            newIface.setAddress(unnumbered);
+            newIface.setAllAddresses(ImmutableSet.of(unnumbered));
+            // No address metadata needed — unnumbered addresses don't generate connected routes.
+            break;
+          }
+        }
         // All prefixes is the combination of the interface prefix + any secondary prefixes.
         ImmutableSet.Builder<ConcreteInterfaceAddress> allPrefixesBuilder = ImmutableSet.builder();
         if (iface.getAddress() != null) {
@@ -1347,15 +1362,11 @@ public final class AristaConfiguration extends VendorConfiguration {
         allPrefixesBuilder.addAll(iface.getSecondaryAddresses());
         ImmutableSet<ConcreteInterfaceAddress> allPrefixes = allPrefixesBuilder.build();
         newIface.setAllAddresses(allPrefixes);
+        ConnectedRouteMetadata metadata =
+            ConnectedRouteMetadata.builder().setGenerateLocalRoute(false).build();
         newIface.setAddressMetadata(
             allPrefixes.stream()
-                .collect(
-                    toImmutableSortedMap(
-                        Function.identity(),
-                        addr ->
-                            ConnectedRouteMetadata.builder()
-                                .setGenerateLocalRoute(false)
-                                .build())));
+                .collect(toImmutableSortedMap(Function.identity(), addr -> metadata)));
 
         break;
 
@@ -1783,6 +1794,13 @@ public final class AristaConfiguration extends VendorConfiguration {
     }
     ospfSettings.setHelloInterval(toOspfHelloInterval(vsIface, networkType));
     ospfSettings.setDeadInterval(toOspfDeadInterval(vsIface, networkType));
+    // For unnumbered interfaces, set explicit OSPF addresses so neighbor init can find the IP.
+    if (vsIface.getUnnumberedSourceInterface() != null) {
+      Interface sourceIface = _interfaces.get(vsIface.getUnnumberedSourceInterface());
+      if (sourceIface != null && sourceIface.getAddress() != null) {
+        ospfSettings.setOspfAddresses(OspfAddresses.of(ImmutableList.of(sourceIface.getAddress())));
+      }
+    }
 
     iface.setOspfSettings(ospfSettings.build());
   }

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaStructureUsage.java
@@ -51,6 +51,7 @@ public enum AristaStructureUsage implements StructureUsage {
   INTERFACE_IGMP_ACCESS_GROUP_ACL("interface igmp access-group acl"),
   INTERFACE_IGMP_HOST_PROXY_ACCESS_LIST("interface igmp host-proxy access-list"),
   INTERFACE_IGMP_STATIC_GROUP_ACL("interface igmp static-group acl"),
+  INTERFACE_IP_ADDRESS_UNNUMBERED("interface ip address unnumbered"),
   INTERFACE_IP_ACCESS_GROUP_IN("interface ip access-group in"),
   INTERFACE_IP_ACCESS_GROUP_OUT("interface ip access-group out"),
   INTERFACE_IP_INBAND_ACCESS_GROUP("interface ip inband access-group"),

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/Interface.java
@@ -141,6 +141,8 @@ public class Interface implements Serializable {
 
   private ConcreteInterfaceAddress _address;
 
+  private @Nullable String _unnumberedSourceInterface;
+
   private boolean _proxyArp;
 
   private String _routingPolicy;
@@ -368,6 +370,10 @@ public class Interface implements Serializable {
     return _address;
   }
 
+  public @Nullable String getUnnumberedSourceInterface() {
+    return _unnumberedSourceInterface;
+  }
+
   public boolean getProxyArp() {
     return _proxyArp;
   }
@@ -557,6 +563,10 @@ public class Interface implements Serializable {
 
   public void setAddress(ConcreteInterfaceAddress address) {
     _address = address;
+  }
+
+  public void setUnnumberedSourceInterface(@Nullable String unnumberedSourceInterface) {
+    _unnumberedSourceInterface = unnumberedSourceInterface;
   }
 
   public void setProxyArp(boolean proxyArp) {

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -193,6 +193,7 @@ import org.batfish.datamodel.SnmpCommunity;
 import org.batfish.datamodel.SnmpServer;
 import org.batfish.datamodel.SwitchportEncapsulationType;
 import org.batfish.datamodel.SwitchportMode;
+import org.batfish.datamodel.UnnumberedAddress;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.VrrpGroup;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
@@ -2773,6 +2774,50 @@ public class AristaGrammarTest {
                                 .build()))),
                 isActive())));
     assertThat(c, hasInterface("UnconnectedEthernet5", hasInterfaceType(InterfaceType.UNKNOWN)));
+  }
+
+  @Test
+  public void testInterfaceIpUnnumberedExtraction() {
+    AristaConfiguration config = parseVendorConfig("arista_interface_ip_unnumbered");
+    org.batfish.vendor.arista.representation.Interface eth1 =
+        config.getInterfaces().get("Ethernet1");
+    assertThat(eth1.getUnnumberedSourceInterface(), equalTo("Loopback0"));
+    assertThat(eth1.getAddress(), nullValue());
+    org.batfish.vendor.arista.representation.Interface eth2 =
+        config.getInterfaces().get("Ethernet2");
+    assertThat(eth2.getUnnumberedSourceInterface(), equalTo("Loopback0"));
+    org.batfish.vendor.arista.representation.Interface lo0 =
+        config.getInterfaces().get("Loopback0");
+    assertThat(lo0.getUnnumberedSourceInterface(), nullValue());
+  }
+
+  @Test
+  public void testInterfaceIpUnnumberedConversion() {
+    Configuration c = parseConfig("arista_interface_ip_unnumbered", true);
+    ConcreteInterfaceAddress loopbackAddr = ConcreteInterfaceAddress.parse("10.0.0.1/32");
+    UnnumberedAddress unnumberedAddr = UnnumberedAddress.of("Loopback0", Ip.parse("10.0.0.1"));
+    // Loopback0 has its own concrete address
+    assertThat(c, hasInterface("Loopback0", hasAllAddresses(contains(loopbackAddr))));
+    // Unnumbered interfaces get UnnumberedAddress, not ConcreteInterfaceAddress
+    Interface eth1 = c.getAllInterfaces().get("Ethernet1");
+    assertThat(eth1.getAddress(), equalTo(unnumberedAddr));
+    assertThat(eth1.getAllAddresses(), contains(unnumberedAddr));
+    assertThat(eth1.getAllConcreteAddresses(), empty());
+    assertThat(eth1.getAddressMetadata(), anEmptyMap());
+    // OSPF addresses set for neighbor formation
+    assertThat(eth1.getOspfSettings(), notNullValue());
+    assertThat(eth1.getOspfSettings().getOspfAddresses().getAddresses(), contains(loopbackAddr));
+  }
+
+  @Test
+  public void testInterfaceIpUnnumberedReferences() throws IOException {
+    String hostname = "arista_interface_ip_unnumbered";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    // Loopback0 is referenced by two unnumbered interfaces + its own self-ref
+    assertThat(ccae, hasNumReferrers(filename, INTERFACE, "Loopback0", 3));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_interface_ip_unnumbered
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_interface_ip_unnumbered
@@ -1,0 +1,22 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_interface_ip_unnumbered
+!
+interface Loopback0
+  ip address 10.0.0.1/32
+!
+interface Ethernet1
+  no switchport
+  ip address unnumbered Loopback0
+  ip ospf network point-to-point
+  ip ospf area 0.0.0.0
+!
+interface Ethernet2
+  no switchport
+  ip address unnumbered Loopback0
+!
+ip routing
+!
+router ospf 1
+  router-id 10.0.0.1
+!

--- a/projects/common/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/common/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -473,13 +473,12 @@ public final class TopologyUtil {
                         // Keep if virtual wire
                         || isVirtualWireSameDevice(edge));
     NetworkConfigurations nc = NetworkConfigurations.of(configurations);
-    // For link-layer edges, we see if there is a unique point-to-point interface in the same
-    // broadcast domain that is unnumbered. If so, we create an edge, otherwise there is no
-    // neighbor.
-    Stream<Edge> linkLocalEdges =
+    // For point-to-point interfaces that don't participate in subnet-based L3 synthesis (link-local
+    // or unnumbered addresses), create edges via physical adjacency instead.
+    Stream<Edge> pointToPointEdges =
         configurations.values().stream()
             .flatMap(Configuration::activeInterfaces)
-            .filter(i -> !i.getAllLinkLocalAddresses().isEmpty())
+            .filter(TopologyUtil::hasPointToPointAddress)
             .map(i -> NodeInterfacePair.of(i.getOwner().getHostname(), i.getName()))
             .flatMap(
                 nip -> {
@@ -490,10 +489,7 @@ public final class TopologyUtil {
                           .filter(
                               other ->
                                   nc.getInterface(other.getHostname(), other.getInterface())
-                                      .map(
-                                          i ->
-                                              i.getActive()
-                                                  && !i.getAllLinkLocalAddresses().isEmpty())
+                                      .map(i -> i.getActive() && hasPointToPointAddress(i))
                                       .orElse(false))
                           .orElse(null);
                   if (paired == null) {
@@ -503,7 +499,7 @@ public final class TopologyUtil {
                 });
 
     return new Topology(
-        Streams.concat(filteredEdgeStream, linkLocalEdges)
+        Streams.concat(filteredEdgeStream, pointToPointEdges)
             .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
   }
 
@@ -647,6 +643,17 @@ public final class TopologyUtil {
           }
         });
     return prefixInterfaces;
+  }
+
+  /**
+   * Returns true if the interface has link-local or unnumbered addresses (i.e., addresses that
+   * don't participate in subnet-based L3 topology synthesis and need point-to-point physical
+   * adjacency edges instead).
+   */
+  @VisibleForTesting
+  static boolean hasPointToPointAddress(Interface iface) {
+    return !iface.getAllLinkLocalAddresses().isEmpty()
+        || !iface.getAllUnnumberedAddresses().isEmpty();
   }
 
   /**

--- a/projects/common/src/main/java/org/batfish/datamodel/ConcreteInterfaceAddress.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/ConcreteInterfaceAddress.java
@@ -75,11 +75,8 @@ public final class ConcreteInterfaceAddress extends InterfaceAddress {
   }
 
   @Override
-  public int compareTo(InterfaceAddress rhs) {
-    if (rhs instanceof ConcreteInterfaceAddress) {
-      return COMPARATOR.compare(this, (ConcreteInterfaceAddress) rhs);
-    }
-    return 1;
+  protected int compareSameClass(InterfaceAddress o) {
+    return COMPARATOR.compare(this, (ConcreteInterfaceAddress) o);
   }
 
   @Override

--- a/projects/common/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Interface.java
@@ -718,6 +718,9 @@ public final class Interface extends ComparableStructure<String> {
   /** Cache of all link-local addresses */
   private @Nullable transient Set<LinkLocalAddress> _allLinkLocalAddresses;
 
+  /** Cache of all unnumbered addresses */
+  private @Nullable transient Set<UnnumberedAddress> _allUnnumberedAddresses;
+
   private boolean _autoState;
   private @Nullable Double _bandwidth;
   private @Nullable Boolean _blacklisted;
@@ -984,6 +987,18 @@ public final class Interface extends ComparableStructure<String> {
               .collect(ImmutableSet.toImmutableSet());
     }
     return _allLinkLocalAddresses;
+  }
+
+  @JsonIgnore
+  public Set<UnnumberedAddress> getAllUnnumberedAddresses() {
+    if (_allUnnumberedAddresses == null) {
+      _allUnnumberedAddresses =
+          _allAddresses.stream()
+              .filter(a -> a instanceof UnnumberedAddress)
+              .map(a -> (UnnumberedAddress) a)
+              .collect(ImmutableSet.toImmutableSet());
+    }
+    return _allUnnumberedAddresses;
   }
 
   public @Nonnull Set<InterfaceAddress> getAllAddresses() {
@@ -1425,6 +1440,7 @@ public final class Interface extends ComparableStructure<String> {
     // Clear cached values
     _allLinkLocalAddresses = null;
     _allConcreteAddresses = null;
+    _allUnnumberedAddresses = null;
   }
 
   @JsonProperty(PROP_AUTOSTATE)

--- a/projects/common/src/main/java/org/batfish/datamodel/InterfaceAddress.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/InterfaceAddress.java
@@ -8,9 +8,32 @@ import javax.annotation.Nullable;
 
 public abstract class InterfaceAddress implements Serializable, Comparable<InterfaceAddress> {
 
+  @Override
+  public final int compareTo(InterfaceAddress o) {
+    if (this == o) {
+      return 0;
+    }
+    int ret = getClass().getSimpleName().compareTo(o.getClass().getSimpleName());
+    if (ret != 0) {
+      return ret;
+    }
+    return compareSameClass(o);
+  }
+
+  protected abstract int compareSameClass(InterfaceAddress o);
+
+  @Override
+  public abstract boolean equals(Object o);
+
+  @Override
+  public abstract int hashCode();
+
   @JsonCreator
   private static InterfaceAddress jsonCreator(@Nullable String text) {
     checkArgument(text != null);
+    if (text.startsWith(UnnumberedAddress.STR_PREFIX + ":")) {
+      return UnnumberedAddress.parse(text);
+    }
     try {
       // Try the common case first
       return ConcreteInterfaceAddress.parse(text);

--- a/projects/common/src/main/java/org/batfish/datamodel/LinkLocalAddress.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/LinkLocalAddress.java
@@ -82,10 +82,7 @@ public final class LinkLocalAddress extends InterfaceAddress {
   }
 
   @Override
-  public int compareTo(InterfaceAddress o) {
-    if (o instanceof LinkLocalAddress) {
-      return _ip.compareTo(((LinkLocalAddress) o).getIp());
-    }
-    return -1;
+  protected int compareSameClass(InterfaceAddress o) {
+    return _ip.compareTo(((LinkLocalAddress) o).getIp());
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/UnnumberedAddress.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/UnnumberedAddress.java
@@ -1,0 +1,96 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * An unnumbered interface address that borrows its IP from another interface (typically a
+ * loopback).
+ *
+ * <p>Unnumbered interfaces do not own a connected route for the borrowed IP and do not participate
+ * in subnet-based L3 topology synthesis. They form adjacencies (e.g., OSPF point-to-point) via
+ * physical link adjacency rather than shared subnets.
+ */
+@ParametersAreNonnullByDefault
+public final class UnnumberedAddress extends InterfaceAddress {
+
+  static final String STR_PREFIX = "unnumbered";
+
+  private final @Nonnull String _sourceInterfaceName;
+  private final @Nonnull Ip _ip;
+
+  private UnnumberedAddress(String sourceInterfaceName, Ip ip) {
+    _sourceInterfaceName = sourceInterfaceName;
+    _ip = ip;
+  }
+
+  public static UnnumberedAddress of(String sourceInterfaceName, Ip ip) {
+    checkArgument(!sourceInterfaceName.isEmpty(), "Source interface name must not be empty");
+    return new UnnumberedAddress(sourceInterfaceName, ip);
+  }
+
+  public @Nonnull String getSourceInterfaceName() {
+    return _sourceInterfaceName;
+  }
+
+  public @Nonnull Ip getIp() {
+    return _ip;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UnnumberedAddress)) {
+      return false;
+    }
+    UnnumberedAddress that = (UnnumberedAddress) o;
+    return _sourceInterfaceName.equals(that._sourceInterfaceName) && _ip.equals(that._ip);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_sourceInterfaceName, _ip);
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return STR_PREFIX + ":" + _sourceInterfaceName + ":" + _ip;
+  }
+
+  @JsonCreator
+  private static UnnumberedAddress jsonCreator(@Nullable String text) {
+    checkArgument(text != null);
+    return parse(text);
+  }
+
+  public static UnnumberedAddress parse(String text) {
+    checkArgument(
+        text.startsWith(STR_PREFIX + ":"),
+        "Invalid %s string: \"%s\"",
+        UnnumberedAddress.class.getSimpleName(),
+        text);
+    String remainder = text.substring(STR_PREFIX.length() + 1);
+    int lastColon = remainder.lastIndexOf(':');
+    checkArgument(
+        lastColon > 0, "Invalid %s string: \"%s\"", UnnumberedAddress.class.getSimpleName(), text);
+    String sourceInterface = remainder.substring(0, lastColon);
+    Ip ip = Ip.parse(remainder.substring(lastColon + 1));
+    return of(sourceInterface, ip);
+  }
+
+  @Override
+  protected int compareSameClass(InterfaceAddress o) {
+    UnnumberedAddress that = (UnnumberedAddress) o;
+    int c = _sourceInterfaceName.compareTo(that._sourceInterfaceName);
+    return c != 0 ? c : _ip.compareTo(that._ip);
+  }
+}


### PR DESCRIPTION
Add UnnumberedAddress, a new InterfaceAddress subclass for interfaces
that borrow their IP from another interface (e.g., `ip address
unnumbered Loopback0`). Unlike copying the source's
ConcreteInterfaceAddress, UnnumberedAddress naturally suppresses
connected route generation and IP ownership claims, and provides an
explicit signal for topology computation.

Parse and extract the `ip address unnumbered <interface>` syntax on
Arista EOS interfaces. During conversion, resolve the source
interface's IP and set UnnumberedAddress on the VI interface. Set
OspfAddresses on the OSPF interface settings so that OSPF neighbor
init can find the borrowed IP for adjacency formation.

Extend TopologyUtil.computeRawLayer3Topology() to create L3 edges for
interfaces with UnnumberedAddress (or LinkLocalAddress) via physical
adjacency, since neither type participates in subnet-based L3
topology synthesis.

Fixes https://github.com/batfish/batfish/issues/7227

----

Prompt:
```
Investigate https://github.com/batfish/batfish/issues/7227. Create a
ceos lab that exhibits the behavior, test it, triage it against
current batfish (origin/master) and commit it with a complete sickbay
including new bugs if appropriate, referencing the original. Then
start closing the gaps in Batfish. Work autonomously, until complete.
```