### PR TITLE
java-format: pre-commit wrapper to dodge ARG_MAX on huge changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: java-format
         name: java-format
-        entry: bazel --noblock_for_lock run //tools/format:format.fix --
+        entry: tools/fix_java_format.sh
         language: system
         files: '\.java$'
         require_serial: true

--- a/tools/fix_java_format.sh
+++ b/tools/fix_java_format.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Pre-commit wrapper for //tools/format:format.fix.
+#
+# Writes the file list to an @argfile and passes only that single arg
+# through `bazel run`. Avoids ARG_MAX (E2BIG) when bazel's launcher
+# execvs /bin/bash on commits that touch thousands of .java files.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ARGFILE="$(mktemp -t batfish-format-XXXXXX)"
+trap 'rm -f "${ARGFILE}"' EXIT
+
+# Pre-commit passes paths relative to the repo root; absolutize them so
+# bazel run (which changes cwd) can resolve them.
+for f in "$@"; do
+  case "${f}" in
+    /*) printf '%s\n' "${f}" ;;
+    *)  printf '%s/%s\n' "${REPO_ROOT}" "${f}" ;;
+  esac
+done > "${ARGFILE}"
+
+cd "${REPO_ROOT}"
+bazel --noblock_for_lock run //tools/format:format.fix -- "@${ARGFILE}"

--- a/tools/format/format.sh
+++ b/tools/format/format.sh
@@ -48,6 +48,7 @@ if [ "$#" -gt 0 ]; then
   FILES=()
   for f in "$@"; do
     case "${f}" in
+      @*) FILES+=("${f}") ;;
       /*) FILES+=("${f}") ;;
       *)  FILES+=("${WORKDIR}/${f}") ;;
     esac


### PR DESCRIPTION
`bazel run //tools/format:format.fix -- <files>` execvs /bin/bash
(the launcher script). On commits that touch thousands of .java
files, the argv plus bazel's env exceeds the kernel's ARG_MAX and
execv fails with E2BIG. pre-commit's own batching is by raw argv
length and doesn't account for the bazel wrapper's overhead, so
several batches still tripped the limit.

Restore tools/fix_java_format.sh as a thin pre-commit wrapper:
write the file list to a temp @argfile and pass only that single
argument through bazel run. google-java-format reads @argfile
natively (the pre-#9962 fix_java_format.sh used the same trick).
Teach format.sh to pass @-prefixed args through unchanged instead
of treating them as relative paths.

CI is unaffected -- //tools/format:format.check runs with no file
args and scans via the find path inside format.sh.

----

Prompt:
```
pre-commit fails on a really big change:

There were tests whose specified size is too big. Use the
--test_verbose_timeout_warnings command line option to see which
ones these are.
bazel test //... succeeded
java-format..............................................................Failed
- hook id: java-format
- exit code: 37

Target //tools/format:format.fix up-to-date:
bazel-bin/tools/format/format.fix
FATAL: execv of '/bin/bash' failed: (error: 7): Argument list too long
```

Refined through the conversation: keep the old tools/fix_java_format.sh
name for the wrapper rather than introducing tools/format/format-precommit.sh.

---
**Stack**:
- #9965 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*