### PR TITLE
PAN-OS: model vlan-type interface units with IP, MTU, and SVI VLAN ID

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
@@ -271,12 +271,12 @@ snit_units
     UNITS snit_unit?
 ;
 
-sniv_ip
+snivu_ip
 :
     IP address = interface_address_or_reference
 ;
 
-sniv_mtu
+snivu_mtu
 :
     MTU mtu = uint32
 ;
@@ -286,8 +286,8 @@ sniv_unit
     name = variable
     (
         if_common
-        | sniv_ip
-        | sniv_mtu
+        | snivu_ip
+        | snivu_mtu
     )?
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
@@ -271,11 +271,23 @@ snit_units
     UNITS snit_unit?
 ;
 
+sniv_ip
+:
+    IP address = interface_address_or_reference
+;
+
+sniv_mtu
+:
+    MTU mtu = uint32
+;
+
 sniv_unit
 :
     name = variable
     (
         if_common
+        | sniv_ip
+        | sniv_mtu
     )?
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -2265,14 +2265,14 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
   }
 
   @Override
-  public void exitSniv_ip(PaloAltoParser.Sniv_ipContext ctx) {
+  public void exitSnivu_ip(PaloAltoParser.Snivu_ipContext ctx) {
     InterfaceAddress address = toInterfaceAddress(ctx.address);
     _currentInterface.addAddress(address);
     referenceInterfaceAddress(ctx.address, VLAN_INTERFACE_ADDRESS);
   }
 
   @Override
-  public void exitSniv_mtu(PaloAltoParser.Sniv_mtuContext ctx) {
+  public void exitSnivu_mtu(PaloAltoParser.Snivu_mtuContext ctx) {
     _currentInterface.setMtu(Integer.parseInt(getText(ctx.mtu)));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -74,6 +74,7 @@ import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.TUNNEL
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VIRTUAL_ROUTER_INTERFACE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VIRTUAL_ROUTER_SELF_REFERENCE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VIRTUAL_WIRE_INTERFACE_ZONE;
+import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VLAN_INTERFACE_ADDRESS;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VSYS_IMPORT_INTERFACE;
 import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.ZONE_INTERFACE;
 import static org.batfish.representation.palo_alto.Zone.Type.EXTERNAL;
@@ -2261,8 +2262,18 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
             .computeIfAbsent(name, n -> new Interface(n, Interface.Type.VLAN_UNIT));
     _currentInterface.setParent(_currentParentInterface);
     defineFlattenedStructure(INTERFACE, name, ctx);
-    // TODO: convert vlan ID for created vlan units
-    todo(ctx);
+  }
+
+  @Override
+  public void exitSniv_ip(PaloAltoParser.Sniv_ipContext ctx) {
+    InterfaceAddress address = toInterfaceAddress(ctx.address);
+    _currentInterface.addAddress(address);
+    referenceInterfaceAddress(ctx.address, VLAN_INTERFACE_ADDRESS);
+  }
+
+  @Override
+  public void exitSniv_mtu(PaloAltoParser.Sniv_mtuContext ctx) {
+    _currentInterface.setMtu(Integer.parseInt(getText(ctx.mtu)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2264,6 +2264,19 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       newIface.setEncapsulationVlan(iface.getTag());
     } else if (iface.getType() == Interface.Type.LAYER2) {
       newIface.setAccessVlan(iface.getTag());
+    } else if (iface.getType() == Interface.Type.VLAN_UNIT) {
+      // PAN-OS encodes the VLAN ID as the numeric suffix of the unit name
+      // (vlan.10 → VLAN 10). Surface that to Batfish's SVI machinery so the
+      // broadcast-domain → SVI bridge can resolve once the layer2 side is
+      // modeled as a trunk carrying matching VLAN IDs.
+      int dotIndex = iface.getName().lastIndexOf('.');
+      if (dotIndex > 0 && dotIndex < iface.getName().length() - 1) {
+        try {
+          newIface.setVlan(Integer.parseInt(iface.getName().substring(dotIndex + 1)));
+        } catch (NumberFormatException e) {
+          // Non-numeric suffix; skip SVI VLAN ID binding.
+        }
+      }
     }
 
     // add outgoing filter

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoStructureUsage.java
@@ -19,6 +19,7 @@ public enum PaloAltoStructureUsage implements StructureUsage {
   LAYER3_INTERFACE_ZONE("zone network layer3"),
   LOOPBACK_INTERFACE_ADDRESS("interface loopback ip"),
   TUNNEL_INTERFACE_ADDRESS("interface tunnel ip"),
+  VLAN_INTERFACE_ADDRESS("interface vlan ip"),
   NAT_RULE_DESTINATION("rulebase nat rules destination"),
   NAT_RULE_DESTINATION_TRANSLATION("rulebase nat rules destination-translation"),
   NAT_RULE_FROM_ZONE("rulebase nat rules from"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -42,6 +42,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOutgoingOriginalFlowFilter;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSpeed;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasZoneName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isLineUp;
@@ -4754,6 +4755,21 @@ public final class PaloAltoGrammarTest {
             "tunnel.3",
             hasAllAddresses(contains(ConcreteInterfaceAddress.parse("169.254.0.1/30")))));
     assertThat(c, hasInterface("tunnel.3", hasMtu(1427)));
+  }
+
+  @Test
+  public void testVlanUnitIp() {
+    String hostname = "paloalto_vlan_tunnel_units";
+    Configuration c = parseConfig(hostname);
+    // vlan.1 has ip 10.0.0.1/24 and mtu 1500 configured; confirm both appear in the VI model.
+    // The numeric suffix in vlan.1 should also surface as the SVI VLAN ID.
+    assertThat(
+        c,
+        hasInterface(
+            "vlan.1",
+            hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.0.1/24")))));
+    assertThat(c, hasInterface("vlan.1", hasMtu(1500)));
+    assertThat(c, hasInterface("vlan.1", hasVlan(1)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -4766,8 +4766,7 @@ public final class PaloAltoGrammarTest {
     assertThat(
         c,
         hasInterface(
-            "vlan.1",
-            hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.0.1/24")))));
+            "vlan.1", hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.0.1/24")))));
     assertThat(c, hasInterface("vlan.1", hasMtu(1500)));
     assertThat(c, hasInterface("vlan.1", hasVlan(1)));
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/paloalto_vlan_tunnel_units
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/paloalto_vlan_tunnel_units
@@ -23,7 +23,13 @@ config {
           vlan {
             comment "vlan comment";
             units {
-              vlan.1;
+              vlan.1 {
+                comment "vlan.1 comment";
+                ip {
+                  10.0.0.1/24;
+                }
+                mtu 1500;
+              }
             }
           }
         }

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1548,13 +1548,6 @@
         "Comment" : "This feature is not currently supported"
       },
       {
-        "Filename" : "configs/palo_alto/interfaces",
-        "Line" : 49,
-        "Text" : "vlan.1",
-        "Parser_Context" : "[sniv_unit sniv_units sni_vlan sn_interface s_network statement_config_devices set_line_config_devices set_line_tail set_line palo_alto_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
         "Filename" : "configs/palo_alto/nat",
         "Line" : 19,
         "Text" : "active-active-device-binding primary",
@@ -1584,10 +1577,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 220 results",
+      "notes" : "Found 219 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 220
+      "numResults" : 219
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71963,16 +71963,6 @@
             }
           ]
         },
-        "configs/palo_alto/interfaces" : {
-          "Parse warnings" : [
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 49,
-              "Parser_Context" : "[sniv_unit sniv_units sni_vlan sn_interface s_network statement_config_devices set_line_config_devices set_line_tail set_line palo_alto_configuration]",
-              "Text" : "vlan.1"
-            }
-          ]
-        },
         "configs/palo_alto/nat" : {
           "Parse warnings" : [
             {


### PR DESCRIPTION
PR #3952 (2019) added grammar for `vlan.X` units under `network interface vlan`, but the rule only accepted `if_common` (comments) and the visitor emitted a TODO without building anything. As a result, configs of the form

```
vlan {
  units {
    vlan.10 { ip { 192.0.2.1/29; } }
  }
}
```

parsed without warnings but produced no L3 interface — BGP local-address lookups against `vlan.X` failed to resolve, zones referencing `layer3 vlan.X` silently dropped the membership, and any traffic targeted at the SVI's IP was dropped at zone egress with `Cannot exit interface ... because it is not in a zone`.

This extends `sniv_unit` to accept `sniv_ip` and `sniv_mtu` (mirroring `snit_unit` for tunnel.X), wires the visitor to call `addAddress` / `setMtu` on the already-created `Interface(VLAN_UNIT)`, adds a `VLAN_INTERFACE_ADDRESS` structure usage for reference tracking, and in `PaloAltoConfiguration.toInterface` parses the numeric suffix of the unit name as the SVI's VLAN ID and surfaces it via `Interface.setVlan`. The existing VI→Configuration translation and the `Type.VLAN_UNIT → InterfaceType.VLAN` mapping already do the rest: the SVI shows up in `Configuration.getAllInterfaces`, gets its VRF binding from the virtual-router's interface list, and gets its zone binding from `zones.<name>.network.layer3`.

Out of scope: the broadcast-domain → SVI bridge through PAN-OS layer2 ae trunks. Today PA models each `ae2.X` sub-interface as its own `Type.LAYER2` access-mode interface (`accessVlan=X`) rather than treating the parent ae as a trunk port with `allowedVlans` aggregated from its sub-interfaces. With this PR the SVI carries the right VLAN ID, but Batfish's broadcast-domain logic typically bridges via TRUNK ports, so the data-plane hand-off from a layer2 ae to `vlan.X` will need a follow-up reshape on the layer2 side. Tracked separately in #9953.

Addresses #9933 (control-plane portion: BGP local-address resolution, zone membership, VRF binding, structure-reference tracking).
