### PR TITLE
sros: P8 complexity-ladder rungs (static, OSPF, iBGP, route reflection, policy, redistribution, VPRN, misconfig)

### DIFF
--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -390,8 +390,10 @@ sickbayed.
 
 After the first eBGP lab validated end to end, the model was grown one feature
 "rung" at a time, each with its own live lab (in `lab-validation/snapshots/`)
-validated against ground truth. The rungs done so far, with the SR-OS facts
-each one pinned down:
+validated against ground truth. All eight rungs below are done — interfaces +
+static (L1), OSPF (L2), iBGP (L3), route reflection (L4), BGP policy depth (L5),
+redistribution (L6), multi-VRF/VPRN (L7), and deliberate misconfiguration (L8).
+The SR-OS facts each one pinned down:
 
 ### L1 — static routes (`sros_static`)
 
@@ -434,6 +436,53 @@ the type value word (`type <through|range> { … }`) in the canonical tree, so
 over-approximation (and its warning) for those types (`to`/`address-mask` still
 over-approximate). Validated via the cEOS oracle: r2 learns r1's routes with the
 MED and prepended AS-path that r1's policy sets.
+
+### L2 — OSPF single area (`sros_ospf`)
+
+`router "<name>" ospf <instance>` converts to a VI `OspfProcess` (per VRF) with
+its areas and, on each OSPF interface, `OspfInterfaceSettings` (area, cost,
+network type, addresses). Batfish derives the adjacencies and neighbor configs
+from those interface settings in post-processing, so conversion only sets the
+interface settings and area membership. SR-OS facts: OSPF **internal** route
+preference (admin distance) is **10** (external 150) — not the Cisco 110; the
+default `reference-bandwidth` is 100 Gbps (so a 100 Gbps port derives cost 1); an
+explicit interface `metric` wins, a loopback is cost 0. The lab's two SR-OS
+routers form a point-to-point adjacency and each learns the other's system /32.
+
+### L4 — BGP route reflection (`sros_rr`)
+
+A BGP group/neighbor `cluster { cluster-id <ip> }` makes the peer a
+route-reflector client: conversion sets the VI peer's `clusterId` and the address
+family's `routeReflectorClient`, so Batfish reflects routes between clients.
+`next-hop-self true` prepends a `SetNextHop(self)` to the peer export policy.
+Both inherit group→neighbor. Lab finding: with no IGP underlay, an RR's clients
+**receive** a reflected route but mark it invalid (unresolvable originator
+next-hop) and don't install it — `next-hop-self` on the RR is what lets the
+clients resolve it. With it, each client installs the other's loopback.
+
+### L6 — redistribution (`sros_redist`)
+
+A policy entry `from { protocol { name [static direct bgp ospf isis] } }`
+converts to a `MatchProtocol` guard (ANDed with any `from prefix-list`). This
+also fixed a correctness bug: an entry whose only criterion was a (previously
+unmodeled) from-protocol guarded TRUE and leaked **every** route. Origin/MED on
+locally-sourced routes was refined here: a **connected/direct** route advertised
+by an export policy carries origin **IGP**, a **redistributed** route
+(static/OSPF/…) carries origin **INCOMPLETE**; and a non-BGP route is advertised
+with **MED 0** unless a policy explicitly sets the metric (an entry's `metric
+set` still wins). The cEOS oracle confirms the redistributed static prefix
+appears with origin incomplete and MED 0.
+
+### L7 — multi-VRF / VPRN (`sros_vprn`)
+
+`service vprn "<name>"` is a routing instance in its own VRF, modeled as a
+`Router` keyed by the service-name (reusing the interface/static/OSPF/BGP feature
+set), which conversion maps to a same-named VRF — exactly like a non-Base
+`router "<name>"`. So a VPRN's routes/interfaces land in their own VRF, separate
+from Base, with no leak. The validator was extended to validate VPRN VRFs:
+`info json /state service vprn "<name>" route-table`/`interface *` is captured
+and compared (routes tagged with the service-name as the VRF) against Batfish's
+corresponding VRF, so VRF separation is checked substantively, not just on Base.
 
 ### L8 — deliberate misconfiguration (`sros_misconfig`)
 

--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -495,3 +495,10 @@ at commit** and rejects a reference to a non-existent policy-statement
 (`MGMT_CORE #224`), aborting the whole startup config — so a committed device
 config cannot carry an undefined policy reference. Batfish's `undefinedReferences`
 for SR-OS policies is therefore unit-testable but not lab-observable on a device.
+
+Tooling caveat: the `lab_builder` SR-OS `interface_up` precondition check is a
+false-negative on this lab — its heuristic ("`up` present and `down` absent" in
+the `show router interface` line) trips on the `Up/Down` column header, so it
+reports the (genuinely up) link interface as down. It is a collection-time
+precondition, not a lab test, so it does not affect the green result; the lab is
+collected regardless and validates 13/13.

--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -385,3 +385,64 @@ validator: unmatched routes on either side score infinite cost and surface as
 failures, so a green result means the device and Batfish RIBs are
 route-for-route equal — not that one side was empty. No r1 RIB check is
 sickbayed.
+
+## Complexity ladder (P8)
+
+After the first eBGP lab validated end to end, the model was grown one feature
+"rung" at a time, each with its own live lab (in `lab-validation/snapshots/`)
+validated against ground truth. The rungs done so far, with the SR-OS facts
+each one pinned down:
+
+### L1 — static routes (`sros_static`)
+
+`router "<name>" static-routes route <prefix> route-type unicast` with a
+`next-hop <ip>` or a `blackhole` converts to a VI `StaticRoute` (`NextHopIp` /
+`NextHopDiscard`). The SR-OS `preference` is the admin distance and `metric` the
+route metric, with YANG defaults **5** and **1**. The decisive fact, confirmed
+on the live device: **SR-OS does not install a static route unless its
+next-hop/blackhole context is `admin-state enable`** — a route with no
+admin-state leaf is accepted into config but absent from the route-table, so
+conversion skips a non-enabled route. A `loopback` router-interface (no port)
+becomes a VI `LOOPBACK` and installs its connected prefix.
+
+### L3 — iBGP (`sros_ibgp`)
+
+A second SR-OS router peers iBGP (`group … type internal`, peer-as = local AS).
+This exercised the P5 iBGP default-accept path for the first time and forced a
+correction: **iBGP default-accept propagates BGP routes, it does not pull
+connected/static/IGP routes into BGP**. The generated default-accept policy was
+a blanket accept-all, which — combined with `setExportBgpFromBgpRib(false)`
+(export runs over the whole main RIB) — leaked a router's connected /31s into
+iBGP. The default-accept policy is now guarded on the route's protocol being
+BGP/iBGP (on import the route is always a received BGP route, so import
+default-accept is preserved). Validator note: SR-OS reports both eBGP and iBGP
+learned routes as protocol `bgp` in its route-table, while Batfish labels an
+iBGP-learned main-RIB route `ibgp`; the validator maps SR-OS `bgp` to either.
+iBGP-learned routes are admin **170**, same as eBGP on SR-OS.
+
+### L5 — BGP policy depth (`sros_bgp_policy`)
+
+Policy-statement entry `action` set-clauses now convert: `metric set <n>` →
+`SetMetric` (BGP MED), `as-path-prepend as-path <asn> [repeat <n>]` →
+`PrependAsPath` (the AS repeated `n` times), and `community add ["<name>"]` →
+`SetCommunities` unioning the named `policy-options community` list's members
+onto the route. Prefix-list match-type **bounds** are now captured:
+`through-length` / `start-length` / `end-length` nest in the block hanging off
+the type value word (`type <through|range> { … }`) in the canonical tree, so
+`through` converts to the exact window `[len, through-length]` and `range` to
+`[start-length, end-length]` — removing the P5 "this length or longer"
+over-approximation (and its warning) for those types (`to`/`address-mask` still
+over-approximate). Validated via the cEOS oracle: r2 learns r1's routes with the
+MED and prepended AS-path that r1's policy sets.
+
+### L8 — deliberate misconfiguration (`sros_misconfig`)
+
+An AS-mismatch lab (r1's ebgp group sets peer-as 65099 while r2 is AS 65002) —
+no Batfish modeling change, this validates the **diagnostics**: Batfish predicts
+the eBGP session `NOT_COMPATIBLE` on both sides and learns no BGP routes,
+matching the device (r1's BGP RIB has 0 learned routes; r2 never learns r1's
+system prefix). Finding: **SR-OS enforces the BGP import/export policy leafref
+at commit** and rejects a reference to a non-existent policy-statement
+(`MGMT_CORE #224`), aborting the whole startup config — so a committed device
+config cannot carry an undefined policy reference. Batfish's `undefinedReferences`
+for SR-OS policies is therefore unit-testable but not lab-observable on a device.

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -37,6 +37,7 @@ import org.batfish.vendor.sros.representation.RouterInterface;
 import org.batfish.vendor.sros.representation.SrosConfiguration;
 import org.batfish.vendor.sros.representation.SrosStructureType;
 import org.batfish.vendor.sros.representation.SrosStructureUsage;
+import org.batfish.vendor.sros.representation.StaticRoute;
 
 /**
  * Populates a {@link SrosConfiguration}'s typed feature model from the canonical, preprocessed
@@ -73,6 +74,12 @@ public final class SrosFeatureExtractor {
 
   /** policy-statement {@code entry-id}: YANG {@code uint32 range "1..65535"}. */
   private static final LongSpace ENTRY_ID_SPACE = LongSpace.of(Range.closed(1L, 65535L));
+
+  /** static-route next-hop/blackhole {@code metric}: YANG {@code uint32 range "0..65535"}. */
+  private static final IntegerSpace STATIC_METRIC_SPACE = IntegerSpace.of(new SubRange(0, 65535));
+
+  /** static-route next-hop/blackhole {@code preference}: YANG {@code uint32 range "1..255"}. */
+  private static final IntegerSpace STATIC_PREFERENCE_SPACE = IntegerSpace.of(new SubRange(1, 255));
 
   /** Port {@code admin-state} enumeration: enable -> up, disable -> down. */
   private static final Map<String, Boolean> ADMIN_STATE =
@@ -212,6 +219,7 @@ public final class SrosFeatureExtractor {
               "autonomous-system")
           .ifPresent(router::setAutonomousSystem);
       extractInterfaces(router, routerNode.getChild("interface"));
+      extractStaticRoutes(router, routerNode.getChild("static-routes"));
       extractBgp(router, routerNode.getChild("bgp"));
       _c.getRouters().put(name, router);
     }
@@ -240,6 +248,88 @@ public final class SrosFeatureExtractor {
       }
       router.getInterfaces().put(name, iface);
     }
+  }
+
+  /**
+   * Extract {@code static-routes route <prefix> route-type <unicast|multicast>} entries. Each route
+   * is reached via a {@code next-hop <ip>} or a {@code blackhole}; both sub-contexts carry an
+   * {@code admin-state} (a route is only RIB-installed when it is {@code enable} — see {@link
+   * StaticRoute}), and optional {@code metric}/{@code preference}. Only the unicast IPv4 case is
+   * modeled here; a non-IPv4 prefix is warned and skipped by {@link #toPrefix}.
+   */
+  private void extractStaticRoutes(Router router, @Nullable SrosStatementTree staticRoutes) {
+    if (staticRoutes == null) {
+      return;
+    }
+    SrosStatementTree routeList = staticRoutes.getChild("route");
+    if (routeList == null) {
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : routeList.getChildren().entrySet()) {
+      SrosStatementTree prefixNode = e.getValue();
+      Prefix prefix = toPrefix(e.getKey(), prefixNode);
+      if (prefix == null) {
+        continue;
+      }
+      // The route-type ("unicast"/"multicast") is the next path word and keys the route with the
+      // prefix in YANG; the next-hop/blackhole contexts hang under that route-type node.
+      SrosStatementTree routeType = prefixNode.getChild("route-type");
+      SrosStatementTree typeBody = routeType == null ? null : firstChild(routeType);
+      if (typeBody == null) {
+        continue;
+      }
+      StaticRoute route = new StaticRoute(prefix);
+      SrosStatementTree nextHop = typeBody.getChild("next-hop");
+      SrosStatementTree blackhole = typeBody.getChild("blackhole");
+      SrosStatementTree adminStateParent;
+      if (nextHop != null) {
+        // next-hop is itself keyed by the next-hop IP (a list); take the first (no ECMP in scope).
+        SrosStatementTree nhEntry = firstChild(nextHop);
+        if (nhEntry != null) {
+          route.setNextHopIp(toIp(nhKey(nextHop), nhEntry, "static-route next-hop"));
+        }
+        adminStateParent = nhEntry;
+      } else if (blackhole != null) {
+        route.setBlackhole(true);
+        adminStateParent = blackhole;
+      } else {
+        // Neither next-hop nor blackhole: not a modeled route shape; skip.
+        continue;
+      }
+      if (adminStateParent != null) {
+        Boolean adminUp =
+            toEnum(adminStateParent.getChild("admin-state"), ADMIN_STATE, "admin-state");
+        route.setAdminStateEnable(Boolean.TRUE.equals(adminUp));
+        toIntegerInSpace(
+                singleValue(adminStateParent, "metric"),
+                singleValueNode(adminStateParent, "metric"),
+                STATIC_METRIC_SPACE,
+                "static-route metric")
+            .ifPresent(route::setMetric);
+        toIntegerInSpace(
+                singleValue(adminStateParent, "preference"),
+                singleValueNode(adminStateParent, "preference"),
+                STATIC_PREFERENCE_SPACE,
+                "static-route preference")
+            .ifPresent(route::setPreference);
+      }
+      router.getStaticRoutes().add(route);
+    }
+  }
+
+  /** The first (insertion-order) child node of {@code node}, or {@code null} if it has none. */
+  private static @Nullable SrosStatementTree firstChild(SrosStatementTree node) {
+    return node.getChildren().isEmpty() ? null : node.getChildren().values().iterator().next();
+  }
+
+  /**
+   * The first child key of {@code node}, unquoted (e.g. the next-hop IP under the {@code next-hop}
+   * list — the device renders it quoted, {@code next-hop "10.0.0.1"}).
+   */
+  private static @Nullable String nhKey(SrosStatementTree node) {
+    return node.getChildren().isEmpty()
+        ? null
+        : unquote(node.getChildren().keySet().iterator().next());
   }
 
   private void extractBgp(Router router, @Nullable SrosStatementTree bgpNode) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -24,6 +24,7 @@ import org.batfish.vendor.sros.representation.BgpGroup;
 import org.batfish.vendor.sros.representation.BgpNeighbor;
 import org.batfish.vendor.sros.representation.BgpProcess;
 import org.batfish.vendor.sros.representation.Card;
+import org.batfish.vendor.sros.representation.Community;
 import org.batfish.vendor.sros.representation.Mda;
 import org.batfish.vendor.sros.representation.PeerType;
 import org.batfish.vendor.sros.representation.PolicyAction;
@@ -80,6 +81,13 @@ public final class SrosFeatureExtractor {
 
   /** static-route next-hop/blackhole {@code preference}: YANG {@code uint32 range "1..255"}. */
   private static final IntegerSpace STATIC_PREFERENCE_SPACE = IntegerSpace.of(new SubRange(1, 255));
+
+  /** policy action {@code metric set}: BGP MED, YANG {@code int64 range "0..4294967295"}. */
+  private static final LongSpace POLICY_METRIC_SPACE = LongSpace.of(Range.closed(0L, 4294967295L));
+
+  /** as-path-prepend {@code repeat}: YANG {@code uint32 range "1..6"}. */
+  private static final IntegerSpace AS_PATH_PREPEND_REPEAT_SPACE =
+      IntegerSpace.of(new SubRange(1, 6));
 
   /** Port {@code admin-state} enumeration: enable -> up, disable -> down. */
   private static final Map<String, Boolean> ADMIN_STATE =
@@ -317,6 +325,11 @@ public final class SrosFeatureExtractor {
     }
   }
 
+  /** The {@code type} leaf's value word (e.g. {@code through}/{@code range}), or {@code null}. */
+  private static @Nullable String typeWord(SrosStatementTree entryNode) {
+    return singleValue(entryNode, "type");
+  }
+
   /** The first (insertion-order) child node of {@code node}, or {@code null} if it has none. */
   private static @Nullable SrosStatementTree firstChild(SrosStatementTree node) {
     return node.getChildren().isEmpty() ? null : node.getChildren().values().iterator().next();
@@ -412,6 +425,23 @@ public final class SrosFeatureExtractor {
     if (po == null) {
       return;
     }
+    SrosStatementTree communities = po.getChild("community");
+    if (communities != null) {
+      for (Map.Entry<String, SrosStatementTree> e : communities.getChildren().entrySet()) {
+        String name = unquote(e.getKey());
+        SrosStatementTree commNode = e.getValue();
+        defineStructure(SrosStructureType.COMMUNITY, name, commNode);
+        Community community = new Community(name);
+        SrosStatementTree memberNode = commNode.getChild("member");
+        if (memberNode != null) {
+          for (String member : memberNode.getChildren().keySet()) {
+            community.getMembers().add(unquote(member));
+          }
+        }
+        _c.getCommunities().put(name, community);
+      }
+    }
+
     SrosStatementTree prefixLists = po.getChild("prefix-list");
     if (prefixLists != null) {
       for (Map.Entry<String, SrosStatementTree> e : prefixLists.getChildren().entrySet()) {
@@ -426,12 +456,37 @@ public final class SrosFeatureExtractor {
             if (prefix == null) {
               continue;
             }
+            SrosStatementTree entryNode = pe.getValue();
             PrefixListEntry.Type type =
-                toEnum(pe.getValue().getChild("type"), PREFIX_LIST_TYPE, "prefix-list match type");
+                toEnum(entryNode.getChild("type"), PREFIX_LIST_TYPE, "prefix-list match type");
             if (type == null) {
               continue;
             }
-            pl.getEntries().add(new PrefixListEntry(prefix, type));
+            PrefixListEntry ple = new PrefixListEntry(prefix, type);
+            // through/range carry length bounds in the block that hangs off the type value word,
+            // i.e. under `type <through|range> { ... }` -> entryNode.type.<value>.<bound>.
+            SrosStatementTree typeBody = navigate(entryNode, "type", typeWord(entryNode));
+            if (typeBody != null) {
+              toIntegerInSpace(
+                      singleValue(typeBody, "through-length"),
+                      singleValueNode(typeBody, "through-length"),
+                      IPV4_PREFIX_LENGTH_SPACE,
+                      "prefix-list through-length")
+                  .ifPresent(ple::setThroughLength);
+              toIntegerInSpace(
+                      singleValue(typeBody, "start-length"),
+                      singleValueNode(typeBody, "start-length"),
+                      IPV4_PREFIX_LENGTH_SPACE,
+                      "prefix-list start-length")
+                  .ifPresent(ple::setStartLength);
+              toIntegerInSpace(
+                      singleValue(typeBody, "end-length"),
+                      singleValueNode(typeBody, "end-length"),
+                      IPV4_PREFIX_LENGTH_SPACE,
+                      "prefix-list end-length")
+                  .ifPresent(ple::setEndLength);
+            }
+            pl.getEntries().add(ple);
           }
         }
         _c.getPrefixLists().put(name, pl);
@@ -461,8 +516,13 @@ public final class SrosFeatureExtractor {
                 SrosStructureType.PREFIX_LIST,
                 fromPfx,
                 SrosStructureUsage.POLICY_STATEMENT_FROM_PREFIX_LIST);
+            SrosStatementTree action = entryNode.getChild("action");
             entry.setAction(
-                toEnum(navigate(entryNode, "action", "action-type"), POLICY_ACTION, "action-type"));
+                toEnum(
+                    action == null ? null : action.getChild("action-type"),
+                    POLICY_ACTION,
+                    "action-type"));
+            extractEntrySetClauses(entry, action);
             ps.getEntries().put(entryId.get(), entry);
           }
         }
@@ -471,6 +531,56 @@ public final class SrosFeatureExtractor {
                 navigate(psNode, "default-action", "action-type"), POLICY_ACTION, "action-type"));
         _c.getPolicyStatements().put(name, ps);
       }
+    }
+  }
+
+  /**
+   * Extract the modeled {@code action} set-clauses of a policy entry: {@code metric set <n>} (BGP
+   * MED), {@code as-path-prepend as-path <asn> [repeat <n>]}, and {@code community add [...]}.
+   */
+  private void extractEntrySetClauses(
+      PolicyStatementEntry entry, @Nullable SrosStatementTree action) {
+    if (action == null) {
+      return;
+    }
+    // metric set <n>
+    SrosStatementTree metricSet = navigate(action, "metric", "set");
+    toLongInSpace(
+            singleKey(metricSet),
+            metricSet == null ? null : firstChild(metricSet),
+            POLICY_METRIC_SPACE,
+            "policy action metric")
+        .ifPresent(entry::setSetMetric);
+
+    // as-path-prepend as-path <asn> [repeat <n>]
+    SrosStatementTree prepend = action.getChild("as-path-prepend");
+    if (prepend != null) {
+      SrosStatementTree asPath = prepend.getChild("as-path");
+      toLongInSpace(
+              singleKey(asPath),
+              asPath == null ? null : firstChild(asPath),
+              AUTONOMOUS_SYSTEM_SPACE,
+              "as-path-prepend as-path")
+          .ifPresent(entry::setAsPathPrependAsn);
+      SrosStatementTree repeat = prepend.getChild("repeat");
+      toIntegerInSpace(
+              singleKey(repeat),
+              repeat == null ? null : firstChild(repeat),
+              AS_PATH_PREPEND_REPEAT_SPACE,
+              "as-path-prepend repeat")
+          .ifPresent(entry::setAsPathPrependRepeat);
+    }
+
+    // community add [...]
+    SrosStatementTree communityAdd = navigate(action, "community", "add");
+    if (communityAdd != null) {
+      for (String c : communityAdd.getChildren().keySet()) {
+        entry.getCommunityAdds().add(unquote(c));
+      }
+      referenceStructures(
+          SrosStructureType.COMMUNITY,
+          communityAdd,
+          SrosStructureUsage.POLICY_STATEMENT_ACTION_COMMUNITY);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -26,6 +26,9 @@ import org.batfish.vendor.sros.representation.BgpProcess;
 import org.batfish.vendor.sros.representation.Card;
 import org.batfish.vendor.sros.representation.Community;
 import org.batfish.vendor.sros.representation.Mda;
+import org.batfish.vendor.sros.representation.OspfArea;
+import org.batfish.vendor.sros.representation.OspfAreaInterface;
+import org.batfish.vendor.sros.representation.OspfProcess;
 import org.batfish.vendor.sros.representation.PeerType;
 import org.batfish.vendor.sros.representation.PolicyAction;
 import org.batfish.vendor.sros.representation.PolicyStatement;
@@ -143,6 +146,7 @@ public final class SrosFeatureExtractor {
     extractCards(configure.getChild("card"));
     extractPorts(configure.getChild("port"));
     extractPolicyOptions(configure.getChild("policy-options"));
+    extractServices(configure.getChild("service"));
     extractRouters(configure.getChild("router"));
   }
 
@@ -228,7 +232,42 @@ public final class SrosFeatureExtractor {
           .ifPresent(router::setAutonomousSystem);
       extractInterfaces(router, routerNode.getChild("interface"));
       extractStaticRoutes(router, routerNode.getChild("static-routes"));
+      extractOspf(router, routerNode.getChild("ospf"));
       extractBgp(router, routerNode.getChild("bgp"));
+      _c.getRouters().put(name, router);
+    }
+  }
+
+  /**
+   * Extract {@code service vprn "<name>"} instances. A VPRN is a routing instance in its own VRF,
+   * so it is modeled as a {@link Router} keyed by the VPRN service-name (which conversion maps to a
+   * same-named VRF, just like a non-Base {@code router "<name>"}). It carries the same
+   * interface/static-route/OSPF/BGP feature set as the Base router. Only VPRNs are read from the
+   * service tree; other service types (epipe, vpls, ies, ...) are not control-plane routers and are
+   * left unread.
+   */
+  private void extractServices(@Nullable SrosStatementTree service) {
+    if (service == null) {
+      return;
+    }
+    SrosStatementTree vprnList = service.getChild("vprn");
+    if (vprnList == null) {
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : vprnList.getChildren().entrySet()) {
+      String name = unquote(e.getKey());
+      SrosStatementTree vprnNode = e.getValue();
+      Router router = new Router(name);
+      toLongInSpace(
+              singleValue(vprnNode, "autonomous-system"),
+              singleValueNode(vprnNode, "autonomous-system"),
+              AUTONOMOUS_SYSTEM_SPACE,
+              "autonomous-system")
+          .ifPresent(router::setAutonomousSystem);
+      extractInterfaces(router, vprnNode.getChild("interface"));
+      extractStaticRoutes(router, vprnNode.getChild("static-routes"));
+      extractOspf(router, vprnNode.getChild("ospf"));
+      extractBgp(router, vprnNode.getChild("bgp"));
       _c.getRouters().put(name, router);
     }
   }
@@ -330,6 +369,73 @@ public final class SrosFeatureExtractor {
     return singleValue(entryNode, "type");
   }
 
+  // --- ospf -------------------------------------------------------------------------------------
+
+  /** OSPF interface {@code metric} (cost): YANG {@code uint32 range "1..65535"}. */
+  private static final IntegerSpace OSPF_METRIC_SPACE = IntegerSpace.of(new SubRange(1, 65535));
+
+  /** OSPF {@code interface-type} enumeration (the modeled subset). */
+  private static final Map<String, OspfAreaInterface.InterfaceType> OSPF_INTERFACE_TYPE =
+      ImmutableMap.of(
+          "broadcast", OspfAreaInterface.InterfaceType.BROADCAST,
+          "point-to-point", OspfAreaInterface.InterfaceType.POINT_TO_POINT);
+
+  /**
+   * Extract {@code router "<name>" ospf <instance>}: router-id, admin-state, and the per-area
+   * interfaces (with interface-type and metric/cost). Only the first/0 OSPF instance is modeled.
+   */
+  private void extractOspf(Router router, @Nullable SrosStatementTree ospfList) {
+    if (ospfList == null || ospfList.getChildren().isEmpty()) {
+      return;
+    }
+    // ospf is a list keyed by instance; model the first (typically instance 0).
+    Map.Entry<String, SrosStatementTree> e = ospfList.getChildren().entrySet().iterator().next();
+    int instance;
+    try {
+      instance = Integer.parseInt(e.getKey());
+    } catch (NumberFormatException ex) {
+      instance = 0;
+    }
+    SrosStatementTree ospfNode = e.getValue();
+    OspfProcess proc = new OspfProcess(instance);
+    proc.setRouterId(
+        toIp(
+            singleValue(ospfNode, "router-id"),
+            singleValueNode(ospfNode, "router-id"),
+            "ospf router-id"));
+    Boolean adminUp = toEnum(ospfNode.getChild("admin-state"), ADMIN_STATE, "admin-state");
+    proc.setAdminStateEnable(!Boolean.FALSE.equals(adminUp));
+
+    SrosStatementTree areaList = ospfNode.getChild("area");
+    if (areaList != null) {
+      for (Map.Entry<String, SrosStatementTree> ae : areaList.getChildren().entrySet()) {
+        String areaId = unquote(ae.getKey());
+        SrosStatementTree areaNode = ae.getValue();
+        OspfArea area = new OspfArea(areaId);
+        SrosStatementTree ifaceList = areaNode.getChild("interface");
+        if (ifaceList != null) {
+          for (Map.Entry<String, SrosStatementTree> ie : ifaceList.getChildren().entrySet()) {
+            String ifName = unquote(ie.getKey());
+            SrosStatementTree ifNode = ie.getValue();
+            OspfAreaInterface ospfIf = new OspfAreaInterface(ifName);
+            ospfIf.setInterfaceType(
+                toEnum(
+                    ifNode.getChild("interface-type"), OSPF_INTERFACE_TYPE, "ospf interface-type"));
+            toIntegerInSpace(
+                    singleValue(ifNode, "metric"),
+                    singleValueNode(ifNode, "metric"),
+                    OSPF_METRIC_SPACE,
+                    "ospf interface metric")
+                .ifPresent(ospfIf::setMetric);
+            area.getInterfaces().put(ifName, ospfIf);
+          }
+        }
+        proc.getAreas().put(areaId, area);
+      }
+    }
+    router.setOspfProcess(proc);
+  }
+
   /** The first (insertion-order) child node of {@code node}, or {@code null} if it has none. */
   private static @Nullable SrosStatementTree firstChild(SrosStatementTree node) {
     return node.getChildren().isEmpty() ? null : node.getChildren().values().iterator().next();
@@ -374,6 +480,15 @@ public final class SrosFeatureExtractor {
         group.getExportPolicies().addAll(policyNames(groupExport));
         referencePolicies(groupImport, SrosStructureUsage.BGP_GROUP_IMPORT_POLICY);
         referencePolicies(groupExport, SrosStructureUsage.BGP_GROUP_EXPORT_POLICY);
+        SrosStatementTree groupCluster = groupNode.getChild("cluster");
+        if (groupCluster != null) {
+          group.setClusterId(
+              toIp(
+                  singleValue(groupCluster, "cluster-id"),
+                  singleValueNode(groupCluster, "cluster-id"),
+                  "bgp cluster-id"));
+        }
+        group.setNextHopSelf(toBoolean(groupNode.getChild("next-hop-self")));
         proc.getGroups().put(name, group);
       }
     }
@@ -407,6 +522,15 @@ public final class SrosFeatureExtractor {
         neighbor.getExportPolicies().addAll(policyNames(nbrExport));
         referencePolicies(nbrImport, SrosStructureUsage.BGP_NEIGHBOR_IMPORT_POLICY);
         referencePolicies(nbrExport, SrosStructureUsage.BGP_NEIGHBOR_EXPORT_POLICY);
+        SrosStatementTree nbrCluster = nbrNode.getChild("cluster");
+        if (nbrCluster != null) {
+          neighbor.setClusterId(
+              toIp(
+                  singleValue(nbrCluster, "cluster-id"),
+                  singleValueNode(nbrCluster, "cluster-id"),
+                  "bgp cluster-id"));
+        }
+        neighbor.setNextHopSelf(toBoolean(nbrNode.getChild("next-hop-self")));
         proc.getNeighbors().put(ip, neighbor);
       }
     }
@@ -516,6 +640,14 @@ public final class SrosFeatureExtractor {
                 SrosStructureType.PREFIX_LIST,
                 fromPfx,
                 SrosStructureUsage.POLICY_STATEMENT_FROM_PREFIX_LIST);
+            // from protocol name [static direct bgp ...] — the protocol(s) the route was learned
+            // from. Modeled as plain enum words (no structure reference).
+            SrosStatementTree fromProto = navigate(entryNode, "from", "protocol", "name");
+            if (fromProto != null) {
+              for (String p : fromProto.getChildren().keySet()) {
+                entry.getFromProtocols().add(unquote(p));
+              }
+            }
             SrosStatementTree action = entryNode.getChild("action");
             entry.setAction(
                 toEnum(
@@ -735,6 +867,19 @@ public final class SrosFeatureExtractor {
       warn(valueNode, String.format("SR-OS: unrecognized %s '%s'", what, value));
     }
     return result;
+  }
+
+  /**
+   * Interpret a boolean leaf ({@code true}/{@code false}): returns the boxed value, or {@code null}
+   * if the leaf is absent or not single-valued (so an unset flag stays {@code null} for
+   * inheritance).
+   */
+  private static @Nullable Boolean toBoolean(@Nullable SrosStatementTree leafNode) {
+    String value = singleKey(leafNode);
+    if (value == null) {
+      return null;
+    }
+    return Boolean.valueOf("true".equals(value));
   }
 
   private static @Nonnull String unquote(String text) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpGroup.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
 
 /**
  * An SR-OS BGP peer group (template), keyed by group-name (e.g. {@code bgp group "ebgp"}). Groups
@@ -52,9 +53,32 @@ public final class BgpGroup implements Serializable {
     return _exportPolicies;
   }
 
+  /**
+   * The route-reflector {@code cluster cluster-id} for this group, or {@code null} if not a route
+   * reflector. Peers in a group with a cluster-id are route-reflector clients.
+   */
+  public @Nullable Ip getClusterId() {
+    return _clusterId;
+  }
+
+  public void setClusterId(@Nullable Ip clusterId) {
+    _clusterId = clusterId;
+  }
+
+  /** The {@code next-hop-self} flag, or {@code null} if unset. */
+  public @Nullable Boolean getNextHopSelf() {
+    return _nextHopSelf;
+  }
+
+  public void setNextHopSelf(@Nullable Boolean nextHopSelf) {
+    _nextHopSelf = nextHopSelf;
+  }
+
   private final @Nonnull String _name;
   private @Nullable PeerType _type;
   private @Nullable Long _peerAs;
   private final @Nonnull List<String> _importPolicies;
   private final @Nonnull List<String> _exportPolicies;
+  private @Nullable Ip _clusterId;
+  private @Nullable Boolean _nextHopSelf;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpNeighbor.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
 
 /**
  * An SR-OS BGP neighbor (e.g. {@code bgp neighbor "10.0.0.1"}), keyed by peer IP string. A neighbor
@@ -61,6 +62,24 @@ public final class BgpNeighbor implements Serializable {
     return _exportPolicies;
   }
 
+  /** The route-reflector {@code cluster cluster-id}, or {@code null} if not an RR client. */
+  public @Nullable Ip getClusterId() {
+    return _clusterId;
+  }
+
+  public void setClusterId(@Nullable Ip clusterId) {
+    _clusterId = clusterId;
+  }
+
+  /** The {@code next-hop-self} flag, or {@code null} if unset. */
+  public @Nullable Boolean getNextHopSelf() {
+    return _nextHopSelf;
+  }
+
+  public void setNextHopSelf(@Nullable Boolean nextHopSelf) {
+    _nextHopSelf = nextHopSelf;
+  }
+
   /**
    * Fill any attribute not set directly on this neighbor from its {@code group} (per-neighbor
    * config wins). This resolves the SR-OS {@code group}→{@code neighbor} inheritance in the
@@ -84,6 +103,12 @@ public final class BgpNeighbor implements Serializable {
     if (_exportPolicies.isEmpty()) {
       _exportPolicies.addAll(group.getExportPolicies());
     }
+    if (_clusterId == null) {
+      _clusterId = group.getClusterId();
+    }
+    if (_nextHopSelf == null) {
+      _nextHopSelf = group.getNextHopSelf();
+    }
   }
 
   private final @Nonnull String _ipAddress;
@@ -92,4 +117,6 @@ public final class BgpNeighbor implements Serializable {
   private @Nullable Long _peerAs;
   private final @Nonnull List<String> _importPolicies;
   private final @Nonnull List<String> _exportPolicies;
+  private @Nullable Ip _clusterId;
+  private @Nullable Boolean _nextHopSelf;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Community.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Community.java
@@ -1,0 +1,31 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * An SR-OS {@code policy-options community "<name>"} list, keyed by name. Holds the ordered {@code
+ * member} values (e.g. {@code "65001:100"}). A policy {@code action community add ["<name>"]}
+ * references this list by name.
+ */
+public final class Community implements Serializable {
+
+  public Community(String name) {
+    _name = name;
+    _members = new ArrayList<>();
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** The ordered {@code member} values of this community list. */
+  public @Nonnull List<String> getMembers() {
+    return _members;
+  }
+
+  private final @Nonnull String _name;
+  private final @Nonnull List<String> _members;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/OspfArea.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/OspfArea.java
@@ -1,0 +1,31 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * An SR-OS OSPF area ({@code router "<name>" ospf <inst> area <area-id>}), keyed by its area-id
+ * (configured as a dotted-quad, e.g. {@code 0.0.0.0}). Holds the OSPF interfaces enabled in the
+ * area, keyed by router-interface name.
+ */
+public final class OspfArea implements Serializable {
+
+  public OspfArea(String areaId) {
+    _areaId = areaId;
+    _interfaces = new LinkedHashMap<>();
+  }
+
+  public @Nonnull String getAreaId() {
+    return _areaId;
+  }
+
+  /** OSPF interfaces in this area, keyed by router-interface name. */
+  public @Nonnull Map<String, OspfAreaInterface> getInterfaces() {
+    return _interfaces;
+  }
+
+  private final @Nonnull String _areaId;
+  private final @Nonnull Map<String, OspfAreaInterface> _interfaces;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/OspfAreaInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/OspfAreaInterface.java
@@ -1,0 +1,49 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An OSPF interface within an area ({@code ... area <id> interface "<name>"}), keyed by the
+ * router-interface name it enables OSPF on. Holds the modeled subset: the explicit metric (cost)
+ * and the interface-type (broadcast/point-to-point).
+ */
+public final class OspfAreaInterface implements Serializable {
+
+  /** OSPF interface network type (the modeled subset of the SR-OS {@code interface-type} enum). */
+  public enum InterfaceType {
+    BROADCAST,
+    POINT_TO_POINT;
+  }
+
+  public OspfAreaInterface(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** The explicit {@code metric} (OSPF cost), or {@code null} to use the derived/default cost. */
+  public @Nullable Integer getMetric() {
+    return _metric;
+  }
+
+  public void setMetric(@Nullable Integer metric) {
+    _metric = metric;
+  }
+
+  /** The {@code interface-type}, or {@code null} if unset. */
+  public @Nullable InterfaceType getInterfaceType() {
+    return _interfaceType;
+  }
+
+  public void setInterfaceType(@Nullable InterfaceType interfaceType) {
+    _interfaceType = interfaceType;
+  }
+
+  private final @Nonnull String _name;
+  private @Nullable Integer _metric;
+  private @Nullable InterfaceType _interfaceType;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/OspfProcess.java
@@ -1,0 +1,55 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+
+/**
+ * An SR-OS {@code router "<name>" ospf <instance>} process, keyed by its integer instance. Holds
+ * the router-id and the areas; the OSPF-enabled interfaces hang off each {@link OspfArea}. Only the
+ * subset needed to form adjacencies and compute intra-area routes is modeled.
+ */
+public final class OspfProcess implements Serializable {
+
+  public OspfProcess(int instance) {
+    _instance = instance;
+    _areas = new LinkedHashMap<>();
+  }
+
+  public int getInstance() {
+    return _instance;
+  }
+
+  /** The {@code router-id}, or {@code null} if unset (then derived from the system interface). */
+  public @Nullable Ip getRouterId() {
+    return _routerId;
+  }
+
+  public void setRouterId(@Nullable Ip routerId) {
+    _routerId = routerId;
+  }
+
+  /**
+   * Whether the process is {@code admin-state enable}; defaults true when admin-state is absent.
+   */
+  public boolean getAdminStateEnable() {
+    return _adminStateEnable;
+  }
+
+  public void setAdminStateEnable(boolean adminStateEnable) {
+    _adminStateEnable = adminStateEnable;
+  }
+
+  /** OSPF areas, keyed by area-id (a dotted-quad string as configured, e.g. {@code 0.0.0.0}). */
+  public @Nonnull Map<String, OspfArea> getAreas() {
+    return _areas;
+  }
+
+  private final int _instance;
+  private @Nullable Ip _routerId;
+  private boolean _adminStateEnable = true;
+  private final @Nonnull Map<String, OspfArea> _areas;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatementEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatementEntry.java
@@ -17,6 +17,7 @@ public final class PolicyStatementEntry implements Serializable {
   public PolicyStatementEntry(long entryId) {
     _entryId = entryId;
     _fromPrefixLists = new ArrayList<>();
+    _fromProtocols = new ArrayList<>();
     _communityAdds = new ArrayList<>();
   }
 
@@ -27,6 +28,14 @@ public final class PolicyStatementEntry implements Serializable {
   /** The ordered {@code from prefix-list [...]} leaf-list (names of {@link PrefixList}s). */
   public @Nonnull List<String> getFromPrefixLists() {
     return _fromPrefixLists;
+  }
+
+  /**
+   * The {@code from protocol name [...]} leaf-list — protocol names (e.g. {@code static}, {@code
+   * direct}, {@code bgp}, {@code ospf}) the route must have been learned from to match.
+   */
+  public @Nonnull List<String> getFromProtocols() {
+    return _fromProtocols;
   }
 
   /** The entry {@code action action-type}, or {@code null} if unset. */
@@ -72,6 +81,7 @@ public final class PolicyStatementEntry implements Serializable {
 
   private final long _entryId;
   private final @Nonnull List<String> _fromPrefixLists;
+  private final @Nonnull List<String> _fromProtocols;
   private @Nullable PolicyAction _action;
   private @Nullable Long _setMetric;
   private @Nullable Long _asPathPrependAsn;

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatementEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatementEntry.java
@@ -8,14 +8,16 @@ import javax.annotation.Nullable;
 
 /**
  * One numbered entry of an SR-OS {@code policy-statement}, keyed by {@code entry-id}. Holds the
- * {@code from} match criteria modeled for P4 (prefix-list references) and the entry {@code
- * action}'s {@code action-type}.
+ * {@code from} match criteria modeled for P4 (prefix-list references), the entry {@code action}'s
+ * {@code action-type}, and the modeled {@code action} set-clauses (metric/MED, as-path-prepend,
+ * community add).
  */
 public final class PolicyStatementEntry implements Serializable {
 
   public PolicyStatementEntry(long entryId) {
     _entryId = entryId;
     _fromPrefixLists = new ArrayList<>();
+    _communityAdds = new ArrayList<>();
   }
 
   public long getEntryId() {
@@ -36,7 +38,43 @@ public final class PolicyStatementEntry implements Serializable {
     _action = action;
   }
 
+  /** The {@code action metric set <n>} value (BGP MED), or {@code null} if unset. */
+  public @Nullable Long getSetMetric() {
+    return _setMetric;
+  }
+
+  public void setSetMetric(@Nullable Long setMetric) {
+    _setMetric = setMetric;
+  }
+
+  /** The {@code action as-path-prepend as-path <asn>} AS number, or {@code null} if unset. */
+  public @Nullable Long getAsPathPrependAsn() {
+    return _asPathPrependAsn;
+  }
+
+  public void setAsPathPrependAsn(@Nullable Long asPathPrependAsn) {
+    _asPathPrependAsn = asPathPrependAsn;
+  }
+
+  /** The {@code action as-path-prepend repeat <n>} count; defaults to 1 when prepend is set. */
+  public int getAsPathPrependRepeat() {
+    return _asPathPrependRepeat;
+  }
+
+  public void setAsPathPrependRepeat(int asPathPrependRepeat) {
+    _asPathPrependRepeat = asPathPrependRepeat;
+  }
+
+  /** The ordered {@code action community add [...]} community-list names (references). */
+  public @Nonnull List<String> getCommunityAdds() {
+    return _communityAdds;
+  }
+
   private final long _entryId;
   private final @Nonnull List<String> _fromPrefixLists;
   private @Nullable PolicyAction _action;
+  private @Nullable Long _setMetric;
+  private @Nullable Long _asPathPrependAsn;
+  private int _asPathPrependRepeat = 1;
+  private final @Nonnull List<String> _communityAdds;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PrefixListEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PrefixListEntry.java
@@ -3,12 +3,18 @@ package org.batfish.vendor.sros.representation;
 import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Prefix;
 
 /**
  * One entry of an SR-OS {@code prefix-list}. The YANG list is keyed by the composite of the {@code
  * ip-prefix} and the match {@code type} (e.g. {@code exact}, {@code longer}, {@code through},
  * {@code range}), so the same prefix may appear under multiple types.
+ *
+ * <p>The {@code through} and {@code range} types carry length bounds: {@code through} matches the
+ * prefix's own length through {@code through-length}; {@code range} matches {@code start-length}
+ * through {@code end-length}. These are captured so conversion can build an exact length window
+ * rather than over-approximating (see {@link SrosConversions#toRouteFilterList}).
  */
 public final class PrefixListEntry implements Serializable {
 
@@ -35,6 +41,33 @@ public final class PrefixListEntry implements Serializable {
     return _type;
   }
 
+  /** The {@code through-length} bound for a {@code through}-type entry, or {@code null}. */
+  public @Nullable Integer getThroughLength() {
+    return _throughLength;
+  }
+
+  public void setThroughLength(@Nullable Integer throughLength) {
+    _throughLength = throughLength;
+  }
+
+  /** The {@code start-length} bound for a {@code range}-type entry, or {@code null}. */
+  public @Nullable Integer getStartLength() {
+    return _startLength;
+  }
+
+  public void setStartLength(@Nullable Integer startLength) {
+    _startLength = startLength;
+  }
+
+  /** The {@code end-length} bound for a {@code range}-type entry, or {@code null}. */
+  public @Nullable Integer getEndLength() {
+    return _endLength;
+  }
+
+  public void setEndLength(@Nullable Integer endLength) {
+    _endLength = endLength;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -44,14 +77,21 @@ public final class PrefixListEntry implements Serializable {
       return false;
     }
     PrefixListEntry that = (PrefixListEntry) o;
-    return _prefix.equals(that._prefix) && _type == that._type;
+    return _prefix.equals(that._prefix)
+        && _type == that._type
+        && Objects.equals(_throughLength, that._throughLength)
+        && Objects.equals(_startLength, that._startLength)
+        && Objects.equals(_endLength, that._endLength);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_prefix, _type);
+    return Objects.hash(_prefix, _type, _throughLength, _startLength, _endLength);
   }
 
   private final @Nonnull Prefix _prefix;
   private final @Nonnull Type _type;
+  private @Nullable Integer _throughLength;
+  private @Nullable Integer _startLength;
+  private @Nullable Integer _endLength;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
@@ -1,20 +1,24 @@
 package org.batfish.vendor.sros.representation;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
  * An SR-OS routing instance (e.g. {@code router "Base"}), keyed by router-name. {@code Base} is the
- * full-featured instance. Holds the autonomous-system, interfaces, and BGP configuration.
+ * full-featured instance. Holds the autonomous-system, interfaces, static routes, and BGP
+ * configuration.
  */
 public final class Router implements Serializable {
 
   public Router(String name) {
     _name = name;
     _interfaces = new HashMap<>();
+    _staticRoutes = new ArrayList<>();
   }
 
   public @Nonnull String getName() {
@@ -35,6 +39,11 @@ public final class Router implements Serializable {
     return _interfaces;
   }
 
+  /** The {@code static-routes route} entries in this router, in configuration order. */
+  public @Nonnull List<StaticRoute> getStaticRoutes() {
+    return _staticRoutes;
+  }
+
   /** The BGP process for this router, or {@code null} if {@code bgp} is not configured. */
   public @Nullable BgpProcess getBgpProcess() {
     return _bgpProcess;
@@ -47,5 +56,6 @@ public final class Router implements Serializable {
   private final @Nonnull String _name;
   private @Nullable Long _autonomousSystem;
   private final @Nonnull Map<String, RouterInterface> _interfaces;
+  private final @Nonnull List<StaticRoute> _staticRoutes;
   private @Nullable BgpProcess _bgpProcess;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
@@ -53,9 +53,19 @@ public final class Router implements Serializable {
     _bgpProcess = bgpProcess;
   }
 
+  /** The OSPF process for this router, or {@code null} if {@code ospf} is not configured. */
+  public @Nullable OspfProcess getOspfProcess() {
+    return _ospfProcess;
+  }
+
+  public void setOspfProcess(@Nullable OspfProcess ospfProcess) {
+    _ospfProcess = ospfProcess;
+  }
+
   private final @Nonnull String _name;
   private @Nullable Long _autonomousSystem;
   private final @Nonnull Map<String, RouterInterface> _interfaces;
   private final @Nonnull List<StaticRoute> _staticRoutes;
   private @Nullable BgpProcess _bgpProcess;
+  private @Nullable OspfProcess _ospfProcess;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -34,6 +34,7 @@ public final class SrosConfiguration extends VendorConfiguration {
     _routers = new HashMap<>();
     _prefixLists = new HashMap<>();
     _policyStatements = new HashMap<>();
+    _communities = new HashMap<>();
   }
 
   /**
@@ -69,6 +70,11 @@ public final class SrosConfiguration extends VendorConfiguration {
   /** Routing-policy policy-statements, keyed by name. */
   public @Nonnull Map<String, PolicyStatement> getPolicyStatements() {
     return _policyStatements;
+  }
+
+  /** Routing-policy community lists, keyed by name. */
+  public @Nonnull Map<String, Community> getCommunities() {
+    return _communities;
   }
 
   @Override
@@ -153,6 +159,7 @@ public final class SrosConfiguration extends VendorConfiguration {
   private final @Nonnull Map<String, Router> _routers;
   private final @Nonnull Map<String, PrefixList> _prefixLists;
   private final @Nonnull Map<String, PolicyStatement> _policyStatements;
+  private final @Nonnull Map<String, Community> _communities;
   private @Nullable String _hostname;
   private @Nullable ConfigurationFormat _format;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -116,6 +116,7 @@ public final class SrosConfiguration extends VendorConfiguration {
       Vrf vrf = vrfForRouter(router.getName(), c);
       SrosConversions.convertInterfaces(this, router, c, vrf);
       SrosConversions.convertStaticRoutes(router, vrf, getWarnings());
+      SrosConversions.convertOspf(router, c, vrf, getWarnings());
       SrosConversions.convertBgp(router, c, vrf, getWarnings());
     }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -109,6 +109,7 @@ public final class SrosConfiguration extends VendorConfiguration {
     for (Router router : _routers.values()) {
       Vrf vrf = vrfForRouter(router.getName(), c);
       SrosConversions.convertInterfaces(this, router, c, vrf);
+      SrosConversions.convertStaticRoutes(router, vrf, getWarnings());
       SrosConversions.convertBgp(router, c, vrf, getWarnings());
     }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -226,12 +226,17 @@ public final class SrosConversions {
   }
 
   /**
-   * The match condition for one policy entry: a disjunction over its {@code from prefix-list}
-   * references (a route matches if it is permitted by any referenced list). An entry with no
-   * modeled from-criteria matches everything ({@link BooleanExprs#TRUE}).
+   * The match condition for one policy entry. SR-OS ANDs the distinct {@code from} criteria, so the
+   * guard is a conjunction of: the {@code from prefix-list} match (a disjunction over the
+   * referenced lists — a route matches if permitted by any), and the {@code from protocol} match (a
+   * disjunction over the named protocols). An entry with no modeled from-criteria matches
+   * everything ({@link BooleanExprs#TRUE}).
    */
   private static @Nonnull BooleanExpr toGuard(PolicyStatementEntry entry, Configuration c) {
-    List<BooleanExpr> disjuncts = new ArrayList<>();
+    List<BooleanExpr> conjuncts = new ArrayList<>();
+
+    // from prefix-list [...] — OR over the (defined) referenced lists.
+    List<BooleanExpr> pfxDisjuncts = new ArrayList<>();
     for (String plName : entry.getFromPrefixLists()) {
       if (!c.getRouteFilterLists().containsKey(plName)) {
         // Undefined prefix-list: skip this disjunct. The undefined reference is reported by the
@@ -239,15 +244,50 @@ public final class SrosConversions {
         // no warning is emitted here to avoid duplicating it.
         continue;
       }
-      disjuncts.add(new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(plName)));
+      pfxDisjuncts.add(
+          new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet(plName)));
     }
-    if (disjuncts.isEmpty()) {
+    if (!pfxDisjuncts.isEmpty()) {
+      conjuncts.add(pfxDisjuncts.size() == 1 ? pfxDisjuncts.get(0) : new Disjunction(pfxDisjuncts));
+    }
+
+    // from protocol name [...] — OR over the named protocols the route was learned from.
+    List<RoutingProtocol> protocols = new ArrayList<>();
+    for (String proto : entry.getFromProtocols()) {
+      protocols.addAll(toRoutingProtocols(proto));
+    }
+    if (!protocols.isEmpty()) {
+      conjuncts.add(new MatchProtocol(protocols));
+    }
+
+    if (conjuncts.isEmpty()) {
       return BooleanExprs.TRUE;
     }
-    if (disjuncts.size() == 1) {
-      return disjuncts.get(0);
+    if (conjuncts.size() == 1) {
+      return conjuncts.get(0);
     }
-    return new Disjunction(disjuncts);
+    return new org.batfish.datamodel.routing_policy.expr.Conjunction(conjuncts);
+  }
+
+  /**
+   * Maps an SR-OS {@code from protocol name} value to the VI {@link RoutingProtocol}(s) it matches.
+   * {@code direct} is Batfish's CONNECTED; {@code bgp} matches both eBGP and iBGP; others map
+   * one-to-one. An unrecognized protocol maps to nothing (the entry simply won't match on it).
+   */
+  private static @Nonnull List<RoutingProtocol> toRoutingProtocols(String proto) {
+    return switch (proto) {
+      case "static" -> ImmutableList.of(RoutingProtocol.STATIC);
+      case "direct" -> ImmutableList.of(RoutingProtocol.CONNECTED);
+      case "bgp" -> ImmutableList.of(RoutingProtocol.BGP, RoutingProtocol.IBGP);
+      case "ospf" ->
+          ImmutableList.of(
+              RoutingProtocol.OSPF,
+              RoutingProtocol.OSPF_IA,
+              RoutingProtocol.OSPF_E1,
+              RoutingProtocol.OSPF_E2);
+      case "isis" -> ImmutableList.of(RoutingProtocol.ISIS_L1, RoutingProtocol.ISIS_L2);
+      default -> ImmutableList.of();
+    };
   }
 
   /**
@@ -339,6 +379,132 @@ public final class SrosConversions {
       }
       ib.build();
     }
+  }
+
+  /**
+   * Converts a router instance's {@code ospf} process to a VI {@link
+   * org.batfish.datamodel.ospf.OspfProcess} on {@code vrf}, attaching {@link
+   * org.batfish.datamodel.ospf.OspfInterfaceSettings} to each OSPF-enabled interface. Batfish
+   * derives the OSPF adjacencies and neighbor configs from the interface settings (area +
+   * addresses) in post-processing, so only the interface settings and area membership are set here.
+   *
+   * <p>Interface cost: an explicit {@code metric} wins; otherwise the cost is derived from the
+   * reference bandwidth (SR-OS and Batfish both default to a 100 Gbps reference, so a 100 Gbps port
+   * derives cost 1). A loopback gets cost 0 (it has no bandwidth). The process is skipped when
+   * {@code admin-state} is not enable.
+   */
+  static void convertOspf(Router router, Configuration c, Vrf vrf, Warnings w) {
+    org.batfish.vendor.sros.representation.OspfProcess proc = router.getOspfProcess();
+    if (proc == null || !proc.getAdminStateEnable()) {
+      return;
+    }
+    Ip routerId = proc.getRouterId();
+    if (routerId == null) {
+      routerId = systemInterfaceIp(router);
+    }
+    if (routerId == null) {
+      w.redFlagf(
+          "SR-OS: router '%s' OSPF has no router-id and no system interface address; skipping OSPF",
+          router.getName());
+      return;
+    }
+    String procName = Integer.toString(proc.getInstance());
+    org.batfish.datamodel.ospf.OspfProcess newProc =
+        org.batfish.datamodel.ospf.OspfProcess.builder()
+            .setProcessId(procName)
+            .setRouterId(routerId)
+            .setReferenceBandwidth(OSPF_REFERENCE_BANDWIDTH)
+            // SR-OS OSPF route preference (admin distance): internal (intra/inter-area, summary)
+            // default 10, external default 150 — not the Cisco 110/110.
+            .setAdminCosts(OSPF_ADMIN_COSTS)
+            .setAreas(ImmutableMap.of())
+            .setVrf(vrf)
+            .build();
+
+    java.util.Map<Long, org.batfish.datamodel.ospf.OspfArea.Builder> areaBuilders =
+        new java.util.LinkedHashMap<>();
+    for (OspfArea area : proc.getAreas().values()) {
+      long areaNum = Ip.parse(area.getAreaId()).asLong();
+      org.batfish.datamodel.ospf.OspfArea.Builder ab =
+          areaBuilders.computeIfAbsent(
+              areaNum,
+              n -> org.batfish.datamodel.ospf.OspfArea.builder().setNumber(n).setNonStub());
+      for (OspfAreaInterface ospfIf : area.getInterfaces().values()) {
+        Interface viIface = c.getAllInterfaces().get(ospfIf.getName());
+        if (viIface == null) {
+          w.redFlagf(
+              "SR-OS: OSPF area %s references undefined interface '%s'; skipping",
+              area.getAreaId(), ospfIf.getName());
+          continue;
+        }
+        int cost = ospfInterfaceCost(ospfIf, viIface, newProc.getReferenceBandwidth());
+        viIface.setOspfSettings(
+            org.batfish.datamodel.ospf.OspfInterfaceSettings.builder()
+                .setProcess(procName)
+                .setAreaName(areaNum)
+                .setEnabled(true)
+                .setPassive(false)
+                .setNetworkType(toOspfNetworkType(ospfIf.getInterfaceType()))
+                .setCost(cost)
+                .setOspfAddresses(
+                    org.batfish.datamodel.ospf.OspfAddresses.of(viIface.getAllConcreteAddresses()))
+                .build());
+        ab.addInterface(ospfIf.getName());
+      }
+    }
+    java.util.Map<Long, org.batfish.datamodel.ospf.OspfArea> areas = new java.util.TreeMap<>();
+    for (java.util.Map.Entry<Long, org.batfish.datamodel.ospf.OspfArea.Builder> e :
+        areaBuilders.entrySet()) {
+      areas.put(e.getKey(), e.getValue().setOspfProcess(newProc).build());
+    }
+    newProc.setAreas(ImmutableMap.copyOf(areas));
+  }
+
+  /**
+   * SR-OS OSPF default {@code reference-bandwidth} is 100,000,000 kilobps = 100 Gbps, expressed in
+   * bps for the VI reference bandwidth (matches the VI/FRR default).
+   */
+  private static final double OSPF_REFERENCE_BANDWIDTH = 100E9D;
+
+  /**
+   * SR-OS OSPF route preferences (Batfish admin distances): internal routes (intra-area,
+   * inter-area, internal summary) default to {@code preference} 10; external routes (E1/E2) default
+   * to {@code external-preference} 150.
+   */
+  private static final java.util.Map<RoutingProtocol, Integer> OSPF_ADMIN_COSTS =
+      ImmutableMap.of(
+          RoutingProtocol.OSPF, 10,
+          RoutingProtocol.OSPF_IA, 10,
+          RoutingProtocol.OSPF_IS, 10,
+          RoutingProtocol.OSPF_E1, 150,
+          RoutingProtocol.OSPF_E2, 150);
+
+  /**
+   * The OSPF cost for an interface: an explicit {@code metric} wins; a loopback is 0; otherwise the
+   * cost is derived as {@code max(1, referenceBandwidth / interfaceBandwidth)}.
+   */
+  private static int ospfInterfaceCost(
+      OspfAreaInterface ospfIf, Interface viIface, double referenceBandwidth) {
+    if (ospfIf.getMetric() != null) {
+      return ospfIf.getMetric();
+    }
+    if (viIface.getInterfaceType() == InterfaceType.LOOPBACK) {
+      return 0;
+    }
+    Double bw = viIface.getBandwidth();
+    if (bw == null || bw <= 0) {
+      return 1;
+    }
+    return Math.max(1, (int) (referenceBandwidth / bw));
+  }
+
+  private static org.batfish.datamodel.ospf.OspfNetworkType toOspfNetworkType(
+      @Nullable OspfAreaInterface.InterfaceType type) {
+    if (type == OspfAreaInterface.InterfaceType.POINT_TO_POINT) {
+      return org.batfish.datamodel.ospf.OspfNetworkType.POINT_TO_POINT;
+    }
+    // SR-OS default and BROADCAST both map to the broadcast network type.
+    return org.batfish.datamodel.ospf.OspfNetworkType.BROADCAST;
   }
 
   /**
@@ -476,17 +642,23 @@ public final class SrosConversions {
     boolean ebgp =
         neighbor.getType() != null ? neighbor.getType() == PeerType.EXTERNAL : peerAs != localAs;
 
+    boolean nextHopSelf = Boolean.TRUE.equals(neighbor.getNextHopSelf());
     String importPolicyName =
         generatedBgpPeerImportPolicyName(router.getName(), neighbor.getIpAddress());
     String exportPolicyName =
         generatedBgpPeerExportPolicyName(router.getName(), neighbor.getIpAddress());
-    buildPeerPolicy(importPolicyName, neighbor.getImportPolicies(), ebgp, false, c);
-    buildPeerPolicy(exportPolicyName, neighbor.getExportPolicies(), ebgp, true, c);
+    buildPeerPolicy(importPolicyName, neighbor.getImportPolicies(), ebgp, false, false, c);
+    buildPeerPolicy(exportPolicyName, neighbor.getExportPolicies(), ebgp, true, nextHopSelf, c);
 
+    // Route-reflection: a neighbor with a cluster-id (configured or inherited from its group) is a
+    // route-reflector client. Mark the address family as an RR client and set the cluster-id, so
+    // Batfish reflects routes between clients.
+    Ip clusterId = neighbor.getClusterId();
     Ipv4UnicastAddressFamily af =
         Ipv4UnicastAddressFamily.builder()
             .setImportPolicy(importPolicyName)
             .setExportPolicy(exportPolicyName)
+            .setRouteReflectorClient(clusterId != null)
             .setAddressFamilyCapabilities(
                 AddressFamilyCapabilities.builder()
                     .setSendCommunity(true)
@@ -505,6 +677,7 @@ public final class SrosConversions {
         .setPeerAddress(peerAddress)
         .setRemoteAsns(LongSpace.of(peerAs))
         .setLocalAs(localAs)
+        .setClusterId(clusterId == null ? null : clusterId.asLong())
         .setIpv4UnicastAddressFamily(af)
         .setBgpProcess(newProc)
         .build();
@@ -516,18 +689,41 @@ public final class SrosConversions {
    * (SR-OS eBGP default-reject). Mirrors the Junos generated-peer-policy idiom.
    */
   private static void buildPeerPolicy(
-      String name, List<String> policyNames, boolean ebgp, boolean isExport, Configuration c) {
+      String name,
+      List<String> policyNames,
+      boolean ebgp,
+      boolean isExport,
+      boolean nextHopSelf,
+      Configuration c) {
     List<Statement> statements = new ArrayList<>();
-    // SR-OS originates locally-sourced routes (the system/connected prefixes advertised via an
-    // export policy) into BGP with origin IGP, like Junos. Set origin IGP for non-BGP routes at
-    // the head of the export policy so advertised local routes carry origin igp, not the Batfish
-    // redistribution default of incomplete. (Caught by lab validation against the eBGP peer, P5-V.)
+    // next-hop-self: on export, rewrite the BGP next-hop to this router's address. Needed for an
+    // iBGP route reflector with no IGP underlay so its clients can resolve reflected routes (L4).
+    if (isExport && nextHopSelf) {
+      statements.add(
+          new org.batfish.datamodel.routing_policy.statement.SetNextHop(
+              org.batfish.datamodel.routing_policy.expr.SelfNextHop.getInstance()));
+    }
+    // SR-OS BGP origin on locally-sourced routes: a connected/direct route (e.g. the system or an
+    // interface prefix) advertised by an export policy carries origin IGP; a redistributed route
+    // (static/OSPF/etc.) carries origin INCOMPLETE. Set IGP for connected/local routes at the head
+    // of the export policy; leave everything else at Batfish's redistribution default (incomplete),
+    // which matches the device. (System-prefix IGP caught at P5-V; static=incomplete at L6.)
     if (isExport) {
+      statements.add(
+          new If(
+              new MatchProtocol(RoutingProtocol.CONNECTED, RoutingProtocol.LOCAL),
+              ImmutableList.of(new SetOrigin(new LiteralOrigin(OriginType.IGP, null))),
+              ImmutableList.of()));
+      // SR-OS does not carry a non-BGP route's IGP/static metric into the advertised MED: a
+      // locally-sourced or redistributed route is advertised with MED 0 unless a policy explicitly
+      // sets the metric. Reset MED to 0 for non-BGP routes at the policy head; an entry's explicit
+      // `metric set` (modeled as SetMetric in the entry's set-clauses) runs later and overrides it.
+      // (L6: redistributed static appears on the peer with MED 0, not the route metric 1.)
       statements.add(
           new If(
               new MatchProtocol(RoutingProtocol.BGP, RoutingProtocol.IBGP),
               ImmutableList.of(),
-              ImmutableList.of(new SetOrigin(new LiteralOrigin(OriginType.IGP, null)))));
+              ImmutableList.of(new SetMetric(new LiteralLong(0L)))));
     }
     // The default policy backs the chain when no named policy makes a terminal decision.
     String defaultPolicyName = ebgp ? defaultRejectPolicy(c) : defaultAcceptPolicy(c);

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -262,6 +262,42 @@ public final class SrosConversions {
   }
 
   /**
+   * Converts a router instance's {@code static-routes} to VI {@link
+   * org.batfish.datamodel.StaticRoute}s on {@code vrf}. Only routes whose next-hop/blackhole
+   * context is {@code admin-state enable} are installed — SR-OS does not put a disabled (or
+   * admin-state unset) static route into the RIB (confirmed on SR-SIM 26.3.R1). A next-hop route
+   * maps to a {@link org.batfish.datamodel.route.nh.NextHopIp}; a blackhole maps to {@link
+   * org.batfish.datamodel.route.nh.NextHopDiscard}. The SR-OS {@code preference} is the Batfish
+   * admin distance and {@code metric} is the route metric (YANG defaults 5 and 1).
+   */
+  static void convertStaticRoutes(Router router, Vrf vrf, Warnings w) {
+    for (StaticRoute sr : router.getStaticRoutes()) {
+      if (!sr.getAdminStateEnable()) {
+        // Configured but not admin-state enable -> not installed on the device; skip it.
+        continue;
+      }
+      org.batfish.datamodel.StaticRoute.Builder b =
+          org.batfish.datamodel.StaticRoute.builder()
+              .setNetwork(sr.getPrefix())
+              .setAdministrativeCost(sr.getPreference())
+              .setMetric(sr.getMetric());
+      if (sr.getBlackhole()) {
+        b.setNextHop(org.batfish.datamodel.route.nh.NextHopDiscard.instance());
+      } else {
+        Ip nhIp = sr.getNextHopIp();
+        if (nhIp == null) {
+          w.redFlagf(
+              "SR-OS: static route %s has neither a next-hop IP nor blackhole; skipping",
+              sr.getPrefix());
+          continue;
+        }
+        b.setNextHop(org.batfish.datamodel.route.nh.NextHopIp.of(nhIp));
+      }
+      vrf.getStaticRoutes().add(b.build());
+    }
+  }
+
+  /**
    * Creates the addressless {@link InterfaceType#PHYSICAL} VI interface for an SR-OS port if it
    * does not already exist on {@code c}. This is the interface a user Layer-1 topology references;
    * the L3 router-interface binds to it. The port is admin-up unless its {@code admin-state} is

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -31,19 +31,31 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetUnion;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
+import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
+import org.batfish.datamodel.routing_policy.communities.SetCommunities;
+import org.batfish.datamodel.routing_policy.expr.AsExpr;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.BooleanExprs;
 import org.batfish.datamodel.routing_policy.expr.CallExpr;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
+import org.batfish.datamodel.routing_policy.expr.ExplicitAs;
 import org.batfish.datamodel.routing_policy.expr.FirstMatchChain;
+import org.batfish.datamodel.routing_policy.expr.LiteralAsList;
+import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy;
+import org.batfish.datamodel.routing_policy.statement.SetMetric;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
@@ -92,20 +104,44 @@ public final class SrosConversions {
           switch (entry.getType()) {
             case EXACT -> SubRange.singleton(len);
             case LONGER -> new SubRange(len + 1, Prefix.MAX_PREFIX_LENGTH);
-            case THROUGH, RANGE, TO, ADDRESS_MASK -> {
-              // The upper/lower bound leaves for these types are not modeled in P4 yet; match this
-              // length or longer as a conservative over-approximation, and warn that the filter is
-              // broader than the device's until the bounds are modeled.
-              w.redFlagf(
-                  "SR-OS: prefix-list '%s' entry %s match type '%s' is not fully modeled; matching"
-                      + " '%s' or longer (over-approximation)",
-                  pl.getName(), prefix, entry.getType(), prefix);
-              yield new SubRange(len, Prefix.MAX_PREFIX_LENGTH);
+            case THROUGH -> {
+              // through-length: match this prefix's length through through-length (inclusive). If
+              // the bound is missing (older capture), fall back to "this length or longer" + warn.
+              Integer through = entry.getThroughLength();
+              if (through == null) {
+                yield overApproximate(pl, entry, w);
+              }
+              yield new SubRange(len, through);
+            }
+            case RANGE -> {
+              // range: match start-length through end-length (inclusive).
+              Integer start = entry.getStartLength();
+              Integer end = entry.getEndLength();
+              if (start == null || end == null) {
+                yield overApproximate(pl, entry, w);
+              }
+              yield new SubRange(start, end);
+            }
+            case TO, ADDRESS_MASK -> {
+              // The bound leaves for these types are not modeled yet; match this length or longer
+              // as a conservative over-approximation, and warn until the bounds are modeled.
+              yield overApproximate(pl, entry, w);
             }
           };
       lines.add(new RouteFilterLine(LineAction.PERMIT, prefix, lengthRange));
     }
     return new RouteFilterList(pl.getName(), lines);
+  }
+
+  /** The "this length or longer" over-approximation + warning, for unmodeled match-type bounds. */
+  private static @Nonnull SubRange overApproximate(
+      PrefixList pl, PrefixListEntry entry, Warnings w) {
+    Prefix prefix = entry.getPrefix();
+    w.redFlagf(
+        "SR-OS: prefix-list '%s' entry %s match type '%s' is not fully modeled; matching '%s' or"
+            + " longer (over-approximation)",
+        pl.getName(), prefix, entry.getType(), prefix);
+    return new SubRange(prefix.getPrefixLength(), Prefix.MAX_PREFIX_LENGTH);
   }
 
   /**
@@ -118,15 +154,19 @@ public final class SrosConversions {
    */
   static void convertPolicyStatements(SrosConfiguration vc, Configuration c) {
     for (PolicyStatement ps : vc.getPolicyStatements().values()) {
-      c.getRoutingPolicies().put(ps.getName(), toRoutingPolicy(ps, c));
+      c.getRoutingPolicies().put(ps.getName(), toRoutingPolicy(vc, ps, c));
     }
   }
 
-  private static @Nonnull RoutingPolicy toRoutingPolicy(PolicyStatement ps, Configuration c) {
+  private static @Nonnull RoutingPolicy toRoutingPolicy(
+      SrosConfiguration vc, PolicyStatement ps, Configuration c) {
     List<Statement> statements = new ArrayList<>();
     for (PolicyStatementEntry entry : ps.getEntries().values()) {
       BooleanExpr guard = toGuard(entry, c);
-      List<Statement> onMatch = actionStatements(entry.getAction());
+      // On a match, apply the entry's set-clauses (metric/MED, as-path-prepend, community) before
+      // its terminal action, so the modifications take effect on the matched route.
+      List<Statement> onMatch = new ArrayList<>(setStatements(vc, entry));
+      onMatch.addAll(actionStatements(entry.getAction()));
       if (guard == BooleanExprs.TRUE) {
         // No from-criteria: the entry always matches. Emit its action unconditionally.
         statements.addAll(onMatch);
@@ -143,6 +183,46 @@ public final class SrosConversions {
         .setOwner(c)
         .setStatements(statements)
         .build();
+  }
+
+  /**
+   * The set-clause statements for one policy entry, applied (in SR-OS order) when the entry
+   * matches: {@code metric set} → {@link SetMetric}; {@code as-path-prepend} → {@link
+   * PrependAsPath} (the AS repeated {@code repeat} times); {@code community add} → {@link
+   * SetCommunities} unioning the named community members onto the route's existing communities.
+   */
+  private static @Nonnull List<Statement> setStatements(
+      SrosConfiguration vc, PolicyStatementEntry entry) {
+    List<Statement> statements = new ArrayList<>();
+    if (entry.getSetMetric() != null) {
+      statements.add(new SetMetric(new LiteralLong(entry.getSetMetric())));
+    }
+    if (entry.getAsPathPrependAsn() != null) {
+      List<AsExpr> ases = new ArrayList<>();
+      for (int i = 0; i < entry.getAsPathPrependRepeat(); i++) {
+        ases.add(new ExplicitAs(entry.getAsPathPrependAsn()));
+      }
+      statements.add(new PrependAsPath(new LiteralAsList(ases)));
+    }
+    List<org.batfish.datamodel.bgp.community.Community> communitiesToAdd = new ArrayList<>();
+    for (String commName : entry.getCommunityAdds()) {
+      Community community = vc.getCommunities().get(commName);
+      if (community == null) {
+        // Undefined community reference: reported by the structure manager; skip silently here.
+        continue;
+      }
+      for (String member : community.getMembers()) {
+        StandardCommunity.tryParse(member).ifPresent(communitiesToAdd::add);
+      }
+    }
+    if (!communitiesToAdd.isEmpty()) {
+      statements.add(
+          new SetCommunities(
+              CommunitySetUnion.of(
+                  InputCommunities.instance(),
+                  new LiteralCommunitySet(CommunitySet.of(communitiesToAdd)))));
+    }
+    return statements;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -468,13 +468,32 @@ public final class SrosConversions {
     RoutingPolicy.builder().setName(name).setOwner(c).setStatements(statements).build();
   }
 
-  /** Lazily creates and returns the name of a shared "accept all" default policy on {@code c}. */
+  /**
+   * Lazily creates and returns the name of the shared iBGP default-accept policy on {@code c}.
+   *
+   * <p>SR-OS iBGP "default-accept" (no import/export policy on the group) accepts <em>BGP</em>
+   * routes — it propagates routes already in BGP, but does <em>not</em> pull connected/static/IGP
+   * routes into BGP. (A connected route like the system prefix is advertised only when an explicit
+   * export policy matches it; the default never does.) So the default-accept policy accepts iff the
+   * route's protocol is BGP/iBGP, and otherwise rejects. This matters on export: with {@code
+   * setExportBgpFromBgpRib(false)} Batfish runs the export policy over the whole main RIB, and a
+   * blanket accept-all would leak the connected /31s the device never advertises (confirmed on the
+   * L3 iBGP lab, where r1 advertises only 1.1.1.1/32 (explicit policy) and the eBGP-learned
+   * 2.2.2.2/32 to its iBGP peer, not its connected interface prefixes). On import the route being
+   * evaluated is always a received BGP route, so the protocol guard accepts everything — preserving
+   * iBGP default-accept on import.
+   */
   private static @Nonnull String defaultAcceptPolicy(Configuration c) {
     if (!c.getRoutingPolicies().containsKey(DEFAULT_BGP_ACCEPT_POLICY_NAME)) {
       RoutingPolicy.builder()
           .setName(DEFAULT_BGP_ACCEPT_POLICY_NAME)
           .setOwner(c)
-          .setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()))
+          .setStatements(
+              ImmutableList.of(
+                  new If(
+                      new MatchProtocol(RoutingProtocol.BGP, RoutingProtocol.IBGP),
+                      ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
+                      ImmutableList.of(Statements.ExitReject.toStaticStatement()))))
           .build();
     }
     return DEFAULT_BGP_ACCEPT_POLICY_NAME;

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosStructureType.java
@@ -7,12 +7,13 @@ import org.batfish.vendor.StructureType;
 /** Named structures defined in a Nokia SR-OS configuration that may be referenced elsewhere. */
 public enum SrosStructureType implements StructureType {
   BGP_GROUP("bgp group"),
+  COMMUNITY("community"),
   POLICY_STATEMENT("policy-statement"),
   PREFIX_LIST("prefix-list");
 
   /** All concrete structure types, for {@code markConcreteStructure} at the end of conversion. */
   public static final List<SrosStructureType> CONCRETE_STRUCTURES =
-      ImmutableList.of(BGP_GROUP, POLICY_STATEMENT, PREFIX_LIST);
+      ImmutableList.of(BGP_GROUP, COMMUNITY, POLICY_STATEMENT, PREFIX_LIST);
 
   private final String _description;
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosStructureUsage.java
@@ -9,7 +9,8 @@ public enum SrosStructureUsage implements StructureUsage {
   BGP_NEIGHBOR_GROUP("bgp neighbor group"),
   BGP_NEIGHBOR_IMPORT_POLICY("bgp neighbor import policy"),
   BGP_NEIGHBOR_EXPORT_POLICY("bgp neighbor export policy"),
-  POLICY_STATEMENT_FROM_PREFIX_LIST("policy-statement entry from prefix-list");
+  POLICY_STATEMENT_FROM_PREFIX_LIST("policy-statement entry from prefix-list"),
+  POLICY_STATEMENT_ACTION_COMMUNITY("policy-statement entry action community add");
 
   private final String _description;
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/StaticRoute.java
@@ -1,0 +1,92 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+
+/**
+ * An SR-OS static route entry under {@code router "<name>" static-routes route <prefix> route-type
+ * <unicast|multicast>}. The YANG list is keyed by {@code (ip-prefix, route-type)}; this models the
+ * unicast IPv4 case.
+ *
+ * <p>The destination is reached either via a directly-connected {@code next-hop <ip>} or via a
+ * {@code blackhole} (discard). Both the next-hop and the blackhole contexts carry an {@code
+ * admin-state}: SR-OS does <em>not</em> install a static route into the RIB unless that admin-state
+ * is {@code enable} (an absent or {@code disable} admin-state leaves the route configured but not
+ * installed — confirmed on SR-SIM 26.3.R1). Once installed, the YANG defaults are {@code preference
+ * 5} (Batfish admin distance) and {@code metric 1}.
+ */
+public final class StaticRoute implements Serializable {
+
+  /** YANG default {@code preference} for a static route next-hop/blackhole. */
+  public static final int DEFAULT_PREFERENCE = 5;
+
+  /** YANG default {@code metric} for a static route next-hop/blackhole. */
+  public static final int DEFAULT_METRIC = 1;
+
+  public StaticRoute(Prefix prefix) {
+    _prefix = prefix;
+  }
+
+  public @Nonnull Prefix getPrefix() {
+    return _prefix;
+  }
+
+  /** The next-hop IP, or {@code null} if this is a blackhole route (or no next-hop is set). */
+  public @Nullable Ip getNextHopIp() {
+    return _nextHopIp;
+  }
+
+  public void setNextHopIp(@Nullable Ip nextHopIp) {
+    _nextHopIp = nextHopIp;
+  }
+
+  /** Whether this route is a {@code blackhole} (discard) route. */
+  public boolean getBlackhole() {
+    return _blackhole;
+  }
+
+  public void setBlackhole(boolean blackhole) {
+    _blackhole = blackhole;
+  }
+
+  /**
+   * Whether the next-hop / blackhole context is {@code admin-state enable}. A route is installed
+   * into the RIB only when this is true (SR-OS leaves a route with no/disabled admin-state
+   * uninstalled).
+   */
+  public boolean getAdminStateEnable() {
+    return _adminStateEnable;
+  }
+
+  public void setAdminStateEnable(boolean adminStateEnable) {
+    _adminStateEnable = adminStateEnable;
+  }
+
+  /** The {@code preference} (Batfish admin distance); defaults to {@link #DEFAULT_PREFERENCE}. */
+  public int getPreference() {
+    return _preference;
+  }
+
+  public void setPreference(int preference) {
+    _preference = preference;
+  }
+
+  /** The {@code metric}; defaults to {@link #DEFAULT_METRIC}. */
+  public int getMetric() {
+    return _metric;
+  }
+
+  public void setMetric(int metric) {
+    _metric = metric;
+  }
+
+  private final @Nonnull Prefix _prefix;
+  private @Nullable Ip _nextHopIp;
+  private boolean _blackhole;
+  private boolean _adminStateEnable;
+  private int _preference = DEFAULT_PREFERENCE;
+  private int _metric = DEFAULT_METRIC;
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -253,6 +253,93 @@ public final class SrosConversionTest {
   }
 
   /**
+   * OSPF conversion: a VI OspfProcess on the default VRF with area 0, the OSPF interfaces carrying
+   * OspfInterfaceSettings (area, cost, network type), and SR-OS admin distance 10 for internal
+   * routes.
+   */
+  @Test
+  public void testOspfConversion() throws IOException {
+    Configuration c = parseConfig("ospf.txt");
+    org.batfish.datamodel.ospf.OspfProcess proc = c.getDefaultVrf().getOspfProcesses().get("0");
+    assertNotNull(proc);
+    assertThat(proc.getRouterId(), equalTo(Ip.parse("1.1.1.1")));
+    // SR-OS OSPF internal route preference is 10 (not the Cisco 110).
+    assertThat(proc.getAdminCosts().get(org.batfish.datamodel.RoutingProtocol.OSPF), equalTo(10));
+    assertThat(proc.getAreas(), hasKey(0L));
+    assertThat(proc.getAreas().get(0L).getInterfaces(), containsInAnyOrder("system", "to-r3"));
+
+    // The to-r3 interface has OSPF settings with the explicit metric 100 and p2p network type.
+    Interface toR3 = c.getAllInterfaces().get("to-r3");
+    assertNotNull(toR3.getOspfSettings());
+    assertThat(toR3.getOspfSettings().getAreaName(), equalTo(0L));
+    assertThat(toR3.getOspfSettings().getCost(), equalTo(100));
+    assertThat(
+        toR3.getOspfSettings().getNetworkType(),
+        equalTo(org.batfish.datamodel.ospf.OspfNetworkType.POINT_TO_POINT));
+  }
+
+  /** VPRN conversion: a {@code service vprn "red"} becomes a separate VRF holding its interface. */
+  @Test
+  public void testVprnConversion() throws IOException {
+    Configuration c = parseConfig("vprn.txt");
+    assertThat(c.getVrfs(), hasKey("red"));
+    // The VPRN interface is in the "red" VRF, not the default VRF.
+    Interface redLo = c.getAllInterfaces().get("red-lo");
+    assertNotNull(redLo);
+    assertThat(redLo.getVrfName(), equalTo("red"));
+    assertThat(redLo.getConcreteAddress().toString(), equalTo("172.16.0.1/32"));
+    // No leak: the Base "system" interface is in the default VRF, not "red".
+    assertThat(
+        c.getAllInterfaces().get("system").getVrfName(), equalTo(Configuration.DEFAULT_VRF_NAME));
+  }
+
+  /** Route-reflector conversion: an RR-client neighbor gets cluster-id + route-reflector-client. */
+  @Test
+  public void testRouteReflectorConversion() throws IOException {
+    Configuration c = parseConfig("route_reflector.txt");
+    BgpActivePeerConfig peer =
+        c.getDefaultVrf().getBgpProcess().getActiveNeighbors().get(Ip.parse("10.0.0.1"));
+    assertNotNull(peer);
+    assertThat(peer.getClusterId(), equalTo(Ip.parse("1.1.1.1").asLong()));
+    assertTrue(peer.getIpv4UnicastAddressFamily().getRouteReflectorClient());
+  }
+
+  /**
+   * from-protocol conversion: a policy entry {@code from protocol name [static]} only matches
+   * static routes — a static route is accepted, a connected route is not (it falls through to the
+   * eBGP default-reject), so the connected interface prefix is not advertised.
+   */
+  @Test
+  public void testFromProtocolConversion() throws IOException {
+    Configuration c = parseConfig("redistribute_static.txt");
+    BgpActivePeerConfig peer =
+        c.getDefaultVrf().getBgpProcess().getActiveNeighbors().get(Ip.parse("10.0.0.1"));
+    RoutingPolicy exportPolicy =
+        c.getRoutingPolicies().get(peer.getIpv4UnicastAddressFamily().getExportPolicy());
+    assertNotNull(exportPolicy);
+    // A static route to 192.0.2.0/24 is accepted (matches from protocol static).
+    assertTrue(staticRouteAccepted(exportPolicy, Prefix.parse("192.0.2.0/24")));
+    // A connected route is not matched by from-protocol-static, so eBGP default-reject drops it.
+    assertFalse(
+        connectedRouteAccepted(
+            exportPolicy, Prefix.parse("10.0.0.0/31"), Environment.Direction.OUT));
+  }
+
+  /** Whether {@code policy} accepts a static route for {@code network} on export. */
+  private static boolean staticRouteAccepted(RoutingPolicy policy, Prefix network) {
+    org.batfish.datamodel.StaticRoute route =
+        org.batfish.datamodel.StaticRoute.builder()
+            .setNetwork(network)
+            .setNextHop(org.batfish.datamodel.route.nh.NextHopDiscard.instance())
+            .setAdministrativeCost(5)
+            .build();
+    return policy.process(
+        route,
+        Bgpv4Route.testBuilder().setNetwork(network).setOriginatorIp(Ip.parse("1.1.1.1")),
+        Environment.Direction.OUT);
+  }
+
+  /**
    * Hardware (cards/ports) is parsed but not converted; conversion emits a red-flag warning rather
    * than silently dropping it.
    */

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -158,6 +158,49 @@ public final class SrosConversionTest {
   }
 
   /**
+   * iBGP default-accept (an iBGP group with no import/export policy, or whose policy falls through)
+   * accepts BGP routes but does not pull connected/static routes into BGP. Verified behaviorally on
+   * the generated peer policies of an iBGP neighbor:
+   *
+   * <ul>
+   *   <li>import: a received BGP route is accepted by default (no import policy).
+   *   <li>export: a BGP route is accepted, but a connected route that no explicit export policy
+   *       matches is rejected by the default-accept backstop — so connected interface prefixes are
+   *       not leaked into iBGP (confirmed against the L3 lab, where SR-OS advertised only its
+   *       policy-matched system prefix and its BGP-learned routes, not its connected /31s).
+   * </ul>
+   */
+  @Test
+  public void testIbgpDefaultAcceptOnlyBgpRoutes() throws IOException {
+    Configuration c = parseConfig("ibgp_default_accept.txt");
+    BgpActivePeerConfig peer =
+        c.getDefaultVrf().getBgpProcess().getActiveNeighbors().get(Ip.parse("10.0.1.1"));
+    assertNotNull(peer);
+
+    // import: no import policy on the iBGP group -> default-accept any received BGP route.
+    RoutingPolicy importPolicy =
+        c.getRoutingPolicies().get(peer.getIpv4UnicastAddressFamily().getImportPolicy());
+    assertNotNull(importPolicy);
+    assertTrue(
+        bgpRouteAccepted(importPolicy, Prefix.parse("9.9.9.9/32"), Environment.Direction.IN));
+
+    RoutingPolicy exportPolicy =
+        c.getRoutingPolicies().get(peer.getIpv4UnicastAddressFamily().getExportPolicy());
+    assertNotNull(exportPolicy);
+    // export: a BGP route is accepted by the iBGP default-accept backstop...
+    assertTrue(
+        bgpRouteAccepted(exportPolicy, Prefix.parse("2.2.2.2/32"), Environment.Direction.OUT));
+    // ...the explicit export-system policy still accepts the system prefix...
+    assertTrue(
+        connectedRouteAccepted(
+            exportPolicy, Prefix.parse("1.1.1.1/32"), Environment.Direction.OUT));
+    // ...but a connected route that no policy matches is NOT pulled into iBGP by default-accept.
+    assertFalse(
+        connectedRouteAccepted(
+            exportPolicy, Prefix.parse("10.0.1.0/31"), Environment.Direction.OUT));
+  }
+
+  /**
    * Hardware (cards/ports) is parsed but not converted; conversion emits a red-flag warning rather
    * than silently dropping it.
    */
@@ -325,9 +368,30 @@ public final class SrosConversionTest {
 
   private static boolean routeAccepted(
       RoutingPolicy policy, Prefix network, Environment.Direction direction) {
+    return bgpRouteAccepted(policy, network, direction);
+  }
+
+  /** Whether {@code policy} accepts a BGP route for {@code network}. */
+  private static boolean bgpRouteAccepted(
+      RoutingPolicy policy, Prefix network, Environment.Direction direction) {
     Bgpv4Route route =
         Bgpv4Route.testBuilder().setNetwork(network).setOriginatorIp(Ip.parse("1.1.1.1")).build();
     return policy.process(route, route.toBuilder(), direction);
+  }
+
+  /**
+   * Whether {@code policy} accepts a <em>connected</em> route for {@code network} (used to confirm
+   * the iBGP default-accept backstop does not pull non-BGP routes into BGP). The output builder is
+   * a BGP route builder, as in an export context.
+   */
+  private static boolean connectedRouteAccepted(
+      RoutingPolicy policy, Prefix network, Environment.Direction direction) {
+    org.batfish.datamodel.ConnectedRoute route =
+        new org.batfish.datamodel.ConnectedRoute(network, "iface");
+    return policy.process(
+        route,
+        Bgpv4Route.testBuilder().setNetwork(network).setOriginatorIp(Ip.parse("1.1.1.1")),
+        direction);
   }
 
   private static final String TESTCONFIGS_PREFIX = "org/batfish/vendor/sros/grammar/testconfigs/";

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -201,6 +201,58 @@ public final class SrosConversionTest {
   }
 
   /**
+   * Policy set-clauses convert and take effect when the entry matches: {@code metric set} sets the
+   * MED, {@code as-path-prepend} prepends the AS the configured number of times, {@code community
+   * add} unions the named community onto the route, and a {@code through} prefix-list converts to
+   * an exact length window (not the old over-approximation).
+   */
+  @Test
+  public void testPolicySetClausesConversion() throws IOException {
+    Configuration c = parseConfig("policy_set_clauses.txt");
+
+    // through-length 32 on a /16 -> exact window [16,32], so a /32 inside the block matches but a
+    // shorter (e.g. /15) does not. (Previously over-approximated to [16,32-or-longer] with a warn.)
+    RouteFilterList loRange = c.getRouteFilterLists().get("lo-range");
+    assertNotNull(loRange);
+    assertTrue(loRange.permits(Prefix.parse("192.168.1.0/24")));
+    assertTrue(loRange.permits(Prefix.parse("192.168.1.1/32")));
+    assertFalse(loRange.permits(Prefix.parse("192.0.0.0/15")));
+
+    // range start-length 24 end-length 32 on 10.0.0.0/8 -> window [24,32].
+    RouteFilterList hostRange = c.getRouteFilterLists().get("host-range");
+    assertNotNull(hostRange);
+    assertTrue(hostRange.permits(Prefix.parse("10.1.2.0/24")));
+    assertTrue(hostRange.permits(Prefix.parse("10.1.2.3/32")));
+    assertFalse(hostRange.permits(Prefix.parse("10.1.0.0/16")));
+
+    // entry 10 matches 1.1.1.1/32 (system-pfx) and applies metric 50 + prepend 65001 x2 +
+    // community.
+    RoutingPolicy exportPolicy = c.getRoutingPolicies().get("export-to-r2");
+    assertNotNull(exportPolicy);
+    Bgpv4Route in =
+        Bgpv4Route.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setOriginatorIp(Ip.parse("1.1.1.1"))
+            .setOriginType(org.batfish.datamodel.OriginType.IGP)
+            .setProtocol(org.batfish.datamodel.RoutingProtocol.BGP)
+            .build();
+    Bgpv4Route.Builder out = in.toBuilder();
+    boolean permitted = exportPolicy.process(in, out, Environment.Direction.OUT);
+    assertTrue(permitted);
+    Bgpv4Route result = out.build();
+    assertThat(result.getMetric(), equalTo(50L));
+    // as-path: 65001 prepended twice.
+    assertThat(
+        result.getAsPath(),
+        equalTo(org.batfish.datamodel.AsPath.ofSingletonAsSets(65001L, 65001L)));
+    // community 65001:100 added.
+    assertThat(
+        result.getCommunities().getCommunities(),
+        org.hamcrest.Matchers.hasItem(
+            org.batfish.datamodel.bgp.community.StandardCommunity.parse("65001:100")));
+  }
+
+  /**
    * Hardware (cards/ports) is parsed but not converted; conversion emits a red-flag warning rather
    * than silently dropping it.
    */

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -276,6 +276,46 @@ public final class SrosConversionTest {
         hasRedFlagWarning("bgp-type-and-inheritance", containsString("is not fully modeled")));
   }
 
+  /**
+   * static-routes conversion: an admin-state-enable next-hop route and a blackhole route become VI
+   * {@link org.batfish.datamodel.StaticRoute}s (NextHopIp / NextHopDiscard) with the SR-OS
+   * preference as admin distance and the metric; a route whose next-hop has no admin-state is NOT
+   * installed (matching the device).
+   */
+  @Test
+  public void testStaticRoutesConversion() throws IOException {
+    Configuration c = parseConfig("static_routes.txt");
+    Map<Prefix, org.batfish.datamodel.StaticRoute> byPrefix =
+        c.getDefaultVrf().getStaticRoutes().stream()
+            .collect(
+                java.util.stream.Collectors.toMap(
+                    org.batfish.datamodel.AbstractRoute::getNetwork, r -> r));
+
+    // The next-hop route (default preference 5 / metric 1).
+    org.batfish.datamodel.StaticRoute nh = byPrefix.get(Prefix.parse("192.0.2.0/24"));
+    assertNotNull(nh);
+    assertThat(
+        nh.getNextHop(),
+        equalTo(org.batfish.datamodel.route.nh.NextHopIp.of(Ip.parse("10.0.0.1"))));
+    assertThat(nh.getAdministrativeCost(), equalTo(5L));
+    assertThat(nh.getMetric(), equalTo(1L));
+
+    // The blackhole route -> discard next-hop.
+    org.batfish.datamodel.StaticRoute bh = byPrefix.get(Prefix.parse("198.51.100.0/24"));
+    assertNotNull(bh);
+    assertThat(bh.getNextHop(), equalTo(org.batfish.datamodel.route.nh.NextHopDiscard.instance()));
+
+    // The next-hop route with explicit preference 100 / metric 50.
+    org.batfish.datamodel.StaticRoute nhPref = byPrefix.get(Prefix.parse("203.0.113.0/24"));
+    assertNotNull(nhPref);
+    assertThat(nhPref.getAdministrativeCost(), equalTo(100L));
+    assertThat(nhPref.getMetric(), equalTo(50L));
+
+    // The route whose next-hop has no admin-state is not installed (SR-OS leaves it out of the
+    // RIB).
+    assertThat(byPrefix, not(hasKey(Prefix.parse("100.64.0.0/24"))));
+  }
+
   private @Nonnull Configuration parseConfig(String filename) throws IOException {
     SortedMap<String, Configuration> configs =
         BatfishTestUtils.parseTextConfigs(_folder, TESTCONFIGS_PREFIX + filename);

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
@@ -38,6 +38,7 @@ import org.batfish.vendor.sros.representation.PrefixListEntry;
 import org.batfish.vendor.sros.representation.Router;
 import org.batfish.vendor.sros.representation.RouterInterface;
 import org.batfish.vendor.sros.representation.SrosConfiguration;
+import org.batfish.vendor.sros.representation.StaticRoute;
 import org.junit.Test;
 
 /** Tests of SR-OS feature extraction (P4): the canonical tree, the preprocessor, and the model. */
@@ -131,6 +132,47 @@ public final class SrosExtractionTest {
   public void testHostnameExtraction() {
     SrosConfiguration vc = parseVendorConfig("hostname.txt");
     assertThat(vc.getHostname(), equalTo("sros-r1"));
+  }
+
+  /**
+   * static-routes extraction: next-hop and blackhole routes, the admin-state-enable flag, and the
+   * preference/metric leaves (with their YANG defaults when absent).
+   */
+  @Test
+  public void testStaticRoutesExtraction() {
+    SrosConfiguration vc = parseVendorConfig("static_routes.txt");
+    assertThat(vc.getWarnings().getParseWarnings(), empty());
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    List<StaticRoute> routes = vc.getRouters().get("Base").getStaticRoutes();
+    assertThat(routes, hasSize(4));
+
+    // route 1: next-hop, admin-state enable, default preference 5 / metric 1.
+    StaticRoute nh = routes.get(0);
+    assertThat(nh.getPrefix(), equalTo(Prefix.parse("192.0.2.0/24")));
+    assertThat(nh.getNextHopIp(), equalTo(Ip.parse("10.0.0.1")));
+    assertThat(nh.getBlackhole(), equalTo(false));
+    assertThat(nh.getAdminStateEnable(), equalTo(true));
+    assertThat(nh.getPreference(), equalTo(StaticRoute.DEFAULT_PREFERENCE));
+    assertThat(nh.getMetric(), equalTo(StaticRoute.DEFAULT_METRIC));
+
+    // route 2: blackhole, admin-state enable.
+    StaticRoute bh = routes.get(1);
+    assertThat(bh.getPrefix(), equalTo(Prefix.parse("198.51.100.0/24")));
+    assertThat(bh.getNextHopIp(), nullValue());
+    assertThat(bh.getBlackhole(), equalTo(true));
+    assertThat(bh.getAdminStateEnable(), equalTo(true));
+
+    // route 3: next-hop with explicit preference 100 / metric 50.
+    StaticRoute nhPref = routes.get(2);
+    assertThat(nhPref.getPrefix(), equalTo(Prefix.parse("203.0.113.0/24")));
+    assertThat(nhPref.getPreference(), equalTo(100));
+    assertThat(nhPref.getMetric(), equalTo(50));
+
+    // route 4: next-hop with no admin-state -> not enabled (will not be installed in conversion).
+    StaticRoute nhNoAdmin = routes.get(3);
+    assertThat(nhNoAdmin.getPrefix(), equalTo(Prefix.parse("100.64.0.0/24")));
+    assertThat(nhNoAdmin.getNextHopIp(), equalTo(Ip.parse("10.0.0.1")));
+    assertThat(nhNoAdmin.getAdminStateEnable(), equalTo(false));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.util.List;
@@ -214,6 +215,70 @@ public final class SrosExtractionTest {
     assertThat(e20.getSetMetric(), equalTo(200L));
     assertThat(e20.getAsPathPrependAsn(), nullValue());
     assertThat(e20.getCommunityAdds(), empty());
+  }
+
+  /**
+   * OSPF extraction: instance, router-id, admin-state, areas, and per-area interface type/metric.
+   */
+  @Test
+  public void testOspfExtraction() {
+    SrosConfiguration vc = parseVendorConfig("ospf.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    org.batfish.vendor.sros.representation.OspfProcess proc =
+        vc.getRouters().get("Base").getOspfProcess();
+    assertThat(proc, notNullValue());
+    assertThat(proc.getInstance(), equalTo(0));
+    assertThat(proc.getRouterId(), equalTo(Ip.parse("1.1.1.1")));
+    assertThat(proc.getAdminStateEnable(), equalTo(true));
+    org.batfish.vendor.sros.representation.OspfArea area = proc.getAreas().get("0.0.0.0");
+    assertThat(area, notNullValue());
+    assertThat(area.getInterfaces().keySet(), containsInAnyOrder("system", "to-r3"));
+    org.batfish.vendor.sros.representation.OspfAreaInterface toR3 =
+        area.getInterfaces().get("to-r3");
+    assertThat(
+        toR3.getInterfaceType(),
+        equalTo(
+            org.batfish.vendor.sros.representation.OspfAreaInterface.InterfaceType.POINT_TO_POINT));
+    assertThat(toR3.getMetric(), equalTo(100));
+    assertThat(area.getInterfaces().get("system").getMetric(), nullValue());
+  }
+
+  /**
+   * VPRN extraction: a {@code service vprn "<name>"} becomes a {@link Router} with its interfaces.
+   */
+  @Test
+  public void testVprnExtraction() {
+    SrosConfiguration vc = parseVendorConfig("vprn.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    assertThat(vc.getRouters().keySet(), containsInAnyOrder("Base", "red"));
+    Router red = vc.getRouters().get("red");
+    assertThat(red.getInterfaces(), hasKey("red-lo"));
+    assertThat(
+        red.getInterfaces().get("red-lo").getPrimaryAddress(), equalTo(Ip.parse("172.16.0.1")));
+    assertThat(red.getInterfaces().get("red-lo").getPort(), nullValue());
+  }
+
+  /** Route-reflector extraction: a group's cluster-id and next-hop-self inherit to its neighbor. */
+  @Test
+  public void testRouteReflectorExtraction() {
+    SrosConfiguration vc = parseVendorConfig("route_reflector.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    BgpGroup clients = vc.getRouters().get("Base").getBgpProcess().getGroups().get("clients");
+    assertThat(clients.getClusterId(), equalTo(Ip.parse("1.1.1.1")));
+    assertThat(clients.getNextHopSelf(), equalTo(true));
+    BgpNeighbor nbr = vc.getRouters().get("Base").getBgpProcess().getNeighbors().get("10.0.0.1");
+    // inherited from the group
+    assertThat(nbr.getClusterId(), equalTo(Ip.parse("1.1.1.1")));
+    assertThat(nbr.getNextHopSelf(), equalTo(true));
+  }
+
+  /** from-protocol extraction: {@code from protocol name [static]} on a policy entry. */
+  @Test
+  public void testFromProtocolExtraction() {
+    SrosConfiguration vc = parseVendorConfig("redistribute_static.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    PolicyStatement ps = vc.getPolicyStatements().get("export-redist");
+    assertThat(ps.getEntries().get(20L).getFromProtocols(), contains("static"));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
@@ -30,9 +30,11 @@ import org.batfish.vendor.sros.representation.BgpGroup;
 import org.batfish.vendor.sros.representation.BgpNeighbor;
 import org.batfish.vendor.sros.representation.BgpProcess;
 import org.batfish.vendor.sros.representation.Card;
+import org.batfish.vendor.sros.representation.Community;
 import org.batfish.vendor.sros.representation.PeerType;
 import org.batfish.vendor.sros.representation.PolicyAction;
 import org.batfish.vendor.sros.representation.PolicyStatement;
+import org.batfish.vendor.sros.representation.PolicyStatementEntry;
 import org.batfish.vendor.sros.representation.PrefixList;
 import org.batfish.vendor.sros.representation.PrefixListEntry;
 import org.batfish.vendor.sros.representation.Router;
@@ -173,6 +175,45 @@ public final class SrosExtractionTest {
     assertThat(nhNoAdmin.getPrefix(), equalTo(Prefix.parse("100.64.0.0/24")));
     assertThat(nhNoAdmin.getNextHopIp(), equalTo(Ip.parse("10.0.0.1")));
     assertThat(nhNoAdmin.getAdminStateEnable(), equalTo(false));
+  }
+
+  /**
+   * Policy set-clause + community-list + prefix-list-bound extraction: {@code action metric set},
+   * {@code as-path-prepend as-path/repeat}, {@code community add}, a {@code community} list, and
+   * the {@code through-length}/{@code start-length}/{@code end-length} prefix-list bounds.
+   */
+  @Test
+  public void testPolicySetClausesExtraction() {
+    SrosConfiguration vc = parseVendorConfig("policy_set_clauses.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+
+    // community list "comm-tag" with one member.
+    assertThat(vc.getCommunities(), hasKey("comm-tag"));
+    Community comm = vc.getCommunities().get("comm-tag");
+    assertThat(comm.getMembers(), contains("65001:100"));
+
+    // prefix-list bounds: through-length on lo-range, start/end-length on host-range.
+    PrefixListEntry through = vc.getPrefixLists().get("lo-range").getEntries().get(0);
+    assertThat(through.getType(), equalTo(PrefixListEntry.Type.THROUGH));
+    assertThat(through.getThroughLength(), equalTo(32));
+    PrefixListEntry range = vc.getPrefixLists().get("host-range").getEntries().get(0);
+    assertThat(range.getType(), equalTo(PrefixListEntry.Type.RANGE));
+    assertThat(range.getStartLength(), equalTo(24));
+    assertThat(range.getEndLength(), equalTo(32));
+
+    // entry 10 set-clauses: metric 50, as-path-prepend 65001 x2, community add comm-tag.
+    PolicyStatement ps = vc.getPolicyStatements().get("export-to-r2");
+    PolicyStatementEntry e10 = ps.getEntries().get(10L);
+    assertThat(e10.getSetMetric(), equalTo(50L));
+    assertThat(e10.getAsPathPrependAsn(), equalTo(65001L));
+    assertThat(e10.getAsPathPrependRepeat(), equalTo(2));
+    assertThat(e10.getCommunityAdds(), contains("comm-tag"));
+
+    // entry 20 set-clause: metric 200, no prepend (default repeat), no community.
+    PolicyStatementEntry e20 = ps.getEntries().get(20L);
+    assertThat(e20.getSetMetric(), equalTo(200L));
+    assertThat(e20.getAsPathPrependAsn(), nullValue());
+    assertThat(e20.getCommunityAdds(), empty());
   }
 
   /**

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/ibgp_default_accept.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/ibgp_default_accept.txt
@@ -1,0 +1,53 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    policy-options {
+        prefix-list "system-pfx" {
+            prefix 1.1.1.1/32 type exact {
+            }
+        }
+        policy-statement "export-system" {
+            entry 10 {
+                from {
+                    prefix-list ["system-pfx"]
+                }
+                action {
+                    action-type accept
+                }
+            }
+        }
+    }
+    router "Base" {
+        autonomous-system 65001
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r3" {
+            port 1/1/c2/1
+            ipv4 {
+                primary {
+                    address 10.0.1.0
+                    prefix-length 31
+                }
+            }
+        }
+        bgp {
+            router-id 1.1.1.1
+            group "ibgp" {
+                type internal
+                peer-as 65001
+                export {
+                    policy ["export-system"]
+                }
+            }
+            neighbor "10.0.1.1" {
+                group "ibgp"
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/ospf.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/ospf.txt
@@ -1,0 +1,36 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r3" {
+            port 1/1/c1/1
+            ipv4 {
+                primary {
+                    address 10.0.1.0
+                    prefix-length 31
+                }
+            }
+        }
+        ospf 0 {
+            admin-state enable
+            router-id 1.1.1.1
+            area 0.0.0.0 {
+                interface "system" {
+                    interface-type point-to-point
+                }
+                interface "to-r3" {
+                    interface-type point-to-point
+                    metric 100
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/policy_set_clauses.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/policy_set_clauses.txt
@@ -1,0 +1,55 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    policy-options {
+        community "comm-tag" {
+            member "65001:100"
+        }
+        prefix-list "system-pfx" {
+            prefix 1.1.1.1/32 type exact {
+            }
+        }
+        prefix-list "lo-range" {
+            prefix 192.168.0.0/16 type through {
+                through-length 32
+            }
+        }
+        prefix-list "host-range" {
+            prefix 10.0.0.0/8 type range {
+                start-length 24
+                end-length 32
+            }
+        }
+        policy-statement "export-to-r2" {
+            entry 10 {
+                from {
+                    prefix-list ["system-pfx"]
+                }
+                action {
+                    action-type accept
+                    community {
+                        add ["comm-tag"]
+                    }
+                    metric {
+                        set 50
+                    }
+                    as-path-prepend {
+                        as-path 65001
+                        repeat 2
+                    }
+                }
+            }
+            entry 20 {
+                from {
+                    prefix-list ["lo-range"]
+                }
+                action {
+                    action-type accept
+                    metric {
+                        set 200
+                    }
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/redistribute_static.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/redistribute_static.txt
@@ -1,0 +1,57 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    policy-options {
+        policy-statement "export-redist" {
+            entry 20 {
+                from {
+                    protocol {
+                        name [static]
+                    }
+                }
+                action {
+                    action-type accept
+                }
+            }
+        }
+    }
+    router "Base" {
+        autonomous-system 65001
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r2" {
+            port 1/1/c1/1
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                    prefix-length 31
+                }
+            }
+        }
+        static-routes {
+            route 192.0.2.0/24 route-type unicast {
+                next-hop 10.0.0.1 {
+                    admin-state enable
+                }
+            }
+        }
+        bgp {
+            router-id 1.1.1.1
+            group "ebgp" {
+                peer-as 65002
+                export {
+                    policy ["export-redist"]
+                }
+            }
+            neighbor "10.0.0.1" {
+                group "ebgp"
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/route_reflector.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/route_reflector.txt
@@ -1,0 +1,38 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        autonomous-system 65001
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r2" {
+            port 1/1/c1/1
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                    prefix-length 31
+                }
+            }
+        }
+        bgp {
+            router-id 1.1.1.1
+            group "clients" {
+                type internal
+                peer-as 65001
+                next-hop-self true
+                cluster {
+                    cluster-id 1.1.1.1
+                }
+            }
+            neighbor "10.0.0.1" {
+                group "clients"
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/static_routes.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/static_routes.txt
@@ -1,0 +1,38 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        interface "to-r2" {
+            port 1/1/c1/1
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                    prefix-length 31
+                }
+            }
+        }
+        static-routes {
+            route 192.0.2.0/24 route-type unicast {
+                next-hop 10.0.0.1 {
+                    admin-state enable
+                }
+            }
+            route 198.51.100.0/24 route-type unicast {
+                blackhole {
+                    admin-state enable
+                }
+            }
+            route 203.0.113.0/24 route-type unicast {
+                next-hop 10.0.0.1 {
+                    admin-state enable
+                    preference 100
+                    metric 50
+                }
+            }
+            route 100.64.0.0/24 route-type unicast {
+                next-hop 10.0.0.1 {
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/vprn.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/vprn.txt
@@ -1,0 +1,33 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    service {
+        customer "1" {
+            customer-id 1
+        }
+        vprn "red" {
+            admin-state enable
+            service-id 1
+            customer "1"
+            interface "red-lo" {
+                loopback
+                ipv4 {
+                    primary {
+                        address 172.16.0.1
+                        prefix-length 32
+                    }
+                }
+            }
+        }
+    }
+    router "Base" {
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the **P8 complexity-ladder** rungs for Nokia SR-OS on top of the merged
#9986 base (parse → extract → convert → post-process → RIB validation). Each
rung was modeled against a live SR-SIM 26.3.R1 lab and validated route-for-route
against device ground truth in the sibling `lab-validation` repo (9 SR-OS labs,
123 lab tests, no sickbays).

The 7 commits are independent and meant to be reviewed one at a time:

1. **sros: model static routes (L1)** — `static-routes route … next-hop/blackhole`
   → VI StaticRoute; only `admin-state enable` routes install.
2. **sros: scope iBGP default-accept to BGP routes (L3)** — iBGP default-accept
   propagates BGP routes only, not connected/static; fixes a connected-/31 leak.
3. **sros: model policy set-clauses and prefix-list match bounds (L5)** —
   metric/as-path-prepend/community set; prefix-list through/range length windows
   (removes the prior over-approximation for those types).
4. **docs: P8 ladder L1/L3/L5/L8** — vendor-guide section.
5. **sros: model OSPF, route reflection, redistribution, and VPRN (L2/L4/L6/L7)**
   — OspfProcess/area/interface-settings (admin 10, 100 Gbps ref-bw); RR
   cluster-id + next-hop-self; `from protocol` policy match (fixes a TRUE-guard
   leak); connected=IGP/redistributed=incomplete origin + MED-0 export;
   `service vprn` → same-named VRF.
6. **docs: P8 ladder L2/L4/L6/L7** — vendor-guide section.
7. **docs: L8 interface_up lab_builder false-negative** — records a collection
   tooling caveat.

Known modeled-but-unexercised gaps (documented in the vendor guide, no test
fails): ISIS; multi-area / external (E1/E2) OSPF; VPRN with BGP + RD/RT;
aggregate/redundant interfaces; `to`/`address-mask` prefix-list bounds (still
over-approximated + warned).

The matching `lab-validation` snapshots/validator changes are on that repo's
`sros-p8` branch (separate PR to follow).

Per-commit testing: SR-OS Java suite + PMD green; `fix_java_format` + checkstyle
+ buildifier clean. Lab validation green for all 9 SR-OS labs.
