### PR TITLE
PAN: bridge layer2 ae trunks to vlan-type SVIs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2264,6 +2264,22 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       newIface.setEncapsulationVlan(iface.getTag());
     } else if (iface.getType() == Interface.Type.LAYER2) {
       newIface.setAccessVlan(iface.getTag());
+    } else if (iface.getType() == Interface.Type.AGGREGATED_ETHERNET
+        && iface.getUnits().values().stream().anyMatch(u -> u.getType() == Interface.Type.LAYER2)) {
+      // PAN-OS layer2 aes carry one VLAN per tagged sub-interface (ae2.10 with
+      // tag 10, ae2.20 with tag 20, ...). Surface that to Batfish's L2
+      // topology by modeling the parent as a TRUNK port whose allowedVlans is
+      // the union of child tags, so a packet arriving on ae2 tagged X bridges
+      // to vlan.X for L3 processing.
+      IntegerSpace.Builder allowed = IntegerSpace.builder();
+      iface.getUnits().values().stream()
+          .filter(u -> u.getType() == Interface.Type.LAYER2)
+          .map(Interface::getTag)
+          .filter(Objects::nonNull)
+          .forEach(allowed::including);
+      newIface.setSwitchport(true);
+      newIface.setSwitchportMode(SwitchportMode.TRUNK);
+      newIface.setAllowedVlans(allowed.build());
     } else if (iface.getType() == Interface.Type.VLAN_UNIT) {
       // PAN-OS encodes the VLAN ID as the numeric suffix of the unit name
       // (vlan.10 → VLAN 10). Surface that to Batfish's SVI machinery so the
@@ -3358,6 +3374,11 @@ public class PaloAltoConfiguration extends VendorConfiguration {
           _w.redFlagf(
               "Interface %s is not in a virtual-router, placing in %s and shutting it down.",
               iface.getName(), nullVrf.getName());
+        } else if (iface.getSwitchportMode() == SwitchportMode.TRUNK) {
+          // Layer2 trunk parents (e.g., layer2 aes) don't belong to a
+          // virtual-router. Keep the trunk semantics so packets bridge through
+          // to SVIs; just place the interface in the null VRF as a
+          // placeholder.
         } else {
           // This is a parent interface. We can't shut it down, so instead we must just clear L2/L3
           // data.

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -34,6 +34,7 @@ import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMa
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAddress;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAddressMetadata;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasBandwidth;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDependencies;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
@@ -42,10 +43,12 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOutgoingOriginalFlowFilter;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSpeed;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSwitchPortMode;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasZoneName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isLineUp;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.isSwitchport;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.accepts;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
@@ -169,6 +172,7 @@ import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.common.matchers.ParseWarningMatchers;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.runtime.SnapshotRuntimeData;
+import org.batfish.common.topology.L3Adjacencies;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
@@ -184,6 +188,7 @@ import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.ConnectedRouteMetadata;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.DiffieHellmanGroup;
+import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.ExprAclLine;
@@ -206,11 +211,14 @@ import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.SwitchportMode;
+import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.collections.InsertOrderedMap;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.matchers.InterfaceMatchers;
 import org.batfish.datamodel.matchers.NssaSettingsMatchers;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
@@ -4769,6 +4777,61 @@ public final class PaloAltoGrammarTest {
             "vlan.1", hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.0.0.1/24")))));
     assertThat(c, hasInterface("vlan.1", hasMtu(1500)));
     assertThat(c, hasInterface("vlan.1", hasVlan(1)));
+  }
+
+  @Test
+  public void testLayer2AeBridgesToVlanUnit() {
+    // ae1 is a layer2 trunk carrying VLAN 10 and 20 via tagged sub-interfaces
+    // ae1.10 and ae1.20. vlan.10 and vlan.20 are SVIs for the matching VLANs.
+    // The parent ae must be modeled as a TRUNK with allowedVlans = {10, 20} so
+    // Batfish's L2 topology can bridge a tagged frame on ae1 to its SVI for L3
+    // processing.
+    String hostname = "paloalto_layer2_ae_svi";
+    Configuration c = parseConfig(hostname);
+    assertThat(c, hasInterface("ae1", isSwitchport()));
+    assertThat(c, hasInterface("ae1", hasSwitchPortMode(SwitchportMode.TRUNK)));
+    assertThat(
+        c,
+        hasInterface(
+            "ae1",
+            hasAllowedVlans(IntegerSpace.unionOf(IntegerSpace.of(10), IntegerSpace.of(20)))));
+    assertThat(c, hasInterface("vlan.10", hasVlan(10)));
+    assertThat(c, hasInterface("vlan.20", hasVlan(20)));
+  }
+
+  /**
+   * End-to-end check that a packet on a PAN-OS layer2 ae trunk bridges to its matching {@code
+   * vlan.X} SVI for L3 processing. Two PA devices: {@code pa_fw} has a layer2 ae1 carrying VLAN 10
+   * (sub-interface ae1.10 tag 10) plus an SVI vlan.10 (10.0.10.1/24); {@code r1} has an aggregate
+   * ae1 with a layer3 sub-interface ae1.10 tag 10 (10.0.10.2/24). The L1 link is ethernet1/1 ↔
+   * ethernet1/1. We expect pa_fw.vlan.10 and r1.ae1.10 to land in the same broadcast domain and to
+   * form a layer-3 edge.
+   */
+  @Test
+  public void testLayer2AeBridgesToVlanUnitL3() throws IOException {
+    String snapshotName = "layer2_ae_trunk";
+    String pa = "pa_fw";
+    String r1 = "r1";
+    String resourcePrefix = SNAPSHOTS_PREFIX + snapshotName;
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setLayer1TopologyPrefix(resourcePrefix)
+                .setConfigurationFiles(resourcePrefix, ImmutableSet.of(pa, r1))
+                .build(),
+            _folder);
+    batfish.loadConfigurations(batfish.getSnapshot());
+
+    L3Adjacencies adjacencies =
+        batfish.getTopologyProvider().getInitialL3Adjacencies(batfish.getSnapshot());
+    NodeInterfacePair svi = NodeInterfacePair.of(pa, "vlan.10");
+    NodeInterfacePair peer = NodeInterfacePair.of(r1, "ae1.10");
+    assertTrue(adjacencies.inSameBroadcastDomain(svi, peer));
+
+    Topology layer3Topology =
+        batfish.getTopologyProvider().getInitialLayer3Topology(batfish.getSnapshot());
+    Edge edge = Edge.of(pa, "vlan.10", r1, "ae1.10");
+    assertThat(layer3Topology.getEdges(), containsInAnyOrder(edge, edge.reverse()));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots/layer2_ae_trunk/configs/pa_fw
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots/layer2_ae_trunk/configs/pa_fw
@@ -1,0 +1,46 @@
+!RANCID-CONTENT-TYPE: paloalto
+config {
+  devices {
+    localhost.localdomain {
+      deviceconfig {
+        system {
+          hostname "pa_fw";
+        }
+      }
+      network {
+        interface {
+          ethernet {
+            ethernet1/1 {
+              aggregate-group ae1;
+            }
+          }
+          aggregate-ethernet {
+            ae1 {
+              layer2 {
+                units {
+                  ae1.10 {
+                    tag 10;
+                  }
+                }
+              }
+            }
+          }
+          vlan {
+            units {
+              vlan.10 {
+                ip {
+                  10.0.10.1/24;
+                }
+              }
+            }
+          }
+        }
+        virtual-router {
+          default {
+            interface [ vlan.10 ];
+          }
+        }
+      }
+    }
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots/layer2_ae_trunk/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots/layer2_ae_trunk/configs/r1
@@ -1,0 +1,40 @@
+!RANCID-CONTENT-TYPE: paloalto
+config {
+  devices {
+    localhost.localdomain {
+      deviceconfig {
+        system {
+          hostname "r1";
+        }
+      }
+      network {
+        interface {
+          ethernet {
+            ethernet1/1 {
+              aggregate-group ae1;
+            }
+          }
+          aggregate-ethernet {
+            ae1 {
+              layer3 {
+                units {
+                  ae1.10 {
+                    tag 10;
+                    ip {
+                      10.0.10.2/24;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        virtual-router {
+          default {
+            interface [ ae1.10 ];
+          }
+        }
+      }
+    }
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots/layer2_ae_trunk/layer1_topology.json
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots/layer2_ae_trunk/layer1_topology.json
@@ -1,0 +1,14 @@
+{
+  "edges": [
+    {
+      "node1": {
+        "hostname": "pa_fw",
+        "interfaceName": "ethernet1/1"
+      },
+      "node2": {
+        "hostname": "r1",
+        "interfaceName": "ethernet1/1"
+      }
+    }
+  ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/paloalto_layer2_ae_svi
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/paloalto_layer2_ae_svi
@@ -1,0 +1,54 @@
+!RANCID-CONTENT-TYPE: paloalto
+config {
+  devices {
+    localhost.localdomain {
+      deviceconfig {
+        system {
+          hostname "paloalto_layer2_ae_svi";
+        }
+      }
+      network {
+        interface {
+          ethernet {
+            ethernet1/1 {
+              aggregate-group ae1;
+            }
+          }
+          aggregate-ethernet {
+            ae1 {
+              layer2 {
+                units {
+                  ae1.10 {
+                    tag 10;
+                  }
+                  ae1.20 {
+                    tag 20;
+                  }
+                }
+              }
+            }
+          }
+          vlan {
+            units {
+              vlan.10 {
+                ip {
+                  10.0.10.1/24;
+                }
+              }
+              vlan.20 {
+                ip {
+                  10.0.20.1/24;
+                }
+              }
+            }
+          }
+        }
+        virtual-router {
+          default {
+            interface [ vlan.10 vlan.20 ];
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A PAN layer2 ae carries one VLAN per tagged sub-interface (ae2.10 tag
10, ae2.20 tag 20, ...). The control-plane side (vlan.X with IP, MTU,
VLAN ID) was modeled previously, but the parent ae was still emitted
as a plain AGGREGATED interface with no switchport semantics, so a
packet arriving on the ae tagged X never reached vlan.X for L3.

Emit the parent ae as a TRUNK switchport whose allowedVlans is the
union of its layer2 sub-interface tags. Combined with setVlan(N) on
vlan.N units, the L2 broadcast-domain → SVI bridge now wires the trunk
to the matching SVI. Preserve switchportMode/allowedVlans on layer2
trunk parents during orphan-VRF cleanup; layer2 trunks have no VRF by
design and the existing scrub would zero them out.

Tested with a 2-node snapshot (ae1 ↔ ae1 over an L1 link) confirming
both inSameBroadcastDomain and the initial layer3 topology agree
pa_fw.vlan.10 ↔ r1.ae1.10.

Fix batfish/batfish#9933, fix batfish/batfish#9953.

----

Prompt:
```
Analyze and implement https://github.com/batfish/batfish/issues/9933 , https://github.com/batfish/batfish/issues/9953
```

Follow-up: added the 2-node L3-adjacency snapshot
(snapshots/layer2_ae_trunk) to verify the bridge establishes, not just
the structural shape of the parent ae.

---
**Stack**:
- #9957 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*