### PR TITLE
sros: parse Nokia SR-OS configs (lexer + grammar + extractor scaffold)

### DIFF
--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -44,21 +44,69 @@ config contains tokens those heuristics would otherwise claim (e.g.
 `policy-options {`, `interface …`). RANCID content types `sros` and `sros-md`
 also map to `NOKIA_SROS` (previously routed to `UNSUPPORTED`).
 
-## Preprocessing decision
+## Parser (P3)
 
-SR-OS will follow the Junos two-grammar **flatten → preprocess** model (mirrors
-`juniper` → `JuniperFlattener` → `flatjuniper`), decided during
-characterization. The rationale:
+The parser lives under the vendor-scoped path
+[`org.batfish.vendor.sros.grammar`](../../../projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/):
+`SrosLexer.g4`, `SrosParser.g4`, `SrosCombinedParser`, `SrosBaseLexer`,
+`SrosControlPlaneExtractor`, and `SrosConfigurationBuilder`. It produces an
+`SrosConfiguration` (in the `representation` subpackage).
 
-- Both brace and flat forms are legitimate, mixable inputs, so an outer grammar
-  recognizes both and flattens braced blocks to one canonical absolute-path
-  `/configure …` stream.
-- Incremental edit verbs are grammar (`delete`/`-`/`~`/`insert before|after`/
-  `replace … with`/`copy`/`rename`); a preprocessor applies them in order.
-- `apply-groups` config-group inheritance must be expanded by Batfish (configs
-  ship unexpanded): regex/wildcard key match, first-listed-wins precedence,
+### Canonical form: one hierarchical grammar, not a flatten pass
+
+P1 left an open architecture question: flatten brace → flat `/configure …` lines
+(the Junos/Palo Alto pattern), or keep a single hierarchical grammar and treat
+flat lines as ordinary statements. **P3 chose the single-grammar
+hierarchical-canonical approach.** One grammar accepts all three input forms,
+because they are structurally the same token stream of statements:
+
+- the brace/hierarchical form from `admin show configuration` (`configure { … }`),
+- the absolute-path flat form, where each line is a `/configure …` statement, and
+- a mix of the two in one file.
+
+A flat `/configure …` line is simply a leaf `statement` whose first word begins
+with `/`. The `SrosConfigurationBuilder` walks the tree and normalizes **every**
+leaf (or empty block) to one canonical absolute-path string — the path words
+joined by spaces, with a leading `/configure` rewritten to `configure`. So all
+three forms yield the identical set of canonical statements; the mixed case (the
+one that breaks designs assuming one form per file) is correct by construction.
+
+Why this over the flatten pipeline:
+
+- **Mixed-form equivalence is the literal output**, with no second grammar and no
+  `FlattenerLineMap` round-trip.
+- **True source line numbers are preserved**, so parse warnings point at the
+  original config without offset bookkeeping.
+- **Fewest moving parts** for the P3 gate (parse the captured config with zero
+  FATAL warnings). The Palo Alto flattener already builds a `SetStatementTree`
+  internally, so the "flatten" and "tree" camps converge anyway.
+
+This mirrors the *spirit* of the Junos pipeline (one canonical statement form fed
+to extraction) while avoiding the text round-trip.
+
+### Deferred to extraction (P4+)
+
+The following were characterized in P1 and are deferred to the extraction phase,
+where feature-specific modeling needs them; they operate on the canonical
+statement tree this parser produces:
+
+- Incremental edit verbs (`delete`/`-`/`~`/`insert before|after`/`replace … with`/
+  `copy`/`rename`) — applied in order as a preprocessor stage.
+- `apply-groups` config-group inheritance — Batfish must expand it (configs ship
+  unexpanded): regex/wildcard key match, first-listed-wins precedence,
   `apply-groups-exclude`.
-- Per-list ordering comes from YANG `ordered-by`; an absent leaf means the YANG
-  default. BGP group→neighbor inheritance is resolved in extraction.
+- Per-list ordering from YANG `ordered-by`; absent leaf ⇒ YANG default. BGP
+  group→neighbor inheritance resolved in extraction.
 
-The grammar, preprocessor, and extractor are implemented in later phases (P3+).
+As of P3 the builder records the canonical statements and extracts the system
+name as the hostname; feature extraction and conversion are P4/P5.
+
+### Tests
+
+[`SrosGrammarTest`](../../../projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosGrammarTest.java)
+covers the P3 gate and the mixed-form acceptance requirement:
+
+- the captured P0 lab r1 `admin show configuration` parses with zero FATAL
+  warnings and nothing unrecognized;
+- pure-brace, pure-flat, and mixed inputs describing the same configuration
+  produce the identical canonical statement list.

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/BUILD.bazel
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("//skylark:antlr.bzl", "antlr_grammar")
+
+package(default_visibility = ["//visibility:public"])
+
+antlr_grammar(
+    name = "grammar_generated",
+    srcs = glob(["*.g4"]),
+    package = "org.batfish.vendor.sros.grammar",
+)
+
+java_library(
+    name = "grammar",
+    srcs = [":grammar_generated"],
+    javacopts = ["-XepDisableAllChecks"],
+    deps = [
+        "//projects/batfish/src/main/java/org/batfish/vendor/sros/grammar:sros_base",
+        "//projects/common:parser_common",
+        "@maven//:org_antlr_antlr4_runtime",
+    ],
+)

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/SrosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/SrosLexer.g4
@@ -1,0 +1,76 @@
+lexer grammar SrosLexer;
+
+options {
+  superClass = 'SrosBaseLexer';
+}
+
+tokens {
+  RIGHT_BRACKET,
+  STRING
+}
+
+// BEGIN other tokens
+
+// Whole-line comments. SR-OS `admin show configuration` output begins each metadata
+// line with `#` (e.g. the TiMOS banner, "Configuration format version ...", and the
+// trailing "# Finished ..." line). Only treat `#` as a comment when it begins a line.
+COMMENT_LINE
+:
+  F_Whitespace* '#' F_NonNewline*
+  (
+    F_Newline
+    | EOF
+  )
+  {lastTokenType() == NEWLINE || lastTokenType() == -1}? -> channel(HIDDEN)
+;
+
+OPEN_BRACE: '{';
+CLOSE_BRACE: '}';
+
+DOUBLE_QUOTE: '"' -> pushMode(M_DoubleQuotedString);
+OPEN_BRACKET: '[' -> pushMode(M_StringList);
+
+NEWLINE: F_Newline;
+
+// A bare word: any run of characters that are not structural punctuation, quotes, or
+// whitespace. This deliberately includes `/`, `.`, `:`, `-`, and digits so that IP
+// addresses/prefixes (1.1.1.1, 1.1.1.1/32), port paths (1/1/c1/1), and the leading
+// `/configure` of the flat form all lex as a single WORD. Type-level validation of
+// these (parsing an IP, an integer range, etc.) happens in extraction (P4).
+WORD: F_WordChar+;
+
+WS: F_Whitespace -> channel(HIDDEN);
+
+// END other tokens
+
+fragment
+F_Newline: [\r\n]+;
+
+fragment
+F_NonNewline: ~[\r\n];
+
+fragment
+F_Whitespace: [ \t]+;
+
+fragment
+F_WordChar: ~[ \t\r\n{}[\]"];
+
+mode M_DoubleQuotedString;
+
+M_DoubleQuotedString_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+M_DoubleQuotedString_STRING: ~["\r\n]+ -> type(STRING);
+M_DoubleQuotedString_DOUBLE_QUOTE: '"' -> type(DOUBLE_QUOTE), popMode;
+
+mode M_StringList;
+
+M_StringList_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+M_StringList_WS: F_Whitespace -> channel(HIDDEN);
+M_StringList_DOUBLE_QUOTE: '"' -> type(DOUBLE_QUOTE), mode(M_StringListDoubleQuotedString);
+M_StringList_UNQUOTED_STRING: F_WordChar+ -> type(STRING);
+M_StringList_RIGHT_BRACKET: ']' -> type(RIGHT_BRACKET), popMode;
+
+mode M_StringListDoubleQuotedString;
+
+M_StringListDoubleQuotedString_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+M_StringListDoubleQuotedString_STRING: ~["\r\n]+ -> type(STRING);
+M_StringListDoubleQuotedString_DOUBLE_QUOTE: '"' -> type(DOUBLE_QUOTE), mode(M_StringList);

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/SrosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/SrosParser.g4
@@ -1,0 +1,65 @@
+parser grammar SrosParser;
+
+options {
+  superClass = 'org.batfish.grammar.BatfishParser';
+  tokenVocab = SrosLexer;
+}
+
+// An SR-OS MD-CLI configuration. This single grammar accepts all three input forms the
+// device and operators produce, because they are structurally the same token stream of
+// statements:
+//   - the brace/hierarchical form emitted by `admin show configuration`
+//     (`configure { ... }`),
+//   - the absolute-path flat form (the Junos-`set` analog), where each line is a
+//     `/configure ...` statement, and
+//   - a mix of the two in one file (a brace production config with appended flat
+//     `/configure ...` edits).
+// A flat `/configure ...` line is simply a leaf `statement` whose first word begins with
+// `/`; the extractor normalizes every leaf to one canonical absolute path, so all three
+// forms yield the same model. See docs/parsing/vendors/sros.md.
+sros_configuration
+:
+  NEWLINE* statement* EOF
+;
+
+statement
+:
+  words += word+
+  (
+    block
+    | bracketed_clause statement_end
+    | statement_end
+  )
+;
+
+// A brace-delimited block: `<words> { <newline> <statements> }`. The opening brace sits on
+// the same line as the leading words; the closing brace is on its own line.
+block
+:
+  OPEN_BRACE NEWLINE+ statement* CLOSE_BRACE statement_end
+;
+
+// A leaf-list value, e.g. `prefix-list ["a" "b"]` or `member ["administrative"]`.
+bracketed_clause
+:
+  OPEN_BRACKET word* RIGHT_BRACKET
+;
+
+// One or more newlines terminate a statement; runs of blank lines collapse in the lexer,
+// but separate runs (e.g. around hidden comment lines) can produce adjacent NEWLINE tokens.
+statement_end
+:
+  NEWLINE+
+;
+
+word
+:
+  WORD
+  | string
+;
+
+string
+:
+  STRING
+  | DOUBLE_QUOTE STRING? DOUBLE_QUOTE
+;

--- a/projects/batfish/src/main/java/org/batfish/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/BUILD.bazel
@@ -50,6 +50,8 @@ java_library(
         "//projects/batfish/src/main/java/org/batfish/vendor/check_point_management/parsing",
         "//projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar",
         "//projects/batfish/src/main/java/org/batfish/vendor/sonic/grammar",
+        "//projects/batfish/src/main/java/org/batfish/vendor/sros/grammar",
+        "//projects/batfish/src/main/java/org/batfish/vendor/sros/representation",
         "//projects/bdd",
         "//projects/common",
         "//projects/symbolic",

--- a/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ParseVendorConfigurationJob.java
@@ -79,6 +79,8 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosCombinedParser;
 import org.batfish.vendor.cisco_nxos.grammar.NxosControlPlaneExtractor;
 import org.batfish.vendor.sonic.grammar.SonicControlPlaneExtractor;
 import org.batfish.vendor.sonic.grammar.SonicControlPlaneExtractor.SonicFileType;
+import org.batfish.vendor.sros.grammar.SrosCombinedParser;
+import org.batfish.vendor.sros.grammar.SrosControlPlaneExtractor;
 
 @ParametersAreNonnullByDefault
 public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigurationResult> {
@@ -93,9 +95,6 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
           ConfigurationFormat.METAMAKO,
           ConfigurationFormat.MRV_COMMANDS,
           ConfigurationFormat.MSS,
-          // NOKIA_SROS is registered and detected as of P2, but the parser/extractor land
-          // in P3. Until then it is routed here so detection is exercised without a crash.
-          ConfigurationFormat.NOKIA_SROS,
           ConfigurationFormat.RUCKUS_ICX,
           ConfigurationFormat.UNSUPPORTED,
           ConfigurationFormat.VXWORKS);
@@ -567,6 +566,24 @@ public class ParseVendorConfigurationJob extends BatfishJob<ParseVendorConfigura
                   _fileResults.get(filename).getWarnings(),
                   _fileResults.get(filename).getSilentSyntax());
           parseFile(filename, mrvParser, extractor);
+          vc = extractor.getVendorConfiguration();
+          vc.setFilename(filename);
+          break;
+        }
+
+      case NOKIA_SROS:
+        {
+          Entry<String, String> fileEntry = Iterables.getOnlyElement(_fileTexts.entrySet());
+          String filename = fileEntry.getKey();
+          String fileText = fileEntry.getValue();
+          SrosCombinedParser srosParser = new SrosCombinedParser(fileText, _settings);
+          ControlPlaneExtractor extractor =
+              new SrosControlPlaneExtractor(
+                  fileText,
+                  srosParser,
+                  _fileResults.get(filename).getWarnings(),
+                  _fileResults.get(filename).getSilentSyntax());
+          parseFile(filename, srosParser, extractor);
           vc = extractor.getVendorConfiguration();
           vc.setFilename(filename);
           break;

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@batfish//skylark:pmd_test.bzl", "pmd_test")
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "sros_base",
+    srcs = [
+        ":SrosBaseLexer.java",
+    ],
+    deps = [
+        "//projects/common:parser_common",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:org_antlr_antlr4_runtime",
+    ],
+)
+
+java_library(
+    name = "grammar",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["SrosBaseLexer.java"],
+    ),
+    deps = [
+        "//projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar",
+        "//projects/batfish/src/main/java/org/batfish/vendor/sros/representation",
+        "//projects/common",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_antlr_antlr4_runtime",
+    ],
+)
+
+pmd_test(
+    name = "pmd",
+    lib = ":grammar",
+)

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosBaseLexer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosBaseLexer.java
@@ -1,0 +1,29 @@
+package org.batfish.vendor.sros.grammar;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Token;
+import org.batfish.grammar.BatfishLexer;
+
+/** SR-OS lexer base class providing additional functionality on top of {@link BatfishLexer}. */
+@ParametersAreNonnullByDefault
+public abstract class SrosBaseLexer extends BatfishLexer {
+
+  private int _lastTokenType = -1;
+
+  public SrosBaseLexer(CharStream input) {
+    super(input);
+  }
+
+  @Override
+  public final void emit(Token token) {
+    super.emit(token);
+    if (token.getChannel() != HIDDEN) {
+      _lastTokenType = token.getType();
+    }
+  }
+
+  protected final int lastTokenType() {
+    return _lastTokenType;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosCombinedParser.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosCombinedParser.java
@@ -1,0 +1,30 @@
+package org.batfish.vendor.sros.grammar;
+
+import org.batfish.grammar.BatfishANTLRErrorStrategy;
+import org.batfish.grammar.BatfishANTLRErrorStrategy.BatfishANTLRErrorStrategyFactory;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishLexerRecoveryStrategy;
+import org.batfish.grammar.GrammarSettings;
+import org.batfish.vendor.sros.grammar.SrosParser.Sros_configurationContext;
+
+/** Combined lexer + parser for Nokia SR-OS (MD-CLI) configurations. */
+public class SrosCombinedParser extends BatfishCombinedParser<SrosParser, SrosLexer> {
+
+  private static final BatfishANTLRErrorStrategyFactory NEWLINE_BASED_RECOVERY =
+      new BatfishANTLRErrorStrategy.BatfishANTLRErrorStrategyFactory(SrosLexer.NEWLINE, "\n");
+
+  public SrosCombinedParser(String input, GrammarSettings settings) {
+    super(
+        SrosParser.class,
+        SrosLexer.class,
+        input,
+        settings,
+        NEWLINE_BASED_RECOVERY,
+        BatfishLexerRecoveryStrategy.WHITESPACE_AND_NEWLINES);
+  }
+
+  @Override
+  public Sros_configurationContext parse() {
+    return _parser.sros_configuration();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosConfigurationBuilder.java
@@ -1,0 +1,163 @@
+package org.batfish.vendor.sros.grammar;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.batfish.common.Warnings;
+import org.batfish.common.Warnings.ParseWarning;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.SilentSyntaxListener;
+import org.batfish.grammar.UnrecognizedLineToken;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.vendor.sros.grammar.SrosParser.Bracketed_clauseContext;
+import org.batfish.vendor.sros.grammar.SrosParser.StatementContext;
+import org.batfish.vendor.sros.representation.SrosConfiguration;
+
+/**
+ * Walks an SR-OS parse tree and records the configuration's canonical absolute-path statements into
+ * a {@link SrosConfiguration}.
+ *
+ * <p>The grammar accepts the brace/hierarchical form, the flat {@code /configure ...} form, and a
+ * mix of the two. This builder normalizes all of them to one canonical form: for every configured
+ * leaf (or empty block) it emits a single space-joined path string from the implicit root, e.g.
+ * {@code configure router "Base" bgp router-id 1.1.1.1}. A leading {@code /configure} from the flat
+ * form is normalized to {@code configure} so that the three input forms produce identical output.
+ */
+@ParametersAreNonnullByDefault
+public final class SrosConfigurationBuilder extends SrosParserBaseListener
+    implements SilentSyntaxListener {
+
+  public SrosConfigurationBuilder(
+      SrosCombinedParser parser,
+      String text,
+      Warnings warnings,
+      SilentSyntaxCollection silentSyntax) {
+    _parser = parser;
+    _text = text;
+    _c = new SrosConfiguration();
+    _w = warnings;
+    _silentSyntax = silentSyntax;
+    _stack = new ArrayDeque<>();
+  }
+
+  @Override
+  public void enterStatement(StatementContext ctx) {
+    _stack.addLast(joinWords(ctx));
+  }
+
+  @Override
+  public void exitStatement(StatementContext ctx) {
+    // Emit a canonical line for a leaf statement (no block) or an empty block. A non-empty block's
+    // presence is implied by its children, so it gets no line of its own (mirrors Juniper
+    // flattening).
+    boolean isLeaf = ctx.block() == null;
+    boolean isEmptyBlock = ctx.block() != null && ctx.block().statement().isEmpty();
+    if (isLeaf || isEmptyBlock) {
+      _c.getStatements().add(canonicalLine(ctx));
+    }
+    _stack.removeLast();
+  }
+
+  /** Build the full canonical path string for a leaf/empty-block statement {@code ctx}. */
+  private @Nonnull String canonicalLine(StatementContext ctx) {
+    String line = String.join(" ", _stack);
+    Bracketed_clauseContext bracket = ctx.bracketed_clause();
+    if (bracket != null && !bracket.word().isEmpty()) {
+      line =
+          line
+              + " [ "
+              + bracket.word().stream()
+                  .map(ParserRuleContext::getText)
+                  .collect(Collectors.joining(" "))
+              + " ]";
+    }
+    // Normalize the flat form's leading "/configure" to the brace form's "configure".
+    if (line.startsWith("/")) {
+      line = line.substring(1);
+    }
+    maybeSetHostname(line);
+    return line;
+  }
+
+  /** The SR-OS system name maps to the Batfish hostname: {@code configure system name "<name>"}. */
+  private void maybeSetHostname(String line) {
+    String prefix = "configure system name ";
+    if (line.startsWith(prefix)) {
+      _c.setHostname(unquote(line.substring(prefix.length()).trim()));
+    }
+  }
+
+  private static @Nonnull String joinWords(StatementContext ctx) {
+    return ctx.word().stream().map(ParserRuleContext::getText).collect(Collectors.joining(" "));
+  }
+
+  private static @Nonnull String unquote(String text) {
+    if (text.length() >= 2 && text.charAt(0) == '"' && text.charAt(text.length() - 1) == '"') {
+      return text.substring(1, text.length() - 1);
+    }
+    return text;
+  }
+
+  @Override
+  public void visitErrorNode(ErrorNode errorNode) {
+    Token token = errorNode.getSymbol();
+    int line = token.getLine();
+    String lineText = errorNode.getText().replace("\n", "").replace("\r", "").trim();
+    _c.setUnrecognized(true);
+
+    if (token instanceof UnrecognizedLineToken) {
+      UnrecognizedLineToken unrecToken = (UnrecognizedLineToken) token;
+      _w.getParseWarnings()
+          .add(
+              new ParseWarning(
+                  line, lineText, unrecToken.getParserContext(), "This syntax is unrecognized"));
+    } else {
+      _w.redFlagf(
+          "Unrecognized Line: %d: %s SUBSEQUENT LINES MAY NOT BE PROCESSED CORRECTLY",
+          line, lineText);
+    }
+  }
+
+  @Override
+  public void exitEveryRule(ParserRuleContext ctx) {
+    tryProcessSilentSyntax(ctx);
+  }
+
+  @Override
+  public @Nonnull SilentSyntaxCollection getSilentSyntax() {
+    return _silentSyntax;
+  }
+
+  @Override
+  public @Nonnull String getInputText() {
+    return _text;
+  }
+
+  @Override
+  public @Nonnull BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Override
+  public @Nonnull Warnings getWarnings() {
+    return _w;
+  }
+
+  public @Nonnull SrosConfiguration getConfiguration() {
+    return _c;
+  }
+
+  private final @Nonnull SrosCombinedParser _parser;
+  private final @Nonnull String _text;
+  private final @Nonnull SrosConfiguration _c;
+  private final @Nonnull Warnings _w;
+  private final @Nonnull SilentSyntaxCollection _silentSyntax;
+
+  /** Stack of space-joined word segments for the currently-open statements, root first. */
+  private final @Nonnull Deque<String> _stack;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosControlPlaneExtractor.java
@@ -1,0 +1,58 @@
+package org.batfish.vendor.sros.grammar;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.Warnings;
+import org.batfish.grammar.BatfishParseTreeWalker;
+import org.batfish.grammar.ControlPlaneExtractor;
+import org.batfish.grammar.ImplementedRules;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.vendor.VendorConfiguration;
+import org.batfish.vendor.sros.grammar.SrosParser.Sros_configurationContext;
+
+/** Extracts data from an SR-OS parse tree into a {@link SrosConfiguration}. */
+public final class SrosControlPlaneExtractor implements ControlPlaneExtractor {
+
+  public SrosControlPlaneExtractor(
+      String fileText,
+      SrosCombinedParser combinedParser,
+      Warnings warnings,
+      SilentSyntaxCollection silentSyntax) {
+    _text = fileText;
+    _parser = combinedParser;
+    _w = warnings;
+    _silentSyntax = silentSyntax;
+  }
+
+  @Override
+  public Set<String> implementedRuleNames() {
+    return ImplementedRules.getImplementedRules(SrosConfigurationBuilder.class);
+  }
+
+  @Override
+  public VendorConfiguration getVendorConfiguration() {
+    return _configuration;
+  }
+
+  @Override
+  public void processParseTree(NetworkSnapshot snapshot, ParserRuleContext tree) {
+    checkArgument(
+        tree instanceof Sros_configurationContext,
+        "Expected %s, not %s",
+        Sros_configurationContext.class,
+        tree.getClass());
+    SrosConfigurationBuilder cb = new SrosConfigurationBuilder(_parser, _text, _w, _silentSyntax);
+    new BatfishParseTreeWalker(_parser).walk(cb, tree);
+    _configuration = cb.getConfiguration();
+  }
+
+  private org.batfish.vendor.sros.representation.SrosConfiguration _configuration;
+  private final @Nonnull SrosCombinedParser _parser;
+  private final @Nonnull String _text;
+  private final @Nonnull Warnings _w;
+  private final @Nonnull SilentSyntaxCollection _silentSyntax;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/package-info.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.vendor.sros.grammar;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@batfish//skylark:pmd_test.bzl", "pmd_test")
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "representation",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["BUILD.bazel"],
+    ),
+    deps = [
+        "//projects/common",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+    ],
+)
+
+pmd_test(
+    name = "pmd",
+    lib = ":representation",
+)

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -1,0 +1,63 @@
+package org.batfish.vendor.sros.representation;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.VendorConversionException;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.vendor.VendorConfiguration;
+
+/**
+ * Vendor-specific data model for a Nokia SR-OS (MD-CLI) configuration.
+ *
+ * <p>As of P3 (parsing) this holds the set of canonical absolute-path statements extracted from the
+ * configuration, regardless of whether the input was the brace/hierarchical form, the flat {@code
+ * /configure ...} form, or a mix of the two. Feature-specific extraction (interfaces, BGP, policy,
+ * etc.) and conversion to the vendor-independent {@link Configuration} model are P4/P5 work.
+ */
+public final class SrosConfiguration extends VendorConfiguration {
+
+  public SrosConfiguration() {
+    _statements = new ArrayList<>();
+  }
+
+  /**
+   * The canonical absolute-path statements in the configuration, in input order. Each entry is the
+   * space-joined path from the implicit root to a configured leaf or empty block, e.g. {@code
+   * "configure router \"Base\" bgp router-id 1.1.1.1"}. Brace, flat {@code /configure ...}, and
+   * mixed inputs that describe the same configuration produce the same list.
+   */
+  public @Nonnull List<String> getStatements() {
+    return _statements;
+  }
+
+  @Override
+  public @Nullable String getHostname() {
+    return _hostname;
+  }
+
+  @Override
+  public void setHostname(String hostname) {
+    _hostname = hostname;
+  }
+
+  @Override
+  public void setVendor(ConfigurationFormat format) {
+    _format = format;
+  }
+
+  @Override
+  public List<Configuration> toVendorIndependentConfigurations() throws VendorConversionException {
+    // Conversion to the vendor-independent model is P5 work; nothing is produced yet.
+    return ImmutableList.of();
+  }
+
+  private final @Nonnull List<String> _statements;
+  private @Nullable String _hostname;
+
+  @SuppressWarnings("unused")
+  private @Nullable ConfigurationFormat _format;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/package-info.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.batfish.vendor.sros.representation;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/projects/batfish/src/test/java/BUILD.bazel
+++ b/projects/batfish/src/test/java/BUILD.bazel
@@ -41,6 +41,7 @@ junit_tests(
     ]),
     resources = [
         "//projects/batfish/src/test/resources",
+        "//projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs",
     ],
     tags = ["cpu:4"],
     deps = [

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
@@ -68,9 +68,9 @@ public class ParseVendorConfigurationJobTest {
   }
 
   @Test
-  public void testNokiaSrosDetectedButUnimplemented() {
-    // SR-OS is registered and detected as of P2; the parser/extractor land in P3, so for now
-    // the job routes a detected SR-OS config to the unsupported path rather than crashing.
+  public void testNokiaSrosDetectedAndParsed() {
+    // SR-OS is detected (P2) and, as of P3, parsed by the SR-OS grammar/extractor. A detected
+    // SR-OS config now flows through the job to a non-null vendor configuration with status PASSED.
     String sros = "# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1\nconfigure {\n}\n";
     ParseResult result =
         new ParseVendorConfigurationJob(
@@ -83,8 +83,8 @@ public class ParseVendorConfigurationJobTest {
             .parse();
     assertThat(result.getFormat(), equalTo(ConfigurationFormat.NOKIA_SROS));
     assertThat(result.getFailureCause(), nullValue());
-    assertThat(result.getConfig(), nullValue());
-    assertThat(result.getParseStatus("config"), equalTo(Optional.of(ParseStatus.UNSUPPORTED)));
+    assertThat(result.getConfig(), not(nullValue()));
+    assertThat(result.getParseStatus("config"), equalTo(Optional.of(ParseStatus.PASSED)));
   }
 
   // Tests that empty files are detected as empty, even when another format is provided.

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/BUILD.bazel
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    resources = [
+        "//projects/batfish/src/test/resources:log4j_config",
+        "//projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs",
+    ],
+    tags = ["cpu:4"],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish/src/main/java/org/batfish/vendor/sros/grammar",
+        "//projects/batfish/src/main/java/org/batfish/vendor/sros/representation",
+        "//projects/common",
+        "//projects/common/src/test/java/org/batfish/common/matchers",
+        "//projects/common/src/test/java/org/batfish/datamodel/matchers",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:junit_junit",
+        "@maven//:org_antlr_antlr4_runtime",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosGrammarTest.java
@@ -1,0 +1,113 @@
+package org.batfish.vendor.sros.grammar;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
+import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import javax.annotation.Nonnull;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
+import org.batfish.config.Settings;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.main.Batfish;
+import org.batfish.vendor.sros.representation.SrosConfiguration;
+import org.junit.Test;
+
+/** Tests of the Nokia SR-OS grammar, extraction scaffold, and brace/flat/mixed equivalence. */
+public final class SrosGrammarTest {
+
+  /**
+   * The captured P0 lab r1 config (full {@code admin show configuration} output) must parse with no
+   * FATAL parse errors. {@link #parseVendorConfig} runs with {@code throwOnParserError} + {@code
+   * throwOnLexerError} set, so any FATAL would throw; reaching the assertions proves the zero-FATAL
+   * P3 gate, and we additionally assert nothing was left unrecognized.
+   */
+  @Test
+  public void testR1ConfigParsesCleanly() {
+    SrosConfiguration vc = parseVendorConfig("r1_admin_show_configuration.txt");
+    assertThat(vc.getUnrecognized(), equalTo(false));
+    assertThat(vc.getWarnings().getParseWarnings(), empty());
+    // Spot-check a few canonical statements drawn from across the brace hierarchy.
+    assertThat(vc.getStatements(), hasItem("configure router \"Base\" autonomous-system 65001"));
+    assertThat(vc.getStatements(), hasItem("configure router \"Base\" bgp router-id 1.1.1.1"));
+    assertThat(
+        vc.getStatements(),
+        hasItem("configure router \"Base\" bgp neighbor \"10.0.0.1\" group \"ebgp\""));
+    assertThat(vc.getStatements(), hasItem("configure card 1 card-type iom-1"));
+  }
+
+  /**
+   * The P3 acceptance test (findings "OPEN ARCH QUESTION", dhalperi 2026-06-04): the brace form,
+   * the flat {@code /configure ...} form, and a mix of the two describing the same configuration
+   * must all yield the same extracted model. The mixed case is the one that breaks designs assuming
+   * one form per file, so it is exercised explicitly.
+   */
+  @Test
+  public void testBraceFlatMixedEquivalence() {
+    SrosConfiguration brace = parseVendorConfig("equivalence_brace.txt");
+    SrosConfiguration flat = parseVendorConfig("equivalence_flat.txt");
+    SrosConfiguration mixed = parseVendorConfig("equivalence_mixed.txt");
+
+    assertThat(brace.getStatements(), equalTo(flat.getStatements()));
+    assertThat(brace.getStatements(), equalTo(mixed.getStatements()));
+
+    assertThat(
+        brace.getStatements(),
+        contains(
+            "configure router \"Base\" autonomous-system 65001",
+            "configure router \"Base\" interface \"system\" ipv4 primary address 1.1.1.1",
+            "configure router \"Base\" interface \"system\" ipv4 primary prefix-length 32",
+            "configure router \"Base\" bgp router-id 1.1.1.1",
+            "configure router \"Base\" bgp group \"ebgp\" peer-as 65002",
+            "configure router \"Base\" bgp group \"ebgp\" import policy [ \"import-all\" ]"));
+  }
+
+  /** Each equivalence config must parse with no FATAL errors and nothing unrecognized. */
+  @Test
+  public void testEquivalenceConfigsClean() {
+    for (String name :
+        new String[] {"equivalence_brace.txt", "equivalence_flat.txt", "equivalence_mixed.txt"}) {
+      SrosConfiguration vc = parseVendorConfig(name);
+      assertThat(vc.getUnrecognized(), equalTo(false));
+      assertThat(vc.getWarnings().getParseWarnings(), empty());
+      // A non-empty block (e.g. the bgp container) emits no line of its own.
+      assertThat(vc.getStatements(), not(hasItem("configure router \"Base\" bgp")));
+    }
+  }
+
+  @Test
+  public void testHostnameExtraction() {
+    SrosConfiguration vc = parseVendorConfig("hostname.txt");
+    assertThat(vc.getHostname(), equalTo("sros-r1"));
+  }
+
+  private static @Nonnull SrosConfiguration parseVendorConfig(String filename) {
+    String src = readResource(TESTCONFIGS_PREFIX + filename, UTF_8);
+    Settings settings = new Settings();
+    configureBatfishTestSettings(settings);
+    SrosCombinedParser parser = new SrosCombinedParser(src, settings);
+    Warnings warnings = new Warnings(true, true, true);
+    SrosControlPlaneExtractor extractor =
+        new SrosControlPlaneExtractor(src, parser, warnings, new SilentSyntaxCollection());
+    ParserRuleContext tree =
+        Batfish.parse(parser, new BatfishLogger(BatfishLogger.LEVELSTR_FATAL, false), settings);
+    extractor.processParseTree(DUMMY_SNAPSHOT_1, tree);
+    SrosConfiguration vc = (SrosConfiguration) extractor.getVendorConfiguration();
+    vc.setFilename(TESTCONFIGS_PREFIX + filename);
+    // Crash if not serializable.
+    vc = SerializationUtils.clone(vc);
+    vc.setWarnings(warnings);
+    return vc;
+  }
+
+  private static final String TESTCONFIGS_PREFIX = "org/batfish/vendor/sros/grammar/testconfigs/";
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/BUILD.bazel
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/BUILD.bazel
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "testconfigs",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD.bazel"],
+    ),
+)

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/equivalence_brace.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/equivalence_brace.txt
@@ -1,0 +1,24 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        autonomous-system 65001
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        bgp {
+            router-id 1.1.1.1
+            group "ebgp" {
+                peer-as 65002
+                import {
+                    policy ["import-all"]
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/equivalence_flat.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/equivalence_flat.txt
@@ -1,0 +1,8 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+/configure router "Base" autonomous-system 65001
+/configure router "Base" interface "system" ipv4 primary address 1.1.1.1
+/configure router "Base" interface "system" ipv4 primary prefix-length 32
+/configure router "Base" bgp router-id 1.1.1.1
+/configure router "Base" bgp group "ebgp" peer-as 65002
+/configure router "Base" bgp group "ebgp" import policy ["import-all"]

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/equivalence_mixed.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/equivalence_mixed.txt
@@ -1,0 +1,20 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        autonomous-system 65001
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        bgp {
+            router-id 1.1.1.1
+        }
+    }
+}
+/configure router "Base" bgp group "ebgp" peer-as 65002
+/configure router "Base" bgp group "ebgp" import policy ["import-all"]

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/hostname.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/hostname.txt
@@ -1,0 +1,7 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    system {
+        name "sros-r1"
+    }
+}


### PR DESCRIPTION
Add the SR-OS parser under the vendor-scoped path
org.batfish.vendor.sros (grammar + representation), and route detected
NOKIA_SROS configs to it in ParseVendorConfigurationJob (removing
NOKIA_SROS from UNIMPLEMENTED_FORMATS). The captured SR-SIM lab config
now parses with zero FATAL warnings.

Architecture: a single hierarchical ANTLR grammar handles all three
input forms SR-OS operators produce — the brace form from `admin show
configuration`, the absolute-path flat form (`/configure ...`, the
Junos-`set` analog), and a mix of the two in one file. A flat line is
just a leaf statement whose first word starts with `/`; the
SrosConfigurationBuilder normalizes every leaf to one canonical
absolute-path string (rewriting a leading `/configure` to `configure`),
so the three forms yield the identical model. This resolves the P1
flatten-vs-hierarchical open question in favor of the
hierarchical-canonical approach rather than a flatjuniper-style
flatten-to-set-lines pass: the mixed-form equivalence is correct by
construction, true source line numbers are preserved for warnings (no
FlattenerLineMap round-trip), and it is the fewest moving parts for the
zero-FATAL parse gate. Edit verbs and apply-groups expansion are
deferred to extraction (P4), where they operate on this canonical
statement tree.

SrosGrammarTest covers the gate and the mixed-form acceptance
requirement: the captured r1 config parses cleanly with nothing
unrecognized, and pure-brace, pure-flat, and mixed inputs describing
the same configuration produce the identical canonical statement list.
Updates docs/parsing/vendors/sros.md with a "Parser (P3)" section
recording the decision and rationale.

----

Prompt:
```
Complete P3 (the Nokia SR-OS parser: lexer + grammar) to its Done-when
condition: the captured r1 config parses via the SR-OS grammar with
zero FATAL parse warnings and bazel test //...sros...grammar... is
green, following ORCHESTRATION.md, ROADMAP, and the other tracking
files; resolve the flatten-vs-hierarchical open question at P3 start
and write the mixed brace+flat acceptance test. Ensure accurate updates
to all tracking data.
```

---
**Stack**:
- #9981
- #9980
- #9979
- #9978
- #9977
- #9976 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*