### PR TITLE
nxos: model IS-IS (router isis, ip router isis, single instance)

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosLexer.g4
@@ -9,6 +9,7 @@ tokens {
   BANNER_DELIMITER,
   HSRP_VERSION_1,
   HSRP_VERSION_2,
+  ISO_ADDRESS,
   MAC_ADDRESS_LITERAL,
   MOTD,
   PASSWORD_0,
@@ -107,6 +108,8 @@ ADDRGROUP
 ;
 
 ADJACENCY: 'adjacency';
+
+ADJACENCY_CHECK: 'adjacency-check';
 
 ADJMGR: 'adjmgr';
 
@@ -218,6 +221,10 @@ AUTH: 'auth';
 AUTHENTICATE: 'authenticate';
 
 AUTHENTICATION: 'authentication';
+
+AUTHENTICATION_CHECK: 'authentication-check';
+
+AUTHENTICATION_TYPE: 'authentication-type';
 
 AUTHENTICATION_KEY
 :
@@ -337,6 +344,8 @@ CHANNEL_GROUP: 'channel-group';
 CHARGEN: 'chargen';
 
 CIR: 'cir';
+
+CIRCUIT_TYPE: 'circuit-type';
 
 CLASS
 :
@@ -460,6 +469,8 @@ CRITICAL: 'critical';
 CRON: 'cron';
 
 CRYPTO: 'crypto';
+
+CSNP_INTERVAL: 'csnp-interval';
 
 CS1: 'cs1';
 
@@ -873,6 +884,10 @@ HELLO_AUTHENTICATION: 'hello-authentication';
 
 HELLO_INTERVAL: 'hello-interval';
 
+HELLO_MULTIPLIER: 'hello-multiplier';
+
+HELLO_PADDING: 'hello-padding';
+
 HELPER_DISABLE: 'helper-disable';
 
 HEX_UINT32
@@ -1043,10 +1058,20 @@ ISAKMP: 'isakmp';
 
 ISIS
 :
-  'isis' -> pushMode ( M_Word )
+  'isis'
+  // A process tag follows in `router isis <tag>`, `ip router isis <tag>`, and
+  // `redistribute isis <tag>`. Interface lines like `isis circuit-type ...`
+  // are followed by keywords in the default mode.
+  {
+    if (lastTokenType() == ROUTER || lastTokenType() == REDISTRIBUTE) {
+      pushMode(M_Word);
+    }
+  }
 ;
 
 ISOLATE: 'isolate';
+
+IS_TYPE: 'is-type';
 
 JP_INTERVAL: 'jp-interval';
 
@@ -1147,6 +1172,12 @@ LE: 'le';
 
 LEVEL: 'level';
 
+LEVEL_1: 'level-1';
+
+LEVEL_1_2: 'level-1-2';
+
+LEVEL_2: 'level-2';
+
 LICENSE: 'license';
 
 LIMIT_RESOURCE: 'limit-resource' -> pushMode ( M_Remark );
@@ -1217,6 +1248,8 @@ LOCATION
   'location' -> pushMode ( M_Remark )
 ;
 
+LOCATOR: 'locator' -> pushMode ( M_Word );
+
 LOG: 'log';
 
 LOG_ADJACENCY_CHANGES: 'log-adjacency-changes';
@@ -1262,6 +1295,12 @@ LSA_ARRIVAL: 'lsa-arrival';
 
 LSA_GROUP_PACING: 'lsa-group-pacing';
 
+LSP_GEN_INTERVAL: 'lsp-gen-interval';
+
+LSP_INTERVAL: 'lsp-interval';
+
+LSP_MTU: 'lsp-mtu';
+
 LT: 'lt';
 
 MAC: 'mac';
@@ -1299,6 +1338,8 @@ MAX_LENGTH: 'max-length';
 MAX_LINKS: 'max-links';
 
 MAX_LSA: 'max-lsa';
+
+MAX_LSP_LIFETIME: 'max-lsp-lifetime';
 
 MAX_METRIC: 'max-metric';
 
@@ -1360,6 +1401,8 @@ MEMBER
 
 MERGE_FAILURE: 'merge-failure';
 
+MESH_GROUP: 'mesh-group';
+
 MESSAGE_DIGEST: 'message-digest';
 
 MESSAGE_DIGEST_KEY: 'message-digest-key';
@@ -1367,6 +1410,8 @@ MESSAGE_DIGEST_KEY: 'message-digest-key';
 METHOD: 'method';
 
 METRIC: 'metric';
+
+METRIC_STYLE: 'metric-style';
 
 METRIC_TYPE: 'metric-type';
 
@@ -1427,9 +1472,13 @@ MST: 'mst';
 
 MTU: 'mtu';
 
+MTU_CHECK: 'mtu-check';
+
 MTU_FAILURE: 'mtu-failure';
 
 MULTICAST: 'multicast';
+
+MULTI_TOPOLOGY: 'multi-topology';
 
 MULTIPATH_RELAX: 'multipath-relax';
 
@@ -1477,6 +1526,11 @@ NEIGHBOR_POLICY
 ;
 
 NEQ: 'neq';
+
+// IS-IS NET (network entity title). The address that follows is lexed in
+// M_ISO_Address. Longer 'net*' tokens (NETWORK, NET_REDIRECT, ...) win by
+// ANTLR's longest-match rule, so only a standalone `net` enters this mode.
+NET: 'net' -> pushMode ( M_ISO_Address );
 
 NETBIOS_DGM: 'netbios-dgm';
 
@@ -1773,6 +1827,8 @@ PREEMPT: 'preempt';
 
 PREFER: 'prefer';
 
+PREFIX_ATTRIBUTES: 'prefix-attributes';
+
 PREFIX_LIST
 :
   'prefix-list' -> pushMode ( M_Word )
@@ -1932,6 +1988,8 @@ RETAIN: 'retain';
 
 RETRANSMIT_INTERVAL: 'retransmit-interval';
 
+RETRANSMIT_THROTTLE_INTERVAL: 'retransmit-throttle-interval';
+
 RIP
 :
   'rip'
@@ -2027,6 +2085,8 @@ SECURE: 'secure';
 
 SECURITY_VIOLATION: 'security-violation';
 
+SEGMENT_ROUTING: 'segment-routing';
+
 SELECTION: 'selection';
 
 SEND: 'send';
@@ -2058,6 +2118,10 @@ SESSION: 'session';
 SESSION_LIMIT: 'session-limit';
 
 SET: 'set';
+
+SET_ATTACHED_BIT: 'set-attached-bit';
+
+SET_OVERLOAD_BIT: 'set-overload-bit';
 
 SFLOW: 'sflow';
 
@@ -2135,11 +2199,15 @@ SPEED: 'speed';
 
 SPF: 'spf';
 
+SPF_INTERVAL: 'spf-interval';
+
 SPINE_ANYCAST_GATEWAY: 'spine-anycast-gateway';
 
 SRC_IP: 'src-ip';
 
 SRC_MAC: 'src-mac';
+
+SRV6: 'srv6';
 
 SSH: 'ssh';
 
@@ -2207,6 +2275,8 @@ SUPPRESS_INACTIVE: 'suppress-inactive';
 SUPPRESS_MAP: 'suppress-map' -> pushMode(M_Word);
 
 SUPPRESS_RA: 'suppress-ra';
+
+SUPPRESSED: 'suppressed';
 
 // sic
 SUPRESS_FA: 'supress-fa';
@@ -2334,6 +2404,8 @@ TRAFFIC_FILTER
 :
   'traffic-filter' -> pushMode ( M_Word )
 ;
+
+TRANSITION: 'transition';
 
 TRANSLATE: 'translate';
 
@@ -3756,6 +3828,21 @@ M_TwoWords_WORD
 ;
 
 M_TwoWords_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN )
+;
+
+mode M_ISO_Address;
+
+M_ISO_Address_ISO_ADDRESS
+:
+  F_HexDigit+
+  (
+    '.' F_HexDigit+
+  )+ -> type ( ISO_ADDRESS ) , popMode
+;
+
+M_ISO_Address_WS
 :
   F_Whitespace+ -> channel ( HIDDEN )
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosParser.g4
@@ -18,6 +18,7 @@ import
   CiscoNxos_ip_prefix_list,
   CiscoNxos_ipv6_access_list,
   CiscoNxos_ipv6_prefix_list,
+  CiscoNxos_isis,
   CiscoNxos_lacp,
   CiscoNxos_line,
   CiscoNxos_logging,
@@ -485,6 +486,7 @@ s_router
   (
     router_bgp
     | router_eigrp
+    | router_isis
     | router_ospf
     | router_ospfv3
     | router_rip

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_common.g4
@@ -422,6 +422,13 @@ isis_instance
   ISIS router_isis_process_tag
 ;
 
+isis_level
+:
+  LEVEL_1
+  | LEVEL_1_2
+  | LEVEL_2
+;
+
 ospf_instance
 :
   OSPF router_ospf_name

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_interface.g4
@@ -47,6 +47,7 @@ s_interface_regular
     | i_hsrp
     | i_ip
     | i_ipv6
+    | i_isis
     | i_lacp
     | i_mac_address
     | i_mtu
@@ -850,6 +851,7 @@ i_ip_router
   ROUTER
   (
     iipr_eigrp
+    | iipr_isis
     | iipr_ospf
     | iipr_rip
   )
@@ -858,6 +860,11 @@ i_ip_router
 iipr_eigrp
 :
   eigrp_instance NEWLINE
+;
+
+iipr_isis
+:
+  ISIS tag = router_isis_process_tag NEWLINE
 ;
 
 iipr_ospf
@@ -919,8 +926,14 @@ iip6_router
 :
   ROUTER
   (
-    iip6r_ospfv3
+    iip6r_isis
+    | iip6r_ospfv3
   )
+;
+
+iip6r_isis
+:
+  ISIS tag = router_isis_process_tag NEWLINE
 ;
 
 iip6_traffic_filter
@@ -935,6 +948,279 @@ iip6_traffic_filter
 iip6r_ospfv3
 :
   ospfv3_instance AREA area = ospf_area_id NEWLINE
+;
+
+i_isis
+:
+  ISIS
+  (
+    iisis_authentication_null
+    | iisis_authentication_check_null
+    | iisis_authentication_type_null
+    | iisis_bfd_null
+    | iisis_circuit_type
+    | iisis_csnp_interval_null
+    | iisis_hello_interval_null
+    | iisis_hello_multiplier_null
+    | iisis_hello_padding_null
+    | iisis_ipv6_null
+    | iisis_lsp_interval_null
+    | iisis_mesh_group_null
+    | iisis_metric_null
+    | iisis_mtu_check_null
+    | iisis_network
+    | iisis_no
+    | iisis_passive_interface_null
+    | iisis_prefix_attributes_null
+    | iisis_priority_null
+    | iisis_retransmit_interval_null
+    | iisis_retransmit_throttle_interval_null
+    | iisis_shutdown_null
+    | iisis_suppressed_null
+  )
+;
+
+iisis_authentication_null
+:
+  AUTHENTICATION null_rest_of_line
+;
+
+iisis_authentication_check_null
+:
+  AUTHENTICATION_CHECK null_rest_of_line
+;
+
+iisis_authentication_type_null
+:
+  AUTHENTICATION_TYPE null_rest_of_line
+;
+
+iisis_bfd_null
+:
+  BFD null_rest_of_line
+;
+
+iisis_circuit_type
+:
+  CIRCUIT_TYPE level = isis_level NEWLINE
+;
+
+iisis_csnp_interval_null
+:
+  CSNP_INTERVAL null_rest_of_line
+;
+
+iisis_hello_interval_null
+:
+  HELLO_INTERVAL null_rest_of_line
+;
+
+iisis_hello_multiplier_null
+:
+  HELLO_MULTIPLIER null_rest_of_line
+;
+
+iisis_hello_padding_null
+:
+  HELLO_PADDING null_rest_of_line
+;
+
+iisis_ipv6_null
+:
+  IPV6 null_rest_of_line
+;
+
+iisis_lsp_interval_null
+:
+  LSP_INTERVAL null_rest_of_line
+;
+
+iisis_mesh_group_null
+:
+  MESH_GROUP null_rest_of_line
+;
+
+iisis_metric_null
+:
+  METRIC null_rest_of_line
+;
+
+iisis_mtu_check_null
+:
+  MTU_CHECK null_rest_of_line
+;
+
+iisis_network
+:
+  NETWORK POINT_TO_POINT null_rest_of_line
+;
+
+iisis_passive_interface_null
+:
+  PASSIVE_INTERFACE null_rest_of_line
+;
+
+iisis_prefix_attributes_null
+:
+  PREFIX_ATTRIBUTES null_rest_of_line
+;
+
+iisis_priority_null
+:
+  PRIORITY null_rest_of_line
+;
+
+iisis_retransmit_interval_null
+:
+  RETRANSMIT_INTERVAL null_rest_of_line
+;
+
+iisis_retransmit_throttle_interval_null
+:
+  RETRANSMIT_THROTTLE_INTERVAL null_rest_of_line
+;
+
+iisis_shutdown_null
+:
+  SHUTDOWN null_rest_of_line
+;
+
+iisis_suppressed_null
+:
+  SUPPRESSED null_rest_of_line
+;
+
+iisis_no
+:
+  NO
+  (
+    iisisno_authentication_null
+    | iisisno_authentication_check_null
+    | iisisno_authentication_type_null
+    | iisisno_bfd_null
+    | iisisno_csnp_interval_null
+    | iisisno_hello_interval_null
+    | iisisno_hello_multiplier_null
+    | iisisno_hello_padding_null
+    | iisisno_ipv6_null
+    | iisisno_lsp_interval_null
+    | iisisno_mesh_group_null
+    | iisisno_metric_null
+    | iisisno_mtu_check_null
+    | iisisno_network_null
+    | iisisno_passive_interface_null
+    | iisisno_prefix_attributes_null
+    | iisisno_priority_null
+    | iisisno_retransmit_interval_null
+    | iisisno_retransmit_throttle_interval_null
+    | iisisno_shutdown_null
+    | iisisno_suppressed_null
+  )
+;
+
+iisisno_authentication_null
+:
+  AUTHENTICATION null_rest_of_line
+;
+
+iisisno_authentication_check_null
+:
+  AUTHENTICATION_CHECK null_rest_of_line
+;
+
+iisisno_authentication_type_null
+:
+  AUTHENTICATION_TYPE null_rest_of_line
+;
+
+iisisno_bfd_null
+:
+  BFD null_rest_of_line
+;
+
+iisisno_csnp_interval_null
+:
+  CSNP_INTERVAL null_rest_of_line
+;
+
+iisisno_hello_interval_null
+:
+  HELLO_INTERVAL null_rest_of_line
+;
+
+iisisno_hello_multiplier_null
+:
+  HELLO_MULTIPLIER null_rest_of_line
+;
+
+iisisno_hello_padding_null
+:
+  HELLO_PADDING null_rest_of_line
+;
+
+iisisno_ipv6_null
+:
+  IPV6 null_rest_of_line
+;
+
+iisisno_lsp_interval_null
+:
+  LSP_INTERVAL null_rest_of_line
+;
+
+iisisno_mesh_group_null
+:
+  MESH_GROUP null_rest_of_line
+;
+
+iisisno_metric_null
+:
+  METRIC null_rest_of_line
+;
+
+iisisno_mtu_check_null
+:
+  MTU_CHECK null_rest_of_line
+;
+
+iisisno_network_null
+:
+  NETWORK null_rest_of_line
+;
+
+iisisno_passive_interface_null
+:
+  PASSIVE_INTERFACE null_rest_of_line
+;
+
+iisisno_prefix_attributes_null
+:
+  PREFIX_ATTRIBUTES null_rest_of_line
+;
+
+iisisno_priority_null
+:
+  PRIORITY null_rest_of_line
+;
+
+iisisno_retransmit_interval_null
+:
+  RETRANSMIT_INTERVAL null_rest_of_line
+;
+
+iisisno_retransmit_throttle_interval_null
+:
+  RETRANSMIT_THROTTLE_INTERVAL null_rest_of_line
+;
+
+iisisno_shutdown_null
+:
+  SHUTDOWN null_rest_of_line
+;
+
+iisisno_suppressed_null
+:
+  SUPPRESSED null_rest_of_line
 ;
 
 i_lacp

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_isis.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_isis.g4
@@ -1,0 +1,436 @@
+parser grammar CiscoNxos_isis;
+
+import CiscoNxos_common;
+
+options {
+  tokenVocab = CiscoNxosLexer;
+}
+
+router_isis
+:
+  ISIS tag = router_isis_process_tag NEWLINE
+  (
+    ri_common
+    | ri_distribute_null
+    | ri_flush_routes_null
+    | ri_isolate_null
+    | ri_mpls_null
+    | ri_no
+    | ri_vrf
+  )*
+;
+
+// Commands valid both at the top level and inside a `vrf` block.
+ri_common
+:
+  ri_address_family
+  | ri_authentication_null
+  | ri_authentication_check_null
+  | ri_authentication_type_null
+  | ri_graceful_restart_null
+  | ri_hostname_null
+  | ri_is_type
+  | ri_log_adjacency_changes_null
+  | ri_lsp_gen_interval_null
+  | ri_lsp_mtu_null
+  | ri_max_lsp_lifetime_null
+  | ri_metric_style_null
+  | ri_net
+  | ri_passive_interface_null
+  | ri_queue_limit_null
+  | ri_reference_bandwidth_null
+  | ri_set_overload_bit_null
+  | ri_shutdown_null
+  | ri_spf_interval_null
+  | ri_summary_address_null
+;
+
+ri_vrf
+:
+  VRF name = vrf_non_default_name NEWLINE
+  (
+    ri_common
+    | ri_no
+  )*
+;
+
+ri_authentication_null
+:
+  AUTHENTICATION null_rest_of_line
+;
+
+ri_authentication_check_null
+:
+  AUTHENTICATION_CHECK null_rest_of_line
+;
+
+ri_authentication_type_null
+:
+  AUTHENTICATION_TYPE null_rest_of_line
+;
+
+ri_distribute_null
+:
+  DISTRIBUTE null_rest_of_line
+;
+
+ri_flush_routes_null
+:
+  FLUSH_ROUTES NEWLINE
+;
+
+ri_graceful_restart_null
+:
+  GRACEFUL_RESTART null_rest_of_line
+;
+
+ri_hostname_null
+:
+  HOSTNAME null_rest_of_line
+;
+
+ri_is_type
+:
+  IS_TYPE level = isis_level NEWLINE
+;
+
+ri_isolate_null
+:
+  ISOLATE NEWLINE
+;
+
+ri_log_adjacency_changes_null
+:
+  LOG_ADJACENCY_CHANGES NEWLINE
+;
+
+ri_lsp_gen_interval_null
+:
+  LSP_GEN_INTERVAL null_rest_of_line
+;
+
+ri_lsp_mtu_null
+:
+  LSP_MTU null_rest_of_line
+;
+
+ri_max_lsp_lifetime_null
+:
+  MAX_LSP_LIFETIME null_rest_of_line
+;
+
+ri_metric_style_null
+:
+  METRIC_STYLE null_rest_of_line
+;
+
+ri_mpls_null
+:
+  MPLS null_rest_of_line
+;
+
+ri_net
+:
+  NET net = ISO_ADDRESS NEWLINE
+;
+
+ri_passive_interface_null
+:
+  PASSIVE_INTERFACE null_rest_of_line
+;
+
+ri_queue_limit_null
+:
+  QUEUE_LIMIT null_rest_of_line
+;
+
+ri_reference_bandwidth_null
+:
+  REFERENCE_BANDWIDTH null_rest_of_line
+;
+
+ri_set_overload_bit_null
+:
+  SET_OVERLOAD_BIT null_rest_of_line
+;
+
+ri_shutdown_null
+:
+  SHUTDOWN NEWLINE
+;
+
+ri_spf_interval_null
+:
+  SPF_INTERVAL null_rest_of_line
+;
+
+ri_summary_address_null
+:
+  SUMMARY_ADDRESS null_rest_of_line
+;
+
+ri_no
+:
+  NO
+  (
+    rino_authentication_null
+    | rino_authentication_check_null
+    | rino_authentication_type_null
+    | rino_graceful_restart_null
+    | rino_hostname_null
+    | rino_log_adjacency_changes_null
+    | rino_metric_style_null
+    | rino_passive_interface_null
+    | rino_set_overload_bit_null
+    | rino_shutdown_null
+  )
+;
+
+rino_authentication_null
+:
+  AUTHENTICATION null_rest_of_line
+;
+
+rino_authentication_check_null
+:
+  AUTHENTICATION_CHECK null_rest_of_line
+;
+
+rino_authentication_type_null
+:
+  AUTHENTICATION_TYPE null_rest_of_line
+;
+
+rino_graceful_restart_null
+:
+  GRACEFUL_RESTART null_rest_of_line
+;
+
+rino_hostname_null
+:
+  HOSTNAME null_rest_of_line
+;
+
+rino_log_adjacency_changes_null
+:
+  LOG_ADJACENCY_CHANGES null_rest_of_line
+;
+
+rino_metric_style_null
+:
+  METRIC_STYLE null_rest_of_line
+;
+
+rino_passive_interface_null
+:
+  PASSIVE_INTERFACE null_rest_of_line
+;
+
+rino_set_overload_bit_null
+:
+  SET_OVERLOAD_BIT null_rest_of_line
+;
+
+rino_shutdown_null
+:
+  SHUTDOWN NEWLINE
+;
+
+ri_address_family
+:
+  ADDRESS_FAMILY
+  (
+    IPV4
+    | IPV6
+  ) UNICAST NEWLINE
+  (
+    riaf_adjacency_check_null
+    | riaf_advertise_null
+    | riaf_bfd_null
+    | riaf_default_information_null
+    | riaf_distance_null
+    | riaf_distribute_null
+    | riaf_locator_null
+    | riaf_maximum_paths_null
+    | riaf_multi_topology_null
+    | riaf_no
+    | riaf_redistribute_null
+    | riaf_router_id_null
+    | riaf_segment_routing_null
+    | riaf_set_attached_bit_null
+    | riaf_summary_address_null
+    | riaf_table_map_null
+  )*
+;
+
+riaf_adjacency_check_null
+:
+  ADJACENCY_CHECK null_rest_of_line
+;
+
+riaf_advertise_null
+:
+  ADVERTISE null_rest_of_line
+;
+
+riaf_bfd_null
+:
+  BFD null_rest_of_line
+;
+
+riaf_default_information_null
+:
+  DEFAULT_INFORMATION null_rest_of_line
+;
+
+riaf_distance_null
+:
+  DISTANCE null_rest_of_line
+;
+
+riaf_distribute_null
+:
+  DISTRIBUTE null_rest_of_line
+;
+
+riaf_locator_null
+:
+  LOCATOR null_rest_of_line
+;
+
+riaf_maximum_paths_null
+:
+  MAXIMUM_PATHS null_rest_of_line
+;
+
+riaf_multi_topology_null
+:
+  MULTI_TOPOLOGY null_rest_of_line
+;
+
+riaf_redistribute_null
+:
+  REDISTRIBUTE null_rest_of_line
+;
+
+riaf_router_id_null
+:
+  ROUTER_ID null_rest_of_line
+;
+
+riaf_segment_routing_null
+:
+  SEGMENT_ROUTING null_rest_of_line
+;
+
+riaf_set_attached_bit_null
+:
+  SET_ATTACHED_BIT null_rest_of_line
+;
+
+riaf_summary_address_null
+:
+  SUMMARY_ADDRESS null_rest_of_line
+;
+
+riaf_table_map_null
+:
+  TABLE_MAP null_rest_of_line
+;
+
+riaf_no
+:
+  NO
+  (
+    riafno_adjacency_check_null
+    | riafno_advertise_null
+    | riafno_bfd_null
+    | riafno_default_information_null
+    | riafno_distance_null
+    | riafno_distribute_null
+    | riafno_locator_null
+    | riafno_maximum_paths_null
+    | riafno_multi_topology_null
+    | riafno_redistribute_null
+    | riafno_router_id_null
+    | riafno_segment_routing_null
+    | riafno_set_attached_bit_null
+    | riafno_summary_address_null
+    | riafno_table_map_null
+  )
+;
+
+riafno_adjacency_check_null
+:
+  ADJACENCY_CHECK null_rest_of_line
+;
+
+riafno_advertise_null
+:
+  ADVERTISE null_rest_of_line
+;
+
+riafno_bfd_null
+:
+  BFD null_rest_of_line
+;
+
+riafno_default_information_null
+:
+  DEFAULT_INFORMATION null_rest_of_line
+;
+
+riafno_distance_null
+:
+  DISTANCE null_rest_of_line
+;
+
+riafno_distribute_null
+:
+  DISTRIBUTE null_rest_of_line
+;
+
+riafno_locator_null
+:
+  LOCATOR null_rest_of_line
+;
+
+riafno_maximum_paths_null
+:
+  MAXIMUM_PATHS null_rest_of_line
+;
+
+riafno_multi_topology_null
+:
+  MULTI_TOPOLOGY null_rest_of_line
+;
+
+riafno_redistribute_null
+:
+  REDISTRIBUTE null_rest_of_line
+;
+
+riafno_router_id_null
+:
+  ROUTER_ID null_rest_of_line
+;
+
+riafno_segment_routing_null
+:
+  SEGMENT_ROUTING null_rest_of_line
+;
+
+riafno_set_attached_bit_null
+:
+  SET_ATTACHED_BIT null_rest_of_line
+;
+
+riafno_summary_address_null
+:
+  SUMMARY_ADDRESS null_rest_of_line
+;
+
+riafno_table_map_null
+:
+  TABLE_MAP null_rest_of_line
+;

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosControlPlaneExtractor.java
@@ -120,6 +120,7 @@ import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsa
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.INTERFACE_IP_RIP_ROUTE_FILTER_PREFIX_LIST;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.INTERFACE_IP_RIP_ROUTE_FILTER_ROUTE_MAP;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.INTERFACE_IP_ROUTER_EIGRP;
+import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.INTERFACE_IP_ROUTER_ISIS;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.INTERFACE_IP_ROUTER_OSPF;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.INTERFACE_IP_ROUTER_RIP;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.INTERFACE_SELF_REFERENCE;
@@ -173,6 +174,7 @@ import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsa
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.RIP_AF6_REDISTRIBUTE_INSTANCE;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.RIP_AF6_REDISTRIBUTE_ROUTE_MAP;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.ROUTER_EIGRP_SELF_REFERENCE;
+import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.ROUTER_ISIS_SELF_REFERENCE;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.ROUTER_OSPFV3_SELF_REFERENCE;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.ROUTER_OSPF_SELF_REFERENCE;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.ROUTER_RIP_SELF_REFERENCE;
@@ -237,6 +239,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IsoAddress;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.LongSpace;
@@ -251,6 +254,7 @@ import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.isis.IsisLevel;
 import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.SilentSyntaxListener;
 import org.batfish.grammar.UnrecognizedLineToken;
@@ -392,6 +396,7 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ihg_priorityContext
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ihg_timersContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ihg_trackContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ihgam_key_chainContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iip6r_isisContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iip6r_ospfv3Context;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iip_port_access_groupContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iipdl_prefix_listContext;
@@ -409,10 +414,13 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iipp_jp_policy_rout
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iipp_neighbor_policy_prefix_listContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iipp_neighbor_policy_route_mapContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iipr_eigrpContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iipr_isisContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iipr_ospfContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iipr_ripContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iiprip_rf_prefix_listContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iiprip_rf_route_mapContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iisis_circuit_typeContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Iisis_networkContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Il_min_linksContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Inherit_sequence_numberContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Inoip_forwardContext;
@@ -458,6 +466,7 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ipv6_prefix_listCon
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ipv6_prefix_list_line_prefix_lengthContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ipv6_routeContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Isis_instanceContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Isis_levelContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ispt_qosContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ispt_queuingContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Last_as_num_prependsContext;
@@ -608,6 +617,9 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Recaf6_redistribute
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Recaf_default_metricContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Recaf_ipv4Context;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Recaf_ipv6Context;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ri_is_typeContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ri_netContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ri_vrfContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Rip_instanceContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Rm_continueContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Rmm_as_numberContext;
@@ -675,6 +687,7 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Route_target_or_aut
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Router_bgpContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Router_eigrpContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Router_eigrp_process_tagContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Router_isisContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Router_isis_process_tagContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Router_ospfContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Router_ospf_nameContext;
@@ -805,6 +818,8 @@ import org.batfish.vendor.cisco_nxos.representation.IpPrefixListLine;
 import org.batfish.vendor.cisco_nxos.representation.Ipv6AccessList;
 import org.batfish.vendor.cisco_nxos.representation.Ipv6PrefixList;
 import org.batfish.vendor.cisco_nxos.representation.Ipv6PrefixListLine;
+import org.batfish.vendor.cisco_nxos.representation.IsisProcess;
+import org.batfish.vendor.cisco_nxos.representation.IsisVrfConfiguration;
 import org.batfish.vendor.cisco_nxos.representation.Layer3Options;
 import org.batfish.vendor.cisco_nxos.representation.LiteralIpAddressSpec;
 import org.batfish.vendor.cisco_nxos.representation.LiteralPortSpec;
@@ -1180,6 +1195,17 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     return Long.parseLong(ctx.getText());
   }
 
+  private static @Nonnull IsisLevel toIsisLevel(Isis_levelContext ctx) {
+    if (ctx.LEVEL_1() != null) {
+      return IsisLevel.LEVEL_1;
+    } else if (ctx.LEVEL_2() != null) {
+      return IsisLevel.LEVEL_2;
+    } else {
+      assert ctx.LEVEL_1_2() != null;
+      return IsisLevel.LEVEL_1_2;
+    }
+  }
+
   private static @Nonnull PortSpec toPortSpec(Acllal4tcp_port_spec_port_groupContext ctx) {
     return new PortGroupPortSpec(ctx.name.getText());
   }
@@ -1342,6 +1368,8 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   private Optional<Integer> _currentHsrpGroupNumber;
   private List<Interface> _currentInterfaces;
   private IpAccessList _currentIpAccessList;
+  private IsisProcess _currentIsisProcess;
+  private IsisVrfConfiguration _currentIsisVrf;
   private Optional<Long> _currentIpAccessListLineNum;
   private IpPrefixList _currentIpPrefixList;
 
@@ -2381,6 +2409,41 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
+  public void exitIipr_isis(Iipr_isisContext ctx) {
+    Optional<String> tagOrErr = toString(ctx, ctx.tag);
+    if (!tagOrErr.isPresent()) {
+      return;
+    }
+    String isisProc = tagOrErr.get();
+    _currentInterfaces.forEach(iface -> iface.setIsisProcess(isisProc));
+    _c.referenceStructure(
+        ROUTER_ISIS, isisProc, INTERFACE_IP_ROUTER_ISIS, ctx.tag.getStart().getLine());
+  }
+
+  @Override
+  public void exitIip6r_isis(Iip6r_isisContext ctx) {
+    // `ipv6 router isis` is parsed but not modeled; still resolve the structure reference so the
+    // process tag is not reported as undefined.
+    Optional<String> tagOrErr = toString(ctx, ctx.tag);
+    if (!tagOrErr.isPresent()) {
+      return;
+    }
+    _c.referenceStructure(
+        ROUTER_ISIS, tagOrErr.get(), INTERFACE_IP_ROUTER_ISIS, ctx.tag.getStart().getLine());
+  }
+
+  @Override
+  public void exitIisis_circuit_type(Iisis_circuit_typeContext ctx) {
+    IsisLevel level = toIsisLevel(ctx.level);
+    _currentInterfaces.forEach(iface -> iface.setIsisInterfaceCircuitType(level));
+  }
+
+  @Override
+  public void exitIisis_network(Iisis_networkContext ctx) {
+    _currentInterfaces.forEach(iface -> iface.setIsisNetworkPointToPoint(true));
+  }
+
+  @Override
   public void enterIp_access_list(Ip_access_listContext ctx) {
     Optional<String> nameOpt = toString(ctx, ctx.name);
     if (!nameOpt.isPresent()) {
@@ -3280,6 +3343,54 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     _currentEigrpProcess = null;
     _currentEigrpVrf = null;
     _currentEigrpVrfIpAf = null;
+  }
+
+  @Override
+  public void enterRouter_isis(Router_isisContext ctx) {
+    Optional<String> processTagOrErr = toString(ctx, ctx.tag);
+    if (processTagOrErr.isPresent()) {
+      String processTag = processTagOrErr.get();
+      _currentIsisProcess = _c.getOrCreateIsisProcess(processTag);
+      _c.defineStructure(ROUTER_ISIS, processTag, ctx);
+      _c.referenceStructure(
+          ROUTER_ISIS, processTag, ROUTER_ISIS_SELF_REFERENCE, ctx.tag.getStart().getLine());
+    } else {
+      // Dummy process, with all inner config also dummy.
+      _currentIsisProcess = new IsisProcess("dummy");
+    }
+    _currentIsisVrf = _currentIsisProcess.getOrCreateVrf(DEFAULT_VRF_NAME);
+  }
+
+  @Override
+  public void exitRouter_isis(Router_isisContext ctx) {
+    _currentIsisProcess = null;
+    _currentIsisVrf = null;
+  }
+
+  @Override
+  public void enterRi_vrf(Ri_vrfContext ctx) {
+    Optional<String> nameOrErr = toString(ctx, ctx.name);
+    if (nameOrErr.isPresent()) {
+      _currentIsisVrf = _currentIsisProcess.getOrCreateVrf(nameOrErr.get());
+    } else {
+      // Dummy so parsing doesn't crash.
+      _currentIsisVrf = new IsisVrfConfiguration();
+    }
+  }
+
+  @Override
+  public void exitRi_vrf(Ri_vrfContext ctx) {
+    _currentIsisVrf = _currentIsisProcess.getOrCreateVrf(DEFAULT_VRF_NAME);
+  }
+
+  @Override
+  public void exitRi_net(Ri_netContext ctx) {
+    _currentIsisVrf.setNetAddress(new IsoAddress(ctx.net.getText()));
+  }
+
+  @Override
+  public void exitRi_is_type(Ri_is_typeContext ctx) {
+    _currentIsisVrf.setLevel(toIsisLevel(ctx.level));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
@@ -135,6 +135,11 @@ import org.batfish.datamodel.eigrp.EigrpMetricValues;
 import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
+import org.batfish.datamodel.isis.IsisInterfaceLevelSettings;
+import org.batfish.datamodel.isis.IsisInterfaceMode;
+import org.batfish.datamodel.isis.IsisInterfaceSettings;
+import org.batfish.datamodel.isis.IsisLevel;
+import org.batfish.datamodel.isis.IsisLevelSettings;
 import org.batfish.datamodel.isis.IsisMetricType;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
@@ -325,6 +330,12 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   private static final IntegerSpace DEFAULT_RESERVED_VLAN_RANGE =
       IntegerSpace.of(Range.closed(3968, 4094));
 
+  /** Default NX-OS IS-IS (wide) interface metric on non-loopback interfaces. */
+  private static final long DEFAULT_ISIS_METRIC = 40L;
+
+  /** Default NX-OS IS-IS (wide) interface metric on loopback interfaces. */
+  private static final long DEFAULT_LOOPBACK_ISIS_METRIC = 1L;
+
   private static final int MAX_FRAGMENT_OFFSET = (1 << 13) - 1;
   private static final AclLineMatchExpr MATCH_INITIAL_FRAGMENT_OFFSET =
       match(
@@ -427,6 +438,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   private final @Nonnull Map<String, IpPrefixList> _ipPrefixLists;
   private final @Nonnull Map<String, Ipv6AccessList> _ipv6AccessLists;
   private final @Nonnull Map<String, Ipv6PrefixList> _ipv6PrefixLists;
+  private final @Nonnull Map<String, IsisProcess> _isisProcesses;
   private final @Nonnull Map<String, LoggingServer> _loggingServers;
   private @Nullable String _loggingSourceInterface;
   private @Nonnull NxosMajorVersion _majorVersion;
@@ -462,6 +474,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     _ipPrefixLists = new HashMap<>();
     _ipv6AccessLists = new HashMap<>();
     _ipv6PrefixLists = new HashMap<>();
+    _isisProcesses = new HashMap<>();
     _loggingServers = new HashMap<>();
     _majorVersion = NxosMajorVersion.UNKNOWN;
     _ntpServers = new HashMap<>();
@@ -916,6 +929,41 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   private void convertEigrp() {
     getEigrpProcesses().forEach(this::convertEigrpProcess);
+  }
+
+  /** Convert IS-IS processes. A VRF's IS-IS is modeled only if it specifies a {@code net}. */
+  private void convertIsis() {
+    _isisProcesses.values().forEach(this::convertIsisProcess);
+  }
+
+  private void convertIsisProcess(IsisProcess proc) {
+    proc.getVrfs()
+        .forEach((vrfName, vrfConfig) -> convertIsisVrf(proc.getTag(), vrfName, vrfConfig));
+  }
+
+  private void convertIsisVrf(String procTag, String vrfName, IsisVrfConfiguration vrfConfig) {
+    org.batfish.datamodel.Vrf vrf = _c.getVrfs().get(vrfName);
+    if (vrf == null) {
+      return;
+    }
+    if (vrfConfig.getNetAddress() == null) {
+      _w.redFlagf(
+          "Cannot create IS-IS process %s in vrf %s without specifying a net address",
+          procTag, vrfName);
+      return;
+    }
+    org.batfish.datamodel.isis.IsisProcess.Builder newProcess =
+        org.batfish.datamodel.isis.IsisProcess.builder().setNetAddress(vrfConfig.getNetAddress());
+    IsisLevelSettings levelSettings = IsisLevelSettings.builder().build();
+    switch (vrfConfig.getLevel()) {
+      case LEVEL_1 -> newProcess.setLevel1(levelSettings);
+      case LEVEL_2 -> newProcess.setLevel2(levelSettings);
+      case LEVEL_1_2 -> {
+        newProcess.setLevel1(levelSettings);
+        newProcess.setLevel2(levelSettings);
+      }
+    }
+    vrf.setIsisProcess(newProcess.build());
   }
 
   private void convertEigrpProcess(String procName, EigrpProcessConfiguration processConfig) {
@@ -1717,6 +1765,18 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     return _eigrpProcesses.computeIfAbsent(processTag, name -> new EigrpProcessConfiguration());
   }
 
+  public @Nonnull Map<String, IsisProcess> getIsisProcesses() {
+    return Collections.unmodifiableMap(_isisProcesses);
+  }
+
+  public @Nullable IsisProcess getIsisProcess(String processTag) {
+    return _isisProcesses.get(processTag);
+  }
+
+  public @Nonnull IsisProcess getOrCreateIsisProcess(String processTag) {
+    return _isisProcesses.computeIfAbsent(processTag, IsisProcess::new);
+  }
+
   public @Nullable Evpn getEvpn() {
     return _evpn;
   }
@@ -2313,8 +2373,58 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       }
     }
 
+    // IS-IS: an interface running `ip router isis <tag>` gets IS-IS settings if its VRF's IS-IS is
+    // modeled (i.e. has a net address).
+    String isisProcessTag = iface.getIsisProcess();
+    if (isisProcessTag != null) {
+      IsisProcess isisProcess = _isisProcesses.get(isisProcessTag);
+      IsisVrfConfiguration isisVrf = isisProcess == null ? null : isisProcess.getVrf(vrfName);
+      if (isisVrf != null && isisVrf.getNetAddress() != null) {
+        IsisInterfaceSettings isis = toIsisInterfaceSettings(iface, isisVrf, newIface);
+        if (isis != null) {
+          newIface.setIsis(isis);
+        }
+      }
+    }
+
     newIface.setOwner(_c);
     return newIface;
+  }
+
+  /**
+   * Build VI {@link IsisInterfaceSettings} for an interface enrolled in the given IS-IS VRF {@code
+   * config}. The active level is the VRF's {@code is-type} intersected with any per-interface
+   * {@code isis circuit-type}. Returns {@code null} if the resulting level set is empty.
+   */
+  private static @Nullable IsisInterfaceSettings toIsisInterfaceSettings(
+      Interface iface, IsisVrfConfiguration config, org.batfish.datamodel.Interface viIface) {
+    // The interface circuit-type narrows the process level; when unset, the interface uses the
+    // process level directly.
+    IsisLevel circuitType = iface.getIsisInterfaceCircuitType();
+    IsisLevel level =
+        circuitType == null
+            ? config.getLevel()
+            : IsisLevel.intersection(config.getLevel(), circuitType);
+    if (level == null) {
+      return null;
+    }
+    // NX-OS uses wide metrics by default: a default metric of 40 on most interfaces, and 1 on
+    // loopbacks.
+    long cost = viIface.isLoopback() ? DEFAULT_LOOPBACK_ISIS_METRIC : DEFAULT_ISIS_METRIC;
+    IsisInterfaceLevelSettings levelSettings =
+        IsisInterfaceLevelSettings.builder()
+            .setCost(cost)
+            .setMode(IsisInterfaceMode.ACTIVE)
+            .build();
+    IsisInterfaceSettings.Builder builder =
+        IsisInterfaceSettings.builder().setPointToPoint(iface.getIsisNetworkPointToPoint());
+    if (level.includes(IsisLevel.LEVEL_1)) {
+      builder.setLevel1(levelSettings);
+    }
+    if (level.includes(IsisLevel.LEVEL_2)) {
+      builder.setLevel2(levelSettings);
+    }
+    return builder.build();
   }
 
   /**
@@ -3904,6 +4014,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     convertNves();
     convertBgp();
     convertEigrp();
+    convertIsis();
     makeLeakConfigs();
 
     markStructures();

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosStructureUsage.java
@@ -75,6 +75,7 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   INTERFACE_IP_RIP_ROUTE_FILTER_PREFIX_LIST("interface ip rip route-filter prefix-list"),
   INTERFACE_IP_RIP_ROUTE_FILTER_ROUTE_MAP("interface ip rip route-filter route-map"),
   INTERFACE_IP_ROUTER_EIGRP("interface ip router eigrp"),
+  INTERFACE_IP_ROUTER_ISIS("interface ip router isis"),
   INTERFACE_IP_ROUTER_OSPF("interface ip router ospf"),
   INTERFACE_IP_ROUTER_RIP("interface ip router rip"),
   INTERFACE_IPV6_ROUTER_OSPFV3("interface ipv6 router ospfv3"),

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/Interface.java
@@ -12,6 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.isis.IsisLevel;
 
 /** A layer-2- or layer-3-capable network interface */
 public final class Interface implements Serializable {
@@ -162,6 +163,9 @@ public final class Interface implements Serializable {
   private boolean _ipv6AddressDhcp;
   private final @Nonnull Set<InterfaceIpv6AddressWithAttributes> _ipv6AddressSecondaries;
   private @Nullable Boolean _ipProxyArp;
+  private @Nullable String _isisProcess;
+  private @Nullable IsisLevel _isisInterfaceCircuitType;
+  private boolean _isisNetworkPointToPoint;
   private @Nullable Lacp _lacp;
   private @Nullable Integer _mtu;
   private final @Nonnull String _name;
@@ -329,6 +333,33 @@ public final class Interface implements Serializable {
 
   public void setIpProxyArp(@Nullable Boolean ipProxyArp) {
     _ipProxyArp = ipProxyArp;
+  }
+
+  /** The tag of the IS-IS process this interface participates in via {@code ip router isis}. */
+  public @Nullable String getIsisProcess() {
+    return _isisProcess;
+  }
+
+  public void setIsisProcess(@Nullable String isisProcess) {
+    _isisProcess = isisProcess;
+  }
+
+  /** The per-interface {@code isis circuit-type}, or {@code null} if not configured. */
+  public @Nullable IsisLevel getIsisInterfaceCircuitType() {
+    return _isisInterfaceCircuitType;
+  }
+
+  public void setIsisInterfaceCircuitType(@Nullable IsisLevel isisInterfaceCircuitType) {
+    _isisInterfaceCircuitType = isisInterfaceCircuitType;
+  }
+
+  /** Whether {@code isis network point-to-point} is configured on this interface. */
+  public boolean getIsisNetworkPointToPoint() {
+    return _isisNetworkPointToPoint;
+  }
+
+  public void setIsisNetworkPointToPoint(boolean isisNetworkPointToPoint) {
+    _isisNetworkPointToPoint = isisNetworkPointToPoint;
   }
 
   public @Nullable Lacp getLacp() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/IsisProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/IsisProcess.java
@@ -1,0 +1,46 @@
+package org.batfish.vendor.cisco_nxos.representation;
+
+import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosConfiguration.DEFAULT_VRF_NAME;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Represents an IS-IS routing process (a single {@code router isis <tag>} instance) in Cisco NX-OS.
+ *
+ * <p>Per-VRF settings (the {@code config-router} and {@code config-router-vrf} {@code net} / {@code
+ * is-type}) live in {@link IsisVrfConfiguration}; the default VRF always exists.
+ */
+public final class IsisProcess implements Serializable {
+
+  public IsisProcess(String tag) {
+    _tag = tag;
+    _vrfs = new HashMap<>();
+    // The default VRF always exists.
+    getOrCreateVrf(DEFAULT_VRF_NAME);
+  }
+
+  public @Nonnull String getTag() {
+    return _tag;
+  }
+
+  /** A read-only map containing the per-VRF IS-IS configuration. */
+  public @Nonnull Map<String, IsisVrfConfiguration> getVrfs() {
+    return Collections.unmodifiableMap(_vrfs);
+  }
+
+  public @Nonnull IsisVrfConfiguration getOrCreateVrf(String vrfName) {
+    return _vrfs.computeIfAbsent(vrfName, name -> new IsisVrfConfiguration());
+  }
+
+  public @Nullable IsisVrfConfiguration getVrf(String vrfName) {
+    return _vrfs.get(vrfName);
+  }
+
+  private final @Nonnull String _tag;
+  private final @Nonnull Map<String, IsisVrfConfiguration> _vrfs;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/IsisVrfConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/IsisVrfConfiguration.java
@@ -1,0 +1,40 @@
+package org.batfish.vendor.cisco_nxos.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.IsoAddress;
+import org.batfish.datamodel.isis.IsisLevel;
+
+/**
+ * Represents the VRF-specific IS-IS configuration for an IS-IS process in Cisco NX-OS.
+ *
+ * <p>Holds the {@code net} and {@code is-type} settings, which are configurable both at the {@code
+ * config-router} level (default VRF) and inside a {@code vrf} block.
+ */
+public final class IsisVrfConfiguration implements Serializable {
+
+  public IsisVrfConfiguration() {
+    // NX-OS defaults to level-1-2 when is-type is not specified.
+    _level = IsisLevel.LEVEL_1_2;
+  }
+
+  public @Nonnull IsisLevel getLevel() {
+    return _level;
+  }
+
+  public void setLevel(@Nonnull IsisLevel level) {
+    _level = level;
+  }
+
+  public @Nullable IsoAddress getNetAddress() {
+    return _netAddress;
+  }
+
+  public void setNetAddress(@Nullable IsoAddress netAddress) {
+    _netAddress = netAddress;
+  }
+
+  private @Nonnull IsisLevel _level;
+  private @Nullable IsoAddress _netAddress;
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
@@ -130,6 +130,7 @@ import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosConfiguratio
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosConfiguration.toJavaRegex;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureType.BGP_NEIGHBOR;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureType.OBJECT_GROUP_IP_ADDRESS;
+import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureType.ROUTER_ISIS;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureType.ROUTE_MAP;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.BGP_NEXTHOP_ROUTE_MAP;
 import static org.batfish.vendor.cisco_nxos.representation.Conversions.generatedAttributeMapName;
@@ -241,6 +242,7 @@ import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IsoAddress;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LocalRoute;
 import org.batfish.datamodel.LongSpace;
@@ -283,6 +285,8 @@ import org.batfish.datamodel.eigrp.EigrpMetricValues;
 import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
+import org.batfish.datamodel.isis.IsisInterfaceSettings;
+import org.batfish.datamodel.isis.IsisLevel;
 import org.batfish.datamodel.matchers.HsrpGroupMatchers;
 import org.batfish.datamodel.matchers.IpAccessListMatchers;
 import org.batfish.datamodel.matchers.NssaSettingsMatchers;
@@ -370,6 +374,8 @@ import org.batfish.vendor.cisco_nxos.representation.IpPrefixList;
 import org.batfish.vendor.cisco_nxos.representation.IpPrefixListLine;
 import org.batfish.vendor.cisco_nxos.representation.Ipv6PrefixList;
 import org.batfish.vendor.cisco_nxos.representation.Ipv6PrefixListLine;
+import org.batfish.vendor.cisco_nxos.representation.IsisProcess;
+import org.batfish.vendor.cisco_nxos.representation.IsisVrfConfiguration;
 import org.batfish.vendor.cisco_nxos.representation.Lacp;
 import org.batfish.vendor.cisco_nxos.representation.Layer3Options;
 import org.batfish.vendor.cisco_nxos.representation.LiteralIpAddressSpec;
@@ -2099,6 +2105,73 @@ public final class CiscoNxosGrammarTest {
       assertThat(p12345.getExternalAdminCost(), equalTo(22));
       assertThat(p12345.getMetricVersion(), equalTo(EigrpMetricVersion.V2));
     }
+  }
+
+  @Test
+  public void testIsisExtraction() {
+    CiscoNxosConfiguration c = parseVendorConfig("nxos_isis");
+    assertThat(c.getIsisProcesses(), hasKeys("UNDERLAY"));
+    IsisProcess proc = c.getIsisProcess("UNDERLAY");
+    assertThat(proc.getVrfs(), hasKeys(DEFAULT_VRF_NAME, "TENANT"));
+    {
+      IsisVrfConfiguration vrf = proc.getVrf(DEFAULT_VRF_NAME);
+      assertThat(vrf.getNetAddress(), equalTo(new IsoAddress("49.0001.0000.0000.0011.00")));
+      assertThat(vrf.getLevel(), equalTo(IsisLevel.LEVEL_2));
+    }
+    {
+      IsisVrfConfiguration vrf = proc.getVrf("TENANT");
+      assertThat(vrf.getNetAddress(), equalTo(new IsoAddress("49.0001.0000.0000.0099.00")));
+      assertThat(vrf.getLevel(), equalTo(IsisLevel.LEVEL_1_2));
+    }
+    {
+      Interface iface = c.getInterfaces().get("Ethernet1/1");
+      assertThat(iface.getIsisProcess(), equalTo("UNDERLAY"));
+      assertThat(iface.getIsisInterfaceCircuitType(), equalTo(IsisLevel.LEVEL_2));
+      assertTrue(iface.getIsisNetworkPointToPoint());
+    }
+    {
+      Interface iface = c.getInterfaces().get("loopback0");
+      assertThat(iface.getIsisProcess(), equalTo("UNDERLAY"));
+      assertThat(iface.getIsisInterfaceCircuitType(), nullValue());
+      assertFalse(iface.getIsisNetworkPointToPoint());
+    }
+  }
+
+  @Test
+  public void testIsisConversion() throws Exception {
+    Configuration c = parseConfig("nxos_isis");
+    org.batfish.datamodel.isis.IsisProcess proc = c.getDefaultVrf().getIsisProcess();
+    assertThat(proc, notNullValue());
+    assertThat(proc.getNetAddress(), equalTo(new IsoAddress("49.0001.0000.0000.0011.00")));
+    // is-type level-2: only level 2 is active.
+    assertThat(proc.getLevel1(), nullValue());
+    assertThat(proc.getLevel2(), notNullValue());
+    {
+      IsisInterfaceSettings isis = c.getAllInterfaces().get("Ethernet1/1").getIsis();
+      assertThat(isis, notNullValue());
+      assertTrue(isis.getPointToPoint());
+      assertThat(isis.getLevel1(), nullValue());
+      assertThat(isis.getLevel2(), notNullValue());
+    }
+    {
+      // Loopback with `ip router isis` but no circuit-type still gets level-2 from the process.
+      IsisInterfaceSettings isis = c.getAllInterfaces().get("loopback0").getIsis();
+      assertThat(isis, notNullValue());
+      assertThat(isis.getLevel2(), notNullValue());
+    }
+  }
+
+  @Test
+  public void testIsisReferences() throws Exception {
+    String hostname = "nxos_isis";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    assertThat(ccae, hasDefinedStructure(filename, ROUTER_ISIS, "UNDERLAY"));
+    // Self-reference plus the two `ip router isis` interface references.
+    assertThat(ccae, hasNumReferrers(filename, ROUTER_ISIS, "UNDERLAY", 3));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_isis
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_isis
@@ -1,0 +1,43 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_isis
+!
+feature isis
+!
+interface Ethernet1/1
+  no switchport
+  ip address 10.0.0.0/31
+  isis network point-to-point
+  isis circuit-type level-2
+  ip router isis UNDERLAY
+  no shutdown
+!
+interface loopback0
+  ip address 1.1.1.1/32
+  ip router isis UNDERLAY
+!
+router isis UNDERLAY
+  net 49.0001.0000.0000.0011.00
+  is-type level-2
+  log-adjacency-changes
+  metric-style transition
+  set-overload-bit on-startup 120
+  lsp-gen-interval 50 50 50
+  max-lsp-lifetime 65535
+  graceful-restart
+  passive-interface default level-2
+  address-family ipv4 unicast
+    bfd
+    distance 115
+    maximum-paths 8
+    summary-address 10.0.0.0/8 level-2
+  address-family ipv6 unicast
+    multi-topology
+    set-attached-bit
+    segment-routing srv6
+      locator MY_LOCATOR
+  vrf TENANT
+    net 49.0001.0000.0000.0099.00
+    is-type level-1-2
+    address-family ipv4 unicast
+      distance 116


### PR DESCRIPTION
Add NX-OS IS-IS support end to end: parse the `router isis` hierarchy and
interface `ip router isis` / `isis circuit-type` / `isis network
point-to-point` lines, extract a per-tag IsisProcess, and convert the
default-VRF process to the vendor-independent IS-IS model so adjacencies
form and isisL2 routes install.

The grammar follows the actual NX-OS command hierarchy (Nexus 9000 command
reference): the `router isis` process body, a `vrf` sub-mode, `address-family
ipv4|ipv6 unicast` sub-modes, and `segment-routing srv6` with a `locator`
sub-mode. Only `net`, `is-type`, `ip router isis`, `isis circuit-type`, and
`isis network point-to-point` are modeled; the rest of the hierarchy is
parsed and ignored via per-token null rules so real configs do not regress
to unrecognized syntax. The lexer's `isis` token now pushes M_Word only
after ROUTER/REDISTRIBUTE so interface `isis` subcommands lex as keywords,
and a `net`/ISO-address lexer mode is added.

Interface IS-IS metrics use the NX-OS wide-metric defaults (40 per transit
link, 1 on loopbacks) so learned route metrics match device output.

Validated with the nxos_isis lab in lab-validation: the level-2 adjacency
forms over the point-to-point link and each router installs the other's
loopback as isisL2 (1.1.1.1/32, 2.2.2.2/32). The lab's route test remains
sickbay'd only for the unrelated management-VRF default route.

Fixes batfish/batfish#10003.

----

Prompt:
```
Add NX-OS parsing support for is-is constructs, using the new nxos_isis
lab (../lab-validation) for validation
```
