### PR TITLE
Junos: model commit-time and runtime semantics of policy-statement then actions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1214,6 +1214,7 @@ import org.batfish.representation.juniper.PsThenNextHopPeerAddress;
 import org.batfish.representation.juniper.PsThenNextHopReject;
 import org.batfish.representation.juniper.PsThenNextHopSelf;
 import org.batfish.representation.juniper.PsThenNextPolicy;
+import org.batfish.representation.juniper.PsThenNextTerm;
 import org.batfish.representation.juniper.PsThenOrigin;
 import org.batfish.representation.juniper.PsThenPreference;
 import org.batfish.representation.juniper.PsThenReject;
@@ -2569,12 +2570,25 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   private void addPsThen(PsThen then, ParserRuleContext ctx) {
     List<String> cleared = _currentPsThens.addPsThen(then);
-    if (!cleared.isEmpty()) {
-      warnRisky(
-          ctx,
-          String.format(
-              "Overwriting existing %s %s",
-              cleared.size() > 1 ? "thens" : "then", String.join(", ", cleared)));
+    for (String entry : cleared) {
+      if (entry.contains("(suppressed-by-next-term-or-policy)")) {
+        warnRisky(
+            ctx,
+            "then next term/next policy suppresses prior then accept/reject in the same term:"
+                + " accept/reject does not fire");
+      } else if (entry.contains("(dead-after-next-term-or-policy)")) {
+        warnRisky(
+            ctx,
+            "then accept/reject has no effect when then next term/next policy is also present in"
+                + " the same term: accept/reject does not fire");
+      } else if (entry.contains("(dedup)")) {
+        warnRisky(ctx, String.format("Duplicate then %s", entry.replace(" (dedup)", "")));
+      } else if (entry.contains("(conflict)")) {
+        warnRisky(
+            ctx, String.format("Conflicts with prior then %s", entry.replace(" (conflict)", "")));
+      } else {
+        warnRisky(ctx, String.format("Overwriting existing then %s", entry));
+      }
     }
   }
 
@@ -7012,10 +7026,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitPopst_next_term(Popst_next_termContext ctx) {
-    // The next-term action itself is a no-op in Batfish, so we do not model this behavior.
-    //
-    // TODO(https://github.com/batfish/batfish/issues/1551): need to implement next_term replacing
-    // any existing flow control action.
+    addPsThen(PsThenNextTerm.INSTANCE, ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3329,11 +3329,22 @@ public final class JuniperConfiguration extends VendorConfiguration {
         || then instanceof PsThenNextPolicy;
   }
 
-  private List<Statement> toStatements(Set<PsThen> thens) {
+  private List<Statement> toStatements(List<PsThen> thens) {
+    // If `next term` or `next policy` is present, it suppresses any `accept`/`reject` in the
+    // same term: both lines are retained at commit, but at runtime the `accept`/`reject` does
+    // not fire. default-action is unaffected.
+    boolean hasNextTermOrPolicy =
+        thens.stream().anyMatch(t -> t instanceof PsThenNextTerm || t instanceof PsThenNextPolicy);
+    Stream<PsThen> filtered =
+        hasNextTermOrPolicy
+            ? thens.stream()
+                .filter(t -> !(t instanceof PsThenAccept) && !(t instanceof PsThenReject))
+            : thens.stream();
+    List<PsThen> all = filtered.collect(ImmutableList.toImmutableList());
     List<Statement> thenStatements = new ArrayList<>();
     Stream.concat(
-            thens.stream().filter(then -> !isFinalThen(then)),
-            thens.stream().filter(JuniperConfiguration::isFinalThen))
+            all.stream().filter(then -> !isFinalThen(then)),
+            all.stream().filter(JuniperConfiguration::isFinalThen))
         .forEach(then -> then.applyTo(thenStatements, this, _c, _w));
     return thenStatements;
   }
@@ -4414,6 +4425,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
           || then instanceof PsThenDefaultActionAccept
           || then instanceof PsThenDefaultActionReject
           || then instanceof PsThenNextPolicy
+          || then instanceof PsThenNextTerm
           || then instanceof PsThenLoadBalance) {
         // Control flow or forwarding-table-specific actions — no warning.
         continue;
@@ -4913,7 +4925,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
               if (nextTerminalAction.isPresent()) {
                 // Check that the terminal action is the ONLY action.
                 // If there are multiple thens, some are likely mutating actions that are skipped
-                Set<PsThen> allThens = nextTerm.getThens().getAllThens();
+                List<PsThen> allThens = nextTerm.getThens().getAllThens();
                 if (allThens.size() == 1) {
                   return;
                 }
@@ -4950,7 +4962,16 @@ public final class JuniperConfiguration extends VendorConfiguration {
       return Optional.empty();
     }
 
-    return term.getThens().getAllThens().stream()
+    List<PsThen> allThens = term.getThens().getAllThens();
+    // `next term` overrides any accept/reject in the same term: at runtime the route falls
+    // through to the next term, so this term is not terminal. (`next term` and `next policy`
+    // share a last-wins slot in PsThens, so at most one is present here.)
+    if (allThens.stream().anyMatch(t -> t instanceof PsThenNextTerm)) {
+      return Optional.empty();
+    }
+    // `next policy` similarly suppresses accept/reject at runtime, but it does terminate
+    // policy evaluation (returning the route to BGP processing), so it is the terminal action.
+    return allThens.stream()
         .filter(
             then ->
                 then instanceof PsThenAccept

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAsPathExpandAsList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAsPathExpandAsList.java
@@ -36,5 +36,21 @@ public final class PsThenAsPathExpandAsList extends PsThenAsPathExpand {
     return _asList;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenAsPathExpandAsList)) {
+      return false;
+    }
+    PsThenAsPathExpandAsList that = (PsThenAsPathExpandAsList) o;
+    return _asList.equals(that._asList);
+  }
+
+  @Override
+  public int hashCode() {
+    return _asList.hashCode();
+  }
+
   private final @Nonnull List<Long> _asList;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAsPathExpandLastAs.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAsPathExpandLastAs.java
@@ -47,5 +47,21 @@ public final class PsThenAsPathExpandLastAs extends PsThenAsPathExpand {
     return _count;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenAsPathExpandLastAs)) {
+      return false;
+    }
+    PsThenAsPathExpandLastAs that = (PsThenAsPathExpandLastAs) o;
+    return _count == that._count;
+  }
+
+  @Override
+  public int hashCode() {
+    return Integer.hashCode(_count);
+  }
+
   private final int _count;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAsPathPrepend.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAsPathPrepend.java
@@ -35,5 +35,21 @@ public final class PsThenAsPathPrepend extends PsThen {
     return _asList;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenAsPathPrepend)) {
+      return false;
+    }
+    PsThenAsPathPrepend that = (PsThenAsPathPrepend) o;
+    return _asList.equals(that._asList);
+  }
+
+  @Override
+  public int hashCode() {
+    return _asList.hashCode();
+  }
+
   private final @Nonnull List<Long> _asList;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunityDelete.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenCommunityDelete.java
@@ -36,5 +36,21 @@ public final class PsThenCommunityDelete extends PsThen {
     return _name;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenCommunityDelete)) {
+      return false;
+    }
+    PsThenCommunityDelete that = (PsThenCommunityDelete) o;
+    return _name.equals(that._name);
+  }
+
+  @Override
+  public int hashCode() {
+    return _name.hashCode();
+  }
+
   private final String _name;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenExternal.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenExternal.java
@@ -28,4 +28,20 @@ public final class PsThenExternal extends PsThen {
   public OspfMetricType getType() {
     return _type;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenExternal)) {
+      return false;
+    }
+    PsThenExternal that = (PsThenExternal) o;
+    return _type == that._type;
+  }
+
+  @Override
+  public int hashCode() {
+    return _type.hashCode();
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLoadBalance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLoadBalance.java
@@ -38,6 +38,22 @@ public final class PsThenLoadBalance extends PsThen {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenLoadBalance)) {
+      return false;
+    }
+    PsThenLoadBalance that = (PsThenLoadBalance) o;
+    return _method == that._method;
+  }
+
+  @Override
+  public int hashCode() {
+    return _method.hashCode();
+  }
+
+  @Override
   public void applyTo(
       List<Statement> statements,
       JuniperConfiguration juniperVendorConfiguration,

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenNextHopIp.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenNextHopIp.java
@@ -30,4 +30,20 @@ public final class PsThenNextHopIp extends PsThen {
   public Ip getNextHopIp() {
     return _nextHopIp;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenNextHopIp)) {
+      return false;
+    }
+    PsThenNextHopIp that = (PsThenNextHopIp) o;
+    return _nextHopIp.equals(that._nextHopIp);
+  }
+
+  @Override
+  public int hashCode() {
+    return _nextHopIp.hashCode();
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenNextTerm.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenNextTerm.java
@@ -1,0 +1,29 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * The {@code then next term} action. Causes Junos to skip the remaining actions in this term and
+ * continue evaluating the next term in the same policy. When present in a {@code then} block, it
+ * suppresses any bare {@code accept}/{@code reject} in the same block; suppression is handled in
+ * {@link JuniperConfiguration#toStatements}, so this {@link #applyTo} emits no statement and the
+ * term naturally falls through to the next.
+ */
+public final class PsThenNextTerm extends PsThen {
+
+  public static final PsThenNextTerm INSTANCE = new PsThenNextTerm();
+
+  private PsThenNextTerm() {}
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings w) {
+    // No-op: term naturally falls through when no exit/return statement is emitted.
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenOrigin.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenOrigin.java
@@ -29,4 +29,20 @@ public final class PsThenOrigin extends PsThen {
   public OriginType getOriginType() {
     return _originType;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenOrigin)) {
+      return false;
+    }
+    PsThenOrigin that = (PsThenOrigin) o;
+    return _originType == that._originType;
+  }
+
+  @Override
+  public int hashCode() {
+    return _originType.hashCode();
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
@@ -1,48 +1,87 @@
 package org.batfish.representation.juniper;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** Represents all {@link PsThen} statements in a single {@link PsTerm} */
+/**
+ * Represents all {@link PsThen} statements in a single {@link PsTerm}.
+ *
+ * <p>Models Junos runtime behavior for actions within a single {@code then} block:
+ *
+ * <ul>
+ *   <li>Scalar/numeric families (origin, metric, local-preference, next-hop, tunnel-attribute,
+ *       etc.) use last-wins semantics: only the last action is retained.
+ *   <li>Community actions (set/add/delete) live in a single ordered list, executed in declared
+ *       order. A new {@code community set} wipes all prior community actions (since {@code set}
+ *       replaces the route's communities, prior add/delete are no-ops). Within add/delete, a new
+ *       action that conflicts with a prior one on the same community name (e.g., {@code add X}
+ *       followed by {@code delete X}) is retained — order matters at runtime — but a warning is
+ *       emitted.
+ *   <li>{@code next term} and {@code next policy} share one last-wins slot: a {@code then} block
+ *       holds at most one such action. {@code accept}/{@code reject} live in a separate slot and
+ *       also use last-wins. When both a {@code next term}/{@code next policy} and an {@code
+ *       accept}/{@code reject} appear in the same term, both lines stay in retained config but
+ *       {@code next term}/{@code next policy} wins at runtime: the {@code accept}/{@code reject}
+ *       does not fire.
+ * </ul>
+ *
+ * <p>All cleared/eliminated actions produce a RISKY warning so the user can audit the config.
+ */
 public final class PsThens implements Serializable {
 
   /**
    * Incorporates the given {@code then foo} statement in this {@link PsThens}. Returns the list of
-   * prior {@code then foo} that may have been cleared or overwritten by this operation.
+   * prior {@code then foo} that may have been cleared or overwritten by this operation, or a
+   * one-element list with a {@code "(dedup)"} suffix if the new statement was an exact duplicate.
    */
   public @Nonnull List<String> addPsThen(PsThen then) {
-    if (then instanceof PsThenAsPathExpand) {
-      return setAsPathExpand((PsThenAsPathExpand) then);
-    } else if (then instanceof PsThenAsPathPrepend) {
-      return setAsPathPrepend((PsThenAsPathPrepend) then);
-    } else if (then instanceof PsThenCommunitySet) {
-      return setCommunitySet((PsThenCommunitySet) then);
-    } else if (then instanceof PsThenCommunityAdd) {
-      return addCommunityAdd((PsThenCommunityAdd) then);
+    if (isCommunityAction(then)) {
+      return addCommunityAction(then);
     }
-    _others.add(then);
-    return ImmutableList.of();
+    if (isNextTermOrPolicy(then)) {
+      return setNextTermOrPolicy(then);
+    }
+    if (then instanceof PsThenAccept || then instanceof PsThenReject) {
+      return setAcceptOrReject(then);
+    }
+    String family = getFamily(then);
+    if (family == null) {
+      // Unclassified action (flow-control, unmodeled, etc.) — always retain
+      _others.add(then);
+      return ImmutableList.of();
+    }
+    return setLastWins(then, family);
   }
 
-  public @Nonnull Set<PsThen> getAllThens() {
-    ImmutableSet.Builder<PsThen> allThens = ImmutableSet.builder();
-    if (_asPathPrepend != null) {
-      allThens.add(_asPathPrepend);
+  /**
+   * Returns all retained actions in a canonical order that matches Junos commit-time normalization.
+   * AS-path-prepend always comes before as-path-expand (Junos applies prepend first). Community
+   * actions are emitted in their declared order (set/add/delete are interleaved as typed).
+   *
+   * <p>The result is a list rather than a set because community actions can repeat (e.g., {@code
+   * add X; delete X; add X}) and order matters at runtime. All other families dedup naturally via
+   * last-wins semantics, so they contribute at most one entry each.
+   */
+  public @Nonnull List<PsThen> getAllThens() {
+    ImmutableList.Builder<PsThen> allThens = ImmutableList.builder();
+    for (String family : SCALAR_CANONICAL_ORDER) {
+      List<PsThen> actions = _familyActions.get(family);
+      if (actions != null) {
+        allThens.addAll(actions);
+      }
     }
-    if (_asPathExpand != null) {
-      allThens.add(_asPathExpand);
+    allThens.addAll(_communityActions);
+    if (_nextTermOrPolicy != null) {
+      allThens.add(_nextTermOrPolicy);
     }
-    if (_communitySet != null) {
-      allThens.add(_communitySet);
-    }
-    if (!_communityAdds.isEmpty()) {
-      allThens.addAll(_communityAdds);
+    if (_acceptOrReject != null) {
+      allThens.add(_acceptOrReject);
     }
     allThens.addAll(_others);
     return allThens.build();
@@ -52,57 +91,216 @@ public final class PsThens implements Serializable {
     return getAllThens().isEmpty();
   }
 
-  private @Nullable PsThenAsPathExpand _asPathExpand;
-  private @Nullable PsThenAsPathPrepend _asPathPrepend;
-
-  private @Nullable PsThenCommunitySet _communitySet;
-  private final @Nonnull List<PsThenCommunityAdd> _communityAdds;
-
-  private final @Nonnull List<PsThen> _others;
-
   PsThens() {
-    _communityAdds = new ArrayList<>(0);
+    _familyActions = new HashMap<>();
+    _communityActions = new ArrayList<>(0);
     _others = new ArrayList<>(0);
   }
 
-  private @Nonnull List<String> setAsPathExpand(@Nullable PsThenAsPathExpand asPathExpand) {
-    List<String> cleared = new ArrayList<>();
-    if (_asPathExpand != null) {
-      cleared.add("as-path-expand");
+  // Canonical output order for scalar last-wins families. Matches Junos commit-time
+  // normalization (e.g., as-path-prepend is applied before as-path-expand). After scalars,
+  // getAllThens emits communities, then the `next term`/`next policy` slot, then the
+  // `accept`/`reject` slot, then _others.
+  private static final ImmutableList<String> SCALAR_CANONICAL_ORDER =
+      ImmutableList.of(
+          "as-path-prepend",
+          "as-path-expand",
+          "origin",
+          "preference",
+          "tag",
+          "next-hop",
+          "external",
+          "local-preference",
+          "metric",
+          "metric2",
+          "load-balance",
+          "source-class",
+          "tunnel-attribute set",
+          "tunnel-attribute remove");
+
+  // --- Family classification (scalar last-wins families only) ---
+
+  /**
+   * Returns the family name for a scalar last-wins {@link PsThen} action, or null if unclassified.
+   * Community actions, {@code next term}/{@code next policy}, and bare {@code accept}/{@code
+   * reject} are handled separately and are not classified by this method.
+   */
+  static @Nullable String getFamily(PsThen then) {
+    if (then instanceof PsThenOrigin) {
+      return "origin";
+    } else if (then instanceof PsThenPreference) {
+      return "preference";
+    } else if (then instanceof PsThenTag) {
+      return "tag";
+    } else if (then instanceof PsThenNextHopIp
+        || then instanceof PsThenNextHopSelf
+        || then instanceof PsThenNextHopPeerAddress
+        || then instanceof PsThenNextHopDiscard
+        || then instanceof PsThenNextHopReject) {
+      return "next-hop";
+    } else if (then instanceof PsThenExternal) {
+      return "external";
+    } else if (then instanceof PsThenLocalPreference) {
+      return "local-preference";
+    } else if (then instanceof PsThenMetric) {
+      return "metric";
+    } else if (then instanceof PsThenMetric2) {
+      return "metric2";
+    } else if (then instanceof PsThenLoadBalance) {
+      return "load-balance";
+    } else if (then instanceof PsThenAsPathPrepend) {
+      return "as-path-prepend";
+    } else if (then instanceof PsThenAsPathExpand) {
+      return "as-path-expand";
+    } else if (then instanceof PsThenTunnelAttributeSet) {
+      return "tunnel-attribute set";
+    } else if (then instanceof PsThenTunnelAttributeRemove) {
+      return "tunnel-attribute remove";
+    } else if (then instanceof PsThenSourceClass) {
+      return "source-class";
     }
-    _asPathExpand = asPathExpand;
-    return cleared;
+    return null;
   }
 
-  private List<String> setAsPathPrepend(@Nullable PsThenAsPathPrepend asPathPrepend) {
-    List<String> cleared = new ArrayList<>();
-    if (_asPathPrepend != null) {
-      cleared.add("as-path-prepend");
-    }
-    _asPathPrepend = asPathPrepend;
-    return cleared;
+  private static boolean isCommunityAction(PsThen then) {
+    return then instanceof PsThenCommunitySet
+        || then instanceof PsThenCommunityAdd
+        || then instanceof PsThenCommunityDelete;
   }
 
-  private List<String> setCommunitySet(PsThenCommunitySet set) {
-    List<String> cleared = new ArrayList<>();
-    if (_communitySet != null) {
-      cleared.add("community set");
+  private static @Nonnull String communityLabel(PsThen then) {
+    if (then instanceof PsThenCommunitySet) {
+      return "community set " + ((PsThenCommunitySet) then).getName();
+    } else if (then instanceof PsThenCommunityAdd) {
+      return "community add " + ((PsThenCommunityAdd) then).getName();
+    } else {
+      return "community delete " + ((PsThenCommunityDelete) then).getName();
     }
-    if (!_communityAdds.isEmpty()) {
-      cleared.add("community add");
-    }
-    _communitySet = set;
-    _communityAdds.clear();
-    // TODO: do we also clear deletes?
-    return cleared;
   }
 
-  private List<String> addCommunityAdd(PsThenCommunityAdd add) {
-    _communityAdds.add(add);
-    return ImmutableList.of();
+  private static @Nullable String communityActionName(PsThen then) {
+    if (then instanceof PsThenCommunitySet) {
+      return ((PsThenCommunitySet) then).getName();
+    } else if (then instanceof PsThenCommunityAdd) {
+      return ((PsThenCommunityAdd) then).getName();
+    } else if (then instanceof PsThenCommunityDelete) {
+      return ((PsThenCommunityDelete) then).getName();
+    }
+    return null;
   }
 
-  private @Nonnull List<PsThen> getOthers() {
-    return _others;
+  // --- Last-wins logic for scalar families ---
+
+  private @Nonnull List<String> setLastWins(PsThen then, String family) {
+    List<PsThen> existing = _familyActions.get(family);
+    if (existing == null) {
+      List<PsThen> list = new ArrayList<>(1);
+      list.add(then);
+      _familyActions.put(family, list);
+      return ImmutableList.of();
+    }
+    // Overwrite: clear all prior and replace with this one
+    PsThen prior = existing.get(0);
+    existing.clear();
+    existing.add(then);
+    if (then.equals(prior)) {
+      return ImmutableList.of(family + " (dedup)");
+    }
+    return ImmutableList.of(family);
   }
+
+  // --- Community actions: ordered list with set-as-barrier and add/delete conflict detection ---
+
+  private @Nonnull List<String> addCommunityAction(PsThen then) {
+    // Dedup only against the immediately preceding community action: e.g., `add X; add X`
+    // collapses, but `add X; delete X; add X` must keep the second add (the intervening delete
+    // changes the runtime effect). Set-as-barrier (below) handles set-after-anything.
+    if (!_communityActions.isEmpty()
+        && _communityActions.get(_communityActions.size() - 1).equals(then)) {
+      return ImmutableList.of(communityLabel(then) + " (dedup)");
+    }
+
+    // A new `community set` wipes ALL prior community actions (set replaces the route's
+    // communities, so prior set/add/delete are no-ops). Warn for each cleared action.
+    if (then instanceof PsThenCommunitySet) {
+      List<String> cleared = new ArrayList<>();
+      for (PsThen prior : _communityActions) {
+        cleared.add(communityLabel(prior));
+      }
+      _communityActions.clear();
+      _communityActions.add(then);
+      return cleared;
+    }
+
+    // For add/delete: warn if a prior add/delete on the same name is the opposite kind. Both
+    // are retained because order matters at runtime — `add X; delete X` zeroes X out, while
+    // `delete X; add X` results in X being present.
+    List<String> conflicts = new ArrayList<>();
+    String name = communityActionName(then);
+    boolean isAdd = then instanceof PsThenCommunityAdd;
+    for (PsThen prior : _communityActions) {
+      String priorName = communityActionName(prior);
+      if (!java.util.Objects.equals(priorName, name)) {
+        continue;
+      }
+      boolean priorIsAdd = prior instanceof PsThenCommunityAdd;
+      boolean priorIsDelete = prior instanceof PsThenCommunityDelete;
+      if ((isAdd && priorIsDelete) || (!isAdd && priorIsAdd)) {
+        conflicts.add(communityLabel(prior) + " (conflict)");
+      }
+    }
+    _communityActions.add(then);
+    return conflicts;
+  }
+
+  // --- `next term` and `next policy` share one last-wins slot ---
+
+  private static boolean isNextTermOrPolicy(PsThen then) {
+    return then instanceof PsThenNextTerm || then instanceof PsThenNextPolicy;
+  }
+
+  private @Nonnull List<String> setNextTermOrPolicy(PsThen then) {
+    ImmutableList.Builder<String> warnings = ImmutableList.builder();
+    if (_nextTermOrPolicy != null) {
+      if (_nextTermOrPolicy.equals(then)) {
+        warnings.add("next-term-or-policy (dedup)");
+      } else {
+        warnings.add("next-term-or-policy");
+      }
+    }
+    _nextTermOrPolicy = then;
+    if (_acceptOrReject != null) {
+      // `then next term`/`then next policy` suppresses any `accept`/`reject` in the same term,
+      // regardless of source order. Both lines are retained at commit, but the `accept`/`reject`
+      // does not fire.
+      warnings.add("accept-or-reject (suppressed-by-next-term-or-policy)");
+    }
+    return warnings.build();
+  }
+
+  // --- accept/reject: dedicated slot, last-wins, suppressed by next term/next policy ---
+
+  private @Nonnull List<String> setAcceptOrReject(PsThen then) {
+    ImmutableList.Builder<String> warnings = ImmutableList.builder();
+    if (_acceptOrReject != null) {
+      if (_acceptOrReject.equals(then)) {
+        warnings.add("accept-or-reject (dedup)");
+      } else {
+        warnings.add("accept-or-reject");
+      }
+    }
+    _acceptOrReject = then;
+    if (_nextTermOrPolicy != null) {
+      // Adding `accept`/`reject` when `next term`/`next policy` is already present: the new
+      // line is dead — `next term`/`next policy` wins at runtime.
+      warnings.add("accept-or-reject (dead-after-next-term-or-policy)");
+    }
+    return warnings.build();
+  }
+
+  private final @Nonnull Map<String, List<PsThen>> _familyActions;
+  private final @Nonnull List<PsThen> _communityActions;
+  private @Nullable PsThen _nextTermOrPolicy;
+  private @Nullable PsThen _acceptOrReject;
+  private final @Nonnull List<PsThen> _others;
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -496,6 +496,7 @@ import org.batfish.representation.juniper.PsThenAsPathExpandAsList;
 import org.batfish.representation.juniper.PsThenAsPathExpandLastAs;
 import org.batfish.representation.juniper.PsThenAsPathPrepend;
 import org.batfish.representation.juniper.PsThenCommunityAdd;
+import org.batfish.representation.juniper.PsThenCommunityDelete;
 import org.batfish.representation.juniper.PsThenCommunitySet;
 import org.batfish.representation.juniper.PsThenLoadBalance;
 import org.batfish.representation.juniper.PsThenLoadBalance.LoadBalanceMethod;
@@ -503,6 +504,8 @@ import org.batfish.representation.juniper.PsThenLocalPreference;
 import org.batfish.representation.juniper.PsThenLocalPreference.Operator;
 import org.batfish.representation.juniper.PsThenMetric;
 import org.batfish.representation.juniper.PsThenMetric2;
+import org.batfish.representation.juniper.PsThenNextHopIp;
+import org.batfish.representation.juniper.PsThenOrigin;
 import org.batfish.representation.juniper.PsThenPreference;
 import org.batfish.representation.juniper.PsThenSourceClass;
 import org.batfish.representation.juniper.PsThenTag;
@@ -5413,13 +5416,267 @@ public final class FlatJuniperGrammarTest {
     JuniperConfiguration c = parseJuniperConfig("juniper-ps-then-community");
     Map<String, PsTerm> pses =
         c.getMasterLogicalSystem().getPolicyStatements().get("PS").getTerms();
+    // set COMM1; set COMM2 — second set wipes first (last-wins)
     assertThat(
         pses.get("MULTI_SET").getThens().getAllThens(), contains(new PsThenCommunitySet("COMM2")));
+    // set COMM1; add COMM2 — both retained (set replaces, add unions)
     assertThat(
         pses.get("SET_ADD").getThens().getAllThens(),
         contains(new PsThenCommunitySet("COMM1"), new PsThenCommunityAdd("COMM2")));
+    // add COMM1; set COMM2 — set wipes prior add (no-op once set replaces)
     assertThat(
         pses.get("ADD_SET").getThens().getAllThens(), contains(new PsThenCommunitySet("COMM2")));
+  }
+
+  @Test
+  public void testPsThenConflictsExtraction() {
+    JuniperConfiguration c = parseJuniperConfig("juniper-ps-then-conflicts");
+    Map<String, PolicyStatement> pses = c.getMasterLogicalSystem().getPolicyStatements();
+
+    // §1 Scalar last-wins: origin igp; origin egp → only egp retained
+    assertThat(
+        pses.get("ORIGIN-DIFF").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenOrigin(OriginType.EGP)));
+
+    // §2 Numeric last-wins: local-preference 200; local-preference 50 → only 50
+    assertThat(
+        pses.get("LP-SET-DIFF").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenLocalPreference(50, PsThenLocalPreference.Operator.SET)));
+
+    // local-preference 200; local-preference add 50 → only add 50
+    assertThat(
+        pses.get("LP-SET-ADD").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenLocalPreference(50, PsThenLocalPreference.Operator.ADD)));
+
+    // local-preference add 50; local-preference 200 → only set 200
+    assertThat(
+        pses.get("LP-ADD-SET").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenLocalPreference(200, PsThenLocalPreference.Operator.SET)));
+
+    // metric 200; metric 50 → only 50
+    assertThat(
+        pses.get("MED-SET-DIFF").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenMetric(50, PsThenMetric.Operator.SET)));
+
+    // metric 200; metric add 50 → only add 50
+    assertThat(
+        pses.get("MED-SET-ADD").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenMetric(50, PsThenMetric.Operator.ADD)));
+
+    // metric add 50; metric 200 → only set 200
+    assertThat(
+        pses.get("MED-ADD-SET").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenMetric(200, PsThenMetric.Operator.SET)));
+
+    // next-hop self; next-hop 192.0.2.1 → only ip
+    assertThat(
+        pses.get("NEXTHOP-SELF-VS-IP").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenNextHopIp(Ip.parse("192.0.2.1"))));
+
+    // §4 set RED; set BLUE → second wipes first (last-wins)
+    assertThat(
+        pses.get("COMM-SET-SET").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenCommunitySet("BLUE")));
+
+    // add RED; add BLUE → both retained (add is cumulative)
+    assertThat(
+        pses.get("COMM-ADD-ADD").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenCommunityAdd("RED"), new PsThenCommunityAdd("BLUE")));
+
+    // set RED; add BLUE → both retained (set replaces, add unions)
+    assertThat(
+        pses.get("COMM-SET-ADD").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenCommunitySet("RED"), new PsThenCommunityAdd("BLUE")));
+
+    // add RED; set BLUE → set wipes prior add; only set retained
+    assertThat(
+        pses.get("COMM-ADD-SET").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenCommunitySet("BLUE")));
+
+    // add RED; delete RED → both retained (order matters), warning emitted at parse time
+    assertThat(
+        pses.get("COMM-ADD-DEL-SAME").getTerms().get("t1").getThens().getAllThens(),
+        contains(new PsThenCommunityAdd("RED"), new PsThenCommunityDelete("RED")));
+
+    // delete RED; add BLUE; delete GREEN → all retained in declared order
+    assertThat(
+        pses.get("COMM-ORDERED").getTerms().get("t1").getThens().getAllThens(),
+        contains(
+            new PsThenCommunityDelete("RED"),
+            new PsThenCommunityAdd("BLUE"),
+            new PsThenCommunityDelete("GREEN")));
+
+    // §7 Cross-attribute: all three families coexist
+    List<PsThen> crossThens = pses.get("CROSS-ATTR").getTerms().get("t1").getThens().getAllThens();
+    assertThat(crossThens, hasSize(3));
+    assertThat(
+        crossThens,
+        containsInAnyOrder(
+            new PsThenLocalPreference(200, PsThenLocalPreference.Operator.SET),
+            new PsThenMetric(100, PsThenMetric.Operator.SET),
+            new PsThenCommunityAdd("RED")));
+  }
+
+  @Test
+  public void testPsThenConflictsConversion() {
+    Configuration c = parseConfig("juniper-ps-then-conflicts");
+
+    Bgpv4Route baseRoute =
+        Bgpv4Route.builder()
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginMechanism(LEARNED)
+            .setOriginType(OriginType.IGP)
+            .setReceivedFrom(ReceivedFromIp.of(Ip.parse("10.0.0.1")))
+            .setNetwork(Prefix.parse("10.0.0.0/24"))
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHop(NextHopDiscard.instance())
+            .setLocalPreference(100)
+            .setMetric(500)
+            .build();
+
+    // LP-SET-DIFF: last-wins → lp 50
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("LP-SET-DIFF");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      rp.process(baseRoute, out, IN);
+      assertThat(out.getLocalPreference(), equalTo(50L));
+    }
+    // LP-SET-ADD: last-wins → add 50 to input 100 = 150
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("LP-SET-ADD");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      rp.process(baseRoute, out, IN);
+      assertThat(out.getLocalPreference(), equalTo(150L));
+    }
+    // LP-ADD-SET: last-wins → set 200
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("LP-ADD-SET");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      rp.process(baseRoute, out, IN);
+      assertThat(out.getLocalPreference(), equalTo(200L));
+    }
+    // MED-SET-DIFF: last-wins → metric 50
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("MED-SET-DIFF");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      rp.process(baseRoute, out, IN);
+      assertThat(out.getMetric(), equalTo(50L));
+    }
+    // MED-SET-ADD: last-wins → add 50 to input 500 = 550
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("MED-SET-ADD");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      rp.process(baseRoute, out, IN);
+      assertThat(out.getMetric(), equalTo(550L));
+    }
+    // MED-ADD-SET: last-wins → set 200
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("MED-ADD-SET");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      rp.process(baseRoute, out, IN);
+      assertThat(out.getMetric(), equalTo(200L));
+    }
+
+    // §5: Flow-control conversion behavior
+    // FC-ACCEPT-REJECT: accept; reject → reject wins (last-wins within accept/reject)
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("FC-ACCEPT-REJECT");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      assertFalse(rp.process(baseRoute, out, IN));
+    }
+    // FC-REJECT-ACCEPT: reject; accept → accept wins
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("FC-REJECT-ACCEPT");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      assertTrue(rp.process(baseRoute, out, IN));
+    }
+    // FC-ACCEPT-NEXT-TERM: t1 has accept; next term — next-term wins, route falls through to t2
+    // which accepts. The community add in t1 fires before the fall-through.
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("FC-ACCEPT-NEXT-TERM");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      assertTrue(rp.process(baseRoute, out, IN));
+      assertThat(
+          out.getCommunities().getCommunities(), hasItem(StandardCommunity.parse("65000:1")));
+    }
+    // FC-NEXT-TERM-ACCEPT: same as above with reversed source order — still falls through
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("FC-NEXT-TERM-ACCEPT");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      assertTrue(rp.process(baseRoute, out, IN));
+      assertThat(
+          out.getCommunities().getCommunities(), hasItem(StandardCommunity.parse("65000:1")));
+    }
+    // FC-ACCEPT-DEFAULT-REJECT: accept fires, default-action reject is dead config
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("FC-ACCEPT-DEFAULT-REJECT");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      assertTrue(rp.process(baseRoute, out, IN));
+    }
+    // FC-REJECT-DEFAULT-ACCEPT: reject fires, default-action accept is dead config
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("FC-REJECT-DEFAULT-ACCEPT");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      assertFalse(rp.process(baseRoute, out, IN));
+    }
+    // FC-NEXT-TERM-NEXT-POLICY: next-term; next-policy — last-wins → next-policy retained.
+    // The community add in t1 fires, then next-policy emits FallThrough which leaves the
+    // policy result undecided (false here, since this test calls a single policy in isolation).
+    // The point of the test is that next-term did NOT win: t1 did not jump to t2 (which rejects),
+    // so the community add in t1 fires before fall-through.
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("FC-NEXT-TERM-NEXT-POLICY");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      rp.process(baseRoute, out, IN);
+      assertThat(
+          out.getCommunities().getCommunities(), hasItem(StandardCommunity.parse("65000:1")));
+    }
+    // FC-NEXT-POLICY-NEXT-TERM: next-policy; next-term — last-wins → next-term retained.
+    // The community add in t1 fires, then next-term jumps to t2 which rejects.
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("FC-NEXT-POLICY-NEXT-TERM");
+      Bgpv4Route.Builder out = baseRoute.toBuilder();
+      assertFalse(rp.process(baseRoute, out, IN));
+    }
+  }
+
+  @Test
+  public void testPsThenConflictsWarnings() {
+    JuniperConfiguration c = parseJuniperConfig("juniper-ps-then-conflicts");
+    List<ParseWarning> riskyWarnings = c.getWarnings().getRiskyParseWarnings();
+
+    // Last-wins cases should emit "Overwriting existing then <family>" warnings
+    assertThat(
+        riskyWarnings,
+        hasItems(
+            hasComment("RISK: Overwriting existing then origin"),
+            hasComment("RISK: Overwriting existing then local-preference"),
+            hasComment("RISK: Overwriting existing then metric"),
+            hasComment("RISK: Overwriting existing then next-hop"),
+            // community set wipes prior community set (last-wins)
+            hasComment("RISK: Overwriting existing then community set RED"),
+            // community set wipes prior community add (set is a barrier)
+            hasComment("RISK: Overwriting existing then community add RED"),
+            // community delete X conflicts with prior community add X (both retained)
+            hasComment("RISK: Conflicts with prior then community add RED"),
+            // accept; reject — last-wins within accept/reject
+            hasComment("RISK: Overwriting existing then accept-or-reject"),
+            // next term; next policy — same family, last-wins
+            hasComment("RISK: Overwriting existing then next-term-or-policy"),
+            // accept; next term — prior accept suppressed at runtime by next term/next policy
+            hasComment(
+                "RISK: then next term/next policy suppresses prior then accept/reject in the"
+                    + " same term: accept/reject does not fire"),
+            // next term; accept — accept after next term/next policy is dead config
+            hasComment(
+                "RISK: then accept/reject has no effect when then next term/next policy is also"
+                    + " present in the same term: accept/reject does not fire")));
+
+    // COMM-ORDERED has no conflicts — no warnings should mention BLUE or GREEN
+    assertTrue(
+        riskyWarnings.stream().noneMatch(w -> w.getComment().contains("community add BLUE")));
+    assertTrue(
+        riskyWarnings.stream().noneMatch(w -> w.getComment().contains("community delete GREEN")));
   }
 
   @Test
@@ -9656,6 +9913,8 @@ public final class FlatJuniperGrammarTest {
 
   @Test
   public void testCommunityOverlapWarnings() throws IOException {
+    // Two community set actions in the same term: second wipes the first (last-wins). Emit a
+    // RISK warning naming the prior community set being overwritten.
     String hostname = "overlapping-policy";
     Batfish batfish = getBatfishForConfigurationNames(hostname);
 
@@ -9668,7 +9927,7 @@ public final class FlatJuniperGrammarTest {
 
     assertThat(
         riskyParseWarnings,
-        containsInAnyOrder(hasComment("RISK: Overwriting existing then community set")));
+        containsInAnyOrder(hasComment("RISK: Overwriting existing then community set LOC1")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThensTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThensTest.java
@@ -2,35 +2,729 @@ package org.batfish.representation.juniper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.ospf.OspfMetricType;
 import org.junit.Test;
 
+/** Tests for {@link PsThens} last-wins and cumulative semantics per the Junos commit-time model. */
 public class PsThensTest {
-  @Test
-  public void testCommunities() {
-    PsThenCommunitySet set = new PsThenCommunitySet("set");
-    PsThenCommunityAdd add1 = new PsThenCommunityAdd("add1");
-    PsThenCommunityAdd add2 = new PsThenCommunityAdd("add2");
 
+  // ==========================================================================
+  // §1: Scalar last-wins
+  // ==========================================================================
+
+  @Test
+  public void testOriginDedup() {
     PsThens ps = new PsThens();
-    assertThat(ps.addPsThen(set), empty());
-    assertThat(ps.addPsThen(set), contains("community set"));
-    assertThat(ps.addPsThen(add1), empty());
-    assertThat(ps.addPsThen(add2), empty());
-    assertThat(ps.addPsThen(set), contains("community set", "community add"));
+    PsThenOrigin igp = new PsThenOrigin(OriginType.IGP);
+    assertThat(ps.addPsThen(igp), empty());
+    assertThat(ps.addPsThen(igp), contains("origin (dedup)"));
+    assertEquals(ImmutableList.of(igp), ps.getAllThens());
   }
 
   @Test
-  public void testAsPath() {
-    PsThenAsPathPrepend prepend = new PsThenAsPathPrepend(ImmutableList.of(1L, 2L, 3L));
-    PsThenAsPathExpand expand = new PsThenAsPathExpandLastAs(3);
-
+  public void testOriginLastWins() {
     PsThens ps = new PsThens();
+    PsThenOrigin igp = new PsThenOrigin(OriginType.IGP);
+    PsThenOrigin egp = new PsThenOrigin(OriginType.EGP);
+    assertThat(ps.addPsThen(igp), empty());
+    assertThat(ps.addPsThen(egp), contains("origin"));
+    assertEquals(ImmutableList.of(egp), ps.getAllThens());
+  }
+
+  @Test
+  public void testPreferenceDedup() {
+    PsThens ps = new PsThens();
+    PsThenPreference pref = new PsThenPreference(100, PsThenPreference.Operator.SET);
+    assertThat(ps.addPsThen(pref), empty());
+    assertThat(ps.addPsThen(pref), contains("preference (dedup)"));
+    assertEquals(ImmutableList.of(pref), ps.getAllThens());
+  }
+
+  @Test
+  public void testPreferenceLastWins() {
+    PsThens ps = new PsThens();
+    PsThenPreference p100 = new PsThenPreference(100, PsThenPreference.Operator.SET);
+    PsThenPreference p200 = new PsThenPreference(200, PsThenPreference.Operator.SET);
+    assertThat(ps.addPsThen(p100), empty());
+    assertThat(ps.addPsThen(p200), contains("preference"));
+    assertEquals(ImmutableList.of(p200), ps.getAllThens());
+  }
+
+  @Test
+  public void testTagDedup() {
+    PsThens ps = new PsThens();
+    PsThenTag tag = new PsThenTag(100);
+    assertThat(ps.addPsThen(tag), empty());
+    assertThat(ps.addPsThen(tag), contains("tag (dedup)"));
+    assertEquals(ImmutableList.of(tag), ps.getAllThens());
+  }
+
+  @Test
+  public void testTagLastWins() {
+    PsThens ps = new PsThens();
+    PsThenTag t100 = new PsThenTag(100);
+    PsThenTag t200 = new PsThenTag(200);
+    assertThat(ps.addPsThen(t100), empty());
+    assertThat(ps.addPsThen(t200), contains("tag"));
+    assertEquals(ImmutableList.of(t200), ps.getAllThens());
+  }
+
+  @Test
+  public void testNextHopIpDedup() {
+    PsThens ps = new PsThens();
+    PsThenNextHopIp nh = new PsThenNextHopIp(Ip.parse("192.0.2.1"));
+    assertThat(ps.addPsThen(nh), empty());
+    // PsThenNextHopIp doesn't implement equals, so this won't be a dedup — it's the same instance
+    assertThat(ps.addPsThen(nh), contains("next-hop (dedup)"));
+    assertEquals(ImmutableList.of(nh), ps.getAllThens());
+  }
+
+  @Test
+  public void testNextHopIpLastWins() {
+    PsThens ps = new PsThens();
+    PsThenNextHopIp nh1 = new PsThenNextHopIp(Ip.parse("192.0.2.1"));
+    PsThenNextHopIp nh2 = new PsThenNextHopIp(Ip.parse("192.0.2.2"));
+    assertThat(ps.addPsThen(nh1), empty());
+    assertThat(ps.addPsThen(nh2), contains("next-hop"));
+    assertEquals(ImmutableList.of(nh2), ps.getAllThens());
+  }
+
+  @Test
+  public void testNextHopSelfVsIp() {
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextHopSelf.INSTANCE), empty());
+    PsThenNextHopIp nhIp = new PsThenNextHopIp(Ip.parse("192.0.2.1"));
+    assertThat(ps.addPsThen(nhIp), contains("next-hop"));
+    assertEquals(ImmutableList.of(nhIp), ps.getAllThens());
+  }
+
+  @Test
+  public void testNextHopSelfVsPeer() {
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextHopSelf.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenNextHopPeerAddress.INSTANCE), contains("next-hop"));
+    assertEquals(ImmutableList.of(PsThenNextHopPeerAddress.INSTANCE), ps.getAllThens());
+  }
+
+  @Test
+  public void testNextHopRejectVsDiscard() {
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextHopReject.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenNextHopDiscard.INSTANCE), contains("next-hop"));
+    assertEquals(ImmutableList.of(PsThenNextHopDiscard.INSTANCE), ps.getAllThens());
+  }
+
+  @Test
+  public void testExternalDedup() {
+    PsThens ps = new PsThens();
+    PsThenExternal e1 = new PsThenExternal(OspfMetricType.E1);
+    assertThat(ps.addPsThen(e1), empty());
+    assertThat(ps.addPsThen(e1), contains("external (dedup)"));
+    assertEquals(ImmutableList.of(e1), ps.getAllThens());
+  }
+
+  @Test
+  public void testExternalLastWins() {
+    PsThens ps = new PsThens();
+    PsThenExternal e1 = new PsThenExternal(OspfMetricType.E1);
+    PsThenExternal e2 = new PsThenExternal(OspfMetricType.E2);
+    assertThat(ps.addPsThen(e1), empty());
+    assertThat(ps.addPsThen(e2), contains("external"));
+    assertEquals(ImmutableList.of(e2), ps.getAllThens());
+  }
+
+  @Test
+  public void testLoadBalanceLastWins() {
+    PsThens ps = new PsThens();
+    PsThenLoadBalance perPacket =
+        new PsThenLoadBalance(PsThenLoadBalance.LoadBalanceMethod.PER_PACKET);
+    PsThenLoadBalance consistentHash =
+        new PsThenLoadBalance(PsThenLoadBalance.LoadBalanceMethod.CONSISTENT_HASH);
+    assertThat(ps.addPsThen(perPacket), empty());
+    assertThat(ps.addPsThen(consistentHash), contains("load-balance"));
+    assertEquals(ImmutableList.of(consistentHash), ps.getAllThens());
+  }
+
+  // ==========================================================================
+  // §2: Numeric last-wins (local-preference, metric)
+  // ==========================================================================
+
+  @Test
+  public void testLocalPreferenceSetDiff() {
+    PsThens ps = new PsThens();
+    PsThenLocalPreference lp200 =
+        new PsThenLocalPreference(200, PsThenLocalPreference.Operator.SET);
+    PsThenLocalPreference lp50 = new PsThenLocalPreference(50, PsThenLocalPreference.Operator.SET);
+    assertThat(ps.addPsThen(lp200), empty());
+    assertThat(ps.addPsThen(lp50), contains("local-preference"));
+    assertEquals(ImmutableList.of(lp50), ps.getAllThens());
+  }
+
+  @Test
+  public void testLocalPreferenceSetSame() {
+    PsThens ps = new PsThens();
+    PsThenLocalPreference lp = new PsThenLocalPreference(200, PsThenLocalPreference.Operator.SET);
+    assertThat(ps.addPsThen(lp), empty());
+    assertThat(ps.addPsThen(lp), contains("local-preference (dedup)"));
+    assertEquals(ImmutableList.of(lp), ps.getAllThens());
+  }
+
+  @Test
+  public void testLocalPreferenceSetThenAdd() {
+    PsThens ps = new PsThens();
+    PsThenLocalPreference lpSet =
+        new PsThenLocalPreference(200, PsThenLocalPreference.Operator.SET);
+    PsThenLocalPreference lpAdd = new PsThenLocalPreference(50, PsThenLocalPreference.Operator.ADD);
+    assertThat(ps.addPsThen(lpSet), empty());
+    assertThat(ps.addPsThen(lpAdd), contains("local-preference"));
+    assertEquals(ImmutableList.of(lpAdd), ps.getAllThens());
+  }
+
+  @Test
+  public void testLocalPreferenceAddThenSet() {
+    PsThens ps = new PsThens();
+    PsThenLocalPreference lpAdd = new PsThenLocalPreference(50, PsThenLocalPreference.Operator.ADD);
+    PsThenLocalPreference lpSet =
+        new PsThenLocalPreference(200, PsThenLocalPreference.Operator.SET);
+    assertThat(ps.addPsThen(lpAdd), empty());
+    assertThat(ps.addPsThen(lpSet), contains("local-preference"));
+    assertEquals(ImmutableList.of(lpSet), ps.getAllThens());
+  }
+
+  @Test
+  public void testLocalPreferenceSetThenSubtract() {
+    PsThens ps = new PsThens();
+    PsThenLocalPreference lpSet =
+        new PsThenLocalPreference(200, PsThenLocalPreference.Operator.SET);
+    PsThenLocalPreference lpSub =
+        new PsThenLocalPreference(50, PsThenLocalPreference.Operator.SUBTRACT);
+    assertThat(ps.addPsThen(lpSet), empty());
+    assertThat(ps.addPsThen(lpSub), contains("local-preference"));
+    assertEquals(ImmutableList.of(lpSub), ps.getAllThens());
+  }
+
+  @Test
+  public void testLocalPreferenceAddDiff() {
+    PsThens ps = new PsThens();
+    PsThenLocalPreference lpAdd200 =
+        new PsThenLocalPreference(200, PsThenLocalPreference.Operator.ADD);
+    PsThenLocalPreference lpAdd50 =
+        new PsThenLocalPreference(50, PsThenLocalPreference.Operator.ADD);
+    assertThat(ps.addPsThen(lpAdd200), empty());
+    assertThat(ps.addPsThen(lpAdd50), contains("local-preference"));
+    assertEquals(ImmutableList.of(lpAdd50), ps.getAllThens());
+  }
+
+  @Test
+  public void testLocalPreferenceAddThenSubtract() {
+    PsThens ps = new PsThens();
+    PsThenLocalPreference lpAdd =
+        new PsThenLocalPreference(200, PsThenLocalPreference.Operator.ADD);
+    PsThenLocalPreference lpSub =
+        new PsThenLocalPreference(50, PsThenLocalPreference.Operator.SUBTRACT);
+    assertThat(ps.addPsThen(lpAdd), empty());
+    assertThat(ps.addPsThen(lpSub), contains("local-preference"));
+    assertEquals(ImmutableList.of(lpSub), ps.getAllThens());
+  }
+
+  @Test
+  public void testMetricSetDiff() {
+    PsThens ps = new PsThens();
+    PsThenMetric m200 = new PsThenMetric(200, PsThenMetric.Operator.SET);
+    PsThenMetric m50 = new PsThenMetric(50, PsThenMetric.Operator.SET);
+    assertThat(ps.addPsThen(m200), empty());
+    assertThat(ps.addPsThen(m50), contains("metric"));
+    assertEquals(ImmutableList.of(m50), ps.getAllThens());
+  }
+
+  @Test
+  public void testMetricSetSame() {
+    PsThens ps = new PsThens();
+    PsThenMetric m = new PsThenMetric(200, PsThenMetric.Operator.SET);
+    assertThat(ps.addPsThen(m), empty());
+    assertThat(ps.addPsThen(m), contains("metric (dedup)"));
+    assertEquals(ImmutableList.of(m), ps.getAllThens());
+  }
+
+  @Test
+  public void testMetricSetThenAdd() {
+    PsThens ps = new PsThens();
+    PsThenMetric mSet = new PsThenMetric(200, PsThenMetric.Operator.SET);
+    PsThenMetric mAdd = new PsThenMetric(50, PsThenMetric.Operator.ADD);
+    assertThat(ps.addPsThen(mSet), empty());
+    assertThat(ps.addPsThen(mAdd), contains("metric"));
+    assertEquals(ImmutableList.of(mAdd), ps.getAllThens());
+  }
+
+  @Test
+  public void testMetricAddThenSet() {
+    PsThens ps = new PsThens();
+    PsThenMetric mAdd = new PsThenMetric(50, PsThenMetric.Operator.ADD);
+    PsThenMetric mSet = new PsThenMetric(200, PsThenMetric.Operator.SET);
+    assertThat(ps.addPsThen(mAdd), empty());
+    assertThat(ps.addPsThen(mSet), contains("metric"));
+    assertEquals(ImmutableList.of(mSet), ps.getAllThens());
+  }
+
+  @Test
+  public void testMetricAddDiff() {
+    PsThens ps = new PsThens();
+    PsThenMetric mAdd200 = new PsThenMetric(200, PsThenMetric.Operator.ADD);
+    PsThenMetric mAdd50 = new PsThenMetric(50, PsThenMetric.Operator.ADD);
+    assertThat(ps.addPsThen(mAdd200), empty());
+    assertThat(ps.addPsThen(mAdd50), contains("metric"));
+    assertEquals(ImmutableList.of(mAdd50), ps.getAllThens());
+  }
+
+  @Test
+  public void testMetricAddThenSubtract() {
+    PsThens ps = new PsThens();
+    PsThenMetric mAdd = new PsThenMetric(200, PsThenMetric.Operator.ADD);
+    PsThenMetric mSub = new PsThenMetric(50, PsThenMetric.Operator.SUBTRACT);
+    assertThat(ps.addPsThen(mAdd), empty());
+    assertThat(ps.addPsThen(mSub), contains("metric"));
+    assertEquals(ImmutableList.of(mSub), ps.getAllThens());
+  }
+
+  // ==========================================================================
+  // §3: AS-Path
+  // ==========================================================================
+
+  @Test
+  public void testPrependLastWins() {
+    PsThens ps = new PsThens();
+    PsThenAsPathPrepend p1 = new PsThenAsPathPrepend(ImmutableList.of(65010L));
+    PsThenAsPathPrepend p2 = new PsThenAsPathPrepend(ImmutableList.of(65020L));
+    assertThat(ps.addPsThen(p1), empty());
+    assertThat(ps.addPsThen(p2), contains("as-path-prepend"));
+    assertEquals(ImmutableList.of(p2), ps.getAllThens());
+  }
+
+  @Test
+  public void testPrependDedup() {
+    PsThens ps = new PsThens();
+    PsThenAsPathPrepend p = new PsThenAsPathPrepend(ImmutableList.of(65010L));
+    assertThat(ps.addPsThen(p), empty());
+    assertThat(
+        ps.addPsThen(new PsThenAsPathPrepend(ImmutableList.of(65010L))),
+        contains("as-path-prepend (dedup)"));
+  }
+
+  @Test
+  public void testPrependMultiVsSingle() {
+    PsThens ps = new PsThens();
+    PsThenAsPathPrepend multi = new PsThenAsPathPrepend(ImmutableList.of(65010L, 65020L));
+    PsThenAsPathPrepend single = new PsThenAsPathPrepend(ImmutableList.of(65030L));
+    assertThat(ps.addPsThen(multi), empty());
+    assertThat(ps.addPsThen(single), contains("as-path-prepend"));
+    assertEquals(ImmutableList.of(single), ps.getAllThens());
+  }
+
+  @Test
+  public void testPrependAndExpandBothRetained() {
+    PsThens ps = new PsThens();
+    PsThenAsPathPrepend prepend = new PsThenAsPathPrepend(ImmutableList.of(65010L));
+    PsThenAsPathExpandAsList expand = new PsThenAsPathExpandAsList(ImmutableList.of(65020L));
     assertThat(ps.addPsThen(prepend), empty());
-    assertThat(ps.addPsThen(prepend), contains("as-path-prepend"));
     assertThat(ps.addPsThen(expand), empty());
-    assertThat(ps.addPsThen(expand), contains("as-path-expand"));
+    assertEquals(ImmutableList.of(prepend, expand), ps.getAllThens());
+  }
+
+  @Test
+  public void testExpandAndPrependBothRetained() {
+    PsThens ps = new PsThens();
+    PsThenAsPathExpandAsList expand = new PsThenAsPathExpandAsList(ImmutableList.of(65020L));
+    PsThenAsPathPrepend prepend = new PsThenAsPathPrepend(ImmutableList.of(65010L));
+    assertThat(ps.addPsThen(expand), empty());
+    assertThat(ps.addPsThen(prepend), empty());
+    // Canonical order: prepend before expand (Junos applies prepend first)
+    assertEquals(ImmutableList.of(prepend, expand), ps.getAllThens());
+  }
+
+  @Test
+  public void testExpandLastWins() {
+    PsThens ps = new PsThens();
+    PsThenAsPathExpandAsList e1 = new PsThenAsPathExpandAsList(ImmutableList.of(65010L));
+    PsThenAsPathExpandAsList e2 = new PsThenAsPathExpandAsList(ImmutableList.of(65020L));
+    assertThat(ps.addPsThen(e1), empty());
+    assertThat(ps.addPsThen(e2), contains("as-path-expand"));
+    assertEquals(ImmutableList.of(e2), ps.getAllThens());
+  }
+
+  @Test
+  public void testExpandLastAsLastWins() {
+    PsThens ps = new PsThens();
+    PsThenAsPathExpandLastAs e2 = new PsThenAsPathExpandLastAs(2);
+    PsThenAsPathExpandLastAs e3 = new PsThenAsPathExpandLastAs(3);
+    assertThat(ps.addPsThen(e2), empty());
+    assertThat(ps.addPsThen(e3), contains("as-path-expand"));
+    assertEquals(ImmutableList.of(e3), ps.getAllThens());
+  }
+
+  @Test
+  public void testExpandLastAsPlusPrependBothRetained() {
+    PsThens ps = new PsThens();
+    PsThenAsPathExpandLastAs expand = new PsThenAsPathExpandLastAs(2);
+    PsThenAsPathPrepend prepend = new PsThenAsPathPrepend(ImmutableList.of(65010L));
+    assertThat(ps.addPsThen(expand), empty());
+    assertThat(ps.addPsThen(prepend), empty());
+    // Canonical order: prepend before expand
+    assertEquals(ImmutableList.of(prepend, expand), ps.getAllThens());
+  }
+
+  // ==========================================================================
+  // §4: Communities — single ordered list with set-as-barrier and add/delete conflict detection
+  // ==========================================================================
+
+  @Test
+  public void testCommunityAddDifferent() {
+    // add RED; add BLUE — both retained, no conflict
+    PsThens ps = new PsThens();
+    PsThenCommunityAdd red = new PsThenCommunityAdd("RED");
+    PsThenCommunityAdd blue = new PsThenCommunityAdd("BLUE");
+    assertThat(ps.addPsThen(red), empty());
+    assertThat(ps.addPsThen(blue), empty());
+    assertThat(ps.getAllThens(), contains(red, blue));
+  }
+
+  @Test
+  public void testCommunityAddDedup() {
+    // add RED; add RED — second is exact duplicate of the immediately preceding action
+    PsThens ps = new PsThens();
+    PsThenCommunityAdd red = new PsThenCommunityAdd("RED");
+    assertThat(ps.addPsThen(red), empty());
+    assertThat(ps.addPsThen(new PsThenCommunityAdd("RED")), contains("community add RED (dedup)"));
+    assertEquals(ImmutableList.of(red), ps.getAllThens());
+  }
+
+  @Test
+  public void testCommunityAddDeleteAddNoDedup() {
+    // add RED; delete RED; add RED — the second add is NOT a dedup: the intervening delete
+    // changes the runtime effect, so all three must be retained (final route has RED).
+    PsThens ps = new PsThens();
+    PsThenCommunityAdd addRed1 = new PsThenCommunityAdd("RED");
+    PsThenCommunityDelete delRed = new PsThenCommunityDelete("RED");
+    PsThenCommunityAdd addRed2 = new PsThenCommunityAdd("RED");
+    assertThat(ps.addPsThen(addRed1), empty());
+    assertThat(ps.addPsThen(delRed), contains("community add RED (conflict)"));
+    assertThat(ps.addPsThen(addRed2), contains("community delete RED (conflict)"));
+    assertThat(ps.getAllThens(), contains(addRed1, delRed, addRed2));
+  }
+
+  @Test
+  public void testCommunityDeleteDifferent() {
+    // delete RED; delete BLUE — both retained
+    PsThens ps = new PsThens();
+    PsThenCommunityDelete delRed = new PsThenCommunityDelete("RED");
+    PsThenCommunityDelete delBlue = new PsThenCommunityDelete("BLUE");
+    assertThat(ps.addPsThen(delRed), empty());
+    assertThat(ps.addPsThen(delBlue), empty());
+    assertThat(ps.getAllThens(), contains(delRed, delBlue));
+  }
+
+  @Test
+  public void testCommunityDeleteDedup() {
+    PsThens ps = new PsThens();
+    PsThenCommunityDelete delRed = new PsThenCommunityDelete("RED");
+    assertThat(ps.addPsThen(delRed), empty());
+    assertThat(
+        ps.addPsThen(new PsThenCommunityDelete("RED")), contains("community delete RED (dedup)"));
+    assertEquals(ImmutableList.of(delRed), ps.getAllThens());
+  }
+
+  @Test
+  public void testCommunitySetThenAdd() {
+    // set RED; add BLUE — both retained (set replaces, then add unions)
+    PsThens ps = new PsThens();
+    PsThenCommunitySet setRed = new PsThenCommunitySet("RED");
+    PsThenCommunityAdd addBlue = new PsThenCommunityAdd("BLUE");
+    assertThat(ps.addPsThen(setRed), empty());
+    assertThat(ps.addPsThen(addBlue), empty());
+    assertThat(ps.getAllThens(), contains(setRed, addBlue));
+  }
+
+  @Test
+  public void testCommunityAddThenSetWipesAdd() {
+    // add RED; set BLUE — set wipes prior add (now a no-op); only set retained, warning
+    PsThens ps = new PsThens();
+    PsThenCommunityAdd addRed = new PsThenCommunityAdd("RED");
+    PsThenCommunitySet setBlue = new PsThenCommunitySet("BLUE");
+    assertThat(ps.addPsThen(addRed), empty());
+    assertThat(ps.addPsThen(setBlue), contains("community add RED"));
+    assertEquals(ImmutableList.of(setBlue), ps.getAllThens());
+  }
+
+  @Test
+  public void testCommunitySetThenSetWipesPriorSet() {
+    // set RED; set BLUE — second set wipes first (last-wins); warning
+    PsThens ps = new PsThens();
+    PsThenCommunitySet setRed = new PsThenCommunitySet("RED");
+    PsThenCommunitySet setBlue = new PsThenCommunitySet("BLUE");
+    assertThat(ps.addPsThen(setRed), empty());
+    assertThat(ps.addPsThen(setBlue), contains("community set RED"));
+    assertEquals(ImmutableList.of(setBlue), ps.getAllThens());
+  }
+
+  @Test
+  public void testCommunitySetThenSetDedup() {
+    // set RED; set RED — exact duplicate
+    PsThens ps = new PsThens();
+    PsThenCommunitySet setRed = new PsThenCommunitySet("RED");
+    assertThat(ps.addPsThen(setRed), empty());
+    assertThat(ps.addPsThen(new PsThenCommunitySet("RED")), contains("community set RED (dedup)"));
+    assertEquals(ImmutableList.of(setRed), ps.getAllThens());
+  }
+
+  @Test
+  public void testCommunityAddThenDeleteSameNameConflicts() {
+    // add RED; delete RED — both retained (order matters for runtime), warn about conflict
+    PsThens ps = new PsThens();
+    PsThenCommunityAdd addRed = new PsThenCommunityAdd("RED");
+    PsThenCommunityDelete delRed = new PsThenCommunityDelete("RED");
+    assertThat(ps.addPsThen(addRed), empty());
+    assertThat(ps.addPsThen(delRed), contains("community add RED (conflict)"));
+    assertThat(ps.getAllThens(), contains(addRed, delRed));
+  }
+
+  @Test
+  public void testCommunityDeleteThenAddSameNameConflicts() {
+    // delete RED; add RED — both retained (order matters), warn about conflict
+    PsThens ps = new PsThens();
+    PsThenCommunityDelete delRed = new PsThenCommunityDelete("RED");
+    PsThenCommunityAdd addRed = new PsThenCommunityAdd("RED");
+    assertThat(ps.addPsThen(delRed), empty());
+    assertThat(ps.addPsThen(addRed), contains("community delete RED (conflict)"));
+    assertThat(ps.getAllThens(), contains(delRed, addRed));
+  }
+
+  @Test
+  public void testCommunityAddThenDeleteDifferentNamesNoConflict() {
+    // add RED; delete BLUE — different names, both retained
+    PsThens ps = new PsThens();
+    PsThenCommunityAdd addRed = new PsThenCommunityAdd("RED");
+    PsThenCommunityDelete delBlue = new PsThenCommunityDelete("BLUE");
+    assertThat(ps.addPsThen(addRed), empty());
+    assertThat(ps.addPsThen(delBlue), empty());
+    assertThat(ps.getAllThens(), contains(addRed, delBlue));
+  }
+
+  @Test
+  public void testCommunitySetThenDeleteBothRetained() {
+    // set RED; delete RED — set replaces, then delete removes RED → both retained
+    PsThens ps = new PsThens();
+    PsThenCommunitySet setRed = new PsThenCommunitySet("RED");
+    PsThenCommunityDelete delRed = new PsThenCommunityDelete("RED");
+    assertThat(ps.addPsThen(setRed), empty());
+    assertThat(ps.addPsThen(delRed), empty());
+    assertThat(ps.getAllThens(), contains(setRed, delRed));
+  }
+
+  @Test
+  public void testCommunityDeclaredOrderPreserved() {
+    // delete RED; add BLUE; delete GREEN — all retained, in declared order
+    PsThens ps = new PsThens();
+    PsThenCommunityDelete delRed = new PsThenCommunityDelete("RED");
+    PsThenCommunityAdd addBlue = new PsThenCommunityAdd("BLUE");
+    PsThenCommunityDelete delGreen = new PsThenCommunityDelete("GREEN");
+    assertThat(ps.addPsThen(delRed), empty());
+    assertThat(ps.addPsThen(addBlue), empty());
+    assertThat(ps.addPsThen(delGreen), empty());
+    assertThat(ps.getAllThens(), contains(delRed, addBlue, delGreen));
+  }
+
+  @Test
+  public void testCommunitySetWipesAllPrior() {
+    // add RED; delete BLUE; set GREEN — set wipes both prior actions; warnings for each
+    PsThens ps = new PsThens();
+    PsThenCommunityAdd addRed = new PsThenCommunityAdd("RED");
+    PsThenCommunityDelete delBlue = new PsThenCommunityDelete("BLUE");
+    PsThenCommunitySet setGreen = new PsThenCommunitySet("GREEN");
+    assertThat(ps.addPsThen(addRed), empty());
+    assertThat(ps.addPsThen(delBlue), empty());
+    assertThat(ps.addPsThen(setGreen), contains("community add RED", "community delete BLUE"));
+    assertEquals(ImmutableList.of(setGreen), ps.getAllThens());
+  }
+
+  // ==========================================================================
+  // §6: Forwarding
+  // ==========================================================================
+
+  @Test
+  public void testLoadBalanceDedup() {
+    PsThens ps = new PsThens();
+    PsThenLoadBalance lb = new PsThenLoadBalance(PsThenLoadBalance.LoadBalanceMethod.PER_PACKET);
+    assertThat(ps.addPsThen(lb), empty());
+    assertThat(ps.addPsThen(lb), contains("load-balance (dedup)"));
+    assertEquals(ImmutableList.of(lb), ps.getAllThens());
+  }
+
+  // ==========================================================================
+  // §7: Cross-attribute — different families coexist
+  // ==========================================================================
+
+  @Test
+  public void testCrossAttributeAllRetained() {
+    PsThens ps = new PsThens();
+    PsThenLocalPreference lp = new PsThenLocalPreference(200, PsThenLocalPreference.Operator.SET);
+    PsThenMetric met = new PsThenMetric(100, PsThenMetric.Operator.SET);
+    PsThenCommunityAdd add = new PsThenCommunityAdd("RED");
+    assertThat(ps.addPsThen(lp), empty());
+    assertThat(ps.addPsThen(met), empty());
+    assertThat(ps.addPsThen(add), empty());
+    assertThat(ps.getAllThens(), containsInAnyOrder(lp, met, add));
+  }
+
+  // ==========================================================================
+  // Tunnel-attribute set — last-wins (only one tunnel attribute applies on a BGP route)
+  // ==========================================================================
+
+  @Test
+  public void testTunnelAttributeSetDedup() {
+    PsThens ps = new PsThens();
+    PsThenTunnelAttributeSet ta1 = new PsThenTunnelAttributeSet("ta1");
+    assertThat(ps.addPsThen(ta1), empty());
+    assertThat(
+        ps.addPsThen(new PsThenTunnelAttributeSet("ta1")),
+        contains("tunnel-attribute set (dedup)"));
+    assertEquals(ImmutableList.of(ta1), ps.getAllThens());
+  }
+
+  @Test
+  public void testTunnelAttributeSetLastWins() {
+    PsThens ps = new PsThens();
+    PsThenTunnelAttributeSet ta1 = new PsThenTunnelAttributeSet("ta1");
+    PsThenTunnelAttributeSet ta2 = new PsThenTunnelAttributeSet("ta2");
+    assertThat(ps.addPsThen(ta1), empty());
+    assertThat(ps.addPsThen(ta2), contains("tunnel-attribute set"));
+    assertEquals(ImmutableList.of(ta2), ps.getAllThens());
+  }
+
+  // ==========================================================================
+  // §5: Bare terminators collapse last-wins; named non-bare flow control retained
+  // ==========================================================================
+
+  @Test
+  public void testAcceptThenRejectLastWins() {
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenAccept.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), contains("accept-or-reject"));
+    assertEquals(ImmutableList.of(PsThenReject.INSTANCE), ps.getAllThens());
+  }
+
+  @Test
+  public void testRejectThenAcceptLastWins() {
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenAccept.INSTANCE), contains("accept-or-reject"));
+    assertEquals(ImmutableList.of(PsThenAccept.INSTANCE), ps.getAllThens());
+  }
+
+  @Test
+  public void testAcceptDedup() {
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenAccept.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenAccept.INSTANCE), contains("accept-or-reject (dedup)"));
+    assertEquals(ImmutableList.of(PsThenAccept.INSTANCE), ps.getAllThens());
+  }
+
+  @Test
+  public void testDefaultActionAndBareTerminatorBothRetained() {
+    // default-action accept and bare reject are different families. Both retained at commit.
+    PsThens ps = new PsThens();
+    PsThenDefaultActionAccept defaultAccept = new PsThenDefaultActionAccept();
+    assertThat(ps.addPsThen(defaultAccept), empty());
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), empty());
+    assertThat(ps.getAllThens(), containsInAnyOrder(defaultAccept, PsThenReject.INSTANCE));
+  }
+
+  @Test
+  public void testAcceptThenNextTermSuppresses() {
+    // accept; next term — both retained at commit; next-term wins at runtime
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenAccept.INSTANCE), empty());
+    assertThat(
+        ps.addPsThen(PsThenNextTerm.INSTANCE),
+        contains("accept-or-reject (suppressed-by-next-term-or-policy)"));
+    assertThat(
+        ps.getAllThens(), containsInAnyOrder(PsThenAccept.INSTANCE, PsThenNextTerm.INSTANCE));
+  }
+
+  @Test
+  public void testAcceptThenNextPolicySuppresses() {
+    // accept; next policy — same as next-term: accept does not fire at runtime
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenAccept.INSTANCE), empty());
+    assertThat(
+        ps.addPsThen(PsThenNextPolicy.INSTANCE),
+        contains("accept-or-reject (suppressed-by-next-term-or-policy)"));
+    assertThat(
+        ps.getAllThens(), containsInAnyOrder(PsThenAccept.INSTANCE, PsThenNextPolicy.INSTANCE));
+  }
+
+  @Test
+  public void testNextTermThenAcceptIsDead() {
+    // next term; accept — bare accept is dead config when next-term already present
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextTerm.INSTANCE), empty());
+    assertThat(
+        ps.addPsThen(PsThenAccept.INSTANCE),
+        contains("accept-or-reject (dead-after-next-term-or-policy)"));
+    assertThat(
+        ps.getAllThens(), containsInAnyOrder(PsThenAccept.INSTANCE, PsThenNextTerm.INSTANCE));
+  }
+
+  @Test
+  public void testNextPolicyThenRejectIsDead() {
+    // next policy; reject — bare reject is dead config when next-policy already present
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextPolicy.INSTANCE), empty());
+    assertThat(
+        ps.addPsThen(PsThenReject.INSTANCE),
+        contains("accept-or-reject (dead-after-next-term-or-policy)"));
+    assertThat(
+        ps.getAllThens(), containsInAnyOrder(PsThenReject.INSTANCE, PsThenNextPolicy.INSTANCE));
+  }
+
+  @Test
+  public void testNextTermDedup() {
+    // §5 row 4011: next term; next term — dedup (same family)
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextTerm.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenNextTerm.INSTANCE), contains("next-term-or-policy (dedup)"));
+    assertEquals(ImmutableList.of(PsThenNextTerm.INSTANCE), ps.getAllThens());
+  }
+
+  @Test
+  public void testNextPolicyDedup() {
+    // §5 row 4012: next policy; next policy — dedup (same family)
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextPolicy.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenNextPolicy.INSTANCE), contains("next-term-or-policy (dedup)"));
+    assertEquals(ImmutableList.of(PsThenNextPolicy.INSTANCE), ps.getAllThens());
+  }
+
+  @Test
+  public void testNextTermThenNextPolicyLastWins() {
+    // §5 row 4013: next term; next policy — same family, last-wins → next-policy retained
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextTerm.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenNextPolicy.INSTANCE), contains("next-term-or-policy"));
+    assertEquals(ImmutableList.of(PsThenNextPolicy.INSTANCE), ps.getAllThens());
+  }
+
+  @Test
+  public void testNextPolicyThenNextTermLastWins() {
+    // §5 row 4014: next policy; next term — last-wins → next-term retained
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenNextPolicy.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenNextTerm.INSTANCE), contains("next-term-or-policy"));
+    assertEquals(ImmutableList.of(PsThenNextTerm.INSTANCE), ps.getAllThens());
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-ps-then-conflicts
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-ps-then-conflicts
@@ -1,0 +1,104 @@
+#
+set system host-name juniper-ps-then-conflicts
+#
+# Communities for testing
+set policy-options community RED members 65000:1
+set policy-options community BLUE members 65000:2
+set policy-options community GREEN members 65000:3
+#
+# §1: Scalar last-wins
+set policy-options policy-statement ORIGIN-DIFF term t1 then origin igp
+set policy-options policy-statement ORIGIN-DIFF term t1 then origin egp
+#
+set policy-options policy-statement LP-SET-DIFF term t1 then local-preference 200
+set policy-options policy-statement LP-SET-DIFF term t1 then local-preference 50
+#
+set policy-options policy-statement LP-SET-ADD term t1 then local-preference 200
+set policy-options policy-statement LP-SET-ADD term t1 then local-preference add 50
+#
+set policy-options policy-statement LP-ADD-SET term t1 then local-preference add 50
+set policy-options policy-statement LP-ADD-SET term t1 then local-preference 200
+#
+set policy-options policy-statement MED-SET-DIFF term t1 then metric 200
+set policy-options policy-statement MED-SET-DIFF term t1 then metric 50
+#
+set policy-options policy-statement MED-SET-ADD term t1 then metric 200
+set policy-options policy-statement MED-SET-ADD term t1 then metric add 50
+#
+set policy-options policy-statement MED-ADD-SET term t1 then metric add 50
+set policy-options policy-statement MED-ADD-SET term t1 then metric 200
+#
+set policy-options policy-statement NEXTHOP-SELF-VS-IP term t1 then next-hop self
+set policy-options policy-statement NEXTHOP-SELF-VS-IP term t1 then next-hop 192.0.2.1
+#
+# §4: Community cumulative
+set policy-options policy-statement COMM-SET-SET term t1 then community set RED
+set policy-options policy-statement COMM-SET-SET term t1 then community set BLUE
+#
+set policy-options policy-statement COMM-ADD-ADD term t1 then community add RED
+set policy-options policy-statement COMM-ADD-ADD term t1 then community add BLUE
+#
+set policy-options policy-statement COMM-SET-ADD term t1 then community set RED
+set policy-options policy-statement COMM-SET-ADD term t1 then community add BLUE
+#
+# add then set: set wipes the prior add (warning, only set retained)
+set policy-options policy-statement COMM-ADD-SET term t1 then community add RED
+set policy-options policy-statement COMM-ADD-SET term t1 then community set BLUE
+#
+# add then delete on same name: delete makes prior add a no-op (warning, only delete retained)
+set policy-options policy-statement COMM-ADD-DEL-SAME term t1 then community add RED
+set policy-options policy-statement COMM-ADD-DEL-SAME term t1 then community delete RED
+#
+# delete then add interleaved with another delete; declared order preserved
+set policy-options policy-statement COMM-ORDERED term t1 then community delete RED
+set policy-options policy-statement COMM-ORDERED term t1 then community add BLUE
+set policy-options policy-statement COMM-ORDERED term t1 then community delete GREEN
+#
+# §7: Cross-attribute
+set policy-options policy-statement CROSS-ATTR term t1 then local-preference 200
+set policy-options policy-statement CROSS-ATTR term t1 then metric 100
+set policy-options policy-statement CROSS-ATTR term t1 then community add RED
+#
+# §5: Flow-control
+# accept; reject — last-wins within accept/reject (only reject retained)
+set policy-options policy-statement FC-ACCEPT-REJECT term t1 then accept
+set policy-options policy-statement FC-ACCEPT-REJECT term t1 then reject
+#
+# reject; accept — last-wins (only accept retained)
+set policy-options policy-statement FC-REJECT-ACCEPT term t1 then reject
+set policy-options policy-statement FC-REJECT-ACCEPT term t1 then accept
+#
+# accept; next term — both retained at commit, but next-term wins at runtime: t1 falls through
+set policy-options policy-statement FC-ACCEPT-NEXT-TERM term t1 then community add RED
+set policy-options policy-statement FC-ACCEPT-NEXT-TERM term t1 then accept
+set policy-options policy-statement FC-ACCEPT-NEXT-TERM term t1 then next term
+set policy-options policy-statement FC-ACCEPT-NEXT-TERM term t2 then accept
+#
+# next term; accept — same as above; t1 falls through to t2 regardless of source order
+set policy-options policy-statement FC-NEXT-TERM-ACCEPT term t1 then community add RED
+set policy-options policy-statement FC-NEXT-TERM-ACCEPT term t1 then next term
+set policy-options policy-statement FC-NEXT-TERM-ACCEPT term t1 then accept
+set policy-options policy-statement FC-NEXT-TERM-ACCEPT term t2 then accept
+#
+# accept; default-action reject — accept fires, default-action reject is dead config
+set policy-options policy-statement FC-ACCEPT-DEFAULT-REJECT term t1 then accept
+set policy-options policy-statement FC-ACCEPT-DEFAULT-REJECT term t1 then default-action reject
+#
+# reject; default-action accept — reject fires
+set policy-options policy-statement FC-REJECT-DEFAULT-ACCEPT term t1 then reject
+set policy-options policy-statement FC-REJECT-DEFAULT-ACCEPT term t1 then default-action accept
+#
+# §5 row 4013: next term; next policy — same family, last-wins (next-policy retained)
+# next-policy returns to BGP processing → route accepted
+set policy-options policy-statement FC-NEXT-TERM-NEXT-POLICY term t1 then community add RED
+set policy-options policy-statement FC-NEXT-TERM-NEXT-POLICY term t1 then next term
+set policy-options policy-statement FC-NEXT-TERM-NEXT-POLICY term t1 then next policy
+set policy-options policy-statement FC-NEXT-TERM-NEXT-POLICY term t2 then reject
+#
+# §5 row 4014: next policy; next term — last-wins (next-term retained)
+# next-term jumps to t2 which rejects
+set policy-options policy-statement FC-NEXT-POLICY-NEXT-TERM term t1 then community add RED
+set policy-options policy-statement FC-NEXT-POLICY-NEXT-TERM term t1 then next policy
+set policy-options policy-statement FC-NEXT-POLICY-NEXT-TERM term t1 then next term
+set policy-options policy-statement FC-NEXT-POLICY-NEXT-TERM term t2 then reject
+#

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1479,10 +1479,45 @@
       },
       {
         "Filename" : "configs/juniper_policy_statement",
+        "Line" : 30,
+        "Text" : "add 20",
+        "Parser_Context" : "[popstm_add popst_metric popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "RISK: Overwriting existing then metric"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
         "Line" : 32,
         "Text" : "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
         "Parser_Context" : "[popstnh_ipv6 popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
+        "Line" : 33,
+        "Text" : "discard",
+        "Parser_Context" : "[popstnh_discard popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "RISK: Overwriting existing then next-hop"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
+        "Line" : 34,
+        "Text" : "peer-address",
+        "Parser_Context" : "[popstnh_peer_address popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "RISK: Overwriting existing then next-hop"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
+        "Line" : 35,
+        "Text" : "reject",
+        "Parser_Context" : "[popstnh_reject popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "RISK: Overwriting existing then next-hop"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
+        "Line" : 36,
+        "Text" : "self",
+        "Parser_Context" : "[popstnh_self popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "RISK: Overwriting existing then next-hop"
       },
       {
         "Filename" : "configs/juniper_rib_groups",
@@ -1542,10 +1577,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 214 results",
+      "notes" : "Found 219 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 214
+      "numResults" : 219
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71882,10 +71882,40 @@
               "Text" : "as-path-prepend \"456 123.1 789"
             },
             {
+              "Comment" : "RISK: Overwriting existing then metric",
+              "Line" : 30,
+              "Parser_Context" : "[popstm_add popst_metric popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "add 20"
+            },
+            {
               "Comment" : "This feature is not currently supported",
               "Line" : 32,
               "Parser_Context" : "[popstnh_ipv6 popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+            },
+            {
+              "Comment" : "RISK: Overwriting existing then next-hop",
+              "Line" : 33,
+              "Parser_Context" : "[popstnh_discard popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "discard"
+            },
+            {
+              "Comment" : "RISK: Overwriting existing then next-hop",
+              "Line" : 34,
+              "Parser_Context" : "[popstnh_peer_address popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "peer-address"
+            },
+            {
+              "Comment" : "RISK: Overwriting existing then next-hop",
+              "Line" : 35,
+              "Parser_Context" : "[popstnh_reject popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "reject"
+            },
+            {
+              "Comment" : "RISK: Overwriting existing then next-hop",
+              "Line" : 36,
+              "Parser_Context" : "[popstnh_self popst_next_hop popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "self"
             }
           ]
         },


### PR DESCRIPTION
Refactors PsThens to faithfully model Junos commit-time collapse and
runtime ordering for actions within a single `then` block, as
characterized by the junos_then_action_conflicts lab in lab-validation.

Last-wins / cumulative families:

- Scalar/numeric families (origin, preference, tag, next-hop, external,
local-preference, metric, load-balance, as-path-prepend,
as-path-expand, source-class, etc.) use last-wins semantics: only the
last action is retained, exact duplicates collapse to one.
- Community actions (set/add/delete) and tunnel-attribute set are
cumulative: all distinct actions are retained, duplicates dedup.
Multiple community-set actions in one term are converted with union
semantics (matching Junos, where every set contributes cumulatively).
- getAllThens() returns actions in a canonical order matching Junos
commit-time normalization (as-path-prepend before as-path-expand,
side-effects before terminators).
- Adds equals/hashCode to PsThen subclasses that lacked it, enabling
proper dedup detection.

Flow-control terminators:

- Bare `accept`/`reject` form a "bare-terminator" family with last-wins
semantics: `accept; reject` collapses to `reject`-only, and
vice-versa. `default-action accept`/`reject` and `next policy` are
separate families and are retained alongside bare terminators.
- `then next term` is now modeled (was a no-op TODO since 2017,
closes #1551). It is its own family. At runtime, `next term`
suppresses any bare `accept`/`reject` in the same term: both lines
are retained at commit, but the route falls through to the next term
regardless of source order. This is enforced in
JuniperConfiguration.toStatements (which strips bare terminators
when next-term is present) and in getTerminalAction (which no longer
flags such terms as terminal for dead-code detection).

Risky parse warnings:

- Same-family overwrites emit "Overwriting existing then <family>".
- Same-family duplicates emit "Duplicate then <family>".
- Community add/delete on the same name emit "Conflicts with prior
then community add/delete <name>" when both are retained but their
combined runtime effect cancels out.
- Adding `then next term` after a prior bare `accept`/`reject` emits
"then next term suppresses prior then accept/reject ... route falls
through". Adding `then accept`/`reject` after a prior `then next
term` emits the converse "then accept/reject has no effect when then
next term is also present". These asymmetric messages point at the
removable line in each direction.

----

Prompt:
```
Read the new junos_then_action_conflicts lab in lab-validation
(../lab-validation). That has a lot to say about Juniper
policy-statements with duplicate/conflicting terms. Let's add unit
tests to Batfish that mirror the lab and make sure Batfish implements
the ordering correctly. A few notes:

1. We should emit RISKY warnings every time one of these overwrites,
including dedupes, happens.
1. We should emit RISKY warnings if both statements are preserved, but
don't both have an effect. E.g., two community set lines.
1. We should match Junos behavior, but it's preferred to eliminate
statements that don't have an effect (like lines that have been
overwritten) during conversion.
```

Follow-ups in the same commit responding to lab-validation README
updates: add bare-terminator last-wins family, model `then next term`
and its conflict with bare terminators (both retained at commit, route
falls through at runtime), add unit tests for `default-action`
overridden by bare terminator, and add asymmetric cross-family RISKY
warnings for `next term` + bare terminator interactions.

---
**Stack**:
- #9949 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*