### PR TITLE
sros: register and detect Nokia SR-OS configuration format

### DIFF
--- a/docs/parsing/README.md
+++ b/docs/parsing/README.md
@@ -19,6 +19,7 @@ Different vendors have unique configuration formats and parsing requirements. Fo
 
 - [Cisco IOS-XR](vendors/ios_xr.md) - IOS-XR-specific parsing and extraction details
 - [Juniper](vendors/juniper.md) - Juniper-specific parsing and extraction details
+- [Nokia SR-OS](vendors/sros.md) - SR-OS-specific parsing and extraction details
 - [ANTLR4 Tips and Tricks](antlr4_tips.md) - Practical ANTLR4 patterns, lexer rules, parser design, debugging
 
 Most developers wanting to make changes to Batfish parsing will not need to perform all the

--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -1,0 +1,64 @@
+# Nokia SR-OS-Specific Parsing and Extraction
+
+This document covers the unique aspects of parsing and extracting Nokia SR-OS
+(SR-SIM) configurations in Batfish. It is written incrementally as support is
+built; sections appear as the corresponding pipeline stage lands.
+
+## Configuration format
+
+SR-OS runs two CLI engines: classic CLI and MD-CLI. Modern collected
+configurations are MD-CLI, a curly-brace hierarchical format rooted at
+`configure { ... }` — structurally closer to Junos than to line-oriented IOS.
+A device emits this form via `admin show configuration`.
+
+```
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1 Copyright (c) 2000-2026 Nokia.
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        autonomous-system 65001
+        ...
+    }
+}
+```
+
+SR-OS also supports an absolute-path flat form — each line is a full path from
+root, e.g. `/configure router "Base" autonomous-system 65001`. This is the
+Junos-`set` analog (`pwc cli-path`, `info full-context`): position-independent,
+copy-pasteable, and an editable input. The two forms can be **mixed in one
+input** (a brace production config with appended flat `/configure …` edits).
+
+## Format detection
+
+SR-OS is registered as `ConfigurationFormat.NOKIA_SROS`. Detection lives in
+[`VendorConfigurationFormatDetector`](../../../projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java)
+(`checkSros`) and keys on SR-OS-specific tells rather than brace structure
+alone (which collides with Juniper/Palo Alto heuristics):
+
+- the TiMOS banner (`# TiMOS-…`),
+- the `# Configuration format version <X.Y> revision <N>` header, or
+- absolute-path flat lines (`/configure …`).
+
+`checkSros` runs **before** `checkJuniper`/`checkCisco` because an SR-OS brace
+config contains tokens those heuristics would otherwise claim (e.g.
+`policy-options {`, `interface …`). RANCID content types `sros` and `sros-md`
+also map to `NOKIA_SROS` (previously routed to `UNSUPPORTED`).
+
+## Preprocessing decision
+
+SR-OS will follow the Junos two-grammar **flatten → preprocess** model (mirrors
+`juniper` → `JuniperFlattener` → `flatjuniper`), decided during
+characterization. The rationale:
+
+- Both brace and flat forms are legitimate, mixable inputs, so an outer grammar
+  recognizes both and flattens braced blocks to one canonical absolute-path
+  `/configure …` stream.
+- Incremental edit verbs are grammar (`delete`/`-`/`~`/`insert before|after`/
+  `replace … with`/`copy`/`rename`); a preprocessor applies them in order.
+- `apply-groups` config-group inheritance must be expanded by Batfish (configs
+  ship unexpanded): regex/wildcard key match, first-listed-wins precedence,
+  `apply-groups-exclude`.
+- Per-list ordering comes from YANG `ordered-by`; an absent leaf means the YANG
+  default. BGP group→neighbor inheritance is resolved in extraction.
+
+The grammar, preprocessor, and extractor are implemented in later phases (P3+).

--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -54,6 +54,17 @@ public final class VendorConfigurationFormatDetector {
       Pattern.compile("(?m)^configuration hostname .*$");
   private static final Pattern MSS_PATTERN = Pattern.compile("(?m)^set system name");
 
+  // checkSros patterns (Nokia SR-OS / SR-SIM, MD-CLI). SR-OS configs are emitted by
+  // `admin show configuration` (brace/hierarchical, rooted at `configure {`) and can also
+  // be supplied in the absolute-path flat form (`/configure ...` lines, the Junos-`set`
+  // analog). The TiMOS banner and the "Configuration format version" header are
+  // SR-OS-specific tells that brace form alone (which collides with Juniper) is not.
+  private static final Pattern SROS_TIMOS_PATTERN = Pattern.compile("(?m)^# *TiMOS-");
+  private static final Pattern SROS_CONFIG_VERSION_PATTERN =
+      Pattern.compile("(?m)^# *Configuration format version \\d+\\.\\d+ revision \\d+");
+  private static final Pattern SROS_FLAT_CONFIGURE_PATTERN =
+      Pattern.compile("(?m)^\\s*/configure ");
+
   private static final Pattern RANCID_BASE_PATTERN =
       Pattern.compile("(?m)^[!#]RANCID-CONTENT-TYPE: ([a-zA-Z0-9_-]+)");
 
@@ -393,6 +404,9 @@ public final class VendorConfigurationFormatDetector {
         return ConfigurationFormat.MRV;
       case "paloalto":
         return checkPaloAlto(true);
+      case "sros":
+      case "sros-md":
+        return ConfigurationFormat.NOKIA_SROS;
       case "agm":
       case "alteon":
       case "arbor":
@@ -432,8 +446,6 @@ public final class VendorConfigurationFormatDetector {
       case "riverstone":
       case "routeros":
       case "smc":
-      case "sros":
-      case "sros-md":
       case "vrp":
       case "xirrus":
       case "zebra":
@@ -442,6 +454,15 @@ public final class VendorConfigurationFormatDetector {
         // We don't recognize the RANCID string, assert this config is unknown.
         return ConfigurationFormat.UNKNOWN;
     }
+  }
+
+  private @Nullable ConfigurationFormat checkSros() {
+    if (fileTextMatches(SROS_TIMOS_PATTERN)
+        || fileTextMatches(SROS_CONFIG_VERSION_PATTERN)
+        || fileTextMatches(SROS_FLAT_CONFIGURE_PATTERN)) {
+      return ConfigurationFormat.NOKIA_SROS;
+    }
+    return null;
   }
 
   private static final Pattern RUCKUS_ICX_MODULE_PATTERN =
@@ -491,6 +512,10 @@ public final class VendorConfigurationFormatDetector {
     }
 
     format = (format == null) ? checkA10() : format;
+    // SR-OS must run before checkJuniper/checkCisco: an SR-OS brace config contains
+    // tokens (e.g. `policy-options {`, `interface ...`) that those heuristics would
+    // otherwise claim. checkSros keys on SR-OS-specific tells, so it is safe to run early.
+    format = (format == null) ? checkSros() : format;
     format = (format == null) ? checkCheckPoint() : format;
     format = (format == null) ? checkFortios() : format;
     format = (format == null) ? checkRuckusIcx() : format;

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -93,6 +93,9 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           ConfigurationFormat.METAMAKO,
           ConfigurationFormat.MRV_COMMANDS,
           ConfigurationFormat.MSS,
+          // NOKIA_SROS is registered and detected as of P2, but the parser/extractor land
+          // in P3. Until then it is routed here so detection is exercised without a crash.
+          ConfigurationFormat.NOKIA_SROS,
           ConfigurationFormat.RUCKUS_ICX,
           ConfigurationFormat.UNSUPPORTED,
           ConfigurationFormat.VXWORKS);

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -1,5 +1,7 @@
 package org.batfish.grammar;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.ConfigurationFormat.A10_ACOS;
 import static org.batfish.datamodel.ConfigurationFormat.ARISTA;
 import static org.batfish.datamodel.ConfigurationFormat.CADANT;
@@ -13,6 +15,7 @@ import static org.batfish.datamodel.ConfigurationFormat.FLAT_JUNIPER;
 import static org.batfish.datamodel.ConfigurationFormat.IBM_BNT;
 import static org.batfish.datamodel.ConfigurationFormat.JUNIPER;
 import static org.batfish.datamodel.ConfigurationFormat.JUNIPER_SWITCH;
+import static org.batfish.datamodel.ConfigurationFormat.NOKIA_SROS;
 import static org.batfish.datamodel.ConfigurationFormat.PALO_ALTO;
 import static org.batfish.datamodel.ConfigurationFormat.PALO_ALTO_NESTED;
 import static org.batfish.datamodel.ConfigurationFormat.RUCKUS_ICX;
@@ -322,6 +325,35 @@ public class VendorConfigurationFormatDetectorTest {
     String basic = "stack unit 2\n" + "  module 1 icx7450-48p-poe-management-module\n";
     for (String fileText : ImmutableList.of(basic)) {
       assertThat(identifyConfigurationFormat(fileText), equalTo(RUCKUS_ICX));
+    }
+  }
+
+  @Test
+  public void testSros() {
+    // The config captured from the SR-SIM lab (admin show configuration, MD-CLI brace form).
+    String capturedR1 =
+        readResource(
+            "org/batfish/vendor/sros/grammar/testconfigs/r1_admin_show_configuration.txt", UTF_8);
+
+    // A flat absolute-path form (the Junos-`set` analog) of the same kind of config.
+    String flat =
+        """
+        /configure router "Base" autonomous-system 65001
+        /configure router "Base" bgp group "ebgp" peer-as 65002
+        """;
+
+    // RANCID headers for the two SR-OS aliases (previously routed to UNSUPPORTED).
+    String rancidSros = "!RANCID-CONTENT-TYPE: sros\n";
+    String rancidSrosMd = "!RANCID-CONTENT-TYPE: sros-md\n";
+
+    // Minimal tells, absent any other vendor's brace/keyword tokens.
+    String timosOnly = "# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1\n";
+    String versionHeaderOnly = "# Configuration format version 26.3 revision 0\nconfigure {\n}\n";
+
+    for (String fileText :
+        ImmutableList.of(
+            capturedR1, flat, rancidSros, rancidSrosMd, timosOnly, versionHeaderOnly)) {
+      assertThat(fileText, identifyConfigurationFormat(fileText), equalTo(NOKIA_SROS));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
@@ -67,6 +67,26 @@ public class ParseVendorConfigurationJobTest {
     assertThat(result.getParseStatus("config"), equalTo(Optional.of(ParseStatus.UNSUPPORTED)));
   }
 
+  @Test
+  public void testNokiaSrosDetectedButUnimplemented() {
+    // SR-OS is registered and detected as of P2; the parser/extractor land in P3, so for now
+    // the job routes a detected SR-OS config to the unsupported path rather than crashing.
+    String sros = "# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1\nconfigure {\n}\n";
+    ParseResult result =
+        new ParseVendorConfigurationJob(
+                new Settings(),
+                new NetworkSnapshot(new NetworkId("net"), new SnapshotId("ss")),
+                ImmutableMap.of("config", sros),
+                new Warnings.Settings(false, false, false),
+                ConfigurationFormat.UNKNOWN,
+                ImmutableMultimap.of())
+            .parse();
+    assertThat(result.getFormat(), equalTo(ConfigurationFormat.NOKIA_SROS));
+    assertThat(result.getFailureCause(), nullValue());
+    assertThat(result.getConfig(), nullValue());
+    assertThat(result.getParseStatus("config"), equalTo(Optional.of(ParseStatus.UNSUPPORTED)));
+  }
+
   // Tests that empty files are detected as empty, even when another format is provided.
   @Test
   public void testDetectFormatEmpty() {

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/r1_admin_show_configuration.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/r1_admin_show_configuration.txt
@@ -1,0 +1,329 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1 Copyright (c) 2000-2026 Nokia.
+# All rights reserved. All use subject to applicable license agreements.
+# Built on Wed Mar 11 20:17:13 UTC 2026 by builder in /builds/263B/R1/panos
+# Configuration format version 26.3 revision 0
+
+# Generated 2026-06-05T04:46:54.8+00:00 by admin from 172.20.20.1
+# Last modified 2026-06-05T04:36:26.6+00:00 by system (MD-CLI) from Console
+
+configure {
+    card 1 {
+        card-type iom-1
+        mda 1 {
+            mda-type me6-100gb-qsfp28
+        }
+    }
+    policy-options {
+        prefix-list "system-pfx" {
+            prefix 1.1.1.1/32 type exact {
+            }
+        }
+        policy-statement "export-system" {
+            entry 10 {
+                from {
+                    prefix-list ["system-pfx"]
+                }
+                action {
+                    action-type accept
+                }
+            }
+        }
+        policy-statement "import-all" {
+            default-action {
+                action-type accept
+            }
+        }
+    }
+    port 1/1/c1 {
+        admin-state enable
+        connector {
+            breakout c1-100g
+        }
+    }
+    port 1/1/c1/1 {
+        admin-state enable
+    }
+    router "Base" {
+        autonomous-system 65001
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r2" {
+            port 1/1/c1/1
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                    prefix-length 31
+                }
+            }
+        }
+        bgp {
+            router-id 1.1.1.1
+            group "ebgp" {
+                peer-as 65002
+                import {
+                    policy ["import-all"]
+                }
+                export {
+                    policy ["export-system"]
+                }
+            }
+            neighbor "10.0.0.1" {
+                group "ebgp"
+            }
+        }
+    }
+    system {
+        security {
+            aaa {
+                local-profiles {
+                    profile "administrative" {
+                        default-action permit-all
+                        entry 10 {
+                            match "configure system security"
+                            action permit
+                        }
+                        entry 20 {
+                            match "show system security"
+                            action permit
+                        }
+                        entry 30 {
+                            match "tools perform security"
+                            action permit
+                        }
+                        entry 40 {
+                            match "tools dump security"
+                            action permit
+                        }
+                        entry 42 {
+                            match "tools dump system security"
+                            action permit
+                        }
+                        entry 50 {
+                            match "admin system security"
+                            action permit
+                        }
+                        entry 100 {
+                            match "configure li"
+                            action deny
+                        }
+                        entry 110 {
+                            match "show li"
+                            action deny
+                        }
+                        entry 111 {
+                            match "clear li"
+                            action deny
+                        }
+                        entry 112 {
+                            match "tools dump li"
+                            action deny
+                        }
+                        entry 113 {
+                            match "tools perform system security"
+                            action permit
+                        }
+                        netconf {
+                            base-op-authorization {
+                                action true
+                                cancel-commit true
+                                close-session true
+                                commit true
+                                copy-config true
+                                create-subscription true
+                                delete-config true
+                                discard-changes true
+                                edit-config true
+                                get true
+                                get-config true
+                                get-data true
+                                get-schema true
+                                kill-session true
+                                lock true
+                                validate true
+                            }
+                        }
+                    }
+                    profile "default" {
+                        entry 10 {
+                            match "exec"
+                            action permit
+                        }
+                        entry 20 {
+                            match "exit"
+                            action permit
+                        }
+                        entry 30 {
+                            match "help"
+                            action permit
+                        }
+                        entry 40 {
+                            match "logout"
+                            action permit
+                        }
+                        entry 50 {
+                            match "password"
+                            action permit
+                        }
+                        entry 60 {
+                            match "show config"
+                            action deny
+                        }
+                        entry 65 {
+                            match "show li"
+                            action deny
+                        }
+                        entry 66 {
+                            match "clear li"
+                            action deny
+                        }
+                        entry 67 {
+                            match "tools dump li"
+                            action deny
+                        }
+                        entry 68 {
+                            match "state li"
+                            action deny
+                        }
+                        entry 70 {
+                            match "show"
+                            action permit
+                        }
+                        entry 75 {
+                            match "state"
+                            action permit
+                        }
+                        entry 80 {
+                            match "enable-admin"
+                            action permit
+                        }
+                        entry 90 {
+                            match "enable"
+                            action permit
+                        }
+                        entry 100 {
+                            match "configure li"
+                            action deny
+                        }
+                    }
+                }
+            }
+            ssh {
+                server-cipher-list-v2 {
+                    cipher 190 {
+                        name aes256-ctr
+                    }
+                    cipher 192 {
+                        name aes192-ctr
+                    }
+                    cipher 194 {
+                        name aes128-ctr
+                    }
+                    cipher 200 {
+                        name aes128-cbc
+                    }
+                    cipher 205 {
+                        name 3des-cbc
+                    }
+                    cipher 225 {
+                        name aes192-cbc
+                    }
+                    cipher 230 {
+                        name aes256-cbc
+                    }
+                }
+                client-cipher-list-v2 {
+                    cipher 190 {
+                        name aes256-ctr
+                    }
+                    cipher 192 {
+                        name aes192-ctr
+                    }
+                    cipher 194 {
+                        name aes128-ctr
+                    }
+                    cipher 200 {
+                        name aes128-cbc
+                    }
+                    cipher 205 {
+                        name 3des-cbc
+                    }
+                    cipher 225 {
+                        name aes192-cbc
+                    }
+                    cipher 230 {
+                        name aes256-cbc
+                    }
+                }
+                server-mac-list-v2 {
+                    mac 200 {
+                        name hmac-sha2-512
+                    }
+                    mac 210 {
+                        name hmac-sha2-256
+                    }
+                    mac 215 {
+                        name hmac-sha1
+                    }
+                    mac 220 {
+                        name hmac-sha1-96
+                    }
+                    mac 225 {
+                        name hmac-md5
+                    }
+                    mac 240 {
+                        name hmac-md5-96
+                    }
+                }
+                client-mac-list-v2 {
+                    mac 200 {
+                        name hmac-sha2-512
+                    }
+                    mac 210 {
+                        name hmac-sha2-256
+                    }
+                    mac 215 {
+                        name hmac-sha1
+                    }
+                    mac 220 {
+                        name hmac-sha1-96
+                    }
+                    mac 225 {
+                        name hmac-md5
+                    }
+                    mac 240 {
+                        name hmac-md5-96
+                    }
+                }
+            }
+            user-params {
+                local-user {
+                    user "admin" {
+                        password "$2y$10$TQrZlpBDra86.qoexZUzQeBXDY1FcdDhGWdD9lLxMuFyPVSm0OGy6"
+                        restricted-to-home false
+                        access {
+                            console true
+                        }
+                        console {
+                            member ["administrative"]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+persistent-indices {
+    description "Persistent indices are maintained by the system and must not be modified."
+    vrtr-if-id {
+        router-name "Base" interface-name "to-r2" vrtr-id 1 if-index 2
+    }
+}
+
+# Finished 2026-06-05T04:46:54.8+00:00

--- a/projects/common/src/main/java/org/batfish/datamodel/ConfigurationFormat.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/ConfigurationFormat.java
@@ -35,6 +35,7 @@ public enum ConfigurationFormat {
   MRV("mrv"),
   MRV_COMMANDS("mrv_commands"),
   MSS("mss"),
+  NOKIA_SROS("nokia_sros"),
   SONIC("sonic"),
   PALO_ALTO("paloalto"),
   PALO_ALTO_NESTED("paloalto"),


### PR DESCRIPTION
Add ConfigurationFormat.NOKIA_SROS and teach the detector to recognize
SR-OS (Nokia SR-SIM, MD-CLI) configs. checkSros keys on SR-OS-specific
tells — the TiMOS banner, the "Configuration format version <X.Y>
revision <N>" header, and absolute-path flat /configure lines — rather
than brace structure alone, which collides with the Juniper and Palo
Alto heuristics. It runs before checkJuniper/checkCisco because an
SR-OS brace config contains tokens (policy-options {, interface ...)
those checks would otherwise claim. RANCID content types sros and
sros-md now map to NOKIA_SROS instead of UNSUPPORTED.

The grammar and extractor are not built yet (deferred to a later
phase), so NOKIA_SROS is listed in UNIMPLEMENTED_FORMATS: a detected
SR-OS config is routed deterministically (UNSUPPORTED parse status)
instead of falling through to an exception.

Adds docs/parsing/vendors/sros.md documenting the format, detection,
and the planned two-grammar flatten-then-preprocess pipeline (the Junos
model), and links it from the parsing README. The detector test
classifies the config captured from the SR-SIM lab (added as a test
resource) along with the flat form and both RANCID aliases.

----

Prompt:
```
Register the Nokia SR-OS configuration format in Batfish: add
ConfigurationFormat.NOKIA_SROS, teach VendorConfigurationFormatDetector
to classify the captured SR-OS config (today "sros"/"sros-md" route to
UNSUPPORTED), add the case in ParseVendorConfigurationJob, and record
the preprocessing decision. Prove detection with a test.
```

---
**Stack**:
- #9974 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*