### PR TITLE
TransferBDD: MatchLocalPreference

### DIFF
--- a/docs/symbolic_engine/route_policies.md
+++ b/docs/symbolic_engine/route_policies.md
@@ -278,11 +278,9 @@ modified by `SetLocalPreference`, which dispatches through
 `SetMetric`, `SetTag`, and `SetWeight` use the same infrastructure with their
 respective `BDDRoute` integer fields.
 
-There is no `MatchLocalPreference` handler in `TransferBDD`. Any policy that
-uses `MatchLocalPreference` falls through to the catch-all and is marked
-unsupported. By contrast, `MatchMetric` and `MatchTag` are supported via
-direct integer comparisons. Adding `MatchLocalPreference` would be a
-mechanical change.
+`MatchLocalPreference`, `MatchMetric`, and `MatchTag` are all supported via
+`matchLongComparison`, which compiles a literal-`LongExpr` comparison into a
+constraint on the corresponding `BDDRoute` integer field.
 
 ## Non-BGP Routes
 
@@ -346,8 +344,6 @@ references are to classes in
   (`_prependedASes`), so only paths with identical prepend sequences can be
   merged in `combineSymbolicResults`. Policies with many distinct prepend
   combinations produce many paths.
-- **No `MatchLocalPreference`.** No handler exists in `TransferBDD`; affected
-  paths are marked unsupported.
 - **No symbolic intermediate-attribute tracking across calls in some cases.**
   `TransferParam` updates made inside expression visits can be dropped — see
   the TODO in `TransferBDD.compute(BooleanExpr, ...)`.

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -87,6 +87,7 @@ import org.batfish.datamodel.routing_policy.expr.LongExpr;
 import org.batfish.datamodel.routing_policy.expr.MatchClusterListLength;
 import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
+import org.batfish.datamodel.routing_policy.expr.MatchLocalPreference;
 import org.batfish.datamodel.routing_policy.expr.MatchMetric;
 import org.batfish.datamodel.routing_policy.expr.MatchPeerAddress;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
@@ -616,6 +617,12 @@ public class TransferBDD {
       MatchMetric mm = (MatchMetric) expr;
       BDD mmBDD = matchLongComparison(mm.getComparator(), mm.getMetric(), currRoute.getMed());
       finalResults.add(result.setReturnValueBDD(mmBDD).setReturnValueAccepted(true));
+
+    } else if (expr instanceof MatchLocalPreference) {
+      MatchLocalPreference mlp = (MatchLocalPreference) expr;
+      BDD mlpBDD =
+          matchLongComparison(mlp.getComparator(), mlp.getMetric(), currRoute.getLocalPref());
+      finalResults.add(result.setReturnValueBDD(mlpBDD).setReturnValueAccepted(true));
 
     } else if (expr instanceof MatchClusterListLength) {
       MatchClusterListLength mcll = (MatchClusterListLength) expr;

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -117,6 +117,7 @@ import org.batfish.datamodel.routing_policy.expr.MatchClusterListLength;
 import org.batfish.datamodel.routing_policy.expr.MatchColor;
 import org.batfish.datamodel.routing_policy.expr.MatchInterface;
 import org.batfish.datamodel.routing_policy.expr.MatchIpv4;
+import org.batfish.datamodel.routing_policy.expr.MatchLocalPreference;
 import org.batfish.datamodel.routing_policy.expr.MatchMetric;
 import org.batfish.datamodel.routing_policy.expr.MatchPeerAddress;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
@@ -1505,6 +1506,112 @@ public class TransferBDDTest {
             .addStatement(
                 new If(
                     new MatchMetric(IntComparator.EQ, new VarLong("var")),
+                    ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
+            .build();
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
+
+    TransferBDD tbdd = new TransferBDD(_configAPs);
+    List<TransferReturn> paths = tbdd.computePaths(policy, true);
+
+    BDDRoute any = anyRoute(tbdd.getFactory());
+    any.setUnsupported(true);
+
+    assertEquals(paths, ImmutableList.of(new TransferReturn(any, tbdd.getFactory().one(), false)));
+  }
+
+  @Test
+  public void testMatchLocalPreference() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    new MatchLocalPreference(IntComparator.EQ, new LiteralLong(42)),
+                    ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
+            .build();
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
+
+    TransferBDD tbdd = new TransferBDD(_configAPs);
+    List<TransferReturn> paths = tbdd.computePaths(policy, true);
+
+    BDDRoute any = anyRoute(tbdd.getFactory());
+
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, any.getLocalPref().value(42), true),
+            new TransferReturn(any, any.getLocalPref().value(42).not(), false)));
+    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+  }
+
+  @Test
+  public void testMatchLocalPreferenceGE() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    new MatchLocalPreference(IntComparator.GE, new LiteralLong(2)),
+                    ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
+            .build();
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
+
+    TransferBDD tbdd = new TransferBDD(_configAPs);
+    List<TransferReturn> paths = tbdd.computePaths(policy, true);
+
+    BDDRoute any = anyRoute(tbdd.getFactory());
+
+    BDD lpGETwo = any.getLocalPref().value(0).or(any.getLocalPref().value(1)).not();
+
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(any, lpGETwo, true), new TransferReturn(any, lpGETwo.not(), false)));
+    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+  }
+
+  @Test
+  public void testSetThenMatchLocalPreference() {
+    List<Statement> stmts =
+        ImmutableList.of(
+            new SetLocalPreference(new LiteralLong(42)),
+            new If(
+                new MatchLocalPreference(IntComparator.EQ, new LiteralLong(42)),
+                ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
+    RoutingPolicy policy = _policyBuilder.setStatements(stmts).build();
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
+
+    // the analysis will use the original route for matching
+    TransferBDD tbdd = new TransferBDD(_configAPs);
+    List<TransferReturn> paths = tbdd.computePaths(policy, true);
+
+    BDDRoute any = anyRoute(tbdd.getFactory());
+    BDDRoute expected = new BDDRoute(any);
+    MutableBDDInteger lp = expected.getLocalPref();
+    expected.setLocalPref(MutableBDDInteger.makeFromValue(lp.getFactory(), 32, 42));
+
+    assertEquals(
+        paths,
+        ImmutableList.of(
+            new TransferReturn(expected, any.getLocalPref().value(42), true),
+            new TransferReturn(expected, any.getLocalPref().value(42).not(), false)));
+    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+
+    // now do the analysis again but use the output attributes for matching
+    setup(ConfigurationFormat.JUNIPER);
+    policy = _policyBuilder.setStatements(stmts).build();
+    paths = tbdd.computePaths(policy, true);
+
+    assertEquals(
+        paths, ImmutableList.of(new TransferReturn(expected, tbdd.getFactory().one(), true)));
+    assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
+  }
+
+  @Test
+  public void testMatchLocalPreferenceUnsupported() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    new MatchLocalPreference(IntComparator.EQ, new VarLong("var")),
                     ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
     _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);


### PR DESCRIPTION
Add support for MatchLocalPreference to the symbolic routing-policy
analysis, matching the existing MatchTag and MatchMetric handling
(literal LongExpr comparisons via matchLongComparison; non-literal
comparisons remain unsupported and mark the path).

Also remove the now-stale "no MatchLocalPreference handler" note from
docs/symbolic_engine/route_policies.md.

----

Prompt:
```
Add MatchLocalPreference to TransferBDD as a follow-on commit. Don't
make a PR or anything like that, please.
```

---
**Stack**:
- #9945 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*