### PR TITLE
Arista: fix OSPF default interface cost when auto-cost is not configured

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
@@ -1584,7 +1584,8 @@ public final class AristaConfiguration extends VendorConfiguration {
     org.batfish.datamodel.ospf.OspfProcess newProcess =
         org.batfish.datamodel.ospf.OspfProcess.builder()
             .setProcessId(proc.getName())
-            .setReferenceBandwidth(proc.getReferenceBandwidth())
+            .setReferenceBandwidth(
+                firstNonNull(proc.getReferenceBandwidth(), OspfProcess.DEFAULT_REFERENCE_BANDWIDTH))
             .setAdminCosts(
                 org.batfish.datamodel.ospf.OspfProcess.computeDefaultAdminCosts(
                     c.getConfigurationFormat()))
@@ -1795,12 +1796,15 @@ public final class AristaConfiguration extends VendorConfiguration {
     org.batfish.datamodel.ospf.OspfNetworkType networkType =
         toOspfNetworkType(vsIface.getOspfNetworkType(), _w);
     ospfSettings.setNetworkType(networkType);
-    if (vsIface.getOspfCost() == null
-        && iface.isLoopback()
-        && networkType != OspfNetworkType.POINT_TO_POINT) {
+    if (vsIface.getOspfCost() != null) {
+      ospfSettings.setCost(vsIface.getOspfCost());
+    } else if (proc != null && proc.getReferenceBandwidth() == null) {
+      // EOS: when auto-cost reference-bandwidth is not configured, use flat default cost of 10.
+      ospfSettings.setCost(OspfProcess.DEFAULT_INTERFACE_OSPF_COST);
+    } else if (iface.isLoopback() && networkType != OspfNetworkType.POINT_TO_POINT) {
       ospfSettings.setCost(DEFAULT_LOOPBACK_OSPF_COST);
     } else {
-      ospfSettings.setCost(vsIface.getOspfCost());
+      ospfSettings.setCost(null);
     }
     ospfSettings.setHelloInterval(toOspfHelloInterval(vsIface, networkType));
     ospfSettings.setDeadInterval(toOspfDeadInterval(vsIface, networkType));

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/OspfProcess.java
@@ -29,7 +29,11 @@ public class OspfProcess implements Serializable {
 
   public static final long DEFAULT_MAX_METRIC_SUMMARY_LSA = 0xFF0000L;
 
-  private static final double DEFAULT_REFERENCE_BANDWIDTH_10_MBPS = 10E6D;
+  /** Default cost for Ethernet interfaces when auto-cost reference-bandwidth is not configured. */
+  public static final int DEFAULT_INTERFACE_OSPF_COST = 10;
+
+  /** Default reference bandwidth (100 Mbps) when auto-cost reference-bandwidth IS configured. */
+  public static final double DEFAULT_REFERENCE_BANDWIDTH = 100E6D;
 
   public static final long MAX_METRIC_ROUTER_LSA = 0xFFFFL;
 
@@ -77,7 +81,7 @@ public class OspfProcess implements Serializable {
 
   private Map<RedistributionSourceProtocol, OspfRedistributionPolicy> _redistributionPolicies;
 
-  private double _referenceBandwidth;
+  private @Nullable Double _referenceBandwidth;
 
   private @Nullable Boolean _rfc1583Compatible;
 
@@ -85,9 +89,12 @@ public class OspfProcess implements Serializable {
 
   private Map<Long, Map<Prefix, OspfAreaSummary>> _summaries;
 
+  /**
+   * Returns the default reference bandwidth (100 Mbps) used when {@code auto-cost
+   * reference-bandwidth} IS explicitly configured without a rate. Per EOS manual, Chapter 27.
+   */
   public static double getReferenceOspfBandwidth() {
-    // EOS manual, Chapter 27, "auto-cost reference-bandwidth (OSPFv2)"
-    return DEFAULT_REFERENCE_BANDWIDTH_10_MBPS;
+    return DEFAULT_REFERENCE_BANDWIDTH;
   }
 
   public long getEffectiveDefaultMetric() {
@@ -101,7 +108,6 @@ public class OspfProcess implements Serializable {
 
   public OspfProcess(String name) {
     _name = name;
-    _referenceBandwidth = getReferenceOspfBandwidth();
     _networks = new TreeSet<>();
     _defaultInformationMetric = DEFAULT_DEFAULT_INFORMATION_METRIC;
     _defaultInformationMetricType = DEFAULT_DEFAULT_INFORMATION_METRIC_TYPE;
@@ -199,7 +205,7 @@ public class OspfProcess implements Serializable {
     return _redistributionPolicies;
   }
 
-  public double getReferenceBandwidth() {
+  public @Nullable Double getReferenceBandwidth() {
     return _referenceBandwidth;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -242,6 +242,7 @@ import org.batfish.vendor.arista.representation.IpAsPathAccessListLine;
 import org.batfish.vendor.arista.representation.MlagConfiguration;
 import org.batfish.vendor.arista.representation.NatProtocol;
 import org.batfish.vendor.arista.representation.OspfNetwork;
+import org.batfish.vendor.arista.representation.OspfProcess;
 import org.batfish.vendor.arista.representation.PrefixList;
 import org.batfish.vendor.arista.representation.PrefixListLine;
 import org.batfish.vendor.arista.representation.RouteMap;
@@ -641,6 +642,33 @@ public class AristaGrammarTest {
     assertThat(
         defaults.getDefaultVrf().getOspfProcesses().get("1").getReferenceBandwidth(),
         equalTo(getReferenceOspfBandwidth()));
+  }
+
+  @Test
+  public void testAristaOspfDefaultInterfaceCost() throws IOException {
+    // When auto-cost reference-bandwidth is not configured, EOS uses a flat default cost of 10
+    // for all interfaces, including loopbacks.
+    Configuration c = parseConfig("arista_ospf_default_cost");
+    assertThat(
+        c.getAllInterfaces().get("Loopback0").getOspfSettings().getCost(),
+        equalTo(OspfProcess.DEFAULT_INTERFACE_OSPF_COST));
+    assertThat(
+        c.getAllInterfaces().get("Ethernet1").getOspfSettings().getCost(),
+        equalTo(OspfProcess.DEFAULT_INTERFACE_OSPF_COST));
+    assertThat(c.getAllInterfaces().get("Ethernet2").getOspfSettings().getCost(), equalTo(42));
+  }
+
+  @Test
+  public void testAristaOspfAutoCostInterfaceCost() throws IOException {
+    // When auto-cost reference-bandwidth is configured, cost is computed from reference bandwidth.
+    Configuration c = parseConfig("arista_ospf_auto_cost");
+    assertThat(
+        c.getDefaultVrf().getOspfProcesses().get("1").getReferenceBandwidth(), equalTo(100e6d));
+    assertThat(
+        c.getAllInterfaces().get("Loopback0").getOspfSettings().getCost(),
+        equalTo(OspfProcess.DEFAULT_LOOPBACK_OSPF_COST));
+    // auto-cost 100 (100 Mbps) / 1 Gbps Ethernet = cost 1 (computed by initInterfaceCosts)
+    assertThat(c.getAllInterfaces().get("Ethernet1").getOspfSettings().getCost(), equalTo(1));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_ospf_auto_cost
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_ospf_auto_cost
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_ospf_auto_cost
+!
+interface Loopback0
+  ip address 2.2.2.2/32
+!
+interface Ethernet1
+  no switchport
+  ip address 10.0.0.1/31
+!
+ip routing
+!
+router ospf 1
+  router-id 2.2.2.2
+  auto-cost reference-bandwidth 100
+  network 0.0.0.0/0 area 0
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_ospf_default_cost
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_ospf_default_cost
@@ -1,0 +1,22 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_ospf_default_cost
+!
+interface Loopback0
+  ip address 1.1.1.1/32
+!
+interface Ethernet1
+  no switchport
+  ip address 10.0.0.1/31
+!
+interface Ethernet2
+  no switchport
+  ip address 10.0.1.0/31
+  ip ospf cost 42
+!
+ip routing
+!
+router ospf 1
+  router-id 1.1.1.1
+  network 0.0.0.0/0 area 0
+!


### PR DESCRIPTION
Per the EOS 4.36 manual, when `auto-cost reference-bandwidth` is not
configured, all interfaces get a flat default OSPF cost of 10 (the
"default ip ospf cost value"). The reference-bandwidth formula
(`rate * 1 Mbps / bandwidth`) is only used when `auto-cost
reference-bandwidth` is explicitly present in the config.

Batfish previously always computed cost from a reference bandwidth,
using an incorrect default of 10 Mbps. This produced cost 1 for
typical interfaces instead of cost 10.

The fix:
- Make the VS OspfProcess reference bandwidth nullable to distinguish
"auto-cost configured" from "not configured"
- When not configured, set all interface costs to 10 during conversion
- Fix the default reference bandwidth from 10 Mbps to 100 Mbps (the
documented default when the command IS explicitly configured)

Fixes batfish/batfish#9922

Prompt:
```
Let's try to fix the batfish issue first.
```