### PR TITLE
caches: migrate Guava caches to Caffeine, ban Guava cache imports

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -31,9 +31,9 @@ import static org.batfish.specifier.LocationInfoUtils.computeLocationInfo;
 import static org.batfish.vendor.check_point_management.parsing.CheckpointManagementParser.parseCheckpointManagementData;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
-import com.google.common.cache.Cache;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -74,7 +74,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -1136,23 +1135,24 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @Override
   public DataPlane loadDataPlane(NetworkSnapshot snapshot) {
-    try {
-      return _cachedDataPlanes.get(
-          snapshot,
-          () -> {
-            LOGGER.info("Data plane cache miss on snapshot {}", snapshot);
-            long start = System.currentTimeMillis();
-            newBatch("Loading data plane from disk", 0);
-            DataPlane dp = _storage.loadDataPlane(snapshot);
-            LOGGER.info(
-                "Loading data plane for snapshot {} took {}ms",
-                snapshot,
-                System.currentTimeMillis() - start);
-            return dp;
-          });
-    } catch (ExecutionException e) {
-      throw new RuntimeException(e);
-    }
+    return _cachedDataPlanes.get(
+        snapshot,
+        key -> {
+          LOGGER.info("Data plane cache miss on snapshot {}", key);
+          long start = System.currentTimeMillis();
+          newBatch("Loading data plane from disk", 0);
+          DataPlane dp;
+          try {
+            dp = _storage.loadDataPlane(key);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+          LOGGER.info(
+              "Loading data plane for snapshot {} took {}ms",
+              key,
+              System.currentTimeMillis() - start);
+          return dp;
+        });
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/main/BfCache.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BfCache.java
@@ -1,7 +1,7 @@
 package org.batfish.main;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
@@ -33,7 +33,7 @@ public final class BfCache {
   private BfCache() {}
 
   static Cache<NetworkSnapshot, DataPlane> buildDataPlaneCache() {
-    return CacheBuilder.newBuilder().softValues().maximumSize(MAX_CACHED_DATA_PLANES).build();
+    return Caffeine.newBuilder().softValues().maximumSize(MAX_CACHED_DATA_PLANES).build();
   }
 
   static Map<NetworkSnapshot, SortedMap<String, BgpAdvertisementsByVrf>>
@@ -42,13 +42,10 @@ public final class BfCache {
   }
 
   static Cache<NetworkSnapshot, SortedMap<String, Configuration>> buildTestrigCache() {
-    return CacheBuilder.newBuilder().softValues().maximumSize(MAX_CACHED_TESTRIGS).build();
+    return Caffeine.newBuilder().softValues().maximumSize(MAX_CACHED_TESTRIGS).build();
   }
 
   static Cache<NetworkSnapshot, Map<String, VendorConfiguration>> buildVendorConfigurationCache() {
-    return CacheBuilder.newBuilder()
-        .softValues()
-        .maximumSize(MAX_CACHED_VENDOR_CONFIGURATIONS)
-        .build();
+    return Caffeine.newBuilder().softValues().maximumSize(MAX_CACHED_VENDOR_CONFIGURATIONS).build();
   }
 }

--- a/projects/batfish/src/test/java/BUILD.bazel
+++ b/projects/batfish/src/test/java/BUILD.bazel
@@ -19,6 +19,7 @@ java_library(
         "//projects/common",
         "//projects/common/src/test/java/org/batfish/datamodel:testlib",
         "//projects/symbolic",
+        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -9,8 +9,8 @@ import static org.batfish.common.BfConsts.RELPATH_HOST_CONFIGS_DIR;
 import static org.batfish.common.BfConsts.RELPATH_SONIC_CONFIGS_DIR;
 import static org.batfish.common.util.Resources.readResourceBytes;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -63,7 +63,7 @@ public class BatfishTestUtils {
   }
 
   private static Cache<NetworkSnapshot, SortedMap<String, Configuration>> makeTestrigCache() {
-    return CacheBuilder.newBuilder().softValues().maximumSize(5).build();
+    return Caffeine.newBuilder().softValues().maximumSize(5).build();
   }
 
   private static Map<NetworkSnapshot, SortedMap<String, BgpAdvertisementsByVrf>> makeEnvBgpCache() {
@@ -71,12 +71,12 @@ public class BatfishTestUtils {
   }
 
   private static Cache<NetworkSnapshot, DataPlane> makeDataPlaneCache() {
-    return CacheBuilder.newBuilder().softValues().maximumSize(2).build();
+    return Caffeine.newBuilder().softValues().maximumSize(2).build();
   }
 
   private static Cache<NetworkSnapshot, Map<String, VendorConfiguration>>
       makeVendorConfigurationCache() {
-    return CacheBuilder.newBuilder().softValues().maximumSize(2).build();
+    return Caffeine.newBuilder().softValues().maximumSize(2).build();
   }
 
   private static void setNextTestNetworkSnapshot(Settings settings) {

--- a/projects/checkstyle-suppressions.xml
+++ b/projects/checkstyle-suppressions.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <!--
+    IpSpaceToBDD relies on Guava cache behavior that Caffeine does not support: a loader that
+    recurses into the same cache, and a synchronous removalListener that frees evicted BDDs on
+    the calling thread. See the comment on the class. Exempt it from the com.google.common.cache
+    import ban.
+  -->
+  <suppress checks="IllegalImport"
+            files="org[\\/]batfish[\\/]common[\\/]bdd[\\/]IpSpaceToBDD\.java"/>
+</suppressions>

--- a/projects/checkstyle.xml
+++ b/projects/checkstyle.xml
@@ -37,6 +37,11 @@
   <!-- Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation -->
   <module name="SuppressWarningsFilter"/>
 
+  <!-- File-scoped suppressions (e.g. exempting specific files from the com.google.common.cache ban) -->
+  <module name="SuppressionFilter">
+    <property name="file" value="projects/checkstyle-suppressions.xml"/>
+  </module>
+
   <module name="TreeWalker">
     <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
     <module name="SuppressWarningsHolder"/>
@@ -44,7 +49,7 @@
     <module name="IllegalImport">
       <property name="illegalClasses"
                 value="com.google.common.io.Files,com.google.common.base.Objects,org.hamcrest.CoreMatchers,org.hamcrest.MatcherAssert,com.fasterxml.jackson.annotation.JsonPropertyDescription,com.google.common.collect.Sets.SetView"/>
-      <property name="illegalPkgs" value="sun.reflect,org.checkerframework.checker.nullness.qual,org.glassfish.jersey.internal"/>
+      <property name="illegalPkgs" value="sun.reflect,org.checkerframework.checker.nullness.qual,org.glassfish.jersey.internal,com.google.common.cache"/>
     </module>
 
     <!-- Repeated this module with regex filter for classes -->

--- a/projects/common/src/main/java/org/batfish/common/bdd/IpSpaceToBDD.java
+++ b/projects/common/src/main/java/org/batfish/common/bdd/IpSpaceToBDD.java
@@ -42,6 +42,11 @@ import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
  * <p>For all implementations, it must be the case that all returned {@link BDD} objects are owned
  * by the caller and may be freed.
  */
+// Guava's cache is used here rather than Caffeine because this cache relies on behavior Caffeine
+// does not support: a loader that recurses into the same cache (Caffeine's get is built on
+// ConcurrentHashMap.computeIfAbsent, which forbids recursive updates) and a synchronous
+// removalListener that frees evicted BDDs on the calling thread (BDDFactory is not threadsafe).
+// The Guava cache imports are exempted from the IllegalImport ban in checkstyle-suppressions.xml.
 public final class IpSpaceToBDD implements GenericIpSpaceVisitor<BDD> {
 
   private final BDDInteger _bddInteger;

--- a/projects/common/src/main/java/org/batfish/common/util/PatternProvider.java
+++ b/projects/common/src/main/java/org/batfish/common/util/PatternProvider.java
@@ -1,8 +1,7 @@
 package org.batfish.common.util;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -12,7 +11,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public final class PatternProvider {
 
   public static @Nonnull Pattern fromString(String regex) {
-    return CACHE.getUnchecked(regex);
+    return CACHE.get(regex);
   }
 
   private PatternProvider() {}
@@ -20,8 +19,5 @@ public final class PatternProvider {
   // Soft values: let it be garbage collected in times of pressure.
   // Maximum size 2^16: Just some upper bound on cache size, well less than GiB.
   private static final LoadingCache<String, Pattern> CACHE =
-      CacheBuilder.newBuilder()
-          .softValues()
-          .maximumSize(1 << 16)
-          .build(CacheLoader.<String, Pattern>from(Pattern::compile));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 16).build(Pattern::compile);
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/AsPath.java
@@ -4,10 +4,9 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.Predicates;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
@@ -53,10 +52,7 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
   // Maximum size 2^16: Just some upper bound on cache size, well less than GiB.
   //   (24 bytes seems smallest possible entry (list(set(long)), would be 1.5 MiB total).
   private static final LoadingCache<ImmutableList<AsSet>, AsPath> CACHE =
-      CacheBuilder.newBuilder()
-          .softValues()
-          .maximumSize(1 << 16)
-          .build(CacheLoader.from(AsPath::new));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 16).build(AsPath::new);
 
   private AsPath(ImmutableList<AsSet> asSets) {
     _asSets = asSets;
@@ -83,7 +79,7 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
       return empty();
     }
     ImmutableList<AsSet> immutableValue = ImmutableList.copyOf(asSets);
-    return CACHE.getUnchecked(immutableValue);
+    return CACHE.get(immutableValue);
   }
 
   /**

--- a/projects/common/src/main/java/org/batfish/datamodel/Ip.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Ip.java
@@ -4,9 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
@@ -21,7 +20,7 @@ public class Ip implements Comparable<Ip>, Serializable {
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   //   (4 bytes seems smallest possible entry (int), would be 4 MiB total).
   private static final LoadingCache<Ip, Ip> CACHE =
-      CacheBuilder.newBuilder().softValues().maximumSize(1 << 20).build(CacheLoader.from(x -> x));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(x -> x);
 
   public static final Ip FIRST_CLASS_A_PRIVATE_IP = parse("10.0.0.0");
 
@@ -144,7 +143,7 @@ public class Ip implements Comparable<Ip>, Serializable {
   /** Create an {@link Ip} from the unsigned 32-bit representation stored in an {@code int}. */
   public static Ip create(int ipAsInt) {
     Ip ip = new Ip(ipAsInt);
-    return CACHE.getUnchecked(ip);
+    return CACHE.get(ip);
   }
 
   public long asLong() {
@@ -250,6 +249,6 @@ public class Ip implements Comparable<Ip>, Serializable {
   /** Cache after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(this);
+    return CACHE.get(this);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/Ip6Ip6Space.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Ip6Ip6Space.java
@@ -2,10 +2,9 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import javax.annotation.Nonnull;
@@ -16,17 +15,14 @@ public class Ip6Ip6Space extends Ip6Space {
   // Soft values: let it be garbage collected in times of pressure.
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   private static final LoadingCache<Ip6, Ip6Ip6Space> CACHE =
-      CacheBuilder.newBuilder()
-          .softValues()
-          .maximumSize(1 << 20)
-          .build(CacheLoader.from(Ip6Ip6Space::new));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(Ip6Ip6Space::new);
   private static final String PROP_IP6 = "ip6";
 
   private final Ip6 _ip6;
 
   @JsonCreator
   static Ip6Ip6Space create(@JsonProperty(PROP_IP6) Ip6 ip6) {
-    return CACHE.getUnchecked(ip6);
+    return CACHE.get(ip6);
   }
 
   private Ip6Ip6Space(Ip6 ip6) {
@@ -66,6 +62,6 @@ public class Ip6Ip6Space extends Ip6Space {
   /** Cache after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(_ip6);
+    return CACHE.get(_ip6);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/Ip6WildcardIp6Space.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Ip6WildcardIp6Space.java
@@ -2,10 +2,9 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import javax.annotation.Nonnull;
@@ -15,17 +14,14 @@ public class Ip6WildcardIp6Space extends Ip6Space {
   // Soft values: let it be garbage collected in times of pressure.
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   private static final LoadingCache<Ip6Wildcard, Ip6WildcardIp6Space> CACHE =
-      CacheBuilder.newBuilder()
-          .softValues()
-          .maximumSize(1 << 20)
-          .build(CacheLoader.from(Ip6WildcardIp6Space::new));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(Ip6WildcardIp6Space::new);
   private static final String PROP_IP6_WILDCARD = "ip6Wildcard";
 
   private final Ip6Wildcard _ip6Wildcard;
 
   @JsonCreator
   static Ip6WildcardIp6Space create(@JsonProperty(PROP_IP6_WILDCARD) Ip6Wildcard ip6Wildcard) {
-    return CACHE.getUnchecked(ip6Wildcard);
+    return CACHE.get(ip6Wildcard);
   }
 
   private Ip6WildcardIp6Space(Ip6Wildcard ip6Wildcard) {
@@ -65,6 +61,6 @@ public class Ip6WildcardIp6Space extends Ip6Space {
   /** Cache after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(_ip6Wildcard);
+    return CACHE.get(_ip6Wildcard);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/IpIpSpace.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/IpIpSpace.java
@@ -2,10 +2,9 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
@@ -15,17 +14,14 @@ public class IpIpSpace extends IpSpace {
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   //   (12 bytes seems smallest possible entry (long + int), would be 12 MiB total).
   private static final LoadingCache<Ip, IpIpSpace> CACHE =
-      CacheBuilder.newBuilder()
-          .softValues()
-          .maximumSize(1 << 20)
-          .build(CacheLoader.from(IpIpSpace::new));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(IpIpSpace::new);
   private static final String PROP_IP = "ip";
 
   private final Ip _ip;
 
   @JsonCreator
   static IpIpSpace create(@JsonProperty(PROP_IP) Ip ip) {
-    return CACHE.getUnchecked(ip);
+    return CACHE.get(ip);
   }
 
   private IpIpSpace(Ip ip) {
@@ -65,6 +61,6 @@ public class IpIpSpace extends IpSpace {
   /** Cache after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(_ip);
+    return CACHE.get(_ip);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/IpWildcard.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/IpWildcard.java
@@ -5,9 +5,8 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
@@ -23,7 +22,7 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   //   (16 bytes seems smallest possible entry (long), would be 16 MiB total).
   private static final LoadingCache<IpWildcard, IpWildcard> CACHE =
-      CacheBuilder.newBuilder().softValues().maximumSize(1 << 20).build(CacheLoader.from(x -> x));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(x -> x);
 
   private final @Nonnull Ip _ip;
   // Set bits are "don't care" bits
@@ -68,7 +67,7 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
    */
   public static IpWildcard ipWithWildcardMask(Ip address, long wildcardMask) {
     IpWildcard wildcard = new IpWildcard(address, wildcardMask);
-    return CACHE.getUnchecked(wildcard);
+    return CACHE.get(wildcard);
   }
 
   /**
@@ -223,6 +222,6 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
   /** Cache after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(this);
+    return CACHE.get(this);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/IpWildcardIpSpace.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/IpWildcardIpSpace.java
@@ -2,10 +2,9 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
@@ -15,17 +14,14 @@ public class IpWildcardIpSpace extends IpSpace {
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   //   (12 bytes seems smallest possible entry (long + int), would be 12 MiB total).
   private static final LoadingCache<IpWildcard, IpWildcardIpSpace> CACHE =
-      CacheBuilder.newBuilder()
-          .softValues()
-          .maximumSize(1 << 20)
-          .build(CacheLoader.from(IpWildcardIpSpace::new));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(IpWildcardIpSpace::new);
   private static final String PROP_IP_WILDCARD = "ipWildcard";
 
   private final IpWildcard _ipWildcard;
 
   @JsonCreator
   static IpWildcardIpSpace create(@JsonProperty(PROP_IP_WILDCARD) IpWildcard ipWildcard) {
-    return CACHE.getUnchecked(ipWildcard);
+    return CACHE.get(ipWildcard);
   }
 
   private IpWildcardIpSpace(IpWildcard ipWildcard) {
@@ -65,6 +61,6 @@ public class IpWildcardIpSpace extends IpSpace {
   /** Cache after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(_ipWildcard);
+    return CACHE.get(_ipWildcard);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/PrefixIp6Space.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/PrefixIp6Space.java
@@ -2,10 +2,9 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import javax.annotation.Nonnull;
@@ -16,17 +15,14 @@ import org.batfish.datamodel.visitors.GenericIp6SpaceVisitor;
 @ParametersAreNonnullByDefault
 public class PrefixIp6Space extends Ip6Space {
   private static final LoadingCache<Prefix6, PrefixIp6Space> CACHE =
-      CacheBuilder.newBuilder()
-          .softValues()
-          .maximumSize(1 << 20)
-          .build(CacheLoader.from(PrefixIp6Space::new));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(PrefixIp6Space::new);
 
   private static final String PROP_PREFIX = "prefix";
   private final Prefix6 _prefix6;
 
   @JsonCreator
   private static PrefixIp6Space jsonCreator(@JsonProperty(PROP_PREFIX) @Nullable Prefix6 prefix6) {
-    return CACHE.getUnchecked(prefix6);
+    return CACHE.get(prefix6);
   }
 
   public PrefixIp6Space(Prefix6 prefix6) {
@@ -66,6 +62,6 @@ public class PrefixIp6Space extends Ip6Space {
   /** Cache after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(_prefix6);
+    return CACHE.get(_prefix6);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/PrefixIpSpace.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/PrefixIpSpace.java
@@ -2,10 +2,9 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -17,10 +16,7 @@ public final class PrefixIpSpace extends IpSpace {
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   //   (12 bytes seems smallest possible entry (long + int), would be 12 MiB total).
   private static final LoadingCache<Prefix, PrefixIpSpace> CACHE =
-      CacheBuilder.newBuilder()
-          .softValues()
-          .maximumSize(1 << 20)
-          .build(CacheLoader.from(PrefixIpSpace::new));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(PrefixIpSpace::new);
 
   private static final String PROP_PREFIX = "prefix";
 
@@ -28,7 +24,7 @@ public final class PrefixIpSpace extends IpSpace {
 
   @JsonCreator
   static PrefixIpSpace create(@JsonProperty(PROP_PREFIX) Prefix prefix) {
-    return CACHE.getUnchecked(prefix);
+    return CACHE.get(prefix);
   }
 
   private PrefixIpSpace(Prefix prefix) {
@@ -68,6 +64,6 @@ public final class PrefixIpSpace extends IpSpace {
   /** Cache after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(_prefix);
+    return CACHE.get(_prefix);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/collections/NodeInterfacePair.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/collections/NodeInterfacePair.java
@@ -5,9 +5,8 @@ import static org.batfish.datamodel.Names.escapeNameIfNeeded;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
@@ -24,7 +23,7 @@ public final class NodeInterfacePair implements Serializable, Comparable<NodeInt
   // Maximum size 2^18: Just some upper bound on cache size, well less than GiB.
   //   (~40 bytes reasonable entry size: 12+12+pointers, would be 10 MiB total).
   private static final LoadingCache<NodeInterfacePair, NodeInterfacePair> CACHE =
-      CacheBuilder.newBuilder().softValues().maximumSize(1 << 18).build(CacheLoader.from(x -> x));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 18).build(x -> x);
 
   private static final String PROP_HOSTNAME = "hostname";
   private static final String PROP_INTERFACE = "interface";
@@ -42,7 +41,7 @@ public final class NodeInterfacePair implements Serializable, Comparable<NodeInt
   }
 
   public static NodeInterfacePair of(String hostname, String interfaceName) {
-    return CACHE.getUnchecked(new NodeInterfacePair(hostname, interfaceName));
+    return CACHE.get(new NodeInterfacePair(hostname, interfaceName));
   }
 
   public static NodeInterfacePair of(Interface iface) {
@@ -98,6 +97,6 @@ public final class NodeInterfacePair implements Serializable, Comparable<NodeInt
   /** Re-intern after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(this);
+    return CACHE.get(this);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/route/nh/NextHopInterface.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/route/nh/NextHopInterface.java
@@ -4,10 +4,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.MoreObjects;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.util.Objects;
@@ -30,7 +29,7 @@ public final class NextHopInterface implements NextHop {
   // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
   //   (8 bytes seems smallest possible entry (long), would be 8 MiB total).
   private static final LoadingCache<NextHopInterface, NextHopInterface> CACHE =
-      CacheBuilder.newBuilder().softValues().maximumSize(1 << 20).build(CacheLoader.from(x -> x));
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(x -> x);
 
   /** The interface name to which the traffic should be routed */
   @JsonProperty(PROP_INTERFACE)
@@ -52,7 +51,7 @@ public final class NextHopInterface implements NextHop {
    *     Interface#NULL_INTERFACE_NAME}
    */
   public static @Nonnull NextHopInterface of(String interfaceName) {
-    return CACHE.getUnchecked(new NextHopInterface(interfaceName, null));
+    return CACHE.get(new NextHopInterface(interfaceName, null));
   }
 
   /**
@@ -64,7 +63,7 @@ public final class NextHopInterface implements NextHop {
    *     Interface#NULL_INTERFACE_NAME} or the IP is invalid, e.g., {@link Ip#AUTO}
    */
   public static @Nonnull NextHopInterface of(String interfaceName, Ip ip) {
-    return CACHE.getUnchecked(new NextHopInterface(interfaceName, ip));
+    return CACHE.get(new NextHopInterface(interfaceName, ip));
   }
 
   @Override
@@ -132,6 +131,6 @@ public final class NextHopInterface implements NextHop {
   /** Re-intern after deserialization. */
   @Serial
   private Object readResolve() throws ObjectStreamException {
-    return CACHE.getUnchecked(this);
+    return CACHE.get(this);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
@@ -4,9 +4,8 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.ObjectStreamException;
@@ -41,10 +40,8 @@ public final class CommunitySet implements Serializable {
       return empty();
     }
     if (communities instanceof ImmutableSet) {
-      // Skip a cache operation if the input is immutable.
-      @SuppressWarnings("unchecked") // safe since you cannot insert into ImmutableSet
-      ImmutableSet<Community> immutableKey = (ImmutableSet<Community>) communities;
-      return CACHE.getUnchecked(immutableKey);
+      // Skip a copy if the input is already immutable.
+      return CACHE.get(communities);
     }
     // Skip a copy if a mutable copy of the key is already present.
     CommunitySet ret = CACHE.getIfPresent(communities);
@@ -135,16 +132,17 @@ public final class CommunitySet implements Serializable {
 
   // Soft values: let it be garbage collected in times of pressure.
   // Maximum size 2^24: Just some upper bound on cache size, well less than GiB.
-  private static final LoadingCache<Set<Community>, CommunitySet> CACHE =
-      CacheBuilder.newBuilder()
+  private static final LoadingCache<Set<? extends Community>, CommunitySet> CACHE =
+      Caffeine.newBuilder()
           .softValues()
           .maximumSize(1 << 24)
           .build(
-              CacheLoader.from(
-                  set -> {
-                    assert set instanceof ImmutableSet;
-                    return new CommunitySet((ImmutableSet<Community>) set);
-                  }));
+              set -> {
+                assert set instanceof ImmutableSet;
+                @SuppressWarnings("unchecked") // only ImmutableSet keys are ever inserted
+                ImmutableSet<Community> immutableSet = (ImmutableSet<Community>) set;
+                return new CommunitySet(immutableSet);
+              });
 
   /** Re-intern after deserialization. */
   @Serial


### PR DESCRIPTION
Guava's own javadoc recommends Caffeine as the successor to its caching
API (better performance, fewer bugs). Convert all Guava caches to
Caffeine and forbid future com.google.common.cache imports via
checkstyle.

Most conversions are mechanical: CacheBuilder.newBuilder() ->
Caffeine.newBuilder(), .build(CacheLoader.from(f)) -> .build(f), and
.getUnchecked(k) -> .get(k).

Two call sites needed adjustment:
- Batfish.loadDataPlane used Guava's get(key, Callable), which throws
ExecutionException. Caffeine's get(key, Function) cannot throw checked
exceptions, so the loader's IOException is wrapped in
UncheckedIOException and the now-dead try/catch is removed.
- CommunitySet's cache key is retyped from Set<Community> to
Set<? extends Community> to match the of(...) parameter. Under Guava
the looser getIfPresent(Object) hid the mismatch; Caffeine's typed
getIfPresent(K) made it explicit. The retype removes two casts at the
call sites, leaving one in the loader where an assert documents that
only ImmutableSet keys are ever inserted.

IpSpaceToBDD stays on Guava: its loader recurses into the same cache
(forbidden by Caffeine's ConcurrentHashMap.computeIfAbsent) and it
relies on a synchronous removalListener to free BDDs on the calling
thread, since BDDFactory is not threadsafe. It is exempted from the
import ban via a checkstyle SuppressionFilter.

----

Prompt:
```
It seems that Guava caches are slow and even they recommend we switch to
Caffeine on their wiki. Let's do that conversion globally, and then also
forbid importing Guava caches in findbugs or pmd or whatever we use for
this.
```

Follow-ups during the task: the recommendation is in Guava's CacheBuilder
javadoc, not their wiki. Per review, do not convert the most complicated
BDD cache (IpSpaceToBDD) -- leave it on Guava. And type the CommunitySet
cache on Set<? extends Community> rather than casting at the call sites.

---
**Stack**:
- #9973 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*