### PR TITLE
Junos: warn on dead-config in policy-statement then actions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2581,6 +2581,18 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
             ctx,
             "then accept/reject has no effect when then next term/next policy is also present in"
                 + " the same term: accept/reject does not fire");
+      } else if (entry.contains("(dead-with-bare-terminator)")) {
+        warnRisky(
+            ctx,
+            "then default-action is overridden by bare then accept/reject in the same term:"
+                + " default-action does not fire");
+      } else if (entry.contains("(dead-with-bare-reject)")) {
+        warnRisky(
+            ctx,
+            String.format(
+                "then %s has no effect on the propagated route when then reject is also present"
+                    + " in the same term",
+                entry.replace(" (dead-with-bare-reject)", "")));
       } else if (entry.contains("(dedup)")) {
         warnRisky(ctx, String.format("Duplicate then %s", entry.replace(" (dedup)", "")));
       } else if (entry.contains("(conflict)")) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenDefaultActionAccept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenDefaultActionAccept.java
@@ -16,4 +16,14 @@ public class PsThenDefaultActionAccept extends PsThen {
       Warnings warnings) {
     statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
   }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof PsThenDefaultActionAccept;
+  }
+
+  @Override
+  public int hashCode() {
+    return PsThenDefaultActionAccept.class.hashCode();
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenDefaultActionReject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenDefaultActionReject.java
@@ -16,4 +16,14 @@ public class PsThenDefaultActionReject extends PsThen {
       Warnings warnings) {
     statements.add(Statements.SetDefaultActionReject.toStaticStatement());
   }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof PsThenDefaultActionReject;
+  }
+
+  @Override
+  public int hashCode() {
+    return PsThenDefaultActionReject.class.hashCode();
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
@@ -29,9 +29,17 @@ import javax.annotation.Nullable;
  *       accept}/{@code reject} appear in the same term, both lines stay in retained config but
  *       {@code next term}/{@code next policy} wins at runtime: the {@code accept}/{@code reject}
  *       does not fire.
+ *   <li>{@code default-action accept}/{@code default-action reject} share one last-wins slot, and
+ *       are a separate family from bare {@code accept}/{@code reject}. When a bare terminator and a
+ *       {@code default-action} coexist in the same term, the bare terminator wins at runtime and
+ *       the {@code default-action} is dead config.
+ *   <li>When a bare {@code reject} fires (i.e., it is present and not suppressed by {@code next
+ *       term}/{@code next policy}), any mutating action in the same term has no effect on the
+ *       propagated route since the route is discarded.
  * </ul>
  *
- * <p>All cleared/eliminated actions produce a RISKY warning so the user can audit the config.
+ * <p>All cleared/eliminated actions, and dead-config combinations, produce a RISKY warning so the
+ * user can audit the config.
  */
 public final class PsThens implements Serializable {
 
@@ -42,7 +50,8 @@ public final class PsThens implements Serializable {
    */
   public @Nonnull List<String> addPsThen(PsThen then) {
     if (isCommunityAction(then)) {
-      return addCommunityAction(then);
+      List<String> warnings = addCommunityAction(then);
+      return appendBareRejectWarningIfMutating(then, warnings);
     }
     if (isNextTermOrPolicy(then)) {
       return setNextTermOrPolicy(then);
@@ -50,13 +59,17 @@ public final class PsThens implements Serializable {
     if (then instanceof PsThenAccept || then instanceof PsThenReject) {
       return setAcceptOrReject(then);
     }
+    if (isDefaultAction(then)) {
+      return setDefaultAction(then);
+    }
     String family = getFamily(then);
     if (family == null) {
       // Unclassified action (flow-control, unmodeled, etc.) — always retain
       _others.add(then);
-      return ImmutableList.of();
+      return appendBareRejectWarningIfMutating(then, ImmutableList.of());
     }
-    return setLastWins(then, family);
+    List<String> warnings = setLastWins(then, family);
+    return appendBareRejectWarningIfMutating(then, warnings);
   }
 
   /**
@@ -80,6 +93,9 @@ public final class PsThens implements Serializable {
     if (_nextTermOrPolicy != null) {
       allThens.add(_nextTermOrPolicy);
     }
+    if (_defaultAction != null) {
+      allThens.add(_defaultAction);
+    }
     if (_acceptOrReject != null) {
       allThens.add(_acceptOrReject);
     }
@@ -100,7 +116,7 @@ public final class PsThens implements Serializable {
   // Canonical output order for scalar last-wins families. Matches Junos commit-time
   // normalization (e.g., as-path-prepend is applied before as-path-expand). After scalars,
   // getAllThens emits communities, then the `next term`/`next policy` slot, then the
-  // `accept`/`reject` slot, then _others.
+  // `default-action` slot, then the `accept`/`reject` slot, then _others.
   private static final ImmutableList<String> SCALAR_CANONICAL_ORDER =
       ImmutableList.of(
           "as-path-prepend",
@@ -282,8 +298,9 @@ public final class PsThens implements Serializable {
 
   private @Nonnull List<String> setAcceptOrReject(PsThen then) {
     ImmutableList.Builder<String> warnings = ImmutableList.builder();
-    if (_acceptOrReject != null) {
-      if (_acceptOrReject.equals(then)) {
+    PsThen prior = _acceptOrReject;
+    if (prior != null) {
+      if (prior.equals(then)) {
         warnings.add("accept-or-reject (dedup)");
       } else {
         warnings.add("accept-or-reject");
@@ -295,12 +312,125 @@ public final class PsThens implements Serializable {
       // line is dead — `next term`/`next policy` wins at runtime.
       warnings.add("accept-or-reject (dead-after-next-term-or-policy)");
     }
+    if (_defaultAction != null) {
+      // Bare terminator overrides any `default-action` in the same term: the `default-action` is
+      // dead config.
+      warnings.add("default-action (dead-with-bare-terminator)");
+    }
+    if (then instanceof PsThenReject
+        && _nextTermOrPolicy == null
+        && !(prior instanceof PsThenReject)) {
+      // First time reject is the retained terminator and it will actually fire (not suppressed by
+      // next-term/next-policy). Any mutating action already in the same term has no effect on the
+      // propagated route. Skip on dedup (prior reject already triggered these warnings).
+      for (String label : mutatingLabels()) {
+        warnings.add(label + " (dead-with-bare-reject)");
+      }
+    }
     return warnings.build();
+  }
+
+  // --- default-action: dedicated last-wins slot, dead when bare terminator is also present ---
+
+  private static boolean isDefaultAction(PsThen then) {
+    return then instanceof PsThenDefaultActionAccept || then instanceof PsThenDefaultActionReject;
+  }
+
+  private @Nonnull List<String> setDefaultAction(PsThen then) {
+    ImmutableList.Builder<String> warnings = ImmutableList.builder();
+    if (_defaultAction != null) {
+      if (_defaultAction.equals(then)) {
+        warnings.add("default-action (dedup)");
+      } else {
+        warnings.add("default-action");
+      }
+    }
+    _defaultAction = then;
+    if (_acceptOrReject != null) {
+      // Bare terminator overrides default-action regardless of source order; this new
+      // default-action is dead config.
+      warnings.add("default-action (dead-with-bare-terminator)");
+    }
+    return warnings.build();
+  }
+
+  // --- mutating-action vs bare-reject ---
+
+  /**
+   * Returns true when {@code then} mutates the route in a way that would be observable on a
+   * propagated route. Flow-control actions (accept/reject, next-term/next-policy, default-action)
+   * are excluded.
+   */
+  private static boolean isMutatingAction(PsThen then) {
+    return !(then instanceof PsThenAccept
+        || then instanceof PsThenReject
+        || then instanceof PsThenNextTerm
+        || then instanceof PsThenNextPolicy
+        || then instanceof PsThenDefaultActionAccept
+        || then instanceof PsThenDefaultActionReject);
+  }
+
+  /**
+   * If a bare {@code reject} that will actually fire is already retained in this {@link PsThens}
+   * and the newly added {@code then} is a mutating action that ended up retained (i.e., not a pure
+   * dedup), append a "dead-with-bare-reject" warning for the new action.
+   */
+  private @Nonnull List<String> appendBareRejectWarningIfMutating(
+      PsThen then, List<String> baseWarnings) {
+    if (!(_acceptOrReject instanceof PsThenReject) || _nextTermOrPolicy != null) {
+      return baseWarnings;
+    }
+    if (!isMutatingAction(then)) {
+      return baseWarnings;
+    }
+    // Skip pure dedup: the prior action was already flagged when reject was added.
+    for (String warning : baseWarnings) {
+      if (warning.contains("(dedup)")) {
+        return baseWarnings;
+      }
+    }
+    return ImmutableList.<String>builder()
+        .addAll(baseWarnings)
+        .add(actionLabel(then) + " (dead-with-bare-reject)")
+        .build();
+  }
+
+  /**
+   * Returns labels for every retained mutating action, in canonical (output) order. Used when a
+   * bare {@code reject} is added after mutating actions to emit one warning per action.
+   */
+  private @Nonnull List<String> mutatingLabels() {
+    ImmutableList.Builder<String> labels = ImmutableList.builder();
+    for (PsThen then : getAllThens()) {
+      if (isMutatingAction(then)) {
+        labels.add(actionLabel(then));
+      }
+    }
+    return labels.build();
+  }
+
+  /** Returns a short human-readable label for a mutating action (used in warning text). */
+  private static @Nonnull String actionLabel(PsThen then) {
+    if (isCommunityAction(then)) {
+      return communityLabel(then);
+    }
+    String family = getFamily(then);
+    if (family != null) {
+      return family;
+    }
+    // Unclassified actions in _others (e.g., aigp-originate) — fall back to class-name-derived
+    // label.
+    String simpleName = then.getClass().getSimpleName();
+    if (simpleName.startsWith("PsThen")) {
+      simpleName = simpleName.substring("PsThen".length());
+    }
+    return simpleName;
   }
 
   private final @Nonnull Map<String, List<PsThen>> _familyActions;
   private final @Nonnull List<PsThen> _communityActions;
   private @Nullable PsThen _nextTermOrPolicy;
   private @Nullable PsThen _acceptOrReject;
+  private @Nullable PsThen _defaultAction;
   private final @Nonnull List<PsThen> _others;
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5670,7 +5670,20 @@ public final class FlatJuniperGrammarTest {
             // next term; accept — accept after next term/next policy is dead config
             hasComment(
                 "RISK: then accept/reject has no effect when then next term/next policy is also"
-                    + " present in the same term: accept/reject does not fire")));
+                    + " present in the same term: accept/reject does not fire"),
+            // metric/community before bare reject — dead since route is rejected
+            hasComment(
+                "RISK: then metric has no effect on the propagated route when then reject is"
+                    + " also present in the same term"),
+            hasComment(
+                "RISK: then community add RED has no effect on the propagated route when then"
+                    + " reject is also present in the same term"),
+            // default-action with bare terminator — default-action is dead
+            hasComment(
+                "RISK: then default-action is overridden by bare then accept/reject in the same"
+                    + " term: default-action does not fire"),
+            // default-action accept; default-action reject — last-wins within default-action
+            hasComment("RISK: Overwriting existing then default-action")));
 
     // COMM-ORDERED has no conflicts — no warnings should mention BLUE or GREEN
     assertTrue(

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThensTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThensTest.java
@@ -637,10 +637,13 @@ public class PsThensTest {
   @Test
   public void testDefaultActionAndBareTerminatorBothRetained() {
     // default-action accept and bare reject are different families. Both retained at commit.
+    // Bare terminator overrides default-action: dead-with-bare-terminator warning fires.
     PsThens ps = new PsThens();
     PsThenDefaultActionAccept defaultAccept = new PsThenDefaultActionAccept();
     assertThat(ps.addPsThen(defaultAccept), empty());
-    assertThat(ps.addPsThen(PsThenReject.INSTANCE), empty());
+    assertThat(
+        ps.addPsThen(PsThenReject.INSTANCE),
+        contains("default-action (dead-with-bare-terminator)"));
     assertThat(ps.getAllThens(), containsInAnyOrder(defaultAccept, PsThenReject.INSTANCE));
   }
 
@@ -726,5 +729,136 @@ public class PsThensTest {
     assertThat(ps.addPsThen(PsThenNextPolicy.INSTANCE), empty());
     assertThat(ps.addPsThen(PsThenNextTerm.INSTANCE), contains("next-term-or-policy"));
     assertEquals(ImmutableList.of(PsThenNextTerm.INSTANCE), ps.getAllThens());
+  }
+
+  // ==========================================================================
+  // default-action: separate last-wins family; dead when bare terminator is also present
+  // ==========================================================================
+
+  @Test
+  public void testDefaultActionAcceptDedup() {
+    PsThens ps = new PsThens();
+    PsThenDefaultActionAccept da1 = new PsThenDefaultActionAccept();
+    PsThenDefaultActionAccept da2 = new PsThenDefaultActionAccept();
+    assertThat(ps.addPsThen(da1), empty());
+    assertThat(ps.addPsThen(da2), contains("default-action (dedup)"));
+    assertThat(ps.getAllThens(), contains(da2));
+  }
+
+  @Test
+  public void testDefaultActionAcceptThenRejectLastWins() {
+    PsThens ps = new PsThens();
+    PsThenDefaultActionAccept daAccept = new PsThenDefaultActionAccept();
+    PsThenDefaultActionReject daReject = new PsThenDefaultActionReject();
+    assertThat(ps.addPsThen(daAccept), empty());
+    assertThat(ps.addPsThen(daReject), contains("default-action"));
+    assertThat(ps.getAllThens(), contains(daReject));
+  }
+
+  @Test
+  public void testBareAcceptThenDefaultActionIsDead() {
+    // accept; default-action reject — default-action is dead config when added after a bare
+    // terminator. Both lines retained at commit.
+    PsThens ps = new PsThens();
+    PsThenDefaultActionReject defaultReject = new PsThenDefaultActionReject();
+    assertThat(ps.addPsThen(PsThenAccept.INSTANCE), empty());
+    assertThat(ps.addPsThen(defaultReject), contains("default-action (dead-with-bare-terminator)"));
+    assertThat(ps.getAllThens(), containsInAnyOrder(PsThenAccept.INSTANCE, defaultReject));
+  }
+
+  @Test
+  public void testDefaultActionRejectThenBareAcceptIsDeadConfig() {
+    // default-action reject; accept — adding the bare terminator makes the default-action dead
+    // config (the default-action was authored first but never fires).
+    PsThens ps = new PsThens();
+    PsThenDefaultActionReject defaultReject = new PsThenDefaultActionReject();
+    assertThat(ps.addPsThen(defaultReject), empty());
+    assertThat(
+        ps.addPsThen(PsThenAccept.INSTANCE),
+        contains("default-action (dead-with-bare-terminator)"));
+    assertThat(ps.getAllThens(), containsInAnyOrder(PsThenAccept.INSTANCE, defaultReject));
+  }
+
+  // ==========================================================================
+  // mutating action vs bare reject: mutating action is dead since route is rejected
+  // ==========================================================================
+
+  @Test
+  public void testMutatingThenRejectFlagsAllPriorMutations() {
+    // metric 100; community add RED; reject — metric and community are dead config; one warning
+    // per prior mutating action.
+    PsThens ps = new PsThens();
+    PsThenMetric m = new PsThenMetric(100, PsThenMetric.Operator.SET);
+    PsThenCommunityAdd add = new PsThenCommunityAdd("RED");
+    assertThat(ps.addPsThen(m), empty());
+    assertThat(ps.addPsThen(add), empty());
+    assertThat(
+        ps.addPsThen(PsThenReject.INSTANCE),
+        contains("metric (dead-with-bare-reject)", "community add RED (dead-with-bare-reject)"));
+  }
+
+  @Test
+  public void testRejectThenMutatingIsDead() {
+    // reject; metric 100 — metric is dead since reject already fires. Both retained at commit.
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), empty());
+    assertThat(
+        ps.addPsThen(new PsThenMetric(100, PsThenMetric.Operator.SET)),
+        contains("metric (dead-with-bare-reject)"));
+  }
+
+  @Test
+  public void testRejectThenCommunityAddIsDead() {
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), empty());
+    assertThat(
+        ps.addPsThen(new PsThenCommunityAdd("RED")),
+        contains("community add RED (dead-with-bare-reject)"));
+  }
+
+  @Test
+  public void testRejectAcceptThenMutatingNotDead() {
+    // reject; accept — accept wins (last-wins). A mutating action after that is NOT dead because
+    // the route is accepted.
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), empty());
+    assertThat(ps.addPsThen(PsThenAccept.INSTANCE), contains("accept-or-reject"));
+    assertThat(ps.addPsThen(new PsThenMetric(100, PsThenMetric.Operator.SET)), empty());
+  }
+
+  @Test
+  public void testRejectThenNextTermNotDead() {
+    // reject; next term — next-term suppresses the reject. A mutating action added after is not
+    // dead-with-bare-reject because reject does not fire.
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), empty());
+    assertThat(
+        ps.addPsThen(PsThenNextTerm.INSTANCE),
+        contains("accept-or-reject (suppressed-by-next-term-or-policy)"));
+    assertThat(ps.addPsThen(new PsThenMetric(100, PsThenMetric.Operator.SET)), empty());
+  }
+
+  @Test
+  public void testRejectThenMutatingDedupNotDoubleWarned() {
+    // metric 100; reject; metric 100 — the second metric is a dedup. Don't double-warn (the
+    // earlier metric was already warned when reject was added).
+    PsThens ps = new PsThens();
+    PsThenMetric m = new PsThenMetric(100, PsThenMetric.Operator.SET);
+    assertThat(ps.addPsThen(m), empty());
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), contains("metric (dead-with-bare-reject)"));
+    // dedup: only the dedup warning, not the dead-with-bare-reject one
+    assertThat(ps.addPsThen(m), contains("metric (dedup)"));
+  }
+
+  @Test
+  public void testRejectThenMutatingOverwriteWarned() {
+    // metric 100; reject; metric 200 — metric 200 IS new dead config; warn for both the
+    // overwrite and the dead-with-reject. (Author wrote a new metric line that has no effect.)
+    PsThens ps = new PsThens();
+    assertThat(ps.addPsThen(new PsThenMetric(100, PsThenMetric.Operator.SET)), empty());
+    assertThat(ps.addPsThen(PsThenReject.INSTANCE), contains("metric (dead-with-bare-reject)"));
+    assertThat(
+        ps.addPsThen(new PsThenMetric(200, PsThenMetric.Operator.SET)),
+        contains("metric", "metric (dead-with-bare-reject)"));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-ps-then-conflicts
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-ps-then-conflicts
@@ -102,3 +102,20 @@ set policy-options policy-statement FC-NEXT-POLICY-NEXT-TERM term t1 then next p
 set policy-options policy-statement FC-NEXT-POLICY-NEXT-TERM term t1 then next term
 set policy-options policy-statement FC-NEXT-POLICY-NEXT-TERM term t2 then reject
 #
+# Mutating action + bare reject — every mutating line in the term is dead config
+set policy-options policy-statement FC-MUTATE-THEN-REJECT term t1 then metric 100
+set policy-options policy-statement FC-MUTATE-THEN-REJECT term t1 then community add RED
+set policy-options policy-statement FC-MUTATE-THEN-REJECT term t1 then reject
+#
+# Bare reject before a mutation — same dead-config interpretation
+set policy-options policy-statement FC-REJECT-THEN-MUTATE term t1 then reject
+set policy-options policy-statement FC-REJECT-THEN-MUTATE term t1 then metric 100
+#
+# default-action reject + bare accept — default-action is dead config (bare terminator wins)
+set policy-options policy-statement FC-DEFAULT-REJECT-THEN-ACCEPT term t1 then default-action reject
+set policy-options policy-statement FC-DEFAULT-REJECT-THEN-ACCEPT term t1 then accept
+#
+# default-action accept; default-action reject — same family last-wins
+set policy-options policy-statement FC-DEFAULT-ACCEPT-DEFAULT-REJECT term t1 then default-action accept
+set policy-options policy-statement FC-DEFAULT-ACCEPT-DEFAULT-REJECT term t1 then default-action reject
+#

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1479,6 +1479,13 @@
       },
       {
         "Filename" : "configs/juniper_policy_statement",
+        "Line" : 27,
+        "Text" : "default-action reject",
+        "Parser_Context" : "[popst_default_action_reject popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+        "Comment" : "RISK: Overwriting existing then default-action"
+      },
+      {
+        "Filename" : "configs/juniper_policy_statement",
         "Line" : 30,
         "Text" : "add 20",
         "Parser_Context" : "[popstm_add popst_metric popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
@@ -1577,10 +1584,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 219 results",
+      "notes" : "Found 220 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 219
+      "numResults" : 220
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71882,6 +71882,12 @@
               "Text" : "as-path-prepend \"456 123.1 789"
             },
             {
+              "Comment" : "RISK: Overwriting existing then default-action",
+              "Line" : 27,
+              "Parser_Context" : "[popst_default_action_reject popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "default-action reject"
+            },
+            {
               "Comment" : "RISK: Overwriting existing then metric",
               "Line" : 30,
               "Parser_Context" : "[popstm_add popst_metric popst_common pops_then pops_common pops_term po_policy_statement s_policy_options s_common statement set_line_tail set_line flat_juniper_configuration]",


### PR DESCRIPTION
Adds two RISKY warnings for `policy-statement` `then` blocks where
multiple actions in one term combine to leave config that does not fire
at runtime:

- **mutating action + bare `reject`**: when a term contains a bare
`reject` that actually fires (i.e. not suppressed by `next term`/
`next policy`), every mutating action in the same term (metric,
community add/delete/set, local-preference, etc.) is dead — the route
is discarded so changes don't propagate. One warning per dead line:
"then X has no effect on the propagated route when then reject is
also present in the same term".

- **`default-action` + bare terminator**: when a term contains both
`default-action accept`/`reject` and a bare `accept`/`reject` (in
either order), the bare terminator wins at runtime and the
`default-action` is dead. Warning: "then default-action is overridden
by bare then accept/reject in the same term: default-action does not
fire".

While here, treat `default-action accept`/`reject` as their own
last-wins family so that `default-action accept; default-action reject`
emits an "Overwriting existing then default-action" warning and
duplicates dedup. This catches a real conflict in the existing
`juniper_policy_statement` parsing fixture (lines 26-27).

`PsThenDefaultAction{Accept,Reject}` gain `equals`/`hashCode` so the
dedup detection works.

----

Prompt:
```
In the recent commit, we really improved Junos modeling of PsThen. I
had a few questions about risky warnings.

- If the terminal action of a policy is "then reject", but there are
mutating actions (not logging or sampling, but then metric for
example) this should be a warning -- mutating in the same term as
rejecting.
- If the term is definitive (accept/reject) then
default-action(-accept/-reject) is a no-op and should be a warning.
- Look around - are there other candidates?

Research and implement if missing
```

---
**Stack**:
- #9950 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*