### PR TITLE
Transformation: serialize deep orElse chains iteratively

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/transformation/Transformation.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/transformation/Transformation.java
@@ -8,7 +8,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -162,5 +165,48 @@ public final class Transformation implements Serializable {
         .add("andThen", _andThen)
         .add("orElse", _orElse)
         .toString();
+  }
+
+  @Serial
+  private Object writeReplace() throws ObjectStreamException {
+    return new SerializedForm(this);
+  }
+
+  /**
+   * Serializable representation of a {@link Transformation} that avoids deep recursion.
+   *
+   * <p>A device's NAT rule-set is converted into a chain of {@link Transformation}s linked via
+   * {@code orElse} (one link per rule). Configs with thousands of NAT rules produce a chain
+   * thousands of links deep. Default Java serialization recurses once per link, so serializing or
+   * deserializing such a chain overflows the stack. This proxy flattens the {@code orElse} spine
+   * into a list, writing and reading it iteratively so chains of any depth survive a round trip.
+   */
+  private static final class SerializedForm implements Serializable {
+    private final @Nonnull List<AclLineMatchExpr> _guards;
+    private final @Nonnull List<List<TransformationStep>> _steps;
+    private final @Nonnull List<Transformation> _andThens;
+
+    SerializedForm(Transformation transformation) {
+      _guards = new ArrayList<>();
+      _steps = new ArrayList<>();
+      _andThens = new ArrayList<>();
+      // Walk the orElse spine iteratively; andThen sub-trees are not part of the spine and are
+      // serialized normally (they are not deep in practice).
+      for (Transformation t = transformation; t != null; t = t._orElse) {
+        _guards.add(t._guard);
+        _steps.add(t._transformationSteps);
+        _andThens.add(t._andThen);
+      }
+    }
+
+    @Serial
+    private Object readResolve() throws ObjectStreamException {
+      // Rebuild the orElse spine from the tail forward so each node's orElse is already built.
+      Transformation orElse = null;
+      for (int i = _guards.size() - 1; i >= 0; i--) {
+        orElse = new Transformation(_guards.get(i), _steps.get(i), _andThens.get(i), orElse);
+      }
+      return orElse;
+    }
   }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/transformation/TransformationTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/transformation/TransformationTest.java
@@ -5,8 +5,11 @@ import static org.batfish.datamodel.transformation.Noop.NOOP_SOURCE_NAT;
 import static org.batfish.datamodel.transformation.Transformation.always;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.shiftDestinationIp;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.datamodel.Prefix;
 import org.junit.Test;
 
@@ -22,5 +25,47 @@ public class TransformationTest {
         .addEqualityGroup(always().apply(NOOP_SOURCE_NAT).setAndThen(trivial).build())
         .addEqualityGroup(always().apply(NOOP_SOURCE_NAT).setOrElse(trivial).build())
         .testEquals();
+  }
+
+  @Test
+  public void testSerialization() {
+    Transformation t =
+        when(FALSE)
+            .apply(shiftDestinationIp(Prefix.ZERO))
+            .setAndThen(always().apply(NOOP_SOURCE_NAT).build())
+            .setOrElse(always().apply(NOOP_SOURCE_NAT).build())
+            .build();
+    assertEquals(t, SerializationUtils.clone(t));
+  }
+
+  /**
+   * A NAT rule-set is converted into a chain of {@link Transformation}s linked by {@code orElse}
+   * (see {@code NatRuleSet#rulesTransformation}). A rule-set with thousands of rules produces a
+   * chain thousands of links deep. Default Java serialization recurses once per link, so such a
+   * chain must round-trip without a {@link StackOverflowError}.
+   */
+  @Test
+  public void testSerializationDeepOrElseChain() {
+    int depth = 100_000;
+    Transformation t = null;
+    for (int i = 0; i < depth; i++) {
+      t = when(FALSE).apply(NOOP_SOURCE_NAT).setOrElse(t).build();
+    }
+
+    Transformation cloned = SerializationUtils.clone(t);
+
+    // Walk both orElse spines iteratively (recursive equals would itself overflow) and confirm the
+    // chain survived the round-trip intact.
+    Transformation original = t;
+    int count = 0;
+    while (original != null) {
+      assertEquals(original.getGuard(), cloned.getGuard());
+      assertEquals(original.getTransformationSteps(), cloned.getTransformationSteps());
+      original = original.getOrElse();
+      cloned = cloned.getOrElse();
+      count++;
+    }
+    assertEquals(depth, count);
+    assertNull(cloned);
   }
 }


### PR DESCRIPTION
A Juniper NAT rule-set is converted into a chain of Transformations
linked via orElse, one link per rule (NatRuleSet#rulesTransformation).
A rule-set with thousands of rules produces a chain thousands of links
deep. Transformation used default Java serialization, which recurses
once per link, so initializing a snapshot with such a config threw
StackOverflowError while deserializing the vendor-independent
configurations (during completion-metadata computation).

Add a writeReplace/readResolve serialization proxy that walks the orElse
spine iteratively into flat lists on write and rebuilds it iteratively
on read, matching the existing Prefix.SerializedForm pattern. Chains of
any depth now round-trip without recursion. andThen sub-trees are not
part of the spine and are not deep in practice, so they are left to
normal serialization.

----

Prompt:
```
A Juniper SRX config with a NAT rule-set containing thousands of rules
crashed Batfish during snapshot initialization. Investigate and fix it.
```

