### PR TITLE
sros: qualify VPRN interface names with their VRF

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/sros/representation/SrosConversions.java
@@ -457,13 +457,17 @@ public final class SrosConversions {
    *       its physical port, so an L1 edge between ports yields the L3 edge between the router
    *       interfaces (and the logical interface shares the port's fate).
    * </ul>
+   *
+   * <p>A non-Base (VPRN) interface's VI name is qualified with its VRF — see {@link
+   * #viInterfaceName} — because SR-OS scopes interface names per router instance and Batfish keys
+   * interfaces by name per node.
    */
   static void convertInterfaces(SrosConfiguration vc, Router router, Configuration c, Vrf vrf) {
     for (RouterInterface ri : router.getInterfaces().values()) {
       String portPath = ri.getPort();
       Interface.Builder ib =
           Interface.builder()
-              .setName(ri.getName())
+              .setName(viInterfaceName(router, ri.getName()))
               .setOwner(c)
               .setVrf(vrf)
               // SR-OS router interfaces have no shutdown leaf in the modeled subset; they are up
@@ -543,7 +547,8 @@ public final class SrosConversions {
               areaNum,
               n -> org.batfish.datamodel.ospf.OspfArea.builder().setNumber(n).setNonStub());
       for (OspfAreaInterface ospfIf : area.getInterfaces().values()) {
-        Interface viIface = c.getAllInterfaces().get(ospfIf.getName());
+        String viName = viInterfaceName(router, ospfIf.getName());
+        Interface viIface = c.getAllInterfaces().get(viName);
         if (viIface == null) {
           w.redFlagf(
               "router '%s' OSPF area %s references undefined interface '%s'; skipping",
@@ -562,7 +567,7 @@ public final class SrosConversions {
                 .setOspfAddresses(
                     org.batfish.datamodel.ospf.OspfAddresses.of(viIface.getAllConcreteAddresses()))
                 .build());
-        ab.addInterface(ospfIf.getName());
+        ab.addInterface(viName);
       }
     }
     Map<Long, org.batfish.datamodel.ospf.OspfArea> areas = new TreeMap<>();
@@ -630,7 +635,7 @@ public final class SrosConversions {
 
     for (org.batfish.vendor.sros.representation.IsisProcessInterface isisIf :
         proc.getInterfaces().values()) {
-      Interface viIface = c.getAllInterfaces().get(isisIf.getName());
+      Interface viIface = c.getAllInterfaces().get(viInterfaceName(router, isisIf.getName()));
       if (viIface == null) {
         w.redFlagf(
             "router '%s' IS-IS references undefined interface '%s'; skipping",
@@ -1080,6 +1085,20 @@ public final class SrosConversions {
           .build();
     }
     return DEFAULT_BGP_REJECT_POLICY_NAME;
+  }
+
+  /**
+   * The VI {@link Interface} name for an SR-OS router-interface. Batfish keys interfaces by name
+   * within a node, but SR-OS scopes interface names to the router instance: the same name (e.g.
+   * {@code to-cea}) can be configured in two different VPRNs, each a separate VRF. To keep both, a
+   * non-Base (VPRN) interface is qualified with its router (VRF) name as {@code <vrf>.<name>}; the
+   * {@code Base} instance's interfaces keep their bare names. The qualification is applied
+   * uniformly to every VPRN interface (not only on a detected collision) so the VI name is a
+   * deterministic function of the VPRN and interface alone — independent of what other VPRNs
+   * configure.
+   */
+  static @Nonnull String viInterfaceName(Router router, String interfaceName) {
+    return router.getName().equals("Base") ? interfaceName : router.getName() + "." + interfaceName;
   }
 
   /** The {@code system} interface's primary IP, used as router-id fallback and BGP local-ip. */

--- a/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/sros/grammar/SrosConversionTest.java
@@ -413,18 +413,45 @@ public final class SrosConversionTest {
   public void testVprnConversion() throws IOException {
     Configuration c = parseConfig("vprn.txt");
     assertThat(c.getVrfs(), hasKey("red"));
-    // The VPRN interface is in the "red" VRF, not the default VRF.
-    Interface redLo = c.getAllInterfaces().get("red-lo");
+    // The VPRN interface is in the "red" VRF, not the default VRF, and its VI name is qualified
+    // with the VRF ("red.red-lo") since SR-OS scopes interface names per router instance.
+    Interface redLo = c.getAllInterfaces().get("red.red-lo");
     assertNotNull(redLo);
     assertThat(redLo.getVrfName(), equalTo("red"));
     assertThat(redLo.getConcreteAddress().toString(), equalTo("172.16.0.1/32"));
-    // No leak: the Base "system" interface is in the default VRF, not "red".
+    // No leak: the Base "system" interface is in the default VRF, not "red", and keeps its bare
+    // name (Base interfaces are not qualified).
     assertThat(
         c.getAllInterfaces().get("system").getVrfName(), equalTo(Configuration.DEFAULT_VRF_NAME));
     // The bgp-ipvpn route-distinguisher converts onto the VRF (the VI model stores an RD per VRF).
     assertThat(
         c.getVrfs().get("red").getRouteDistinguisher(),
         equalTo(org.batfish.datamodel.bgp.RouteDistinguisher.parse("65000:1")));
+  }
+
+  /**
+   * The same interface name configured in two different VPRNs is modeled in both VRFs: SR-OS scopes
+   * interface names per router instance, so a non-Base interface's VI name is qualified with its
+   * VRF ({@code <vrf>.<name>}). Without that, Batfish would key both by the bare name and keep only
+   * the first-configured one. (lab-validation#203 — pe1 reuses {@code to-cea} across RED and BLUE.)
+   */
+  @Test
+  public void testVprnReusedInterfaceName() throws IOException {
+    Configuration c = parseConfig("vprn_reused_interface.txt");
+    assertThat(c.getVrfs(), allOf(hasKey("RED"), hasKey("BLUE")));
+
+    Interface red = c.getAllInterfaces().get("RED.to-cea");
+    assertNotNull(red);
+    assertThat(red.getVrfName(), equalTo("RED"));
+    assertThat(red.getConcreteAddress().toString(), equalTo("192.168.30.254/24"));
+
+    Interface blue = c.getAllInterfaces().get("BLUE.to-cea");
+    assertNotNull(blue);
+    assertThat(blue.getVrfName(), equalTo("BLUE"));
+    assertThat(blue.getConcreteAddress().toString(), equalTo("192.168.40.254/24"));
+
+    // The bare name is not present — both copies survive under their qualified names.
+    assertThat(c.getAllInterfaces(), not(hasKey("to-cea")));
   }
 
   /** Route-reflector conversion: an RR-client neighbor gets cluster-id + route-reflector-client. */

--- a/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/vprn_reused_interface.txt
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/sros/grammar/testconfigs/vprn_reused_interface.txt
@@ -1,0 +1,45 @@
+# TiMOS-B-26.3.R1 both/x86_64 Nokia 7750 SR-1
+# Configuration format version 26.3 revision 0
+configure {
+    service {
+        customer "1" {
+            customer-id 1
+        }
+        vprn "BLUE" {
+            admin-state enable
+            service-id 40
+            customer "1"
+            interface "to-cea" {
+                ipv4 {
+                    primary {
+                        address 192.168.40.254
+                        prefix-length 24
+                    }
+                }
+            }
+        }
+        vprn "RED" {
+            admin-state enable
+            service-id 30
+            customer "1"
+            interface "to-cea" {
+                ipv4 {
+                    primary {
+                        address 192.168.30.254
+                        prefix-length 24
+                    }
+                }
+            }
+        }
+    }
+    router "Base" {
+        interface "system" {
+            ipv4 {
+                primary {
+                    address 1.1.1.1
+                    prefix-length 32
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
SR-OS scopes interface names per router instance, so the same name (e.g.
to-cea) can be configured in two different VPRNs, each its own VRF. The
VI model keys interfaces by name within a node, so a name reused across
two VPRNs collided and only the first-configured copy survived; the
other was silently dropped.

Name every non-Base (VPRN) interface <vrf>.<name> in the VI model so
both copies survive under distinct keys; Base-instance interfaces keep
their bare names. The qualification is applied uniformly to all VPRN
interfaces (not only on a detected collision) so the VI name is a
deterministic function of the VPRN and interface alone. The OSPF and
IS-IS interface lookups use the same qualified name.

Surfaced by the lab-validation sros_services lab, where pe1 reuses
to-cea across the RED and BLUE VPRNs (pe3: to-cez) with distinct
addresses; the device reports the interface in both VRFs but Batfish
modeled only one.

Fixes batfish/lab-validation#203.

----

Prompt:
```
Let's fix the interface duplicating naming across VPRN bug you just
filed, and make that part of the lab pass. (See recent PR to
lab-validation). I think the idiomatic fix is to name both interfaces
<vrf>.<iface> when collisions happen
```

Refined in conversation: name all non-Base VPRN interfaces <vrf>.<iface>
unconditionally (not only on collision), for a deterministic VI name.
