### PR TITLE
Junos: fatal red flag error for unnormalized static routes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3273,7 +3273,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _currentAreaRangeRestrict = false;
 
     if (ctx.prefix != null) {
-      _currentAreaRangePrefix = toPrefix(ctx.prefix);
+      _currentAreaRangePrefix = toNormalizedPrefix(ctx.prefix, "OSPF area-range");
     } else {
       todo(ctx);
     }
@@ -3660,7 +3660,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void enterRoa_route(Roa_routeContext ctx) {
     if (ctx.prefix != null) {
-      Prefix prefix = toPrefix(ctx.prefix);
+      Prefix prefix = toNormalizedPrefix(ctx.prefix, "Aggregate route");
       Map<Prefix, AggregateRoute> aggregateRoutes = _currentRib.getAggregateRoutes();
       _currentAggregateRoute = aggregateRoutes.computeIfAbsent(prefix, AggregateRoute::new);
     } else {
@@ -3696,7 +3696,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void enterRog_route(Rog_routeContext ctx) {
     if (ctx.prefix != null) {
-      Prefix prefix = toPrefix(ctx.prefix);
+      Prefix prefix = toNormalizedPrefix(ctx.prefix, "Generated route");
       Map<Prefix, GeneratedRoute> generatedRoutes = _currentRib.getGeneratedRoutes();
       _currentGeneratedRoute = generatedRoutes.computeIfAbsent(prefix, GeneratedRoute::new);
     } else if (ctx.prefix6 != null) {
@@ -3800,7 +3800,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void enterRos_route4(Ros_route4Context ctx) {
-    Prefix prefix = toPrefix(ctx.prefix);
+    Prefix prefix = toNormalizedPrefix(ctx.prefix, "Static route destination");
     Map<Prefix, StaticRouteV4> staticRoutes = _currentRib.getStaticRoutes();
     _currentStaticRoute = staticRoutes.computeIfAbsent(prefix, StaticRouteV4::new);
   }
@@ -5499,7 +5499,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitFftt_next_ip(Fftt_next_ipContext ctx) {
-    FwThenNextIp then = new FwThenNextIp(toPrefix(ctx.prefix));
+    FwThenNextIp then = new FwThenNextIp(toNormalizedPrefix(ctx.prefix, "Firewall next-ip"));
     _currentFwTerm.getThens().add(then);
     _currentFwTerm.getThens().add(FwThenAccept.INSTANCE);
     _currentFilter.setUsedForFBF(true);
@@ -8868,7 +8868,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitPocondiafi_prefix(Pocondiafi_prefixContext ctx) {
-    _currentCondition.getIfRouteExists().setPrefix(toPrefix(ctx.prefix));
+    _currentCondition
+        .getIfRouteExists()
+        .setPrefix(toNormalizedPrefix(ctx.prefix, "Condition if-route-exists"));
   }
 
   @Override
@@ -8884,6 +8886,35 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitPocondiaf_ccc(Pocondiaf_cccContext ctx) {
     todo(ctx);
+  }
+
+  /**
+   * Parses a prefix from context, issuing a fatal red flag if host bits are set. Junos rejects
+   * unnormalized prefixes at commit time in certain contexts.
+   */
+  private @Nonnull Prefix toNormalizedPrefix(Ip_prefix_default_32Context ctx, String description) {
+    if (ctx.IP_PREFIX() != null) {
+      String text = ctx.IP_PREFIX().getText();
+      Ip originalIp = Ip.parse(text.substring(0, text.indexOf('/')));
+      Prefix prefix = Prefix.parse(text);
+      if (!originalIp.equals(prefix.getStartIp())) {
+        _w.fatalRedFlag(
+            "%s %s is not a valid network prefix (host bits are set)", description, text);
+      }
+      return prefix;
+    }
+    assert ctx.IP_ADDRESS() != null;
+    return Ip.parse(ctx.getText()).toPrefix();
+  }
+
+  private @Nonnull Prefix toNormalizedPrefix(Ip_prefixContext ctx, String description) {
+    String text = ctx.IP_PREFIX().getText();
+    Ip originalIp = Ip.parse(text.substring(0, text.indexOf('/')));
+    Prefix prefix = Prefix.parse(text);
+    if (!originalIp.equals(prefix.getStartIp())) {
+      _w.fatalRedFlag("%s %s is not a valid network prefix (host bits are set)", description, text);
+    }
+    return prefix;
   }
 
   private static @Nonnull Prefix toPrefix(Ip_prefixContext ctx) {
@@ -9134,7 +9165,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       return toIpWildcard(ctx.ip_and_mask);
     } else {
       assert ctx.prefix != null;
-      return toIpWildcard(ctx.prefix);
+      return IpWildcard.create(toNormalizedPrefix(ctx.prefix, "Firewall address"));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1434,6 +1434,51 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testStaticRoutePrefixValidationFatalError() throws IOException {
+    String fileKey = "static-route-prefix-validation";
+    String warningKey = "configs/" + fileKey;
+
+    Batfish batfish = getBatfishForConfigurationNames(fileKey);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    ParseVendorConfigurationAnswerElement pvcae =
+        batfish.loadParseVendorConfigurationAnswerElement(batfish.getSnapshot());
+
+    // contains is exhaustive — also verifies no warning for the valid route 192.168.1.0/24
+    assertThat(
+        pvcae.getWarnings().get(warningKey).getFatalRedFlagWarnings(),
+        contains(
+            WarningMatchers.hasText(containsString("10.0.0.5/8")),
+            WarningMatchers.hasText(containsString("192.168.1.111/24"))));
+  }
+
+  @Test
+  public void testPrefixNormalizationValidation() throws IOException {
+    String fileKey = "prefix-normalization-validation";
+    String warningKey = "configs/" + fileKey;
+
+    Batfish batfish = getBatfishForConfigurationNames(fileKey);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    ParseVendorConfigurationAnswerElement pvcae =
+        batfish.loadParseVendorConfigurationAnswerElement(batfish.getSnapshot());
+
+    assertThat(
+        pvcae.getWarnings().get(warningKey).getFatalRedFlagWarnings(),
+        containsInAnyOrder(
+            WarningMatchers.hasText(
+                allOf(containsString("Aggregate route"), containsString("10.1.2.3/8"))),
+            WarningMatchers.hasText(
+                allOf(containsString("Generated route"), containsString("172.16.5.5/12"))),
+            WarningMatchers.hasText(
+                allOf(containsString("OSPF area-range"), containsString("192.168.1.1/16"))),
+            WarningMatchers.hasText(
+                allOf(containsString("Firewall address"), containsString("10.0.0.1/8"))),
+            WarningMatchers.hasText(
+                allOf(containsString("Firewall next-ip"), containsString("10.0.0.99/24"))),
+            WarningMatchers.hasText(
+                allOf(containsString("Condition if-route-exists"), containsString("10.0.0.5/8")))));
+  }
+
+  @Test
   public void testBgpKeepExtraction() {
     JuniperConfiguration c = parseJuniperConfig("bgp-keep");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/prefix-normalization-validation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/prefix-normalization-validation
@@ -1,0 +1,18 @@
+#
+set system host-name prefix-normalization-validation
+#
+# Valid prefixes (no warnings expected)
+set routing-options aggregate route 10.0.0.0/8 discard
+set routing-options generate route 172.16.0.0/12 discard
+set protocols ospf area 0 area-range 192.168.0.0/16
+set firewall filter F1 term T1 from address 10.0.0.0/8
+set firewall filter F1 term T1 then next-ip 10.0.0.0/24
+set policy-options condition C1 if-route-exists 10.0.0.0/8
+#
+# Invalid prefixes (host bits set — fatal red flag expected)
+set routing-options aggregate route 10.1.2.3/8 discard
+set routing-options generate route 172.16.5.5/12 discard
+set protocols ospf area 0 area-range 192.168.1.1/16
+set firewall filter F2 term T2 from address 10.0.0.1/8
+set firewall filter F2 term T2 then next-ip 10.0.0.99/24
+set policy-options condition C2 if-route-exists 10.0.0.5/8

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-route-prefix-validation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-route-prefix-validation
@@ -1,0 +1,9 @@
+#
+set system host-name static-route-prefix-validation
+#
+# Valid static route (host bits are zero)
+set routing-options static route 192.168.1.0/24 reject
+# Invalid static route (host bits are set)
+set routing-options static route 192.168.1.111/24 reject
+# Another invalid static route
+set routing-options static route 10.0.0.5/8 reject

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71723,6 +71723,16 @@
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options timestamp"
             }
+          ],
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "FATAL: Firewall address 5.5.5.5/31 is not a valid network prefix (host bits are set)"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "FATAL: Firewall next-ip 1.2.3.4/5 is not a valid network prefix (host bits are set)"
+            }
           ]
         },
         "configs/juniper_forwarding_options" : {


### PR DESCRIPTION
Junos commit checks require that static route prefixes be normalized (i.e. not host bits set). Add a fatal red flag warning for that. 

note: I suspect this is enforced other places too. For now, I'm limiting to the static route case that I know about