### PR TITLE
sros: aggregate routes, LAG, multi-area OSPF, and richer policy

### DIFF
--- a/docs/parsing/vendors/sros.md
+++ b/docs/parsing/vendors/sros.md
@@ -583,3 +583,62 @@ from the computed main RIB; those two main-RIB checks are sickbayed to
 batfish/batfish#9991. Everything else (config/interfaces/BGP RIB/RD-on-VRF)
 validates green. Device-confirmed: BGP-VPN learned route preference 170,
 resolved over an LDP tunnel; VPRN `red` stays separate from Base.
+
+## Follow-up rungs (P10): aggregate routes, LAG, multi-area OSPF, policy depth
+
+A third pass added four more feature areas, each modeled against a live SR-SIM
+26.3.R1 lab.
+
+### Aggregate routes (`sros_aggregate`)
+
+`router "Base" aggregates aggregate <prefix>` converts to a discard {@code
+GeneratedRoute} at admin distance 130 (the device's aggregate preference).
+Batfish's generated-route activation matches SR-OS — the aggregate installs only
+when a contributing more-specific route exists — so no explicit contributor
+check is needed. Device-confirmed: with `summary-only`, the peer learns the /16
+aggregate but not the /24 contributors.
+
+### LAG (`sros_aggregate`)
+
+`lag "<name>"` converts to an `AGGREGATED` interface whose member ports are
+`AGGREGATE` dependencies (post-processing sums their bandwidth) and channel-group
+members; each member's `channelGroup` is set to the LAG. That channel-group
+linkage is essential: it lets the logical-Layer-1 computation collapse the
+members' per-port physical edges into a single `lag`↔`lag` edge, so the LAG
+comes up via a BIND dependency on its single logical neighbor. Without it, the
+members look like two separate L1 neighbors and the dependency logic deactivates
+the LAG as an LACP failure. The validator skips the synthetic `AGGREGATED` (and
+`PHYSICAL`) interfaces, which are not in the device's router-interface state.
+Note: the device interface state carries no bandwidth, so the lab validates the
+LAG interface's presence and the routes over it, not the bandwidth-sum value
+(that is unit-tested). A LACP `lag … { lacp { mode active } }` requires a
+mandatory `administrative-key`, or the whole startup config is rejected at boot
+("MGMT_CORE #236 … Missing mandatory fields").
+
+### Multi-area OSPF (`sros_ospf_multiarea`)
+
+No conversion change was needed — the existing OSPF area loop already converts N
+areas to N VI `OspfArea`s, making a router with interfaces in two areas an ABR.
+Batfish's dataplane then computes the inter-area (IA) routes; device-confirmed
+(each side learns the other area's prefixes as OSPF IA, preference 10, via the
+ABR). **OSPF external redistribution does not work via an `export-policy` on
+SR-SIM 26.3.R1**: an `ospf <n> export-policy [p]` accepting static/connected
+routes committed cleanly but never made the router an ASBR or originated any
+AS-external LSA (`show router ospf status` stayed `AS Border Router: False`,
+0 external LSAs), for static (by prefix-list and by `from protocol name
+[static]`) and for connected (`from protocol name [direct]`). BGP export of the
+same statics works (see `sros_redist`), so this is OSPF-export-specific. E1/E2
+redistribution is therefore left unmodeled pending a dedicated probe.
+
+### Policy depth (`sros_policy_depth`)
+
+Extends policy-statement matching and actions beyond the P8 set:
+- `from community { name <name> }` → match any member of the named community
+  list (`MatchCommunities` over `HasCommunity(CommunityIs(...))`).
+- `from as-path { name <name> }` → match the named as-path list's `expression`
+  regex (`MatchAsPath` / `AsPathMatchRegex`); a new `AsPathList` model holds it.
+- actions `local-preference`, `metric add` (→ `IncrementMetric`), and `origin`.
+Device-confirmed behaviorally: a community-tagged route is accepted with
+local-pref 250 and a community add; an AS-path-matched route gets its metric
+incremented and origin set; `next-entry` chaining and `default-action` work as
+configured.

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -22,6 +22,8 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.vendor.StructureType;
 import org.batfish.vendor.StructureUsage;
+import org.batfish.vendor.sros.representation.Aggregate;
+import org.batfish.vendor.sros.representation.AsPathList;
 import org.batfish.vendor.sros.representation.BgpGroup;
 import org.batfish.vendor.sros.representation.BgpIpvpn;
 import org.batfish.vendor.sros.representation.BgpNeighbor;
@@ -31,6 +33,7 @@ import org.batfish.vendor.sros.representation.Community;
 import org.batfish.vendor.sros.representation.FromProtocol;
 import org.batfish.vendor.sros.representation.IsisProcess;
 import org.batfish.vendor.sros.representation.IsisProcessInterface;
+import org.batfish.vendor.sros.representation.Lag;
 import org.batfish.vendor.sros.representation.Mda;
 import org.batfish.vendor.sros.representation.OspfArea;
 import org.batfish.vendor.sros.representation.OspfAreaInterface;
@@ -95,6 +98,17 @@ public final class SrosFeatureExtractor {
 
   /** policy action {@code metric set}: BGP MED, YANG {@code int64 range "0..4294967295"}. */
   private static final LongSpace POLICY_METRIC_SPACE = LongSpace.of(Range.closed(0L, 4294967295L));
+
+  /** policy action {@code local-preference}: BGP local-pref, YANG {@code uint32}. */
+  private static final LongSpace LOCAL_PREFERENCE_SPACE =
+      LongSpace.of(Range.closed(0L, 4294967295L));
+
+  /** policy action {@code origin} enumeration. */
+  private static final Map<String, org.batfish.datamodel.OriginType> ORIGIN_TYPE =
+      ImmutableMap.of(
+          "igp", org.batfish.datamodel.OriginType.IGP,
+          "egp", org.batfish.datamodel.OriginType.EGP,
+          "incomplete", org.batfish.datamodel.OriginType.INCOMPLETE);
 
   /** as-path-prepend {@code repeat}: YANG {@code uint32 range "1..6"}. */
   private static final IntegerSpace AS_PATH_PREPEND_REPEAT_SPACE =
@@ -163,6 +177,7 @@ public final class SrosFeatureExtractor {
     extractSystem(configure.getChild("system"));
     extractCards(configure.getChild("card"));
     extractPorts(configure.getChild("port"));
+    extractLags(configure.getChild("lag"));
     extractPolicyOptions(configure.getChild("policy-options"));
     extractServices(configure.getChild("service"));
     extractRouters(configure.getChild("router"));
@@ -232,6 +247,31 @@ public final class SrosFeatureExtractor {
     }
   }
 
+  /**
+   * Extract {@code lag "<name>"} link-aggregation groups: the name, admin-state, and member port
+   * paths (the {@code port} list keyed by port-id). A router interface may bind a LAG by name; the
+   * LAG interface's bandwidth is the sum of its members' (see {@link Lag}).
+   */
+  private void extractLags(@Nullable SrosStatementTree lagList) {
+    if (lagList == null) {
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : lagList.getChildren().entrySet()) {
+      String name = unquote(e.getKey());
+      SrosStatementTree lagNode = e.getValue();
+      Lag lag = new Lag(name);
+      Boolean adminUp = toEnum(lagNode.getChild("admin-state"), ADMIN_STATE, "admin-state");
+      lag.setAdminStateEnable(!Boolean.FALSE.equals(adminUp));
+      SrosStatementTree portList = lagNode.getChild("port");
+      if (portList != null) {
+        for (String portKey : portList.getChildren().keySet()) {
+          lag.getMemberPorts().add(unquote(portKey));
+        }
+      }
+      _c.getLags().put(name, lag);
+    }
+  }
+
   // --- routers, interfaces, bgp -----------------------------------------------------------------
 
   private void extractRouters(@Nullable SrosStatementTree routerList) {
@@ -250,6 +290,7 @@ public final class SrosFeatureExtractor {
           .ifPresent(router::setAutonomousSystem);
       extractInterfaces(router, routerNode.getChild("interface"));
       extractStaticRoutes(router, routerNode.getChild("static-routes"));
+      extractAggregates(router, routerNode.getChild("aggregates"));
       extractOspf(router, routerNode.getChild("ospf"));
       extractIsis(router, routerNode.getChild("isis"));
       extractBgp(router, routerNode.getChild("bgp"));
@@ -452,6 +493,35 @@ public final class SrosFeatureExtractor {
             ROUTE_PREFERENCE_SPACE,
             "static-route preference")
         .ifPresent(route::setPreference);
+  }
+
+  /**
+   * Extract {@code router "Base" aggregates aggregate <prefix>} entries: the prefix, {@code
+   * summary-only}, and any {@code community} values. An aggregate installs as a discard summary
+   * route (preference 130) only when a contributing more-specific exists (see {@link Aggregate}).
+   */
+  private void extractAggregates(Router router, @Nullable SrosStatementTree aggregates) {
+    if (aggregates == null) {
+      return;
+    }
+    SrosStatementTree aggList = aggregates.getChild("aggregate");
+    if (aggList == null) {
+      return;
+    }
+    for (Map.Entry<String, SrosStatementTree> e : aggList.getChildren().entrySet()) {
+      SrosStatementTree aggNode = e.getValue();
+      Prefix prefix = toPrefix(e.getKey(), aggNode);
+      if (prefix == null) {
+        continue;
+      }
+      Aggregate agg = new Aggregate(prefix);
+      Boolean summaryOnly = toBoolean(aggNode.getChild("summary-only"), "aggregate summary-only");
+      agg.setSummaryOnly(firstNonNull(summaryOnly, Boolean.FALSE));
+      for (String c : policyNames(aggNode.getChild("community"))) {
+        agg.getCommunities().add(c);
+      }
+      router.getAggregates().add(agg);
+    }
   }
 
   /** The {@code type} leaf's value word (e.g. {@code through}/{@code range}), or {@code null}. */
@@ -764,6 +834,18 @@ public final class SrosFeatureExtractor {
       }
     }
 
+    SrosStatementTree asPaths = po.getChild("as-path");
+    if (asPaths != null) {
+      for (Map.Entry<String, SrosStatementTree> e : asPaths.getChildren().entrySet()) {
+        String name = unquote(e.getKey());
+        SrosStatementTree apNode = e.getValue();
+        AsPathList ap = new AsPathList(name);
+        String expr = singleValue(apNode, "expression");
+        ap.setExpression(expr == null ? null : unquote(expr));
+        _c.getAsPathLists().put(name, ap);
+      }
+    }
+
     SrosStatementTree prefixLists = po.getChild("prefix-list");
     if (prefixLists != null) {
       for (Map.Entry<String, SrosStatementTree> e : prefixLists.getChildren().entrySet()) {
@@ -877,6 +959,18 @@ public final class SrosFeatureExtractor {
                 entry.getFromProtocols().add(fp);
               }
             }
+            // from community name <name> — the route's communities must match the named list.
+            SrosStatementTree fromCommNode = navigate(entryNode, "from", "community");
+            String fromComm = fromCommNode == null ? null : singleValue(fromCommNode, "name");
+            if (fromComm != null) {
+              entry.getFromCommunities().add(unquote(fromComm));
+            }
+            // from as-path name <name> — the route's AS path must match the named as-path list.
+            SrosStatementTree fromApNode = navigate(entryNode, "from", "as-path");
+            String fromAsPath = fromApNode == null ? null : singleValue(fromApNode, "name");
+            if (fromAsPath != null) {
+              entry.getFromAsPaths().add(unquote(fromAsPath));
+            }
             SrosStatementTree action = entryNode.getChild("action");
             entry.setAction(
                 toEnum(
@@ -912,6 +1006,26 @@ public final class SrosFeatureExtractor {
             POLICY_METRIC_SPACE,
             "policy action metric")
         .ifPresent(entry::setSetMetric);
+
+    // metric add <n>
+    SrosStatementTree metricAdd = navigate(action, "metric", "add");
+    toLongInSpace(
+            singleKey(metricAdd),
+            metricAdd == null ? null : firstChild(metricAdd),
+            POLICY_METRIC_SPACE,
+            "policy action metric add")
+        .ifPresent(entry::setMetricAdd);
+
+    // local-preference <n>
+    toLongInSpace(
+            singleValue(action, "local-preference"),
+            singleValueNode(action, "local-preference"),
+            LOCAL_PREFERENCE_SPACE,
+            "policy action local-preference")
+        .ifPresent(entry::setSetLocalPreference);
+
+    // origin <igp|egp|incomplete>
+    entry.setSetOrigin(toEnum(action.getChild("origin"), ORIGIN_TYPE, "policy action origin"));
 
     // as-path-prepend as-path <asn> [repeat <n>]
     SrosStatementTree prepend = action.getChild("as-path-prepend");

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Aggregate.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Aggregate.java
@@ -1,0 +1,48 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.Prefix;
+
+/**
+ * An SR-OS {@code router "Base" aggregates aggregate <prefix>} entry: a summary route activated by
+ * a contributing more-specific route in the RIB. Models the subset that affects conversion: the
+ * prefix, {@code summary-only} (suppress the contributing more-specifics on export), and any {@code
+ * community} values attached to the aggregate.
+ *
+ * <p>Confirmed on SR-SIM 26.3.R1: the aggregate installs with protocol {@code aggregate},
+ * preference 130, as a discard route, only when a contributing route exists.
+ */
+public final class Aggregate implements Serializable {
+
+  /** SR-OS aggregate route preference (Batfish admin distance), device-confirmed. */
+  public static final int PREFERENCE = 130;
+
+  public Aggregate(Prefix prefix) {
+    _prefix = prefix;
+  }
+
+  public @Nonnull Prefix getPrefix() {
+    return _prefix;
+  }
+
+  /** Whether {@code summary-only} is set (advertise only the aggregate, suppress contributors). */
+  public boolean getSummaryOnly() {
+    return _summaryOnly;
+  }
+
+  public void setSummaryOnly(boolean summaryOnly) {
+    _summaryOnly = summaryOnly;
+  }
+
+  /** The {@code community} values attached to the aggregate (e.g. {@code 65001:100}). */
+  public @Nonnull List<String> getCommunities() {
+    return _communities;
+  }
+
+  private final @Nonnull Prefix _prefix;
+  private boolean _summaryOnly;
+  private final @Nonnull List<String> _communities = new ArrayList<>();
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/AsPathList.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/AsPathList.java
@@ -1,0 +1,33 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An SR-OS {@code policy-options as-path "<name>"} entry, keyed by name. Holds the {@code
+ * expression} — a regex over the AS path (e.g. {@code "65003"} matches a path containing AS 65003).
+ * A policy {@code from as-path name "<name>"} references this by name.
+ */
+public final class AsPathList implements Serializable {
+
+  public AsPathList(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** The {@code expression} regex over the AS path, or {@code null} if unset. */
+  public @Nullable String getExpression() {
+    return _expression;
+  }
+
+  public void setExpression(@Nullable String expression) {
+    _expression = expression;
+  }
+
+  private final @Nonnull String _name;
+  private @Nullable String _expression;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Lag.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Lag.java
@@ -1,0 +1,41 @@
+package org.batfish.vendor.sros.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * An SR-OS {@code lag "<name>"} (Link Aggregation Group). The LAG name matches {@code lag-.+} (e.g.
+ * {@code lag-1}) and a router interface binds it as a port. Models the subset that affects
+ * conversion: the LAG name, its admin-state, and the member port names — the LAG interface's
+ * bandwidth is the sum of its members' bandwidths.
+ */
+public final class Lag implements Serializable {
+
+  public Lag(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  /** Whether the LAG is {@code admin-state enable}; defaults true when absent. */
+  public boolean getAdminStateEnable() {
+    return _adminStateEnable;
+  }
+
+  public void setAdminStateEnable(boolean adminStateEnable) {
+    _adminStateEnable = adminStateEnable;
+  }
+
+  /** The member port paths (e.g. {@code 1/1/c1/1}), in configuration order. */
+  public @Nonnull List<String> getMemberPorts() {
+    return _memberPorts;
+  }
+
+  private final @Nonnull String _name;
+  private boolean _adminStateEnable = true;
+  private final @Nonnull List<String> _memberPorts = new ArrayList<>();
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatementEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/PolicyStatementEntry.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.OriginType;
 
 /**
  * One numbered entry of an SR-OS {@code policy-statement}, keyed by {@code entry-id}. Holds the
@@ -18,6 +19,8 @@ public final class PolicyStatementEntry implements Serializable {
     _entryId = entryId;
     _fromPrefixLists = new ArrayList<>();
     _fromProtocols = new ArrayList<>();
+    _fromCommunities = new ArrayList<>();
+    _fromAsPaths = new ArrayList<>();
     _communityAdds = new ArrayList<>();
   }
 
@@ -38,9 +41,46 @@ public final class PolicyStatementEntry implements Serializable {
     return _fromProtocols;
   }
 
+  /** The {@code from community name <name>} community-list names the route must match (ANDed). */
+  public @Nonnull List<String> getFromCommunities() {
+    return _fromCommunities;
+  }
+
+  /** The {@code from as-path name <name>} as-path-list names the route's AS path must match. */
+  public @Nonnull List<String> getFromAsPaths() {
+    return _fromAsPaths;
+  }
+
   /** The entry {@code action action-type}, or {@code null} if unset. */
   public @Nullable PolicyAction getAction() {
     return _action;
+  }
+
+  /** The {@code action local-preference <n>} value (BGP local-pref), or {@code null} if unset. */
+  public @Nullable Long getSetLocalPreference() {
+    return _setLocalPreference;
+  }
+
+  public void setSetLocalPreference(@Nullable Long setLocalPreference) {
+    _setLocalPreference = setLocalPreference;
+  }
+
+  /** The {@code action origin <igp|egp|incomplete>} value, or {@code null} if unset. */
+  public @Nullable OriginType getSetOrigin() {
+    return _setOrigin;
+  }
+
+  public void setSetOrigin(@Nullable OriginType setOrigin) {
+    _setOrigin = setOrigin;
+  }
+
+  /** The {@code action metric add <n>} value (added to the route's metric), or {@code null}. */
+  public @Nullable Long getMetricAdd() {
+    return _metricAdd;
+  }
+
+  public void setMetricAdd(@Nullable Long metricAdd) {
+    _metricAdd = metricAdd;
   }
 
   public void setAction(@Nullable PolicyAction action) {
@@ -82,8 +122,13 @@ public final class PolicyStatementEntry implements Serializable {
   private final long _entryId;
   private final @Nonnull List<String> _fromPrefixLists;
   private final @Nonnull List<FromProtocol> _fromProtocols;
+  private final @Nonnull List<String> _fromCommunities;
+  private final @Nonnull List<String> _fromAsPaths;
   private @Nullable PolicyAction _action;
   private @Nullable Long _setMetric;
+  private @Nullable Long _setLocalPreference;
+  private @Nullable OriginType _setOrigin;
+  private @Nullable Long _metricAdd;
   private @Nullable Long _asPathPrependAsn;
   private int _asPathPrependRepeat = 1;
   private final @Nonnull List<String> _communityAdds;

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/Router.java
@@ -19,6 +19,7 @@ public final class Router implements Serializable {
     _name = name;
     _interfaces = new HashMap<>();
     _staticRoutes = new ArrayList<>();
+    _aggregates = new ArrayList<>();
   }
 
   public @Nonnull String getName() {
@@ -42,6 +43,11 @@ public final class Router implements Serializable {
   /** The {@code static-routes route} entries in this router, in configuration order. */
   public @Nonnull List<StaticRoute> getStaticRoutes() {
     return _staticRoutes;
+  }
+
+  /** The {@code aggregates aggregate} entries in this router, in configuration order. */
+  public @Nonnull List<Aggregate> getAggregates() {
+    return _aggregates;
   }
 
   /** The BGP process for this router, or {@code null} if {@code bgp} is not configured. */
@@ -87,6 +93,7 @@ public final class Router implements Serializable {
   private @Nullable Long _autonomousSystem;
   private final @Nonnull Map<String, RouterInterface> _interfaces;
   private final @Nonnull List<StaticRoute> _staticRoutes;
+  private final @Nonnull List<Aggregate> _aggregates;
   private @Nullable BgpProcess _bgpProcess;
   private @Nullable OspfProcess _ospfProcess;
   private @Nullable IsisProcess _isisProcess;

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConfiguration.java
@@ -31,10 +31,12 @@ public final class SrosConfiguration extends VendorConfiguration {
     _statements = new ArrayList<>();
     _cards = new HashMap<>();
     _ports = new HashMap<>();
+    _lags = new HashMap<>();
     _routers = new HashMap<>();
     _prefixLists = new HashMap<>();
     _policyStatements = new HashMap<>();
     _communities = new HashMap<>();
+    _asPathLists = new HashMap<>();
   }
 
   /**
@@ -57,6 +59,11 @@ public final class SrosConfiguration extends VendorConfiguration {
     return _ports;
   }
 
+  /** Link aggregation groups, keyed by LAG name (e.g. {@code lag-1}). */
+  public @Nonnull Map<String, Lag> getLags() {
+    return _lags;
+  }
+
   /** Routing instances, keyed by router-name (e.g. {@code Base}). */
   public @Nonnull Map<String, Router> getRouters() {
     return _routers;
@@ -75,6 +82,11 @@ public final class SrosConfiguration extends VendorConfiguration {
   /** Routing-policy community lists, keyed by name. */
   public @Nonnull Map<String, Community> getCommunities() {
     return _communities;
+  }
+
+  /** Routing-policy as-path lists, keyed by name. */
+  public @Nonnull Map<String, AsPathList> getAsPathLists() {
+    return _asPathLists;
   }
 
   @Override
@@ -116,6 +128,7 @@ public final class SrosConfiguration extends VendorConfiguration {
       Vrf vrf = vrfForRouter(router.getName(), c);
       SrosConversions.convertInterfaces(this, router, c, vrf);
       SrosConversions.convertStaticRoutes(router, vrf, getWarnings());
+      SrosConversions.convertAggregates(router, vrf);
       SrosConversions.convertOspf(router, c, vrf, getWarnings());
       SrosConversions.convertIsis(router, c, vrf, getWarnings());
       SrosConversions.convertBgp(router, c, vrf, getWarnings());
@@ -159,10 +172,12 @@ public final class SrosConfiguration extends VendorConfiguration {
   private final @Nonnull List<String> _statements;
   private final @Nonnull Map<Integer, Card> _cards;
   private final @Nonnull Map<String, Port> _ports;
+  private final @Nonnull Map<String, Lag> _lags;
   private final @Nonnull Map<String, Router> _routers;
   private final @Nonnull Map<String, PrefixList> _prefixLists;
   private final @Nonnull Map<String, PolicyStatement> _policyStatements;
   private final @Nonnull Map<String, Community> _communities;
+  private final @Nonnull Map<String, AsPathList> _asPathLists;
   private @Nullable String _hostname;
   private @Nullable ConfigurationFormat _format;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -219,7 +219,7 @@ public final class SrosConversions {
       SrosConfiguration vc, PolicyStatement ps, Configuration c) {
     List<Statement> statements = new ArrayList<>();
     for (PolicyStatementEntry entry : ps.getEntries().values()) {
-      BooleanExpr guard = toGuard(entry, c);
+      BooleanExpr guard = toGuard(vc, entry, c);
       // On a match, apply the entry's set-clauses (metric/MED, as-path-prepend, community) before
       // its terminal action, so the modifications take effect on the matched route.
       List<Statement> onMatch = new ArrayList<>(setStatements(vc, entry));
@@ -253,6 +253,19 @@ public final class SrosConversions {
     List<Statement> statements = new ArrayList<>();
     if (entry.getSetMetric() != null) {
       statements.add(new SetMetric(new LiteralLong(entry.getSetMetric())));
+    }
+    if (entry.getMetricAdd() != null) {
+      statements.add(
+          new SetMetric(
+              new org.batfish.datamodel.routing_policy.expr.IncrementMetric(entry.getMetricAdd())));
+    }
+    if (entry.getSetLocalPreference() != null) {
+      statements.add(
+          new org.batfish.datamodel.routing_policy.statement.SetLocalPreference(
+              new LiteralLong(entry.getSetLocalPreference())));
+    }
+    if (entry.getSetOrigin() != null) {
+      statements.add(new SetOrigin(new LiteralOrigin(entry.getSetOrigin(), null)));
     }
     if (entry.getAsPathPrependAsn() != null) {
       List<AsExpr> ases = new ArrayList<>();
@@ -289,7 +302,8 @@ public final class SrosConversions {
    * disjunction over the named protocols). An entry with no modeled from-criteria matches
    * everything ({@link BooleanExprs#TRUE}).
    */
-  private static @Nonnull BooleanExpr toGuard(PolicyStatementEntry entry, Configuration c) {
+  private static @Nonnull BooleanExpr toGuard(
+      SrosConfiguration vc, PolicyStatementEntry entry, Configuration c) {
     List<BooleanExpr> conjuncts = new ArrayList<>();
 
     // from prefix-list [...] — OR over the (defined) referenced lists.
@@ -316,6 +330,48 @@ public final class SrosConversions {
     }
     if (!protocols.isEmpty()) {
       conjuncts.add(new MatchProtocol(protocols));
+    }
+
+    // from community name <name> — the route must carry any member of the named community list.
+    for (String commName : entry.getFromCommunities()) {
+      Community comm = vc.getCommunities().get(commName);
+      if (comm == null) {
+        continue;
+      }
+      List<org.batfish.datamodel.routing_policy.communities.CommunityMatchExpr> members =
+          new ArrayList<>();
+      for (String member : comm.getMembers()) {
+        members.add(
+            new org.batfish.datamodel.routing_policy.communities.CommunityIs(
+                StandardCommunity.parse(member)));
+      }
+      if (!members.isEmpty()) {
+        conjuncts.add(
+            new org.batfish.datamodel.routing_policy.communities.MatchCommunities(
+                InputCommunities.instance(),
+                new org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAny(
+                    members.stream()
+                        .map(
+                            m ->
+                                (org.batfish.datamodel.routing_policy.communities
+                                        .CommunitySetMatchExpr)
+                                    new org.batfish.datamodel.routing_policy.communities
+                                        .HasCommunity(m))
+                        .collect(ImmutableList.toImmutableList()))));
+      }
+    }
+
+    // from as-path name <name> — the route's AS path must match the named list's regex.
+    for (String apName : entry.getFromAsPaths()) {
+      AsPathList ap = vc.getAsPathLists().get(apName);
+      if (ap == null || ap.getExpression() == null) {
+        continue;
+      }
+      conjuncts.add(
+          org.batfish.datamodel.routing_policy.as_path.MatchAsPath.of(
+              org.batfish.datamodel.routing_policy.as_path.InputAsPath.instance(),
+              org.batfish.datamodel.routing_policy.as_path.AsPathMatchRegex.of(
+                  ap.getExpression())));
     }
 
     if (conjuncts.isEmpty()) {
@@ -697,6 +753,27 @@ public final class SrosConversions {
   }
 
   /**
+   * Converts a router instance's {@code aggregates} to VI {@link
+   * org.batfish.datamodel.GeneratedRoute}s on {@code vrf}. SR-OS installs an aggregate as a discard
+   * summary route (preference 130) only when a contributing more-specific exists; Batfish's
+   * generated-route mechanism has the same activation semantics (a generated route is installed
+   * only when a contributing route is present), so each aggregate maps to a discard generated route
+   * at admin distance 130. {@code summary-only}/{@code community} affect advertisement, not RIB
+   * installation, and are not modeled here.
+   */
+  static void convertAggregates(Router router, Vrf vrf) {
+    for (Aggregate agg : router.getAggregates()) {
+      vrf.getGeneratedRoutes()
+          .add(
+              org.batfish.datamodel.GeneratedRoute.builder()
+                  .setNetwork(agg.getPrefix())
+                  .setAdmin(Aggregate.PREFERENCE)
+                  .setDiscard(true)
+                  .build());
+    }
+  }
+
+  /**
    * Creates the addressless {@link InterfaceType#PHYSICAL} VI interface for an SR-OS port if it
    * does not already exist on {@code c}. This is the interface a user Layer-1 topology references;
    * the L3 router-interface binds to it. The port is admin-up unless its {@code admin-state} is
@@ -706,6 +783,38 @@ public final class SrosConversions {
   private static void ensurePortInterface(
       SrosConfiguration vc, String portPath, Configuration c, Vrf vrf) {
     if (c.getAllInterfaces().containsKey(portPath)) {
+      return;
+    }
+    // A LAG (lag-N): model it as an AGGREGATED interface whose member ports are AGGREGATE
+    // dependencies, so post-processing sums their bandwidth into the bundle. Each member port gets
+    // its own PHYSICAL interface and is marked as part of this channel-group; the LAG records its
+    // members as channel-group members. The channel-group linkage is what lets the logical-Layer-1
+    // computation collapse the members' physical edges into a single lag<->lag edge — without it,
+    // the two member edges look like two L1 neighbors and the dependency logic deactivates the LAG
+    // as an LACP failure. With it, the LAG gets a BIND dependency on its single logical neighbor
+    // and comes up when its members are up.
+    Lag lag = vc.getLags().get(portPath);
+    if (lag != null) {
+      for (String member : lag.getMemberPorts()) {
+        ensurePortInterface(vc, member, c, vrf);
+        Interface memberIface = c.getAllInterfaces().get(member);
+        if (memberIface != null) {
+          memberIface.setChannelGroup(portPath);
+        }
+      }
+      Interface lagIface =
+          Interface.builder()
+              .setName(portPath)
+              .setOwner(c)
+              .setVrf(vrf)
+              .setType(InterfaceType.AGGREGATED)
+              .setAdminUp(lag.getAdminStateEnable())
+              .setChannelGroupMembers(lag.getMemberPorts())
+              .build();
+      lagIface.setDependencies(
+          lag.getMemberPorts().stream()
+              .map(m -> new Interface.Dependency(m, Interface.DependencyType.AGGREGATE))
+              .collect(ImmutableList.toImmutableList()));
       return;
     }
     Port port = vc.getPorts().get(portPath);

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
@@ -315,6 +316,26 @@ public final class SrosConversionTest {
   }
 
   /**
+   * Multi-area OSPF (ABR): two areas convert to two VI {@link
+   * org.batfish.datamodel.ospf.OspfArea}s, with each interface attached to its configured area.
+   * Batfish's dataplane computes the inter-area routes from this (device-confirmed in the
+   * sros_ospf_multiarea lab).
+   */
+  @Test
+  public void testOspfMultiAreaConversion() throws IOException {
+    Configuration c = parseConfig("ospf_multiarea.txt");
+    org.batfish.datamodel.ospf.OspfProcess proc = c.getDefaultVrf().getOspfProcesses().get("0");
+    assertNotNull(proc);
+    // Two areas: backbone 0.0.0.0 (= 0L) and 0.0.0.1 (= 1L).
+    assertThat(proc.getAreas(), hasKey(0L));
+    assertThat(proc.getAreas(), hasKey(1L));
+    assertThat(proc.getAreas().get(0L).getInterfaces(), containsInAnyOrder("system", "to-r2"));
+    assertThat(proc.getAreas().get(1L).getInterfaces(), containsInAnyOrder("to-r3"));
+    // The to-r3 interface is in area 1, making this router an ABR.
+    assertThat(c.getAllInterfaces().get("to-r3").getOspfSettings().getAreaName(), equalTo(1L));
+  }
+
+  /**
    * IS-IS conversion: a VI IsisProcess with the NET built from area-address + system-id + 00, a
    * level-2 process, and per-interface settings (point-to-point, passive mode). SR-OS L2 internal
    * admin distance is 18 (set via the NOKIA_SROS RoutingProtocol default).
@@ -571,6 +592,98 @@ public final class SrosConversionTest {
                         hasMetric(20L))))));
     // The route whose next-hop has no admin-state is not installed (SR-OS leaves it out of the
     // RIB), so 100.64.0.0/24 is absent (containsInAnyOrder is exhaustive).
+  }
+
+  /**
+   * An {@code aggregates aggregate} converts to a discard {@link
+   * org.batfish.datamodel.GeneratedRoute} at admin distance 130 (SR-OS aggregate preference). It is
+   * generated only when a contributing more-specific exists — Batfish's generated-route semantics.
+   */
+  @Test
+  public void testAggregateConversion() throws IOException {
+    Configuration c = parseConfig("aggregate.txt");
+    java.util.Set<org.batfish.datamodel.GeneratedRoute> generated =
+        c.getDefaultVrf().getGeneratedRoutes();
+    assertThat(generated, hasSize(1));
+    org.batfish.datamodel.GeneratedRoute agg = generated.iterator().next();
+    assertThat(agg.getNetwork(), equalTo(Prefix.parse("10.100.0.0/16")));
+    assertThat(agg.getAdministrativeCost(), equalTo(130L));
+    assertTrue(agg.getDiscard());
+  }
+
+  /**
+   * A {@code lag} bound to a router interface converts to an AGGREGATED VI interface with AGGREGATE
+   * dependencies on its member ports, so post-processing sums their bandwidth into the bundle. The
+   * L3 router-interface binds the LAG interface (the port/router-interface split).
+   */
+  @Test
+  public void testLagConversion() throws IOException {
+    Configuration c = parseConfig("lag.txt");
+    Interface lag = c.getAllInterfaces().get("lag-1");
+    assertNotNull(lag);
+    assertThat(lag.getInterfaceType(), equalTo(InterfaceType.AGGREGATED));
+    assertThat(
+        lag.getDependencies(),
+        containsInAnyOrder(
+            new Interface.Dependency("1/1/c1/1", Interface.DependencyType.AGGREGATE),
+            new Interface.Dependency("1/1/c2/1", Interface.DependencyType.AGGREGATE)));
+    // The member ports exist as PHYSICAL interfaces.
+    assertThat(
+        c.getAllInterfaces().get("1/1/c1/1").getInterfaceType(), equalTo(InterfaceType.PHYSICAL));
+    // The L3 router-interface binds the LAG (BIND dependency on lag-1).
+    Interface toPeer = c.getAllInterfaces().get("to-peer");
+    assertThat(toPeer.getConcreteAddress().toString(), equalTo("10.0.0.0/31"));
+    assertThat(
+        toPeer.getDependencies(),
+        hasItem(new Interface.Dependency("lag-1", Interface.DependencyType.BIND)));
+  }
+
+  /**
+   * Comprehensive import policy conversion, evaluated behaviorally: entry 10 ({@code from
+   * community}) accepts a 65002:100-tagged route and sets local-preference 250 + adds community
+   * 65001:777; entry 20 ({@code from as-path}) accepts a route whose AS path contains 65003 and
+   * adds 33 to its metric with origin IGP.
+   */
+  @Test
+  public void testComprehensivePolicyConversion() throws IOException {
+    Configuration c = parseConfig("policy_comprehensive.txt");
+    RoutingPolicy policy = c.getRoutingPolicies().get("import-rich");
+    assertNotNull(policy);
+
+    // entry 10: a route with community 65002:100 -> accept, local-pref 250, +community 65001:777.
+    Bgpv4Route inComm =
+        Bgpv4Route.testBuilder()
+            .setNetwork(Prefix.parse("2.2.2.2/32"))
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(org.batfish.datamodel.OriginType.IGP)
+            .setProtocol(org.batfish.datamodel.RoutingProtocol.BGP)
+            .setCommunities(
+                org.batfish.datamodel.routing_policy.communities.CommunitySet.of(
+                    org.batfish.datamodel.bgp.community.StandardCommunity.parse("65002:100")))
+            .build();
+    Bgpv4Route.Builder outComm = inComm.toBuilder();
+    assertTrue(policy.process(inComm, outComm, Environment.Direction.IN));
+    Bgpv4Route rComm = outComm.build();
+    assertThat(rComm.getLocalPreference(), equalTo(250L));
+    assertThat(
+        rComm.getCommunities().getCommunities(),
+        hasItem(org.batfish.datamodel.bgp.community.StandardCommunity.parse("65001:777")));
+
+    // entry 20: a route whose AS path contains 65003 -> accept, metric += 33, origin IGP.
+    Bgpv4Route inAsp =
+        Bgpv4Route.testBuilder()
+            .setNetwork(Prefix.parse("100.64.0.1/32"))
+            .setOriginatorIp(Ip.parse("2.2.2.2"))
+            .setOriginType(org.batfish.datamodel.OriginType.EGP)
+            .setProtocol(org.batfish.datamodel.RoutingProtocol.BGP)
+            .setAsPath(org.batfish.datamodel.AsPath.ofSingletonAsSets(65003L))
+            .setMetric(10L)
+            .build();
+    Bgpv4Route.Builder outAsp = inAsp.toBuilder();
+    assertTrue(policy.process(inAsp, outAsp, Environment.Direction.IN));
+    Bgpv4Route rAsp = outAsp.build();
+    assertThat(rAsp.getMetric(), equalTo(43L));
+    assertThat(rAsp.getOriginType(), equalTo(org.batfish.datamodel.OriginType.IGP));
   }
 
   private @Nonnull Configuration parseConfig(String filename) throws IOException {

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosExtractionTest.java
@@ -194,6 +194,60 @@ public final class SrosExtractionTest {
         ImmutableSet.of(ecmp1.getMetric(), ecmp2.getMetric()), equalTo(ImmutableSet.of(10, 20)));
   }
 
+  /** aggregates extraction: the aggregate prefix and its {@code summary-only} flag. */
+  @Test
+  public void testAggregateExtraction() {
+    SrosConfiguration vc = parseVendorConfig("aggregate.txt");
+    assertThat(vc.getWarnings().getParseWarnings(), empty());
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    List<org.batfish.vendor.sros.representation.Aggregate> aggs =
+        vc.getRouters().get("Base").getAggregates();
+    assertThat(aggs, hasSize(1));
+    assertThat(aggs.get(0).getPrefix(), equalTo(Prefix.parse("10.100.0.0/16")));
+    assertThat(aggs.get(0).getSummaryOnly(), equalTo(true));
+  }
+
+  /**
+   * Comprehensive policy extraction: {@code from community name}, {@code from as-path name}, and
+   * the {@code action} clauses local-preference / metric add / origin; plus the as-path list
+   * expression.
+   */
+  @Test
+  public void testComprehensivePolicyExtraction() {
+    SrosConfiguration vc = parseVendorConfig("policy_comprehensive.txt");
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    assertThat(vc.getAsPathLists(), hasKey("via-65003"));
+    assertThat(vc.getAsPathLists().get("via-65003").getExpression(), equalTo("65003"));
+
+    PolicyStatement ps = vc.getPolicyStatements().get("import-rich");
+    PolicyStatementEntry e10 = ps.getEntries().get(10L);
+    assertThat(e10.getFromCommunities(), contains("from-r2-100"));
+    assertThat(e10.getSetLocalPreference(), equalTo(250L));
+    assertThat(e10.getCommunityAdds(), contains("tag-local"));
+
+    PolicyStatementEntry e20 = ps.getEntries().get(20L);
+    assertThat(e20.getFromAsPaths(), contains("via-65003"));
+    assertThat(e20.getMetricAdd(), equalTo(33L));
+    assertThat(e20.getSetOrigin(), equalTo(org.batfish.datamodel.OriginType.IGP));
+
+    assertThat(ps.getDefaultAction(), equalTo(PolicyAction.ACCEPT));
+  }
+
+  /** LAG extraction: the lag name, admin-state, and its member ports. */
+  @Test
+  public void testLagExtraction() {
+    SrosConfiguration vc = parseVendorConfig("lag.txt");
+    assertThat(vc.getWarnings().getParseWarnings(), empty());
+    assertThat(vc.getWarnings().getRedFlagWarnings(), empty());
+    assertThat(vc.getLags(), hasKey("lag-1"));
+    org.batfish.vendor.sros.representation.Lag lag = vc.getLags().get("lag-1");
+    assertThat(lag.getAdminStateEnable(), equalTo(true));
+    assertThat(lag.getMemberPorts(), containsInAnyOrder("1/1/c1/1", "1/1/c2/1"));
+    // The router interface binds the LAG by name.
+    assertThat(
+        vc.getRouters().get("Base").getInterfaces().get("to-peer").getPort(), equalTo("lag-1"));
+  }
+
   /**
    * Policy set-clause + community-list + prefix-list-bound extraction: {@code action metric set},
    * {@code as-path-prepend as-path/repeat}, {@code community add}, a {@code community} list, and

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/aggregate.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/aggregate.txt
@@ -1,0 +1,18 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        aggregates {
+            aggregate 10.100.0.0/16 {
+                summary-only true
+            }
+        }
+        static-routes {
+            route 10.100.1.0/24 route-type unicast {
+                blackhole {
+                    admin-state enable
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/lag.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/lag.txt
@@ -1,0 +1,50 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    card 1 {
+        card-type iom-1
+        mda 1 {
+            mda-type me6-100gb-qsfp28
+        }
+    }
+    port 1/1/c1 {
+        admin-state enable
+        connector {
+            breakout c1-100g
+        }
+    }
+    port 1/1/c1/1 {
+        admin-state enable
+    }
+    port 1/1/c2 {
+        admin-state enable
+        connector {
+            breakout c1-100g
+        }
+    }
+    port 1/1/c2/1 {
+        admin-state enable
+    }
+    lag "lag-1" {
+        admin-state enable
+        lacp {
+            mode active
+            administrative-key 1
+        }
+        port 1/1/c1/1 {
+        }
+        port 1/1/c2/1 {
+        }
+    }
+    router "Base" {
+        interface "to-peer" {
+            port lag-1
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                    prefix-length 31
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/ospf_multiarea.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/ospf_multiarea.txt
@@ -1,0 +1,49 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    router "Base" {
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+        interface "to-r2" {
+            port 1/1/c1/1
+            ipv4 {
+                primary {
+                    address 10.0.0.0
+                    prefix-length 31
+                }
+            }
+        }
+        interface "to-r3" {
+            port 1/1/c2/1
+            ipv4 {
+                primary {
+                    address 10.0.1.0
+                    prefix-length 31
+                }
+            }
+        }
+        ospf 0 {
+            admin-state enable
+            router-id 1.1.1.1
+            area 0.0.0.0 {
+                interface "system" {
+                    interface-type point-to-point
+                }
+                interface "to-r2" {
+                    interface-type point-to-point
+                }
+            }
+            area 0.0.0.1 {
+                interface "to-r3" {
+                    interface-type point-to-point
+                }
+            }
+        }
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/policy_comprehensive.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/policy_comprehensive.txt
@@ -1,0 +1,48 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    policy-options {
+        community "from-r2-100" {
+            member "65002:100"
+        }
+        community "tag-local" {
+            member "65001:777"
+        }
+        as-path "via-65003" {
+            expression "65003"
+        }
+        policy-statement "import-rich" {
+            entry 10 {
+                from {
+                    community {
+                        name "from-r2-100"
+                    }
+                }
+                action {
+                    action-type accept
+                    local-preference 250
+                    community {
+                        add ["tag-local"]
+                    }
+                }
+            }
+            entry 20 {
+                from {
+                    as-path {
+                        name "via-65003"
+                    }
+                }
+                action {
+                    action-type accept
+                    metric {
+                        add 33
+                    }
+                    origin igp
+                }
+            }
+            default-action {
+                action-type accept
+            }
+        }
+    }
+}


### PR DESCRIPTION
Four more SR-OS feature areas on top of the merged P9 work (#9992), each modeled
against a live SR-SIM 26.3.R1 lab and validated route-for-route in the sibling
lab-validation repo.

**Aggregate routes** — `router "Base" aggregates aggregate <prefix>` → a discard
`GeneratedRoute` at admin 130. Batfish's generated-route activation matches SR-OS
(installed only with a contributing more-specific); device-confirmed that the
peer learns the /16 aggregate but not the /24 contributors under `summary-only`.

**LAG** — `lag "<name>"` → an `AGGREGATED` interface with `AGGREGATE` member
dependencies and channel-group members; the members' `channelGroup` is set so the
logical-L1 computation collapses the per-member edges into one `lag`↔`lag` edge
and the LAG comes up via a BIND dependency rather than an LACP failure. (Device
note: `lacp mode active` requires a mandatory `administrative-key`.)

**Multi-area OSPF** — no conversion change needed (the existing area loop handles
N areas / ABR); added tests proving a two-area config → two VI `OspfArea`s.
(OSPF `export-policy` redistribution into OSPF did not originate AS-external LSAs
on SR-SIM 26.3.R1, so E1/E2 is left unmodeled and documented.)

**Policy depth** — `from community` / `from as-path` matching (named community /
as-path lists; adds an `AsPathList` model), and the actions `local-preference`,
`metric add`, and `origin`.

Each feature has extraction + conversion unit tests; the comprehensive policy and
multi-area cases are tested behaviorally. SR-OS Java suite + PMD + checkstyle +
buildifier clean. Validated green across the three new lab-validation labs
(sros_aggregate, sros_ospf_multiarea, sros_policy_depth) plus no regression on the
14 existing SR-OS labs. Vendor guide updated.
