### PR TITLE
Junos: don't crash on community regex with dk.brics-reserved chars

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RegexCommunityMember.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RegexCommunityMember.java
@@ -8,6 +8,7 @@ import dk.brics.automaton.Automaton;
 import dk.brics.automaton.RegExp;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.community.Community;
@@ -60,6 +61,19 @@ public final class RegexCommunityMember implements CommunityMember {
     return REGEX_CACHE.get(junosRegex);
   }
 
+  /**
+   * Characters that have no special meaning in Java regex but are reserved in dk.brics automaton's
+   * {@link RegExp} syntax (e.g., {@code <0-65535>} for numeric ranges, {@code ~} for complement,
+   * {@code &} for intersection, {@code @} for any string, {@code #} for empty language, {@code "}
+   * for literal strings). Escape these when feeding a Java-regex-like pattern to dk.brics so that
+   * they are treated as literals — matching what {@link java.util.regex.Pattern} does at runtime.
+   */
+  private static final Pattern DK_BRICS_SPECIAL_CHARS = Pattern.compile("([<>~&@#\"])");
+
+  private static String escapeForDkBrics(String javaRegex) {
+    return DK_BRICS_SPECIAL_CHARS.matcher(javaRegex).replaceAll("\\\\$1");
+  }
+
   private static List<String> getUnintendedCommunityMatchesImpl(String junosRegex) {
     if (junosRegex.split(":", -1).length != 2) {
       return ImmutableList.of();
@@ -80,7 +94,7 @@ public final class RegexCommunityMember implements CommunityMember {
     // This replacement is necessary because otherwise something like .....:..... will be treated as
     // allowing shorter communities such as 1:2 by matching, e.g., xx^^1:2$$xx. Make the . only
     // match numbers to disallow this. This stems from the lack of ^$ support.
-    String regex = javaRegex.replaceAll("\\.", "[0-9]");
+    String regex = escapeForDkBrics(javaRegex.replaceAll("\\.", "[0-9]"));
 
     RegExp r = new RegExp(".*" + regex + ".*");
     RegExp rClipped = new RegExp("^?^" + regex + "$$?");

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/CommunityMemberParseResultTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/CommunityMemberParseResultTest.java
@@ -105,5 +105,13 @@ public class CommunityMemberParseResultTest {
     assertThat(
         parseCommunityMember("^123:456$"),
         equalTo(new CommunityMemberParseResult(new RegexCommunityMember("^123:456$"), null)));
+    // Regex with a dk.brics-reserved char that's a literal in Java regex: parse without crash, and
+    // surface a warning describing the unintended-match risk introduced by the optional '<'.
+    assertThat(
+        parseCommunityMember("12345<?:1"),
+        equalTo(
+            new CommunityMemberParseResult(
+                new RegexCommunityMember("12345<?:1"),
+                "Community regex 12345<?:1 allows longer matches such as 12345:10")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/RegexCommunityMemberTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/RegexCommunityMemberTest.java
@@ -31,4 +31,30 @@ public class RegexCommunityMemberTest {
     assertThat(getUnintendedCommunityMatches("12345:5[12][34]"), contains("12345:5130"));
     assertThat(getUnintendedCommunityMatches("12345:"), contains("12345:0"));
   }
+
+  /**
+   * The dk.brics RegExp syntax reserves chars (e.g., {@code <>~&#@"}) that have no special meaning
+   * in Java regex. Such chars must be escaped before passing to dk.brics so analysis doesn't crash.
+   * The chars themselves can never appear in a real BGP community (digits and {@code :} only), so
+   * any regex containing them as literals matches nothing valid; analysis still proceeds on the
+   * surrounding parts of the regex.
+   *
+   * <p>Verified on vJunos 25.4R1.12 that {@code set policy-options community FOO members
+   * "12345<?:1"} (quoted or unquoted) is accepted by the CLI and passes {@code commit check}, so
+   * Batfish must handle it.
+   */
+  @Test
+  public void testDkBricsReservedCharsDoNotCrash() {
+    // 12345<?:1 is literal "12345", optional "<", then ":1" — analysis suggests "12345:10" which
+    // is reasonable: the regex matches both "12345:1" and "12345<:1" and can extend at the end.
+    assertThat(getUnintendedCommunityMatches("12345<?:1"), contains("12345:10"));
+    // Each of these chars is literal in Java regex but special in dk.brics; escaping prevents the
+    // crash. Returns empty because the literal char rules out matching any standard community.
+    assertThat(getUnintendedCommunityMatches("123<:456"), empty());
+    assertThat(getUnintendedCommunityMatches("123~:456"), empty());
+    assertThat(getUnintendedCommunityMatches("123&:456"), empty());
+    assertThat(getUnintendedCommunityMatches("123@:456"), empty());
+    assertThat(getUnintendedCommunityMatches("123#:456"), empty());
+    assertThat(getUnintendedCommunityMatches("123\":456"), empty());
+  }
 }


### PR DESCRIPTION
The community regex risk-analysis path constructs dk.brics RegExp objects
from user-supplied Java-regex syntax. Chars like `<`, `>`, `~`, `&`, `@`,
`#`, and `"` are literals in Java regex but are reserved in dk.brics
syntax (numeric ranges, complement, intersection, etc.). A Junos config
with `community FOO members 12345<?:1` thus crashed the parser with
`IllegalArgumentException: expected '>'`, propagating up to a
`BatfishParseException` that caused the entire snapshot to fail to load
even in lenient mode.

Escape these chars before feeding the user's regex to dk.brics so they
are treated as literals — matching what java.util.regex does at runtime.
The risk-analysis warnings now fire on the surrounding regex parts
(e.g., `12345<?:1` warns about unintended longer matches such as
`12345:10`) rather than crashing.

Verified on vJunos 25.4R1.12 that `set policy-options community FOO
members "12345<?:1"` is accepted by the CLI and passes commit check, so
Batfish must handle such configs gracefully.

----

Prompt:
```
A config file is purported to crash Batfish's junos parser. Create a
minimal repro, then use red/green TDD to fix it.
```

---
**Stack**:
- #9964 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*