### PR TITLE
sros: ECMP, prefix-list to/address-mask, IS-IS, communities, VPRN RD (P9 follow-ups)

### DIFF
--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -502,3 +502,84 @@ the `show router interface` line) trips on the `Up/Down` column header, so it
 reports the (genuinely up) link interface as down. It is a collection-time
 precondition, not a lab test, so it does not affect the green result; the lab is
 collected regardless and validates 13/13.
+
+## Follow-up rungs (P9): ECMP, prefix-list bounds, communities, IS-IS, L3VPN
+
+A second pass closed the two deferred review bugs and added three more rungs,
+each modeled against a fresh live SR-SIM 26.3.R1 collection.
+
+### Empty same-line block `{ }` (grammar)
+
+The device renders a list entry with no body inline as `<words> { }` (open
+brace, optional whitespace, close brace, no newline) — e.g. the `to-prefix`es
+of a `prefix-list ... type to`, `mask-pattern`s, or a community `member`. The
+`block` rule required `OPEN_BRACE NEWLINE+ ...` and rejected `{ }` with a FATAL
+"extraneous input '}' expecting NEWLINE", corrupting any empty-body list entry;
+the rule now also accepts `OPEN_BRACE CLOSE_BRACE`. Lesson banked: test fixtures
+must mirror device-rendered output (inline empty blocks), not idealized
+hand-written multi-line form — the bug was masked by a `{ \n }` fixture and
+exposed only by a device-collected config.
+
+### ECMP static routes (`sros_ecmp`, batfish/batfish#9989)
+
+A `static-routes route <prefix>` with multiple `next-hop` entries is an ECMP
+route. Extraction now emits one VI `StaticRoute` per next-hop (each with its own
+admin-state/metric/preference) instead of taking the first and warning;
+Batfish's best-preference selection installs the equal-preference legs as ECMP
+and drops worse ones. Device-confirmed: two equal-preference next-hops both
+install (route-table `nexthop` list has two entries); two unequal-preference
+next-hops install only the lower-preference leg.
+
+### prefix-list `to` / `address-mask` bounds (batfish/batfish#9990)
+
+Both were over-approximated as "this length or longer" and warned. Device
+probing settled the semantics. `type to` is a **length-range match**: a route
+matches iff it is contained in the base network and its length is in
+`[base-length .. to-prefix-length]` — the to-prefix supplies the upper length
+bound (the sibling of `through`), and must be nested in the base (commit rejects
+a non-nested to-prefix: `PLCY #1001 ... does not share same most significant
+bits`). It is modeled as one exact `RouteFilterLine` per ancestor length of each
+to-prefix, so off-path siblings do not match (a single base-prefix line with a
+length range would wrongly match them). `address-mask` with a contiguous mask
+equal to the base length is an exact match; a non-contiguous mask cannot be a
+length `SubRange` and is over-approximated with a warning.
+
+### BGP communities + complex attributes (`sros_bgp_comm_in`)
+
+The cEOS oracle (r2) advertises three loopbacks to r1 tagged with standard
+communities, MED, and AS-path prepend; r1 imports all, so its BGP RIB carries
+non-empty attributes validated on both sides. Finding: **SR-OS renders
+well-known communities symbolically** (`no-export`), so the validator
+canonicalizes them to numeric (`no-export` → `65535:65281`, etc.) to match
+Batfish, raising on an unknown symbolic name rather than masking. Also: for a
+BGP route the device's main-RIB metric is the IGP cost to the next-hop (0 for a
+directly-connected peer) while Batfish carries the MED into the main-RIB metric,
+so the validator compares the BGP MED on the BGP RIB and skips the main-RIB
+metric for BGP-protocol routes.
+
+### IS-IS single area (`sros_isis`)
+
+`router "<name>" isis <instance>` is parsed into a typed `IsisProcess`
+(system-id, area-address, level-capability, per-interface interface-type/passive)
+and converted to a VI `IsisProcess`: the NET is the first area-address +
+system-id + an `00` N-selector, a passive interface advertises its subnet but
+forms no adjacency (VI `PASSIVE` mode), and per-level interface settings carry
+the point-to-point flag. SR-OS IS-IS route preferences (admin distances) were
+added to the `NOKIA_SROS` `RoutingProtocol` defaults — L1 15 / L2 18 internal,
+L1 160 / L2 165 external — confirmed on device (an L2 internal route installs at
+preference 18, default interface metric 10). Validated with a two-SR-SIM L2
+adjacency: each router learns the other's system loopback via IS-IS.
+
+### Multi-VRF L3VPN (`sros_vprn_bgp`, partial — batfish/batfish#9991)
+
+A real MPLS L3VPN between two SR-SIM PEs (OSPF+LDP underlay, MP-BGP `vpn-ipv4`
+between loopbacks, VPRN `red` with RD + shared `vrf-target`). SR-OS extraction
+captures `bgp-ipvpn mpls` route-distinguisher + vrf-target import/export
+route-targets (`BgpIpvpn`), and conversion sets the route-distinguisher on the
+VI VRF. The PE-to-PE vpn-ipv4 route import is **not** modeled — the VI datamodel
+has no VPNv4 address family and its cross-VRF leaking is intra-node only — so the
+VPRN's RT-imported routes (e.g. pe1 `red` learning `172.16.2.1/32`) are absent
+from the computed main RIB; those two main-RIB checks are sickbayed to
+batfish/batfish#9991. Everything else (config/interfaces/BGP RIB/RD-on-VRF)
+validates green. Device-confirmed: BGP-VPN learned route preference 170,
+resolved over an LDP tunnel; VPRN `red` stays separate from Base.

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/SrosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/sros/grammar/SrosParser.g4
@@ -33,10 +33,14 @@ statement
 ;
 
 // A brace-delimited block: `<words> { <newline> <statements> }`. The opening brace sits on
-// the same line as the leading words; the closing brace is on its own line.
+// the same line as the leading words; the closing brace is on its own line. A list entry with
+// no body is rendered by the device on a single line as `<words> { }` (open brace, optional
+// whitespace, close brace, no intervening newline) — e.g. `to-prefix 10.0.0.0/8 { }` — so an
+// empty same-line block is also accepted.
 block
 :
   OPEN_BRACE NEWLINE+ statement* CLOSE_BRACE statement_end
+  | OPEN_BRACE CLOSE_BRACE statement_end
 ;
 
 // A leaf-list value, e.g. `prefix-list ["a" "b"]` or `member ["administrative"]`.

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -1,5 +1,6 @@
 package org.batfish.vendor.sros.grammar;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -395,17 +396,12 @@ public final class SrosFeatureExtractor {
         // unequal pair installs only the lower-preference leg). See
         // https://github.com/batfish/batfish/issues/9989.
         for (Map.Entry<String, SrosStatementTree> nhe : nextHop.getChildren().entrySet()) {
-          SrosStatementTree nhEntry = nhe.getValue();
-          StaticRoute route = new StaticRoute(prefix);
-          route.setNextHopIp(toIp(unquote(nhe.getKey()), nhEntry, "static-route next-hop"));
-          applyAdminStateMetricPreference(route, nhEntry);
-          router.getStaticRoutes().add(route);
+          router
+              .getStaticRoutes()
+              .add(toStaticRoute(prefix, nhe.getValue(), unquote(nhe.getKey())));
         }
       } else if (blackhole != null) {
-        StaticRoute route = new StaticRoute(prefix);
-        route.setBlackhole(true);
-        applyAdminStateMetricPreference(route, blackhole);
-        router.getStaticRoutes().add(route);
+        router.getStaticRoutes().add(toStaticRoute(prefix, blackhole, null));
       } else {
         // Neither next-hop nor blackhole: an unmodeled route shape (e.g. indirect, cpe-check).
         // Warn rather than silently skip.
@@ -418,13 +414,32 @@ public final class SrosFeatureExtractor {
   }
 
   /**
-   * Apply the {@code admin-state}/{@code metric}/{@code preference} leaves from a static-route
-   * next-hop or blackhole context onto {@code route}, defaulting metric/preference per YANG when
-   * absent.
+   * Build a {@link StaticRoute} for one leg: a {@code next-hop} entry (whose list key {@code
+   * nextHopKey} is the next-hop IP) or, when {@code nextHopKey} is {@code null}, a {@code
+   * blackhole}. Both shapes carry the same {@code admin-state}/{@code metric}/{@code preference}
+   * leaves on their context {@code leg}.
    */
-  private void applyAdminStateMetricPreference(StaticRoute route, SrosStatementTree ctx) {
-    Boolean adminUp = toEnum(ctx.getChild("admin-state"), ADMIN_STATE, "admin-state");
-    route.setAdminStateEnable(Boolean.TRUE.equals(adminUp));
+  private @Nonnull StaticRoute toStaticRoute(
+      Prefix prefix, SrosStatementTree leg, @Nullable String nextHopKey) {
+    StaticRoute route = new StaticRoute(prefix);
+    if (nextHopKey == null) {
+      route.setBlackhole(true);
+    } else {
+      route.setNextHopIp(toIp(nextHopKey, leg, "static-route next-hop"));
+    }
+    Boolean adminUp = toEnum(leg.getChild("admin-state"), ADMIN_STATE, "admin-state");
+    // admin-state defaults to disable for a static route: it is installed only when explicitly
+    // enable.
+    route.setAdminStateEnable(firstNonNull(adminUp, Boolean.FALSE));
+    applyMetricPreference(route, leg);
+    return route;
+  }
+
+  /**
+   * Apply the {@code metric}/{@code preference} leaves from a static-route next-hop or blackhole
+   * context onto {@code route}, defaulting per YANG when absent.
+   */
+  private void applyMetricPreference(StaticRoute route, SrosStatementTree ctx) {
     toIntegerInSpace(
             singleValue(ctx, "metric"),
             singleValueNode(ctx, "metric"),
@@ -525,13 +540,11 @@ public final class SrosFeatureExtractor {
     }
     // ospf is a list keyed by instance; model the first (typically instance 0).
     Map.Entry<String, SrosStatementTree> e = ospfList.getChildren().entrySet().iterator().next();
-    int instance;
-    try {
-      instance = Integer.parseInt(e.getKey());
-    } catch (NumberFormatException ex) {
-      instance = 0;
-    }
     SrosStatementTree ospfNode = e.getValue();
+    Integer instance = toInstanceId(e.getKey(), ospfNode, "ospf");
+    if (instance == null) {
+      return;
+    }
     OspfProcess proc = new OspfProcess(instance);
     proc.setRouterId(
         toIp(
@@ -539,7 +552,8 @@ public final class SrosFeatureExtractor {
             singleValueNode(ospfNode, "router-id"),
             "ospf router-id"));
     Boolean adminUp = toEnum(ospfNode.getChild("admin-state"), ADMIN_STATE, "admin-state");
-    proc.setAdminStateEnable(!Boolean.FALSE.equals(adminUp));
+    // admin-state defaults to enable for an OSPF/IS-IS process: enabled unless explicitly disable.
+    proc.setAdminStateEnable(firstNonNull(adminUp, Boolean.TRUE));
 
     SrosStatementTree areaList = ospfNode.getChild("area");
     if (areaList != null) {
@@ -582,16 +596,15 @@ public final class SrosFeatureExtractor {
     }
     // isis is a list keyed by instance; model the first (typically instance 0).
     Map.Entry<String, SrosStatementTree> e = isisList.getChildren().entrySet().iterator().next();
-    int instance;
-    try {
-      instance = Integer.parseInt(e.getKey());
-    } catch (NumberFormatException ex) {
-      instance = 0;
-    }
     SrosStatementTree isisNode = e.getValue();
+    Integer instance = toInstanceId(e.getKey(), isisNode, "isis");
+    if (instance == null) {
+      return;
+    }
     IsisProcess proc = new IsisProcess(instance);
     Boolean adminUp = toEnum(isisNode.getChild("admin-state"), ADMIN_STATE, "admin-state");
-    proc.setAdminStateEnable(!Boolean.FALSE.equals(adminUp));
+    // admin-state defaults to enable for an OSPF/IS-IS process: enabled unless explicitly disable.
+    proc.setAdminStateEnable(firstNonNull(adminUp, Boolean.TRUE));
     proc.setSystemId(singleValue(isisNode, "system-id"));
     proc.getAreaAddresses().addAll(policyNames(isisNode.getChild("area-address")));
     IsisProcess.LevelCapability level =
@@ -610,11 +623,25 @@ public final class SrosFeatureExtractor {
         isisIf.setInterfaceType(
             toEnum(ifNode.getChild("interface-type"), ISIS_INTERFACE_TYPE, "isis interface-type"));
         Boolean passive = toBoolean(ifNode.getChild("passive"), "isis interface passive");
-        isisIf.setPassive(Boolean.TRUE.equals(passive));
+        isisIf.setPassive(firstNonNull(passive, Boolean.FALSE));
         proc.getInterfaces().put(ifName, isisIf);
       }
     }
     router.setIsisProcess(proc);
+  }
+
+  /**
+   * Parse an IGP process instance-id (the list key, e.g. the {@code 0} in {@code ospf 0}). The YANG
+   * key is an integer; a non-numeric key is malformed input, so warn and return {@code null} (skip
+   * the process) rather than silently defaulting to instance 0.
+   */
+  private @Nullable Integer toInstanceId(String key, SrosStatementTree ctx, String protocol) {
+    try {
+      return Integer.parseInt(key);
+    } catch (NumberFormatException ex) {
+      warnf(ctx, "%s instance '%s' is not an integer; skipping", protocol, key);
+      return null;
+    }
   }
 
   /** The first (insertion-order) child node of {@code node}, or {@code null} if it has none. */

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -313,8 +313,9 @@ public final class SrosFeatureExtractor {
 
   /**
    * Extract {@code static-routes route <prefix> route-type <unicast|multicast>} entries. Each route
-   * is reached via a {@code next-hop <ip>} or a {@code blackhole}; both sub-contexts carry an
-   * {@code admin-state} (a route is only RIB-installed when it is {@code enable} — see {@link
+   * is reached via one or more {@code next-hop <ip>} entries (multiple = ECMP, one VI {@link
+   * StaticRoute} per next-hop) or a {@code blackhole}; each sub-context carries an {@code
+   * admin-state} (a route is only RIB-installed when it is {@code enable} — see {@link
    * StaticRoute}), and optional {@code metric}/{@code preference}. Only the unicast IPv4 case is
    * modeled here; a non-IPv4 prefix is warned and skipped by {@link #toPrefix}.
    */
@@ -339,30 +340,28 @@ public final class SrosFeatureExtractor {
       if (typeBody == null) {
         continue;
       }
-      StaticRoute route = new StaticRoute(prefix);
       SrosStatementTree nextHop = typeBody.getChild("next-hop");
       SrosStatementTree blackhole = typeBody.getChild("blackhole");
-      SrosStatementTree adminStateParent;
       if (nextHop != null) {
-        // next-hop is a list keyed by the next-hop IP. The model holds a single next-hop; if the
-        // route configures more than one (ECMP), warn that only the first is modeled rather than
-        // silently dropping the rest. TODO: model ECMP static routes —
-        // https://github.com/batfish/batfish/issues/9989
-        if (nextHop.getChildren().size() > 1) {
-          warnf(
-              typeBody,
-              "static route %s has %d next-hops (ECMP); only the first is modeled",
-              prefix,
-              nextHop.getChildren().size());
+        // next-hop is a YANG list keyed by the next-hop IP; more than one entry is an ECMP route.
+        // Each entry carries its own admin-state/metric/preference, so emit one StaticRoute per
+        // next-hop — VI ECMP is the set of equal-preference legs to the same prefix, and Batfish's
+        // own best-preference selection installs the equal-best legs and drops worse-preference
+        // ones (confirmed on SR-SIM 26.3.R1: two equal-preference next-hops both install; an
+        // unequal pair installs only the lower-preference leg). See
+        // https://github.com/batfish/batfish/issues/9989.
+        for (Map.Entry<String, SrosStatementTree> nhe : nextHop.getChildren().entrySet()) {
+          SrosStatementTree nhEntry = nhe.getValue();
+          StaticRoute route = new StaticRoute(prefix);
+          route.setNextHopIp(toIp(unquote(nhe.getKey()), nhEntry, "static-route next-hop"));
+          applyAdminStateMetricPreference(route, nhEntry);
+          router.getStaticRoutes().add(route);
         }
-        SrosStatementTree nhEntry = firstChild(nextHop);
-        if (nhEntry != null) {
-          route.setNextHopIp(toIp(nhKey(nextHop), nhEntry, "static-route next-hop"));
-        }
-        adminStateParent = nhEntry;
       } else if (blackhole != null) {
+        StaticRoute route = new StaticRoute(prefix);
         route.setBlackhole(true);
-        adminStateParent = blackhole;
+        applyAdminStateMetricPreference(route, blackhole);
+        router.getStaticRoutes().add(route);
       } else {
         // Neither next-hop nor blackhole: an unmodeled route shape (e.g. indirect, cpe-check).
         // Warn rather than silently skip.
@@ -370,27 +369,30 @@ public final class SrosFeatureExtractor {
             typeBody,
             "static route %s has no modeled next-hop or blackhole; not converted",
             prefix);
-        continue;
       }
-      if (adminStateParent != null) {
-        Boolean adminUp =
-            toEnum(adminStateParent.getChild("admin-state"), ADMIN_STATE, "admin-state");
-        route.setAdminStateEnable(Boolean.TRUE.equals(adminUp));
-        toIntegerInSpace(
-                singleValue(adminStateParent, "metric"),
-                singleValueNode(adminStateParent, "metric"),
-                STATIC_METRIC_SPACE,
-                "static-route metric")
-            .ifPresent(route::setMetric);
-        toIntegerInSpace(
-                singleValue(adminStateParent, "preference"),
-                singleValueNode(adminStateParent, "preference"),
-                ROUTE_PREFERENCE_SPACE,
-                "static-route preference")
-            .ifPresent(route::setPreference);
-      }
-      router.getStaticRoutes().add(route);
     }
+  }
+
+  /**
+   * Apply the {@code admin-state}/{@code metric}/{@code preference} leaves from a static-route
+   * next-hop or blackhole context onto {@code route}, defaulting metric/preference per YANG when
+   * absent.
+   */
+  private void applyAdminStateMetricPreference(StaticRoute route, SrosStatementTree ctx) {
+    Boolean adminUp = toEnum(ctx.getChild("admin-state"), ADMIN_STATE, "admin-state");
+    route.setAdminStateEnable(Boolean.TRUE.equals(adminUp));
+    toIntegerInSpace(
+            singleValue(ctx, "metric"),
+            singleValueNode(ctx, "metric"),
+            STATIC_METRIC_SPACE,
+            "static-route metric")
+        .ifPresent(route::setMetric);
+    toIntegerInSpace(
+            singleValue(ctx, "preference"),
+            singleValueNode(ctx, "preference"),
+            ROUTE_PREFERENCE_SPACE,
+            "static-route preference")
+        .ifPresent(route::setPreference);
   }
 
   /** The {@code type} leaf's value word (e.g. {@code through}/{@code range}), or {@code null}. */
@@ -515,16 +517,6 @@ public final class SrosFeatureExtractor {
   /** The first (insertion-order) child node of {@code node}, or {@code null} if it has none. */
   private static @Nullable SrosStatementTree firstChild(SrosStatementTree node) {
     return node.getChildren().isEmpty() ? null : node.getChildren().values().iterator().next();
-  }
-
-  /**
-   * The first child key of {@code node}, unquoted (e.g. the next-hop IP under the {@code next-hop}
-   * list — the device renders it quoted, {@code next-hop "10.0.0.1"}).
-   */
-  private static @Nullable String nhKey(SrosStatementTree node) {
-    return node.getChildren().isEmpty()
-        ? null
-        : unquote(node.getChildren().keySet().iterator().next());
   }
 
   private void extractBgp(Router router, @Nullable SrosStatementTree bgpNode) {
@@ -685,6 +677,28 @@ public final class SrosFeatureExtractor {
                       IPV4_PREFIX_LENGTH_SPACE,
                       "prefix-list end-length")
                   .ifPresent(ple::setEndLength);
+              // `to` carries a to-prefix list (each nested in the base prefix); `address-mask`
+              // carries a mask-pattern list. Both key their list entries by the value word.
+              SrosStatementTree toPrefixes = typeBody.getChild("to-prefix");
+              if (toPrefixes != null) {
+                for (Map.Entry<String, SrosStatementTree> tpe :
+                    toPrefixes.getChildren().entrySet()) {
+                  Prefix tp = toPrefix(tpe.getKey(), tpe.getValue());
+                  if (tp != null) {
+                    ple.getToPrefixes().add(tp);
+                  }
+                }
+              }
+              SrosStatementTree maskPatterns = typeBody.getChild("mask-pattern");
+              if (maskPatterns != null) {
+                for (Map.Entry<String, SrosStatementTree> mpe :
+                    maskPatterns.getChildren().entrySet()) {
+                  Ip mask = toIp(unquote(mpe.getKey()), mpe.getValue(), "prefix-list mask-pattern");
+                  if (mask != null) {
+                    ple.getMaskPatterns().add(mask);
+                  }
+                }
+              }
             }
             // Warn against the type value node (e.g. the `through`/`range` word), which carries a
             // source context even when the entry's bound block is empty.

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -27,6 +27,8 @@ import org.batfish.vendor.sros.representation.BgpProcess;
 import org.batfish.vendor.sros.representation.Card;
 import org.batfish.vendor.sros.representation.Community;
 import org.batfish.vendor.sros.representation.FromProtocol;
+import org.batfish.vendor.sros.representation.IsisProcess;
+import org.batfish.vendor.sros.representation.IsisProcessInterface;
 import org.batfish.vendor.sros.representation.Mda;
 import org.batfish.vendor.sros.representation.OspfArea;
 import org.batfish.vendor.sros.representation.OspfAreaInterface;
@@ -247,6 +249,7 @@ public final class SrosFeatureExtractor {
       extractInterfaces(router, routerNode.getChild("interface"));
       extractStaticRoutes(router, routerNode.getChild("static-routes"));
       extractOspf(router, routerNode.getChild("ospf"));
+      extractIsis(router, routerNode.getChild("isis"));
       extractBgp(router, routerNode.getChild("bgp"));
       _c.getRouters().put(name, router);
     }
@@ -281,6 +284,7 @@ public final class SrosFeatureExtractor {
       extractInterfaces(router, vprnNode.getChild("interface"));
       extractStaticRoutes(router, vprnNode.getChild("static-routes"));
       extractOspf(router, vprnNode.getChild("ospf"));
+      extractIsis(router, vprnNode.getChild("isis"));
       extractBgp(router, vprnNode.getChild("bgp"));
       _c.getRouters().put(name, router);
     }
@@ -458,6 +462,19 @@ public final class SrosFeatureExtractor {
           "broadcast", OspfAreaInterface.InterfaceType.BROADCAST,
           "point-to-point", OspfAreaInterface.InterfaceType.POINT_TO_POINT);
 
+  /** IS-IS interface {@code interface-type} enumeration (nokia-types-isis:interface-type). */
+  private static final Map<String, IsisProcessInterface.InterfaceType> ISIS_INTERFACE_TYPE =
+      ImmutableMap.of(
+          "broadcast", IsisProcessInterface.InterfaceType.BROADCAST,
+          "point-to-point", IsisProcessInterface.InterfaceType.POINT_TO_POINT);
+
+  /** IS-IS {@code level-capability} enumeration (nokia-types-isis:level). */
+  private static final Map<String, IsisProcess.LevelCapability> ISIS_LEVEL_CAPABILITY =
+      ImmutableMap.of(
+          "1", IsisProcess.LevelCapability.LEVEL_1,
+          "2", IsisProcess.LevelCapability.LEVEL_2,
+          "1/2", IsisProcess.LevelCapability.LEVEL_1_2);
+
   /**
    * Extract {@code router "<name>" ospf <instance>}: router-id, admin-state, and the per-area
    * interfaces (with interface-type and metric/cost). Only the first/0 OSPF instance is modeled.
@@ -512,6 +529,52 @@ public final class SrosFeatureExtractor {
       }
     }
     router.setOspfProcess(proc);
+  }
+
+  /**
+   * Extract {@code router "<name>" isis <instance>}: admin-state, system-id, area-address(es),
+   * level-capability, and the per-interface {@code interface-type}/{@code passive}. Only the
+   * first/0 IS-IS instance is modeled.
+   */
+  private void extractIsis(Router router, @Nullable SrosStatementTree isisList) {
+    if (isisList == null || isisList.getChildren().isEmpty()) {
+      return;
+    }
+    // isis is a list keyed by instance; model the first (typically instance 0).
+    Map.Entry<String, SrosStatementTree> e = isisList.getChildren().entrySet().iterator().next();
+    int instance;
+    try {
+      instance = Integer.parseInt(e.getKey());
+    } catch (NumberFormatException ex) {
+      instance = 0;
+    }
+    SrosStatementTree isisNode = e.getValue();
+    IsisProcess proc = new IsisProcess(instance);
+    Boolean adminUp = toEnum(isisNode.getChild("admin-state"), ADMIN_STATE, "admin-state");
+    proc.setAdminStateEnable(!Boolean.FALSE.equals(adminUp));
+    proc.setSystemId(singleValue(isisNode, "system-id"));
+    proc.getAreaAddresses().addAll(policyNames(isisNode.getChild("area-address")));
+    IsisProcess.LevelCapability level =
+        toEnum(
+            isisNode.getChild("level-capability"), ISIS_LEVEL_CAPABILITY, "isis level-capability");
+    if (level != null) {
+      proc.setLevelCapability(level);
+    }
+
+    SrosStatementTree ifaceList = isisNode.getChild("interface");
+    if (ifaceList != null) {
+      for (Map.Entry<String, SrosStatementTree> ie : ifaceList.getChildren().entrySet()) {
+        String ifName = unquote(ie.getKey());
+        SrosStatementTree ifNode = ie.getValue();
+        IsisProcessInterface isisIf = new IsisProcessInterface(ifName);
+        isisIf.setInterfaceType(
+            toEnum(ifNode.getChild("interface-type"), ISIS_INTERFACE_TYPE, "isis interface-type"));
+        Boolean passive = toBoolean(ifNode.getChild("passive"), "isis interface passive");
+        isisIf.setPassive(Boolean.TRUE.equals(passive));
+        proc.getInterfaces().put(ifName, isisIf);
+      }
+    }
+    router.setIsisProcess(proc);
   }
 
   /** The first (insertion-order) child node of {@code node}, or {@code null} if it has none. */

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.vendor.StructureType;
 import org.batfish.vendor.StructureUsage;
 import org.batfish.vendor.sros.representation.BgpGroup;
+import org.batfish.vendor.sros.representation.BgpIpvpn;
 import org.batfish.vendor.sros.representation.BgpNeighbor;
 import org.batfish.vendor.sros.representation.BgpProcess;
 import org.batfish.vendor.sros.representation.Card;
@@ -286,8 +287,47 @@ public final class SrosFeatureExtractor {
       extractOspf(router, vprnNode.getChild("ospf"));
       extractIsis(router, vprnNode.getChild("isis"));
       extractBgp(router, vprnNode.getChild("bgp"));
+      extractBgpIpvpn(router, vprnNode.getChild("bgp-ipvpn"));
       _c.getRouters().put(name, router);
     }
+  }
+
+  /**
+   * Extract {@code service vprn "<name>" bgp-ipvpn mpls}: the {@code route-distinguisher} and the
+   * {@code vrf-target} route-targets (the single {@code community} form populates both import and
+   * export; the {@code import-community}/{@code export-community} form sets them separately). These
+   * drive MPLS L3VPN import/export on the device; only the route-distinguisher converts to the VI
+   * model (inter-PE VPN-IPv4 import is unmodeled — see {@link
+   * org.batfish.vendor.sros.representation.BgpIpvpn}).
+   */
+  private void extractBgpIpvpn(Router router, @Nullable SrosStatementTree bgpIpvpn) {
+    if (bgpIpvpn == null) {
+      return;
+    }
+    SrosStatementTree mpls = bgpIpvpn.getChild("mpls");
+    if (mpls == null) {
+      return;
+    }
+    BgpIpvpn ipvpn = new BgpIpvpn();
+    String rd = singleValue(mpls, "route-distinguisher");
+    ipvpn.setRouteDistinguisher(rd == null ? null : unquote(rd));
+    SrosStatementTree vrfTarget = mpls.getChild("vrf-target");
+    if (vrfTarget != null) {
+      String both = singleValue(vrfTarget, "community");
+      if (both != null) {
+        ipvpn.getImportRouteTargets().add(unquote(both));
+        ipvpn.getExportRouteTargets().add(unquote(both));
+      }
+      String imp = singleValue(vrfTarget, "import-community");
+      if (imp != null) {
+        ipvpn.getImportRouteTargets().add(unquote(imp));
+      }
+      String exp = singleValue(vrfTarget, "export-community");
+      if (exp != null) {
+        ipvpn.getExportRouteTargets().add(unquote(exp));
+      }
+    }
+    router.setBgpIpvpn(ipvpn);
   }
 
   private void extractInterfaces(Router router, @Nullable SrosStatementTree ifaceList) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpIpvpn.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/BgpIpvpn.java
@@ -1,0 +1,47 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * The {@code service vprn "<name>" bgp-ipvpn mpls} settings: the {@code route-distinguisher} and
+ * the {@code vrf-target} import/export route-targets that drive MPLS L3VPN (RFC 4364) route
+ * import/export.
+ *
+ * <p>The {@code vrf-target} has two forms: a single {@code community <rt>} (used for both import
+ * and export), or separate {@code import-community}/{@code export-community}. Both are captured as
+ * import + export RT lists (the single-community form populates both).
+ *
+ * <p>Note: the route-distinguisher converts onto the VI VRF, but inter-PE VPN-IPv4 route import
+ * (PE-to-PE MP-BGP L3VPN) is <em>not</em> reproduced by the Batfish VI dataplane (no VPNv4 address
+ * family; cross-VRF leaking is intra-node only). These fields are extracted for completeness and
+ * structure tracking; see docs/parsing/vendors/sros.md and the tracked L3VPN follow-up issue.
+ */
+public final class BgpIpvpn implements Serializable {
+
+  /** The {@code route-distinguisher} (e.g. {@code 65000:1}), or {@code null} if unset. */
+  public @Nullable String getRouteDistinguisher() {
+    return _routeDistinguisher;
+  }
+
+  public void setRouteDistinguisher(@Nullable String routeDistinguisher) {
+    _routeDistinguisher = routeDistinguisher;
+  }
+
+  /** The {@code vrf-target} import route-target communities (e.g. {@code target:65000:1}). */
+  public @Nonnull List<String> getImportRouteTargets() {
+    return _importRouteTargets;
+  }
+
+  /** The {@code vrf-target} export route-target communities (e.g. {@code target:65000:1}). */
+  public @Nonnull List<String> getExportRouteTargets() {
+    return _exportRouteTargets;
+  }
+
+  private @Nullable String _routeDistinguisher;
+  private final @Nonnull List<String> _importRouteTargets = new ArrayList<>();
+  private final @Nonnull List<String> _exportRouteTargets = new ArrayList<>();
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/IsisProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/IsisProcess.java
@@ -1,0 +1,84 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS {@code router "<name>" isis <instance>} process, keyed by its integer instance. Holds
+ * the {@code system-id}, {@code area-address}(es), level-capability, and the ISIS-enabled
+ * interfaces. The NET (used to build the VI {@link org.batfish.datamodel.isis.IsisProcess}) is the
+ * area-address + system-id + an {@code 00} N-selector. Only the subset needed to form adjacencies
+ * and compute IS-IS routes is modeled.
+ */
+public final class IsisProcess implements Serializable {
+
+  /** IS-IS routing level capability. */
+  public enum LevelCapability {
+    LEVEL_1,
+    LEVEL_2,
+    LEVEL_1_2;
+  }
+
+  public IsisProcess(int instance) {
+    _instance = instance;
+    _areaAddresses = new ArrayList<>();
+    _interfaces = new LinkedHashMap<>();
+  }
+
+  public int getInstance() {
+    return _instance;
+  }
+
+  /**
+   * Whether the process is {@code admin-state enable}; defaults true when admin-state is absent.
+   */
+  public boolean getAdminStateEnable() {
+    return _adminStateEnable;
+  }
+
+  public void setAdminStateEnable(boolean adminStateEnable) {
+    _adminStateEnable = adminStateEnable;
+  }
+
+  /** The {@code system-id} (e.g. {@code 0100.1000.0001}), or {@code null} if unset. */
+  public @Nullable String getSystemId() {
+    return _systemId;
+  }
+
+  public void setSystemId(@Nullable String systemId) {
+    _systemId = systemId;
+  }
+
+  /**
+   * The {@code area-address}(es) (NSAP area, e.g. {@code 49.0001}); the first is used for the NET.
+   */
+  public @Nonnull List<String> getAreaAddresses() {
+    return _areaAddresses;
+  }
+
+  /** The {@code level-capability}; defaults to {@link LevelCapability#LEVEL_2} when unset. */
+  public @Nonnull LevelCapability getLevelCapability() {
+    return _levelCapability;
+  }
+
+  public void setLevelCapability(LevelCapability levelCapability) {
+    _levelCapability = levelCapability;
+  }
+
+  /** ISIS-enabled interfaces, keyed by the router-interface name. */
+  public @Nonnull Map<String, IsisProcessInterface> getInterfaces() {
+    return _interfaces;
+  }
+
+  private final int _instance;
+  private boolean _adminStateEnable = true;
+  private @Nullable String _systemId;
+  private final @Nonnull List<String> _areaAddresses;
+  private @Nonnull LevelCapability _levelCapability = LevelCapability.LEVEL_2;
+  private final @Nonnull Map<String, IsisProcessInterface> _interfaces;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/IsisProcessInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/IsisProcessInterface.java
@@ -1,0 +1,50 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An IS-IS interface within a process ({@code ... isis <instance> interface "<name>"}), keyed by
+ * the router-interface name it enables IS-IS on. Holds the modeled subset: whether it is {@code
+ * passive} (advertised but forms no adjacency) and the {@code interface-type}
+ * (broadcast/point-to-point).
+ */
+public final class IsisProcessInterface implements Serializable {
+
+  /** IS-IS interface type (the modeled subset of the SR-OS {@code interface-type} enum). */
+  public enum InterfaceType {
+    BROADCAST,
+    POINT_TO_POINT;
+  }
+
+  public IsisProcessInterface(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** Whether the interface is {@code passive} (its subnet is advertised, no adjacency formed). */
+  public boolean getPassive() {
+    return _passive;
+  }
+
+  public void setPassive(boolean passive) {
+    _passive = passive;
+  }
+
+  /** The {@code interface-type}, or {@code null} if unset. */
+  public @Nullable InterfaceType getInterfaceType() {
+    return _interfaceType;
+  }
+
+  public void setInterfaceType(@Nullable InterfaceType interfaceType) {
+    _interfaceType = interfaceType;
+  }
+
+  private final @Nonnull String _name;
+  private boolean _passive;
+  private @Nullable InterfaceType _interfaceType;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PrefixListEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PrefixListEntry.java
@@ -1,20 +1,29 @@
 package org.batfish.vendor.sros.representation;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 
 /**
  * One entry of an SR-OS {@code prefix-list}. The YANG list is keyed by the composite of the {@code
  * ip-prefix} and the match {@code type} (e.g. {@code exact}, {@code longer}, {@code through},
- * {@code range}), so the same prefix may appear under multiple types.
+ * {@code range}, {@code to}, {@code address-mask}), so the same prefix may appear under multiple
+ * types.
  *
  * <p>The {@code through} and {@code range} types carry length bounds: {@code through} matches the
  * prefix's own length through {@code through-length}; {@code range} matches {@code start-length}
- * through {@code end-length}. These are captured so conversion can build an exact length window
- * rather than over-approximating (see {@link SrosConversions#toRouteFilterList}).
+ * through {@code end-length}. The {@code to} type carries a list of {@code to-prefix}es, each
+ * nested in the base prefix: it matches every prefix contained in the base whose length is in
+ * {@code [base-length .. to-prefix-length]} (a length range like {@code through}, with the upper
+ * bound supplied by the to-prefix — confirmed on SR-SIM 26.3.R1). The {@code address-mask} type
+ * carries {@code mask-pattern}s; with a contiguous mask equal to the base prefix's length it is an
+ * exact match. These are captured so conversion can build an exact length window rather than
+ * over-approximating (see {@link SrosConversions#toRouteFilterList}).
  */
 public final class PrefixListEntry implements Serializable {
 
@@ -68,6 +77,19 @@ public final class PrefixListEntry implements Serializable {
     _endLength = endLength;
   }
 
+  /**
+   * The {@code to-prefix}es for a {@code to}-type entry (each nested in {@link #getPrefix()}).
+   * Empty for other types.
+   */
+  public @Nonnull List<Prefix> getToPrefixes() {
+    return _toPrefixes;
+  }
+
+  /** The {@code mask-pattern}s for an {@code address-mask}-type entry. Empty for other types. */
+  public @Nonnull List<Ip> getMaskPatterns() {
+    return _maskPatterns;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -81,12 +103,15 @@ public final class PrefixListEntry implements Serializable {
         && _type == that._type
         && Objects.equals(_throughLength, that._throughLength)
         && Objects.equals(_startLength, that._startLength)
-        && Objects.equals(_endLength, that._endLength);
+        && Objects.equals(_endLength, that._endLength)
+        && _toPrefixes.equals(that._toPrefixes)
+        && _maskPatterns.equals(that._maskPatterns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_prefix, _type, _throughLength, _startLength, _endLength);
+    return Objects.hash(
+        _prefix, _type, _throughLength, _startLength, _endLength, _toPrefixes, _maskPatterns);
   }
 
   private final @Nonnull Prefix _prefix;
@@ -94,4 +119,6 @@ public final class PrefixListEntry implements Serializable {
   private @Nullable Integer _throughLength;
   private @Nullable Integer _startLength;
   private @Nullable Integer _endLength;
+  private final @Nonnull List<Prefix> _toPrefixes = new ArrayList<>();
+  private final @Nonnull List<Ip> _maskPatterns = new ArrayList<>();
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
@@ -62,10 +62,20 @@ public final class Router implements Serializable {
     _ospfProcess = ospfProcess;
   }
 
+  /** The IS-IS process for this router, or {@code null} if {@code isis} is not configured. */
+  public @Nullable IsisProcess getIsisProcess() {
+    return _isisProcess;
+  }
+
+  public void setIsisProcess(@Nullable IsisProcess isisProcess) {
+    _isisProcess = isisProcess;
+  }
+
   private final @Nonnull String _name;
   private @Nullable Long _autonomousSystem;
   private final @Nonnull Map<String, RouterInterface> _interfaces;
   private final @Nonnull List<StaticRoute> _staticRoutes;
   private @Nullable BgpProcess _bgpProcess;
   private @Nullable OspfProcess _ospfProcess;
+  private @Nullable IsisProcess _isisProcess;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
@@ -71,6 +71,18 @@ public final class Router implements Serializable {
     _isisProcess = isisProcess;
   }
 
+  /**
+   * The BGP-IPVPN (MPLS L3VPN) settings — route-distinguisher and route-targets — for a VPRN, or
+   * {@code null} if not configured. Only the {@code Base} router never has these.
+   */
+  public @Nullable BgpIpvpn getBgpIpvpn() {
+    return _bgpIpvpn;
+  }
+
+  public void setBgpIpvpn(@Nullable BgpIpvpn bgpIpvpn) {
+    _bgpIpvpn = bgpIpvpn;
+  }
+
   private final @Nonnull String _name;
   private @Nullable Long _autonomousSystem;
   private final @Nonnull Map<String, RouterInterface> _interfaces;
@@ -78,4 +90,5 @@ public final class Router implements Serializable {
   private @Nullable BgpProcess _bgpProcess;
   private @Nullable OspfProcess _ospfProcess;
   private @Nullable IsisProcess _isisProcess;
+  private @Nullable BgpIpvpn _bgpIpvpn;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -119,6 +119,7 @@ public final class SrosConfiguration extends VendorConfiguration {
       SrosConversions.convertOspf(router, c, vrf, getWarnings());
       SrosConversions.convertIsis(router, c, vrf, getWarnings());
       SrosConversions.convertBgp(router, c, vrf, getWarnings());
+      SrosConversions.convertBgpIpvpn(router, vrf, getWarnings());
     }
 
     warnUnconvertedHardware();

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -117,6 +117,7 @@ public final class SrosConfiguration extends VendorConfiguration {
       SrosConversions.convertInterfaces(this, router, c, vrf);
       SrosConversions.convertStaticRoutes(router, vrf, getWarnings());
       SrosConversions.convertOspf(router, c, vrf, getWarnings());
+      SrosConversions.convertIsis(router, c, vrf, getWarnings());
       SrosConversions.convertBgp(router, c, vrf, getWarnings());
     }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -594,6 +594,29 @@ public final class SrosConversions {
     }
   }
 
+  /**
+   * Converts a VPRN's {@code bgp-ipvpn mpls} settings to the VI model. Only the {@code
+   * route-distinguisher} is applied (onto the VRF) — the VI model stores an RD per VRF. The {@code
+   * vrf-target} route-targets and inter-PE VPN-IPv4 (L3VPN) route import are NOT modeled: the VI
+   * datamodel has no VPNv4 address family and its cross-VRF leaking is intra-node only, so PE-to-PE
+   * MP-BGP L3VPN route exchange is not reproducible. See {@link BgpIpvpn} and the tracked
+   * follow-up.
+   */
+  static void convertBgpIpvpn(Router router, Vrf vrf, Warnings w) {
+    BgpIpvpn ipvpn = router.getBgpIpvpn();
+    if (ipvpn == null || ipvpn.getRouteDistinguisher() == null) {
+      return;
+    }
+    try {
+      vrf.setRouteDistinguisher(
+          org.batfish.datamodel.bgp.RouteDistinguisher.parse(ipvpn.getRouteDistinguisher()));
+    } catch (IllegalArgumentException e) {
+      w.redFlagf(
+          "VPRN '%s' route-distinguisher '%s' is invalid; not set",
+          router.getName(), ipvpn.getRouteDistinguisher());
+    }
+  }
+
   /** OSPF default {@code reference-bandwidth}: 100,000,000 kilobps (100 Gbps), expressed in bps. */
   private static final double OSPF_REFERENCE_BANDWIDTH = 100E9D;
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -23,6 +23,7 @@ import org.batfish.datamodel.ConnectedRouteMetadata;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IsoAddress;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.OriginType;
@@ -512,6 +513,85 @@ public final class SrosConversions {
       areas.put(e.getKey(), e.getValue().setOspfProcess(newProc).build());
     }
     newProc.setAreas(ImmutableMap.copyOf(areas));
+  }
+
+  /**
+   * Converts a router instance's {@code isis} process to a VI {@link
+   * org.batfish.datamodel.isis.IsisProcess} on {@code vrf}, attaching {@link
+   * org.batfish.datamodel.isis.IsisInterfaceSettings} to each IS-IS-enabled interface. The NET is
+   * built from the first {@code area-address} + {@code system-id} + an {@code 00} N-selector. A
+   * {@code passive} interface advertises its subnet but forms no adjacency (VI {@link
+   * org.batfish.datamodel.isis.IsisInterfaceMode#PASSIVE}). Admin distances come from the
+   * NOKIA_SROS {@link org.batfish.datamodel.RoutingProtocol} defaults (L1 15 / L2 18 internal).
+   */
+  static void convertIsis(Router router, Configuration c, Vrf vrf, Warnings w) {
+    org.batfish.vendor.sros.representation.IsisProcess proc = router.getIsisProcess();
+    if (proc == null || !proc.getAdminStateEnable()) {
+      return;
+    }
+    String systemId = proc.getSystemId();
+    if (systemId == null || proc.getAreaAddresses().isEmpty()) {
+      w.redFlagf(
+          "router '%s' IS-IS has no system-id or area-address; skipping IS-IS", router.getName());
+      return;
+    }
+    // NET = <area-address>.<system-id>.00 (e.g. 49.0001.0100.1000.0001.00). Build the IsoAddress
+    // from the dotted form, stripping the dots the IsoAddress parser does not expect.
+    String net = proc.getAreaAddresses().get(0) + "." + systemId + ".00";
+    IsoAddress netAddress;
+    try {
+      netAddress = new IsoAddress(net);
+    } catch (IllegalArgumentException e) {
+      w.redFlagf("router '%s' IS-IS NET '%s' is invalid; skipping IS-IS", router.getName(), net);
+      return;
+    }
+
+    boolean level1 =
+        proc.getLevelCapability()
+            != org.batfish.vendor.sros.representation.IsisProcess.LevelCapability.LEVEL_2;
+    boolean level2 =
+        proc.getLevelCapability()
+            != org.batfish.vendor.sros.representation.IsisProcess.LevelCapability.LEVEL_1;
+    org.batfish.datamodel.isis.IsisProcess.Builder newProc =
+        org.batfish.datamodel.isis.IsisProcess.builder().setNetAddress(netAddress).setVrf(vrf);
+    if (level1) {
+      newProc.setLevel1(org.batfish.datamodel.isis.IsisLevelSettings.builder().build());
+    }
+    if (level2) {
+      newProc.setLevel2(org.batfish.datamodel.isis.IsisLevelSettings.builder().build());
+    }
+    newProc.build();
+
+    for (org.batfish.vendor.sros.representation.IsisProcessInterface isisIf :
+        proc.getInterfaces().values()) {
+      Interface viIface = c.getAllInterfaces().get(isisIf.getName());
+      if (viIface == null) {
+        w.redFlagf(
+            "router '%s' IS-IS references undefined interface '%s'; skipping",
+            router.getName(), isisIf.getName());
+        continue;
+      }
+      org.batfish.datamodel.isis.IsisInterfaceMode mode =
+          isisIf.getPassive()
+              ? org.batfish.datamodel.isis.IsisInterfaceMode.PASSIVE
+              : org.batfish.datamodel.isis.IsisInterfaceMode.ACTIVE;
+      org.batfish.datamodel.isis.IsisInterfaceLevelSettings levelSettings =
+          org.batfish.datamodel.isis.IsisInterfaceLevelSettings.builder().setMode(mode).build();
+      org.batfish.datamodel.isis.IsisInterfaceSettings.Builder ifSettings =
+          org.batfish.datamodel.isis.IsisInterfaceSettings.builder()
+              .setIsoAddress(netAddress)
+              .setPointToPoint(
+                  isisIf.getInterfaceType()
+                      == org.batfish.vendor.sros.representation.IsisProcessInterface.InterfaceType
+                          .POINT_TO_POINT);
+      if (level1) {
+        ifSettings.setLevel1(levelSettings);
+      }
+      if (level2) {
+        ifSettings.setLevel2(levelSettings);
+      }
+      viIface.setIsis(ifSettings.build());
+    }
   }
 
   /** OSPF default {@code reference-bandwidth}: 100,000,000 kilobps (100 Gbps), expressed in bps. */

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -92,11 +92,15 @@ public final class SrosConversions {
 
   /**
    * Converts an SR-OS {@code prefix-list} to a {@link RouteFilterList} (all lines permit; a
-   * route-policy decides accept/reject). The match {@code type} maps to a prefix-length {@link
-   * SubRange}: {@code exact} matches only the configured length; {@code longer} matches strictly
-   * longer. {@code through}/{@code range}/{@code to}/{@code address-mask} carry extra bounds the P4
-   * model does not yet capture, so they are over-approximated as "this length or longer" and a
-   * warning is emitted (the resulting filter is broader than the device's — see the warning).
+   * route-policy decides accept/reject). The match {@code type} determines the lines: {@code exact}
+   * matches only the configured length; {@code longer} matches strictly longer; {@code through}
+   * matches this length through {@code through-length}; {@code range} matches {@code
+   * start-length}..{@code end-length}. {@code to} matches, for each {@code to-prefix} (nested in
+   * the base), every ancestor prefix on the path from the base length down to the to-prefix length
+   * — emitted as one exact line per length (a line over the base prefix with a length range would
+   * wrongly match siblings off that path; confirmed on SR-SIM 26.3.R1). {@code address-mask} with a
+   * contiguous mask equal to the base length is an exact match; a non-contiguous mask cannot be a
+   * length {@link SubRange} and is over-approximated with a warning.
    */
   @VisibleForTesting
   static @Nonnull RouteFilterList toRouteFilterList(PrefixList pl, Warnings w) {
@@ -104,36 +108,83 @@ public final class SrosConversions {
     for (PrefixListEntry entry : pl.getEntries()) {
       Prefix prefix = entry.getPrefix();
       int len = prefix.getPrefixLength();
-      SubRange lengthRange =
-          switch (entry.getType()) {
-            case EXACT -> SubRange.singleton(len);
-            case LONGER -> new SubRange(len + 1, Prefix.MAX_PREFIX_LENGTH);
-            case THROUGH -> {
-              // through-length: match this prefix's length through through-length (inclusive). If
-              // the bound is missing (older capture), fall back to "this length or longer" + warn.
-              Integer through = entry.getThroughLength();
-              if (through == null) {
-                yield overApproximate(pl, entry, w);
-              }
-              yield new SubRange(len, through);
+      switch (entry.getType()) {
+        case EXACT ->
+            lines.add(new RouteFilterLine(LineAction.PERMIT, prefix, SubRange.singleton(len)));
+        case LONGER ->
+            lines.add(
+                new RouteFilterLine(
+                    LineAction.PERMIT, prefix, new SubRange(len + 1, Prefix.MAX_PREFIX_LENGTH)));
+        case THROUGH -> {
+          // through-length: match this prefix's length through through-length (inclusive). If the
+          // bound is missing (older capture), fall back to "this length or longer" + warn.
+          Integer through = entry.getThroughLength();
+          lines.add(
+              new RouteFilterLine(
+                  LineAction.PERMIT,
+                  prefix,
+                  through == null ? overApproximate(pl, entry, w) : new SubRange(len, through)));
+        }
+        case RANGE -> {
+          // range: match start-length through end-length (inclusive).
+          Integer start = entry.getStartLength();
+          Integer end = entry.getEndLength();
+          lines.add(
+              new RouteFilterLine(
+                  LineAction.PERMIT,
+                  prefix,
+                  start == null || end == null
+                      ? overApproximate(pl, entry, w)
+                      : new SubRange(start, end)));
+        }
+        case TO -> {
+          // `to`: match the ancestors of each to-prefix at lengths [base-length .. to-length].
+          // Each is a distinct prefix (the to-prefix truncated to that length), so emit one exact
+          // line per length rather than a single base-prefix line (which would match off-path
+          // siblings). An empty to-prefix list (older capture) falls back to over-approximation.
+          if (entry.getToPrefixes().isEmpty()) {
+            lines.add(
+                new RouteFilterLine(LineAction.PERMIT, prefix, overApproximate(pl, entry, w)));
+            break;
+          }
+          for (Prefix toPrefix : entry.getToPrefixes()) {
+            for (int l = len; l <= toPrefix.getPrefixLength(); l++) {
+              Prefix ancestor = Prefix.create(toPrefix.getStartIp(), l);
+              lines.add(new RouteFilterLine(LineAction.PERMIT, ancestor, SubRange.singleton(l)));
             }
-            case RANGE -> {
-              // range: match start-length through end-length (inclusive).
-              Integer start = entry.getStartLength();
-              Integer end = entry.getEndLength();
-              if (start == null || end == null) {
-                yield overApproximate(pl, entry, w);
-              }
-              yield new SubRange(start, end);
+          }
+        }
+        case ADDRESS_MASK -> {
+          // address-mask: a route matches if (address & mask) equals the entry's masked prefix and
+          // the mask length matches. A contiguous mask is a prefix length; model it as an exact
+          // match at that length on the masked prefix. A non-contiguous mask is not a length range
+          // -> over-approximate + warn.
+          List<Ip> masks = entry.getMaskPatterns();
+          if (masks.isEmpty()) {
+            lines.add(
+                new RouteFilterLine(LineAction.PERMIT, prefix, overApproximate(pl, entry, w)));
+            break;
+          }
+          for (Ip mask : masks) {
+            int maskLen = mask.numSubnetBits();
+            if (!mask.equals(Ip.numSubnetBitsToSubnetMask(maskLen))) {
+              // Non-contiguous mask: cannot express as a prefix-length range.
+              w.redFlagf(
+                  "prefix-list '%s' entry %s address-mask '%s' is non-contiguous; not fully"
+                      + " modeled, matching '%s' or longer (over-approximation)",
+                  pl.getName(), prefix, mask, prefix);
+              lines.add(
+                  new RouteFilterLine(
+                      LineAction.PERMIT,
+                      prefix,
+                      new SubRange(prefix.getPrefixLength(), Prefix.MAX_PREFIX_LENGTH)));
+              continue;
             }
-            case TO, ADDRESS_MASK -> {
-              // The bound leaves for these types are not modeled yet; match this length or longer
-              // as a conservative over-approximation, and warn until the bounds are modeled.
-              // TODO: model to/address-mask bounds — https://github.com/batfish/batfish/issues/9990
-              yield overApproximate(pl, entry, w);
-            }
-          };
-      lines.add(new RouteFilterLine(LineAction.PERMIT, prefix, lengthRange));
+            Prefix masked = Prefix.create(prefix.getStartIp(), maskLen);
+            lines.add(new RouteFilterLine(LineAction.PERMIT, masked, SubRange.singleton(maskLen)));
+          }
+        }
+      }
     }
     return new RouteFilterList(pl.getName(), lines);
   }

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -234,6 +234,31 @@ public final class SrosConversionTest {
     assertTrue(hostRange.permits(Prefix.parse("10.1.2.3/32")));
     assertFalse(hostRange.permits(Prefix.parse("10.1.0.0/16")));
 
+    // `to`: base 10.20.0.0/16 with to-prefixes /20 and 10.20.16.0/24. SR-SIM 26.3.R1 confirmed it
+    // matches the ANCESTORS of each to-prefix at lengths [base-length .. to-length], and nothing
+    // off that path.
+    RouteFilterList toList = c.getRouteFilterLists().get("to-list");
+    assertNotNull(toList);
+    // On-path ancestors of 10.20.0.0/20 (lengths 16..20):
+    assertTrue(toList.permits(Prefix.parse("10.20.0.0/16")));
+    assertTrue(toList.permits(Prefix.parse("10.20.0.0/17")));
+    assertTrue(toList.permits(Prefix.parse("10.20.0.0/18")));
+    assertTrue(toList.permits(Prefix.parse("10.20.0.0/20")));
+    // On-path ancestors of 10.20.16.0/24 (lengths 21..24, plus the shared 16..20 prefixes):
+    assertTrue(toList.permits(Prefix.parse("10.20.16.0/24")));
+    assertTrue(toList.permits(Prefix.parse("10.20.16.0/21")));
+    // Beyond the to-prefix length, off the base network, and longer than the deepest to-prefix:
+    assertFalse(toList.permits(Prefix.parse("10.20.0.0/21")));
+    assertFalse(toList.permits(Prefix.parse("10.20.128.0/17")));
+    assertFalse(toList.permits(Prefix.parse("10.20.16.0/25")));
+
+    // `address-mask`: 172.16.0.0/16 mask 255.255.0.0 -> exact match on 172.16.0.0/16 only.
+    RouteFilterList maskList = c.getRouteFilterLists().get("mask-list");
+    assertNotNull(maskList);
+    assertTrue(maskList.permits(Prefix.parse("172.16.0.0/16")));
+    assertFalse(maskList.permits(Prefix.parse("172.16.5.0/24")));
+    assertFalse(maskList.permits(Prefix.parse("172.17.0.0/16")));
+
     // entry 10 matches 1.1.1.1/32 (system-pfx) and applies metric 50 + prepend 65001 x2 +
     // community.
     RoutingPolicy exportPolicy = c.getRoutingPolicies().get("export-to-r2");
@@ -495,12 +520,19 @@ public final class SrosConversionTest {
                     allOf(
                         hasPrefix(Prefix.parse("203.0.113.0/24")),
                         hasAdministrativeCost(100),
-                        hasMetric(50L))))));
+                        hasMetric(50L)),
+                    // ECMP route: one VI static route per next-hop, each with its own metric
+                    // (batfish/batfish#9989). Equal preference (default 5) -> both install as ECMP.
+                    allOf(
+                        hasPrefix(Prefix.parse("192.0.2.128/25")),
+                        hasNextHop(NextHopIp.of(Ip.parse("10.0.0.1"))),
+                        hasMetric(10L)),
+                    allOf(
+                        hasPrefix(Prefix.parse("192.0.2.128/25")),
+                        hasNextHop(NextHopIp.of(Ip.parse("10.0.1.1"))),
+                        hasMetric(20L))))));
     // The route whose next-hop has no admin-state is not installed (SR-OS leaves it out of the
-    // RIB):
-    // exactly the three routes above are present (containsInAnyOrder is exhaustive), so
-    // 100.64.0.0/24
-    // is absent.
+    // RIB), so 100.64.0.0/24 is absent (containsInAnyOrder is exhaustive).
   }
 
   private @Nonnull Configuration parseConfig(String filename) throws IOException {

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -357,6 +357,10 @@ public final class SrosConversionTest {
     // No leak: the Base "system" interface is in the default VRF, not "red".
     assertThat(
         c.getAllInterfaces().get("system").getVrfName(), equalTo(Configuration.DEFAULT_VRF_NAME));
+    // The bgp-ipvpn route-distinguisher converts onto the VRF (the VI model stores an RD per VRF).
+    assertThat(
+        c.getVrfs().get("red").getRouteDistinguisher(),
+        equalTo(org.batfish.datamodel.bgp.RouteDistinguisher.parse("65000:1")));
   }
 
   /** Route-reflector conversion: an RR-client neighbor gets cluster-id + route-reflector-client. */

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -11,6 +11,8 @@ import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMa
 import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.hasNumReferrers;
 import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.hasRedFlagWarning;
 import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.hasUndefinedReference;
+import static org.batfish.datamodel.matchers.RouteFilterListMatchers.permits;
+import static org.batfish.datamodel.matchers.RouteFilterListMatchers.rejects;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -106,8 +108,8 @@ public final class SrosConversionTest {
     assertThat(c.getRouteFilterLists(), hasKey("system-pfx"));
     RouteFilterList rfl = c.getRouteFilterLists().get("system-pfx");
     // exact type: matches 1.1.1.1/32 exactly, not a more-specific (no more-specific exists at /32).
-    assertTrue(rfl.permits(Prefix.parse("1.1.1.1/32")));
-    assertFalse(rfl.permits(Prefix.parse("2.2.2.2/32")));
+    assertThat(rfl, permits(Prefix.parse("1.1.1.1/32")));
+    assertThat(rfl, rejects(Prefix.parse("2.2.2.2/32")));
   }
 
   /**
@@ -223,16 +225,16 @@ public final class SrosConversionTest {
     // shorter (e.g. /15) does not. (Previously over-approximated to [16,32-or-longer] with a warn.)
     RouteFilterList loRange = c.getRouteFilterLists().get("lo-range");
     assertNotNull(loRange);
-    assertTrue(loRange.permits(Prefix.parse("192.168.1.0/24")));
-    assertTrue(loRange.permits(Prefix.parse("192.168.1.1/32")));
-    assertFalse(loRange.permits(Prefix.parse("192.0.0.0/15")));
+    assertThat(loRange, permits(Prefix.parse("192.168.1.0/24")));
+    assertThat(loRange, permits(Prefix.parse("192.168.1.1/32")));
+    assertThat(loRange, rejects(Prefix.parse("192.0.0.0/15")));
 
     // range start-length 24 end-length 32 on 10.0.0.0/8 -> window [24,32].
     RouteFilterList hostRange = c.getRouteFilterLists().get("host-range");
     assertNotNull(hostRange);
-    assertTrue(hostRange.permits(Prefix.parse("10.1.2.0/24")));
-    assertTrue(hostRange.permits(Prefix.parse("10.1.2.3/32")));
-    assertFalse(hostRange.permits(Prefix.parse("10.1.0.0/16")));
+    assertThat(hostRange, permits(Prefix.parse("10.1.2.0/24")));
+    assertThat(hostRange, permits(Prefix.parse("10.1.2.3/32")));
+    assertThat(hostRange, rejects(Prefix.parse("10.1.0.0/16")));
 
     // `to`: base 10.20.0.0/16 with to-prefixes /20 and 10.20.16.0/24. SR-SIM 26.3.R1 confirmed it
     // matches the ANCESTORS of each to-prefix at lengths [base-length .. to-length], and nothing
@@ -240,24 +242,24 @@ public final class SrosConversionTest {
     RouteFilterList toList = c.getRouteFilterLists().get("to-list");
     assertNotNull(toList);
     // On-path ancestors of 10.20.0.0/20 (lengths 16..20):
-    assertTrue(toList.permits(Prefix.parse("10.20.0.0/16")));
-    assertTrue(toList.permits(Prefix.parse("10.20.0.0/17")));
-    assertTrue(toList.permits(Prefix.parse("10.20.0.0/18")));
-    assertTrue(toList.permits(Prefix.parse("10.20.0.0/20")));
+    assertThat(toList, permits(Prefix.parse("10.20.0.0/16")));
+    assertThat(toList, permits(Prefix.parse("10.20.0.0/17")));
+    assertThat(toList, permits(Prefix.parse("10.20.0.0/18")));
+    assertThat(toList, permits(Prefix.parse("10.20.0.0/20")));
     // On-path ancestors of 10.20.16.0/24 (lengths 21..24, plus the shared 16..20 prefixes):
-    assertTrue(toList.permits(Prefix.parse("10.20.16.0/24")));
-    assertTrue(toList.permits(Prefix.parse("10.20.16.0/21")));
+    assertThat(toList, permits(Prefix.parse("10.20.16.0/24")));
+    assertThat(toList, permits(Prefix.parse("10.20.16.0/21")));
     // Beyond the to-prefix length, off the base network, and longer than the deepest to-prefix:
-    assertFalse(toList.permits(Prefix.parse("10.20.0.0/21")));
-    assertFalse(toList.permits(Prefix.parse("10.20.128.0/17")));
-    assertFalse(toList.permits(Prefix.parse("10.20.16.0/25")));
+    assertThat(toList, rejects(Prefix.parse("10.20.0.0/21")));
+    assertThat(toList, rejects(Prefix.parse("10.20.128.0/17")));
+    assertThat(toList, rejects(Prefix.parse("10.20.16.0/25")));
 
     // `address-mask`: 172.16.0.0/16 mask 255.255.0.0 -> exact match on 172.16.0.0/16 only.
     RouteFilterList maskList = c.getRouteFilterLists().get("mask-list");
     assertNotNull(maskList);
-    assertTrue(maskList.permits(Prefix.parse("172.16.0.0/16")));
-    assertFalse(maskList.permits(Prefix.parse("172.16.5.0/24")));
-    assertFalse(maskList.permits(Prefix.parse("172.17.0.0/16")));
+    assertThat(maskList, permits(Prefix.parse("172.16.0.0/16")));
+    assertThat(maskList, rejects(Prefix.parse("172.16.5.0/24")));
+    assertThat(maskList, rejects(Prefix.parse("172.17.0.0/16")));
 
     // entry 10 matches 1.1.1.1/32 (system-pfx) and applies metric 50 + prepend 65001 x2 +
     // community.

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -312,6 +312,38 @@ public final class SrosConversionTest {
         equalTo(org.batfish.datamodel.ospf.OspfNetworkType.POINT_TO_POINT));
   }
 
+  /**
+   * IS-IS conversion: a VI IsisProcess with the NET built from area-address + system-id + 00, a
+   * level-2 process, and per-interface settings (point-to-point, passive mode). SR-OS L2 internal
+   * admin distance is 18 (set via the NOKIA_SROS RoutingProtocol default).
+   */
+  @Test
+  public void testIsisConversion() throws IOException {
+    Configuration c = parseConfig("isis.txt");
+    org.batfish.datamodel.isis.IsisProcess proc = c.getDefaultVrf().getIsisProcess();
+    assertNotNull(proc);
+    // NET = 49.0001 (area) + 0100.1000.0001 (system-id) + 00 (n-sel).
+    assertThat(
+        proc.getNetAddress(),
+        equalTo(new org.batfish.datamodel.IsoAddress("49.0001.0100.1000.0001.00")));
+    // level-capability 2 -> only the level-2 process is set.
+    assertNotNull(proc.getLevel2());
+    assertThat(proc.getLevel1(), nullValue());
+
+    // The to-r3 interface is IS-IS-active and point-to-point; system is passive.
+    Interface toR3 = c.getAllInterfaces().get("to-r3");
+    assertNotNull(toR3.getIsis());
+    assertThat(toR3.getIsis().getPointToPoint(), equalTo(true));
+    assertThat(
+        toR3.getIsis().getLevel2().getMode(),
+        equalTo(org.batfish.datamodel.isis.IsisInterfaceMode.ACTIVE));
+    Interface system = c.getAllInterfaces().get("system");
+    assertNotNull(system.getIsis());
+    assertThat(
+        system.getIsis().getLevel2().getMode(),
+        equalTo(org.batfish.datamodel.isis.IsisInterfaceMode.PASSIVE));
+  }
+
   /** VPRN conversion: a {@code service vprn "red"} becomes a separate VRF holding its interface. */
   @Test
   public void testVprnConversion() throws IOException {

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
@@ -270,6 +270,37 @@ public final class SrosExtractionTest {
   }
 
   /**
+   * IS-IS extraction: instance, admin-state, system-id, area-address, level-capability, and the
+   * per-interface interface-type/passive.
+   */
+  @Test
+  public void testIsisExtraction() {
+    SrosConfiguration vc = parseVendorConfig("isis.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    org.batfish.vendor.sros.representation.IsisProcess proc =
+        vc.getRouters().get("Base").getIsisProcess();
+    assertThat(proc, notNullValue());
+    assertThat(proc.getInstance(), equalTo(0));
+    assertThat(proc.getAdminStateEnable(), equalTo(true));
+    assertThat(proc.getSystemId(), equalTo("0100.1000.0001"));
+    assertThat(proc.getAreaAddresses(), contains("49.0001"));
+    assertThat(
+        proc.getLevelCapability(),
+        equalTo(org.batfish.vendor.sros.representation.IsisProcess.LevelCapability.LEVEL_2));
+    assertThat(proc.getInterfaces().keySet(), containsInAnyOrder("system", "to-r3"));
+    // system is passive (advertised, no adjacency); to-r3 is point-to-point and active.
+    assertThat(proc.getInterfaces().get("system").getPassive(), equalTo(true));
+    org.batfish.vendor.sros.representation.IsisProcessInterface toR3 =
+        proc.getInterfaces().get("to-r3");
+    assertThat(toR3.getPassive(), equalTo(false));
+    assertThat(
+        toR3.getInterfaceType(),
+        equalTo(
+            org.batfish.vendor.sros.representation.IsisProcessInterface.InterfaceType
+                .POINT_TO_POINT));
+  }
+
+  /**
    * VPRN extraction: a {@code service vprn "<name>"} becomes a {@link Router} with its interfaces.
    */
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -147,7 +148,7 @@ public final class SrosExtractionTest {
     assertThat(vc.getWarnings().getParseWarnings(), empty());
     assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
     List<StaticRoute> routes = vc.getRouters().get("Base").getStaticRoutes();
-    assertThat(routes, hasSize(4));
+    assertThat(routes, hasSize(6));
 
     // route 1: next-hop, admin-state enable, default preference 5 / metric 1.
     StaticRoute nh = routes.get(0);
@@ -176,6 +177,21 @@ public final class SrosExtractionTest {
     assertThat(nhNoAdmin.getPrefix(), equalTo(Prefix.parse("100.64.0.0/24")));
     assertThat(nhNoAdmin.getNextHopIp(), equalTo(Ip.parse("10.0.0.1")));
     assertThat(nhNoAdmin.getAdminStateEnable(), equalTo(false));
+
+    // routes 5-6: an ECMP route with two next-hops -> one StaticRoute per next-hop, each carrying
+    // its own metric (10 / 20). Confirmed on SR-SIM 26.3.R1: equal-preference next-hops both
+    // install (batfish/batfish#9989).
+    StaticRoute ecmp1 = routes.get(4);
+    StaticRoute ecmp2 = routes.get(5);
+    assertThat(ecmp1.getPrefix(), equalTo(Prefix.parse("192.0.2.128/25")));
+    assertThat(ecmp2.getPrefix(), equalTo(Prefix.parse("192.0.2.128/25")));
+    assertThat(
+        ImmutableSet.of(ecmp1.getNextHopIp(), ecmp2.getNextHopIp()),
+        equalTo(ImmutableSet.of(Ip.parse("10.0.0.1"), Ip.parse("10.0.1.1"))));
+    assertThat(ecmp1.getAdminStateEnable(), equalTo(true));
+    assertThat(ecmp2.getAdminStateEnable(), equalTo(true));
+    assertThat(
+        ImmutableSet.of(ecmp1.getMetric(), ecmp2.getMetric()), equalTo(ImmutableSet.of(10, 20)));
   }
 
   /**
@@ -201,6 +217,16 @@ public final class SrosExtractionTest {
     assertThat(range.getType(), equalTo(PrefixListEntry.Type.RANGE));
     assertThat(range.getStartLength(), equalTo(24));
     assertThat(range.getEndLength(), equalTo(32));
+
+    // `to` entry captures its to-prefix list; `address-mask` entry captures its mask-pattern.
+    PrefixListEntry to = vc.getPrefixLists().get("to-list").getEntries().get(0);
+    assertThat(to.getType(), equalTo(PrefixListEntry.Type.TO));
+    assertThat(
+        to.getToPrefixes(),
+        containsInAnyOrder(Prefix.parse("10.20.0.0/20"), Prefix.parse("10.20.16.0/24")));
+    PrefixListEntry mask = vc.getPrefixLists().get("mask-list").getEntries().get(0);
+    assertThat(mask.getType(), equalTo(PrefixListEntry.Type.ADDRESS_MASK));
+    assertThat(mask.getMaskPatterns(), contains(Ip.parse("255.255.0.0")));
 
     // entry 10 set-clauses: metric 50, as-path-prepend 65001 x2, community add comm-tag.
     PolicyStatement ps = vc.getPolicyStatements().get("export-to-r2");
@@ -284,18 +310,13 @@ public final class SrosExtractionTest {
   }
 
   /**
-   * Extraction warns (never silently skips/defaults) on: static-route ECMP (multiple next-hops), an
-   * illegal prefix-list 'through' missing its length, an inverted 'range', an unrecognized
-   * from-protocol, and a non-boolean flag value. Each is a line-stamped parse warning.
+   * Extraction warns (never silently skips/defaults) on: an illegal prefix-list 'through' missing
+   * its length, an inverted 'range', an unrecognized from-protocol, and a non-boolean flag value.
+   * Each is a line-stamped parse warning.
    */
   @Test
   public void testExtractionWarnings() {
     SrosConfiguration vc = parseVendorConfig("warnings.txt");
-    // static route with two next-hops -> ECMP warning, only the first is modeled.
-    warningOnLine(
-        vc, "static route 192.0.2.0/24 has 2 next-hops (ECMP); only the first is modeled");
-    StaticRoute sr = vc.getRouters().get("Base").getStaticRoutes().get(0);
-    assertThat(sr.getNextHopIp(), equalTo(Ip.parse("10.0.0.1")));
     // through entry with no through-length, and an inverted range.
     warningOnLine(vc, "prefix-list 'through' entry is missing through-length");
     warningOnLine(vc, "prefix-list range start-length 30 is greater than end-length 24");

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
@@ -313,6 +313,13 @@ public final class SrosExtractionTest {
     assertThat(
         red.getInterfaces().get("red-lo").getPrimaryAddress(), equalTo(Ip.parse("172.16.0.1")));
     assertThat(red.getInterfaces().get("red-lo").getPort(), nullValue());
+
+    // bgp-ipvpn mpls: route-distinguisher + vrf-target (single community -> import + export).
+    org.batfish.vendor.sros.representation.BgpIpvpn ipvpn = red.getBgpIpvpn();
+    assertThat(ipvpn, notNullValue());
+    assertThat(ipvpn.getRouteDistinguisher(), equalTo("65000:1"));
+    assertThat(ipvpn.getImportRouteTargets(), contains("target:65000:1"));
+    assertThat(ipvpn.getExportRouteTargets(), contains("target:65000:1"));
   }
 
   /** Route-reflector extraction: a group's cluster-id and next-hop-self inherit to its neighbor. */

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosGrammarTest.java
@@ -91,6 +91,24 @@ public final class SrosGrammarTest {
     assertThat(vc.getHostname(), equalTo("sros-r1"));
   }
 
+  /**
+   * The device renders a list entry with no body as an empty same-line block — {@code <words> { }}
+   * (open brace, optional whitespace, close brace, no intervening newline), e.g. the {@code
+   * to-prefix}es of a {@code prefix-list ... type to}. This must parse with no FATAL error and the
+   * entry must still appear as a canonical statement.
+   */
+  @Test
+  public void testInlineEmptyBlockParses() {
+    SrosConfiguration vc = parseVendorConfig("inline_empty_block.txt");
+    assertThat(vc.getUnrecognized(), equalTo(false));
+    assertThat(vc.getWarnings().getParseWarnings(), empty());
+    assertThat(
+        vc.getStatements(),
+        hasItem(
+            "configure policy-options prefix-list \"to-list\" prefix 10.20.0.0/16 type to to-prefix"
+                + " 10.20.0.0/20"));
+  }
+
   private static @Nonnull SrosConfiguration parseVendorConfig(String filename) {
     String src = readResource(TESTCONFIGS_PREFIX + filename, UTF_8);
     Settings settings = new Settings();

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/inline_empty_block.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/inline_empty_block.txt
@@ -1,0 +1,12 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    policy-options {
+        prefix-list "to-list" {
+            prefix 10.20.0.0/16 type to {
+                to-prefix 10.20.0.0/20 { }
+                to-prefix 10.20.16.0/24 { }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/isis.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/isis.txt
@@ -1,0 +1,35 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r3" {
+            port 1/1/c1/1
+            ipv4 {
+                primary {
+                    address 10.0.1.0
+                    prefix-length 31
+                }
+            }
+        }
+        isis 0 {
+            admin-state enable
+            level-capability 2
+            system-id 0100.1000.0001
+            area-address [49.0001]
+            interface "system" {
+                passive true
+            }
+            interface "to-r3" {
+                interface-type point-to-point
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/policy_set_clauses.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/policy_set_clauses.txt
@@ -22,16 +22,13 @@ configure {
         }
         prefix-list "to-list" {
             prefix 10.20.0.0/16 type to {
-                to-prefix 10.20.0.0/20 {
-                }
-                to-prefix 10.20.16.0/24 {
-                }
+                to-prefix 10.20.0.0/20 { }
+                to-prefix 10.20.16.0/24 { }
             }
         }
         prefix-list "mask-list" {
             prefix 172.16.0.0/16 type address-mask {
-                mask-pattern 255.255.0.0 {
-                }
+                mask-pattern 255.255.0.0 { }
             }
         }
         policy-statement "export-to-r2" {

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/policy_set_clauses.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/policy_set_clauses.txt
@@ -20,6 +20,20 @@ configure {
                 end-length 32
             }
         }
+        prefix-list "to-list" {
+            prefix 10.20.0.0/16 type to {
+                to-prefix 10.20.0.0/20 {
+                }
+                to-prefix 10.20.16.0/24 {
+                }
+            }
+        }
+        prefix-list "mask-list" {
+            prefix 172.16.0.0/16 type address-mask {
+                mask-pattern 255.255.0.0 {
+                }
+            }
+        }
         policy-statement "export-to-r2" {
             entry 10 {
                 from {

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/static_routes.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/static_routes.txt
@@ -33,6 +33,16 @@ configure {
                 next-hop 10.0.0.1 {
                 }
             }
+            route 192.0.2.128/25 route-type unicast {
+                next-hop 10.0.0.1 {
+                    admin-state enable
+                    metric 10
+                }
+                next-hop 10.0.1.1 {
+                    admin-state enable
+                    metric 20
+                }
+            }
         }
     }
 }

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/vprn.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/vprn.txt
@@ -9,6 +9,15 @@ configure {
             admin-state enable
             service-id 1
             customer "1"
+            bgp-ipvpn {
+                mpls {
+                    admin-state enable
+                    route-distinguisher "65000:1"
+                    vrf-target {
+                        community "target:65000:1"
+                    }
+                }
+            }
             interface "red-lo" {
                 loopback
                 ipv4 {

--- a/projects/common/src/main/java/org/batfish/datamodel/RoutingProtocol.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/RoutingProtocol.java
@@ -308,6 +308,7 @@ public enum RoutingProtocol {
           case FLAT_JUNIPER:
           case JUNIPER:
           case JUNIPER_SWITCH:
+          case NOKIA_SROS:
             return 160;
           case FLAT_VYOS:
           case VYOS:
@@ -349,6 +350,7 @@ public enum RoutingProtocol {
           case FLAT_JUNIPER:
           case JUNIPER:
           case JUNIPER_SWITCH:
+          case NOKIA_SROS:
             return 165;
           case FLAT_VYOS:
           case VYOS:
@@ -390,6 +392,7 @@ public enum RoutingProtocol {
           case FLAT_JUNIPER:
           case JUNIPER:
           case JUNIPER_SWITCH:
+          case NOKIA_SROS:
             return 15;
           case FLAT_VYOS:
           case VYOS:
@@ -431,6 +434,7 @@ public enum RoutingProtocol {
           case FLAT_JUNIPER:
           case JUNIPER:
           case JUNIPER_SWITCH:
+          case NOKIA_SROS:
             return 18;
           case FLAT_VYOS:
           case VYOS:


### PR DESCRIPTION
SR-OS follow-up rungs on top of the merged P8 ladder (#9988): closes the two
deferred review bugs and adds three more features, each modeled against a fresh
live SR-SIM 26.3.R1 lab and validated route-for-route in the sibling
lab-validation repo. Commits are independent and meant to be reviewed in order.

1. **sros: model ECMP static routes and prefix-list to/address-mask bounds**
   — #9989: a static route with multiple next-hops emits one VI StaticRoute per
   next-hop (equal-preference legs install as ECMP; lower-preference wins).
   #9990: `type to` is a length-range match `[base-length .. to-prefix-length]`
   within the base network (one exact line per ancestor length, so off-path
   siblings don't match); contiguous `address-mask` is an exact match,
   non-contiguous is over-approximated + warned. Both confirmed on device.

2. **sros: parse empty same-line blocks (`{ }`)** — the device renders an
   empty-body list entry inline (`to-prefix X { }`), which the grammar rejected
   with a FATAL. Prerequisite for the to/address-mask extraction above.

3. **sros: model IS-IS (single-area, levels)** — IsisProcess
   (system-id/area/level/interfaces) → VI IsisProcess (NET, levels, per-interface
   point-to-point/passive). Adds NOKIA_SROS IS-IS admin distances to
   RoutingProtocol (L1 15 / L2 18 internal, confirmed on device).

4. **sros: extract VPRN bgp-ipvpn RD/route-targets; convert RD to VRF** — extracts
   `bgp-ipvpn mpls` route-distinguisher + vrf-target and sets the RD on the VI
   VRF. Inter-PE vpn-ipv4 L3VPN import is not modeled (no VI VPNv4 AF; cross-VRF
   leak is intra-node only) — tracked in #9991.

5. **docs** — SR-OS vendor guide section for all of the above.

Fixes #9989. Fixes #9990. For #9991.

SR-OS Java suite + PMD + checkstyle + buildifier clean. Validated green (or
sickbayed to #9991) across the new labs plus no regression on the 9 existing
SR-OS labs.
