### PR TITLE
Arista: fix BGP prefix-list AF tracking in undefined-reference detection

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -999,6 +999,7 @@ import org.batfish.vendor.arista.representation.eos.AristaBgpVlanBase;
 import org.batfish.vendor.arista.representation.eos.AristaBgpVrf;
 import org.batfish.vendor.arista.representation.eos.AristaBgpVrfAddressFamily;
 import org.batfish.vendor.arista.representation.eos.AristaBgpVrfIpv4UnicastAddressFamily;
+import org.batfish.vendor.arista.representation.eos.AristaBgpVrfIpv6UnicastAddressFamily;
 import org.batfish.vendor.arista.representation.eos.AristaEosVxlan;
 import org.batfish.vendor.arista.representation.eos.AristaRedistributeType;
 
@@ -2540,15 +2541,22 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   @Override
   public void exitEos_rbafnc_prefix_list(Eos_rbafnc_prefix_listContext ctx) {
     String name = ctx.name.getText();
+    // The grammar rule eos_rbafnc_prefix_list is shared by both
+    // address-family ipv4 and address-family ipv6 (eos_rb_af_neighbor_common);
+    // the structure type depends on which AF block we're in.
+    AristaStructureType type =
+        _currentAristaBgpVrfAf instanceof AristaBgpVrfIpv6UnicastAddressFamily
+            ? PREFIX6_LIST
+            : PREFIX_LIST;
     if (ctx.IN() != null) {
       _currentAristaBgpNeighborAddressFamily.setPrefixListIn(name);
       _configuration.referenceStructure(
-          PREFIX_LIST, name, BGP_INBOUND_PREFIX_LIST, ctx.getStart().getLine());
+          type, name, BGP_INBOUND_PREFIX_LIST, ctx.getStart().getLine());
     } else {
       assert ctx.OUT() != null;
       _currentAristaBgpNeighborAddressFamily.setPrefixListOut(name);
       _configuration.referenceStructure(
-          PREFIX_LIST, name, BGP_OUTBOUND_PREFIX_LIST, ctx.getStart().getLine());
+          type, name, BGP_OUTBOUND_PREFIX_LIST, ctx.getStart().getLine());
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -2541,9 +2541,6 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   @Override
   public void exitEos_rbafnc_prefix_list(Eos_rbafnc_prefix_listContext ctx) {
     String name = ctx.name.getText();
-    // The grammar rule eos_rbafnc_prefix_list is shared by both
-    // address-family ipv4 and address-family ipv6 (eos_rb_af_neighbor_common);
-    // the structure type depends on which AF block we're in.
     AristaStructureType type =
         _currentAristaBgpVrfAf instanceof AristaBgpVrfIpv6UnicastAddressFamily
             ? PREFIX6_LIST

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -634,10 +634,6 @@ public class AristaGrammarTest {
 
   @Test
   public void testBgpNeighborPrefixListIpv6AddressFamily() throws IOException {
-    // Before this commit, eos_rbafnc_prefix_list always referenced the
-    // binding as PREFIX_LIST regardless of the enclosing address-family
-    // block, so PL-V6 (an ipv6 prefix-list bound under address-family
-    // ipv6) showed up as an ipv4 undefined reference.
     String hostname = "arista_bgp_neighbor_prefix_list_ipv6_af";
     AristaConfiguration vc = parseVendorConfig(hostname);
     assertThat(vc.getWarnings().getParseWarnings(), empty());

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -633,6 +633,22 @@ public class AristaGrammarTest {
   }
 
   @Test
+  public void testBgpNeighborPrefixListIpv6AddressFamily() throws IOException {
+    // Before this commit, eos_rbafnc_prefix_list always referenced the
+    // binding as PREFIX_LIST regardless of the enclosing address-family
+    // block, so PL-V6 (an ipv6 prefix-list bound under address-family
+    // ipv6) showed up as an ipv4 undefined reference.
+    String hostname = "arista_bgp_neighbor_prefix_list_ipv6_af";
+    AristaConfiguration vc = parseVendorConfig(hostname);
+    assertThat(vc.getWarnings().getParseWarnings(), empty());
+
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    assertThat(ccae, hasNoUndefinedReferences());
+  }
+
+  @Test
   public void testAristaOspfReferenceBandwidth() throws IOException {
     Configuration manual = parseConfig("aristaOspfCost");
     assertThat(

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_neighbor_prefix_list_ipv6_af
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_neighbor_prefix_list_ipv6_af
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_bgp_neighbor_prefix_list_ipv6_af
+!
+ip prefix-list PL-V4
+   seq 10 permit 0.0.0.0/0
+!
+ipv6 prefix-list PL-V6
+   seq 10 permit ::/0
+!
+router bgp 65000
+   neighbor PG peer group
+   neighbor PG remote-as 65001
+   neighbor 192.0.2.1 peer group PG
+   address-family ipv4
+      neighbor PG activate
+      neighbor PG prefix-list PL-V4 out
+   address-family ipv6
+      neighbor PG activate
+      neighbor PG prefix-list PL-V6 out


### PR DESCRIPTION
## Summary

`eos_rbafnc_prefix_list` (the per-neighbor prefix-list binding inside `address-family` blocks) always references the binding as `PREFIX_LIST` (IPv4) regardless of which address-family block it appears in. A config that defines an `ipv6 prefix-list` and binds it under `address-family ipv6` produces symmetric false positives:

```
undefinedReferences: ipv4 prefix-list X referenced at bgp inbound prefix-list but not defined
unusedStructures:    ipv6 prefix-list X defined but unused
```

Reference `PREFIX6_LIST` when `_currentAristaBgpVrfAf` is an `AristaBgpVrfIpv6UnicastAddressFamily`.

## Scope

Only the AF-block binding case changes. Top-level neighbor bindings (`neighbor X prefix-list Y in` outside any AF block, where `_currentAristaBgpVrfAf` is null and the prefix-list could be v4 or v6) and non-unicast AFs are unchanged — those cases predate this fix and have their own ambiguities.

## Reproduction

```
ipv6 prefix-list PL-V6
   seq 10 permit ::/0
router bgp 65000
   neighbor PG peer group
   neighbor PG remote-as 65001
   neighbor 192.0.2.1 peer group PG
   address-family ipv6
      neighbor PG activate
      neighbor PG prefix-list PL-V6 out
```

`undefinedReferences` reports `ipv4 prefix-list "PL-V6" referenced at bgp outbound prefix-list but not defined`. EOS resolves `prefix-list` references to `ipv6 prefix-list` definitions when bound under `address-family ipv6` (verified against cEOS 4.35.1F via session-diff).

## Test

`testBgpNeighborPrefixListIpv6AddressFamily` parses a config with both `ip` and `ipv6` prefix-lists bound under their respective AF blocks and asserts `hasNoUndefinedReferences()`. The test fails without the extractor change.