### PR TITLE
Arista: add 50g/400g speed forced and 100g-1/200g-2/400g-4 breakout tokens

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaLexer.g4
@@ -1650,6 +1650,8 @@ FIBER_NODE
    'fiber-node' -> pushMode ( M_FiberNode )
 ;
 
+FIFTYG_FULL: '50gfull';
+
 FILE_TRANSFER: 'file-transfer';
 
 FILTER: 'filter';
@@ -1687,6 +1689,10 @@ FOR: 'for';
 FORMAT: 'format';
 
 FORTYG_FULL: '40gfull';
+
+FOUR_HUNDREDG_4: '400g-4';
+
+FOUR_HUNDREDG_FULL: '400gfull';
 
 FORWARD: 'forward';
 
@@ -3073,6 +3079,8 @@ ON_STARTUP: 'on-startup';
 ON_SUCCESS: 'on-success';
 
 ONE_HUNDRED_FULL: '100full';
+
+ONE_HUNDREDG_1: '100g-1';
 
 ONE_HUNDREDG_FULL: '100gfull';
 
@@ -4643,6 +4651,8 @@ TUNNELED: 'tunneled';
 
 TWENTY_FIVEG_FULL: '25gfull';
 TWENTY_FIVE_GBASE_CR: '25gbase-cr';
+
+TWO_HUNDREDG_2: '200g-2';
 
 TX_QUEUE: 'tx-queue';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/Legacy_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/Legacy_interface.g4
@@ -8,12 +8,17 @@ options {
 
 eos_bandwidth_specifier
 :
-   FORTYG_FULL
+   FIFTYG_FULL
+   | FORTYG_FULL
+   | FOUR_HUNDREDG_4
+   | FOUR_HUNDREDG_FULL
+   | ONE_HUNDREDG_1
    | ONE_HUNDREDG_FULL
    | ONE_HUNDRED_FULL
    | ONE_THOUSAND_FULL
    | TEN_THOUSAND_FULL
    | TWENTY_FIVEG_FULL
+   | TWO_HUNDREDG_2
 ;
 
 eos_vxlan_if_inner

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -5544,18 +5544,28 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   }
 
   private double toBandwidth(Eos_bandwidth_specifierContext ctx) {
-    if (ctx.FORTYG_FULL() != null) {
+    if (ctx.FIFTYG_FULL() != null) {
+      return 50E9D;
+    } else if (ctx.FORTYG_FULL() != null) {
       return 40E9D;
+    } else if (ctx.FOUR_HUNDREDG_4() != null) {
+      return 400E9D;
+    } else if (ctx.FOUR_HUNDREDG_FULL() != null) {
+      return 400E9D;
     } else if (ctx.ONE_HUNDRED_FULL() != null) {
       return 100E6D;
     } else if (ctx.ONE_THOUSAND_FULL() != null) {
       return 1E9D;
+    } else if (ctx.ONE_HUNDREDG_1() != null) {
+      return 100E9D;
     } else if (ctx.ONE_HUNDREDG_FULL() != null) {
       return 100E9D;
     } else if (ctx.TEN_THOUSAND_FULL() != null) {
       return 10E9D;
     } else if (ctx.TWENTY_FIVEG_FULL() != null) {
       return 25E9D;
+    } else if (ctx.TWO_HUNDREDG_2() != null) {
+      return 200E9D;
     } else {
       throw convError(Double.class, ctx);
     }

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -2024,6 +2024,27 @@ public class AristaGrammarTest {
   }
 
   @Test
+  public void testEosInterfaceSpeedBreakout() throws IOException {
+    Configuration c = parseConfig("arista_interface_speed_breakout");
+    assertThat(c, hasInterface("Ethernet1/1", hasSpeed(400E9D)));
+    assertThat(c, hasInterface("Ethernet1/1", hasBandwidth(400E9D)));
+    assertThat(c, hasInterface("Ethernet2/1", hasSpeed(100E9D)));
+    assertThat(c, hasInterface("Ethernet2/1", hasBandwidth(100E9D)));
+    assertThat(c, hasInterface("Ethernet3/1", hasSpeed(10E9D)));
+    assertThat(c, hasInterface("Ethernet3/1", hasBandwidth(10E9D)));
+    assertThat(c, hasInterface("Ethernet4/1", hasSpeed(50E9D)));
+    assertThat(c, hasInterface("Ethernet4/1", hasBandwidth(50E9D)));
+    assertThat(c, hasInterface("Ethernet5/1", hasSpeed(400E9D)));
+    assertThat(c, hasInterface("Ethernet5/1", hasBandwidth(400E9D)));
+    assertThat(c, hasInterface("Ethernet6/1", hasSpeed(200E9D)));
+    assertThat(c, hasInterface("Ethernet6/1", hasBandwidth(200E9D)));
+    assertThat(c, hasInterface("Ethernet7/1", hasSpeed(400E9D)));
+    assertThat(c, hasInterface("Ethernet7/1", hasBandwidth(400E9D)));
+    assertThat(c, hasInterface("Ethernet8/1", hasSpeed(40E9D)));
+    assertThat(c, hasInterface("Ethernet8/1", hasBandwidth(40E9D)));
+  }
+
+  @Test
   public void testEosPortChannel() throws IOException {
     String hostname = "eos-port-channel";
 

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_interface_speed_breakout
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_interface_speed_breakout
@@ -1,0 +1,29 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_interface_speed_breakout
+!
+interface Ethernet1/1
+   speed 400g-4
+!
+interface Ethernet2/1
+   speed 100g-1
+!
+interface Ethernet3/1
+   speed forced 10000full
+!
+interface Ethernet4/1
+   speed forced 50gfull
+!
+interface Ethernet5/1
+   speed forced 400gfull
+!
+interface Ethernet6/1
+   speed 200g-2
+!
+interface Ethernet7/1
+   speed 400g-4
+   speed forced 400gfull
+!
+interface Ethernet8/1
+   speed forced 40gfull
+!


### PR DESCRIPTION
Adds five `eos_bandwidth_specifier` values that EOS accepts but Batfish currently flags as parse warnings:

| Token | EOS CLI | Semantics |
|---|---|---|
| `FIFTYG_FULL` | `speed forced 50gfull` | single-port 50G |
| `FOUR_HUNDREDG_FULL` | `speed forced 400gfull` | single-port 400G |
| `ONE_HUNDREDG_1` | `speed 100g-1` | 1 of 8 sub-ports @100G (breakout) |
| `TWO_HUNDREDG_2` | `speed 200g-2` | 1 of 4 sub-ports @200G |
| `FOUR_HUNDREDG_4` | `speed 400g-4` | 1 of 2 sub-ports @400G |

**Device validation (cEOS-lab 4.35.1F):** all five accepted. Note `200gfull` and `800gfull` do NOT exist (those rates are inherently multi-lane — only the lane-count form is valid), so are intentionally not added.

`toBandwidth()` maps each to the correct bps; test asserts both `hasSpeed` and `hasBandwidth`.

`bazel test //projects/batfish/src/test/java/org/batfish/vendor/arista/...` passes.
