### PR TITLE
Parse IP and MTU on PAN-OS tunnel sub-interface units (tunnel.N)

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
@@ -246,11 +246,23 @@ snil_units
     UNITS snil_unit?
 ;
 
+snit_ip
+:
+    IP address = interface_address_or_reference
+;
+
+snit_mtu
+:
+    MTU mtu = uint32
+;
+
 snit_unit
 :
     name = variable
     (
         if_common
+        | snit_ip
+        | snit_mtu
     )?
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -48,6 +48,7 @@ import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.LAYER2
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.LAYER3_INTERFACE_ADDRESS;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.LAYER3_INTERFACE_ZONE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.LOOPBACK_INTERFACE_ADDRESS;
+import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.TUNNEL_INTERFACE_ADDRESS;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.NAT_RULE_DESTINATION;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.NAT_RULE_DESTINATION_TRANSLATION;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.NAT_RULE_FROM_ZONE;
@@ -283,6 +284,8 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sniel3_mtuContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sniel3_unitContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snil_ipContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snil_unitContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Snit_ipContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Snit_mtuContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snit_unitContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sniv_unitContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snsg_display_nameContext;
@@ -2219,6 +2222,18 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   @Override
   public void exitSnil_unit(Snil_unitContext ctx) {
     _currentInterface = _currentParentInterface;
+  }
+
+  @Override
+  public void exitSnit_ip(Snit_ipContext ctx) {
+    InterfaceAddress address = toInterfaceAddress(ctx.address);
+    _currentInterface.addAddress(address);
+    referenceInterfaceAddress(ctx.address, TUNNEL_INTERFACE_ADDRESS);
+  }
+
+  @Override
+  public void exitSnit_mtu(Snit_mtuContext ctx) {
+    _currentInterface.setMtu(Integer.parseInt(getText(ctx.mtu)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -48,7 +48,6 @@ import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.LAYER2
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.LAYER3_INTERFACE_ADDRESS;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.LAYER3_INTERFACE_ZONE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.LOOPBACK_INTERFACE_ADDRESS;
-import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.TUNNEL_INTERFACE_ADDRESS;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.NAT_RULE_DESTINATION;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.NAT_RULE_DESTINATION_TRANSLATION;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.NAT_RULE_FROM_ZONE;
@@ -71,6 +70,7 @@ import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.STATIC
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.STATIC_ROUTE_NEXT_VR;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.TAP_INTERFACE_ZONE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.TEMPLATE_STACK_TEMPLATES;
+import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.TUNNEL_INTERFACE_ADDRESS;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VIRTUAL_ROUTER_INTERFACE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VIRTUAL_ROUTER_SELF_REFERENCE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VIRTUAL_WIRE_INTERFACE_ZONE;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureUsage.java
@@ -18,6 +18,7 @@ public enum PaloAltoStructureUsage implements StructureUsage {
   LAYER3_INTERFACE_ADDRESS("interface ethernet layer3 ip"),
   LAYER3_INTERFACE_ZONE("zone network layer3"),
   LOOPBACK_INTERFACE_ADDRESS("interface loopback ip"),
+  TUNNEL_INTERFACE_ADDRESS("interface tunnel ip"),
   NAT_RULE_DESTINATION("rulebase nat rules destination"),
   NAT_RULE_DESTINATION_TRANSLATION("rulebase nat rules destination-translation"),
   NAT_RULE_FROM_ZONE("rulebase nat rules from"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -4744,6 +4744,19 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testTunnelUnitIp() {
+    String hostname = "paloalto_vlan_tunnel_units";
+    Configuration c = parseConfig(hostname);
+    // tunnel.3 has ip 169.254.0.1/30 and mtu 1427 configured; confirm both appear in the VI model.
+    assertThat(
+        c,
+        hasInterface(
+            "tunnel.3",
+            hasAllAddresses(contains(ConcreteInterfaceAddress.parse("169.254.0.1/30")))));
+    assertThat(c, hasInterface("tunnel.3", hasMtu(1427)));
+  }
+
+  @Test
   public void testPanoramaRulebaseCopy() {
     String panoramaHostname = "panorama-rulebase-copy";
     PaloAltoConfiguration c = parsePaloAltoConfig(panoramaHostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/paloalto_vlan_tunnel_units
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/paloalto_vlan_tunnel_units
@@ -13,6 +13,10 @@ config {
             units {
               tunnel.3 {
                 comment "tunnel.3 comment";
+                ip {
+                  169.254.0.1/30;
+                }
+                mtu 1427;
               }
             }
           }


### PR DESCRIPTION
## Summary

- `snit_unit` (PAN-OS tunnel interface units) has had no IP or MTU productions since
  PR #3950 (2019). Adds `snit_ip` and `snit_mtu`, mirroring the existing `snil_ip` /
  `sniel3_mtu` rules.
- Wires both into `snit_unit`, adds `exitSnit_ip` and `exitSnit_mtu` listeners in
  `PaloAltoConfigurationBuilder`, and registers `TUNNEL_INTERFACE_ADDRESS` in
  `PaloAltoStructureUsage`.
- Extends the `paloalto_vlan_tunnel_units` test config with a tunnel unit IP and MTU,
  and adds `testTunnelUnitIp` to confirm both appear in the VI model.

## Root cause

`tunnel.N` addresses and MTU values were silently dropped. Missing IPs caused BGP
sessions over tunnel sub-interfaces to show as `NOT_ESTABLISHED` — Batfish had no
connected route for the /30 peer subnet. `TUNNEL_UNIT` interfaces are not subject to
the loopback `/32` filter and generate connected routes by default.

Fixes #9935