### PR TITLE
sros: derive IS-IS system-id, honor OSPF preference and IS-IS interface metric

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosFeatureExtractor.java
@@ -581,6 +581,9 @@ public final class SrosFeatureExtractor {
   /** OSPF interface {@code metric} (cost): YANG {@code uint32 range "1..65535"}. */
   private static final IntegerSpace OSPF_METRIC_SPACE = IntegerSpace.of(new SubRange(1, 65535));
 
+  /** IS-IS interface {@code metric}: YANG wide-metric {@code uint32 range "1..16777215"}. */
+  private static final IntegerSpace ISIS_METRIC_SPACE = IntegerSpace.of(new SubRange(1, 16777215));
+
   /** OSPF {@code interface-type} enumeration (the modeled subset). */
   private static final Map<String, OspfAreaInterface.InterfaceType> OSPF_INTERFACE_TYPE =
       ImmutableMap.of(
@@ -624,6 +627,13 @@ public final class SrosFeatureExtractor {
     Boolean adminUp = toEnum(ospfNode.getChild("admin-state"), ADMIN_STATE, "admin-state");
     // admin-state defaults to enable for an OSPF/IS-IS process: enabled unless explicitly disable.
     proc.setAdminStateEnable(firstNonNull(adminUp, Boolean.TRUE));
+    // OSPF route preference (admin distance) for internal routes; SR-OS default 10.
+    toIntegerInSpace(
+            singleValue(ospfNode, "preference"),
+            singleValueNode(ospfNode, "preference"),
+            ROUTE_PREFERENCE_SPACE,
+            "ospf preference")
+        .ifPresent(proc::setPreference);
 
     SrosStatementTree areaList = ospfNode.getChild("area");
     if (areaList != null) {
@@ -694,6 +704,25 @@ public final class SrosFeatureExtractor {
             toEnum(ifNode.getChild("interface-type"), ISIS_INTERFACE_TYPE, "isis interface-type"));
         Boolean passive = toBoolean(ifNode.getChild("passive"), "isis interface passive");
         isisIf.setPassive(firstNonNull(passive, Boolean.FALSE));
+        // Metric is configured per level (`interface "<name>" level <N> metric <M>`); SR-OS has no
+        // interface-wide metric leaf. Extract each level's metric independently; the default 10
+        // applies per level in conversion when unset.
+        SrosStatementTree ifLevelList = ifNode.getChild("level");
+        if (ifLevelList != null) {
+          for (int lvl : new int[] {1, 2}) {
+            SrosStatementTree levelNode = ifLevelList.getChild(Integer.toString(lvl));
+            if (levelNode == null) {
+              continue;
+            }
+            int metricLevel = lvl;
+            toIntegerInSpace(
+                    singleValue(levelNode, "metric"),
+                    singleValueNode(levelNode, "metric"),
+                    ISIS_METRIC_SPACE,
+                    "isis interface metric")
+                .ifPresent(m -> isisIf.setMetric(metricLevel, m));
+          }
+        }
         proc.getInterfaces().put(ifName, isisIf);
       }
     }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/IsisProcessInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/IsisProcessInterface.java
@@ -44,7 +44,26 @@ public final class IsisProcessInterface implements Serializable {
     _interfaceType = interfaceType;
   }
 
+  /**
+   * The IS-IS interface IPv4 {@code metric} for the given level (the SR-OS {@code interface level
+   * <N> metric} leaf), or {@code null} when unset (then the SR-OS default of 10 applies at
+   * conversion). SR-OS has no interface-wide metric leaf — metric is configured per level.
+   */
+  public @Nullable Integer getMetric(int level) {
+    return level == 1 ? _level1Metric : _level2Metric;
+  }
+
+  public void setMetric(int level, @Nullable Integer metric) {
+    if (level == 1) {
+      _level1Metric = metric;
+    } else {
+      _level2Metric = metric;
+    }
+  }
+
   private final @Nonnull String _name;
   private boolean _passive;
   private @Nullable InterfaceType _interfaceType;
+  private @Nullable Integer _level1Metric;
+  private @Nullable Integer _level2Metric;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/OspfProcess.java
@@ -43,6 +43,19 @@ public final class OspfProcess implements Serializable {
     _adminStateEnable = adminStateEnable;
   }
 
+  /**
+   * The configured route {@code preference} (admin distance) for internal OSPF routes, or {@code
+   * null} when unset (then the SR-OS default of 10 applies). The lab raises this above the IS-IS
+   * preference (18) to make IS-IS the preferred IGP.
+   */
+  public @Nullable Integer getPreference() {
+    return _preference;
+  }
+
+  public void setPreference(@Nullable Integer preference) {
+    _preference = preference;
+  }
+
   /** OSPF areas, keyed by area-id (a dotted-quad string as configured, e.g. {@code 0.0.0.0}). */
   public @Nonnull Map<String, OspfArea> getAreas() {
     return _areas;
@@ -51,5 +64,6 @@ public final class OspfProcess implements Serializable {
   private final int _instance;
   private @Nullable Ip _routerId;
   private boolean _adminStateEnable = true;
+  private @Nullable Integer _preference;
   private final @Nonnull Map<String, OspfArea> _areas;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -528,8 +528,9 @@ public final class SrosConversions {
             .setRouterId(routerId)
             .setReferenceBandwidth(OSPF_REFERENCE_BANDWIDTH)
             // SR-OS OSPF route preference (admin distance): internal (intra/inter-area, summary)
-            // default 10, external default 150 — not the Cisco 110/110.
-            .setAdminCosts(OSPF_ADMIN_COSTS)
+            // default 10, external default 150 — not the Cisco 110/110. An explicit `preference`
+            // overrides the internal default (the lab raises it to 20 so IS-IS, pref 18, wins).
+            .setAdminCosts(ospfAdminCosts(proc.getPreference()))
             .setAreas(ImmutableMap.of())
             .setVrf(vrf)
             .build();
@@ -586,9 +587,18 @@ public final class SrosConversions {
       return;
     }
     String systemId = proc.getSystemId();
+    if (systemId == null) {
+      // SR OS derives the IS-IS system-id from the system interface IPv4 address when it is not
+      // explicitly configured: each of the four octets is zero-padded to three decimal digits and
+      // the resulting twelve digits are regrouped as XXXX.XXXX.XXXX (e.g. 10.10.10.10 ->
+      // 010.010.010.010 -> 0100.1001.0010). Confirmed live on SR-SIM 26.3.R1 (sros_services lab).
+      systemId = deriveIsisSystemId(systemInterfaceIp(router));
+    }
     if (systemId == null || proc.getAreaAddresses().isEmpty()) {
       w.redFlagf(
-          "router '%s' IS-IS has no system-id or area-address; skipping IS-IS", router.getName());
+          "router '%s' IS-IS has no system-id (and none derivable from the system interface) or no"
+              + " area-address; skipping IS-IS",
+          router.getName());
       return;
     }
     // NET = <area-address>.<system-id>.00 (e.g. 49.0001.0100.1000.0001.00). Build the IsoAddress
@@ -631,8 +641,6 @@ public final class SrosConversions {
           isisIf.getPassive()
               ? org.batfish.datamodel.isis.IsisInterfaceMode.PASSIVE
               : org.batfish.datamodel.isis.IsisInterfaceMode.ACTIVE;
-      org.batfish.datamodel.isis.IsisInterfaceLevelSettings levelSettings =
-          org.batfish.datamodel.isis.IsisInterfaceLevelSettings.builder().setMode(mode).build();
       org.batfish.datamodel.isis.IsisInterfaceSettings.Builder ifSettings =
           org.batfish.datamodel.isis.IsisInterfaceSettings.builder()
               .setIsoAddress(netAddress)
@@ -640,14 +648,27 @@ public final class SrosConversions {
                   isisIf.getInterfaceType()
                       == org.batfish.vendor.sros.representation.IsisProcessInterface.InterfaceType
                           .POINT_TO_POINT);
+      // The metric is per level; SR-OS default is 10 (wide metrics) when a level's is unset.
       if (level1) {
-        ifSettings.setLevel1(levelSettings);
+        ifSettings.setLevel1(isisLevelSettings(mode, isisIf.getMetric(1)));
       }
       if (level2) {
-        ifSettings.setLevel2(levelSettings);
+        ifSettings.setLevel2(isisLevelSettings(mode, isisIf.getMetric(2)));
       }
       viIface.setIsis(ifSettings.build());
     }
+  }
+
+  /**
+   * Builds the VI per-level IS-IS interface settings: the given mode and the configured metric, or
+   * the SR-OS default of 10 (wide metrics) when the level's metric is unset.
+   */
+  private static org.batfish.datamodel.isis.IsisInterfaceLevelSettings isisLevelSettings(
+      org.batfish.datamodel.isis.IsisInterfaceMode mode, @Nullable Integer metric) {
+    return org.batfish.datamodel.isis.IsisInterfaceLevelSettings.builder()
+        .setMode(mode)
+        .setCost(metric == null ? ISIS_DEFAULT_METRIC : (long) metric)
+        .build();
   }
 
   /**
@@ -676,18 +697,31 @@ public final class SrosConversions {
   /** OSPF default {@code reference-bandwidth}: 100,000,000 kilobps (100 Gbps), expressed in bps. */
   private static final double OSPF_REFERENCE_BANDWIDTH = 100E9D;
 
+  /** SR-OS default IS-IS interface metric (wide metrics). */
+  private static final long ISIS_DEFAULT_METRIC = 10L;
+
+  /** SR-OS default OSPF internal route preference (intra-area, inter-area, internal summary). */
+  private static final int OSPF_DEFAULT_INTERNAL_PREFERENCE = 10;
+
+  /** SR-OS default OSPF external route preference (E1/E2). */
+  private static final int OSPF_DEFAULT_EXTERNAL_PREFERENCE = 150;
+
   /**
-   * SR-OS OSPF route preferences (Batfish admin distances): internal routes (intra-area,
-   * inter-area, internal summary) default to {@code preference} 10; external routes (E1/E2) default
-   * to {@code external-preference} 150.
+   * SR-OS OSPF route preferences (Batfish admin distances) for a process: internal routes
+   * (intra-area, inter-area, internal summary) use the configured {@code preference} (default 10);
+   * external routes (E1/E2) use the {@code external-preference} default 150. Not the Cisco 110/110.
    */
-  private static final java.util.Map<RoutingProtocol, Integer> OSPF_ADMIN_COSTS =
-      ImmutableMap.of(
-          RoutingProtocol.OSPF, 10,
-          RoutingProtocol.OSPF_IA, 10,
-          RoutingProtocol.OSPF_IS, 10,
-          RoutingProtocol.OSPF_E1, 150,
-          RoutingProtocol.OSPF_E2, 150);
+  private static java.util.Map<RoutingProtocol, Integer> ospfAdminCosts(
+      @Nullable Integer internalPreference) {
+    int internal =
+        internalPreference == null ? OSPF_DEFAULT_INTERNAL_PREFERENCE : internalPreference;
+    return ImmutableMap.of(
+        RoutingProtocol.OSPF, internal,
+        RoutingProtocol.OSPF_IA, internal,
+        RoutingProtocol.OSPF_IS, internal,
+        RoutingProtocol.OSPF_E1, OSPF_DEFAULT_EXTERNAL_PREFERENCE,
+        RoutingProtocol.OSPF_E2, OSPF_DEFAULT_EXTERNAL_PREFERENCE);
+  }
 
   /**
    * The OSPF cost for an interface: an explicit {@code metric} wins; a loopback is 0; otherwise the
@@ -1052,6 +1086,25 @@ public final class SrosConversions {
   private static @Nullable Ip systemInterfaceIp(Router router) {
     RouterInterface system = router.getInterfaces().get("system");
     return system == null ? null : system.getPrimaryAddress();
+  }
+
+  /**
+   * Derives the IS-IS system-id from an IPv4 address the way SR OS does when {@code system-id} is
+   * not explicitly configured: zero-pad each octet to three decimal digits, concatenate the twelve
+   * digits, and regroup as {@code XXXX.XXXX.XXXX} (e.g. {@code 10.10.10.10} -> {@code
+   * 0100.1001.0010}). Returns {@code null} if {@code ip} is null.
+   */
+  @VisibleForTesting
+  static @Nullable String deriveIsisSystemId(@Nullable Ip ip) {
+    if (ip == null) {
+      return null;
+    }
+    long bits = ip.asLong();
+    String digits =
+        String.format(
+            "%03d%03d%03d%03d",
+            (bits >> 24) & 0xFF, (bits >> 16) & 0xFF, (bits >> 8) & 0xFF, bits & 0xFF);
+    return digits.substring(0, 4) + "." + digits.substring(4, 8) + "." + digits.substring(8, 12);
   }
 
   static @Nonnull String generatedBgpPeerImportPolicyName(String router, String peer) {

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -300,8 +300,14 @@ public final class SrosConversionTest {
     org.batfish.datamodel.ospf.OspfProcess proc = c.getDefaultVrf().getOspfProcesses().get("0");
     assertNotNull(proc);
     assertThat(proc.getRouterId(), equalTo(Ip.parse("1.1.1.1")));
-    // SR-OS OSPF internal route preference is 10 (not the Cisco 110).
-    assertThat(proc.getAdminCosts().get(org.batfish.datamodel.RoutingProtocol.OSPF), equalTo(10));
+    // The configured `preference 20` becomes the internal OSPF admin distance (default would be
+    // 10); this lab raises it above the IS-IS preference (18) so IS-IS is the preferred IGP.
+    assertThat(proc.getAdminCosts().get(org.batfish.datamodel.RoutingProtocol.OSPF), equalTo(20));
+    assertThat(
+        proc.getAdminCosts().get(org.batfish.datamodel.RoutingProtocol.OSPF_IA), equalTo(20));
+    // External preference is unchanged at the SR-OS default 150.
+    assertThat(
+        proc.getAdminCosts().get(org.batfish.datamodel.RoutingProtocol.OSPF_E2), equalTo(150));
     assertThat(proc.getAreas(), hasKey(0L));
     assertThat(proc.getAreas().get(0L).getInterfaces(), containsInAnyOrder("system", "to-r3"));
 
@@ -360,11 +366,46 @@ public final class SrosConversionTest {
     assertThat(
         toR3.getIsis().getLevel2().getMode(),
         equalTo(org.batfish.datamodel.isis.IsisInterfaceMode.ACTIVE));
+    // The explicit `level 2 metric 100` becomes the level-2 IS-IS cost (default would be 10).
+    assertThat(toR3.getIsis().getLevel2().getCost(), equalTo(100L));
+    // No level-1 process (level-capability 2), so no level-1 interface settings.
+    assertThat(toR3.getIsis().getLevel1(), nullValue());
     Interface system = c.getAllInterfaces().get("system");
     assertNotNull(system.getIsis());
     assertThat(
         system.getIsis().getLevel2().getMode(),
         equalTo(org.batfish.datamodel.isis.IsisInterfaceMode.PASSIVE));
+  }
+
+  /**
+   * IS-IS interface metric is configured per level; each level's metric is applied independently
+   * and a level with no configured metric falls back to the SR-OS default of 10. Here {@code level
+   * 1 metric 30} and {@code level 2 metric 100} on a level-1-and-2-capable process must produce
+   * distinct per-level costs (not the level-2 value on both).
+   */
+  @Test
+  public void testIsisPerLevelMetric() throws IOException {
+    Configuration c = parseConfig("isis_per_level_metric.txt");
+    Interface toR3 = c.getAllInterfaces().get("to-r3");
+    assertNotNull(toR3.getIsis());
+    assertThat(toR3.getIsis().getLevel1().getCost(), equalTo(30L));
+    assertThat(toR3.getIsis().getLevel2().getCost(), equalTo(100L));
+  }
+
+  /**
+   * IS-IS conversion when {@code system-id} is not explicitly configured: SR OS derives it from the
+   * system interface IPv4 address (10.10.10.10 -> 0100.1001.0010). Confirmed live on SR-SIM 26.3.R1
+   * (the Nokia service_config_qrg lab omits system-id on all six routers).
+   */
+  @Test
+  public void testIsisDerivedSystemId() throws IOException {
+    Configuration c = parseConfig("isis_derived_system_id.txt");
+    org.batfish.datamodel.isis.IsisProcess proc = c.getDefaultVrf().getIsisProcess();
+    assertNotNull(proc);
+    // NET = 49.0000 (area) + 0100.1001.0010 (derived from 10.10.10.10) + 00 (n-sel).
+    assertThat(
+        proc.getNetAddress(),
+        equalTo(new org.batfish.datamodel.IsoAddress("49.0000.0100.1001.0010.00")));
   }
 
   /** VPRN conversion: a {@code service vprn "red"} becomes a separate VRF holding its interface. */

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/isis_derived_system_id.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/isis_derived_system_id.txt
@@ -5,16 +5,16 @@ configure {
         interface "system" {
             ipv4 {
                 primary {
-                    address 1.1.1.1
+                    address 10.10.10.10
                     prefix-length 32
                 }
             }
         }
-        interface "to-r3" {
+        interface "to-pe1" {
             port 1/1/c1/1
             ipv4 {
                 primary {
-                    address 10.0.1.0
+                    address 172.16.10.0
                     prefix-length 31
                 }
             }
@@ -22,16 +22,12 @@ configure {
         isis 0 {
             admin-state enable
             level-capability 2
-            system-id 0100.1000.0001
-            area-address [49.0001]
+            area-address [49.0000]
             interface "system" {
                 passive true
             }
-            interface "to-r3" {
+            interface "to-pe1" {
                 interface-type point-to-point
-                level 2 {
-                    metric 100
-                }
             }
         }
     }

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/isis_per_level_metric.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/isis_per_level_metric.txt
@@ -21,14 +21,14 @@ configure {
         }
         isis 0 {
             admin-state enable
-            level-capability 2
+            level-capability 1/2
             system-id 0100.1000.0001
             area-address [49.0001]
-            interface "system" {
-                passive true
-            }
             interface "to-r3" {
                 interface-type point-to-point
+                level 1 {
+                    metric 30
+                }
                 level 2 {
                     metric 100
                 }

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/ospf.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/ospf.txt
@@ -22,6 +22,7 @@ configure {
         ospf 0 {
             admin-state enable
             router-id 1.1.1.1
+            preference 20
             area 0.0.0.0 {
                 interface "system" {
                     interface-type point-to-point


### PR DESCRIPTION
Three underlay-model gaps surfaced by the Nokia service_config_qrg lab (the
combined 4-PE/2-P topology from github.com/nokia/sros-docs-lab), all confirmed
against live SR-SIM 26.3.R1 ground truth:

- IS-IS system-id auto-derivation. The Nokia configs set no explicit
  `system-id`, so SR OS derives it from the system interface IPv4 address
  (each octet zero-padded to three digits, regrouped as XXXX.XXXX.XXXX, e.g.
  10.10.10.10 -> 0100.1001.0010). Conversion previously skipped IS-IS entirely
  when system-id was absent; now it derives one when the system interface has
  an address.

- OSPF `preference`. Extracted and used as the internal-route admin distance
  (was hardcoded to the SR-OS default 10). The lab raises OSPF preference to 20
  so IS-IS (preference 18) is the preferred IGP; without this the wrong IGP
  populated the RIB.

- IS-IS interface `metric`. Extracted from both the per-interface and per-level
  (`level <N> metric`) forms and applied to the VI interface level settings
  (default 10 when unset). The lab uses `level 2 metric 100`, so without this
  the computed IS-IS route metrics were 10/20 instead of 100/200.

With all three, the six PE/P configs parse with zero FATAL warnings and the
computed main-RIB IS-IS routes match the device route-for-route (admin 18,
metric 100 one-hop / 200 two-hop).

----

Prompt:
```
My Nokia contact tells me they have pre-canned labs that run in containerlab.
Let's use this as our next steps on the complexity ladder. Check these out,
assess whether they have interesting content for us, and then go ahead and run
the full ec2->collect->validate->batfish-fixes-(if appropriate) cycle for them.
Probably, first step is to categorize each lab and organize them in increasing
complexity and flag whether they rely on features not in the Batfish VI model
yet. Prefer lower complexity first, and full Batfish support is better than pure
extraction!

We have several configuration examples here:
https://github.com/nokia/sros-docs-lab based on this guide:
https://documentation.nokia.com/sr/26-3/7750-sr/titles/services-config-quick-ref.html.
They all run in Containerlab so I hope that makes it easy for you.
```

The Nokia repo turned out to be a single combined "kitchen-sink" topology (4 PE
+ 2 P SR-SIM + 4 Linux CE) stacking the full SP service suite on one IGP/MPLS
underlay, not a graded ladder. Per the "full support > extraction, lower
complexity first" steer, this commit models the routed underlay the new lab
exercises (the service overlay parses cleanly and is sickbay'd on the
lab-validation side).
