### PR TITLE
Arista: accept IP address config regardless of position relative to `no switchport`

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -5150,10 +5150,6 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
     ConcreteInterfaceAddress addr = toAddress(ctx.addr);
     _currentInterfaces.forEach(
         i -> {
-          if (i.getSwitchport()) {
-            warn(ctx, String.format("Ignoring IP address for switchport %s", i.getName()));
-            return;
-          }
           if (ctx.SECONDARY() != null) {
             i.getSecondaryAddresses().add(addr);
           } else {
@@ -5170,14 +5166,7 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
         sourceInterface,
         AristaStructureUsage.INTERFACE_IP_ADDRESS_UNNUMBERED,
         ctx.iname.getStart().getLine());
-    _currentInterfaces.forEach(
-        i -> {
-          if (i.getSwitchport()) {
-            warn(ctx, String.format("Ignoring IP address for switchport %s", i.getName()));
-            return;
-          }
-          i.setUnnumberedSourceInterface(sourceInterface);
-        });
+    _currentInterfaces.forEach(i -> i.setUnnumberedSourceInterface(sourceInterface));
   }
 
   @Override
@@ -5186,10 +5175,6 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
     ConcreteInterfaceAddress addr = toAddress(ctx.addr);
     _currentInterfaces.forEach(
         i -> {
-          if (i.getSwitchport()) {
-            warn(ctx, String.format("Ignoring IP address for switchport %s", i.getName()));
-            return;
-          }
           if (ctx.SECONDARY() != null) {
             i.getSecondaryAddresses().add(addr);
           } else {

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
@@ -1372,10 +1372,12 @@ public final class AristaConfiguration extends VendorConfiguration {
 
       case ACCESS:
         // switch settings
+        warnSwitchportWithAddress(iface);
         newIface.setAccessVlan(firstNonNull(iface.getAccessVlan(), 1));
         break;
 
       case TRUNK:
+        warnSwitchportWithAddress(iface);
         newIface.setNativeVlan(firstNonNull(iface.getNativeVlan(), 1));
         /*
          * Compute allowed VLANs as configured allowed vlans (or default) minus vlans in other trunk groups.
@@ -1393,7 +1395,7 @@ public final class AristaConfiguration extends VendorConfiguration {
         break;
 
       default:
-        // not handled
+        warnSwitchportWithAddress(iface);
         break;
     }
 
@@ -1431,6 +1433,14 @@ public final class AristaConfiguration extends VendorConfiguration {
     }
 
     return newIface;
+  }
+
+  private void warnSwitchportWithAddress(Interface iface) {
+    if (iface.getAddress() != null
+        || !iface.getSecondaryAddresses().isEmpty()
+        || iface.getUnnumberedSourceInterface() != null) {
+      _w.redFlag(String.format("Ignoring IP address for switchport interface %s", iface.getName()));
+    }
   }
 
   private void generateDestinationStaticNats(

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -1123,6 +1123,56 @@ public class AristaGrammarTest {
   }
 
   @Test
+  public void testIpAddressBeforeNoSwitchport() throws IOException {
+    // IP address should be accepted on interfaces that ultimately have `no switchport`,
+    // regardless of whether ip address appears before or after `no switchport` in the config.
+    String hostname = "eos_ip_before_no_switchport";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    Configuration c = parseConfig(hostname);
+
+    // Ethernet0/0: ip address BEFORE no switchport — should still get the address
+    assertThat(c, hasInterface("Ethernet0/0", isSwitchport(false)));
+    assertThat(c, hasInterface("Ethernet0/0", hasSwitchPortMode(SwitchportMode.NONE)));
+    assertThat(
+        c,
+        hasInterface(
+            "Ethernet0/0",
+            hasAllAddresses(containsInAnyOrder(ConcreteInterfaceAddress.parse("10.0.0.0/31")))));
+
+    // Ethernet0/1: no switchport BEFORE ip address — the normal order, should work
+    assertThat(c, hasInterface("Ethernet0/1", isSwitchport(false)));
+    assertThat(c, hasInterface("Ethernet0/1", hasSwitchPortMode(SwitchportMode.NONE)));
+    assertThat(
+        c,
+        hasInterface(
+            "Ethernet0/1",
+            hasAllAddresses(containsInAnyOrder(ConcreteInterfaceAddress.parse("10.0.1.0/31")))));
+
+    // Ethernet0/2: ip address + secondary BEFORE no switchport — both should be assigned
+    assertThat(c, hasInterface("Ethernet0/2", isSwitchport(false)));
+    assertThat(c, hasInterface("Ethernet0/2", hasSwitchPortMode(SwitchportMode.NONE)));
+    assertThat(
+        c,
+        hasInterface(
+            "Ethernet0/2",
+            hasAllAddresses(
+                containsInAnyOrder(
+                    ConcreteInterfaceAddress.parse("10.0.2.0/31"),
+                    ConcreteInterfaceAddress.parse("10.0.2.2/31")))));
+
+    // Ethernet0/3: switchport stays (no `no switchport`) — ip address should NOT be assigned
+    assertThat(c, hasInterface("Ethernet0/3", isSwitchport(true)));
+    assertThat(c, hasInterface("Ethernet0/3", hasSwitchPortMode(SwitchportMode.ACCESS)));
+    assertThat(c, hasInterface("Ethernet0/3", hasAllAddresses(empty())));
+    assertThat(
+        ccae,
+        hasRedFlagWarning(
+            hostname, containsString("Ignoring IP address for switchport interface Ethernet0/3")));
+  }
+
+  @Test
   public void testAristaDynamicSourceNat() throws IOException {
     Configuration c = parseConfig("arista-dynamic-source-nat");
     Interface iface = c.getAllInterfaces().get("Ethernet1");

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/eos_ip_before_no_switchport
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/eos_ip_before_no_switchport
@@ -1,0 +1,30 @@
+!
+hostname eos_ip_before_no_switchport
+boot system flash fake.swi
+!
+! Test that IP address is accepted regardless of order relative to `no switchport`.
+!
+! Ethernet0/0: ip address BEFORE no switchport (the bug scenario)
+interface Ethernet0/0
+ ip address 10.0.0.0/31
+ no switchport
+ no shutdown
+!
+! Ethernet0/1: no switchport BEFORE ip address (the normal order)
+interface Ethernet0/1
+ no switchport
+ ip address 10.0.1.0/31
+ no shutdown
+!
+! Ethernet0/2: ip address with secondary BEFORE no switchport
+interface Ethernet0/2
+ ip address 10.0.2.0/31
+ ip address 10.0.2.2/31 secondary
+ no switchport
+ no shutdown
+!
+! Ethernet0/3: switchport stays (ip address should NOT be assigned)
+interface Ethernet0/3
+ ip address 10.0.3.0/31
+ no shutdown
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/ip-nat-source-static
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/ip-nat-source-static
@@ -18,6 +18,7 @@ ip access-list INVALID_ACL
   permit ip any host 11.11.11.11 fragments
 !
 interface Ethernet1
+  no switchport
   ! lots of valid configurations
   ip address 1.0.0.0/31
   ip nat source static 1.1.1.1 2.2.2.2
@@ -26,6 +27,7 @@ interface Ethernet1
   ip nat source static 7.7.7.7 77 access-list ACL 8.8.8.8 88 protocol udp
 !
 interface Ethernet2
+  no switchport
   ip address 2.0.0.0/31
   ip nat source static 1.1.1.1 access-list INVALID_ACL 2.2.2.2
   ip nat source static 3.3.3.3 access-list UNDEFINED_ACL 4.4.4.4


### PR DESCRIPTION
Batfish was rejecting `ip address` on Arista Ethernet interfaces when it
appeared before `no switchport` in the config. Physical interfaces default
to switchport mode, and the extraction code was checking switchport state
at parse time — so IP addresses were silently dropped if they preceded
`no switchport`.

Real EOS devices accept L3 config in either order. Confirmed with a cEOS
4.36.0.1F lab: configuring `ip address` before `no switchport` results in
a working L3 interface. The device normalizes `show running-config` to
display `no switchport` first regardless of input order.

The fix removes the premature switchport guards from IP address extraction.
The conversion layer already correctly ignores addresses for interfaces
that remain in switchport mode.

Prompt:
```
I can't find the report, but a user reported that we are incorrectly
requiring switchport to be disabled before accepting L3 config for Arista
interfaces, but in reality devices may well have L3 config before
`no switchport` in show data. Can you confirm with a new cEOS lab and if
so, fix Batfish behavior.
```