### PR TITLE
sros: fix BGP local-ip, origin, and connected-route modeling

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -93,7 +93,11 @@ public final class SrosConfiguration extends VendorConfiguration {
     c.setDeviceModel(DeviceModel.NOKIA_SROS_UNSPECIFIED);
     c.setDefaultCrossZoneAction(LineAction.PERMIT);
     c.setDefaultInboundAction(LineAction.PERMIT);
-    // SR-OS, like Junos, runs the BGP export pipeline from the main RIB.
+    // SR-OS runs the BGP export pipeline from the main RIB (Junos-like): a route is advertised by
+    // an export policy matching a main-RIB route, not by origination into the BGP RIB. (The
+    // operational `show router bgp routes` table holds only routes learned from peers — the local
+    // entries that the `info /state … bgp rib local-rib` tree additionally lists are a state-tree
+    // display artifact, not BGP-originated routes; see findings.)
     c.setExportBgpFromBgpRib(false);
 
     // Routing policy is referenced by BGP, so convert it before BGP. Prefix-lists before the

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.bgp.NextHopIpTieBreaker.LOWEST_NEXT_HOP_IP;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -15,14 +16,17 @@ import org.batfish.common.Warnings;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConnectedRouteMetadata;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
+import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
@@ -34,10 +38,13 @@ import org.batfish.datamodel.routing_policy.expr.CallExpr;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
+import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
+import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 
@@ -226,6 +233,13 @@ public final class SrosConversions {
       ConcreteInterfaceAddress address = ri.getPrimaryConcreteAddress();
       if (address != null) {
         ib.setAddress(address);
+        // SR-OS installs the connected (subnet) route for an interface address but NOT a
+        // local /32 host route for the interface's own IP — its route-table shows only the
+        // connected prefix. Batfish would otherwise synthesize a local /32; suppress it so the
+        // main RIB matches the device. (Verified against the lab route-table, P5-V.)
+        ib.setAddressMetadata(
+            ImmutableMap.of(
+                address, ConnectedRouteMetadata.builder().setGenerateLocalRoute(false).build()));
       }
       ib.build();
     }
@@ -323,8 +337,8 @@ public final class SrosConversions {
         generatedBgpPeerImportPolicyName(router.getName(), neighbor.getIpAddress());
     String exportPolicyName =
         generatedBgpPeerExportPolicyName(router.getName(), neighbor.getIpAddress());
-    buildPeerPolicy(importPolicyName, importPolicies, ebgp, c);
-    buildPeerPolicy(exportPolicyName, exportPolicies, ebgp, c);
+    buildPeerPolicy(importPolicyName, importPolicies, ebgp, /* isExport= */ false, c);
+    buildPeerPolicy(exportPolicyName, exportPolicies, ebgp, /* isExport= */ true, c);
 
     Ipv4UnicastAddressFamily af =
         Ipv4UnicastAddressFamily.builder()
@@ -337,11 +351,17 @@ public final class SrosConversions {
                     .build())
             .build();
 
+    // Leave local-IP unset: SR-OS auto-selects the source address per peer (the egress
+    // interface address for a directly-connected eBGP peer, the system address for a
+    // multi-hop/iBGP peer). The modeled subset has no explicit BGP local-address leaf, so we
+    // let Batfish resolve the source IP from the topology — for single-hop eBGP it picks the
+    // connected interface toward the peer, matching the device. (Forcing the system address
+    // here would put the local IP off the peering subnet and the session would never
+    // establish.) When local-address modeling is added, set it explicitly here.
     BgpActivePeerConfig.builder()
         .setPeerAddress(peerAddress)
         .setRemoteAsns(LongSpace.of(peerAs))
         .setLocalAs(localAs)
-        .setLocalIp(systemInterfaceIp(router))
         .setIpv4UnicastAddressFamily(af)
         .setBgpProcess(newProc)
         .build();
@@ -368,8 +388,19 @@ public final class SrosConversions {
    * (SR-OS eBGP default-reject). Mirrors the Junos generated-peer-policy idiom.
    */
   private static void buildPeerPolicy(
-      String name, List<String> policyNames, boolean ebgp, Configuration c) {
+      String name, List<String> policyNames, boolean ebgp, boolean isExport, Configuration c) {
     List<Statement> statements = new ArrayList<>();
+    // SR-OS originates locally-sourced routes (the system/connected prefixes advertised via an
+    // export policy) into BGP with origin IGP, like Junos. Set origin IGP for non-BGP routes at
+    // the head of the export policy so advertised local routes carry origin igp, not the Batfish
+    // redistribution default of incomplete. (Caught by lab validation against the eBGP peer, P5-V.)
+    if (isExport) {
+      statements.add(
+          new If(
+              new MatchProtocol(RoutingProtocol.BGP, RoutingProtocol.IBGP),
+              ImmutableList.of(),
+              ImmutableList.of(new SetOrigin(new LiteralOrigin(OriginType.IGP, null)))));
+    }
     // The default policy backs the chain when no named policy makes a terminal decision.
     String defaultPolicyName = ebgp ? defaultRejectPolicy(c) : defaultAcceptPolicy(c);
     statements.add(new SetDefaultPolicy(defaultPolicyName));

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -6,6 +6,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -17,6 +19,7 @@ import javax.annotation.Nonnull;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConnectedRouteMetadata;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
@@ -57,6 +60,12 @@ public final class SrosConversionTest {
     Interface toR2 = c.getAllInterfaces().get("to-r2");
     assertThat(toR2.getInterfaceType(), equalTo(InterfaceType.PHYSICAL));
     assertThat(toR2.getConcreteAddress().toString(), equalTo("10.0.0.0/31"));
+
+    // SR-OS installs the connected route but not a local /32 host route for the interface IP;
+    // the address metadata suppresses Batfish's local-route generation (P5-V finding).
+    ConnectedRouteMetadata toR2Meta = toR2.getAddressMetadata().get(toR2.getConcreteAddress());
+    assertThat(toR2Meta, not(nullValue()));
+    assertThat(toR2Meta.getGenerateLocalRoute(), equalTo(Boolean.FALSE));
   }
 
   /** The prefix-list converts to a RouteFilterList with an exact-length permit line. */
@@ -87,8 +96,11 @@ public final class SrosConversionTest {
     // peer-as 65002 inherited from group "ebgp"; local-as 65001 from the router instance.
     assertThat(peer.getRemoteAsns(), equalTo(org.batfish.datamodel.LongSpace.of(65002L)));
     assertThat(peer.getLocalAs(), equalTo(65001L));
-    // local-ip is the system interface address.
-    assertThat(peer.getLocalIp(), equalTo(Ip.parse("1.1.1.1")));
+    // local-ip is left unset: SR-OS auto-selects the source address per peer, and for a
+    // directly-connected eBGP peer Batfish resolves it from the connected interface toward the
+    // peer. Forcing the system address (1.1.1.1) here would put the local IP off the peering
+    // subnet and the session would never establish (caught by lab validation, P5-V).
+    assertThat(peer.getLocalIp(), nullValue());
     assertNotNull(peer.getIpv4UnicastAddressFamily());
   }
 


### PR DESCRIPTION
Three conversion corrections surfaced by the first lab-validation slice
(P5-V) against the captured srsim+cEOS eBGP snapshot:

- BGP peer local-ip: leave it unset instead of forcing the system
address. SR-OS auto-selects the source address per peer; for a
directly-connected eBGP peer that is the egress interface address, so
Batfish must resolve it from the topology. Forcing the system address
put the local IP off the peering /31 and the session never
established.

- Advertised local routes carry origin IGP. SR-OS originates
locally-sourced routes (the system/connected prefixes a peer learns
via an export policy) with origin igp, like Junos; the generated
per-peer export policy now sets origin IGP for non-BGP routes rather
than leaving Batfish's redistribution default of incomplete. Verified
on the cEOS peer (it learns the system prefix with as-path "65001 i").

- Suppress the local /32 host route. SR-OS installs the connected
subnet route for an interface address but not a local /32 for the
interface's own IP; interface address metadata with
generateLocalRoute=false stops Batfish synthesizing one, so the main
RIB matches the device route-table.

Confirmed the BGP export model is correct as-is (main-RIB export, not
BGP-RIB origination): the device's operational BGP table holds only
learned routes (plaintext "Total Remote Rts: 1"; only the learned route
has in-rtm true in the state tree), so setExportBgpFromBgpRib stays
false. SrosConversionTest updated to assert the three behaviors.

----

Prompt:
```
Complete P5-V, using a clean agent to judge, rejudging after any change.
```

---
**Stack**:
- #9981
- #9980
- #9979 ⬅
- #9978
- #9977
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*