### PR TITLE
AWS tests: hoist snapshot loading to @BeforeClass

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -71,19 +71,19 @@ import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
 import org.batfish.representation.aws.IpPermissions.AddressType;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** Tests for {@link ElasticsearchDomain} */
 public class ElasticsearchDomainTest {
 
-  @Rule public TemporaryFolder _folder = new TemporaryFolder();
-  private StaticRoute.Builder _staticRouteBuilder;
-  private Map<String, Configuration> _configurations;
-  private String _node0Name;
-  private String _node1Name;
+  @ClassRule public static TemporaryFolder _folder = new TemporaryFolder();
+  private static StaticRoute.Builder _staticRouteBuilder;
+  private static Map<String, Configuration> _configurations;
+  private static String _node0Name;
+  private static String _node1Name;
 
   public static final AclLineMatchExpr matchTcp =
       matchIpProtocol(TCP, traceElementForProtocol(TCP));
@@ -93,8 +93,8 @@ public class ElasticsearchDomainTest {
         IntegerSpace.of(new SubRange(fromPort, toPort)), traceElementForDstPorts(fromPort, toPort));
   }
 
-  @Before
-  public void setup() throws IOException {
+  @BeforeClass
+  public static void setup() throws IOException {
     _staticRouteBuilder =
         StaticRoute.testBuilder()
             .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
@@ -110,10 +110,6 @@ public class ElasticsearchDomainTest {
             1,
             "arn:aws:es:us-west-2:118292266645:domain/es-domain",
             "vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com");
-    _configurations = loadAwsConfigurations();
-  }
-
-  private Map<String, Configuration> loadAwsConfigurations() throws IOException {
     List<String> awsFilenames =
         ImmutableList.of(
             "ElasticsearchDomains.json",
@@ -129,11 +125,11 @@ public class ElasticsearchDomainTest {
                 .setAwsFiles("org/batfish/representation/aws/test", awsFilenames)
                 .build(),
             _folder);
-    return batfish.loadConfigurations(batfish.getSnapshot());
+    _configurations = batfish.loadConfigurations(batfish.getSnapshot());
   }
 
   @Test
-  public void testEsSubnetEdge() throws IOException {
+  public void testEsSubnetEdge() {
     Topology topology = TopologyUtil.synthesizeL3Topology(_configurations);
 
     // check that ES instance is a neighbor of both  subnets in which its interfaces are
@@ -155,7 +151,7 @@ public class ElasticsearchDomainTest {
 
   /** Check that IPs are unique for all the interfaces */
   @Test
-  public void testUniqueIps() throws IOException {
+  public void testUniqueIps() {
     List<Ip> ipsAsList =
         _configurations.values().stream()
             .map(Configuration::getAllInterfaces)

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -62,26 +62,24 @@ import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
 import org.batfish.representation.aws.IpPermissions.AddressType;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class RdsInstanceTest {
 
-  @Rule public TemporaryFolder _folder = new TemporaryFolder();
-  private StaticRoute.Builder _staticRouteBuilder;
+  @ClassRule public static TemporaryFolder _folder = new TemporaryFolder();
+  private static StaticRoute.Builder _staticRouteBuilder;
+  private static Map<String, Configuration> _configurations;
 
-  @Before
-  public void setup() {
+  @BeforeClass
+  public static void setup() throws IOException {
     _staticRouteBuilder =
         StaticRoute.testBuilder()
             .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
             .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
             .setNetwork(Prefix.ZERO);
-  }
-
-  public Map<String, Configuration> loadAwsConfigurations() throws IOException {
     List<String> awsFilenames =
         ImmutableList.of(
             "RdsInstances.json",
@@ -97,13 +95,12 @@ public class RdsInstanceTest {
                 .setAwsFiles("org/batfish/representation/aws/test", awsFilenames)
                 .build(),
             _folder);
-    return batfish.loadConfigurations(batfish.getSnapshot());
+    _configurations = batfish.loadConfigurations(batfish.getSnapshot());
   }
 
   @Test
-  public void testRdsSubnetEdge() throws IOException {
-    Map<String, Configuration> configurations = loadAwsConfigurations();
-    Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
+  public void testRdsSubnetEdge() {
+    Topology topology = TopologyUtil.synthesizeL3Topology(_configurations);
 
     // check that RDS instance is a neighbor of the deterministically chosen subnets in which its
     // interfaces are located.
@@ -117,12 +114,10 @@ public class RdsInstanceTest {
   }
 
   @Test
-  public void testUniqueIps() throws IOException {
-    Map<String, Configuration> configurations = loadAwsConfigurations();
-
+  public void testUniqueIps() {
     // check that  IPs are unique for all the interfaces
     List<Ip> ipsAsList =
-        configurations.values().stream()
+        _configurations.values().stream()
             .map(Configuration::getAllInterfaces)
             .map(Map::values)
             .flatMap(Collection::stream)
@@ -135,22 +130,19 @@ public class RdsInstanceTest {
   }
 
   @Test
-  public void testDefaultRoute() throws IOException {
-    Map<String, Configuration> configurations = loadAwsConfigurations();
+  public void testDefaultRoute() {
     StaticRoute defaultRoute = _staticRouteBuilder.setNextHopIp(Ip.parse("192.168.2.17")).build();
 
     // checking that the default route is installed to the deterministically chosen subnet.
-    assertThat(configurations, hasKey("test-rds"));
+    assertThat(_configurations, hasKey("test-rds"));
     assertThat(
-        configurations.get("test-rds").getDefaultVrf().getStaticRoutes(), contains(defaultRoute));
+        _configurations.get("test-rds").getDefaultVrf().getStaticRoutes(), contains(defaultRoute));
   }
 
   @Test
-  public void testSecurityGroupsAcl() throws IOException {
-    Map<String, Configuration> configurations = loadAwsConfigurations();
-
-    assertThat(configurations, hasKey("test-rds"));
-    Configuration testRds = configurations.get("test-rds");
+  public void testSecurityGroupsAcl() {
+    assertThat(_configurations, hasKey("test-rds"));
+    Configuration testRds = _configurations.get("test-rds");
     assertThat(testRds.getAllInterfaces().entrySet(), hasSize(1));
     assertThat(
         testRds


### PR DESCRIPTION
ElasticsearchDomainTest and RdsInstanceTest each loaded their AWS
snapshot inside @Before / per-test, even though the resulting
configurations are not mutated by any test. Switch both to @BeforeClass
+ @ClassRule so the snapshot is loaded once per class instead of 8 and
4 times respectively. Drops AWS representation test wall time from
~19s to ~16.5s.

----

Prompt:
```
//projects/batfish/src/test/java/org/batfish/representation/aws:tests
is pretty slow. Any easy perf improvements?
```

Follow-up: "do 2" -- implement the @BeforeClass hoist for
ElasticsearchDomainTest and RdsInstanceTest (skipping the suggested
shard_count change).

---
**Stack**:
- #9956 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*