### PR TITLE
Junos: warn when then community add/set overlaps then community delete

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/CommunityActionOverlap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/CommunityActionOverlap.java
@@ -1,0 +1,75 @@
+package org.batfish.representation.juniper;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.bgp.community.Community;
+
+/**
+ * Detects overlap between {@link NamedCommunity} structures used in same-term {@code then community
+ * add/set} and {@code then community delete} actions in a Junos {@code policy-statement}.
+ *
+ * <p>Junos applies {@code then} actions in declared order at runtime. When a {@code community
+ * add}/{@code community set} contributes a community that a later {@code community delete} also
+ * matches, the result is that the just-added community is silently removed. This is rarely
+ * intended.
+ *
+ * <p>Junos only contributes {@link LiteralCommunityMember}s when setting/adding (regex members are
+ * skipped at runtime). Junos {@code delete} matches literal and regex members alike, using
+ * substring-style {@link Pattern#find()} semantics on the colon-separated community string. This
+ * class implements that asymmetry.
+ */
+@ParametersAreNonnullByDefault
+final class CommunityActionOverlap {
+
+  /**
+   * Returns the literal communities that would be set/added by {@code adder} and also matched (and
+   * therefore removed) by {@code deleter}, formatted as colon-separated strings.
+   *
+   * <p>Empty result means there is no overlap (no warning is warranted).
+   */
+  static @Nonnull List<String> overlappingCommunities(
+      NamedCommunity adder, NamedCommunity deleter) {
+    ImmutableList.Builder<String> overlap = ImmutableList.builder();
+    for (CommunityMember addMember : adder.getMembers()) {
+      if (!(addMember instanceof LiteralCommunityMember literalAdd)) {
+        // Junos only contributes literal communities on add/set. Regex members are ignored.
+        continue;
+      }
+      Community c = literalAdd.getCommunity();
+      if (deleterMatches(deleter, c)) {
+        overlap.add(c.toString());
+      }
+    }
+    return overlap.build();
+  }
+
+  /**
+   * Returns true if {@code deleter} would match {@code c} according to Junos {@code delete}
+   * semantics: literal members match by equality; regex members match via {@link Pattern#find()} on
+   * the community's match string.
+   */
+  private static boolean deleterMatches(NamedCommunity deleter, Community c) {
+    String matchString = c.matchString();
+    for (CommunityMember m : deleter.getMembers()) {
+      if (m instanceof LiteralCommunityMember literal) {
+        if (literal.getCommunity().equals(c)) {
+          return true;
+        }
+      } else if (m instanceof RegexCommunityMember regex) {
+        try {
+          if (Pattern.compile(regex.getJavaRegex()).matcher(matchString).find()) {
+            return true;
+          }
+        } catch (java.util.regex.PatternSyntaxException ignored) {
+          // Malformed regex — caller already warns elsewhere; treat as non-match here.
+        }
+      }
+    }
+    return false;
+  }
+
+  private CommunityActionOverlap() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3147,6 +3147,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   @VisibleForTesting
   RoutingPolicy toRoutingPolicy(PolicyStatement ps) {
     detectMisplacedTerminalActions(ps);
+    detectCommunityActionOverlaps(ps);
 
     // Ensure map of VRFs referenced in routing policies is initialized
     if (_vrfReferencesInPolicies == null) {
@@ -4991,6 +4992,61 @@ public final class JuniperConfiguration extends VendorConfiguration {
     } else {
       throw new IllegalArgumentException(
           "Unknown terminal action type: " + terminalAction.getClass().getSimpleName());
+    }
+  }
+
+  /**
+   * Detects {@code then community add/set X; then community delete Y} same-term sequences where
+   * {@code X} and {@code Y} can match overlapping communities, so the just-added community is
+   * silently removed by the later delete.
+   */
+  private void detectCommunityActionOverlaps(PolicyStatement policy) {
+    Map<String, NamedCommunity> namedCommunities = _masterLogicalSystem.getNamedCommunities();
+    for (PsTerm term : policy.getTerms().values()) {
+      if (term.getThens() == null) {
+        continue;
+      }
+      List<PsThen> thens = term.getThens().getAllThens();
+      for (int i = 0; i < thens.size(); i++) {
+        PsThen earlier = thens.get(i);
+        if (!(earlier instanceof PsThenCommunityAdd || earlier instanceof PsThenCommunitySet)) {
+          continue;
+        }
+        String addName =
+            earlier instanceof PsThenCommunityAdd
+                ? ((PsThenCommunityAdd) earlier).getName()
+                : ((PsThenCommunitySet) earlier).getName();
+        NamedCommunity addCommunity = namedCommunities.get(addName);
+        if (addCommunity == null) {
+          continue;
+        }
+        String addVerb = earlier instanceof PsThenCommunityAdd ? "add" : "set";
+        for (int j = i + 1; j < thens.size(); j++) {
+          PsThen later = thens.get(j);
+          if (!(later instanceof PsThenCommunityDelete)) {
+            continue;
+          }
+          String delName = ((PsThenCommunityDelete) later).getName();
+          NamedCommunity delCommunity = namedCommunities.get(delName);
+          if (delCommunity == null) {
+            continue;
+          }
+          List<String> overlap =
+              CommunityActionOverlap.overlappingCommunities(addCommunity, delCommunity);
+          if (overlap.isEmpty()) {
+            continue;
+          }
+          _w.riskyRedFlag(
+              "'policy-statement %s term %s': then community %s %s adds %s, which is also matched"
+                  + " by then community delete %s in the same term, so it is removed",
+              policy.getName(),
+              term.getName(),
+              addVerb,
+              addName,
+              String.join(", ", overlap),
+              delName);
+        }
+      }
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -10115,6 +10115,50 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testCommunityAddDeleteOverlapWarnings() throws IOException {
+    String hostname = "juniper-community-add-delete-overlap";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    SortedSet<Warning> riskyWarnings = ccae.getWarnings().get(hostname).getRiskyRedFlagWarnings();
+
+    // Literal add overlapped by regex delete in the same term.
+    assertThat(
+        riskyWarnings,
+        hasItem(
+            WarningMatchers.hasText(
+                "RISK: 'policy-statement ADD-OVERLAPS-DELETE-REGEX term t1': then community add"
+                    + " RED adds 65000:1, which is also matched by then community delete"
+                    + " ALL_65000 in the same term, so it is removed")));
+    // Literal set overlapped by regex delete in the same term.
+    assertThat(
+        riskyWarnings,
+        hasItem(
+            WarningMatchers.hasText(
+                "RISK: 'policy-statement SET-OVERLAPS-DELETE-REGEX term t1': then community set"
+                    + " RED adds 65000:1, which is also matched by then community delete ALL in"
+                    + " the same term, so it is removed")));
+    // Literal add and literal delete on the exact same community.
+    assertThat(
+        riskyWarnings,
+        hasItem(
+            WarningMatchers.hasText(
+                "RISK: 'policy-statement ADD-OVERLAPS-DELETE-LITERAL term t1': then community add"
+                    + " RED adds 65000:1, which is also matched by then community delete RED in"
+                    + " the same term, so it is removed")));
+    // No overlap and delete-then-add cases must not produce overlap warnings.
+    assertTrue(
+        "ADD-NO-OVERLAP must not produce an overlap warning",
+        riskyWarnings.stream()
+            .noneMatch(w -> w.getText().contains("policy-statement ADD-NO-OVERLAP")));
+    assertTrue(
+        "DELETE-THEN-ADD must not produce an overlap warning",
+        riskyWarnings.stream()
+            .noneMatch(w -> w.getText().contains("policy-statement DELETE-THEN-ADD")));
+  }
+
+  @Test
   public void testPsToConditionsFlag() throws IOException {
     String hostname = "risky-terminal-actions";
     JuniperConfiguration juniperConfig = parseJuniperConfig(hostname);

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/CommunityActionOverlapTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/CommunityActionOverlapTest.java
@@ -1,0 +1,104 @@
+package org.batfish.representation.juniper;
+
+import static org.batfish.representation.juniper.CommunityActionOverlap.overlappingCommunities;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.junit.Test;
+
+/** Tests for {@link CommunityActionOverlap}. */
+public class CommunityActionOverlapTest {
+
+  private static NamedCommunity literalCommunity(String name, StandardCommunity... communities) {
+    NamedCommunity nc = new NamedCommunity(name);
+    for (StandardCommunity c : communities) {
+      nc.getMembers().add(new LiteralCommunityMember(c));
+    }
+    return nc;
+  }
+
+  private static NamedCommunity regexCommunity(String name, String... regexes) {
+    NamedCommunity nc = new NamedCommunity(name);
+    for (String r : regexes) {
+      nc.getMembers().add(new RegexCommunityMember(r));
+    }
+    return nc;
+  }
+
+  @Test
+  public void testLiteralVsLiteralExactMatch() {
+    NamedCommunity adder = literalCommunity("ADD", StandardCommunity.of(65000, 1));
+    NamedCommunity deleter = literalCommunity("DEL", StandardCommunity.of(65000, 1));
+    assertThat(overlappingCommunities(adder, deleter), contains("65000:1"));
+  }
+
+  @Test
+  public void testLiteralVsLiteralNoMatch() {
+    NamedCommunity adder = literalCommunity("ADD", StandardCommunity.of(65000, 1));
+    NamedCommunity deleter = literalCommunity("DEL", StandardCommunity.of(65000, 2));
+    assertThat(overlappingCommunities(adder, deleter), empty());
+  }
+
+  @Test
+  public void testLiteralAddVsRegexDeleteCatchAll() {
+    NamedCommunity adder = literalCommunity("ADD", StandardCommunity.of(65000, 1));
+    NamedCommunity deleter = regexCommunity("DEL", ".*:.*");
+    assertThat(overlappingCommunities(adder, deleter), contains("65000:1"));
+  }
+
+  @Test
+  public void testLiteralAddVsRegexDeleteSpecific() {
+    NamedCommunity adder = literalCommunity("ADD", StandardCommunity.of(65000, 1));
+    NamedCommunity deleter = regexCommunity("DEL", "^65000:");
+    assertThat(overlappingCommunities(adder, deleter), contains("65000:1"));
+  }
+
+  @Test
+  public void testLiteralAddVsRegexDeleteNoMatch() {
+    NamedCommunity adder = literalCommunity("ADD", StandardCommunity.of(65000, 1));
+    NamedCommunity deleter = regexCommunity("DEL", "^65001:");
+    assertThat(overlappingCommunities(adder, deleter), empty());
+  }
+
+  @Test
+  public void testMultipleLiteralMembersPartialOverlap() {
+    NamedCommunity adder =
+        literalCommunity(
+            "ADD",
+            StandardCommunity.of(65000, 1),
+            StandardCommunity.of(65000, 2),
+            StandardCommunity.of(65001, 1));
+    NamedCommunity deleter = regexCommunity("DEL", "^65000:");
+    assertThat(overlappingCommunities(adder, deleter), containsInAnyOrder("65000:1", "65000:2"));
+  }
+
+  @Test
+  public void testRegexAdderIsIgnored() {
+    // Junos does not contribute regex members on community add/set, so no overlap is reported
+    // even if the regexes obviously overlap.
+    NamedCommunity adder = regexCommunity("ADD", "^65000:1$");
+    NamedCommunity deleter = regexCommunity("DEL", ".*:.*");
+    assertThat(overlappingCommunities(adder, deleter), empty());
+  }
+
+  @Test
+  public void testMixedAdder() {
+    // Literal members of a mixed adder are checked against the deleter; regex members are
+    // ignored.
+    NamedCommunity adder = new NamedCommunity("ADD");
+    adder.getMembers().add(new LiteralCommunityMember(StandardCommunity.of(65000, 1)));
+    adder.getMembers().add(new RegexCommunityMember("^65001:"));
+    NamedCommunity deleter = regexCommunity("DEL", ".*:.*");
+    assertThat(overlappingCommunities(adder, deleter), contains("65000:1"));
+  }
+
+  @Test
+  public void testEmptyDeleterMembers() {
+    NamedCommunity adder = literalCommunity("ADD", StandardCommunity.of(65000, 1));
+    NamedCommunity deleter = new NamedCommunity("DEL");
+    assertThat(overlappingCommunities(adder, deleter), empty());
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-community-add-delete-overlap
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-community-add-delete-overlap
@@ -1,0 +1,35 @@
+#
+set system host-name juniper-community-add-delete-overlap
+#
+# Communities used in the policy-statements below.
+set policy-options community RED members 65000:1
+set policy-options community BLUE members 65000:2
+set policy-options community ALL_65000 members "^65000:"
+set policy-options community ALL members ".*:.*"
+set policy-options community OTHER members "^65001:"
+#
+# Bug pattern from the ticket: literal `add` of a community that is also matched by a
+# regex `delete` in the same term — the just-added community is silently removed.
+set policy-options policy-statement ADD-OVERLAPS-DELETE-REGEX term t1 then community add RED
+set policy-options policy-statement ADD-OVERLAPS-DELETE-REGEX term t1 then community delete ALL_65000
+set policy-options policy-statement ADD-OVERLAPS-DELETE-REGEX term t1 then accept
+#
+# `community set` followed by `community delete` matching the just-set community.
+set policy-options policy-statement SET-OVERLAPS-DELETE-REGEX term t1 then community set RED
+set policy-options policy-statement SET-OVERLAPS-DELETE-REGEX term t1 then community delete ALL
+set policy-options policy-statement SET-OVERLAPS-DELETE-REGEX term t1 then accept
+#
+# Add and delete with literal members that match exactly.
+set policy-options policy-statement ADD-OVERLAPS-DELETE-LITERAL term t1 then community add RED
+set policy-options policy-statement ADD-OVERLAPS-DELETE-LITERAL term t1 then community delete RED
+set policy-options policy-statement ADD-OVERLAPS-DELETE-LITERAL term t1 then accept
+#
+# No overlap: add RED, delete OTHER (regex that does not match RED). No warning expected.
+set policy-options policy-statement ADD-NO-OVERLAP term t1 then community add RED
+set policy-options policy-statement ADD-NO-OVERLAP term t1 then community delete OTHER
+set policy-options policy-statement ADD-NO-OVERLAP term t1 then accept
+#
+# Delete then add (no overlap warning — the add survives).
+set policy-options policy-statement DELETE-THEN-ADD term t1 then community delete ALL_65000
+set policy-options policy-statement DELETE-THEN-ADD term t1 then community add RED
+set policy-options policy-statement DELETE-THEN-ADD term t1 then accept


### PR DESCRIPTION
Detects same-term `then community add X; then community delete Y` (and
`set X; delete Y`) sequences where X and Y can match overlapping
communities, so the just-added community is silently removed by the
later delete. The bug is easy to write by accident when `delete Y` is a
broad regex (e.g. `.*:.*` or `^65000:`) intended to scrub inbound
communities while a later term re-adds policy-specific markers.

Junos asymmetry between set/add and delete is honored:

- `then community set/add` only contributes literal community members;
regex members are skipped at runtime, so they are not flagged as
adders here.
- `then community delete` matches both literal members (by equality)
and regex members (substring `Pattern.find()` on the colon-separated
community string, matching the runtime evaluator).

Regex-vs-regex (e.g. `add ALL_65000; delete ALL`) is intentionally not
flagged: Junos treats regex `add`/`set` as a no-op, so there is no
literal in the route to flag. Extended/large communities are not
covered for the same reason as the existing risky-regex check.

Wired in via `JuniperConfiguration.toRoutingPolicy` next to
`detectMisplacedTerminalActions`, so existing PsThens parse-time
warnings (overwrite/dedup/conflict) are unchanged.

----

Prompt:
```
Can we extend our regex-based validation to detect bugs like this?

In Junos there are `community set`, `community delete`, and `community
add` actions that you can do in a policy term. There are times when
performing some of these is effectively a no-op, or can be used in an
incorrect order leading to unwanted results.

For example, when adding (or setting) a community then deleting via a
regex that matches it, we end up removing the community even though we
clearly wanted to keep it on the route. Two examples:

term A {
then {
community set COMM1;
community delete ALL-COMMUNITIES;
}
}

term A {
then {
community add COMM1;
community delete ALL-COMMUNITIES;
}
}

Where `ALL-COMMUNITIES` is a regex `.*:.*`, we have effectively deleted
COMM1 even though we clearly wanted to set/add it. The same applies if
the deleting community is a more specific regex but happens to also
match the value of COMM1.

Implement this as a risky warning, including overlap with set.
```

---
**Stack**:
- #9951 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*