### PR TITLE
BGP: honor advertise-inactive on iBGP sessions; add Cisco suppress-inactive

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -5455,6 +5455,8 @@ SUPPRESS_ARP: 'suppress-arp';
 
 SUPPRESS_FIB_PENDING: 'suppress-fib-pending';
 
+SUPPRESS_INACTIVE: 'suppress-inactive';
+
 SUPPRESS_MAP: 'suppress-map';
 
 SUPPRESSED: 'suppressed';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_bgp.g4
@@ -202,6 +202,7 @@ bgp_rb_stanza
    | bgp_redistribute_internal_rb_stanza
    | bgp_refresh_rb_stanza_null
    | bgp_regexp_rb_stanza_null
+   | bgp_suppress_inactive_rb_stanza
    | bgp_transport_rb_stanza_null
    | bgp_update_delay_rb_stanza_null
    | bgp_update_group_rb_stanza_null
@@ -282,6 +283,8 @@ bgp_log_neighbor_changes_rb_stanza_null: LOG_NEIGHBOR_CHANGES null_rest_of_line;
 bgp_maxas_limit_rb_stanza: MAXAS_LIMIT limit = dec NEWLINE;
 
 bgp_redistribute_internal_rb_stanza: REDISTRIBUTE_INTERNAL NEWLINE;
+
+bgp_suppress_inactive_rb_stanza: SUPPRESS_INACTIVE NEWLINE;
 
 bgp_refresh_rb_stanza_null: REFRESH null_rest_of_line;
 bgp_regexp_rb_stanza_null: REGEXP null_rest_of_line;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_bgp.g4
@@ -233,6 +233,11 @@ bgp_redistribute_internal_rb_stanza
    BGP REDISTRIBUTE_INTERNAL NEWLINE
 ;
 
+bgp_suppress_inactive_rb_stanza
+:
+   BGP SUPPRESS_INACTIVE NEWLINE
+;
+
 bgp_scan_time_bgp_tail
 :
    BGP SCAN_TIME secs = dec NEWLINE
@@ -859,6 +864,7 @@ router_bgp_stanza_tail
    | bgp_listen_range_rb_stanza
    | bgp_maxas_limit_rb_stanza
    | bgp_redistribute_internal_rb_stanza
+   | bgp_suppress_inactive_rb_stanza
    | bgp_tail
    | cluster_id_rb_stanza
    | compare_routerid_rb_stanza

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLexer.g4
@@ -5427,6 +5427,8 @@ SUPPRESS_ARP: 'suppress-arp';
 
 SUPPRESS_FIB_PENDING: 'suppress-fib-pending';
 
+SUPPRESS_INACTIVE: 'suppress-inactive';
+
 SUPPRESS_MAP: 'suppress-map';
 
 SUPPRESSED: 'suppressed';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -218,8 +218,6 @@ ADVERTISE_TO: 'advertise-to' -> pushMode(M_Word);
 
 ADVERTISEMENT_INTERVAL: 'advertisement-interval';
 
-ADVERTISE_INACTIVE: 'advertise-inactive';
-
 AES: 'aes';
 
 AESA: 'aesa';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_bgp.g4
@@ -172,11 +172,6 @@ auto_summary_bgp_tail
    NO? AUTO_SUMMARY NEWLINE
 ;
 
-bgp_advertise_inactive_rb_stanza
-:
-   BGP ADVERTISE_INACTIVE NEWLINE
-;
-
 //confederations are not currently implemented
 //not putting this under null so we can warn the user
 
@@ -806,7 +801,6 @@ router_bgp_stanza_tail
    | aggregate_address_rb_stanza
    | always_compare_med_rb_stanza
    | as_path_multipath_relax_rb_stanza
-   | bgp_advertise_inactive_rb_stanza
    | bgp_confederation_rb_stanza
    | bgp_listen_range_rb_stanza
    | bgp_maxas_limit_rb_stanza

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -497,6 +497,7 @@ import org.batfish.grammar.cisco.CiscoParser.Bgp_conf_peers_rb_stanzaContext;
 import org.batfish.grammar.cisco.CiscoParser.Bgp_enforce_first_as_rb_stanzaContext;
 import org.batfish.grammar.cisco.CiscoParser.Bgp_listen_range_rb_stanzaContext;
 import org.batfish.grammar.cisco.CiscoParser.Bgp_redistribute_internal_rb_stanzaContext;
+import org.batfish.grammar.cisco.CiscoParser.Bgp_suppress_inactive_rb_stanzaContext;
 import org.batfish.grammar.cisco.CiscoParser.Cd_match_addressContext;
 import org.batfish.grammar.cisco.CiscoParser.Cd_set_isakmp_profileContext;
 import org.batfish.grammar.cisco.CiscoParser.Cd_set_peerContext;
@@ -1858,6 +1859,12 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   public void exitNo_bgp_enforce_first_as_stanza(No_bgp_enforce_first_as_stanzaContext ctx) {
     BgpProcess proc = currentVrf().getBgpProcess();
     proc.setEnforceFirstAs(false);
+  }
+
+  @Override
+  public void exitBgp_suppress_inactive_rb_stanza(Bgp_suppress_inactive_rb_stanzaContext ctx) {
+    BgpProcess proc = currentVrf().getBgpProcess();
+    proc.getMasterBgpPeerGroup().setSuppressInactive(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
@@ -464,6 +464,7 @@ import org.batfish.grammar.cisco_asa.AsaParser.Bgp_conf_peers_rb_stanzaContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Bgp_enforce_first_as_stanzaContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Bgp_listen_range_rb_stanzaContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Bgp_redistribute_internal_rb_stanzaContext;
+import org.batfish.grammar.cisco_asa.AsaParser.Bgp_suppress_inactive_rb_stanzaContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Cd_match_addressContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Cd_set_isakmp_profileContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Cd_set_peerContext;
@@ -3891,6 +3892,12 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
   public void exitBgp_redistribute_internal_rb_stanza(
       Bgp_redistribute_internal_rb_stanzaContext ctx) {
     todo(ctx); // TODO(https://github.com/batfish/batfish/issues/3230)
+  }
+
+  @Override
+  public void exitBgp_suppress_inactive_rb_stanza(Bgp_suppress_inactive_rb_stanzaContext ctx) {
+    BgpProcess proc = currentVrf().getBgpProcess();
+    proc.getMasterBgpPeerGroup().setSuppressInactive(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -397,7 +397,6 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Aspsee_passes_throughContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Aspsee_unique_lengthContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Auto_summary_bgp_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_address_familyContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_advertise_inactive_rb_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_asnContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_confederation_rb_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_listen_range_rb_stanzaContext;
@@ -3177,11 +3176,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     } else {
       return null;
     }
-  }
-
-  @Override
-  public void exitBgp_advertise_inactive_rb_stanza(Bgp_advertise_inactive_rb_stanzaContext ctx) {
-    _currentPeerGroup.setAdvertiseInactive(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpPeerGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpPeerGroup.java
@@ -51,6 +51,7 @@ public abstract class BgpPeerGroup implements Serializable {
   protected Boolean _sendCommunity;
   private boolean _sendExtendedCommunity;
   protected Boolean _shutdown;
+  protected Boolean _suppressInactive;
   protected String _updateSource;
 
   public BgpPeerGroup() {}
@@ -224,6 +225,10 @@ public abstract class BgpPeerGroup implements Serializable {
     return _shutdown;
   }
 
+  public Boolean getSuppressInactive() {
+    return _suppressInactive;
+  }
+
   public String getUpdateSource() {
     return _updateSource;
   }
@@ -318,6 +323,9 @@ public abstract class BgpPeerGroup implements Serializable {
     }
     if (_shutdown == null) {
       _shutdown = pg.getShutdown();
+    }
+    if (_suppressInactive == null) {
+      _suppressInactive = pg.getSuppressInactive();
     }
     if (_updateSource == null) {
       _updateSource = pg.getUpdateSource();
@@ -477,6 +485,10 @@ public abstract class BgpPeerGroup implements Serializable {
 
   public void setShutdown(boolean shutdown) {
     _shutdown = shutdown;
+  }
+
+  public void setSuppressInactive(boolean suppressInactive) {
+    _suppressInactive = suppressInactive;
   }
 
   public void setUpdateSource(String updateSource) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1177,11 +1177,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
               .setAllowLocalAsIn(lpg.getAllowAsIn())
               .setAllowRemoteAsOut(ALWAYS) /* no outgoing remote-as check on IOS */
               /*
-               * On Cisco IOS, advertise-inactive is true by default. This can be modified by
-               * "bgp suppress-inactive" command,
-               * which we currently do not parse/extract. So we choose the default value here.
+               * On Cisco IOS, advertise-inactive is true by default. The "bgp suppress-inactive"
+               * command disables it.
                */
-              .setAdvertiseInactive(true)
+              .setAdvertiseInactive(!firstNonNull(lpg.getSuppressInactive(), Boolean.FALSE))
               .setSendCommunity(lpg.getSendCommunity())
               .setSendExtendedCommunity(lpg.getSendExtendedCommunity())
               .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -1403,14 +1403,10 @@ public final class AsaConfiguration extends VendorConfiguration {
               .setAllowLocalAsIn(lpg.getAllowAsIn())
               .setAllowRemoteAsOut(ALWAYS) /* no outgoing remote-as check on IOS */
               /*
-               * On Cisco IOS, advertise-inactive is true by default. This can be modified by
-               * "bgp suppress-inactive" command,
-               * which we currently do not parse/extract. So we choose the default value here.
-               *
-               * For other Cisco OS variations (e.g., IOS-XR) we did not find a similar command and for now,
-               * we assume behavior to be identical to IOS family.
+               * On Cisco ASA, advertise-inactive is true by default. The "bgp suppress-inactive"
+               * command disables it.
                */
-              .setAdvertiseInactive(true)
+              .setAdvertiseInactive(!firstNonNull(lpg.getSuppressInactive(), Boolean.FALSE))
               .setSendCommunity(lpg.getSendCommunity())
               .setSendExtendedCommunity(lpg.getSendExtendedCommunity())
               .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/BgpPeerGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/BgpPeerGroup.java
@@ -51,6 +51,7 @@ public abstract class BgpPeerGroup implements Serializable {
   protected Boolean _sendCommunity;
   private boolean _sendExtendedCommunity;
   protected Boolean _shutdown;
+  protected Boolean _suppressInactive;
   protected String _updateSource;
 
   public BgpPeerGroup() {}
@@ -224,6 +225,10 @@ public abstract class BgpPeerGroup implements Serializable {
     return _shutdown;
   }
 
+  public Boolean getSuppressInactive() {
+    return _suppressInactive;
+  }
+
   public String getUpdateSource() {
     return _updateSource;
   }
@@ -318,6 +323,9 @@ public abstract class BgpPeerGroup implements Serializable {
     }
     if (_shutdown == null) {
       _shutdown = pg.getShutdown();
+    }
+    if (_suppressInactive == null) {
+      _suppressInactive = pg.getSuppressInactive();
     }
     if (_updateSource == null) {
       _updateSource = pg.getUpdateSource();
@@ -475,6 +483,10 @@ public abstract class BgpPeerGroup implements Serializable {
 
   public void setShutdown(boolean shutdown) {
     _shutdown = shutdown;
+  }
+
+  public void setSuppressInactive(boolean suppressInactive) {
+    _suppressInactive = suppressInactive;
   }
 
   public void setUpdateSource(String updateSource) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BgpPeerGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BgpPeerGroup.java
@@ -13,7 +13,6 @@ public abstract class BgpPeerGroup implements Serializable {
   protected Boolean _additionalPathsReceive;
   protected Boolean _additionalPathsSelectAll;
   protected Boolean _additionalPathsSend;
-  protected Boolean _advertiseInactive;
   protected Boolean _allowAsIn;
   private Set<Long> _alternateAs;
   protected Ip _clusterId;
@@ -59,10 +58,6 @@ public abstract class BgpPeerGroup implements Serializable {
 
   public Boolean getAdditionalPathsSend() {
     return _additionalPathsSend;
-  }
-
-  public Boolean getAdvertiseInactive() {
-    return _advertiseInactive;
   }
 
   public Boolean getAllowAsIn() {
@@ -219,9 +214,6 @@ public abstract class BgpPeerGroup implements Serializable {
     if (_additionalPathsSend == null) {
       _additionalPathsSend = pg.getAdditionalPathsSend();
     }
-    if (_advertiseInactive == null) {
-      _advertiseInactive = pg.getAdvertiseInactive();
-    }
     if (_allowAsIn == null) {
       _allowAsIn = pg.getAllowAsIn();
     }
@@ -324,10 +316,6 @@ public abstract class BgpPeerGroup implements Serializable {
 
   public void setAdditionalPathsSend(Boolean additionalPathsSend) {
     _additionalPathsSend = additionalPathsSend;
-  }
-
-  public void setAdvertiseInactive(boolean advertiseInactive) {
-    _advertiseInactive = advertiseInactive;
   }
 
   public void setAllowAsIn(boolean allowAsIn) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BgpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BgpProcess.java
@@ -88,7 +88,6 @@ public class BgpProcess implements Serializable {
     _procnum = procnum;
     _redistributionPolicies = new EnumMap<>(RoutingProtocol.class);
     _masterBgpPeerGroup = new MasterBgpPeerGroup();
-    _masterBgpPeerGroup.setAdvertiseInactive(true);
     _masterBgpPeerGroup.setDefaultMetric(DEFAULT_BGP_DEFAULT_METRIC);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -1048,14 +1048,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
               .setAdditionalPathsSend(lpg.getAdditionalPathsSend())
               .setAllowLocalAsIn(lpg.getAllowAsIn())
               .setAllowRemoteAsOut(ALWAYS) // TODO: support 'as-path-loopcheck out disable'
-              /*
-               * On Cisco IOS, advertise-inactive is true by default. This can be modified by
-               * "bgp suppress-inactive" command,
-               * which we currently do not parse/extract. So we choose the default value here.
-               *
-               * For other Cisco OS variations (e.g., IOS-XR) we did not find a similar command and for now,
-               * we assume behavior to be identical to IOS family.
-               */
+              // IOS-XR advertises inactive routes and has no command to suppress that.
               .setAdvertiseInactive(true)
               .setSendCommunity(lpg.getSendCommunity())
               .setSendExtendedCommunity(lpg.getSendExtendedCommunity())

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/MasterBgpPeerGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/MasterBgpPeerGroup.java
@@ -13,7 +13,6 @@ public class MasterBgpPeerGroup extends BgpPeerGroup {
     _additionalPathsReceive = false;
     _additionalPathsSelectAll = false;
     _additionalPathsSend = false;
-    _advertiseInactive = false;
     _allowAsIn = false;
     _defaultOriginate = false;
     _ebgpMultihop = false;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpFilterInactiveIbgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpFilterInactiveIbgpTest.java
@@ -1,0 +1,92 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.batfish.dataplane.ibdp.TestUtils.assertNoRoute;
+import static org.batfish.dataplane.ibdp.TestUtils.assertRoute;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.SortedMap;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests that advertise-inactive (and its suppression) takes effect on iBGP sessions, not just eBGP.
+ *
+ * <p>as1 (AS 1) originates a default route over eBGP to as2 (AS 2). as2 has a static default route
+ * that preempts the eBGP-learned default, leaving the BGP route inactive in the main RIB. as2
+ * advertises to as3 (AS 2) over an iBGP session. The inactive route reaches as3 only when as2
+ * advertises inactive routes, which is the IOS default and is disabled by "bgp suppress-inactive".
+ */
+public final class BgpFilterInactiveIbgpTest {
+
+  private static final String AS1_NAME = "as1";
+  private static final String AS2_ADVERTISE_INACTIVE_NAME = "as2-advertise-inactive";
+  private static final String AS2_SUPPRESS_INACTIVE_NAME = "as2-suppress-inactive";
+  private static final String AS3_NAME = "as3";
+  private static final String SNAPSHOT_PATH = "org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp";
+  private static final Ip STATIC_NEXT_HOP = Ip.parse("10.0.12.254");
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  @Test
+  public void testSuppressInactive() throws IOException {
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(
+                    SNAPSHOT_PATH, AS1_NAME, AS2_SUPPRESS_INACTIVE_NAME, AS3_NAME)
+                .build(),
+            _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dataplane =
+        (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+    SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routes =
+        IncrementalBdpEngine.getRoutes(dataplane);
+
+    assertRoute(routes, RoutingProtocol.STATIC, AS1_NAME, Prefix.ZERO, 0, STATIC_NEXT_HOP);
+    assertRoute(
+        routes,
+        RoutingProtocol.STATIC,
+        AS2_SUPPRESS_INACTIVE_NAME,
+        Prefix.ZERO,
+        0,
+        STATIC_NEXT_HOP);
+    // as2 suppresses inactive routes, so the inactive default is not advertised over iBGP.
+    assertNoRoute(routes, AS3_NAME, Prefix.ZERO);
+  }
+
+  @Test
+  public void testAdvertiseInactive() throws IOException {
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(
+                    SNAPSHOT_PATH, AS1_NAME, AS2_ADVERTISE_INACTIVE_NAME, AS3_NAME)
+                .build(),
+            _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    IncrementalDataPlane dataplane =
+        (IncrementalDataPlane) batfish.loadDataPlane(batfish.getSnapshot());
+    SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routes =
+        IncrementalBdpEngine.getRoutes(dataplane);
+
+    assertRoute(routes, RoutingProtocol.STATIC, AS1_NAME, Prefix.ZERO, 0, STATIC_NEXT_HOP);
+    assertRoute(
+        routes,
+        RoutingProtocol.STATIC,
+        AS2_ADVERTISE_INACTIVE_NAME,
+        Prefix.ZERO,
+        0,
+        STATIC_NEXT_HOP);
+    // as2 advertises inactive routes by default, so as3 learns the default over iBGP.
+    assertRoute(routes, RoutingProtocol.IBGP, AS3_NAME, Prefix.ZERO, 0, Ip.parse("10.0.23.2"));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5956,6 +5956,21 @@ public final class CiscoGrammarTest {
   }
 
   @Test
+  public void testIosSuppressInactive() throws IOException {
+    // "bgp suppress-inactive" disables the default advertise-inactive behavior.
+    Configuration config = parseConfig("ios-suppress-inactive");
+    assertFalse(
+        config
+            .getDefaultVrf()
+            .getBgpProcess()
+            .getActiveNeighbors()
+            .get(Ip.parse("1.1.1.1"))
+            .getIpv4UnicastAddressFamily()
+            .getAddressFamilyCapabilities()
+            .getAdvertiseInactive());
+  }
+
+  @Test
   public void testTunnelTopologyNoReachability() throws IOException {
     Batfish batfish =
         BatfishTestUtils.getBatfishFromTestrigText(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
@@ -1111,6 +1111,35 @@ public final class CiscoAsaGrammarTest {
   }
 
   @Test
+  public void testAsaAdvertiseInactive() throws IOException {
+    Configuration config = parseConfig("asa-advertise-inactive");
+    assertTrue(
+        config
+            .getDefaultVrf()
+            .getBgpProcess()
+            .getActiveNeighbors()
+            .get(Ip.parse("1.1.1.1"))
+            .getIpv4UnicastAddressFamily()
+            .getAddressFamilyCapabilities()
+            .getAdvertiseInactive());
+  }
+
+  @Test
+  public void testAsaSuppressInactive() throws IOException {
+    // "bgp suppress-inactive" disables the default advertise-inactive behavior.
+    Configuration config = parseConfig("asa-suppress-inactive");
+    assertFalse(
+        config
+            .getDefaultVrf()
+            .getBgpProcess()
+            .getActiveNeighbors()
+            .get(Ip.parse("1.1.1.1"))
+            .getIpv4UnicastAddressFamily()
+            .getAddressFamilyCapabilities()
+            .getAdvertiseInactive());
+  }
+
+  @Test
   public void testAggregateAddressConversion() throws IOException {
     String hostname = "asa-aggregate-address";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp/configs/as1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp/configs/as1
@@ -1,0 +1,25 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname as1
+!
+interface Ethernet0/0
+ no switchport
+ ip address 10.0.12.1 255.255.255.0
+ no shutdown
+!
+interface Loopback0
+ ip address 10.1.1.1 255.255.255.255
+!
+ip route 0.0.0.0 0.0.0.0 10.0.12.254
+!
+route-map deny-all deny 10
+!
+route-map permit-all permit 10
+!
+router bgp 1
+ bgp router-id 10.1.1.1
+ neighbor 10.0.12.2 remote-as 2
+ neighbor 10.0.12.2 route-map deny-all in
+ neighbor 10.0.12.2 route-map permit-all out
+ network 0.0.0.0 mask 0.0.0.0
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp/configs/as2-advertise-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp/configs/as2-advertise-inactive
@@ -1,0 +1,33 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname as2-advertise-inactive
+!
+interface Ethernet0/0
+ no switchport
+ ip address 10.0.12.2 255.255.255.0
+ no shutdown
+!
+interface Ethernet0/1
+ no switchport
+ ip address 10.0.23.2 255.255.255.0
+ no shutdown
+!
+interface Loopback0
+ ip address 10.2.2.2 255.255.255.255
+!
+ip route 0.0.0.0 0.0.0.0 10.0.12.254
+!
+route-map deny-all deny 10
+!
+route-map permit-all permit 10
+!
+router bgp 2
+ bgp router-id 10.2.2.2
+ neighbor 10.0.12.1 remote-as 1
+ neighbor 10.0.12.1 route-map permit-all in
+ neighbor 10.0.12.1 route-map deny-all out
+ neighbor 10.0.23.3 remote-as 2
+ neighbor 10.0.23.3 next-hop-self
+ neighbor 10.0.23.3 route-map deny-all in
+ neighbor 10.0.23.3 route-map permit-all out
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp/configs/as2-suppress-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp/configs/as2-suppress-inactive
@@ -1,0 +1,34 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname as2-suppress-inactive
+!
+interface Ethernet0/0
+ no switchport
+ ip address 10.0.12.2 255.255.255.0
+ no shutdown
+!
+interface Ethernet0/1
+ no switchport
+ ip address 10.0.23.2 255.255.255.0
+ no shutdown
+!
+interface Loopback0
+ ip address 10.2.2.2 255.255.255.255
+!
+ip route 0.0.0.0 0.0.0.0 10.0.12.254
+!
+route-map deny-all deny 10
+!
+route-map permit-all permit 10
+!
+router bgp 2
+ bgp router-id 10.2.2.2
+ bgp suppress-inactive
+ neighbor 10.0.12.1 remote-as 1
+ neighbor 10.0.12.1 route-map permit-all in
+ neighbor 10.0.12.1 route-map deny-all out
+ neighbor 10.0.23.3 remote-as 2
+ neighbor 10.0.23.3 next-hop-self
+ neighbor 10.0.23.3 route-map deny-all in
+ neighbor 10.0.23.3 route-map permit-all out
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp/configs/as3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive-ibgp/configs/as3
@@ -1,0 +1,22 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname as3
+!
+interface Ethernet0/1
+ no switchport
+ ip address 10.0.23.3 255.255.255.0
+ no shutdown
+!
+interface Loopback0
+ ip address 10.3.3.3 255.255.255.255
+!
+route-map deny-all deny 10
+!
+route-map permit-all permit 10
+!
+router bgp 2
+ bgp router-id 10.3.3.3
+ neighbor 10.0.23.2 remote-as 2
+ neighbor 10.0.23.2 route-map permit-all in
+ neighbor 10.0.23.2 route-map deny-all out
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-suppress-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-suppress-inactive
@@ -1,0 +1,9 @@
+!
+!
+!RANCID-CONTENT-TYPE: cisco
+hostname ios-suppress-inactive
+!
+router bgp 1
+ bgp suppress-inactive
+ neighbor 1.1.1.1 remote-as 1
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-advertise-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-advertise-inactive
@@ -1,0 +1,17 @@
+! This is an ASA device.
+ASA Version 9.9
+!
+hostname asa-advertise-inactive
+!
+interface GigabitEthernet0/0
+ nameif outside
+ ip address 10.0.0.1 255.255.255.0
+!
+router bgp 1
+ bgp router-id 10.0.0.1
+ ! advertise-inactive is the default behavior
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 remote-as 1
+  neighbor 1.1.1.1 activate
+ exit-address-family
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-suppress-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-suppress-inactive
@@ -1,0 +1,17 @@
+! This is an ASA device.
+ASA Version 9.9
+!
+hostname asa-suppress-inactive
+!
+interface GigabitEthernet0/0
+ nameif outside
+ ip address 10.0.0.1 255.255.255.0
+!
+router bgp 1
+ bgp router-id 10.0.0.1
+ bgp suppress-inactive
+ address-family ipv4 unicast
+  neighbor 1.1.1.1 remote-as 1
+  neighbor 1.1.1.1 activate
+ exit-address-family
+!

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -370,11 +370,10 @@ public final class BgpSessionProperties {
                             .getIpv4UnicastAddressFamily()
                             .getAddressFamilyCapabilities()
                             .getAdvertiseExternal(),
-                    SessionType.isEbgp(sessionType)
-                        && directionalSender
-                            .getIpv4UnicastAddressFamily()
-                            .getAddressFamilyCapabilities()
-                            .getAdvertiseInactive()))
+                    directionalSender
+                        .getIpv4UnicastAddressFamily()
+                        .getAddressFamilyCapabilities()
+                        .getAdvertiseInactive()))
             : ImmutableMap.of(),
         reverseDirection ? listenerLocalAs : initiatorLocalAs,
         reverseDirection ? initiatorLocalAs : listenerLocalAs,

--- a/projects/common/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
@@ -161,6 +161,44 @@ public class BgpSessionPropertiesTest {
   }
 
   @Test
+  public void testSessionCreationIbgpAdvertiseInactive() {
+    // advertiseInactive holds for iBGP sessions, not just eBGP.
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+    long as = 1;
+    Ipv4UnicastAddressFamily addressFamily1 =
+        Ipv4UnicastAddressFamily.builder()
+            .setAddressFamilyCapabilities(
+                AddressFamilyCapabilities.builder().setAdvertiseInactive(true).build())
+            .build();
+    Ipv4UnicastAddressFamily addressFamily2 =
+        Ipv4UnicastAddressFamily.builder()
+            .setAddressFamilyCapabilities(
+                AddressFamilyCapabilities.builder().setAdvertiseInactive(false).build())
+            .build();
+    BgpActivePeerConfig p1 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip1)
+            .setLocalAs(as)
+            .setRemoteAs(as)
+            .setPeerAddress(ip2)
+            .setIpv4UnicastAddressFamily(addressFamily1)
+            .build();
+    BgpActivePeerConfig p2 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip2)
+            .setLocalAs(as)
+            .setRemoteAs(as)
+            .setPeerAddress(ip1)
+            .setIpv4UnicastAddressFamily(addressFamily2)
+            .build();
+    // Forward direction: sender p1 has advertiseInactive set, so it holds.
+    assertThat(BgpSessionProperties.from(p1, p2, false).getAdvertiseInactive(), equalTo(true));
+    // Reverse direction: sender p2 does not have it set.
+    assertThat(BgpSessionProperties.from(p1, p2, true).getAdvertiseInactive(), equalTo(false));
+  }
+
+  @Test
   public void testSessionCreationIbgpAcrossConfederation() {
     Ip ip1 = Ip.parse("1.1.1.1");
     Ip ip2 = Ip.parse("2.2.2.2");


### PR DESCRIPTION
BgpSessionProperties.from gated advertiseInactive on
SessionType.isEbgp, so the flag could never hold for an iBGP session.
That restriction dates to the first BGP advertisement implementation in
2017 ("Only applicable to eBGP sessions") and was carried through every
refactor since without re-examination. Real devices do not gate the
behavior on session type: FRR advertises best paths regardless of
iBGP/eBGP, and Junos advertise-inactive is honored on whichever session
it is configured (the only documented exception is route-reflector VRF
routes). Remove the isEbgp conjunct so advertiseInactive is taken from
the sender's IPv4-unicast capabilities for both session types.

Cisco IOS and ASA advertise inactive routes by default and suppress that
with "bgp suppress-inactive", which Batfish did not parse -- IOS/ASA
conversion hardcoded advertiseInactive=true. Parse the command into a
nullable suppressInactive flag on the peer-group hierarchy (inherited
like other per-neighbor settings, default applied at conversion as
advertiseInactive = !suppressInactive).

IOS-XR had a parser for "bgp advertise-inactive" whose extracted value
conversion ignored, and IOS-XR has no command to suppress inactive
advertisement, so the parsed value could only ever be the default. Delete
that dead chain (lexer token, grammar rule, extractor handler, and the
representation field) and keep the hardcoded model default.

Tests cover the IOS/ASA suppress-inactive grammar, the session-property
layer for iBGP, and an end-to-end iBGP dataplane scenario (an inactive
eBGP-learned route reaches an iBGP peer only when not suppressed) that
fails if the isEbgp gate is restored.

----

Prompt:
```
I've been doing a lot of work on BGP and I discovered an issue: we refuse
to let advertiseInactive hold for an iBGP session. Can you look at git
history and see why? This is in BgpSessionProperties.java
```

Followups: research vendor behavior (FRR/Junos/Cisco) without consulting
Batfish; add suppress-inactive support on Cisco IOS and ASA and any other
vendor with an equivalent feature, remove the isEbgp gate, and run the
full test suite to surface breakage; name the config-derived property
suppressInactive to match the command; keep the IOS flag nullable and
apply the default at conversion after inheritance; delete the dead IOS-XR
advertise-inactive parser; add an end-to-end iBGP dataplane test.
