### PR TITLE
ASA: remove lexer state-variable predicates

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_acl.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_acl.g4
@@ -67,22 +67,6 @@ access_list_mac_range
    )
 ;
 
-appletalk_access_list_null_tail
-:
-   action = access_list_action
-   (
-      (
-         CABLE_RANGE ~NEWLINE*
-      )
-      | OTHER_ACCESS
-   )? NEWLINE
-;
-
-appletalk_access_list_stanza
-:
-   ACCESS_LIST name = ACL_NUM_APPLETALK appletalk_access_list_null_tail
-;
-
 aruba_access_list_action
 :
    action = access_list_action
@@ -267,10 +251,6 @@ extended_access_list_stanza
    (
       (
          IP ACCESS_LIST EXTENDED name = variable_aclname
-      )
-      |
-      (
-         ACCESS_LIST num = ACL_NUM_EXTENDED
       )
       |
       (
@@ -628,16 +608,6 @@ ipv6_prefix_list_tail
    )* NEWLINE
 ;
 
-ipx_sap_access_list_null_tail
-:
-   action = access_list_action null_rest_of_line
-;
-
-ipx_sap_access_list_stanza
-:
-   ACCESS_LIST name = ACL_NUM_IPX_SAP ipx_sap_access_list_null_tail
-;
-
 irs_stanza
 :
    bandwidth_irs_stanza
@@ -765,17 +735,6 @@ null_rs_stanza
    ) null_rest_of_line
 ;
 
-protocol_type_code_access_list_null_tail
-:
-   action = access_list_action null_rest_of_line
-;
-
-protocol_type_code_access_list_stanza
-:
-   ACCESS_LIST name = ACL_NUM_PROTOCOL_TYPE_CODE
-   protocol_type_code_access_list_null_tail
-;
-
 rs_stanza
 :
    interface_rs_stanza
@@ -842,22 +801,10 @@ s_ip_access_list_session
    )*
 ;
 
-s_mac_access_list
-:
-   ACCESS_LIST num = ACL_NUM_MAC action = access_list_action address =
-   MAC_ADDRESS_LITERAL wildcard = MAC_ADDRESS_LITERAL NEWLINE
-;
-
 s_mac_access_list_extended
 :
-   (
-      ACCESS_LIST num = ACL_NUM_EXTENDED_MAC s_mac_access_list_extended_tail
-   )
-   |
-   (
-      MAC ACCESS_LIST EXTENDED? name = variable_permissive EXTENDED? NEWLINE
-      s_mac_access_list_extended_tail*
-   )
+   MAC ACCESS_LIST EXTENDED? name = variable_permissive EXTENDED? NEWLINE
+   s_mac_access_list_extended_tail*
 ;
 
 s_mac_access_list_extended_tail
@@ -937,10 +884,6 @@ standard_access_list_stanza
    (
       (
          IP ACCESS_LIST STANDARD name = variable_aclname
-      )
-      |
-      (
-         ACCESS_LIST num = ACL_NUM_STANDARD
       )
       |
       (

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLexer.g4
@@ -5,16 +5,6 @@ options {
 }
 
 tokens {
-   ACL_NUM_APPLETALK,
-   ACL_NUM_EXTENDED,
-   ACL_NUM_EXTENDED_IPX,
-   ACL_NUM_EXTENDED_MAC,
-   ACL_NUM_IPX,
-   ACL_NUM_IPX_SAP,
-   ACL_NUM_MAC,
-   ACL_NUM_OTHER,
-   ACL_NUM_PROTOCOL_TYPE_CODE,
-   ACL_NUM_STANDARD,
    AS_PATH_SET_REGEX,
    BANNER_BODY,
    COMMUNITY_REGEX,
@@ -73,12 +63,7 @@ ACCESS_CLASS: 'access-class';
 
 ACCESS_GROUP: 'access-group';
 
-ACCESS_LIST
-:
-   'access-list'
-   {_enableAclNum = true; _enableDec = false;_inAccessList = true;}
-
-;
+ACCESS_LIST: 'access-list';
 
 ACCESS_LOG: 'access-log';
 
@@ -394,12 +379,7 @@ ARM_PROFILE: 'arm-profile';
 
 ARM_RF_DOMAIN_PROFILE: 'arm-rf-domain-profile';
 
-ARP
-:
-   'arp'
-   { _enableIpv6Address = false; }
-
-;
+ARP: 'arp';
 
 ARNS: 'arns';
 
@@ -997,12 +977,7 @@ COMMAND
    'command' -> pushMode ( M_Command )
 ;
 
-COMMANDER_ADDRESS
-:
-   'commander-address'
-   { _enableIpv6Address = false; }
-
-;
+COMMANDER_ADDRESS: 'commander-address';
 
 COMMANDS: 'commands';
 
@@ -1014,12 +989,7 @@ COMMON: 'common';
 
 COMMON_NAME: 'common-name';
 
-COMMUNITY
-:
-   'community'
-   { _enableIpv6Address = false; }
-
-;
+COMMUNITY: 'community';
 
 COMMUNITY_LIST: 'community-list' -> pushMode(M_CommunityList);
 
@@ -1959,12 +1929,7 @@ EXTEND: 'extend';
 
 EXTENDABLE: 'extendable';
 
-EXTENDED
-:
-   'extended'
-   { _enableDec = true; _enableAclNum = false; }
-
-;
+EXTENDED: 'extended';
 
 EXTENDED_COUNTERS: 'extended-counters';
 
@@ -2056,12 +2021,7 @@ FILTER: 'filter';
 
 FILTER_LIST: 'filter-list';
 
-FIREWALL
-:
-   'firewall'
-   { _enableIpv6Address = false; }
-
-;
+FIREWALL: 'firewall';
 
 FIREWALL_VISIBILITY: 'firewall-visibility';
 
@@ -2678,7 +2638,7 @@ INTERCEPT: 'intercept';
 INTERFACE
 :
    'int' 'erface'?
-   { _enableIpv6Address = false; if (lastTokenType() == NEWLINE || lastTokenType() == -1) {pushMode(M_Interface);}}
+   { if (lastTokenType() == NEWLINE || lastTokenType() == -1) {pushMode(M_Interface);}}
 
 ;
 
@@ -4823,10 +4783,7 @@ RTR_ADV: 'rtr-adv';
 
 RTSP: 'rtsp';
 
-RULE
-:
-   'rule' {_enableRegex = true;}
-;
+RULE: 'rule';
 
 RULE_NAME: 'rule-name';
 
@@ -5299,12 +5256,7 @@ STALEPATH_TIME: 'stalepath-time';
 
 STALE_ROUTE: 'stale-route';
 
-STANDARD
-:
-   'standard'
-   { _enableDec = true; _enableAclNum = false; }
-
-;
+STANDARD: 'standard';
 
 STANDBY: 'standby';
 
@@ -6262,12 +6214,7 @@ VPNV4: 'vpnv4';
 
 VPNV6: 'vpnv6';
 
-VRF
-:
-   'vrf'
-   {_enableIpv6Address = false;}
-
-;
+VRF: 'vrf';
 
 VRF_ALSO: 'vrf-also';
 
@@ -6457,96 +6404,6 @@ HEX
    '0x' F_HexDigit+
 ;
 
-VARIABLE
-:
-   (
-      (
-         F_Variable_RequiredVarChar
-         (
-            (
-               {!_enableIpv6Address}?
-
-               F_Variable_VarChar*
-            )
-            |
-            (
-               {_enableIpv6Address}?
-
-               F_Variable_VarChar_Ipv6*
-            )
-         )
-      )
-      |
-      (
-         (
-            F_Variable_VarChar
-            {!_enableIpv6Address}?
-
-            F_Variable_VarChar* F_Variable_RequiredVarChar F_Variable_VarChar*
-         )
-         |
-         (
-            F_Variable_VarChar_Ipv6
-            {_enableIpv6Address}?
-
-            F_Variable_VarChar_Ipv6* F_Variable_RequiredVarChar
-            F_Variable_VarChar_Ipv6*
-         )
-      )
-   )
-   {
-      if (_enableAclNum) {
-         _enableAclNum = false;
-         _enableDec = true;
-      }
-   }
-
-;
-
-ACL_NUM
-:
-   F_Digit
-   {_enableAclNum}?
-
-   F_Digit*
-   {
-	int val = Integer.parseInt(getText());
-	if ((1 <= val && val <= 99) || (1300 <= val && val <= 1999)) {
-		_type = ACL_NUM_STANDARD;
-	}
-	else if ((100 <= val && val <= 199) || (2000 <= val && val <= 2699)) {
-		_type = ACL_NUM_EXTENDED;
-	}
-	else if (200 <= val && val <= 299) {
-		_type = ACL_NUM_PROTOCOL_TYPE_CODE;
-	}
-	else if (600 <= val && val <= 699) {
-		_type = ACL_NUM_APPLETALK;
-	}
-   else if (700 <= val && val <= 799) {
-      _type = ACL_NUM_MAC;
-   }
-	else if (800 <= val && val <= 899) {
-		_type = ACL_NUM_IPX;
-	}
-	else if (900 <= val && val <= 999) {
-		_type = ACL_NUM_EXTENDED_IPX;
-	}
-	else if (1000 <= val && val <= 1099) {
-		_type = ACL_NUM_IPX_SAP;
-	}
-	else if (1100 <= val && val <= 1199) {
-		_type = ACL_NUM_EXTENDED_MAC;
-	}
-	else {
-		_type = ACL_NUM_OTHER;
-	}
-	_enableDec = true;
-	_enableAclNum = false;
-}
-
-;
-
 AMPERSAND
 :
    '&'
@@ -6665,38 +6522,21 @@ FORWARD_SLASH
    '/'
 ;
 
-IP_ADDRESS
-:
-  F_IpAddress {_enableIpAddress}?
-;
+IP_ADDRESS: F_IpAddress;
 
-IP_PREFIX
-:
-  F_IpPrefix {_enableIpAddress}?
-;
+IP_PREFIX: F_IpPrefix;
 
 IPV6_ADDRESS
 :
-  F_Ipv6Address {_enableIpv6Address}?
+  F_Ipv6Address
 ;
 
 IPV6_PREFIX
 :
-  F_Ipv6Prefix {_enableIpv6Address}?
+  F_Ipv6Prefix
 ;
 
-NEWLINE
-:
-  F_Newline
-  {
-    _enableIpv6Address = true;
-    _enableIpAddress = true;
-    _enableDec = true;
-    _enableRegex = false;
-    _enableAclNum = false;
-    _inAccessList = false;
-  }
-;
+NEWLINE: F_Newline;
 
 PAREN_LEFT
 :
@@ -6723,16 +6563,6 @@ PLUS
    '+'
 ;
 
-REGEX
-:
-   '/' {_enableRegex}?
-   (
-      ~('/' | '\\')
-      |
-      ( '\\' '/')
-   )* '/'
-;
-
 SEMICOLON
 :
    ';'
@@ -6745,6 +6575,16 @@ SINGLE_QUOTE
 
 UNDERSCORE: '_';
 
+// Lower priority than IP/IPV6 address and prefix tokens, which share a
+// character set with variable names. ANTLR maximal-munch + rule order let
+// those win on equal-length matches. Excludes ':' so that IPv6 addresses
+// tokenize as IPV6_ADDRESS and "keyword:value" trailers (e.g.
+// "Cryptochecksum:<hash>") split into separate tokens.
+VARIABLE
+:
+  F_Variable_VarChar_Ipv6* F_Variable_RequiredVarChar F_Variable_VarChar_Ipv6*
+;
+
 WS
 :
    F_Whitespace+ -> channel ( HIDDEN )
@@ -6755,26 +6595,23 @@ WS
 /////////////////////////////////////////
 UINT8
 :
-  F_Uint8 {_enableDec}?
+  F_Uint8
 ;
 
 UINT16
 :
-  F_Uint16 {_enableDec}?
+  F_Uint16
 ;
 
 UINT32
 :
-  F_Uint32 {_enableDec}?
+  F_Uint32
 ;
 
 // Lower priority than UINT*
 DEC
 :
-   F_Digit
-   {_enableDec}?
-
-   F_Digit*
+   F_Digit+
 ;
 
 DIGIT
@@ -8037,14 +7874,7 @@ M_RouteMap_NEWLINE
 
 M_RouteMap_VARIABLE
 :
-   F_NonWhitespace+
-   {
-      if (_enableAclNum) {
-         _enableAclNum = false;
-         _enableDec = true;
-      }
-   }
-   -> type ( VARIABLE ) , popMode
+   F_NonWhitespace+ -> type ( VARIABLE ) , popMode
 ;
 
 M_RouteMap_WS

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaParser.g4
@@ -2782,14 +2782,9 @@ s_name
    NAME variable variable null_rest_of_line
 ;
 
-s_no_access_list_extended
+s_no_access_list
 :
-   NO ACCESS_LIST ACL_NUM_EXTENDED NEWLINE
-;
-
-s_no_access_list_standard
-:
-   NO ACCESS_LIST ACL_NUM_STANDARD NEWLINE
+   NO ACCESS_LIST name = variable_aclname NEWLINE
 ;
 
 s_no_bfd
@@ -3464,8 +3459,7 @@ ssh_timeout
 
 stanza
 :
-   appletalk_access_list_stanza
-   | asa_comment_stanza
+   asa_comment_stanza
    | asa_access_group
    | community_list_expanded
    | community_list_standard
@@ -3476,14 +3470,12 @@ stanza
    | ip_as_path_regex_mode_stanza
    | ip_prefix_list_stanza
    | ipv6_prefix_list_stanza
-   | ipx_sap_access_list_stanza
    | multicast_routing_stanza
    | no_aaa_group_server_stanza
    | no_failover
    | no_ip_access_list_stanza
    | no_ip_prefix_list_stanza
    | no_route_map_stanza
-   | protocol_type_code_access_list_stanza
    | remark_access_list_stanza
    | route_map_stanza
    | router_bgp_stanza
@@ -3581,7 +3573,6 @@ stanza
    | s_logging
    | s_lpts
    | s_management
-   | s_mac_access_list
    | s_mac_access_list_extended
    | s_map_class
    | s_media_termination
@@ -3595,8 +3586,7 @@ stanza
    | s_netdestination
    | s_netdestination6
    | s_netservice
-   | s_no_access_list_extended
-   | s_no_access_list_standard
+   | s_no_access_list
    | s_no_bfd
    | s_no_enable
    | s_ntp

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
@@ -877,11 +877,9 @@ import org.batfish.grammar.cisco_asa.AsaParser.S_ip_tacacs_source_interfaceConte
 import org.batfish.grammar.cisco_asa.AsaParser.S_l2tp_classContext;
 import org.batfish.grammar.cisco_asa.AsaParser.S_lineContext;
 import org.batfish.grammar.cisco_asa.AsaParser.S_loggingContext;
-import org.batfish.grammar.cisco_asa.AsaParser.S_mac_access_listContext;
 import org.batfish.grammar.cisco_asa.AsaParser.S_mac_access_list_extendedContext;
 import org.batfish.grammar.cisco_asa.AsaParser.S_mtuContext;
-import org.batfish.grammar.cisco_asa.AsaParser.S_no_access_list_extendedContext;
-import org.batfish.grammar.cisco_asa.AsaParser.S_no_access_list_standardContext;
+import org.batfish.grammar.cisco_asa.AsaParser.S_no_access_listContext;
 import org.batfish.grammar.cisco_asa.AsaParser.S_ntpContext;
 import org.batfish.grammar.cisco_asa.AsaParser.S_policy_mapContext;
 import org.batfish.grammar.cisco_asa.AsaParser.S_routeContext;
@@ -2135,8 +2133,6 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
       name = ctx.name.getText();
     } else if (ctx.shortname != null) {
       name = ctx.shortname.getText();
-    } else if (ctx.num != null) {
-      name = ctx.num.getText();
     } else {
       throw new BatfishException("Could not determine acl name");
     }
@@ -3336,24 +3332,8 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
   }
 
   @Override
-  public void enterS_mac_access_list(S_mac_access_listContext ctx) {
-    String name = ctx.num.getText();
-    _currentMacAccessList =
-        _configuration.getMacAccessLists().computeIfAbsent(name, MacAccessList::new);
-    _configuration.defineStructure(MAC_ACCESS_LIST, name, ctx);
-  }
-
-  @Override
   public void enterS_mac_access_list_extended(S_mac_access_list_extendedContext ctx) {
-    String name;
-    if (ctx.num != null) {
-      name = ctx.num.getText();
-
-    } else if (ctx.name != null) {
-      name = ctx.name.getText();
-    } else {
-      throw new BatfishException("Could not determine name of extended mac access-list");
-    }
+    String name = ctx.name.getText();
     _currentMacAccessList =
         _configuration.getMacAccessLists().computeIfAbsent(name, MacAccessList::new);
     _configuration.defineStructure(MAC_ACCESS_LIST, name, ctx);
@@ -3578,8 +3558,6 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
     String name;
     if (ctx.name != null) {
       name = ctx.name.getText();
-    } else if (ctx.num != null) {
-      name = ctx.num.getText();
     } else {
       throw new BatfishException("Invalid standard access-list name");
     }
@@ -8316,14 +8294,9 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
   }
 
   @Override
-  public void exitS_no_access_list_extended(S_no_access_list_extendedContext ctx) {
-    String name = ctx.ACL_NUM_EXTENDED().getText();
+  public void exitS_no_access_list(S_no_access_listContext ctx) {
+    String name = ctx.name.getText();
     _configuration.getExtendedAcls().remove(name);
-  }
-
-  @Override
-  public void exitS_no_access_list_standard(S_no_access_list_standardContext ctx) {
-    String name = ctx.ACL_NUM_STANDARD().getText();
     _configuration.getStandardAcls().remove(name);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/parsing/AsaBaseLexer.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/parsing/AsaBaseLexer.java
@@ -1,6 +1,5 @@
 package org.batfish.grammar.cisco_asa.parsing;
 
-import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.Token;
@@ -33,28 +32,6 @@ public abstract class AsaBaseLexer extends BatfishLexer {
     return _secondToLastTokenType;
   }
 
-  protected boolean _enableAclNum = false;
-  protected boolean _enableDec = true;
-  protected boolean _enableIpv6Address = true;
-  protected boolean _enableIpAddress = true;
-  protected boolean _enableCommunityListNum = false;
-  protected boolean _enableRegex = false;
-
-  protected boolean _inAccessList = false;
-
   private int _lastTokenType = -1;
   private int _secondToLastTokenType = -1;
-
-  @Override
-  public @Nonnull String printStateVariables() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("_enableAclNum: " + _enableAclNum + "\n");
-    sb.append("_enableCommunityListNum: " + _enableCommunityListNum + "\n");
-    sb.append("_enableDec: " + _enableDec + "\n");
-    sb.append("_enableIpAddress: " + _enableIpAddress + "\n");
-    sb.append("_enableIpv6Address: " + _enableIpv6Address + "\n");
-    sb.append("_enableRegex: " + _enableRegex + "\n");
-    sb.append("_inAccessList: " + _inAccessList + "\n");
-    return sb.toString();
-  }
 }


### PR DESCRIPTION
Delete the _enableIpAddress, _enableDec, _enableAclNum, _enableIpv6Address,
and _enableRegex lexer state variables and their semantic predicates,
restoring ANTLR's per-mode lexer DFA cache. Mirrors the IOS-XR cleanup in
batfish/batfish#6840 (and #6798 for _enableIpAddress).

ANTLR disables a lexer mode's DFA cache when any reachable predicate remains
in that mode, forcing full ATN closure on every token instead of cached DFA
edges. DEFAULT_MODE - where access-list bodies are lexed - carried
predicates on UINT8/16/32, DEC, IP_ADDRESS/PREFIX, IPV6_ADDRESS/PREFIX, the
VARIABLE rule, and REGEX. Because the cache is disabled mode-wide as long as
any one predicate survives, removing them individually yields no speedup;
they must all go. On an access-list-heavy config of ~179K lines (~5M
tokens), this cuts cold lex+parse from ~123s to ~1.4s (lexing alone ~122s to
~0.6s).

Changes:
- ACCESS_LIST, ARP, COMMANDER_ADDRESS, COMMUNITY, FIREWALL, VRF, EXTENDED,
  STANDARD, RULE become plain keyword tokens (drop their flag-setting
  actions). INTERFACE keeps its mode push, drops the flag.
- IP_ADDRESS/PREFIX, IPV6_ADDRESS/PREFIX, UINT8/16/32, DEC, NEWLINE become
  predicate-free. VARIABLE is simplified and moved below the IP/IPv6 tokens
  so maximal-munch + rule order disambiguate, matching IOS-XR. VARIABLE
  keeps the colon-excluding character set the predicated rule used by
  default, so IPv6 addresses tokenize as IPV6_ADDRESS and "keyword:value"
  trailers (e.g. cryptochecksum lines) still split into separate tokens.
- Delete the REGEX token: it has no parser consumer (dead Frankenparser
  vestige).
- Remove ACL_NUM and its range-classification (ACL_NUM_STANDARD/EXTENDED/
  APPLETALK/IPX/MAC/...). On ASA a numeric ACL ID is just a name: the ASA
  does not enforce the IOS 1-99/100-199 ranges, and standard vs extended
  comes from the explicit keyword. Numeric names still parse as
  variable_aclname. Delete the IOS-only numbered/appletalk/ipx-sap/
  protocol-type-code/numbered-mac ACL stanzas.
- s_no_access_list_extended/standard collapse into one keyword-free
  s_no_access_list removing from both ACL maps.
- Delete _enableCommunityListNum (declared, never referenced) and the
  now-empty printStateVariables override in AsaBaseLexer.

Verified behavior-preserving on the motivating config: the serialized
vendor-independent model is byte-identical (same SHA-256) and the parse
warnings and parse status are unchanged before and after. The full unit and
reference test suites pass with no ref-file changes.

----

Prompt:
```
A large Cisco ASA config (~179K lines, almost entirely access-list lines)
takes a very long time to parse. Profile it and improve parsing
performance.
```

Profiling (async-profiler via tools/profiling) showed ~100% of parse time in
LexerATNSimulator.closure: the state-variable predicates were defeating the
lexer DFA cache. The fix follows dhalperi's established playbook for these
grammars - make tokens predicate-free, rely on lexer modes and parser-level
disambiguation, and delete vendor-inapplicable Frankenparser alternatives -
using IOS-XR #6840 as the template.
