### PR TITLE
routes: drop legacy Next_Hop_IP and Next_Hop_Interface columns

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
@@ -31,7 +31,6 @@ import org.batfish.datamodel.questions.BgpRouteStatus;
  */
 @ParametersAreNullableByDefault
 public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
-  private final @Nullable String _nextHopInterface;
   private final @Nullable AsPath _asPath;
   private final @Nullable Long _adminDistance;
   private final @Nonnull Set<Long> _clusterList;
@@ -48,7 +47,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   private final @Nullable Integer _weight;
 
   private RouteRowAttribute(
-      String nextHopInterface,
       Long adminDistance,
       Long metric,
       AsPath asPath,
@@ -63,7 +61,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
       BgpRouteStatus status,
       @Nullable TunnelEncapsulationAttribute tunnelEncapsulationAttribute,
       Integer weight) {
-    _nextHopInterface = nextHopInterface;
     _adminDistance = adminDistance;
     _metric = metric;
     _asPath = asPath;
@@ -104,10 +101,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
     return _communities;
   }
 
-  public @Nullable String getNextHopInterface() {
-    return _nextHopInterface;
-  }
-
   public @Nullable String getOriginProtocol() {
     return _originProtocol;
   }
@@ -145,8 +138,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   }
 
   private static final Comparator<RouteRowAttribute> COMPARATOR =
-      comparing(RouteRowAttribute::getNextHopInterface, nullsLast(String::compareTo))
-          .thenComparing(RouteRowAttribute::getAdminDistance, nullsLast(Long::compareTo))
+      comparing(RouteRowAttribute::getAdminDistance, nullsLast(Long::compareTo))
           .thenComparing(RouteRowAttribute::getMetric, nullsLast(Long::compareTo))
           .thenComparing(RouteRowAttribute::getAsPath, nullsLast(AsPath::compareTo))
           .thenComparing(RouteRowAttribute::getLocalPreference, nullsLast(Long::compareTo))
@@ -183,8 +175,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
       return false;
     }
     RouteRowAttribute that = (RouteRowAttribute) o;
-    return Objects.equals(_nextHopInterface, that._nextHopInterface)
-        && Objects.equals(_adminDistance, that._adminDistance)
+    return Objects.equals(_adminDistance, that._adminDistance)
         && Objects.equals(_metric, that._metric)
         && Objects.equals(_asPath, that._asPath)
         && Objects.equals(_localPreference, that._localPreference)
@@ -203,7 +194,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   @Override
   public int hashCode() {
     return Objects.hash(
-        _nextHopInterface,
         _adminDistance,
         _metric,
         _asPath,
@@ -224,7 +214,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   public String toString() {
     return toStringHelper(getClass())
         .omitNullValues()
-        .add("nextHopInterface", _nextHopInterface)
         .add("adminDistance", _adminDistance)
         .add("asPath", _asPath)
         .add("clusterList", _clusterList)
@@ -244,7 +233,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
 
   /** Builder for {@link RouteRowAttribute} */
   public static final class Builder {
-    private @Nullable String _nextHopInterface;
     private @Nullable Long _adminDistance;
     private @Nullable Long _metric;
     private @Nullable AsPath _asPath;
@@ -265,7 +253,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
         _tag = null;
       }
       return new RouteRowAttribute(
-          _nextHopInterface,
           _adminDistance,
           _metric,
           _asPath,
@@ -309,11 +296,6 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
 
     public Builder setCommunities(List<String> communities) {
       _communities = communities;
-      return this;
-    }
-
-    public Builder setNextHopInterface(String nextHopInterface) {
-      _nextHopInterface = nextHopInterface;
       return this;
     }
 

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -58,8 +58,6 @@ public class RoutesAnswerer extends Answerer {
   static final String COL_VRF_NAME = "VRF";
   static final String COL_NETWORK = "Network";
   static final String COL_NEXT_HOP = "Next_Hop";
-  static final String COL_NEXT_HOP_INTERFACE = "Next_Hop_Interface";
-  static final String COL_NEXT_HOP_IP = "Next_Hop_IP";
   static final String COL_PROTOCOL = "Protocol";
   static final String COL_TAG = "Tag";
 
@@ -321,16 +319,6 @@ public class RoutesAnswerer extends Answerer {
                     COL_NEXT_HOP, Schema.NEXT_HOP, "Route's Next Hop", Boolean.FALSE, Boolean.TRUE))
             .add(
                 new ColumnMetadata(
-                    COL_NEXT_HOP_IP, Schema.IP, "Route's Next Hop IP", Boolean.FALSE, Boolean.TRUE))
-            .add(
-                new ColumnMetadata(
-                    COL_NEXT_HOP_INTERFACE,
-                    Schema.STRING,
-                    "Route's Next Hop Interface",
-                    Boolean.FALSE,
-                    Boolean.TRUE))
-            .add(
-                new ColumnMetadata(
                     COL_PROTOCOL, Schema.STRING, "Route's Protocol", Boolean.FALSE, Boolean.TRUE))
             .add(
                 new ColumnMetadata(
@@ -406,16 +394,6 @@ public class RoutesAnswerer extends Answerer {
                     COL_NEXT_HOP, Schema.NEXT_HOP, "Route's Next Hop", Boolean.FALSE, Boolean.TRUE))
             .add(
                 new ColumnMetadata(
-                    COL_NEXT_HOP_IP, Schema.IP, "Route's Next Hop IP", Boolean.FALSE, Boolean.TRUE))
-            .add(
-                new ColumnMetadata(
-                    COL_NEXT_HOP_INTERFACE,
-                    Schema.STRING,
-                    "Route's Next Hop Interface",
-                    Boolean.FALSE,
-                    Boolean.TRUE))
-            .add(
-                new ColumnMetadata(
                     COL_PROTOCOL, Schema.STRING, "Route's Protocol", Boolean.FALSE, Boolean.TRUE))
             .add(
                 new ColumnMetadata(
@@ -485,16 +463,6 @@ public class RoutesAnswerer extends Answerer {
             .add(
                 new ColumnMetadata(
                     COL_NEXT_HOP, Schema.NEXT_HOP, "Route's Next Hop", Boolean.FALSE, Boolean.TRUE))
-            .add(
-                new ColumnMetadata(
-                    COL_NEXT_HOP_IP, Schema.IP, "Route's Next Hop IP", Boolean.FALSE, Boolean.TRUE))
-            .add(
-                new ColumnMetadata(
-                    COL_NEXT_HOP_INTERFACE,
-                    Schema.STRING,
-                    "Route's Next Hop Interface",
-                    Boolean.FALSE,
-                    Boolean.TRUE))
             .add(
                 new ColumnMetadata(
                     COL_PROTOCOL, Schema.STRING, "Route's Protocol", Boolean.FALSE, Boolean.TRUE))
@@ -573,20 +541,6 @@ public class RoutesAnswerer extends Answerer {
                 COL_DELTA_PREFIX + COL_NEXT_HOP,
                 Schema.NEXT_HOP,
                 "Route's Next Hop",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_BASE_PREFIX + COL_NEXT_HOP_IP,
-                Schema.IP,
-                "Route's Next Hop IP",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_DELTA_PREFIX + COL_NEXT_HOP_IP,
-                Schema.IP,
-                "Route's Next Hop IP",
                 Boolean.FALSE,
                 Boolean.TRUE));
         columnBuilder.add(
@@ -981,34 +935,6 @@ public class RoutesAnswerer extends Answerer {
                 COL_DELTA_PREFIX + COL_NEXT_HOP,
                 Schema.NEXT_HOP,
                 "Route's Next Hop",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_BASE_PREFIX + COL_NEXT_HOP_IP,
-                Schema.IP,
-                "Route's Next Hop IP",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_DELTA_PREFIX + COL_NEXT_HOP_IP,
-                Schema.IP,
-                "Route's Next Hop IP",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_BASE_PREFIX + COL_NEXT_HOP_INTERFACE,
-                Schema.STRING,
-                "Route's Next Hop Interface",
-                Boolean.FALSE,
-                Boolean.TRUE));
-        columnBuilder.add(
-            new ColumnMetadata(
-                COL_DELTA_PREFIX + COL_NEXT_HOP_INTERFACE,
-                Schema.STRING,
-                "Route's Next Hop Interface",
                 Boolean.FALSE,
                 Boolean.TRUE));
         columnBuilder.add(

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -16,8 +16,6 @@ import static org.batfish.question.routes.RoutesAnswerer.COL_LOCAL_PREF;
 import static org.batfish.question.routes.RoutesAnswerer.COL_METRIC;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NETWORK;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP;
-import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP_INTERFACE;
-import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP_IP;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NODE;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ORIGINATOR_ID;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ORIGIN_PROTOCOL;
@@ -75,7 +73,6 @@ import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.questions.BgpRouteStatus;
-import org.batfish.datamodel.route.nh.LegacyNextHops;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.Row.RowBuilder;
@@ -87,12 +84,6 @@ import org.batfish.question.routes.RoutesQuestion.RibProtocol;
 import org.batfish.specifier.RoutingProtocolSpecifier;
 
 public class RoutesAnswererUtil {
-
-  /** IPs that are used internally and should not be exposed as next hop IPs */
-  private static final Set<Ip> INTERNAL_USE_IPS =
-      ImmutableSet.of(
-          // BGP unnumbered IP
-          Ip.parse("169.254.0.1"));
 
   public enum RouteEntryPresenceStatus {
     ONLY_IN_SNAPSHOT(TableDiff.COL_KEY_STATUS_ONLY_BASE),
@@ -385,18 +376,11 @@ public class RoutesAnswererUtil {
       String vrfName,
       AbstractRoute abstractRoute,
       Map<String, ColumnMetadata> columnMetadataMap) {
-    // If the route's next hop IP is for internal use, do not show it in the row
-    Ip nextHopIp =
-        INTERNAL_USE_IPS.contains(abstractRoute.getNextHopIp())
-            ? null
-            : abstractRoute.getNextHopIp();
     return Row.builder(columnMetadataMap)
         .put(COL_NODE, new Node(hostName))
         .put(COL_VRF_NAME, vrfName)
         .put(COL_NETWORK, abstractRoute.getNetwork())
         .put(COL_NEXT_HOP, abstractRoute.getNextHop())
-        .put(COL_NEXT_HOP_IP, nextHopIp)
-        .put(COL_NEXT_HOP_INTERFACE, abstractRoute.getNextHopInterface())
         .put(COL_PROTOCOL, abstractRoute.getProtocol())
         .put(
             COL_TAG,
@@ -422,16 +406,11 @@ public class RoutesAnswererUtil {
       Bgpv4Route bgpv4Route,
       Set<BgpRouteStatus> statuses,
       Map<String, ColumnMetadata> columnMetadataMap) {
-    // If the route's next hop IP is for internal use, do not show it in the row
-    Ip nextHopIp =
-        INTERNAL_USE_IPS.contains(bgpv4Route.getNextHopIp()) ? null : bgpv4Route.getNextHopIp();
     return Row.builder(columnMetadataMap)
         .put(COL_NODE, new Node(hostName))
         .put(COL_VRF_NAME, vrfName)
         .put(COL_NETWORK, bgpv4Route.getNetwork())
         .put(COL_NEXT_HOP, bgpv4Route.getNextHop())
-        .put(COL_NEXT_HOP_IP, nextHopIp)
-        .put(COL_NEXT_HOP_INTERFACE, bgpv4Route.getNextHopInterface())
         .put(COL_PROTOCOL, bgpv4Route.getProtocol())
         .put(COL_AS_PATH, bgpv4Route.getAsPath().getAsPathString())
         .put(COL_METRIC, bgpv4Route.getMetric())
@@ -473,16 +452,11 @@ public class RoutesAnswererUtil {
       EvpnRoute<?, ?> evpnRoute,
       Set<BgpRouteStatus> statuses,
       Map<String, ColumnMetadata> columnMetadataMap) {
-    // If the route's next hop IP is for internal use, do not show it in the row
-    Ip nextHopIp =
-        INTERNAL_USE_IPS.contains(evpnRoute.getNextHopIp()) ? null : evpnRoute.getNextHopIp();
     return Row.builder(columnMetadataMap)
         .put(COL_NODE, new Node(hostName))
         .put(COL_VRF_NAME, vrfName)
         .put(COL_NETWORK, evpnRoute.getNetwork())
         .put(COL_NEXT_HOP, evpnRoute.getNextHop())
-        .put(COL_NEXT_HOP_IP, nextHopIp)
-        .put(COL_NEXT_HOP_INTERFACE, evpnRoute.getNextHopInterface())
         .put(COL_PROTOCOL, evpnRoute.getProtocol())
         .put(COL_AS_PATH, evpnRoute.getAsPath().getAsPathString())
         .put(COL_METRIC, evpnRoute.getMetric())
@@ -654,10 +628,6 @@ public class RoutesAnswererUtil {
     public Void visitBgpRouteRowSecondaryKey(BgpRouteRowSecondaryKey bgpRouteRowSecondaryKey) {
       _rowBuilder
           .put(_columnPrefix + COL_NEXT_HOP, bgpRouteRowSecondaryKey.getNextHop())
-          .put(
-              // included for backwards compatibility
-              _columnPrefix + COL_NEXT_HOP_IP,
-              LegacyNextHops.getNextHopIp(bgpRouteRowSecondaryKey.getNextHop()).orElse(null))
           .put(_columnPrefix + COL_PROTOCOL, bgpRouteRowSecondaryKey.getProtocol())
           .put(_columnPrefix + COL_RECEIVED_FROM_IP, bgpRouteRowSecondaryKey.getReceivedFromIp())
           .put(_columnPrefix + COL_PATH_ID, bgpRouteRowSecondaryKey.getPathId());
@@ -681,10 +651,6 @@ public class RoutesAnswererUtil {
         MainRibRouteRowSecondaryKey mainRibRouteRowSecondaryKey) {
       _rowBuilder
           .put(_columnPrefix + COL_NEXT_HOP, mainRibRouteRowSecondaryKey.getNextHop())
-          .put(
-              // included for backwards compatibility
-              _columnPrefix + COL_NEXT_HOP_IP,
-              LegacyNextHops.getNextHopIp(mainRibRouteRowSecondaryKey.getNextHop()).orElse(null))
           .put(_columnPrefix + COL_PROTOCOL, mainRibRouteRowSecondaryKey.getProtocol());
       return null;
     }
@@ -818,9 +784,6 @@ public class RoutesAnswererUtil {
       RowBuilder rowBuilder, @Nullable RouteRowAttribute routeRowAttribute, boolean base) {
     rowBuilder
         .put(
-            (base ? COL_BASE_PREFIX : COL_DELTA_PREFIX) + COL_NEXT_HOP_INTERFACE,
-            routeRowAttribute != null ? routeRowAttribute.getNextHopInterface() : null)
-        .put(
             (base ? COL_BASE_PREFIX : COL_DELTA_PREFIX) + COL_METRIC,
             routeRowAttribute != null ? routeRowAttribute.getMetric() : null)
         .put(
@@ -881,7 +844,6 @@ public class RoutesAnswererUtil {
                             k -> new TreeSet<>())
                         .add(
                             RouteRowAttribute.builder()
-                                .setNextHopInterface(route.getNextHopInterface())
                                 .setAdminDistance(route.getAdministrativeCost())
                                 .setMetric(route.getMetric())
                                 .setTag(route.getTag())

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -17,8 +17,6 @@ import static org.batfish.question.routes.RoutesAnswerer.COL_LOCAL_PREF;
 import static org.batfish.question.routes.RoutesAnswerer.COL_METRIC;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NETWORK;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP;
-import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP_INTERFACE;
-import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP_IP;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NODE;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ORIGINATOR_ID;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ORIGIN_PROTOCOL;
@@ -318,8 +316,6 @@ public class RoutesAnswererTest {
             COL_VRF_NAME,
             COL_NETWORK,
             COL_NEXT_HOP,
-            COL_NEXT_HOP_IP,
-            COL_NEXT_HOP_INTERFACE,
             COL_PROTOCOL,
             COL_METRIC,
             COL_ADMIN_DISTANCE,
@@ -334,8 +330,6 @@ public class RoutesAnswererTest {
             Schema.STRING,
             Schema.PREFIX,
             Schema.NEXT_HOP,
-            Schema.IP,
-            Schema.STRING,
             Schema.STRING,
             Schema.LONG,
             Schema.LONG,
@@ -351,8 +345,6 @@ public class RoutesAnswererTest {
             COL_NETWORK,
             COL_STATUS,
             COL_NEXT_HOP,
-            COL_NEXT_HOP_IP,
-            COL_NEXT_HOP_INTERFACE,
             COL_PROTOCOL,
             // BGP attributes
             COL_AS_PATH,
@@ -387,8 +379,6 @@ public class RoutesAnswererTest {
             COL_STATUS,
             COL_ROUTE_DISTINGUISHER,
             COL_NEXT_HOP,
-            COL_NEXT_HOP_IP,
-            COL_NEXT_HOP_INTERFACE,
             COL_PROTOCOL,
             // BGP attributes
             COL_AS_PATH,
@@ -428,10 +418,6 @@ public class RoutesAnswererTest {
             COL_ROUTE_ENTRY_PRESENCE,
             COL_BASE_PREFIX + COL_NEXT_HOP,
             COL_DELTA_PREFIX + COL_NEXT_HOP,
-            COL_BASE_PREFIX + COL_NEXT_HOP_IP,
-            COL_DELTA_PREFIX + COL_NEXT_HOP_IP,
-            COL_BASE_PREFIX + COL_NEXT_HOP_INTERFACE,
-            COL_DELTA_PREFIX + COL_NEXT_HOP_INTERFACE,
             COL_BASE_PREFIX + COL_PROTOCOL,
             COL_DELTA_PREFIX + COL_PROTOCOL,
             COL_BASE_PREFIX + COL_METRIC,
@@ -452,10 +438,6 @@ public class RoutesAnswererTest {
             Schema.STRING,
             Schema.NEXT_HOP,
             Schema.NEXT_HOP,
-            Schema.IP,
-            Schema.IP,
-            Schema.STRING,
-            Schema.STRING,
             Schema.STRING,
             Schema.STRING,
             Schema.LONG,
@@ -478,8 +460,6 @@ public class RoutesAnswererTest {
         COL_DELTA_PREFIX + COL_STATUS,
         COL_BASE_PREFIX + COL_NEXT_HOP,
         COL_DELTA_PREFIX + COL_NEXT_HOP,
-        COL_BASE_PREFIX + COL_NEXT_HOP_IP,
-        COL_DELTA_PREFIX + COL_NEXT_HOP_IP,
         COL_BASE_PREFIX + COL_PROTOCOL,
         COL_DELTA_PREFIX + COL_PROTOCOL,
         COL_BASE_PREFIX + COL_AS_PATH,
@@ -519,8 +499,6 @@ public class RoutesAnswererTest {
         Schema.list(Schema.STRING),
         Schema.NEXT_HOP,
         Schema.NEXT_HOP,
-        Schema.IP,
-        Schema.IP,
         Schema.STRING,
         Schema.STRING,
         Schema.STRING,
@@ -720,18 +698,13 @@ public class RoutesAnswererTest {
 
     // After key columns, all columns in the non-differential result should correspond to two
     // columns in the differential result (snapshot and reference).
-    // One exception: next hop interface is only present in non-differential for backwards
-    // compatibility, and was never added to differential BGP routes.
-    Set<String> nonDifferentialOnly = ImmutableSet.of(COL_NEXT_HOP_INTERFACE);
     IntStream.range(keyColumns.size(), nonDiffColumns.size())
         .mapToObj(nonDiffColumns::get)
         .forEach(
             c -> {
               expectedNonDiffColumns.add(c);
-              if (!nonDifferentialOnly.contains(c)) {
-                expectedDiffColumns.add(COL_BASE_PREFIX + c);
-                expectedDiffColumns.add(COL_DELTA_PREFIX + c);
-              }
+              expectedDiffColumns.add(COL_BASE_PREFIX + c);
+              expectedDiffColumns.add(COL_DELTA_PREFIX + c);
             });
 
     assertThat(nonDiffColumns, equalTo(expectedNonDiffColumns.build()));
@@ -762,18 +735,13 @@ public class RoutesAnswererTest {
 
     // After key columns, all columns in the non-differential result should correspond to two
     // columns in the differential result (snapshot and reference).
-    // Exception: next hop IP and interface columns are only present in non-differential for
-    // backwards compatibility, and were never added to differential EVPN routes.
-    Set<String> nonDifferentialOnly = ImmutableSet.of(COL_NEXT_HOP_IP, COL_NEXT_HOP_INTERFACE);
     IntStream.range(keyColumns.size(), nonDiffColumns.size())
         .mapToObj(nonDiffColumns::get)
         .forEach(
             c -> {
               expectedNonDiffColumns.add(c);
-              if (!nonDifferentialOnly.contains(c)) {
-                expectedDiffColumns.add(COL_BASE_PREFIX + c);
-                expectedDiffColumns.add(COL_DELTA_PREFIX + c);
-              }
+              expectedDiffColumns.add(COL_BASE_PREFIX + c);
+              expectedDiffColumns.add(COL_DELTA_PREFIX + c);
             });
 
     assertThat(nonDiffColumns, equalTo(expectedNonDiffColumns.build()));

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -12,8 +12,6 @@ import static org.batfish.question.routes.RoutesAnswerer.COL_LOCAL_PREF;
 import static org.batfish.question.routes.RoutesAnswerer.COL_METRIC;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NETWORK;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP;
-import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP_INTERFACE;
-import static org.batfish.question.routes.RoutesAnswerer.COL_NEXT_HOP_IP;
 import static org.batfish.question.routes.RoutesAnswerer.COL_NODE;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ORIGINATOR_ID;
 import static org.batfish.question.routes.RoutesAnswerer.COL_ORIGIN_PROTOCOL;
@@ -229,8 +227,8 @@ public class RoutesAnswererUtilTest {
                 hasColumn(COL_NODE, new Node("n1"), Schema.NODE),
                 hasColumn(COL_VRF_NAME, Configuration.DEFAULT_VRF_NAME, Schema.STRING),
                 hasColumn(COL_NETWORK, Prefix.parse("1.1.1.0/24"), Schema.PREFIX),
-                hasColumn(COL_NEXT_HOP_IP, Ip.parse("1.1.1.2"), Schema.IP),
-                hasColumn(COL_NEXT_HOP_INTERFACE, "e0", Schema.STRING),
+                hasColumn(
+                    COL_NEXT_HOP, NextHopInterface.of("e0", Ip.parse("1.1.1.2")), Schema.NEXT_HOP),
                 hasColumn(COL_PROTOCOL, "ospfE2", Schema.STRING),
                 hasColumn(COL_TAG, equalTo(2L << 30), Schema.LONG),
                 hasColumn(COL_ADMIN_DISTANCE, equalTo(10), Schema.INTEGER),
@@ -306,8 +304,7 @@ public class RoutesAnswererUtilTest {
             // Standard route
             allOf(
                 commonMatcher,
-                hasColumn(COL_NEXT_HOP_IP, ip, Schema.IP),
-                hasColumn(COL_NEXT_HOP_INTERFACE, "dynamic", Schema.STRING),
+                hasColumn(COL_NEXT_HOP, NextHopIp.of(ip), Schema.NEXT_HOP),
                 // order matters
                 hasColumn(
                     COL_CLUSTER_LIST, ImmutableList.of(1L, 3L, 5L), Schema.list(Schema.LONG))),
@@ -315,8 +312,7 @@ public class RoutesAnswererUtilTest {
             // Route from BGP unnumbered session
             allOf(
                 commonMatcher,
-                hasColumn(COL_NEXT_HOP_IP, nullValue(), Schema.IP),
-                hasColumn(COL_NEXT_HOP_INTERFACE, "iface", Schema.STRING),
+                hasColumn(COL_NEXT_HOP, NextHopInterface.of("iface", bgpUnnumIp), Schema.NEXT_HOP),
                 hasColumn(COL_CLUSTER_LIST, nullValue(), Schema.list(Schema.LONG)))));
   }
 
@@ -424,8 +420,7 @@ public class RoutesAnswererUtilTest {
                 hasColumn(COL_TUNNEL_ENCAPSULATION_ATTRIBUTE, equalTo(null), Schema.STRING),
                 hasColumn(COL_WEIGHT, 7, Schema.INTEGER),
                 hasColumn(COL_TAG, nullValue(), Schema.INTEGER),
-                hasColumn(COL_NEXT_HOP_IP, ip, Schema.IP),
-                hasColumn(COL_NEXT_HOP_INTERFACE, "dynamic", Schema.STRING))));
+                hasColumn(COL_NEXT_HOP, NextHopIp.of(ip), Schema.NEXT_HOP))));
   }
 
   @Test
@@ -565,12 +560,7 @@ public class RoutesAnswererUtilTest {
     MainRibRouteRowSecondaryKey secondaryKey =
         new MainRibRouteRowSecondaryKey(NextHopIp.of(Ip.parse("1.1.1.1")), "bgp");
     RouteRowAttribute attrs =
-        RouteRowAttribute.builder()
-            .setAdminDistance(200L)
-            .setNextHopInterface("nhIface")
-            .setMetric(1L)
-            .setTag(2L)
-            .build();
+        RouteRowAttribute.builder().setAdminDistance(200L).setMetric(1L).setTag(2L).build();
 
     List<DiffRoutesOutput> diff =
         ImmutableList.of(
@@ -597,8 +587,6 @@ public class RoutesAnswererUtilTest {
     Map<String, Schema> columnSchemas =
         ImmutableMap.<String, Schema>builder()
             .put(COL_NEXT_HOP, Schema.NEXT_HOP)
-            .put(COL_NEXT_HOP_IP, Schema.IP)
-            .put(COL_NEXT_HOP_INTERFACE, Schema.STRING)
             .put(COL_PROTOCOL, Schema.STRING)
             .put(COL_ADMIN_DISTANCE, Schema.INTEGER)
             .put(COL_METRIC, Schema.LONG)
@@ -661,7 +649,6 @@ public class RoutesAnswererUtilTest {
         ImmutableMap.<String, Schema>builder()
             .put(COL_STATUS, Schema.list(Schema.STRING))
             .put(COL_NEXT_HOP, Schema.NEXT_HOP)
-            .put(COL_NEXT_HOP_IP, Schema.IP)
             .put(COL_PROTOCOL, Schema.STRING)
             .put(COL_RECEIVED_FROM_IP, Schema.IP)
             .put(COL_PATH_ID, Schema.INTEGER)
@@ -809,19 +796,11 @@ public class RoutesAnswererUtilTest {
             new MainRibRouteRowSecondaryKey(
                 NextHopInterface.of("e0", Ip.parse("1.1.1.2")), "ospfE2"),
             ImmutableSortedSet.of(
-                RouteRowAttribute.builder()
-                    .setAdminDistance(10L)
-                    .setMetric(30L)
-                    .setNextHopInterface("e0")
-                    .build()),
+                RouteRowAttribute.builder().setAdminDistance(10L).setMetric(30L).build()),
             new MainRibRouteRowSecondaryKey(
                 NextHopInterface.of("e0", Ip.parse("1.1.1.3")), "ospfE2"),
             ImmutableSortedSet.of(
-                RouteRowAttribute.builder()
-                    .setAdminDistance(10L)
-                    .setMetric(20L)
-                    .setNextHopInterface("e0")
-                    .build()));
+                RouteRowAttribute.builder().setAdminDistance(10L).setMetric(20L).build()));
     // matching the secondary key
     assertThat(innerGroup, equalTo(expectedInnerMap));
   }
@@ -1220,12 +1199,7 @@ public class RoutesAnswererUtilTest {
   @Test
   public void testPopulateRouteRowAttributes() {
     RouteRowAttribute routeRowAttribute =
-        RouteRowAttribute.builder()
-            .setNextHopInterface("nhIface1")
-            .setMetric(1L)
-            .setAdminDistance(1L)
-            .setTag(1L)
-            .build();
+        RouteRowAttribute.builder().setMetric(1L).setAdminDistance(1L).setTag(1L).build();
     Row.RowBuilder rowBuilder = Row.builder();
 
     populateRouteAttributes(rowBuilder, routeRowAttribute, true);
@@ -1234,7 +1208,6 @@ public class RoutesAnswererUtilTest {
         rowBuilder.build(),
         equalTo(
             Row.builder()
-                .put(COL_BASE_PREFIX + COL_NEXT_HOP_INTERFACE, "nhIface1")
                 .put(COL_BASE_PREFIX + COL_METRIC, 1L)
                 .put(COL_BASE_PREFIX + COL_ADMIN_DISTANCE, 1L)
                 .put(COL_BASE_PREFIX + COL_TAG, 1L)

--- a/tests/basic/routes-dc-as-reuse.ref
+++ b/tests/basic/routes-dc-as-reuse.ref
@@ -32,20 +32,6 @@
           "schema" : "NextHop"
         },
         {
-          "description" : "Route's Next Hop IP",
-          "isKey" : false,
-          "isValue" : true,
-          "name" : "Next_Hop_IP",
-          "schema" : "Ip"
-        },
-        {
-          "description" : "Route's Next Hop Interface",
-          "isKey" : false,
-          "isValue" : true,
-          "name" : "Next_Hop_Interface",
-          "schema" : "String"
-        },
-        {
           "description" : "Route's Protocol",
           "isKey" : false,
           "isValue" : true,
@@ -88,8 +74,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -106,8 +90,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -124,8 +106,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -142,8 +122,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -160,8 +138,6 @@
           "type" : "ip",
           "ip" : "2.0.0.0"
         },
-        "Next_Hop_IP" : "2.0.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -178,8 +154,6 @@
           "type" : "ip",
           "ip" : "2.0.0.0"
         },
-        "Next_Hop_IP" : "2.0.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -196,8 +170,6 @@
           "type" : "ip",
           "ip" : "2.1.0.0"
         },
-        "Next_Hop_IP" : "2.1.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -214,8 +186,6 @@
           "type" : "ip",
           "ip" : "2.1.0.0"
         },
-        "Next_Hop_IP" : "2.1.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -232,8 +202,6 @@
           "type" : "ip",
           "ip" : "2.0.0.0"
         },
-        "Next_Hop_IP" : "2.0.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -250,8 +218,6 @@
           "type" : "ip",
           "ip" : "2.0.0.0"
         },
-        "Next_Hop_IP" : "2.0.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -268,8 +234,6 @@
           "type" : "ip",
           "ip" : "2.1.0.0"
         },
-        "Next_Hop_IP" : "2.1.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -286,8 +250,6 @@
           "type" : "ip",
           "ip" : "2.1.0.0"
         },
-        "Next_Hop_IP" : "2.1.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -304,8 +266,6 @@
           "type" : "ip",
           "ip" : "2.0.0.0"
         },
-        "Next_Hop_IP" : "2.0.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -322,8 +282,6 @@
           "type" : "ip",
           "ip" : "2.1.0.0"
         },
-        "Next_Hop_IP" : "2.1.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -340,8 +298,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -358,8 +314,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -376,8 +330,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -394,8 +346,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -412,8 +362,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -430,8 +378,6 @@
           "type" : "ip",
           "ip" : "2.0.1.0"
         },
-        "Next_Hop_IP" : "2.0.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -448,8 +394,6 @@
           "type" : "ip",
           "ip" : "2.0.1.0"
         },
-        "Next_Hop_IP" : "2.0.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -466,8 +410,6 @@
           "type" : "ip",
           "ip" : "2.1.1.0"
         },
-        "Next_Hop_IP" : "2.1.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -484,8 +426,6 @@
           "type" : "ip",
           "ip" : "2.1.1.0"
         },
-        "Next_Hop_IP" : "2.1.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -502,8 +442,6 @@
           "type" : "ip",
           "ip" : "2.0.1.0"
         },
-        "Next_Hop_IP" : "2.0.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -520,8 +458,6 @@
           "type" : "ip",
           "ip" : "2.0.1.0"
         },
-        "Next_Hop_IP" : "2.0.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -538,8 +474,6 @@
           "type" : "ip",
           "ip" : "2.1.1.0"
         },
-        "Next_Hop_IP" : "2.1.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -556,8 +490,6 @@
           "type" : "ip",
           "ip" : "2.1.1.0"
         },
-        "Next_Hop_IP" : "2.1.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -574,8 +506,6 @@
           "type" : "ip",
           "ip" : "2.0.1.0"
         },
-        "Next_Hop_IP" : "2.0.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -592,8 +522,6 @@
           "type" : "ip",
           "ip" : "2.1.1.0"
         },
-        "Next_Hop_IP" : "2.1.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -610,8 +538,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -628,8 +554,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -646,8 +570,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -664,8 +586,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -682,8 +602,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -700,8 +618,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -718,8 +634,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -736,8 +650,6 @@
           "type" : "ip",
           "ip" : "1.0.0.0"
         },
-        "Next_Hop_IP" : "1.0.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -754,8 +666,6 @@
           "type" : "ip",
           "ip" : "1.0.1.0"
         },
-        "Next_Hop_IP" : "1.0.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -772,8 +682,6 @@
           "type" : "ip",
           "ip" : "2.0.0.1"
         },
-        "Next_Hop_IP" : "2.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -790,8 +698,6 @@
           "type" : "ip",
           "ip" : "2.0.0.1"
         },
-        "Next_Hop_IP" : "2.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -808,8 +714,6 @@
           "type" : "ip",
           "ip" : "1.0.0.0"
         },
-        "Next_Hop_IP" : "1.0.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -826,8 +730,6 @@
           "type" : "ip",
           "ip" : "1.0.1.0"
         },
-        "Next_Hop_IP" : "1.0.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -844,8 +746,6 @@
           "type" : "ip",
           "ip" : "2.0.0.1"
         },
-        "Next_Hop_IP" : "2.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -862,8 +762,6 @@
           "type" : "ip",
           "ip" : "2.0.0.1"
         },
-        "Next_Hop_IP" : "2.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -880,8 +778,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -898,8 +794,6 @@
           "type" : "ip",
           "ip" : "2.0.0.1"
         },
-        "Next_Hop_IP" : "2.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -916,8 +810,6 @@
           "type" : "ip",
           "ip" : "2.0.0.1"
         },
-        "Next_Hop_IP" : "2.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -934,8 +826,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -952,8 +842,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -970,8 +858,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -988,8 +874,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1006,8 +890,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1024,8 +906,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1042,8 +922,6 @@
           "type" : "ip",
           "ip" : "1.0.0.2"
         },
-        "Next_Hop_IP" : "1.0.0.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1060,8 +938,6 @@
           "type" : "ip",
           "ip" : "1.0.1.2"
         },
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1078,8 +954,6 @@
           "type" : "ip",
           "ip" : "2.0.1.1"
         },
-        "Next_Hop_IP" : "2.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1096,8 +970,6 @@
           "type" : "ip",
           "ip" : "2.0.1.1"
         },
-        "Next_Hop_IP" : "2.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1114,8 +986,6 @@
           "type" : "ip",
           "ip" : "1.0.0.2"
         },
-        "Next_Hop_IP" : "1.0.0.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1132,8 +1002,6 @@
           "type" : "ip",
           "ip" : "1.0.1.2"
         },
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1150,8 +1018,6 @@
           "type" : "ip",
           "ip" : "2.0.1.1"
         },
-        "Next_Hop_IP" : "2.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1168,8 +1034,6 @@
           "type" : "ip",
           "ip" : "2.0.1.1"
         },
-        "Next_Hop_IP" : "2.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1186,8 +1050,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1204,8 +1066,6 @@
           "type" : "ip",
           "ip" : "2.0.1.1"
         },
-        "Next_Hop_IP" : "2.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1222,8 +1082,6 @@
           "type" : "ip",
           "ip" : "2.0.1.1"
         },
-        "Next_Hop_IP" : "2.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1240,8 +1098,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1258,8 +1114,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1276,8 +1130,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1294,8 +1146,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1312,8 +1162,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1330,8 +1178,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1348,8 +1194,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1366,8 +1210,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1384,8 +1226,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1402,8 +1242,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1420,8 +1258,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1438,8 +1274,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1456,8 +1290,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1474,8 +1306,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1492,8 +1322,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1510,8 +1338,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1528,8 +1354,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1546,8 +1370,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1564,8 +1386,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1582,8 +1402,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1600,8 +1418,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1618,8 +1434,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1636,8 +1450,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1654,8 +1466,6 @@
           "type" : "ip",
           "ip" : "1.0.0.1"
         },
-        "Next_Hop_IP" : "1.0.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1672,8 +1482,6 @@
           "type" : "ip",
           "ip" : "1.0.0.3"
         },
-        "Next_Hop_IP" : "1.0.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1690,8 +1498,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1708,8 +1514,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1726,8 +1530,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1744,8 +1546,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1762,8 +1562,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1780,8 +1578,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1798,8 +1594,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1816,8 +1610,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1834,8 +1626,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1852,8 +1642,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1870,8 +1658,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1888,8 +1674,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1906,8 +1690,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1924,8 +1706,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1942,8 +1722,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1960,8 +1738,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1978,8 +1754,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -1996,8 +1770,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2014,8 +1786,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2032,8 +1802,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2050,8 +1818,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2068,8 +1834,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2086,8 +1850,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2104,8 +1866,6 @@
           "type" : "ip",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2122,8 +1882,6 @@
           "type" : "ip",
           "ip" : "1.0.1.3"
         },
-        "Next_Hop_IP" : "1.0.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2140,8 +1898,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2158,8 +1914,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2176,8 +1930,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2194,8 +1946,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2212,8 +1962,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2230,8 +1978,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2248,8 +1994,6 @@
           "type" : "ip",
           "ip" : "2.1.0.1"
         },
-        "Next_Hop_IP" : "2.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2266,8 +2010,6 @@
           "type" : "ip",
           "ip" : "2.1.0.1"
         },
-        "Next_Hop_IP" : "2.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2284,8 +2026,6 @@
           "type" : "ip",
           "ip" : "1.1.0.0"
         },
-        "Next_Hop_IP" : "1.1.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2302,8 +2042,6 @@
           "type" : "ip",
           "ip" : "1.1.1.0"
         },
-        "Next_Hop_IP" : "1.1.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2320,8 +2058,6 @@
           "type" : "ip",
           "ip" : "2.1.0.1"
         },
-        "Next_Hop_IP" : "2.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2338,8 +2074,6 @@
           "type" : "ip",
           "ip" : "2.1.0.1"
         },
-        "Next_Hop_IP" : "2.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2356,8 +2090,6 @@
           "type" : "ip",
           "ip" : "1.1.0.0"
         },
-        "Next_Hop_IP" : "1.1.0.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2374,8 +2106,6 @@
           "type" : "ip",
           "ip" : "1.1.1.0"
         },
-        "Next_Hop_IP" : "1.1.1.0",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2392,8 +2122,6 @@
           "type" : "ip",
           "ip" : "2.1.0.1"
         },
-        "Next_Hop_IP" : "2.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2410,8 +2138,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2428,8 +2154,6 @@
           "type" : "ip",
           "ip" : "2.1.0.1"
         },
-        "Next_Hop_IP" : "2.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2446,8 +2170,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2464,8 +2186,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2482,8 +2202,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2500,8 +2218,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2518,8 +2234,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2536,8 +2250,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2554,8 +2266,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2572,8 +2282,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2590,8 +2298,6 @@
           "type" : "ip",
           "ip" : "1.1.0.2"
         },
-        "Next_Hop_IP" : "1.1.0.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2608,8 +2314,6 @@
           "type" : "ip",
           "ip" : "1.1.1.2"
         },
-        "Next_Hop_IP" : "1.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2626,8 +2330,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2644,8 +2346,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2662,8 +2362,6 @@
           "type" : "ip",
           "ip" : "1.1.0.2"
         },
-        "Next_Hop_IP" : "1.1.0.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2680,8 +2378,6 @@
           "type" : "ip",
           "ip" : "1.1.1.2"
         },
-        "Next_Hop_IP" : "1.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2698,8 +2394,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2716,8 +2410,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2734,8 +2426,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2752,8 +2442,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2770,8 +2458,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2788,8 +2474,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2806,8 +2490,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2824,8 +2506,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2842,8 +2522,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2860,8 +2538,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2878,8 +2554,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2896,8 +2570,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2914,8 +2586,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2932,8 +2602,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2950,8 +2618,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2968,8 +2634,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2986,8 +2650,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3004,8 +2666,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3022,8 +2682,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3040,8 +2698,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3058,8 +2714,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3076,8 +2730,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3094,8 +2746,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3112,8 +2762,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3130,8 +2778,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3148,8 +2794,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3166,8 +2810,6 @@
           "type" : "ip",
           "ip" : "1.1.0.1"
         },
-        "Next_Hop_IP" : "1.1.0.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3184,8 +2826,6 @@
           "type" : "ip",
           "ip" : "1.1.0.3"
         },
-        "Next_Hop_IP" : "1.1.0.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3202,8 +2842,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3220,8 +2858,6 @@
           "type" : "interface",
           "interface" : "Ethernet1"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet1",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3238,8 +2874,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3256,8 +2890,6 @@
           "type" : "interface",
           "interface" : "Ethernet2"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet2",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3274,8 +2906,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3292,8 +2922,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3310,8 +2938,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3328,8 +2954,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3346,8 +2970,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3364,8 +2986,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3382,8 +3002,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3400,8 +3018,6 @@
           "type" : "interface",
           "interface" : "Ethernet3"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Ethernet3",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3418,8 +3034,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3436,8 +3050,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3454,8 +3066,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3472,8 +3082,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3490,8 +3098,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3508,8 +3114,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3526,8 +3130,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3544,8 +3146,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3562,8 +3162,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3580,8 +3178,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3598,8 +3194,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3616,8 +3210,6 @@
           "type" : "ip",
           "ip" : "1.1.1.1"
         },
-        "Next_Hop_IP" : "1.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3634,8 +3226,6 @@
           "type" : "ip",
           "ip" : "1.1.1.3"
         },
-        "Next_Hop_IP" : "1.1.1.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,

--- a/tests/basic/routes-diff.ref
+++ b/tests/basic/routes-diff.ref
@@ -46,34 +46,6 @@
           "schema" : "NextHop"
         },
         {
-          "description" : "Route's Next Hop IP",
-          "isKey" : false,
-          "isValue" : true,
-          "name" : "Snapshot_Next_Hop_IP",
-          "schema" : "Ip"
-        },
-        {
-          "description" : "Route's Next Hop IP",
-          "isKey" : false,
-          "isValue" : true,
-          "name" : "Reference_Next_Hop_IP",
-          "schema" : "Ip"
-        },
-        {
-          "description" : "Route's Next Hop Interface",
-          "isKey" : false,
-          "isValue" : true,
-          "name" : "Snapshot_Next_Hop_Interface",
-          "schema" : "String"
-        },
-        {
-          "description" : "Route's Next Hop Interface",
-          "isKey" : false,
-          "isValue" : true,
-          "name" : "Reference_Next_Hop_Interface",
-          "schema" : "String"
-        },
-        {
           "description" : "Route's Protocol",
           "isKey" : false,
           "isValue" : true,
@@ -145,18 +117,14 @@
           "type" : "ip",
           "ip" : "10.14.22.4"
         },
-        "Snapshot_Next_Hop_IP" : "10.14.22.4",
         "Snapshot_Protocol" : "ibgp",
-        "Snapshot_Next_Hop_Interface" : "dynamic",
         "Snapshot_Metric" : 20,
         "Snapshot_Admin_Distance" : 200,
         "Snapshot_Tag" : null,
-        "Reference_Next_Hop_Interface" : null,
         "Reference_Metric" : null,
         "Reference_Admin_Distance" : null,
         "Reference_Tag" : null,
         "Reference_Next_Hop" : null,
-        "Reference_Next_Hop_IP" : null,
         "Reference_Protocol" : null
       },
       {
@@ -171,18 +139,14 @@
           "type" : "ip",
           "ip" : "10.14.22.4"
         },
-        "Snapshot_Next_Hop_IP" : "10.14.22.4",
         "Snapshot_Protocol" : "bgp",
-        "Snapshot_Next_Hop_Interface" : "dynamic",
         "Snapshot_Metric" : 20,
         "Snapshot_Admin_Distance" : 20,
         "Snapshot_Tag" : null,
-        "Reference_Next_Hop_Interface" : null,
         "Reference_Metric" : null,
         "Reference_Admin_Distance" : null,
         "Reference_Tag" : null,
         "Reference_Next_Hop" : null,
-        "Reference_Next_Hop_IP" : null,
         "Reference_Protocol" : null
       },
       {
@@ -197,18 +161,14 @@
           "type" : "ip",
           "ip" : "10.14.22.4"
         },
-        "Snapshot_Next_Hop_IP" : "10.14.22.4",
         "Snapshot_Protocol" : "ibgp",
-        "Snapshot_Next_Hop_Interface" : "dynamic",
         "Snapshot_Metric" : 20,
         "Snapshot_Admin_Distance" : 200,
         "Snapshot_Tag" : null,
-        "Reference_Next_Hop_Interface" : null,
         "Reference_Metric" : null,
         "Reference_Admin_Distance" : null,
         "Reference_Tag" : null,
         "Reference_Next_Hop" : null,
-        "Reference_Next_Hop_IP" : null,
         "Reference_Protocol" : null
       }
     ],

--- a/tests/basic/routes.ref
+++ b/tests/basic/routes.ref
@@ -32,20 +32,6 @@
           "schema" : "NextHop"
         },
         {
-          "description" : "Route's Next Hop IP",
-          "isKey" : false,
-          "isValue" : true,
-          "name" : "Next_Hop_IP",
-          "schema" : "Ip"
-        },
-        {
-          "description" : "Route's Next Hop Interface",
-          "isKey" : false,
-          "isValue" : true,
-          "name" : "Next_Hop_Interface",
-          "schema" : "String"
-        },
-        {
           "description" : "Route's Protocol",
           "isKey" : false,
           "isValue" : true,
@@ -88,8 +74,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -106,8 +90,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -125,8 +107,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "1.0.1.2"
         },
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -143,8 +123,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -162,8 +140,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "1.0.1.2"
         },
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -181,8 +157,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "1.0.1.2"
         },
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -199,8 +173,6 @@
           "type" : "ip",
           "ip" : "10.12.11.2"
         },
-        "Next_Hop_IP" : "10.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -217,8 +189,6 @@
           "type" : "ip",
           "ip" : "10.13.22.3"
         },
-        "Next_Hop_IP" : "10.13.22.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -235,8 +205,6 @@
           "type" : "ip",
           "ip" : "10.13.22.3"
         },
-        "Next_Hop_IP" : "10.13.22.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -253,8 +221,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -271,8 +237,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -290,8 +254,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "1.0.1.2"
         },
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -309,8 +271,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "1.0.1.2"
         },
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -328,8 +288,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "1.0.2.2"
         },
-        "Next_Hop_IP" : "1.0.2.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -346,8 +304,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -364,8 +320,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -383,8 +337,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "1.0.2.2"
         },
-        "Next_Hop_IP" : "1.0.2.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -401,8 +353,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -420,8 +370,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "1.0.2.2"
         },
-        "Next_Hop_IP" : "1.0.2.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -438,8 +386,6 @@
           "type" : "ip",
           "ip" : "10.12.11.2"
         },
-        "Next_Hop_IP" : "10.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -456,8 +402,6 @@
           "type" : "ip",
           "ip" : "10.13.22.3"
         },
-        "Next_Hop_IP" : "10.13.22.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -474,8 +418,6 @@
           "type" : "ip",
           "ip" : "10.13.22.3"
         },
-        "Next_Hop_IP" : "10.13.22.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -493,8 +435,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "1.0.2.2"
         },
-        "Next_Hop_IP" : "1.0.2.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -511,8 +451,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -529,8 +467,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -547,8 +483,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -565,8 +499,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -583,8 +515,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -601,8 +531,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -619,8 +547,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -637,8 +563,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -656,8 +580,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -675,8 +597,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "1.0.2.1"
         },
-        "Next_Hop_IP" : "1.0.2.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -693,8 +613,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -711,8 +629,6 @@
           "type" : "ip",
           "ip" : "10.12.11.2"
         },
-        "Next_Hop_IP" : "10.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -729,8 +645,6 @@
           "type" : "ip",
           "ip" : "10.13.22.3"
         },
-        "Next_Hop_IP" : "10.13.22.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -747,8 +661,6 @@
           "type" : "ip",
           "ip" : "10.13.22.3"
         },
-        "Next_Hop_IP" : "10.13.22.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -766,8 +678,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "1.0.1.1"
         },
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -785,8 +695,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "1.0.2.1"
         },
-        "Next_Hop_IP" : "1.0.2.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -804,8 +712,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "1.0.2.1"
         },
-        "Next_Hop_IP" : "1.0.2.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -822,8 +728,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -840,8 +744,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -858,8 +760,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -877,8 +777,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -896,8 +794,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -915,8 +811,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -934,8 +828,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -953,8 +845,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -972,8 +862,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -991,8 +879,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1010,8 +896,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1028,8 +912,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1046,8 +928,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1064,8 +944,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1082,8 +960,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1101,8 +977,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1120,8 +994,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1139,8 +1011,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1158,8 +1028,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1177,8 +1045,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1196,8 +1062,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1215,8 +1079,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1234,8 +1096,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1253,8 +1113,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1272,8 +1130,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1289,8 +1145,6 @@
         "Next_Hop" : {
           "type" : "discard"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "null_interface",
         "Protocol" : "aggregate",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1307,8 +1161,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1325,8 +1177,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1343,8 +1193,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1361,8 +1209,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1379,8 +1225,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1397,8 +1241,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1415,8 +1257,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1433,8 +1273,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1452,8 +1290,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.11.2"
         },
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1471,8 +1307,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.12.2"
         },
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1489,8 +1323,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1507,8 +1339,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1526,8 +1356,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1545,8 +1373,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1563,8 +1389,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1582,8 +1406,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1601,8 +1423,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1620,8 +1440,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1639,8 +1457,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1658,8 +1474,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1677,8 +1491,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1696,8 +1508,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1715,8 +1525,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1733,8 +1541,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1751,8 +1557,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1769,8 +1573,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1787,8 +1589,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -1806,8 +1606,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1825,8 +1623,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1844,8 +1640,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1863,8 +1657,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1882,8 +1674,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1901,8 +1691,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1920,8 +1708,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1939,8 +1725,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1956,8 +1740,6 @@
         "Next_Hop" : {
           "type" : "discard"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "null_interface",
         "Protocol" : "aggregate",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1974,8 +1756,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -1992,8 +1772,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2010,8 +1788,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2028,8 +1804,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2046,8 +1820,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2064,8 +1836,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -2083,8 +1853,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.12.21.2"
         },
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2102,8 +1870,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.22.2"
         },
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2120,8 +1886,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2138,8 +1902,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2156,8 +1918,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2174,8 +1934,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2193,8 +1951,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.12.11.1"
         },
-        "Next_Hop_IP" : "2.12.11.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2212,8 +1968,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.21.1"
         },
-        "Next_Hop_IP" : "2.12.21.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2230,8 +1984,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2249,8 +2001,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.12.11.1"
         },
-        "Next_Hop_IP" : "2.12.11.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2268,8 +2018,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.21.1"
         },
-        "Next_Hop_IP" : "2.12.21.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2287,8 +2035,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.23.11.3"
         },
-        "Next_Hop_IP" : "2.23.11.3",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2306,8 +2052,6 @@
           "interface" : "GigabitEthernet3/0",
           "ip" : "2.23.12.3"
         },
-        "Next_Hop_IP" : "2.23.12.3",
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2325,8 +2069,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.23.11.3"
         },
-        "Next_Hop_IP" : "2.23.11.3",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2344,8 +2086,6 @@
           "interface" : "GigabitEthernet3/0",
           "ip" : "2.23.12.3"
         },
-        "Next_Hop_IP" : "2.23.12.3",
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2362,8 +2102,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2380,8 +2118,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2399,8 +2135,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.12.11.1"
         },
-        "Next_Hop_IP" : "2.12.11.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2417,8 +2151,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2435,8 +2167,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2454,8 +2184,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.21.1"
         },
-        "Next_Hop_IP" : "2.12.21.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2472,8 +2200,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2490,8 +2216,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2508,8 +2232,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet3/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2526,8 +2248,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet3/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2545,8 +2265,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.23.11.3"
         },
-        "Next_Hop_IP" : "2.23.11.3",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2564,8 +2282,6 @@
           "interface" : "GigabitEthernet3/0",
           "ip" : "2.23.12.3"
         },
-        "Next_Hop_IP" : "2.23.12.3",
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2583,8 +2299,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.23.11.3"
         },
-        "Next_Hop_IP" : "2.23.11.3",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2602,8 +2316,6 @@
           "interface" : "GigabitEthernet3/0",
           "ip" : "2.23.12.3"
         },
-        "Next_Hop_IP" : "2.23.12.3",
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2620,8 +2332,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2638,8 +2348,6 @@
           "type" : "ip",
           "ip" : "2.1.1.2"
         },
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2656,8 +2364,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2674,8 +2380,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2692,8 +2396,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2710,8 +2412,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2728,8 +2428,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2746,8 +2444,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2765,8 +2461,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.12.11.1"
         },
-        "Next_Hop_IP" : "2.12.11.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2784,8 +2478,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.21.1"
         },
-        "Next_Hop_IP" : "2.12.21.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2802,8 +2494,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2820,8 +2510,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -2839,8 +2527,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.12.1"
         },
-        "Next_Hop_IP" : "2.12.12.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2858,8 +2544,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.12.22.1"
         },
-        "Next_Hop_IP" : "2.12.22.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2877,8 +2561,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.12.1"
         },
-        "Next_Hop_IP" : "2.12.12.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2896,8 +2578,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.12.22.1"
         },
-        "Next_Hop_IP" : "2.12.22.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2915,8 +2595,6 @@
           "interface" : "GigabitEthernet3/0",
           "ip" : "2.23.21.3"
         },
-        "Next_Hop_IP" : "2.23.21.3",
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2934,8 +2612,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.23.22.3"
         },
-        "Next_Hop_IP" : "2.23.22.3",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2952,8 +2628,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -2971,8 +2645,6 @@
           "interface" : "GigabitEthernet3/0",
           "ip" : "2.23.21.3"
         },
-        "Next_Hop_IP" : "2.23.21.3",
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2990,8 +2662,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.23.22.3"
         },
-        "Next_Hop_IP" : "2.23.22.3",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3009,8 +2679,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.12.1"
         },
-        "Next_Hop_IP" : "2.12.12.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3027,8 +2695,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3045,8 +2711,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3064,8 +2728,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.12.22.1"
         },
-        "Next_Hop_IP" : "2.12.22.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3082,8 +2744,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3100,8 +2760,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3119,8 +2777,6 @@
           "interface" : "GigabitEthernet3/0",
           "ip" : "2.23.21.3"
         },
-        "Next_Hop_IP" : "2.23.21.3",
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3138,8 +2794,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.23.22.3"
         },
-        "Next_Hop_IP" : "2.23.22.3",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3156,8 +2810,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet3/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3174,8 +2826,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet3/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3192,8 +2842,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3210,8 +2858,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3229,8 +2875,6 @@
           "interface" : "GigabitEthernet3/0",
           "ip" : "2.23.21.3"
         },
-        "Next_Hop_IP" : "2.23.21.3",
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3248,8 +2892,6 @@
           "interface" : "GigabitEthernet2/0",
           "ip" : "2.23.22.3"
         },
-        "Next_Hop_IP" : "2.23.22.3",
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3266,8 +2908,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3284,8 +2924,6 @@
           "type" : "ip",
           "ip" : "2.1.1.2"
         },
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3302,8 +2940,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3320,8 +2956,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3338,8 +2972,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3356,8 +2988,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3374,8 +3004,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3392,8 +3020,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3411,8 +3037,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.12.12.1"
         },
-        "Next_Hop_IP" : "2.12.12.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3430,8 +3054,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.12.22.1"
         },
-        "Next_Hop_IP" : "2.12.22.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3448,8 +3070,6 @@
           "type" : "ip",
           "ip" : "2.34.101.3"
         },
-        "Next_Hop_IP" : "2.34.101.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3466,8 +3086,6 @@
           "type" : "ip",
           "ip" : "2.34.201.3"
         },
-        "Next_Hop_IP" : "2.34.201.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3484,8 +3102,6 @@
           "type" : "ip",
           "ip" : "2.34.101.3"
         },
-        "Next_Hop_IP" : "2.34.101.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3502,8 +3118,6 @@
           "type" : "ip",
           "ip" : "2.34.201.3"
         },
-        "Next_Hop_IP" : "2.34.201.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3520,8 +3134,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3538,8 +3150,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3556,8 +3166,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3574,8 +3182,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3592,8 +3198,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3610,8 +3214,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3628,8 +3230,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3646,8 +3246,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet3/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3664,8 +3262,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet3/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3682,8 +3278,6 @@
           "type" : "ip",
           "ip" : "2.34.101.3"
         },
-        "Next_Hop_IP" : "2.34.101.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3700,8 +3294,6 @@
           "type" : "ip",
           "ip" : "2.34.201.3"
         },
-        "Next_Hop_IP" : "2.34.201.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3718,8 +3310,6 @@
           "type" : "ip",
           "ip" : "2.34.101.3"
         },
-        "Next_Hop_IP" : "2.34.101.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3736,8 +3326,6 @@
           "type" : "ip",
           "ip" : "2.34.201.3"
         },
-        "Next_Hop_IP" : "2.34.201.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -3754,8 +3342,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3772,8 +3358,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -3791,8 +3375,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3810,8 +3392,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3829,8 +3409,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3848,8 +3426,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3867,8 +3443,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3886,8 +3460,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3904,8 +3476,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -3923,8 +3493,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3942,8 +3510,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3961,8 +3527,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3980,8 +3544,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3999,8 +3561,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4018,8 +3578,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4036,8 +3594,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4054,8 +3610,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4073,8 +3627,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4091,8 +3643,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4109,8 +3659,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4128,8 +3676,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4146,8 +3692,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4164,8 +3708,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4183,8 +3725,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4202,8 +3742,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4220,8 +3758,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4238,8 +3774,6 @@
           "type" : "ip",
           "ip" : "2.1.1.2"
         },
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4256,8 +3790,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -4274,8 +3806,6 @@
           "type" : "ip",
           "ip" : "2.34.101.4"
         },
-        "Next_Hop_IP" : "2.34.101.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -4292,8 +3822,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4310,8 +3838,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4329,8 +3855,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4348,8 +3872,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4367,8 +3889,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.11.2"
         },
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4386,8 +3906,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.21.2"
         },
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4404,8 +3922,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4422,8 +3938,6 @@
           "type" : "ip",
           "ip" : "10.12.11.1"
         },
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4441,8 +3955,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4460,8 +3972,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4479,8 +3989,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4498,8 +4006,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4517,8 +4023,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4536,8 +4040,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4555,8 +4057,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4574,8 +4074,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4592,8 +4090,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4611,8 +4107,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4630,8 +4124,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4649,8 +4141,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4668,8 +4158,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4687,8 +4175,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4705,8 +4191,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4723,8 +4207,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4742,8 +4224,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4760,8 +4240,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4778,8 +4256,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4797,8 +4273,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4816,8 +4290,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4834,8 +4306,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4852,8 +4322,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -4870,8 +4338,6 @@
           "type" : "ip",
           "ip" : "2.1.1.1"
         },
-        "Next_Hop_IP" : "2.1.1.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4888,8 +4354,6 @@
           "type" : "ip",
           "ip" : "2.1.1.2"
         },
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4906,8 +4370,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -4924,8 +4386,6 @@
           "type" : "ip",
           "ip" : "2.34.201.4"
         },
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -4942,8 +4402,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4960,8 +4418,6 @@
           "type" : "ip",
           "ip" : "10.23.21.3"
         },
-        "Next_Hop_IP" : "10.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -4979,8 +4435,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4998,8 +4452,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5017,8 +4469,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "2.23.12.2"
         },
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5036,8 +4486,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "2.23.22.2"
         },
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5054,8 +4502,6 @@
           "type" : "ip",
           "ip" : "10.13.22.1"
         },
-        "Next_Hop_IP" : "10.13.22.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -5072,8 +4518,6 @@
           "type" : "ip",
           "ip" : "10.13.22.1"
         },
-        "Next_Hop_IP" : "10.13.22.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -5090,8 +4534,6 @@
           "type" : "ip",
           "ip" : "10.23.21.2"
         },
-        "Next_Hop_IP" : "10.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -5108,8 +4550,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5126,8 +4566,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5145,8 +4583,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "3.0.1.2"
         },
-        "Next_Hop_IP" : "3.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5163,8 +4599,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5182,8 +4616,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "3.0.1.2"
         },
-        "Next_Hop_IP" : "3.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5201,8 +4633,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "3.0.1.2"
         },
-        "Next_Hop_IP" : "3.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5220,8 +4650,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "3.0.1.2"
         },
-        "Next_Hop_IP" : "3.0.1.2",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5238,8 +4666,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5256,8 +4682,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5274,8 +4698,6 @@
           "type" : "ip",
           "ip" : "10.13.22.1"
         },
-        "Next_Hop_IP" : "10.13.22.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -5292,8 +4714,6 @@
           "type" : "ip",
           "ip" : "10.13.22.1"
         },
-        "Next_Hop_IP" : "10.13.22.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "bgp",
         "Tag" : null,
         "Admin_Distance" : 20,
@@ -5310,8 +4730,6 @@
           "type" : "ip",
           "ip" : "10.23.21.2"
         },
-        "Next_Hop_IP" : "10.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -5329,8 +4747,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "3.0.2.2"
         },
-        "Next_Hop_IP" : "3.0.2.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5347,8 +4763,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5365,8 +4779,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5384,8 +4796,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "3.0.2.2"
         },
-        "Next_Hop_IP" : "3.0.2.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5402,8 +4812,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5421,8 +4829,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "3.0.2.2"
         },
-        "Next_Hop_IP" : "3.0.2.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5439,8 +4845,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5457,8 +4861,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5476,8 +4878,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "3.0.2.2"
         },
-        "Next_Hop_IP" : "3.0.2.2",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5494,8 +4894,6 @@
           "type" : "ip",
           "ip" : "10.13.22.1"
         },
-        "Next_Hop_IP" : "10.13.22.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -5512,8 +4910,6 @@
           "type" : "ip",
           "ip" : "10.13.22.1"
         },
-        "Next_Hop_IP" : "10.13.22.1",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -5530,8 +4926,6 @@
           "type" : "ip",
           "ip" : "10.23.21.2"
         },
-        "Next_Hop_IP" : "10.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
         "Protocol" : "ibgp",
         "Tag" : null,
         "Admin_Distance" : 200,
@@ -5548,8 +4942,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5566,8 +4958,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet1/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5584,8 +4974,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5602,8 +4990,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet0/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5621,8 +5007,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "3.0.1.1"
         },
-        "Next_Hop_IP" : "3.0.1.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5640,8 +5024,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "3.0.2.1"
         },
-        "Next_Hop_IP" : "3.0.2.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5658,8 +5040,6 @@
           "type" : "interface",
           "interface" : "Loopback0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "Loopback0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5677,8 +5057,6 @@
           "interface" : "GigabitEthernet0/0",
           "ip" : "3.0.2.1"
         },
-        "Next_Hop_IP" : "3.0.2.1",
-        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5696,8 +5074,6 @@
           "interface" : "GigabitEthernet1/0",
           "ip" : "3.0.1.1"
         },
-        "Next_Hop_IP" : "3.0.1.1",
-        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5714,8 +5090,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5732,8 +5106,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet3/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5750,8 +5122,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet2/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5768,8 +5138,6 @@
           "type" : "interface",
           "interface" : "GigabitEthernet3/0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "GigabitEthernet3/0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5787,8 +5155,6 @@
           "interface" : "eth0",
           "ip" : "2.128.0.1"
         },
-        "Next_Hop_IP" : "2.128.0.1",
-        "Next_Hop_Interface" : "eth0",
         "Protocol" : "static",
         "Tag" : null,
         "Admin_Distance" : 1,
@@ -5805,8 +5171,6 @@
           "type" : "interface",
           "interface" : "eth0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "eth0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5823,8 +5187,6 @@
           "type" : "interface",
           "interface" : "eth0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "eth0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5842,8 +5204,6 @@
           "interface" : "eth0",
           "ip" : "2.128.1.1"
         },
-        "Next_Hop_IP" : "2.128.1.1",
-        "Next_Hop_Interface" : "eth0",
         "Protocol" : "static",
         "Tag" : null,
         "Admin_Distance" : 1,
@@ -5860,8 +5220,6 @@
           "type" : "interface",
           "interface" : "eth0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "eth0",
         "Protocol" : "connected",
         "Tag" : null,
         "Admin_Distance" : 0,
@@ -5878,8 +5236,6 @@
           "type" : "interface",
           "interface" : "eth0"
         },
-        "Next_Hop_IP" : null,
-        "Next_Hop_Interface" : "eth0",
         "Protocol" : "local",
         "Tag" : null,
         "Admin_Distance" : 0,


### PR DESCRIPTION
The unified Next_Hop column (Schema.NEXT_HOP) has carried the structured
next hop for every routes/bgpRib/evpnRib row -- both the non-diff and
diff variants -- so the legacy decomposed columns are pure duplication.
Remove them along with the now-orphaned plumbing:

- INTERNAL_USE_IPS, which only existed to mask the BGP-unnumbered IP
out of the Next_Hop_IP column.
- RouteRowAttribute._nextHopInterface; the secondary key already pins
NextHop within a sub-group, so the field was redundant for both
equality and comparison.

----

Prompt:
```
I want to remove the columns like Next_Hop_Ip from all questions. No
Next_Hop_Interface, etc. They should all just hae a Next_Hop column.
Fan out agents to find all questions that have such a column,
especially any that don't have a Next_Hop column and need to be
upgraded
```

Investigation found the legacy columns lived only in RoutesAnswerer
(routes, bgpRib, evpnRib), and every emitting site already produced
Next_Hop alongside them, so no question needed an upgrade. Follow-up
in-conversation: confirmed NextHop is comparable (NextHopComparator)
and the secondary keys hash on it, so dropping _nextHopInterface from
RouteRowAttribute does not lose any ordering or grouping.

---
**Stack**:
- #9944 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*