### PR TITLE
sros: model the port/router-interface split so L1 topology drives L3

### DIFF
--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -165,15 +165,27 @@ main routing instance — maps to the Batfish default VRF (`"default"`); any oth
 instance maps to a VRF of the same name. Interfaces and the BGP process are
 attached to their instance's VRF.
 
-### Interfaces
+### Interfaces (the port / router-interface split)
 
-A router interface with no port binding (`system`, loopbacks) is modeled as
-`InterfaceType.LOOPBACK`; a port-bound interface is `InterfaceType.PHYSICAL`. The
-`ipv4 primary {address, prefix-length}` pair becomes the interface's
-`ConcreteInterfaceAddress`. The hardware tree (cards/MDAs/ports) does **not** map
-to the VI model — Batfish derives interfaces from the router instance, not the
-physical port tree — so it is left unconverted with a single red-flag warning
-(not a silent drop).
+SR-OS separates the physical **port** (e.g. `1/1/c1/1`) from the L3
+**router-interface** (e.g. `to-r2`) that binds it — the same physical/logical
+split as Junos (`ge-0/0/0` vs unit `ge-0/0/0.0`). Batfish models it the same way
+Junos is modeled, so a user-provided Layer-1 topology (which names the physical
+port) drives the router-interface's L3 adjacency:
+
+- A router interface with **no port binding** (`system`, loopbacks) is a single
+  `InterfaceType.LOOPBACK` holding the address.
+- A **port-bound** router interface becomes **two** VI interfaces: an addressless
+  `InterfaceType.PHYSICAL` interface named by the **port path** (the Layer-1
+  endpoint), and an `InterfaceType.LOGICAL` interface named by the
+  router-interface, which holds the `ipv4 primary {address, prefix-length}` and
+  carries a `DependencyType.BIND` dependency on the port.
+
+The hardware tree (cards/MDAs/ports) is otherwise **not** mapped to the VI model
+— Batfish derives the active port interface from the router-interface's port
+binding, not by walking the full physical port tree — so the cards/MDAs/ports are
+left unconverted with a single red-flag warning (not a silent drop). The port's
+`admin-state` is honored on the synthesized `PHYSICAL` interface.
 
 ### BGP group → neighbor inheritance
 
@@ -217,4 +229,47 @@ prefix-list → `RouteFilterList`, BGP group→neighbor inheritance (inherited
 `peer-as`, `local-as`, `local-ip`), **behavioral** eBGP default-reject (the
 generated export policy accepts the system prefix and rejects everything else;
 the import policy with a default-action accept permits all), and the
-hardware-not-converted red-flag warning.
+hardware-not-converted red-flag warning. It also asserts the port /
+router-interface split: `to-r2` is `LOGICAL` with a `BIND` dependency on the
+addressless `PHYSICAL` port `1/1/c1/1`.
+
+## Post-processing (P6)
+
+Post-processing (`Batfish.postProcessSnapshot`) is largely vendor-independent —
+interface dependency resolution, derived bandwidth/IGP costs, Layer-1 topology
+application, protocol-state init. The SR-OS-specific concern is that its
+constructs flow through it correctly. The single design decision that matters
+here is the **port / router-interface split** described under
+[Conversion → Interfaces](#interfaces-the-port--router-interface-split), and it
+exists *because of* post-processing:
+
+- **Layer-1 topology lines up with a real interface.** Collected SR-OS labs name
+  the Layer-1 endpoint by the **physical port path** (`1/1/c1/1`), not the L3
+  router-interface (`to-r2`) — the port path is what containerlab/the device
+  expose. Modeling the port as a distinct `PHYSICAL` interface means the L1 edge
+  canonicalizes to a real interface and survives into the *active logical* L1
+  topology. If the L3 interface were the only thing modeled (the pre-P6 design),
+  the L1 endpoint `1/1/c1/1` would resolve to `INVALID_INTERFACE`, the edge would
+  be silently dropped, and the cross-vendor adjacency would form only by the
+  same-subnet fallback in `HybridL3Adjacencies` (which holds only because the
+  cEOS side is never the `node1` of a resolved L1 edge — fragile and accidental).
+- **The L3 edge is driven by L1.** `PointToPointComputer` walks the `BIND`
+  dependency from `to-r2` to its port `1/1/c1/1`, so the user L1 edge between
+  ports yields the L3 edge between the router interfaces. This is the same
+  mechanism Junos relies on for its unit↔physical split.
+- **Interface activity is correct.** The port is admin-up (its `admin-state` is
+  honored), so interface-dependency resolution leaves both the port and the
+  bound `to-r2` active; `system` (loopback) stays active. No SR-OS interface is
+  spuriously deactivated.
+
+There are no SR-OS aggregate/redundant interfaces or OSPF/EIGRP in the current
+lab, so the bandwidth-sum and IGP-cost post-processing steps are not yet
+exercised; they will be when a later lab (P8+) introduces them.
+
+[`SrosPostProcessingTest`](../../../projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosPostProcessingTest.java)
+loads the captured `sros_ceos_ebgp` lab (SR-OS r1 + cEOS r2 + the user L1
+topology) through the full pipeline and asserts, on the post-processed model:
+every r1 interface is active with the expected type and the `to-r2`→`1/1/c1/1`
+BIND dependency; the user L1 edge (named by the port) survives into the active
+logical L1; the cross-vendor L3 edge `r1:to-r2 ↔ r2:Ethernet1` forms; and the
+eBGP session between r1 and r2 is established.

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -108,7 +108,7 @@ public final class SrosConfiguration extends VendorConfiguration {
     // Each SR-OS router instance is a VRF; the "Base" instance is the Batfish default VRF.
     for (Router router : _routers.values()) {
       Vrf vrf = vrfForRouter(router.getName(), c);
-      SrosConversions.convertInterfaces(router, c, vrf);
+      SrosConversions.convertInterfaces(this, router, c, vrf);
       SrosConversions.convertBgp(router, c, vrf, getWarnings());
     }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -215,21 +215,46 @@ public final class SrosConversions {
 
   /**
    * Converts an SR-OS router instance's interfaces to VI {@link Interface}s, attaching each to
-   * {@code vrf} on {@code c}. The {@code system} interface and any port-less interface is modeled
-   * as {@link InterfaceType#LOOPBACK}; a port-bound interface is {@link InterfaceType#PHYSICAL}.
+   * {@code vrf} on {@code c}.
+   *
+   * <p>SR-OS separates the physical <em>port</em> (e.g. {@code 1/1/c1/1}) from the L3
+   * <em>router-interface</em> (e.g. {@code to-r2}) that binds it — the Junos physical/unit split.
+   * We model it the same way Batfish models Junos so that a user-provided Layer-1 topology, which
+   * names the physical port, drives the L3 adjacency of the router-interface:
+   *
+   * <ul>
+   *   <li>A port-less interface ({@code system}, loopbacks) is a single {@link
+   *       InterfaceType#LOOPBACK} holding the address.
+   *   <li>A port-bound interface becomes two VI interfaces: an addressless {@link
+   *       InterfaceType#PHYSICAL} interface named by the <em>port path</em> (the Layer-1 endpoint),
+   *       and a {@link InterfaceType#LOGICAL} interface named by the router-interface, holding the
+   *       address and carrying a {@link Interface.DependencyType#BIND} dependency on the port.
+   *       {@code PointToPointComputer} follows that BIND dependency to map the L3 interface back to
+   *       its physical port, so an L1 edge between ports yields the L3 edge between the router
+   *       interfaces (and the logical interface shares the port's fate).
+   * </ul>
    */
-  static void convertInterfaces(Router router, Configuration c, Vrf vrf) {
+  static void convertInterfaces(SrosConfiguration vc, Router router, Configuration c, Vrf vrf) {
     for (RouterInterface ri : router.getInterfaces().values()) {
-      InterfaceType type = ri.getPort() == null ? InterfaceType.LOOPBACK : InterfaceType.PHYSICAL;
+      String portPath = ri.getPort();
       Interface.Builder ib =
           Interface.builder()
               .setName(ri.getName())
               .setOwner(c)
               .setVrf(vrf)
-              .setType(type)
               // SR-OS router interfaces have no shutdown leaf in the modeled subset; they are up
-              // once configured (admin-state is provisioned at the port, modeled separately).
+              // once configured (port admin-state is modeled on the PHYSICAL port below).
               .setAdminUp(true);
+      if (portPath == null) {
+        // system / loopback: no port binding, a single loopback interface holds the address.
+        ib.setType(InterfaceType.LOOPBACK);
+      } else {
+        // Port-bound: the L3 router-interface is a LOGICAL interface bound to its physical port.
+        ib.setType(InterfaceType.LOGICAL);
+        ib.setDependencies(
+            ImmutableList.of(new Interface.Dependency(portPath, Interface.DependencyType.BIND)));
+        ensurePortInterface(vc, portPath, c, vrf);
+      }
       ConcreteInterfaceAddress address = ri.getPrimaryConcreteAddress();
       if (address != null) {
         ib.setAddress(address);
@@ -243,6 +268,29 @@ public final class SrosConversions {
       }
       ib.build();
     }
+  }
+
+  /**
+   * Creates the addressless {@link InterfaceType#PHYSICAL} VI interface for an SR-OS port if it
+   * does not already exist on {@code c}. This is the interface a user Layer-1 topology references;
+   * the L3 router-interface binds to it. The port is admin-up unless its {@code admin-state} is
+   * explicitly {@code disable} (an absent admin-state is treated as up to avoid spuriously
+   * deactivating a configured interface; SR-OS lab configs set it explicitly).
+   */
+  private static void ensurePortInterface(
+      SrosConfiguration vc, String portPath, Configuration c, Vrf vrf) {
+    if (c.getAllInterfaces().containsKey(portPath)) {
+      return;
+    }
+    Port port = vc.getPorts().get(portPath);
+    boolean adminUp = port == null || !Boolean.FALSE.equals(port.getAdminStateEnable());
+    Interface.builder()
+        .setName(portPath)
+        .setOwner(c)
+        .setVrf(vrf)
+        .setType(InterfaceType.PHYSICAL)
+        .setAdminUp(adminUp)
+        .build();
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/BUILD.bazel
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/BUILD.bazel
@@ -12,6 +12,7 @@ junit_tests(
     ]),
     resources = [
         "//projects/batfish/src/test/resources:log4j_config",
+        "//projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots",
         "//projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs",
     ],
     tags = ["cpu:4"],

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.sros.grammar;
 
 import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.hasRedFlagWarning;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -50,16 +51,28 @@ public final class SrosConversionTest {
     // The "Base" router instance is the default VRF.
     assertThat(c.getVrfs(), hasKey(Configuration.DEFAULT_VRF_NAME));
 
-    // Interfaces: system (loopback, no port) and to-r2 (physical, port-bound).
-    assertThat(c.getAllInterfaces().keySet(), containsInAnyOrder("system", "to-r2"));
+    // Interfaces: system (loopback, no port), the L3 router-interface to-r2 (LOGICAL, holds the
+    // address), and its physical port 1/1/c1/1 (PHYSICAL, addressless, the Layer-1 endpoint).
+    assertThat(c.getAllInterfaces().keySet(), containsInAnyOrder("system", "to-r2", "1/1/c1/1"));
     Interface system = c.getAllInterfaces().get("system");
     assertThat(system.getInterfaceType(), equalTo(InterfaceType.LOOPBACK));
     assertThat(system.getConcreteAddress().toString(), equalTo("1.1.1.1/32"));
     assertThat(system.getVrfName(), equalTo(Configuration.DEFAULT_VRF_NAME));
     assertTrue(system.getAdminUp());
+
     Interface toR2 = c.getAllInterfaces().get("to-r2");
-    assertThat(toR2.getInterfaceType(), equalTo(InterfaceType.PHYSICAL));
+    assertThat(toR2.getInterfaceType(), equalTo(InterfaceType.LOGICAL));
     assertThat(toR2.getConcreteAddress().toString(), equalTo("10.0.0.0/31"));
+    // The L3 interface binds its physical port: a BIND dependency lets a user Layer-1 topology
+    // (which names the port) drive this interface's L3 adjacency and fate. (P6.)
+    assertThat(
+        toR2.getDependencies(),
+        contains(new Interface.Dependency("1/1/c1/1", Interface.DependencyType.BIND)));
+
+    Interface port = c.getAllInterfaces().get("1/1/c1/1");
+    assertThat(port.getInterfaceType(), equalTo(InterfaceType.PHYSICAL));
+    assertThat(port.getConcreteAddress(), nullValue());
+    assertTrue(port.getAdminUp());
 
     // SR-OS installs the connected route but not a local /32 host route for the interface IP;
     // the address metadata suppresses Batfish's local-route generation (P5-V finding).

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosPostProcessingTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosPostProcessingTest.java
@@ -1,0 +1,167 @@
+package org.batfish.vendor.sros.grammar;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.graph.ValueGraph;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.batfish.common.topology.Layer1Topologies;
+import org.batfish.datamodel.BgpPeerConfigId;
+import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.bgp.BgpTopology;
+import org.batfish.datamodel.bgp.BgpTopologyUtils;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Post-processing (P6) tests for SR-OS. Loads the captured {@code sros_ceos_ebgp} lab — an SR-OS r1
+ * and a cEOS r2 with the user-provided Layer-1 topology — through the full Batfish pipeline (parse,
+ * convert, and {@code Batfish.postProcessSnapshot}) and asserts that SR-OS constructs flow through
+ * post-processing correctly:
+ *
+ * <ul>
+ *   <li>interface dependency resolution leaves the SR-OS interfaces active (no spurious
+ *       deactivation),
+ *   <li>the physical port / logical router-interface split lets the Layer-1 topology — which names
+ *       the physical port — survive into the active logical L1 and drive the cross-vendor L3 edge,
+ *       and
+ *   <li>the eBGP session between r1 and r2 is established on the post-processed model.
+ * </ul>
+ *
+ * <p>The r2 cEOS config is the captured lab config with the {@code system l1} hardware block
+ * removed (that block is L1-only and is not accepted by this Batfish's Arista grammar; it does not
+ * affect routing).
+ */
+public final class SrosPostProcessingTest {
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private static final String SNAPSHOTS_PREFIX =
+      "org/batfish/vendor/sros/grammar/snapshots/sros_ceos_ebgp";
+
+  private Batfish getBatfish() throws IOException {
+    return BatfishTestUtils.getBatfishFromTestrigText(
+        TestrigText.builder()
+            .setConfigurationFiles(SNAPSHOTS_PREFIX, ImmutableList.of("r1", "r2"))
+            .setLayer1TopologyPrefix(SNAPSHOTS_PREFIX)
+            .build(),
+        _folder);
+  }
+
+  /**
+   * Every SR-OS interface stays active through interface-dependency post-processing. The L3
+   * router-interface {@code to-r2} survives even though it BINDs the physical port {@code
+   * 1/1/c1/1}, because the port is active and present in the Layer-1 topology.
+   */
+  @Test
+  public void testSrosInterfacesActiveAfterPostProcessing() throws IOException {
+    Batfish batfish = getBatfish();
+    Configuration r1 = batfish.loadConfigurations(batfish.getSnapshot()).get("r1");
+
+    Interface system = r1.getAllInterfaces().get("system");
+    assertThat(system.getInterfaceType(), equalTo(InterfaceType.LOOPBACK));
+    assertTrue(system.getActive());
+
+    Interface port = r1.getAllInterfaces().get("1/1/c1/1");
+    assertThat(port.getInterfaceType(), equalTo(InterfaceType.PHYSICAL));
+    assertTrue(port.getActive());
+    assertNull(port.getConcreteAddress());
+
+    Interface toR2 = r1.getAllInterfaces().get("to-r2");
+    assertThat(toR2.getInterfaceType(), equalTo(InterfaceType.LOGICAL));
+    assertTrue(toR2.getActive());
+    assertThat(toR2.getConcreteAddress().getPrefix(), equalTo(Prefix.parse("10.0.0.0/31")));
+    // The logical interface binds the physical port (fate-sharing + Layer-1 mapping).
+    assertThat(
+        toR2.getDependencies(),
+        contains(new Interface.Dependency("1/1/c1/1", Interface.DependencyType.BIND)));
+  }
+
+  /**
+   * The user-provided Layer-1 topology — which names r1's <em>physical port</em> {@code 1/1/c1/1}
+   * (not the L3 interface {@code to-r2}) — survives into the active logical L1. This is the payoff
+   * of modeling the port as a distinct {@link InterfaceType#PHYSICAL} interface: the L1 endpoint
+   * lines up with a real interface, so the edge is not dropped.
+   */
+  @Test
+  public void testLayer1TopologyApplied() throws IOException {
+    Batfish batfish = getBatfish();
+    // Realize post-processing first; topology is computed from the post-processed configs.
+    batfish.loadConfigurations(batfish.getSnapshot());
+    Layer1Topologies l1 = batfish.getTopologyProvider().getLayer1Topologies(batfish.getSnapshot());
+
+    NodeInterfacePair r1Port = NodeInterfacePair.of("r1", "1/1/c1/1");
+    NodeInterfacePair r2Eth = NodeInterfacePair.of("r2", "Ethernet1");
+    // The edge between the physical port and r2's Ethernet1 is active in both directions (the
+    // factory makes active edges bidirectional). If the port were not modeled, this would be
+    // empty.
+    assertThat(l1.getActiveLogicalL1().edgeStream().toList(), not(empty()));
+    assertTrue(
+        l1.getActiveLogicalL1()
+            .edgeStream()
+            .anyMatch(
+                e ->
+                    e.getNode1().asNodeInterfacePair().equals(r1Port)
+                        && e.getNode2().asNodeInterfacePair().equals(r2Eth)));
+  }
+
+  /**
+   * The cross-vendor L3 edge forms between r1's {@code to-r2} and r2's {@code Ethernet1}. Because
+   * the L3 interface BINDs the port named in the Layer-1 topology, this edge is driven by the L1
+   * topology (via {@code PointToPointComputer}), not only by the same-subnet fallback.
+   */
+  @Test
+  public void testLayer3EdgeFormsAcrossVendors() throws IOException {
+    Batfish batfish = getBatfish();
+    batfish.loadConfigurations(batfish.getSnapshot());
+    Topology l3 = batfish.getTopologyProvider().getInitialLayer3Topology(batfish.getSnapshot());
+    assertThat(l3.getEdges(), hasItem(Edge.of("r1", "to-r2", "r2", "Ethernet1")));
+    assertThat(l3.getEdges(), hasItem(Edge.of("r2", "Ethernet1", "r1", "to-r2")));
+  }
+
+  /** The eBGP session between r1 (AS 65001) and r2 (AS 65002) is established post-processing. */
+  @Test
+  public void testEbgpSessionEstablished() throws IOException {
+    Batfish batfish = getBatfish();
+    Map<String, Configuration> configs = batfish.loadConfigurations(batfish.getSnapshot());
+    Map<Ip, Map<String, Set<String>>> ipOwners =
+        batfish.getTopologyProvider().getInitialIpOwners(batfish.getSnapshot()).getIpVrfOwners();
+    BgpTopology bgpTopo =
+        BgpTopologyUtils.initBgpTopology(
+            configs,
+            ipOwners,
+            false,
+            batfish.getTopologyProvider().getInitialL3Adjacencies(batfish.getSnapshot()));
+    ValueGraph<BgpPeerConfigId, BgpSessionProperties> g = bgpTopo.getGraph();
+    BgpPeerConfigId r1Peer =
+        new BgpPeerConfigId("r1", DEFAULT_VRF_NAME, Prefix.parse("10.0.0.1/32"), false);
+    BgpPeerConfigId r2Peer =
+        new BgpPeerConfigId("r2", DEFAULT_VRF_NAME, Prefix.parse("10.0.0.0/32"), false);
+    assertTrue(g.nodes().contains(r1Peer));
+    assertTrue(g.hasEdgeConnecting(r1Peer, r2Peer));
+    assertFalse(g.adjacentNodes(r1Peer).isEmpty());
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots/BUILD.bazel
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots/BUILD.bazel
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "snapshots",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD.bazel"],
+    ),
+)

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots/sros_ceos_ebgp/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots/sros_ceos_ebgp/configs/r1
@@ -1,0 +1,329 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1 Copyright (c) 2000-2026 Nokia.
+# All rights reserved. All use subject to applicable license agreements.
+# Built on Wed Mar 11 20:17:13 UTC 2026 by builder in /builds/263B/R1/panos
+# Configuration format version 26.3 revision 0
+
+# Generated 2026-06-05T19:40:02.1+00:00 by admin from 172.20.20.1
+# Last modified 2026-06-05T19:38:19.9+00:00 by system (MD-CLI) from Console
+
+configure {
+    card 1 {
+        card-type iom-1
+        mda 1 {
+            mda-type me6-100gb-qsfp28
+        }
+    }
+    policy-options {
+        prefix-list "system-pfx" {
+            prefix 1.1.1.1/32 type exact {
+            }
+        }
+        policy-statement "export-system" {
+            entry 10 {
+                from {
+                    prefix-list ["system-pfx"]
+                }
+                action {
+                    action-type accept
+                }
+            }
+        }
+        policy-statement "import-all" {
+            default-action {
+                action-type accept
+            }
+        }
+    }
+    port 1/1/c1 {
+        admin-state enable
+        connector {
+            breakout c1-100g
+        }
+    }
+    port 1/1/c1/1 {
+        admin-state enable
+    }
+    router "Base" {
+        autonomous-system 65001
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r2" {
+            port 1/1/c1/1
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                    prefix-length 31
+                }
+            }
+        }
+        bgp {
+            router-id 1.1.1.1
+            group "ebgp" {
+                peer-as 65002
+                import {
+                    policy ["import-all"]
+                }
+                export {
+                    policy ["export-system"]
+                }
+            }
+            neighbor "10.0.0.1" {
+                group "ebgp"
+            }
+        }
+    }
+    system {
+        security {
+            aaa {
+                local-profiles {
+                    profile "administrative" {
+                        default-action permit-all
+                        entry 10 {
+                            match "configure system security"
+                            action permit
+                        }
+                        entry 20 {
+                            match "show system security"
+                            action permit
+                        }
+                        entry 30 {
+                            match "tools perform security"
+                            action permit
+                        }
+                        entry 40 {
+                            match "tools dump security"
+                            action permit
+                        }
+                        entry 42 {
+                            match "tools dump system security"
+                            action permit
+                        }
+                        entry 50 {
+                            match "admin system security"
+                            action permit
+                        }
+                        entry 100 {
+                            match "configure li"
+                            action deny
+                        }
+                        entry 110 {
+                            match "show li"
+                            action deny
+                        }
+                        entry 111 {
+                            match "clear li"
+                            action deny
+                        }
+                        entry 112 {
+                            match "tools dump li"
+                            action deny
+                        }
+                        entry 113 {
+                            match "tools perform system security"
+                            action permit
+                        }
+                        netconf {
+                            base-op-authorization {
+                                action true
+                                cancel-commit true
+                                close-session true
+                                commit true
+                                copy-config true
+                                create-subscription true
+                                delete-config true
+                                discard-changes true
+                                edit-config true
+                                get true
+                                get-config true
+                                get-data true
+                                get-schema true
+                                kill-session true
+                                lock true
+                                validate true
+                            }
+                        }
+                    }
+                    profile "default" {
+                        entry 10 {
+                            match "exec"
+                            action permit
+                        }
+                        entry 20 {
+                            match "exit"
+                            action permit
+                        }
+                        entry 30 {
+                            match "help"
+                            action permit
+                        }
+                        entry 40 {
+                            match "logout"
+                            action permit
+                        }
+                        entry 50 {
+                            match "password"
+                            action permit
+                        }
+                        entry 60 {
+                            match "show config"
+                            action deny
+                        }
+                        entry 65 {
+                            match "show li"
+                            action deny
+                        }
+                        entry 66 {
+                            match "clear li"
+                            action deny
+                        }
+                        entry 67 {
+                            match "tools dump li"
+                            action deny
+                        }
+                        entry 68 {
+                            match "state li"
+                            action deny
+                        }
+                        entry 70 {
+                            match "show"
+                            action permit
+                        }
+                        entry 75 {
+                            match "state"
+                            action permit
+                        }
+                        entry 80 {
+                            match "enable-admin"
+                            action permit
+                        }
+                        entry 90 {
+                            match "enable"
+                            action permit
+                        }
+                        entry 100 {
+                            match "configure li"
+                            action deny
+                        }
+                    }
+                }
+            }
+            ssh {
+                server-cipher-list-v2 {
+                    cipher 190 {
+                        name aes256-ctr
+                    }
+                    cipher 192 {
+                        name aes192-ctr
+                    }
+                    cipher 194 {
+                        name aes128-ctr
+                    }
+                    cipher 200 {
+                        name aes128-cbc
+                    }
+                    cipher 205 {
+                        name 3des-cbc
+                    }
+                    cipher 225 {
+                        name aes192-cbc
+                    }
+                    cipher 230 {
+                        name aes256-cbc
+                    }
+                }
+                client-cipher-list-v2 {
+                    cipher 190 {
+                        name aes256-ctr
+                    }
+                    cipher 192 {
+                        name aes192-ctr
+                    }
+                    cipher 194 {
+                        name aes128-ctr
+                    }
+                    cipher 200 {
+                        name aes128-cbc
+                    }
+                    cipher 205 {
+                        name 3des-cbc
+                    }
+                    cipher 225 {
+                        name aes192-cbc
+                    }
+                    cipher 230 {
+                        name aes256-cbc
+                    }
+                }
+                server-mac-list-v2 {
+                    mac 200 {
+                        name hmac-sha2-512
+                    }
+                    mac 210 {
+                        name hmac-sha2-256
+                    }
+                    mac 215 {
+                        name hmac-sha1
+                    }
+                    mac 220 {
+                        name hmac-sha1-96
+                    }
+                    mac 225 {
+                        name hmac-md5
+                    }
+                    mac 240 {
+                        name hmac-md5-96
+                    }
+                }
+                client-mac-list-v2 {
+                    mac 200 {
+                        name hmac-sha2-512
+                    }
+                    mac 210 {
+                        name hmac-sha2-256
+                    }
+                    mac 215 {
+                        name hmac-sha1
+                    }
+                    mac 220 {
+                        name hmac-sha1-96
+                    }
+                    mac 225 {
+                        name hmac-md5
+                    }
+                    mac 240 {
+                        name hmac-md5-96
+                    }
+                }
+            }
+            user-params {
+                local-user {
+                    user "admin" {
+                        password "$2y$10$TQrZlpBDra86.qoexZUzQeBXDY1FcdDhGWdD9lLxMuFyPVSm0OGy6"
+                        restricted-to-home false
+                        access {
+                            console true
+                        }
+                        console {
+                            member ["administrative"]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+persistent-indices {
+    description "Persistent indices are maintained by the system and must not be modified."
+    vrtr-if-id {
+        router-name "Base" interface-name "to-r2" vrtr-id 1 if-index 2
+    }
+}
+
+# Finished 2026-06-05T19:40:02.1+00:00

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots/sros_ceos_ebgp/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots/sros_ceos_ebgp/configs/r2
@@ -1,0 +1,36 @@
+! Command: show running-config
+! device: r2 (cEOSLab, EOS-4.36.0.1F-47401373.43601F (engineering build))
+!
+no aaa root
+!
+username admin privilege 15 role network-admin secret sha512 $6$kUXjcgdL9Fb6h9hr$aNvZHTBTcQMJkpFyI1xbJaExLUudu1CJGqjm/v/cmCZ9gRRvQRicqOJB3NFM/1yZR3xKn.HrhVoAXeLYKs7Om0
+!
+no service interface inactive port-id allocation disabled
+!
+service routing protocols model multi-agent
+!
+hostname r2
+!
+spanning-tree mode mstp
+!
+aaa authorization exec default local
+!
+interface Ethernet1
+   no switchport
+   ip address 10.0.0.1/31
+!
+interface Loopback0
+   ip address 2.2.2.2/32
+!
+interface Management0
+   ip address 172.20.20.3/24
+   ipv6 address 3fff:172:20:20::3/64
+!
+ip routing
+!
+router bgp 65002
+   router-id 2.2.2.2
+   neighbor 10.0.0.0 remote-as 65001
+   network 2.2.2.2/32
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots/sros_ceos_ebgp/layer1_topology.json
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/snapshots/sros_ceos_ebgp/layer1_topology.json
@@ -1,0 +1,14 @@
+{
+    "edges": [
+        {
+            "node1": {
+                "hostname": "r1",
+                "interfaceName": "1/1/c1/1"
+            },
+            "node2": {
+                "hostname": "r2",
+                "interfaceName": "Ethernet1"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
SR-OS separates the physical port (e.g. 1/1/c1/1) from the L3
router-interface (e.g. to-r2) that binds it -- the same physical/logical
split as Junos (ge-0/0/0 vs unit ge-0/0/0.0). Conversion previously
collapsed a port-bound interface into a single PHYSICAL interface that
held the IP, with no port interface and no dependency. That breaks
Layer-1 topology: collected SR-OS labs name the L1 endpoint by the
physical port path (1/1/c1/1), not the router-interface, so the L1 edge
resolved to INVALID_INTERFACE and was silently dropped. The cross-vendor
eBGP adjacency then formed only via the same-subnet fallback in
HybridL3Adjacencies -- accidental, since it holds only because the cEOS
side is never node1 of a resolved L1 edge.

Model it the way Batfish models Junos: a port-bound router-interface
becomes a LOGICAL interface holding the address with a BIND dependency on
an addressless PHYSICAL interface named by the port path (the L1
endpoint); port-less interfaces (system, loopbacks) stay LOOPBACK.
PointToPointComputer walks the BIND dependency from to-r2 to its port, so
the user L1 edge between ports yields the L3 edge between the router
interfaces. The port's admin-state is honored on the PHYSICAL interface.

New SrosPostProcessingTest loads the captured sros_ceos_ebgp lab (SR-OS r1
+ cEOS r2 + the user L1 topology) through the full pipeline including
postProcessSnapshot and asserts: every r1 interface active with the
expected type and the to-r2 -> 1/1/c1/1 BIND dependency; the user L1 edge
(named by the port) survives into the active logical L1; the L3 edge
r1:to-r2 <-> r2:Ethernet1 forms; and the eBGP session is established.

----

Prompt:
```
Complete P6 including P6-V, using a clean agent to judge, rejudging after any change.
```

---
**Stack**:
- #9981
- #9980 ⬅
- #9979
- #9978
- #9977
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*