### PR TITLE
sros: extract Nokia SR-OS configs into a typed feature model

### DIFF
--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -84,23 +84,6 @@ Why this over the flatten pipeline:
 This mirrors the *spirit* of the Junos pipeline (one canonical statement form fed
 to extraction) while avoiding the text round-trip.
 
-### Deferred to extraction (P4+)
-
-The following were characterized in P1 and are deferred to the extraction phase,
-where feature-specific modeling needs them; they operate on the canonical
-statement tree this parser produces:
-
-- Incremental edit verbs (`delete`/`-`/`~`/`insert before|after`/`replace … with`/
-  `copy`/`rename`) — applied in order as a preprocessor stage.
-- `apply-groups` config-group inheritance — Batfish must expand it (configs ship
-  unexpanded): regex/wildcard key match, first-listed-wins precedence,
-  `apply-groups-exclude`.
-- Per-list ordering from YANG `ordered-by`; absent leaf ⇒ YANG default. BGP
-  group→neighbor inheritance resolved in extraction.
-
-As of P3 the builder records the canonical statements and extracts the system
-name as the hostname; feature extraction and conversion are P4/P5.
-
 ### Tests
 
 [`SrosGrammarTest`](../../../projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosGrammarTest.java)
@@ -110,3 +93,60 @@ covers the P3 gate and the mixed-form acceptance requirement:
   warnings and nothing unrecognized;
 - pure-brace, pure-flat, and mixed inputs describing the same configuration
   produce the identical canonical statement list.
+
+## Extraction (P4)
+
+Extraction turns the canonical statement stream into a navigable tree and then a
+typed feature model.
+
+### Canonical tree (`SrosStatementTree`)
+
+[`SrosConfigurationBuilder`](../../../projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosConfigurationBuilder.java)
+builds an
+[`SrosStatementTree`](../../../projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosStatementTree.java)
+alongside the P3 canonical statement list, from the **same word stream**, so the
+brace, flat `/configure …`, and mixed forms all produce an identical tree. Every
+word of every statement is one level of the tree, so a leaf's value is the single
+child key under the leaf node (`card 1 card-type iom-1` →
+`card → 1 → card-type → iom-1`), and a `policy [ a b ]` leaf-list is the ordered
+children of the `policy` node (order preserved for `ordered-by user` lists).
+
+### Preprocessor (`SrosPreprocessor`)
+
+The two mechanisms P1 deferred from the grammar run here, on the tree, before
+feature extraction:
+
+- **`apply-groups` expansion** — grafts the matching subtree of each
+  `groups group "<name>"` definition onto the branch that applied it. Replicates
+  the §4.13 rules: local config wins over inherited, first-listed group wins,
+  `apply-groups-exclude` suppresses a group at a branch, and group list keys may
+  be regexes (`interface "<to-.*>"`) matched against the branch path. Runs to
+  convergence so groups that themselves apply groups resolve.
+- **`delete`/`-` edits** — incremental mutations that remove the named subtree;
+  deleting an absent element is a silent no-op (§4.5). After expansion so a
+  delete can remove inherited content.
+
+The `groups` definition container is pruned afterward (it is inheritance source,
+not configuration).
+
+### Feature model (`SrosFeatureExtractor`)
+
+Walks the preprocessed tree into the typed
+[representation](../../../projects/batfish/src/main/java/org/batfish/vendor/sros/representation/):
+hardware (`Card`/`Mda`, `Port`), routers (`Router`, `RouterInterface`), BGP
+(`BgpProcess`, `BgpGroup`, `BgpNeighbor`), and routing policy (`PrefixList` with
+composite prefix+type entries, `PolicyStatement` with numbered entries and a
+default-action). List keys follow YANG: card by slot, mda by slot, port by path
+string, router/interface by name, BGP group by name, neighbor by IP,
+policy-statement entry by entry-id. BGP `neighbor/group` inheritance is recorded
+on the neighbor and resolved at conversion (P5).
+
+Subtrees that are valid config but not control-plane-relevant — `system
+security`/`ssh`/`user-params` and `persistent-indices` — are intentionally left
+unread, with no warnings (the device accepts them and so do we). The one system
+leaf that matters, `system name`, becomes the Batfish hostname.
+
+[`SrosExtractionTest`](../../../projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java)
+asserts the full r1 feature model extracts with no warnings, the unmodeled
+subtrees are silently skipped, and the preprocessor handles apply-groups (incl.
+regex keys + exclude) and delete edits.

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosConfigurationBuilder.java
@@ -43,11 +43,30 @@ public final class SrosConfigurationBuilder extends SrosParserBaseListener
     _w = warnings;
     _silentSyntax = silentSyntax;
     _stack = new ArrayDeque<>();
+    _root = new SrosStatementTree();
+    _nodeStack = new ArrayDeque<>();
+    _nodeStack.addLast(_root);
   }
 
   @Override
   public void enterStatement(StatementContext ctx) {
     _stack.addLast(joinWords(ctx));
+
+    // Build the canonical path tree in parallel: descend one level per word from the enclosing
+    // statement's node. This consumes the same word stream as the canonical-line logic, so the
+    // brace, flat /configure, and mixed input forms all produce the identical tree.
+    SrosStatementTree node = _nodeStack.peekLast();
+    for (ParserRuleContext wordCtx : ctx.word()) {
+      node = node.getOrAddChild(normalizeWord(wordCtx.getText()));
+    }
+    Bracketed_clauseContext bracket = ctx.bracketed_clause();
+    if (bracket != null) {
+      // A leaf-list: each bracketed value is an ordered child of the leaf node.
+      for (ParserRuleContext wordCtx : bracket.word()) {
+        node.getOrAddChild(wordCtx.getText());
+      }
+    }
+    _nodeStack.addLast(node);
   }
 
   @Override
@@ -61,6 +80,17 @@ public final class SrosConfigurationBuilder extends SrosParserBaseListener
       _c.getStatements().add(canonicalLine(ctx));
     }
     _stack.removeLast();
+    _nodeStack.removeLast();
+  }
+
+  /** Normalize the flat form's leading {@code /configure} to the brace form's {@code configure}. */
+  private static @Nonnull String normalizeWord(String word) {
+    return word.startsWith("/") ? word.substring(1) : word;
+  }
+
+  /** The canonical path tree built from this configuration. */
+  public @Nonnull SrosStatementTree getTree() {
+    return _root;
   }
 
   /** Build the full canonical path string for a leaf/empty-block statement {@code ctx}. */
@@ -80,27 +110,11 @@ public final class SrosConfigurationBuilder extends SrosParserBaseListener
     if (line.startsWith("/")) {
       line = line.substring(1);
     }
-    maybeSetHostname(line);
     return line;
-  }
-
-  /** The SR-OS system name maps to the Batfish hostname: {@code configure system name "<name>"}. */
-  private void maybeSetHostname(String line) {
-    String prefix = "configure system name ";
-    if (line.startsWith(prefix)) {
-      _c.setHostname(unquote(line.substring(prefix.length()).trim()));
-    }
   }
 
   private static @Nonnull String joinWords(StatementContext ctx) {
     return ctx.word().stream().map(ParserRuleContext::getText).collect(Collectors.joining(" "));
-  }
-
-  private static @Nonnull String unquote(String text) {
-    if (text.length() >= 2 && text.charAt(0) == '"' && text.charAt(text.length() - 1) == '"') {
-      return text.substring(1, text.length() - 1);
-    }
-    return text;
   }
 
   @Override
@@ -160,4 +174,10 @@ public final class SrosConfigurationBuilder extends SrosParserBaseListener
 
   /** Stack of space-joined word segments for the currently-open statements, root first. */
   private final @Nonnull Deque<String> _stack;
+
+  /** Root of the canonical path tree (see {@link SrosStatementTree}). */
+  private final @Nonnull SrosStatementTree _root;
+
+  /** Stack of tree nodes for the currently-open statements; the root is always at the bottom. */
+  private final @Nonnull Deque<SrosStatementTree> _nodeStack;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosControlPlaneExtractor.java
@@ -48,6 +48,12 @@ public final class SrosControlPlaneExtractor implements ControlPlaneExtractor {
     SrosConfigurationBuilder cb = new SrosConfigurationBuilder(_parser, _text, _w, _silentSyntax);
     new BatfishParseTreeWalker(_parser).walk(cb, tree);
     _configuration = cb.getConfiguration();
+
+    // P4: reduce the canonical statement tree (delete edits + apply-groups expansion), then
+    // populate the typed feature model from it.
+    SrosStatementTree root = cb.getTree();
+    SrosPreprocessor.preprocess(root, _w);
+    SrosFeatureExtractor.extract(root, _configuration, _w);
   }
 
   private org.batfish.vendor.sros.representation.SrosConfiguration _configuration;

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -1,0 +1,403 @@
+package org.batfish.vendor.sros.grammar;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.vendor.sros.representation.BgpGroup;
+import org.batfish.vendor.sros.representation.BgpNeighbor;
+import org.batfish.vendor.sros.representation.BgpProcess;
+import org.batfish.vendor.sros.representation.Card;
+import org.batfish.vendor.sros.representation.Mda;
+import org.batfish.vendor.sros.representation.PolicyAction;
+import org.batfish.vendor.sros.representation.PolicyStatement;
+import org.batfish.vendor.sros.representation.PolicyStatementEntry;
+import org.batfish.vendor.sros.representation.Port;
+import org.batfish.vendor.sros.representation.PrefixList;
+import org.batfish.vendor.sros.representation.PrefixListEntry;
+import org.batfish.vendor.sros.representation.Router;
+import org.batfish.vendor.sros.representation.RouterInterface;
+import org.batfish.vendor.sros.representation.SrosConfiguration;
+
+/**
+ * Populates a {@link SrosConfiguration}'s typed feature model from the canonical, preprocessed
+ * {@link SrosStatementTree}.
+ *
+ * <p>Each leaf's value is the single child key under its leaf node (e.g. {@code card 1 card-type
+ * iom-1} is {@code card -> 1 -> card-type -> iom-1}); leaf-lists ({@code policy [a b]}) are the
+ * ordered children of the leaf node. The extractor reads only the paths characterized for P4
+ * (hardware provisioning, router interfaces, BGP peering, routing-policy). Other configured
+ * subtrees present in real configs — {@code system security}/{@code ssh}/{@code user-params},
+ * {@code persistent-indices} — are control-plane-irrelevant and intentionally left unread; they are
+ * not warnings (the device accepts them and so do we). The one system leaf that matters, {@code
+ * system name}, becomes the Batfish hostname.
+ */
+@ParametersAreNonnullByDefault
+public final class SrosFeatureExtractor {
+
+  public static void extract(SrosStatementTree root, SrosConfiguration c, Warnings w) {
+    new SrosFeatureExtractor(c, w).extractFrom(root);
+  }
+
+  private SrosFeatureExtractor(SrosConfiguration c, Warnings w) {
+    _c = c;
+    _w = w;
+  }
+
+  private void extractFrom(SrosStatementTree root) {
+    SrosStatementTree configure = root.getChild("configure");
+    if (configure == null) {
+      return;
+    }
+    extractSystem(configure.getChild("system"));
+    extractCards(configure.getChild("card"));
+    extractPorts(configure.getChild("port"));
+    extractPolicyOptions(configure.getChild("policy-options"));
+    extractRouters(configure.getChild("router"));
+  }
+
+  // --- system -----------------------------------------------------------------------------------
+
+  private void extractSystem(@Nullable SrosStatementTree system) {
+    if (system == null) {
+      return;
+    }
+    // Only the system name is control-plane-relevant; it maps to the Batfish hostname. The rest of
+    // the system subtree (security, ssh, user-params, ...) is intentionally not modeled.
+    String name = singleValue(system, "name");
+    if (name != null) {
+      _c.setHostname(unquote(name));
+    }
+  }
+
+  // --- hardware ---------------------------------------------------------------------------------
+
+  private void extractCards(@Nullable SrosStatementTree cardList) {
+    if (cardList == null) {
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : cardList.getChildren().entrySet()) {
+      Integer slot = parseInt(e.getKey());
+      if (slot == null) {
+        continue;
+      }
+      SrosStatementTree cardNode = e.getValue();
+      Card card = new Card(slot);
+      card.setCardType(singleValue(cardNode, "card-type"));
+      SrosStatementTree mdaList = cardNode.getChild("mda");
+      if (mdaList != null) {
+        for (Map.Entry<String, SrosStatementTree> me : mdaList.getChildren().entrySet()) {
+          Integer mdaSlot = parseInt(me.getKey());
+          if (mdaSlot == null) {
+            continue;
+          }
+          Mda mda = new Mda(mdaSlot);
+          mda.setMdaType(singleValue(me.getValue(), "mda-type"));
+          card.getMdas().put(mdaSlot, mda);
+        }
+      }
+      _c.getCards().put(slot, card);
+    }
+  }
+
+  private void extractPorts(@Nullable SrosStatementTree portList) {
+    if (portList == null) {
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : portList.getChildren().entrySet()) {
+      String name = e.getKey();
+      SrosStatementTree portNode = e.getValue();
+      Port port = new Port(name);
+      Boolean adminState = parseAdminState(singleValue(portNode, "admin-state"));
+      port.setAdminStateEnable(adminState);
+      SrosStatementTree connector = portNode.getChild("connector");
+      if (connector != null) {
+        port.setBreakout(singleValue(connector, "breakout"));
+      }
+      _c.getPorts().put(name, port);
+    }
+  }
+
+  // --- routers, interfaces, bgp -----------------------------------------------------------------
+
+  private void extractRouters(@Nullable SrosStatementTree routerList) {
+    if (routerList == null) {
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : routerList.getChildren().entrySet()) {
+      String name = unquote(e.getKey());
+      SrosStatementTree routerNode = e.getValue();
+      Router router = new Router(name);
+      Long as = parseLong(singleValue(routerNode, "autonomous-system"));
+      router.setAutonomousSystem(as);
+      extractInterfaces(router, routerNode.getChild("interface"));
+      extractBgp(router, routerNode.getChild("bgp"));
+      _c.getRouters().put(name, router);
+    }
+  }
+
+  private void extractInterfaces(Router router, @Nullable SrosStatementTree ifaceList) {
+    if (ifaceList == null) {
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : ifaceList.getChildren().entrySet()) {
+      String name = unquote(e.getKey());
+      SrosStatementTree ifaceNode = e.getValue();
+      RouterInterface iface = new RouterInterface(name);
+      iface.setPort(singleValue(ifaceNode, "port"));
+      SrosStatementTree primary = navigate(ifaceNode, "ipv4", "primary");
+      if (primary != null) {
+        iface.setPrimaryAddress(parseIp(singleValue(primary, "address")));
+        iface.setPrimaryPrefixLength(parseInt(singleValue(primary, "prefix-length")));
+      }
+      router.getInterfaces().put(name, iface);
+    }
+  }
+
+  private void extractBgp(Router router, @Nullable SrosStatementTree bgpNode) {
+    if (bgpNode == null) {
+      return;
+    }
+    BgpProcess proc = new BgpProcess();
+    proc.setRouterId(parseIp(singleValue(bgpNode, "router-id")));
+
+    SrosStatementTree groupList = bgpNode.getChild("group");
+    if (groupList != null) {
+      for (Map.Entry<String, SrosStatementTree> e : groupList.getChildren().entrySet()) {
+        String name = unquote(e.getKey());
+        SrosStatementTree groupNode = e.getValue();
+        BgpGroup group = new BgpGroup(name);
+        group.setPeerAs(parseLong(singleValue(groupNode, "peer-as")));
+        group.getImportPolicies().addAll(policyNames(navigate(groupNode, "import", "policy")));
+        group.getExportPolicies().addAll(policyNames(navigate(groupNode, "export", "policy")));
+        proc.getGroups().put(name, group);
+      }
+    }
+
+    SrosStatementTree neighborList = bgpNode.getChild("neighbor");
+    if (neighborList != null) {
+      for (Map.Entry<String, SrosStatementTree> e : neighborList.getChildren().entrySet()) {
+        String ip = unquote(e.getKey());
+        SrosStatementTree nbrNode = e.getValue();
+        BgpNeighbor neighbor = new BgpNeighbor(ip);
+        String group = singleValue(nbrNode, "group");
+        neighbor.setGroup(group == null ? null : unquote(group));
+        neighbor.setPeerAs(parseLong(singleValue(nbrNode, "peer-as")));
+        neighbor.getImportPolicies().addAll(policyNames(navigate(nbrNode, "import", "policy")));
+        neighbor.getExportPolicies().addAll(policyNames(navigate(nbrNode, "export", "policy")));
+        proc.getNeighbors().put(ip, neighbor);
+      }
+    }
+    router.setBgpProcess(proc);
+  }
+
+  // --- policy-options ---------------------------------------------------------------------------
+
+  private void extractPolicyOptions(@Nullable SrosStatementTree po) {
+    if (po == null) {
+      return;
+    }
+    SrosStatementTree prefixLists = po.getChild("prefix-list");
+    if (prefixLists != null) {
+      for (Map.Entry<String, SrosStatementTree> e : prefixLists.getChildren().entrySet()) {
+        String name = unquote(e.getKey());
+        PrefixList pl = new PrefixList(name);
+        SrosStatementTree prefixNode = e.getValue().getChild("prefix");
+        if (prefixNode != null) {
+          for (Map.Entry<String, SrosStatementTree> pe : prefixNode.getChildren().entrySet()) {
+            Prefix prefix = parsePrefix(pe.getKey());
+            if (prefix == null) {
+              continue;
+            }
+            PrefixListEntry.Type type = parsePrefixType(singleValue(pe.getValue(), "type"));
+            if (type == null) {
+              continue;
+            }
+            pl.getEntries().add(new PrefixListEntry(prefix, type));
+          }
+        }
+        _c.getPrefixLists().put(name, pl);
+      }
+    }
+
+    SrosStatementTree policyStatements = po.getChild("policy-statement");
+    if (policyStatements != null) {
+      for (Map.Entry<String, SrosStatementTree> e : policyStatements.getChildren().entrySet()) {
+        String name = unquote(e.getKey());
+        SrosStatementTree psNode = e.getValue();
+        PolicyStatement ps = new PolicyStatement(name);
+        SrosStatementTree entryList = psNode.getChild("entry");
+        if (entryList != null) {
+          for (Map.Entry<String, SrosStatementTree> ee : entryList.getChildren().entrySet()) {
+            Long entryId = parseLong(ee.getKey());
+            if (entryId == null) {
+              continue;
+            }
+            SrosStatementTree entryNode = ee.getValue();
+            PolicyStatementEntry entry = new PolicyStatementEntry(entryId);
+            entry
+                .getFromPrefixLists()
+                .addAll(policyNames(navigate(entryNode, "from", "prefix-list")));
+            entry.setAction(parseAction(navigate(entryNode, "action", "action-type")));
+            ps.getEntries().put(entryId, entry);
+          }
+        }
+        ps.setDefaultAction(parseAction(navigate(psNode, "default-action", "action-type")));
+        _c.getPolicyStatements().put(name, ps);
+      }
+    }
+  }
+
+  // --- value helpers ----------------------------------------------------------------------------
+
+  /** The single child key of {@code node}'s {@code leaf} child (a leaf value), or {@code null}. */
+  private static @Nullable String singleValue(SrosStatementTree node, String leaf) {
+    SrosStatementTree leafNode = node.getChild(leaf);
+    return singleKey(leafNode);
+  }
+
+  private static @Nullable String singleKey(@Nullable SrosStatementTree node) {
+    if (node == null || node.getChildren().size() != 1) {
+      return null;
+    }
+    return node.getChildren().keySet().iterator().next();
+  }
+
+  /** The ordered, unquoted children of a leaf-list node (policy names), or empty. */
+  private static @Nonnull List<String> policyNames(@Nullable SrosStatementTree leafListNode) {
+    if (leafListNode == null) {
+      return List.of();
+    }
+    return leafListNode.getChildren().keySet().stream()
+        .map(SrosFeatureExtractor::unquote)
+        .collect(java.util.stream.Collectors.toList());
+  }
+
+  private static @Nullable SrosStatementTree navigate(SrosStatementTree start, String... path) {
+    SrosStatementTree node = start;
+    for (String word : path) {
+      node = node.getChild(word);
+      if (node == null) {
+        return null;
+      }
+    }
+    return node;
+  }
+
+  private @Nullable Integer parseInt(@Nullable String text) {
+    if (text == null) {
+      return null;
+    }
+    try {
+      return Integer.valueOf(text);
+    } catch (NumberFormatException e) {
+      _w.redFlagf("SR-OS: expected an integer but got '%s'", text);
+      return null;
+    }
+  }
+
+  private @Nullable Long parseLong(@Nullable String text) {
+    if (text == null) {
+      return null;
+    }
+    try {
+      return Long.valueOf(text);
+    } catch (NumberFormatException e) {
+      _w.redFlagf("SR-OS: expected an integer but got '%s'", text);
+      return null;
+    }
+  }
+
+  private @Nullable Ip parseIp(@Nullable String text) {
+    if (text == null) {
+      return null;
+    }
+    try {
+      return Ip.parse(text);
+    } catch (IllegalArgumentException e) {
+      _w.redFlagf("SR-OS: expected an IPv4 address but got '%s'", text);
+      return null;
+    }
+  }
+
+  private @Nullable Prefix parsePrefix(@Nullable String text) {
+    if (text == null) {
+      return null;
+    }
+    try {
+      return Prefix.parse(text);
+    } catch (IllegalArgumentException e) {
+      _w.redFlagf("SR-OS: expected an IPv4 prefix but got '%s'", text);
+      return null;
+    }
+  }
+
+  private static @Nullable Boolean parseAdminState(@Nullable String text) {
+    if (text == null) {
+      return null;
+    }
+    switch (text) {
+      case "enable":
+        return Boolean.TRUE;
+      case "disable":
+        return Boolean.FALSE;
+      default:
+        return null;
+    }
+  }
+
+  private static @Nullable PrefixListEntry.Type parsePrefixType(@Nullable String text) {
+    if (text == null) {
+      return null;
+    }
+    switch (text) {
+      case "exact":
+        return PrefixListEntry.Type.EXACT;
+      case "longer":
+        return PrefixListEntry.Type.LONGER;
+      case "through":
+        return PrefixListEntry.Type.THROUGH;
+      case "range":
+        return PrefixListEntry.Type.RANGE;
+      case "to":
+        return PrefixListEntry.Type.TO;
+      case "address-mask":
+        return PrefixListEntry.Type.ADDRESS_MASK;
+      default:
+        return null;
+    }
+  }
+
+  private static @Nullable PolicyAction parseAction(@Nullable SrosStatementTree actionTypeNode) {
+    String text = singleKey(actionTypeNode);
+    if (text == null) {
+      return null;
+    }
+    switch (text) {
+      case "accept":
+        return PolicyAction.ACCEPT;
+      case "reject":
+        return PolicyAction.REJECT;
+      case "next-entry":
+        return PolicyAction.NEXT_ENTRY;
+      case "next-policy":
+        return PolicyAction.NEXT_POLICY;
+      default:
+        return null;
+    }
+  }
+
+  private static @Nonnull String unquote(String text) {
+    if (text.length() >= 2 && text.charAt(0) == '"' && text.charAt(text.length() - 1) == '"') {
+      return text.substring(1, text.length() - 1);
+    }
+    return text;
+  }
+
+  private final @Nonnull SrosConfiguration _c;
+  private final @Nonnull Warnings _w;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosPreprocessor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosPreprocessor.java
@@ -1,0 +1,279 @@
+package org.batfish.vendor.sros.grammar;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
+
+/**
+ * Preprocesses the canonical {@link SrosStatementTree} before feature extraction, applying the two
+ * SR-OS mechanisms that were characterized in P1 and deferred to P4 (see {@code
+ * docs/parsing/vendors/sros.md}). Both operate purely on the tree, so they are independent of
+ * whether the input was the brace, flat, or mixed form.
+ *
+ * <p>Order (documented so it is stable):
+ *
+ * <ol>
+ *   <li><b>apply-groups expansion</b> — materializes config inherited from {@code groups}, so a
+ *       subsequent {@code delete} can remove inherited content;
+ *   <li><b>delete edits</b> — applies incremental {@code delete}/{@code -} mutations;
+ *   <li><b>cleanup</b> — prunes the {@code groups} definition container, which is not configuration
+ *       itself.
+ * </ol>
+ */
+@ParametersAreNonnullByDefault
+public final class SrosPreprocessor {
+
+  /** Maximum apply-groups expansion passes before assuming a group reference cycle. */
+  private static final int MAX_APPLY_GROUPS_PASSES = 100;
+
+  public static void preprocess(SrosStatementTree root, Warnings w) {
+    new SrosPreprocessor(root, w).run();
+  }
+
+  private SrosPreprocessor(SrosStatementTree root, Warnings w) {
+    _root = root;
+    _w = w;
+  }
+
+  private void run() {
+    expandApplyGroups();
+    applyDeletes(_root);
+    pruneGroups();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // apply-groups expansion
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Expands every {@code apply-groups [...]} reference by grafting the matching subtree of the
+   * named {@code groups group "<name>"} definition onto the branch that applied it. Replicates the
+   * SR-OS inheritance rules characterized in P1 (MD-CLI Guide §4.13): local config wins over
+   * inherited; first-listed group wins over later ones; {@code apply-groups-exclude} suppresses a
+   * group at a branch; group list keys may be regexes ({@code "<int-.*>"}) matched against the
+   * branch's path. Runs to convergence so groups that themselves apply groups are fully resolved.
+   */
+  private void expandApplyGroups() {
+    SrosStatementTree configure = _root.getChild("configure");
+    if (configure == null) {
+      return;
+    }
+    SrosStatementTree groups = navigate(configure, List.of("groups", "group"));
+    if (groups == null || !groups.hasChildren()) {
+      return;
+    }
+
+    for (int pass = 0; pass < MAX_APPLY_GROUPS_PASSES; pass++) {
+      List<Branch> pending = new ArrayList<>();
+      collectApplyGroupsBranches(configure, new ArrayDeque<>(), pending);
+      if (pending.isEmpty()) {
+        return;
+      }
+      for (Branch branch : pending) {
+        expandBranch(branch, groups);
+      }
+    }
+    _w.redFlagf("SR-OS apply-groups did not converge; possible group reference cycle");
+  }
+
+  /**
+   * Records each node carrying an {@code apply-groups} child along with its path under configure.
+   */
+  private void collectApplyGroupsBranches(
+      SrosStatementTree node, Deque<String> path, List<Branch> out) {
+    if (node.getChild("apply-groups") != null) {
+      out.add(new Branch(node, new ArrayList<>(path)));
+    }
+    for (Map.Entry<String, SrosStatementTree> e : node.getChildren().entrySet()) {
+      String word = e.getKey();
+      // Do not descend into the apply-groups/exclude marker subtrees themselves.
+      if (word.equals("apply-groups") || word.equals("apply-groups-exclude")) {
+        continue;
+      }
+      path.addLast(word);
+      collectApplyGroupsBranches(e.getValue(), path, out);
+      path.removeLast();
+    }
+  }
+
+  private void expandBranch(Branch branch, SrosStatementTree groups) {
+    SrosStatementTree node = branch._node;
+    SrosStatementTree applyGroups = node.getChild("apply-groups");
+    if (applyGroups == null) {
+      return; // Already handled in an earlier branch this pass.
+    }
+    Set<String> exclude = new LinkedHashSet<>();
+    SrosStatementTree excludeNode = node.getChild("apply-groups-exclude");
+    if (excludeNode != null) {
+      exclude.addAll(excludeNode.getChildren().keySet());
+    }
+    // First-listed group has highest precedence; copyInto never overwrites, so applying in listed
+    // order yields first-wins, and local config (already present) beats all groups.
+    for (String groupName : applyGroups.getChildren().keySet()) {
+      if (exclude.contains(groupName)) {
+        continue;
+      }
+      SrosStatementTree groupDef = groups.getChild(groupName);
+      if (groupDef == null) {
+        continue; // Reference to an undefined group: leave for another file/source, do not warn.
+      }
+      SrosStatementTree groupSubtree = navigate(groupDef, branch._path);
+      if (groupSubtree != null) {
+        groupSubtree.copyInto(node);
+      }
+    }
+    node.removeChild("apply-groups");
+    node.removeChild("apply-groups-exclude");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // delete edits
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Applies incremental {@code delete <relative-path>} (and its {@code -} alias) edits. A {@code
+   * delete} child of a node names, relative to that node, the subtree(s) to remove — e.g. a node at
+   * {@code router "Base"} with child {@code delete -> interface -> "to-r2"} removes {@code router
+   * "Base" interface "to-r2"}. Deleting an absent element is a silent no-op (MD-CLI §4.5).
+   */
+  private void applyDeletes(SrosStatementTree node) {
+    for (String verb : new String[] {"delete", "-"}) {
+      SrosStatementTree deleteNode = node.getChild(verb);
+      if (deleteNode != null) {
+        for (List<String> targetPath : leafPaths(deleteNode)) {
+          removePath(node, targetPath);
+        }
+        node.removeChild(verb);
+      }
+    }
+    // Recurse into remaining children (a copy of values avoids concurrent-modification surprises).
+    for (SrosStatementTree child : new ArrayList<>(node.getChildren().values())) {
+      applyDeletes(child);
+    }
+  }
+
+  /** Enumerates every root-to-leaf path under {@code node} (each a deletion target). */
+  private static @Nonnull List<List<String>> leafPaths(SrosStatementTree node) {
+    List<List<String>> out = new ArrayList<>();
+    collectLeafPaths(node, new ArrayDeque<>(), out);
+    return out;
+  }
+
+  private static void collectLeafPaths(
+      SrosStatementTree node, Deque<String> path, List<List<String>> out) {
+    if (!node.hasChildren()) {
+      out.add(new ArrayList<>(path));
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : node.getChildren().entrySet()) {
+      path.addLast(e.getKey());
+      collectLeafPaths(e.getValue(), path, out);
+      path.removeLast();
+    }
+  }
+
+  /** Removes the subtree at {@code path} below {@code from}, if present. */
+  private static void removePath(SrosStatementTree from, List<String> path) {
+    SrosStatementTree parent = from;
+    for (int i = 0; i < path.size() - 1; i++) {
+      parent = parent.getChild(path.get(i));
+      if (parent == null) {
+        return; // Path does not exist: silent no-op.
+      }
+    }
+    if (!path.isEmpty()) {
+      parent.removeChild(path.get(path.size() - 1));
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // cleanup
+  // ---------------------------------------------------------------------------------------------
+
+  /** Removes the {@code groups} definition container; it is inheritance source, not config. */
+  private void pruneGroups() {
+    SrosStatementTree configure = _root.getChild("configure");
+    if (configure != null) {
+      configure.removeChild("groups");
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Navigates from {@code start} along {@code path}, returning the reached node or {@code null}. At
+   * each step an exact child match is preferred; failing that, a group-definition regex key of the
+   * form {@code "<regex>"} whose inner pattern matches the (unquoted) path word is used, supporting
+   * group targets like {@code interface "<int-.*>"}.
+   */
+  private static @Nullable SrosStatementTree navigate(SrosStatementTree start, List<String> path) {
+    SrosStatementTree node = start;
+    for (String word : path) {
+      SrosStatementTree next = node.getChild(word);
+      if (next == null) {
+        next = matchRegexKey(node, word);
+      }
+      if (next == null) {
+        return null;
+      }
+      node = next;
+    }
+    return node;
+  }
+
+  /**
+   * Returns the child reached via a {@code "<regex>"} key matching {@code word}, or {@code null}.
+   */
+  private static @Nullable SrosStatementTree matchRegexKey(SrosStatementTree node, String word) {
+    String target = unquote(word);
+    for (Map.Entry<String, SrosStatementTree> e : node.getChildren().entrySet()) {
+      String key = unquote(e.getKey());
+      if (key.length() >= 2 && key.charAt(0) == '<' && key.charAt(key.length() - 1) == '>') {
+        String regex = key.substring(1, key.length() - 1);
+        try {
+          if (Pattern.matches(regex, target)) {
+            return e.getValue();
+          }
+        } catch (PatternSyntaxException ignored) {
+          // Not a usable regex; ignore this key.
+        }
+      }
+    }
+    return null;
+  }
+
+  private static @Nonnull String unquote(String text) {
+    if (text.length() >= 2 && text.charAt(0) == '"' && text.charAt(text.length() - 1) == '"') {
+      return text.substring(1, text.length() - 1);
+    }
+    return text;
+  }
+
+  /**
+   * A tree node that carries an {@code apply-groups} child, plus its path under {@code configure}.
+   */
+  private static final class Branch {
+    final @Nonnull SrosStatementTree _node;
+    final @Nonnull List<String> _path;
+
+    Branch(SrosStatementTree node, List<String> path) {
+      _node = node;
+      _path = path;
+    }
+  }
+
+  private final @Nonnull SrosStatementTree _root;
+  private final @Nonnull Warnings _w;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosStatementTree.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosStatementTree.java
@@ -1,0 +1,79 @@
+package org.batfish.vendor.sros.grammar;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Intermediate representation of an SR-OS configuration as a tree of per-word path segments.
+ *
+ * <p>Every word of every canonical statement becomes one level of the tree, so a leaf's value is
+ * itself a child node. For example {@code configure card 1 card-type iom-1} produces the path
+ * {@code configure -> card -> 1 -> card-type -> iom-1}; reading the card type means looking at the
+ * (single) child key under the {@code card-type} node. A {@code policy [ "a" "b" ]} leaf-list
+ * produces ordered children {@code "a"}, {@code "b"} under the {@code policy} node.
+ *
+ * <p>Because the {@link SrosConfigurationBuilder} feeds the same word stream regardless of whether
+ * the input was the brace, flat {@code /configure ...}, or mixed form, the resulting tree is
+ * identical across all three forms. Children preserve insertion order (a {@link LinkedHashMap}),
+ * which matters for {@code ordered-by user} leaf-lists such as BGP import/export policies.
+ *
+ * <p>The mutators ({@link #removeChild}, {@link #copyInto}) support the P4 preprocessor: applying
+ * {@code delete} edits and grafting {@code apply-groups} subtrees onto their inheriting branches.
+ */
+@ParametersAreNonnullByDefault
+public final class SrosStatementTree {
+
+  public SrosStatementTree() {
+    _children = new LinkedHashMap<>();
+  }
+
+  /** Returns the child subtree for {@code word}, creating it if absent. */
+  public @Nonnull SrosStatementTree getOrAddChild(String word) {
+    return _children.computeIfAbsent(word, w -> new SrosStatementTree());
+  }
+
+  /** Returns the child subtree for {@code word}, or {@code null} if absent. */
+  public @Nullable SrosStatementTree getChild(String word) {
+    return _children.get(word);
+  }
+
+  /** The children of this node, keyed by path word, in insertion order. */
+  public @Nonnull Map<String, SrosStatementTree> getChildren() {
+    return _children;
+  }
+
+  public boolean hasChildren() {
+    return !_children.isEmpty();
+  }
+
+  /** Removes the child subtree keyed by {@code word} (no-op if absent). Used by {@code delete}. */
+  public void removeChild(String word) {
+    _children.remove(word);
+  }
+
+  /**
+   * Deep-merges this tree's structure into {@code target}: every path present here is ensured to
+   * exist under {@code target}, without overwriting branches {@code target} already has at the leaf
+   * level. Used to expand {@code apply-groups} (group content is inherited only where the target
+   * does not already configure it — local config wins).
+   */
+  public void copyInto(SrosStatementTree target) {
+    for (Map.Entry<String, SrosStatementTree> e : _children.entrySet()) {
+      String word = e.getKey();
+      SrosStatementTree sourceChild = e.getValue();
+      SrosStatementTree existing = target.getChild(word);
+      if (existing == null) {
+        sourceChild.copyInto(target.getOrAddChild(word));
+      } else {
+        // Branch already present in target. Recurse so deeper, non-conflicting group content is
+        // still inherited, but do not disturb values the target already set (local wins).
+        sourceChild.copyInto(existing);
+      }
+    }
+  }
+
+  private final @Nonnull Map<String, SrosStatementTree> _children;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpGroup.java
@@ -1,0 +1,50 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS BGP peer group (template), keyed by group-name (e.g. {@code bgp group "ebgp"}). Groups
+ * and neighbors share the same per-peer leaf set; a neighbor inherits unset values from its group
+ * (resolved at conversion). Import/export policy leaf-lists are {@code ordered-by user}, so order
+ * is preserved.
+ */
+public final class BgpGroup implements Serializable {
+
+  public BgpGroup(String name) {
+    _name = name;
+    _importPolicies = new ArrayList<>();
+    _exportPolicies = new ArrayList<>();
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** The {@code peer-as} for this group, or {@code null} if unset. */
+  public @Nullable Long getPeerAs() {
+    return _peerAs;
+  }
+
+  public void setPeerAs(@Nullable Long peerAs) {
+    _peerAs = peerAs;
+  }
+
+  /** The ordered {@code import policy [...]} leaf-list. */
+  public @Nonnull List<String> getImportPolicies() {
+    return _importPolicies;
+  }
+
+  /** The ordered {@code export policy [...]} leaf-list. */
+  public @Nonnull List<String> getExportPolicies() {
+    return _exportPolicies;
+  }
+
+  private final @Nonnull String _name;
+  private @Nullable Long _peerAs;
+  private final @Nonnull List<String> _importPolicies;
+  private final @Nonnull List<String> _exportPolicies;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpNeighbor.java
@@ -1,0 +1,60 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS BGP neighbor (e.g. {@code bgp neighbor "10.0.0.1"}), keyed by peer IP string. A neighbor
+ * references its template {@link BgpGroup} via the mandatory, immutable {@code group} leafref;
+ * unset per-peer attributes are inherited from that group (resolved at conversion). Per-peer values
+ * configured directly on the neighbor override the group's.
+ */
+public final class BgpNeighbor implements Serializable {
+
+  public BgpNeighbor(String ipAddress) {
+    _ipAddress = ipAddress;
+    _importPolicies = new ArrayList<>();
+    _exportPolicies = new ArrayList<>();
+  }
+
+  public @Nonnull String getIpAddress() {
+    return _ipAddress;
+  }
+
+  /** The name of the {@link BgpGroup} this neighbor inherits from (mandatory in valid config). */
+  public @Nullable String getGroup() {
+    return _group;
+  }
+
+  public void setGroup(@Nullable String group) {
+    _group = group;
+  }
+
+  /** The {@code peer-as} configured directly on the neighbor, or {@code null} (inherit group). */
+  public @Nullable Long getPeerAs() {
+    return _peerAs;
+  }
+
+  public void setPeerAs(@Nullable Long peerAs) {
+    _peerAs = peerAs;
+  }
+
+  /** The ordered {@code import policy [...]} configured directly on the neighbor. */
+  public @Nonnull List<String> getImportPolicies() {
+    return _importPolicies;
+  }
+
+  /** The ordered {@code export policy [...]} configured directly on the neighbor. */
+  public @Nonnull List<String> getExportPolicies() {
+    return _exportPolicies;
+  }
+
+  private final @Nonnull String _ipAddress;
+  private @Nullable String _group;
+  private @Nullable Long _peerAs;
+  private final @Nonnull List<String> _importPolicies;
+  private final @Nonnull List<String> _exportPolicies;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpProcess.java
@@ -1,0 +1,43 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+
+/**
+ * SR-OS BGP configuration under a {@link Router} (e.g. {@code router "Base" bgp}). Holds the
+ * router-id plus the peer {@link BgpGroup}s and {@link BgpNeighbor}s.
+ */
+public final class BgpProcess implements Serializable {
+
+  public BgpProcess() {
+    _groups = new HashMap<>();
+    _neighbors = new HashMap<>();
+  }
+
+  /** The {@code router-id}, or {@code null} if unset (derived elsewhere in that case). */
+  public @Nullable Ip getRouterId() {
+    return _routerId;
+  }
+
+  public void setRouterId(@Nullable Ip routerId) {
+    _routerId = routerId;
+  }
+
+  /** Peer groups (templates), keyed by group-name. */
+  public @Nonnull Map<String, BgpGroup> getGroups() {
+    return _groups;
+  }
+
+  /** Neighbors, keyed by peer IP string. */
+  public @Nonnull Map<String, BgpNeighbor> getNeighbors() {
+    return _neighbors;
+  }
+
+  private @Nullable Ip _routerId;
+  private final @Nonnull Map<String, BgpGroup> _groups;
+  private final @Nonnull Map<String, BgpNeighbor> _neighbors;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Card.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Card.java
@@ -1,0 +1,41 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS line card provisioned in a chassis slot. Keyed by slot number (e.g. {@code card 1}). The
+ * card type and its MDAs must be provisioned in config before datapath ports exist.
+ */
+public final class Card implements Serializable {
+
+  public Card(int slot) {
+    _slot = slot;
+    _mdas = new HashMap<>();
+  }
+
+  public int getSlot() {
+    return _slot;
+  }
+
+  /** The provisioned card type (e.g. {@code iom-1}), or {@code null} if unset. */
+  public @Nullable String getCardType() {
+    return _cardType;
+  }
+
+  public void setCardType(@Nullable String cardType) {
+    _cardType = cardType;
+  }
+
+  /** MDAs provisioned on this card, keyed by mda slot. */
+  public @Nonnull Map<Integer, Mda> getMdas() {
+    return _mdas;
+  }
+
+  private final int _slot;
+  private @Nullable String _cardType;
+  private final @Nonnull Map<Integer, Mda> _mdas;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Mda.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Mda.java
@@ -1,0 +1,31 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS MDA (Media Dependent Adapter) provisioned within a {@link Card}. Keyed by its numeric
+ * mda slot within the card (e.g. {@code mda 1}).
+ */
+public final class Mda implements Serializable {
+
+  public Mda(int slot) {
+    _slot = slot;
+  }
+
+  public int getSlot() {
+    return _slot;
+  }
+
+  /** The provisioned MDA type (e.g. {@code me6-100gb-qsfp28}), or {@code null} if unset. */
+  public @Nullable String getMdaType() {
+    return _mdaType;
+  }
+
+  public void setMdaType(@Nullable String mdaType) {
+    _mdaType = mdaType;
+  }
+
+  private final int _slot;
+  private @Nullable String _mdaType;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyAction.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyAction.java
@@ -1,0 +1,12 @@
+package org.batfish.vendor.sros.representation;
+
+/**
+ * An SR-OS routing-policy {@code action-type} (used by both entry {@code action} and {@code
+ * default-action}). {@code nokia-conf-policy-options.yang}.
+ */
+public enum PolicyAction {
+  ACCEPT,
+  REJECT,
+  NEXT_ENTRY,
+  NEXT_POLICY;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatement.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatement.java
@@ -1,0 +1,42 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS {@code policy-options policy-statement}, keyed by name. Holds its numbered {@link
+ * PolicyStatementEntry entries} (ordered by entry-id) and the {@code default-action action-type}
+ * applied when no entry matches.
+ */
+public final class PolicyStatement implements Serializable {
+
+  public PolicyStatement(String name) {
+    _name = name;
+    _entries = new LinkedHashMap<>();
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** Numbered entries, keyed by entry-id. A {@link LinkedHashMap} preserves configuration order. */
+  public @Nonnull Map<Long, PolicyStatementEntry> getEntries() {
+    return _entries;
+  }
+
+  /** The {@code default-action action-type}, or {@code null} if unset. */
+  public @Nullable PolicyAction getDefaultAction() {
+    return _defaultAction;
+  }
+
+  public void setDefaultAction(@Nullable PolicyAction defaultAction) {
+    _defaultAction = defaultAction;
+  }
+
+  private final @Nonnull String _name;
+  private final @Nonnull Map<Long, PolicyStatementEntry> _entries;
+  private @Nullable PolicyAction _defaultAction;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatementEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatementEntry.java
@@ -1,0 +1,42 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * One numbered entry of an SR-OS {@code policy-statement}, keyed by {@code entry-id}. Holds the
+ * {@code from} match criteria modeled for P4 (prefix-list references) and the entry {@code
+ * action}'s {@code action-type}.
+ */
+public final class PolicyStatementEntry implements Serializable {
+
+  public PolicyStatementEntry(long entryId) {
+    _entryId = entryId;
+    _fromPrefixLists = new ArrayList<>();
+  }
+
+  public long getEntryId() {
+    return _entryId;
+  }
+
+  /** The ordered {@code from prefix-list [...]} leaf-list (names of {@link PrefixList}s). */
+  public @Nonnull List<String> getFromPrefixLists() {
+    return _fromPrefixLists;
+  }
+
+  /** The entry {@code action action-type}, or {@code null} if unset. */
+  public @Nullable PolicyAction getAction() {
+    return _action;
+  }
+
+  public void setAction(@Nullable PolicyAction action) {
+    _action = action;
+  }
+
+  private final long _entryId;
+  private final @Nonnull List<String> _fromPrefixLists;
+  private @Nullable PolicyAction _action;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Port.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Port.java
@@ -1,0 +1,43 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS port, keyed by its slot/mda/connector path string (e.g. {@code 1/1/c1} for a connector
+ * or {@code 1/1/c1/1} for a breakout sub-port). Holds the admin-state and, for connectors, the
+ * breakout setting.
+ */
+public final class Port implements Serializable {
+
+  public Port(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** The {@code admin-state} ({@code enable}/{@code disable}), or {@code null} if unset. */
+  public @Nullable Boolean getAdminStateEnable() {
+    return _adminStateEnable;
+  }
+
+  public void setAdminStateEnable(@Nullable Boolean adminStateEnable) {
+    _adminStateEnable = adminStateEnable;
+  }
+
+  /** The {@code connector breakout} setting (e.g. {@code c1-100g}), or {@code null} if unset. */
+  public @Nullable String getBreakout() {
+    return _breakout;
+  }
+
+  public void setBreakout(@Nullable String breakout) {
+    _breakout = breakout;
+  }
+
+  private final @Nonnull String _name;
+  private @Nullable Boolean _adminStateEnable;
+  private @Nullable String _breakout;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PrefixList.java
@@ -1,0 +1,30 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * An SR-OS {@code policy-options prefix-list}, keyed by name. Holds its match {@link
+ * PrefixListEntry entries} (each a prefix + match type).
+ */
+public final class PrefixList implements Serializable {
+
+  public PrefixList(String name) {
+    _name = name;
+    _entries = new ArrayList<>();
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** The entries of this prefix-list, in configuration order. */
+  public @Nonnull List<PrefixListEntry> getEntries() {
+    return _entries;
+  }
+
+  private final @Nonnull String _name;
+  private final @Nonnull List<PrefixListEntry> _entries;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PrefixListEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PrefixListEntry.java
@@ -1,0 +1,57 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.Prefix;
+
+/**
+ * One entry of an SR-OS {@code prefix-list}. The YANG list is keyed by the composite of the {@code
+ * ip-prefix} and the match {@code type} (e.g. {@code exact}, {@code longer}, {@code through},
+ * {@code range}), so the same prefix may appear under multiple types.
+ */
+public final class PrefixListEntry implements Serializable {
+
+  /** The prefix-list entry match type. */
+  public enum Type {
+    EXACT,
+    LONGER,
+    THROUGH,
+    RANGE,
+    TO,
+    ADDRESS_MASK;
+  }
+
+  public PrefixListEntry(Prefix prefix, Type type) {
+    _prefix = prefix;
+    _type = type;
+  }
+
+  public @Nonnull Prefix getPrefix() {
+    return _prefix;
+  }
+
+  public @Nonnull Type getType() {
+    return _type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PrefixListEntry)) {
+      return false;
+    }
+    PrefixListEntry that = (PrefixListEntry) o;
+    return _prefix.equals(that._prefix) && _type == that._type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_prefix, _type);
+  }
+
+  private final @Nonnull Prefix _prefix;
+  private final @Nonnull Type _type;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
@@ -1,0 +1,51 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS routing instance (e.g. {@code router "Base"}), keyed by router-name. {@code Base} is the
+ * full-featured instance. Holds the autonomous-system, interfaces, and BGP configuration.
+ */
+public final class Router implements Serializable {
+
+  public Router(String name) {
+    _name = name;
+    _interfaces = new HashMap<>();
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** The {@code autonomous-system}, or {@code null} if unset. */
+  public @Nullable Long getAutonomousSystem() {
+    return _autonomousSystem;
+  }
+
+  public void setAutonomousSystem(@Nullable Long autonomousSystem) {
+    _autonomousSystem = autonomousSystem;
+  }
+
+  /** Interfaces in this router, keyed by interface-name. */
+  public @Nonnull Map<String, RouterInterface> getInterfaces() {
+    return _interfaces;
+  }
+
+  /** The BGP process for this router, or {@code null} if {@code bgp} is not configured. */
+  public @Nullable BgpProcess getBgpProcess() {
+    return _bgpProcess;
+  }
+
+  public void setBgpProcess(@Nullable BgpProcess bgpProcess) {
+    _bgpProcess = bgpProcess;
+  }
+
+  private final @Nonnull String _name;
+  private @Nullable Long _autonomousSystem;
+  private final @Nonnull Map<String, RouterInterface> _interfaces;
+  private @Nullable BgpProcess _bgpProcess;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/RouterInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/RouterInterface.java
@@ -1,0 +1,69 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Ip;
+
+/**
+ * An SR-OS router interface (e.g. {@code router "Base" interface "system"}), keyed by its
+ * interface-name string. The "system" and loopback interfaces need no port binding; others bind to
+ * a {@link Port}. The IPv4 primary address is modeled as an {@link Ip} plus prefix-length, since
+ * SR-OS configures the two as separate leaves.
+ */
+public final class RouterInterface implements Serializable {
+
+  public RouterInterface(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /**
+   * The bound port path (e.g. {@code 1/1/c1/1}), or {@code null} for system/loopback interfaces.
+   */
+  public @Nullable String getPort() {
+    return _port;
+  }
+
+  public void setPort(@Nullable String port) {
+    _port = port;
+  }
+
+  /** The {@code ipv4 primary address}, or {@code null} if unset. */
+  public @Nullable Ip getPrimaryAddress() {
+    return _primaryAddress;
+  }
+
+  public void setPrimaryAddress(@Nullable Ip primaryAddress) {
+    _primaryAddress = primaryAddress;
+  }
+
+  /** The {@code ipv4 primary prefix-length}, or {@code null} if unset. */
+  public @Nullable Integer getPrimaryPrefixLength() {
+    return _primaryPrefixLength;
+  }
+
+  public void setPrimaryPrefixLength(@Nullable Integer primaryPrefixLength) {
+    _primaryPrefixLength = primaryPrefixLength;
+  }
+
+  /**
+   * The combined primary {@link ConcreteInterfaceAddress} if both address and prefix-length are
+   * set, else {@code null}.
+   */
+  public @Nullable ConcreteInterfaceAddress getPrimaryConcreteAddress() {
+    if (_primaryAddress == null || _primaryPrefixLength == null) {
+      return null;
+    }
+    return ConcreteInterfaceAddress.create(_primaryAddress, _primaryPrefixLength);
+  }
+
+  private final @Nonnull String _name;
+  private @Nullable String _port;
+  private @Nullable Ip _primaryAddress;
+  private @Nullable Integer _primaryPrefixLength;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -2,7 +2,9 @@ package org.batfish.vendor.sros.representation;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.VendorConversionException;
@@ -13,15 +15,20 @@ import org.batfish.vendor.VendorConfiguration;
 /**
  * Vendor-specific data model for a Nokia SR-OS (MD-CLI) configuration.
  *
- * <p>As of P3 (parsing) this holds the set of canonical absolute-path statements extracted from the
- * configuration, regardless of whether the input was the brace/hierarchical form, the flat {@code
- * /configure ...} form, or a mix of the two. Feature-specific extraction (interfaces, BGP, policy,
- * etc.) and conversion to the vendor-independent {@link Configuration} model are P4/P5 work.
+ * <p>The configuration is first reduced (P3) to a canonical absolute-path statement tree that
+ * unifies the brace/hierarchical form, the flat {@code /configure ...} form, and a mix of the two.
+ * P4 extraction populates the typed feature maps below (hardware, routers/interfaces, BGP, policy)
+ * from that tree. Conversion to the vendor-independent {@link Configuration} model is P5 work.
  */
 public final class SrosConfiguration extends VendorConfiguration {
 
   public SrosConfiguration() {
     _statements = new ArrayList<>();
+    _cards = new HashMap<>();
+    _ports = new HashMap<>();
+    _routers = new HashMap<>();
+    _prefixLists = new HashMap<>();
+    _policyStatements = new HashMap<>();
   }
 
   /**
@@ -32,6 +39,31 @@ public final class SrosConfiguration extends VendorConfiguration {
    */
   public @Nonnull List<String> getStatements() {
     return _statements;
+  }
+
+  /** Provisioned line cards, keyed by slot number. */
+  public @Nonnull Map<Integer, Card> getCards() {
+    return _cards;
+  }
+
+  /** Provisioned ports, keyed by port path string (e.g. {@code 1/1/c1}, {@code 1/1/c1/1}). */
+  public @Nonnull Map<String, Port> getPorts() {
+    return _ports;
+  }
+
+  /** Routing instances, keyed by router-name (e.g. {@code Base}). */
+  public @Nonnull Map<String, Router> getRouters() {
+    return _routers;
+  }
+
+  /** Routing-policy prefix-lists, keyed by name. */
+  public @Nonnull Map<String, PrefixList> getPrefixLists() {
+    return _prefixLists;
+  }
+
+  /** Routing-policy policy-statements, keyed by name. */
+  public @Nonnull Map<String, PolicyStatement> getPolicyStatements() {
+    return _policyStatements;
   }
 
   @Override
@@ -56,6 +88,11 @@ public final class SrosConfiguration extends VendorConfiguration {
   }
 
   private final @Nonnull List<String> _statements;
+  private final @Nonnull Map<Integer, Card> _cards;
+  private final @Nonnull Map<String, Port> _ports;
+  private final @Nonnull Map<String, Router> _routers;
+  private final @Nonnull Map<String, PrefixList> _prefixLists;
+  private final @Nonnull Map<String, PolicyStatement> _policyStatements;
   private @Nullable String _hostname;
 
   @SuppressWarnings("unused")

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
@@ -1,0 +1,192 @@
+package org.batfish.vendor.sros.grammar;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
+import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import javax.annotation.Nonnull;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
+import org.batfish.config.Settings;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.main.Batfish;
+import org.batfish.vendor.sros.representation.BgpGroup;
+import org.batfish.vendor.sros.representation.BgpNeighbor;
+import org.batfish.vendor.sros.representation.BgpProcess;
+import org.batfish.vendor.sros.representation.Card;
+import org.batfish.vendor.sros.representation.PolicyAction;
+import org.batfish.vendor.sros.representation.PolicyStatement;
+import org.batfish.vendor.sros.representation.PrefixList;
+import org.batfish.vendor.sros.representation.PrefixListEntry;
+import org.batfish.vendor.sros.representation.Router;
+import org.batfish.vendor.sros.representation.RouterInterface;
+import org.batfish.vendor.sros.representation.SrosConfiguration;
+import org.junit.Test;
+
+/** Tests of SR-OS feature extraction (P4): the canonical tree, the preprocessor, and the model. */
+public final class SrosExtractionTest {
+
+  /** The captured r1 config extracts the full characterized feature set with no warnings. */
+  @Test
+  public void testR1Extraction() {
+    SrosConfiguration vc = parseVendorConfig("r1_admin_show_configuration.txt");
+    assertThat(vc.getWarnings().getParseWarnings(), empty());
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    assertThat(vc.getWarnings().getUnimplementedWarnings(), empty());
+
+    // Hardware: card 1 (iom-1) with mda 1 (me6-100gb-qsfp28).
+    assertThat(vc.getCards(), hasKey(1));
+    Card card = vc.getCards().get(1);
+    assertThat(card.getCardType(), equalTo("iom-1"));
+    assertThat(card.getMdas(), hasKey(1));
+    assertThat(card.getMdas().get(1).getMdaType(), equalTo("me6-100gb-qsfp28"));
+
+    // Ports: the connector with breakout, and the breakout sub-port. Both admin-state enable.
+    assertThat(vc.getPorts(), hasKey("1/1/c1"));
+    assertThat(vc.getPorts(), hasKey("1/1/c1/1"));
+    assertThat(vc.getPorts().get("1/1/c1").getAdminStateEnable(), equalTo(Boolean.TRUE));
+    assertThat(vc.getPorts().get("1/1/c1").getBreakout(), equalTo("c1-100g"));
+    assertThat(vc.getPorts().get("1/1/c1/1").getAdminStateEnable(), equalTo(Boolean.TRUE));
+    assertThat(vc.getPorts().get("1/1/c1/1").getBreakout(), nullValue());
+
+    // Router Base: AS 65001, two interfaces.
+    assertThat(vc.getRouters(), hasKey("Base"));
+    Router base = vc.getRouters().get("Base");
+    assertThat(base.getAutonomousSystem(), equalTo(65001L));
+    assertThat(base.getInterfaces().keySet(), containsInAnyOrder("system", "to-r2"));
+
+    RouterInterface system = base.getInterfaces().get("system");
+    assertThat(system.getPort(), nullValue());
+    assertThat(system.getPrimaryAddress(), equalTo(Ip.parse("1.1.1.1")));
+    assertThat(system.getPrimaryPrefixLength(), equalTo(32));
+    assertThat(system.getPrimaryConcreteAddress().toString(), equalTo("1.1.1.1/32"));
+
+    RouterInterface toR2 = base.getInterfaces().get("to-r2");
+    assertThat(toR2.getPort(), equalTo("1/1/c1/1"));
+    assertThat(toR2.getPrimaryAddress(), equalTo(Ip.parse("10.0.0.0")));
+    assertThat(toR2.getPrimaryPrefixLength(), equalTo(31));
+
+    // BGP: router-id, one group, one neighbor referencing it.
+    BgpProcess bgp = base.getBgpProcess();
+    assertThat(bgp, not(nullValue()));
+    assertThat(bgp.getRouterId(), equalTo(Ip.parse("1.1.1.1")));
+    assertThat(bgp.getGroups(), hasKey("ebgp"));
+    BgpGroup ebgp = bgp.getGroups().get("ebgp");
+    assertThat(ebgp.getPeerAs(), equalTo(65002L));
+    assertThat(ebgp.getImportPolicies(), contains("import-all"));
+    assertThat(ebgp.getExportPolicies(), contains("export-system"));
+    assertThat(bgp.getNeighbors(), hasKey("10.0.0.1"));
+    BgpNeighbor neighbor = bgp.getNeighbors().get("10.0.0.1");
+    assertThat(neighbor.getGroup(), equalTo("ebgp"));
+
+    // policy-options: one prefix-list with one exact entry; two policy-statements.
+    assertThat(vc.getPrefixLists(), hasKey("system-pfx"));
+    PrefixList pfx = vc.getPrefixLists().get("system-pfx");
+    assertThat(
+        pfx.getEntries(),
+        contains(new PrefixListEntry(Prefix.parse("1.1.1.1/32"), PrefixListEntry.Type.EXACT)));
+
+    assertThat(
+        vc.getPolicyStatements().keySet(), containsInAnyOrder("export-system", "import-all"));
+    PolicyStatement exportSystem = vc.getPolicyStatements().get("export-system");
+    assertThat(exportSystem.getEntries(), hasKey(10L));
+    assertThat(exportSystem.getEntries().get(10L).getFromPrefixLists(), contains("system-pfx"));
+    assertThat(exportSystem.getEntries().get(10L).getAction(), equalTo(PolicyAction.ACCEPT));
+    PolicyStatement importAll = vc.getPolicyStatements().get("import-all");
+    assertThat(importAll.getEntries().keySet(), empty());
+    assertThat(importAll.getDefaultAction(), equalTo(PolicyAction.ACCEPT));
+  }
+
+  /**
+   * r1's security/ssh/user-params/persistent-indices subtrees are silently skipped (no warnings).
+   */
+  @Test
+  public void testR1UnmodeledSubtreesSilentlySkipped() {
+    SrosConfiguration vc = parseVendorConfig("r1_admin_show_configuration.txt");
+    // No hostname configured in r1 (no `system name`); the system subtree is otherwise unread.
+    assertThat(vc.getHostname(), nullValue());
+    assertThat(vc.getWarnings().getUnimplementedWarnings(), empty());
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+  }
+
+  /** A `system name` leaf becomes the Batfish hostname. */
+  @Test
+  public void testHostnameExtraction() {
+    SrosConfiguration vc = parseVendorConfig("hostname.txt");
+    assertThat(vc.getHostname(), equalTo("sros-r1"));
+  }
+
+  /**
+   * apply-groups expansion: a group applied at {@code router "Base"} contributes {@code bgp group
+   * "ebgp" peer-as}, while the locally-configured import policy is preserved (local wins).
+   */
+  @Test
+  public void testApplyGroupsExpansion() {
+    SrosConfiguration vc = parseVendorConfig("apply_groups.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    BgpGroup ebgp = vc.getRouters().get("Base").getBgpProcess().getGroups().get("ebgp");
+    assertThat(ebgp.getPeerAs(), equalTo(65010L)); // inherited from the group
+    assertThat(ebgp.getImportPolicies(), contains("import-all")); // local config preserved
+  }
+
+  /**
+   * apply-groups with a regex list-key ({@code interface "<to-.*>"}) grafts onto matching branches,
+   * and {@code apply-groups-exclude} suppresses inheritance at a branch.
+   */
+  @Test
+  public void testApplyGroupsRegexAndExclude() {
+    SrosConfiguration vc = parseVendorConfig("apply_groups_regex.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    Router base = vc.getRouters().get("Base");
+    // to-r2 matches the regex key and inherits prefix-length 31.
+    assertThat(base.getInterfaces().get("to-r2").getPrimaryPrefixLength(), equalTo(31));
+    // to-r3 excludes the group, so it does not inherit prefix-length.
+    assertThat(base.getInterfaces().get("to-r3").getPrimaryPrefixLength(), nullValue());
+  }
+
+  /**
+   * delete edit: a trailing flat {@code /configure router "Base" delete interface "to-r2"} removes
+   * that interface from the materialized model, leaving the others.
+   */
+  @Test
+  public void testDeleteEdit() {
+    SrosConfiguration vc = parseVendorConfig("delete_edit.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    Router base = vc.getRouters().get("Base");
+    assertThat(base.getInterfaces().keySet(), contains("system"));
+  }
+
+  private static @Nonnull SrosConfiguration parseVendorConfig(String filename) {
+    String src = readResource(TESTCONFIGS_PREFIX + filename, UTF_8);
+    Settings settings = new Settings();
+    configureBatfishTestSettings(settings);
+    SrosCombinedParser parser = new SrosCombinedParser(src, settings);
+    Warnings warnings = new Warnings(true, true, true);
+    SrosControlPlaneExtractor extractor =
+        new SrosControlPlaneExtractor(src, parser, warnings, new SilentSyntaxCollection());
+    ParserRuleContext tree =
+        Batfish.parse(parser, new BatfishLogger(BatfishLogger.LEVELSTR_FATAL, false), settings);
+    extractor.processParseTree(DUMMY_SNAPSHOT_1, tree);
+    SrosConfiguration vc = (SrosConfiguration) extractor.getVendorConfiguration();
+    vc.setFilename(TESTCONFIGS_PREFIX + filename);
+    // Crash if not serializable.
+    vc = SerializationUtils.clone(vc);
+    vc.setWarnings(warnings);
+    return vc;
+  }
+
+  private static final String TESTCONFIGS_PREFIX = "org/batfish/vendor/sros/grammar/testconfigs/";
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/apply_groups.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/apply_groups.txt
@@ -1,0 +1,25 @@
+# Configuration format version 26.3 revision 0
+configure {
+    groups {
+        group "common-bgp" {
+            router "Base" {
+                bgp {
+                    group "ebgp" {
+                        peer-as 65010
+                    }
+                }
+            }
+        }
+    }
+    router "Base" {
+        autonomous-system 65001
+        apply-groups "common-bgp"
+        bgp {
+            group "ebgp" {
+                import {
+                    policy ["import-all"]
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/apply_groups_regex.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/apply_groups_regex.txt
@@ -1,0 +1,35 @@
+# Configuration format version 26.3 revision 0
+configure {
+    groups {
+        group "iface-defaults" {
+            router "Base" {
+                interface "<to-.*>" {
+                    ipv4 {
+                        primary {
+                            prefix-length 31
+                        }
+                    }
+                }
+            }
+        }
+    }
+    router "Base" {
+        interface "to-r2" {
+            apply-groups "iface-defaults"
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                }
+            }
+        }
+        interface "to-r3" {
+            apply-groups-exclude "iface-defaults"
+            apply-groups "iface-defaults"
+            ipv4 {
+                primary {
+                    address 10.0.0.2
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/delete_edit.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/delete_edit.txt
@@ -1,0 +1,23 @@
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        autonomous-system 65001
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r2" {
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                    prefix-length 31
+                }
+            }
+        }
+    }
+}
+/configure router "Base" delete interface "to-r2"


### PR DESCRIPTION
Build the SR-OS extraction stage (P4) on top of the P3 canonical
statement stream: a navigable tree, a preprocessor for the two
mechanisms deferred from the grammar, and a typed feature model.

SrosConfigurationBuilder now builds an SrosStatementTree from the same
word stream that produces the P3 canonical statement list, so the brace,
flat /configure, and mixed input forms all yield an identical tree.
Every word is one level of the tree, so a leaf's value is the single
child key under the leaf node and a `policy [ a b ]` leaf-list is the
ordered children of the policy node (order preserved for ordered-by-user
lists).

SrosPreprocessor runs the mechanisms P1 characterized and P3 deferred,
on the tree, before extraction: apply-groups expansion (graft the
matching subtree of each groups group onto the branch that applied it,
with local-wins, first-listed-group-wins, apply-groups-exclude, regex
list-keys like interface "<to-.*>", and a convergence loop) and
delete/- edits (remove the named subtree, silent no-op when absent).
The groups definition container is pruned afterward.

SrosFeatureExtractor walks the preprocessed tree into the typed
representation: hardware (Card/Mda, Port), routers (Router,
RouterInterface), BGP (BgpProcess, BgpGroup, BgpNeighbor), and routing
policy (PrefixList with composite prefix+type entries, PolicyStatement
with numbered entries and a default-action). List keys follow YANG.
Subtrees that are valid config but not control-plane-relevant
(system security/ssh/user-params, persistent-indices) are intentionally
left unread, with no warnings; the one system leaf that matters,
system name, becomes the hostname.

SrosExtractionTest asserts the full captured r1 feature model extracts
with zero parse, red-flag, and unimplemented warnings, that the
unmodeled subtrees are skipped silently, and that the preprocessor
handles apply-groups (incl. regex keys + exclude + local-wins) and
delete edits. Updates docs/parsing/vendors/sros.md with an
"Extraction (P4)" section.

----

Prompt:
```
complete P4 (SR-OS extraction) to its Done-when: extraction populates the
SR-OS VendorConfiguration for every characterized feature, extraction unit tests
green, no unexpected todo/warn — following ORCHESTRATION/ROADMAP. Use a clean subagent as the judge and make sure to re-judge any time we make changes
```

---
**Stack**:
- #9981
- #9980
- #9979
- #9978
- #9977 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*