### PR TITLE
checkstyle: catch @Nullable/@Nonnull before transient, abstract, synchronized, etc.

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -34,7 +34,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   private final RibTree<R> _tree;
 
   /** Memoized set of all routes in this RIB */
-  private @Nullable transient Set<R> _allRoutes;
+  private transient @Nullable Set<R> _allRoutes;
 
   /**
    * Keep a (insert ordered) set of alternative routes. Used to update the RIB if best routes are

--- a/projects/batfish/src/main/java/org/batfish/main/BatchManager.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatchManager.java
@@ -23,7 +23,7 @@ public final class BatchManager {
     return _instance;
   }
 
-  private @Nullable synchronized Task getTask(Settings settings) {
+  private synchronized @Nullable Task getTask(Settings settings) {
     String taskId = settings.getTaskId();
     if (taskId == null) {
       return null;
@@ -44,7 +44,7 @@ public final class BatchManager {
     }
   }
 
-  public @Nullable synchronized Task getTaskFromLog(String taskId) {
+  public synchronized @Nullable Task getTaskFromLog(String taskId) {
     return _taskLog.get(taskId);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrVendorConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrVendorConfiguration.java
@@ -33,7 +33,7 @@ public abstract class FrrVendorConfiguration extends VendorConfiguration {
    *
    * @throws java.util.NoSuchElementException if the interface does not exist.
    */
-  public @Nonnull abstract List<ConcreteInterfaceAddress> getInterfaceAddresses(String ifaceName);
+  public abstract @Nonnull List<ConcreteInterfaceAddress> getInterfaceAddresses(String ifaceName);
 
   // TODO: Simplify and unbundle what is happening in this method
   public abstract Map<String, Vxlan> getVxlans();

--- a/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/a10/representation/A10Configuration.java
@@ -1170,7 +1170,7 @@ public final class A10Configuration extends VendorConfiguration {
   }
 
   /** Map of interface names to interface. Used for converting aggregate interfaces. */
-  private @Nullable transient Map<String, Interface> _ifaceNametoIface;
+  private transient @Nullable Map<String, Interface> _ifaceNametoIface;
 
   private @Nonnull Map<String, AccessList> _accessLists;
   private @Nullable BgpProcess _bgpProcess;

--- a/projects/checkstyle.xml
+++ b/projects/checkstyle.xml
@@ -28,7 +28,7 @@
   </module>
 
   <module name="RegexpMultiline">
-    <property name="format" value="(@Nullable|@Nonnull)\s*\n\s*(@|public|private|protected|static|final)"/>
+    <property name="format" value="(@Nullable|@Nonnull)\s*\n\s*(@|public|private|protected|static|final|transient|volatile|abstract|default|synchronized|native)"/>
     <property name="message" value="Nullity should annotate the type when possible"/>
     <property name="fileExtensions" value="java"/>
     <property name="matchAcrossLines" value="true"/>
@@ -56,7 +56,7 @@
     </module>
 
     <module name="RegexpSinglelineJava">
-      <property name="format" value="(@Nullable|@Nonnull) (private|public|protected|static|final|@\S+) "/>
+      <property name="format" value="(@Nullable|@Nonnull) (private|public|protected|static|final|transient|volatile|abstract|default|synchronized|native|@\S+) "/>
       <property name="message" value="Nullity should annotate the type when possible"/>
     </module>
 

--- a/projects/common/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
@@ -27,7 +27,7 @@ public abstract class AbstractRouteBuilder<
   private boolean _nonRouting;
   private long _tag = Route.UNSET_ROUTE_TAG;
 
-  public @Nonnull abstract T build();
+  public abstract @Nonnull T build();
 
   public final long getAdmin() {
     return _admin;
@@ -41,7 +41,7 @@ public abstract class AbstractRouteBuilder<
   }
 
   // To handle the class casting exception while returning S in chaining methods
-  protected @Nonnull abstract S getThis();
+  protected abstract @Nonnull S getThis();
 
   public final long getMetric() {
     return _metric;

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -284,10 +284,10 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
     to create a completely new builder which should be of the same type as environment's output
     route builder but we are not sure of the concrete type and only know that it extends the
     abstract BgpRoute's builder. */
-    public @Nonnull abstract B newBuilder();
+    public abstract @Nonnull B newBuilder();
 
     @Override
-    public @Nonnull abstract R build();
+    public abstract @Nonnull R build();
 
     @Override
     public @Nonnull AsPath getAsPath() {
@@ -339,7 +339,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
     }
 
     @Override
-    protected @Nonnull abstract B getThis();
+    protected abstract @Nonnull B getThis();
 
     @Override
     public int getWeight() {

--- a/projects/common/src/main/java/org/batfish/datamodel/EvpnRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/EvpnRoute.java
@@ -62,7 +62,7 @@ public abstract class EvpnRoute<B extends Builder<B, R>, R extends BgpRoute<B, R
     }
 
     @Override
-    public @Nonnull abstract R build();
+    public abstract @Nonnull R build();
   }
 
   /**

--- a/projects/common/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Interface.java
@@ -713,13 +713,13 @@ public final class Interface extends ComparableStructure<String> {
   private @Nonnull SortedMap<ConcreteInterfaceAddress, ConnectedRouteMetadata> _addressMetadata;
 
   /** Cache of all concrete addresses */
-  private @Nullable transient Set<ConcreteInterfaceAddress> _allConcreteAddresses;
+  private transient @Nullable Set<ConcreteInterfaceAddress> _allConcreteAddresses;
 
   /** Cache of all link-local addresses */
-  private @Nullable transient Set<LinkLocalAddress> _allLinkLocalAddresses;
+  private transient @Nullable Set<LinkLocalAddress> _allLinkLocalAddresses;
 
   /** Cache of all unnumbered addresses */
-  private @Nullable transient Set<UnnumberedAddress> _allUnnumberedAddresses;
+  private transient @Nullable Set<UnnumberedAddress> _allUnnumberedAddresses;
 
   private boolean _autoState;
   private @Nullable Double _bandwidth;

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
@@ -158,7 +158,7 @@ public abstract class OspfExternalRoute extends OspfRoute {
   }
 
   @JsonIgnore
-  public @Nonnull abstract OspfMetricType getOspfMetricType();
+  public abstract @Nonnull OspfMetricType getOspfMetricType();
 
   @Override
   public @Nonnull RoutingProtocol getProtocol() {

--- a/projects/common/src/main/java/org/batfish/datamodel/OspfRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/OspfRoute.java
@@ -59,5 +59,5 @@ public abstract class OspfRoute extends AbstractRoute {
   }
 
   @Override
-  public @Nonnull abstract RoutingProtocol getProtocol();
+  public abstract @Nonnull RoutingProtocol getProtocol();
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/AddressFamily.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/AddressFamily.java
@@ -150,9 +150,9 @@ public abstract class AddressFamily implements Serializable {
       return getThis();
     }
 
-    public @Nonnull abstract B getThis();
+    public abstract @Nonnull B getThis();
 
-    public @Nonnull abstract F build();
+    public abstract @Nonnull F build();
   }
 
   /** BGP address family type */

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/community/Community.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/community/Community.java
@@ -25,7 +25,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public abstract class Community implements Serializable, Comparable<Community> {
 
-  private @Nullable transient BigInteger _bigInt;
+  private transient @Nullable BigInteger _bigInt;
 
   @JsonCreator
   private static Community create(@Nullable JsonNode node) {
@@ -88,14 +88,14 @@ public abstract class Community implements Serializable, Comparable<Community> {
    * Return the community value as a {@link java.math.BigInteger} so it can be compared and ordered
    * deterministically regardless of community type
    */
-  protected @Nonnull abstract BigInteger asBigIntImpl();
+  protected abstract @Nonnull BigInteger asBigIntImpl();
 
   /** Return a string representation of the community suitable for regex matching. */
-  public @Nonnull abstract String matchString();
+  public abstract @Nonnull String matchString();
 
   /** Return a string representation of the community in canonical form. */
   @Override
-  public @Nonnull abstract String toString();
+  public abstract @Nonnull String toString();
 
   @Override
   public abstract boolean equals(@Nullable Object obj);

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -50,8 +50,8 @@ public final class ExtendedCommunity extends Community {
   private final long _value;
 
   // Cached string representations
-  private @Nullable transient String _str;
-  private @Nullable transient String _regexStr;
+  private transient @Nullable String _str;
+  private transient @Nullable String _regexStr;
 
   private ExtendedCommunity(int type, int subType, long value) {
     checkArgument(VALID_TYPES.contains(type), "Not a valid BGP extended community type: %s", type);

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/community/StandardCommunity.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/community/StandardCommunity.java
@@ -50,7 +50,7 @@ public final class StandardCommunity extends Community {
   private final long _value;
 
   // Cached string representation
-  private @Nullable transient String _str;
+  private transient @Nullable String _str;
 
   private StandardCommunity(long value) {
     checkArgument(

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -91,7 +91,7 @@ public class RoutingPolicy implements Serializable {
 
   private final @Nonnull String _name;
   private @Nullable Configuration _owner;
-  private @Nullable transient Set<String> _sources;
+  private transient @Nullable Set<String> _sources;
   private @Nonnull List<Statement> _statements;
 
   @JsonCreator

--- a/projects/common/src/main/java/org/batfish/role/NodeRole.java
+++ b/projects/common/src/main/java/org/batfish/role/NodeRole.java
@@ -18,7 +18,7 @@ public class NodeRole implements Comparable<NodeRole> {
   private static final String PROP_NAME = "name";
   private static final String PROP_REGEX = "regex";
 
-  private final @Nonnull transient Pattern _compiledPattern;
+  private final transient @Nonnull Pattern _compiledPattern;
 
   private final @Nonnull String _name;
 

--- a/projects/common/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/common/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -36,7 +36,7 @@ public abstract class VendorConfiguration implements Serializable {
   private transient @Nullable ConversionContext _conversionContext;
   protected String _filename;
   protected @Nonnull List<String> _secondaryFilenames;
-  protected @Nonnull transient SnapshotRuntimeData _runtimeData;
+  protected transient @Nonnull SnapshotRuntimeData _runtimeData;
   private VendorConfiguration _overlayConfiguration;
   protected final @Nonnull StructureManager _structureManager;
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkQueueMgr.java
@@ -273,14 +273,14 @@ public class WorkQueueMgr {
     return work;
   }
 
-  private @Nullable synchronized QueuedWork getWork(UUID workId, QueueType qType) {
+  private synchronized @Nullable QueuedWork getWork(UUID workId, QueueType qType) {
     return switch (qType) {
       case COMPLETED -> _queueCompletedWork.getWork(workId);
       case INCOMPLETE -> _queueIncompleteWork.getWork(workId);
     };
   }
 
-  public @Nullable synchronized QueuedWork getWorkForAssignment() {
+  public synchronized @Nullable QueuedWork getWorkForAssignment() {
 
     for (QueuedWork work : _queueIncompleteWork) {
       if (work.getStatus() == WorkStatusCode.UNASSIGNED) {
@@ -292,7 +292,7 @@ public class WorkQueueMgr {
     return null;
   }
 
-  public @Nonnull synchronized List<QueuedWork> getWorkForChecking() {
+  public synchronized @Nonnull List<QueuedWork> getWorkForChecking() {
     List<QueuedWork> workToCheck = new ArrayList<>();
     for (QueuedWork work : _queueIncompleteWork) {
       if (work.getStatus() == WorkStatusCode.ASSIGNED) {


### PR DESCRIPTION
The nullity annotation placement rules only checked modifiers
private/public/protected/static/final. Add transient, volatile, abstract,
default, synchronized, and native. Fix all 31 existing violations.

Prompt:
```
We have a checkstyle or pmd rule that keeps @Nullable/@Nonnull next to
the type they annotate. I saw one like `private @Nullable transient Set`
-- can we fix the rule so it catches these, and then fix the violations
```