### PR TITLE
sros: report silently-ignored statements in the annotate tool

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosControlPlaneExtractor.java
@@ -53,7 +53,21 @@ public final class SrosControlPlaneExtractor implements ControlPlaneExtractor {
     // populate the typed feature model from it.
     SrosStatementTree root = cb.getTree();
     SrosPreprocessor.preprocess(root, _w);
+
+    // For the annotate tool, track which tree nodes the feature extractor reads (it has no
+    // visit-tracking code of its own — see SrosStatementTree), then report the rest as silently
+    // ignored. SR-OS has no `_null` grammar rules, so this replaces the parse-time mechanism that
+    // grammar-driven vendors use. Tracking starts after preprocessing so that the preprocessor's
+    // tree walk does not count as "read".
+    boolean annotate = _parser.getSettings().getPrintParseTree();
+    if (annotate) {
+      root.beginVisitTracking();
+    }
     SrosFeatureExtractor.extract(root, _configuration, _w, _parser, _text);
+    if (annotate) {
+      root.endVisitTracking();
+      SrosSilentSyntax.sweep(root, _silentSyntax, _text);
+    }
   }
 
   private org.batfish.vendor.sros.representation.SrosConfiguration _configuration;

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosSilentSyntax.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosSilentSyntax.java
@@ -1,0 +1,96 @@
+package org.batfish.vendor.sros.grammar;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection.SilentSyntaxElem;
+
+/**
+ * Sweeps a feature-extracted {@link SrosStatementTree} for statements that were parsed and accepted
+ * but never read by {@link SrosFeatureExtractor}, recording each as a {@link SilentSyntaxElem} so
+ * the {@code annotate} tool can flag it as "SILENTLY IGNORED".
+ *
+ * <p>SR-OS has no {@code _null} grammar rules (its grammar is generic — every statement is a word
+ * sequence), so the parse-time {@link org.batfish.grammar.SilentSyntaxListener} mechanism used by
+ * grammar-driven vendors finds nothing. Instead, the tree's accessors record which nodes the
+ * extractor reads (see {@link SrosStatementTree} visit tracking); this sweep reports the rest.
+ *
+ * <p>Visited nodes form a connected subtree rooted at the (implicitly visited) root: a child is
+ * only reachable by reading its parent, which marks the parent. So once a node is unvisited, its
+ * whole subtree is unvisited. The sweep descends through visited nodes and, at each unvisited
+ * child, emits one element for the maximal ignored statement without descending further — except
+ * that a pure path-prefix node (one with no source context of its own, e.g. the {@code ospf}
+ * interior word above the keyed instances) is descended into so the report lands on the
+ * context-bearing statement(s) below it.
+ */
+@ParametersAreNonnullByDefault
+public final class SrosSilentSyntax {
+
+  /** Synthetic {@link SilentSyntaxElem} rule name; SR-OS has no ANTLR rule to name here. */
+  private static final String RULE_NAME = "sros_unmodeled";
+
+  /**
+   * Walks {@code root} (assumed visited) and records every maximal unvisited statement into {@code
+   * out}. {@code text} is the parsed (preprocessed) configuration text, used to recover a leaf
+   * statement's source line.
+   */
+  public static void sweep(SrosStatementTree root, SilentSyntaxCollection out, String text) {
+    new SrosSilentSyntax(out, text).sweepVisited(root, new ArrayDeque<>());
+  }
+
+  private SrosSilentSyntax(SilentSyntaxCollection out, String text) {
+    _out = out;
+    _text = text;
+  }
+
+  /** Descends through the children of a visited node, reporting unvisited subtrees. */
+  private void sweepVisited(SrosStatementTree node, Deque<String> path) {
+    for (Map.Entry<String, SrosStatementTree> e : node.getChildren().entrySet()) {
+      SrosStatementTree child = e.getValue();
+      path.addLast(e.getKey());
+      if (child.wasVisited()) {
+        sweepVisited(child, path);
+      } else {
+        reportIgnored(child, path);
+      }
+      path.removeLast();
+    }
+  }
+
+  /**
+   * Reports an unvisited subtree. If {@code node} carries a source context it is the ignored
+   * statement and is reported as one element; otherwise it is a pure path prefix and the sweep
+   * descends to the context-bearing statement(s) beneath it.
+   */
+  private void reportIgnored(SrosStatementTree node, Deque<String> path) {
+    ParserRuleContext ctx = node.firstDefContext();
+    if (ctx == null) {
+      for (Map.Entry<String, SrosStatementTree> e : node.getChildren().entrySet()) {
+        path.addLast(e.getKey());
+        reportIgnored(e.getValue(), path);
+        path.removeLast();
+      }
+      return;
+    }
+    int startLine = ctx.getStart().getLine();
+    String elemText;
+    if (ctx.getStart().getLine() == ctx.getStop().getLine()) {
+      // A single-line leaf statement: report its own text (e.g. `persistent-index file ...`).
+      int start = ctx.getStart().getStartIndex();
+      int end = ctx.getStop().getStopIndex();
+      elemText = _text.substring(start, end + 1);
+    } else {
+      // A multi-line brace block (e.g. `security { ... }`): report the path to it, not the whole
+      // block body, so the comment stays one line.
+      elemText = String.join(" ", path);
+    }
+    _out.addElement(new SilentSyntaxElem(RULE_NAME, startLine, elemText));
+  }
+
+  private final @Nonnull SilentSyntaxCollection _out;
+  private final @Nonnull String _text;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosStatementTree.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/grammar/SrosStatementTree.java
@@ -1,9 +1,12 @@
 package org.batfish.vendor.sros.grammar;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -36,31 +39,55 @@ import org.antlr.v4.runtime.ParserRuleContext;
  * configured by more than one statement (mixed brace + flat input, or apply-groups inheritance,
  * which copies the source group's contexts via {@link #copyInto}). The contexts are transient: this
  * tree is built per-parse and discarded after extraction, never serialized into the configuration.
+ *
+ * <p><b>Visit tracking.</b> To let the {@code annotate} tool report SR-OS statements that are
+ * silently ignored (parsed and accepted, but never read by {@link SrosFeatureExtractor}), every
+ * tree shares a {@link VisitRecorder}. While the recorder is {@linkplain #beginVisitTracking()
+ * active} the read accessors ({@link #getChild}, {@link #getChildren}, {@link #hasChildren}) record
+ * the nodes they touch. The extractor's normal reads thus mark visited nodes automatically — it
+ * needs no visit-tracking code of its own. Tracking is activated only for the feature-extraction
+ * pass (not the build or the {@link SrosPreprocessor} walk, whose accesses must not count as
+ * "read"), after which {@link SrosSilentSyntax} sweeps the tree for unvisited subtrees. The
+ * recorder is transient, like the contexts: it is per-parse and never serialized.
  */
 @ParametersAreNonnullByDefault
 public final class SrosStatementTree {
 
+  /** Creates a root node, with a fresh (inactive) visit recorder shared by the whole tree. */
   public SrosStatementTree() {
-    _children = new LinkedHashMap<>();
-    _defContexts = new ArrayList<>(1);
+    this(new VisitRecorder());
   }
 
-  /** Returns the child subtree for {@code word}, creating it if absent. */
+  private SrosStatementTree(VisitRecorder recorder) {
+    _children = new LinkedHashMap<>();
+    _defContexts = new ArrayList<>(1);
+    _recorder = recorder;
+  }
+
+  /** Returns the child subtree for {@code word}, creating it (sharing the recorder) if absent. */
   public @Nonnull SrosStatementTree getOrAddChild(String word) {
-    return _children.computeIfAbsent(word, w -> new SrosStatementTree());
+    return _children.computeIfAbsent(word, w -> new SrosStatementTree(_recorder));
   }
 
   /** Returns the child subtree for {@code word}, or {@code null} if absent. */
   public @Nullable SrosStatementTree getChild(String word) {
-    return _children.get(word);
+    _recorder.record(this);
+    SrosStatementTree child = _children.get(word);
+    if (child != null) {
+      _recorder.record(child);
+    }
+    return child;
   }
 
   /** The children of this node, keyed by path word, in insertion order. */
   public @Nonnull Map<String, SrosStatementTree> getChildren() {
+    _recorder.record(this);
+    _children.values().forEach(_recorder::record);
     return _children;
   }
 
   public boolean hasChildren() {
+    _recorder.record(this);
     return !_children.isEmpty();
   }
 
@@ -117,6 +144,62 @@ public final class SrosStatementTree {
     }
   }
 
+  // --- visit tracking (annotate-only; see class javadoc) ----------------------------------------
+
+  /**
+   * Begins recording read accesses on this whole tree. Call once, on the root, immediately before
+   * the feature-extraction pass so that {@link SrosFeatureExtractor}'s reads mark visited nodes.
+   */
+  public void beginVisitTracking() {
+    _recorder.activate();
+  }
+
+  /**
+   * Stops recording read accesses. Call before {@link SrosSilentSyntax} sweeps the tree, so the
+   * sweep's own accessor calls do not mark nodes as visited.
+   */
+  public void endVisitTracking() {
+    _recorder.deactivate();
+  }
+
+  /** Whether this node was read while visit tracking was active. */
+  public boolean wasVisited() {
+    return _recorder.isVisited(this);
+  }
+
   private final @Nonnull Map<String, SrosStatementTree> _children;
   private final @Nonnull List<ParserRuleContext> _defContexts;
+
+  /** The visit recorder shared by every node of one tree. */
+  private final @Nonnull VisitRecorder _recorder;
+
+  /**
+   * Records which {@link SrosStatementTree} nodes are read while {@linkplain #active active}. One
+   * instance is shared by all nodes of a tree (threaded through {@link #getOrAddChild}). Recording
+   * is by object identity; it is a no-op until {@link #activate} is called, so the build and the
+   * {@link SrosPreprocessor} walk do not count as reads.
+   */
+  private static final class VisitRecorder {
+    private boolean _active;
+    private final @Nonnull Set<SrosStatementTree> _visited =
+        Collections.newSetFromMap(new IdentityHashMap<>());
+
+    void activate() {
+      _active = true;
+    }
+
+    void deactivate() {
+      _active = false;
+    }
+
+    void record(SrosStatementTree node) {
+      if (_active) {
+        _visited.add(node);
+      }
+    }
+
+    boolean isVisited(SrosStatementTree node) {
+      return _visited.contains(node);
+    }
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/main/annotate/AnnotateTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/annotate/AnnotateTest.java
@@ -68,6 +68,19 @@ public final class AnnotateTest {
   }
 
   /**
+   * SR-OS has no {@code _null} grammar rules, so silently-ignored statements are found by tracking
+   * which {@link org.batfish.vendor.sros.grammar.SrosStatementTree} nodes the feature extractor
+   * reads and reporting the rest (see {@link org.batfish.vendor.sros.grammar.SrosSilentSyntax}).
+   * Here the {@code system security} block is parsed and accepted but not modeled, so it is flagged
+   * once at its header line; the modeled {@code system name} and {@code autonomous-system} leaves
+   * are not.
+   */
+  @Test
+  public void testSrosSilentlyIgnored() throws IOException {
+    assertValidPair("annotate-sros-ignored-before", "annotate-sros-ignored-after");
+  }
+
+  /**
    * Assert that running annotate on {@code before} as a direct file input (not a snapshot
    * directory) produces the content of {@code after}.
    */

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosSilentSyntaxTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosSilentSyntaxTest.java
@@ -1,0 +1,95 @@
+package org.batfish.vendor.sros.grammar;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
+import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
+import org.batfish.config.Settings;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.main.Batfish;
+import org.junit.Test;
+
+/**
+ * Tests that {@link SrosSilentSyntax} reports the statements {@link SrosFeatureExtractor} does not
+ * read as silently ignored, and reports nothing for the statements it does read. This is the
+ * regression net for the automatic visit-tracking in {@link SrosStatementTree}: a future extractor
+ * change that stops reading a path must surface it as ignored, and one that starts reading a path
+ * must stop reporting it.
+ */
+public final class SrosSilentSyntaxTest {
+
+  private static final String TESTCONFIGS_PREFIX = "org/batfish/vendor/sros/grammar/testconfigs/";
+
+  /**
+   * The captured r1 config models hardware, interfaces, BGP, and routing-policy, but not the {@code
+   * system security} subtree or the top-level {@code persistent-indices} block. Both — and only
+   * both — are reported as silently ignored; modeled leaves are not.
+   */
+  @Test
+  public void testR1SilentlyIgnored() {
+    List<String> ignored = silentlyIgnored("r1_admin_show_configuration.txt");
+
+    // The two unmodeled subtrees are each reported once, at their block header, and nothing else.
+    assertThat(ignored, containsInAnyOrder("configure system security", "persistent-indices"));
+
+    // None of the modeled keywords appears in any reported element (no false positives).
+    for (String modeled :
+        List.of(
+            "name",
+            "card",
+            "card-type",
+            "autonomous-system",
+            "router-id",
+            "prefix-list",
+            "entry",
+            "policy-statement",
+            "interface",
+            "port")) {
+      assertThat(
+          "no silently-ignored element mentions modeled keyword: " + modeled,
+          ignored.stream().noneMatch(s -> s.contains(modeled)),
+          equalTo(true));
+    }
+  }
+
+  /** A config that is entirely modeled reports nothing as silently ignored. */
+  @Test
+  public void testFullyModeledReportsNothing() {
+    assertThat(silentlyIgnored("hostname.txt"), empty());
+  }
+
+  /**
+   * Parse {@code filename} with parse-tree printing enabled (the mode the annotate tool uses) and
+   * return the text of each silently-ignored element.
+   */
+  private static @Nonnull List<String> silentlyIgnored(String filename) {
+    String src = readResource(TESTCONFIGS_PREFIX + filename, UTF_8);
+    Settings settings = new Settings();
+    configureBatfishTestSettings(settings);
+    // The silent-syntax sweep, like the grammar-driven _null mechanism, only runs when printing the
+    // parse tree (i.e. under the annotate tool).
+    settings.setPrintParseTree(true);
+    SrosCombinedParser parser = new SrosCombinedParser(src, settings);
+    Warnings warnings = new Warnings(true, true, true);
+    SilentSyntaxCollection silentSyntax = new SilentSyntaxCollection();
+    SrosControlPlaneExtractor extractor =
+        new SrosControlPlaneExtractor(src, parser, warnings, silentSyntax);
+    ParserRuleContext tree =
+        Batfish.parse(parser, new BatfishLogger(BatfishLogger.LEVELSTR_FATAL, false), settings);
+    extractor.processParseTree(DUMMY_SNAPSHOT_1, tree);
+    return silentSyntax.getElements().stream()
+        .map(SilentSyntaxCollection.SilentSyntaxElem::getText)
+        .collect(Collectors.toList());
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/main/annotate/testconfigs/annotate-sros-ignored-after
+++ b/projects/batfish/src/test/resources/org/batfish/main/annotate/testconfigs/annotate-sros-ignored-after
@@ -1,0 +1,15 @@
+# Configuration format version 26.3 revision 0
+configure {
+    system {
+        name "r1"
+# SILENTLY IGNORED: configure system security
+        security {
+            ssh {
+                preserve-key true
+            }
+        }
+    }
+    router "Base" {
+        autonomous-system 65001
+    }
+}

--- a/projects/batfish/src/test/resources/org/batfish/main/annotate/testconfigs/annotate-sros-ignored-before
+++ b/projects/batfish/src/test/resources/org/batfish/main/annotate/testconfigs/annotate-sros-ignored-before
@@ -1,0 +1,14 @@
+# Configuration format version 26.3 revision 0
+configure {
+    system {
+        name "r1"
+        security {
+            ssh {
+                preserve-key true
+            }
+        }
+    }
+    router "Base" {
+        autonomous-system 65001
+    }
+}


### PR DESCRIPTION
The annotate tool prints a comment above each config line it parses but
intentionally does not model ("SILENTLY IGNORED"). Grammar-driven
vendors detect these at parse time: any ANTLR rule whose name ends in
`_null` is flagged by SilentSyntaxListener. SR-OS has no such rules — its
grammar is generic (every statement is a word sequence), and the
"do we model this?" decision lives in SrosFeatureExtractor, which reads
only the specific tree paths it knows. So the annotate tool's
SILENTLY IGNORED output was always empty for SR-OS.

Track which SrosStatementTree nodes the extractor reads, then report the
rest. The tracking is automatic: the tree's own read accessors (getChild,
getChildren, hasChildren) record the nodes they touch into a tree-shared
VisitRecorder, so the extractor needs no visit-tracking code of its own.
The recorder is inactive during the build and the SrosPreprocessor walk
(whose accesses must not count as a "read") and is activated by
SrosControlPlaneExtractor only for the extraction pass, and only when
printParseTree is set — so the normal pipeline and reference tests are
unchanged. After extraction, SrosSilentSyntax sweeps the tree and emits
one element per maximal unvisited subtree: a multi-line brace block
collapses to one comment at its header line, a single-line leaf is
reported in place.

Verified against five real lab captures: each flags the unmodeled
`system security` block (one comment, not per-leaf) and the top-level
`persistent-indices` block, and the prefix-bounds lab additionally flags
an unmodeled `family` leaf nested inside a modeled BGP group — with no
false positives on modeled config.

----

Prompt:
```
The annotate tool also prints out lines that are silently ignored. Usually, it
does this by inspecting the ANTLR4 extrator. For SR-OS., however, we don't have
one. Can we develop a way to track which tree leaves have been visited, so that
annotate tool keeps this functionality?
```

Per follow-up direction, the marking is fully automatic in the
SrosStatementTree accessors (no intentional mark() calls in the
extractor), and the tool was run on real lab configs to confirm it works
before writing tests.
