### PR TITLE
Junos: extend prefix normalization fatal error to IPv6 contexts (#9934)

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3275,6 +3275,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     if (ctx.prefix != null) {
       _currentAreaRangePrefix = toNormalizedPrefix(ctx.prefix, "OSPF area-range");
     } else {
+      assert ctx.prefix6 != null;
+      toNormalizedPrefix6(ctx.prefix6, "OSPFv3 area-range");
       todo(ctx);
     }
   }
@@ -3664,6 +3666,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       Map<Prefix, AggregateRoute> aggregateRoutes = _currentRib.getAggregateRoutes();
       _currentAggregateRoute = aggregateRoutes.computeIfAbsent(prefix, AggregateRoute::new);
     } else {
+      assert ctx.prefix6 != null;
+      toNormalizedPrefix6(ctx.prefix6, "Aggregate route");
       _currentAggregateRoute = DUMMY_AGGREGATE_ROUTE;
     }
   }
@@ -3700,6 +3704,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
       Map<Prefix, GeneratedRoute> generatedRoutes = _currentRib.getGeneratedRoutes();
       _currentGeneratedRoute = generatedRoutes.computeIfAbsent(prefix, GeneratedRoute::new);
     } else if (ctx.prefix6 != null) {
+      toNormalizedPrefix6(ctx.prefix6, "Generated route");
       // dummy generated route not added to configuration
       _currentGeneratedRoute = new GeneratedRoute(null);
       todo(ctx);
@@ -3807,7 +3812,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void enterRos_route6(Ros_route6Context ctx) {
-    Prefix6 prefix = toPrefix6(ctx.prefix);
+    Prefix6 prefix = toNormalizedPrefix6(ctx.prefix, "Static route destination");
     Map<Prefix6, StaticRouteV6> staticRoutes = _currentRib.getStaticRoutesV6();
     _currentStaticRoute = staticRoutes.computeIfAbsent(prefix, StaticRouteV6::new);
   }
@@ -8875,7 +8880,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitPocondiafi_prefix6(Pocondiafi_prefix6Context ctx) {
-    _currentCondition.getIfRouteExists().setPrefix6(toPrefix6(ctx.prefix));
+    _currentCondition
+        .getIfRouteExists()
+        .setPrefix6(toNormalizedPrefix6(ctx.prefix, "Condition if-route-exists"));
   }
 
   @Override
@@ -8936,6 +8943,22 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   private static @Nonnull Prefix6 toPrefix6(Ipv6_prefix_default_128Context ctx) {
     if (ctx.IPV6_PREFIX() != null) {
       return Prefix6.parse(ctx.getText());
+    }
+    assert ctx.IPV6_ADDRESS() != null;
+    return Ip6.parse(ctx.getText()).toPrefix6();
+  }
+
+  private @Nonnull Prefix6 toNormalizedPrefix6(
+      Ipv6_prefix_default_128Context ctx, String description) {
+    if (ctx.IPV6_PREFIX() != null) {
+      String text = ctx.IPV6_PREFIX().getText();
+      Ip6 originalIp = Ip6.parse(text.substring(0, text.indexOf('/')));
+      Prefix6 prefix = Prefix6.parse(text);
+      if (!originalIp.equals(prefix.getAddress())) {
+        _w.fatalRedFlag(
+            "%s %s is not a valid network prefix (host bits are set)", description, text);
+      }
+      return prefix;
     }
     assert ctx.IPV6_ADDRESS() != null;
     return Ip6.parse(ctx.getText()).toPrefix6();

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1479,6 +1479,34 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testPrefix6NormalizationValidation() throws IOException {
+    String fileKey = "prefix6-normalization-validation";
+    String warningKey = "configs/" + fileKey;
+
+    Batfish batfish = getBatfishForConfigurationNames(fileKey);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    ParseVendorConfigurationAnswerElement pvcae =
+        batfish.loadParseVendorConfigurationAnswerElement(batfish.getSnapshot());
+
+    assertThat(
+        pvcae.getWarnings().get(warningKey).getFatalRedFlagWarnings(),
+        containsInAnyOrder(
+            WarningMatchers.hasText(
+                allOf(
+                    containsString("Static route destination"), containsString("2001:db8::1/32"))),
+            WarningMatchers.hasText(
+                allOf(containsString("Aggregate route"), containsString("2001:db8:1::1/48"))),
+            WarningMatchers.hasText(
+                allOf(containsString("Generated route"), containsString("2001:db8:2::1/48"))),
+            WarningMatchers.hasText(
+                allOf(containsString("OSPFv3 area-range"), containsString("2001:db8:3::1/48"))),
+            WarningMatchers.hasText(
+                allOf(
+                    containsString("Condition if-route-exists"),
+                    containsString("2001:db8:4::1/48")))));
+  }
+
+  @Test
   public void testBgpKeepExtraction() {
     JuniperConfiguration c = parseJuniperConfig("bgp-keep");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/prefix6-normalization-validation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/prefix6-normalization-validation
@@ -1,0 +1,18 @@
+#
+set system host-name prefix6-normalization-validation
+#
+# Valid IPv6 prefixes (no warnings expected)
+set routing-options rib inet6.0 static route 2001:db8::/32 reject
+set routing-options rib inet6.0 aggregate route 2001:db8:1::/48 discard
+set routing-options rib inet6.0 generate route 2001:db8:2::/48 discard
+set protocols ospf3 area 0 area-range 2001:db8:3::/48
+set policy-options condition C1 if-route-exists 2001:db8:4::/48
+set policy-options condition C1 if-route-exists table inet6.0
+#
+# Invalid IPv6 prefixes (host bits set — fatal red flag expected)
+set routing-options rib inet6.0 static route 2001:db8::1/32 reject
+set routing-options rib inet6.0 aggregate route 2001:db8:1::1/48 discard
+set routing-options rib inet6.0 generate route 2001:db8:2::1/48 discard
+set protocols ospf3 area 0 area-range 2001:db8:3::1/48
+set policy-options condition C2 if-route-exists 2001:db8:4::1/48
+set policy-options condition C2 if-route-exists table inet6.0


### PR DESCRIPTION
Extend the host-bits-set fatal red flag (from #9928) to IPv6 prefixes
in contexts where Junos rejects unnormalized prefixes at commit time:

- routing-options rib inet6.0 static route
- routing-options rib inet6.0 aggregate route
- routing-options rib inet6.0 generate route
- protocols ospf3 area <area> area-range
- policy-options condition <c> if-route-exists (IPv6 prefix)

Empirically validated on vJunos-router 25.4R1.12
(batfish/lab-validation junos_commit_check lab).

Fixes #9934

----

Prompt:
```
Fix https://github.com/batfish/batfish/issues/9934 . Note that we just
fixed the similar issue for IPv4. Apply the fix in ./batfish and then
test it by running batfish again (./batfish/tools/bazel_run.sh) and
testing lab-validation junos-commit-checks lab in ./lab-validation
```