### PR TITLE
Junos: warn when then add-path send-count lacks group add-path send

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2663,6 +2663,8 @@ SELF_PING_DURATION: 'self-ping-duration';
 
 SEND: 'send';
 
+SEND_COUNT: 'send-count';
+
 SERVER: 'server' -> pushMode(M_NameOrIp);
 
 SERVER_GROUP: 'server-group' -> pushMode(M_Name);

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -533,6 +533,11 @@ popst_accept
    ACCEPT
 ;
 
+popst_add_path
+:
+   ADD_PATH SEND_COUNT count = send_path_count
+;
+
 popst_aigp_originate: AIGP_ORIGINATE (distance = uint32)?;
 
 popst_as_path_expand
@@ -581,6 +586,7 @@ popst_color2
 popst_common
 :
    popst_accept
+   | popst_add_path
    | popst_aigp_originate
    | popst_as_path_expand
    | popst_as_path_prepend

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -655,6 +655,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_thenContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_throughContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_uptoContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_acceptContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_add_pathContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_aigp_originateContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_as_path_expandContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_as_path_prependContext;
@@ -1192,6 +1193,7 @@ import org.batfish.representation.juniper.PsProtocol;
 import org.batfish.representation.juniper.PsTerm;
 import org.batfish.representation.juniper.PsThen;
 import org.batfish.representation.juniper.PsThenAccept;
+import org.batfish.representation.juniper.PsThenAddPathSendCount;
 import org.batfish.representation.juniper.PsThenAigpOriginate;
 import org.batfish.representation.juniper.PsThenAsPathExpand;
 import org.batfish.representation.juniper.PsThenAsPathExpandAsList;
@@ -6749,6 +6751,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitPopst_accept(Popst_acceptContext ctx) {
     addPsThen(PsThenAccept.INSTANCE, ctx);
+  }
+
+  @Override
+  public void exitPopst_add_path(Popst_add_pathContext ctx) {
+    toInteger(ctx, ctx.count).ifPresent(count -> addPsThen(new PsThenAddPathSendCount(count), ctx));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -34,9 +34,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Range;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -52,6 +54,7 @@ import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -703,6 +706,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
                 prefix);
           }
         }
+      }
+      // `then add-path send-count` in an export policy is silently ignored by Junos unless add-path
+      // send is enabled at the BGP group/neighbor level. Warn if an export policy uses it but this
+      // neighbor does not have add-path send enabled (path-count set).
+      boolean addPathSendEnabled =
+          addPath != null && addPath.getSend() != null && addPath.getSend().getPathCount() != null;
+      if (!addPathSendEnabled) {
+        warnUnreachableAddPathSendCount(ig.getExportPolicies(), prefix);
       }
       ipv4AfSettingsBuilder.setAllowLocalAsIn(allowLocalAsIn);
       Boolean advertisePeerAs = ig.getAdvertisePeerAs();
@@ -4878,6 +4889,55 @@ public final class JuniperConfiguration extends VendorConfiguration {
       PrefixList prefixList = e.getValue();
       if (!prefixList.getHasIpv6() && prefixList.getPrefixes().isEmpty()) {
         _w.redFlag("Empty prefix-list: '" + name + "'");
+      }
+    }
+  }
+
+  /**
+   * Warns if any policy reachable from the given export policies uses {@code then add-path
+   * send-count} while add-path send is not enabled at the BGP group/neighbor level. Junos silently
+   * ignores the policy-level directive in that case, so the action is dead config.
+   *
+   * <p>Reachability follows {@code from policy} subroutine calls (including conjunction form)
+   * transitively, since a subroutine's {@code then} actions execute as part of evaluating the
+   * calling policy.
+   *
+   * @param exportPolicies names of policies exported toward the neighbor
+   * @param neighbor the neighbor prefix, for the warning message
+   */
+  private void warnUnreachableAddPathSendCount(List<String> exportPolicies, Prefix neighbor) {
+    Set<String> visited = new HashSet<>();
+    Queue<String> queue = new ArrayDeque<>(exportPolicies);
+    while (!queue.isEmpty()) {
+      String policyName = queue.remove();
+      if (!visited.add(policyName)) {
+        continue;
+      }
+      PolicyStatement policy = _masterLogicalSystem.getPolicyStatements().get(policyName);
+      if (policy == null) {
+        continue;
+      }
+      for (PsTerm term :
+          Iterables.concat(ImmutableList.of(policy.getDefaultTerm()), policy.getTerms().values())) {
+        for (PsThen then : term.getThens().getAllThens()) {
+          if (then instanceof PsThenAddPathSendCount) {
+            _w.riskyRedFlag(
+                "policy-statement %s term %s: 'then add-path send-count %d' has no effect because"
+                    + " add-path send is not enabled at the BGP group level for neighbor %s",
+                policyName,
+                term.getName(),
+                ((PsThenAddPathSendCount) then).getSendCount(),
+                neighbor);
+          }
+        }
+        // Follow `from policy` subroutine calls transitively.
+        PsFroms froms = term.getFroms();
+        for (PsFromPolicyStatement from : froms.getFromPolicyStatements()) {
+          queue.add(from.getPolicyStatement());
+        }
+        for (PsFromPolicyStatementConjunction from : froms.getFromPolicyStatementConjunctions()) {
+          queue.addAll(from.getConjuncts());
+        }
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAddPathSendCount.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenAddPathSendCount.java
@@ -1,0 +1,55 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * Represents the {@code then add-path send-count} action in a Juniper routing policy, which caps
+ * the number of additional paths advertised per prefix to routes matched by the term.
+ *
+ * <p>The directive is only honored when add-path send is also enabled at the BGP group/neighbor
+ * level (via {@code family <af> add-path send path-count}); otherwise Junos ignores it.
+ *
+ * <p>Batfish does not yet model the number of additional paths to advertise (the same gap exists
+ * for the group-level {@code add-path send path-count}), so this action is currently a no-op in the
+ * vendor-independent model.
+ */
+public final class PsThenAddPathSendCount extends PsThen {
+
+  private final int _sendCount;
+
+  public PsThenAddPathSendCount(int sendCount) {
+    _sendCount = sendCount;
+  }
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings warnings) {
+    // No-op: add-path send is controlled at the BGP group/neighbor level, not via policy.
+  }
+
+  public int getSendCount() {
+    return _sendCount;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenAddPathSendCount)) {
+      return false;
+    }
+    PsThenAddPathSendCount that = (PsThenAddPathSendCount) o;
+    return _sendCount == that._sendCount;
+  }
+
+  @Override
+  public int hashCode() {
+    return Integer.hashCode(_sendCount);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
@@ -127,7 +127,8 @@ public final class PsThens implements Serializable {
           "load-balance",
           "source-class",
           "tunnel-attribute set",
-          "tunnel-attribute remove");
+          "tunnel-attribute remove",
+          "add-path send-count");
 
   // --- Family classification (scalar last-wins families only) ---
 
@@ -169,6 +170,8 @@ public final class PsThens implements Serializable {
       return "tunnel-attribute remove";
     } else if (then instanceof PsThenSourceClass) {
       return "source-class";
+    } else if (then instanceof PsThenAddPathSendCount) {
+      return "add-path send-count";
     }
     return null;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -491,6 +491,7 @@ import org.batfish.representation.juniper.PsFromValidationDatabase;
 import org.batfish.representation.juniper.PsProtocol;
 import org.batfish.representation.juniper.PsTerm;
 import org.batfish.representation.juniper.PsThen;
+import org.batfish.representation.juniper.PsThenAddPathSendCount;
 import org.batfish.representation.juniper.PsThenAigpOriginate;
 import org.batfish.representation.juniper.PsThenAsPathExpandAsList;
 import org.batfish.representation.juniper.PsThenAsPathExpandLastAs;
@@ -1818,6 +1819,55 @@ public final class FlatJuniperGrammarTest {
             POLICY_STATEMENT,
             "appp",
             JuniperStructureUsage.ADD_PATH_SEND_PREFIX_POLICY));
+  }
+
+  @Test
+  public void testPolicyAddPathSendCountExtraction() {
+    String hostname = "juniper-policy-add-path-send-count";
+    JuniperConfiguration vc = parseJuniperConfig(hostname);
+    PsTerm term =
+        vc.getMasterLogicalSystem()
+            .getPolicyStatements()
+            .get("ADD-PATH-POLICY")
+            .getTerms()
+            .get("t1");
+    assertThat(term.getThens().getAllThens(), hasItem(new PsThenAddPathSendCount(16)));
+  }
+
+  @Test
+  public void testPolicyAddPathSendCountConversionWarning() throws IOException {
+    String hostname = "juniper-policy-add-path-send-count";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    SortedSet<Warning> riskyWarnings = ccae.getWarnings().get(hostname).getRiskyRedFlagWarnings();
+
+    // Group g1 applies the policy without group-level add-path send: dead config -> warning.
+    assertThat(
+        riskyWarnings,
+        hasItem(
+            WarningMatchers.hasText(
+                "RISK: policy-statement ADD-PATH-POLICY term t1: 'then add-path send-count 16' has"
+                    + " no effect because add-path send is not enabled at the BGP group level for"
+                    + " neighbor 10.0.0.1/32")));
+    // Group g2 enables group-level add-path send, so no warning is emitted for 10.0.0.2/32.
+    assertThat(
+        riskyWarnings,
+        not(
+            hasItem(
+                WarningMatchers.hasText(
+                    "RISK: policy-statement ADD-PATH-POLICY term t1: 'then add-path send-count 16'"
+                        + " has no effect because add-path send is not enabled at the BGP group"
+                        + " level for neighbor 10.0.0.2/32"))));
+    // Group g3 reaches the directive only through a `from policy` subroutine call: the warning
+    // names the inner policy that actually contains the directive.
+    assertThat(
+        riskyWarnings,
+        hasItem(
+            WarningMatchers.hasText(
+                "RISK: policy-statement SUBROUTINE-POLICY term t1: 'then add-path send-count 8' has"
+                    + " no effect because add-path send is not enabled at the BGP group level for"
+                    + " neighbor 10.0.0.3/32")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThensTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThensTest.java
@@ -778,4 +778,28 @@ public class PsThensTest {
         contains("default-action (dead-with-bare-terminator)"));
     assertThat(ps.getAllThens(), containsInAnyOrder(PsThenAccept.INSTANCE, defaultReject));
   }
+
+  // ==========================================================================
+  // add-path send-count — scalar last-wins family
+  // ==========================================================================
+
+  @Test
+  public void testAddPathSendCountDedup() {
+    PsThens ps = new PsThens();
+    PsThenAddPathSendCount c16 = new PsThenAddPathSendCount(16);
+    assertThat(ps.addPsThen(c16), empty());
+    assertThat(
+        ps.addPsThen(new PsThenAddPathSendCount(16)), contains("add-path send-count (dedup)"));
+    assertEquals(ImmutableList.of(c16), ps.getAllThens());
+  }
+
+  @Test
+  public void testAddPathSendCountLastWins() {
+    PsThens ps = new PsThens();
+    PsThenAddPathSendCount c16 = new PsThenAddPathSendCount(16);
+    PsThenAddPathSendCount c32 = new PsThenAddPathSendCount(32);
+    assertThat(ps.addPsThen(c16), empty());
+    assertThat(ps.addPsThen(c32), contains("add-path send-count"));
+    assertEquals(ImmutableList.of(c32), ps.getAllThens());
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-add-path-send-count
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-add-path-send-count
@@ -1,0 +1,39 @@
+#RANCID-CONTENT-TYPE: juniper
+set system host-name juniper-policy-add-path-send-count
+
+# Boilerplate
+set interfaces xe-0/0/0 unit 0 family inet address 10.0.0.254/24
+set routing-options autonomous-system 65500
+set routing-options router-id 10.0.0.254
+
+# Export policy that attempts to enable add-path send per-route. This is silently
+# ignored by Junos unless add-path send is enabled at the BGP group/neighbor level.
+set policy-options policy-statement ADD-PATH-POLICY term t1 then add-path send-count 16
+set policy-options policy-statement ADD-PATH-POLICY term t1 then accept
+
+# Group g1: applies the policy but does NOT enable add-path send at the group level.
+# The policy directive is dead config here -> risky warning expected.
+set protocols bgp group g1 type internal
+set protocols bgp group g1 peer-as 65500
+set protocols bgp group g1 export ADD-PATH-POLICY
+set protocols bgp group g1 neighbor 10.0.0.1
+
+# Group g2: applies the policy AND enables add-path send at the group level.
+# The policy directive takes effect here -> no warning expected.
+set protocols bgp group g2 family inet unicast add-path send path-count 16
+set protocols bgp group g2 type internal
+set protocols bgp group g2 peer-as 65500
+set protocols bgp group g2 export ADD-PATH-POLICY
+set protocols bgp group g2 neighbor 10.0.0.2
+
+# Outer policy that reaches the directive only via a `from policy` subroutine call.
+# Group g3 exports OUTER without group-level add-path send -> warning expected naming
+# the inner policy SUBROUTINE-POLICY.
+set policy-options policy-statement SUBROUTINE-POLICY term t1 then add-path send-count 8
+set policy-options policy-statement OUTER-POLICY term t1 from policy SUBROUTINE-POLICY
+set policy-options policy-statement OUTER-POLICY term t1 then accept
+set protocols bgp group g3 type internal
+set protocols bgp group g3 peer-as 65500
+set protocols bgp group g3 export OUTER-POLICY
+set protocols bgp group g3 neighbor 10.0.0.3
+#


### PR DESCRIPTION
Junos ignores a policy's `then add-path send-count N` unless add-path
send is also enabled at the BGP group/neighbor level (`family inet
unicast add-path send path-count N`).

This parses `then add-path send-count` (previously unparsed) and models
it as `PsThenAddPathSendCount`. It is a no-op in the vendor-independent
model, since Batfish does not yet model the additional-paths count (same
gap as the group-level directive). During BGP conversion, neighbors
without effective add-path send get a risky warning for each export
policy using the directive, naming the policy, term, count, and
neighbor.

Follow-up: also handle policies reached indirectly through `from policy`
subroutine calls, not just those listed directly in `export`.
