### PR TITLE
BGP: model tcp_l3mdev_accept via SessionVrfScope (accept from any VRF)

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/e2e/bgp/forwardingcontext/BgpForwardingContextTest.java
+++ b/projects/allinone/src/test/java/org/batfish/e2e/bgp/forwardingcontext/BgpForwardingContextTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.nullValue;
 import java.io.IOException;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.bgp.SessionVrfScope.SpecificVrf;
 import org.batfish.datamodel.questions.BgpSessionStatus;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.main.Batfish;
@@ -107,6 +108,6 @@ public class BgpForwardingContextTest {
             .iterator()
             .next()
             .getSessionVrf(),
-        equalTo("default"));
+        equalTo(new SpecificVrf("default")));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
@@ -89,6 +89,7 @@ import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.SessionVrfScope.AnyVrf;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.ospf.OspfArea;
@@ -492,6 +493,9 @@ public final class CumulusConversions {
     @Nullable
     RoutingPolicy importRoutingPolicy = computeBgpNeighborImportRoutingPolicy(c, neighbor, bgpVrf);
 
+    // Cumulus runs BGP over a listening socket that is not bound to a particular VRF and relies on
+    // the kernel sysctl tcp_l3mdev_accept=1 to accept connections arriving on any VRF.
+    peerConfigBuilder.setSessionVrfScope(AnyVrf.instance());
     peerConfigBuilder
         .setBgpProcess(newProc)
         .setClusterId(inferClusterId(bgpVrf, newProc.getRouterId(), neighbor, localAs))

--- a/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/frr/FrrConversions.java
@@ -88,6 +88,7 @@ import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.SessionVrfScope.AnyVrf;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.ospf.OspfAddresses;
@@ -697,6 +698,9 @@ public final class FrrConversions {
     @Nullable
     BgpNeighborIpv4UnicastAddressFamily ipv4u =
         bgpVrf.getIpv4UnicastConfiguration(neighbor.getName());
+    // FRR/Cumulus/SONiC run BGP over a listening socket that is not bound to a particular VRF and
+    // rely on the kernel sysctl tcp_l3mdev_accept=1 to accept connections arriving on any VRF.
+    peerConfigBuilder.setSessionVrfScope(AnyVrf.instance());
     peerConfigBuilder
         .setBgpProcess(newProc)
         .setClusterId(inferClusterId(bgpVrf, newProc.getRouterId(), neighbor, localAs))

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -139,6 +139,7 @@ import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.SessionVrfScope.SpecificVrf;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.dataplane.rib.RibId;
@@ -876,10 +877,11 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // forwarding-context: resolve the VRF from which the BGP TCP session is sourced
       String forwardingContext = ig.getForwardingContext();
       if (forwardingContext != null) {
-        neighbor.setSessionVrf(
-            forwardingContext.equals(DEFAULT_ROUTING_INSTANCE_NAME)
-                ? Configuration.DEFAULT_VRF_NAME
-                : forwardingContext);
+        neighbor.setSessionVrfScope(
+            new SpecificVrf(
+                forwardingContext.equals(DEFAULT_ROUTING_INSTANCE_NAME)
+                    ? Configuration.DEFAULT_VRF_NAME
+                    : forwardingContext));
       }
       neighbor.setBgpProcess(proc);
       neighbor.setIpv4UnicastAddressFamily(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -347,6 +347,8 @@ import org.batfish.datamodel.bgp.AddressFamily;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.BgpConfederation;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.SessionVrfScope.OwnVrf;
+import org.batfish.datamodel.bgp.SessionVrfScope.SpecificVrf;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -1378,26 +1380,26 @@ public final class FlatJuniperGrammarTest {
 
   @Test
   public void testBgpForwardingContextConversion() {
-    // Test VI conversion: forwarding-context master → sessionVrf = "default"
+    // Test VI conversion: forwarding-context master → sessionVrf = SpecificVrf("default")
     Configuration c = parseConfig("bgp-forwarding-context");
 
     // VRF1 peer (protocol-level forwarding-context)
     BgpActivePeerConfig vrf1Peer =
         c.getVrfs().get("VRF1").getBgpProcess().getActiveNeighbors().get(Ip.parse("10.0.0.2"));
     assertThat(vrf1Peer, notNullValue());
-    assertThat(vrf1Peer.getSessionVrf(), equalTo(Configuration.DEFAULT_VRF_NAME));
+    assertThat(vrf1Peer.getSessionVrf(), equalTo(new SpecificVrf(Configuration.DEFAULT_VRF_NAME)));
 
     // VRF2 peer (group-level forwarding-context)
     BgpActivePeerConfig vrf2Peer =
         c.getVrfs().get("VRF2").getBgpProcess().getActiveNeighbors().get(Ip.parse("10.0.0.3"));
     assertThat(vrf2Peer, notNullValue());
-    assertThat(vrf2Peer.getSessionVrf(), equalTo(Configuration.DEFAULT_VRF_NAME));
+    assertThat(vrf2Peer.getSessionVrf(), equalTo(new SpecificVrf(Configuration.DEFAULT_VRF_NAME)));
 
-    // Default VRF peers should not have sessionVrf set
+    // Default VRF peers should not have sessionVrf set (own VRF)
     BgpProcess defaultProc = c.getDefaultVrf().getBgpProcess();
     if (defaultProc != null) {
       for (BgpActivePeerConfig peer : defaultProc.getActiveNeighbors().values()) {
-        assertThat(peer.getSessionVrf(), nullValue());
+        assertThat(peer.getSessionVrf(), equalTo(OwnVrf.instance()));
       }
     }
   }

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpActivePeerConfig.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.SessionVrfScope;
 import org.batfish.datamodel.dataplane.rib.RibGroup;
 
 /** Represent a BGP config which allows peering with a single remote peer. */
@@ -42,7 +43,7 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
       @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport,
-      @JsonProperty(PROP_SESSION_VRF) @Nullable String sessionVrf) {
+      @JsonProperty(PROP_SESSION_VRF) @Nullable SessionVrfScope sessionVrf) {
     return new BgpActivePeerConfig(
         appliedRibGroup,
         authenticationSettings,
@@ -84,7 +85,7 @@ public final class BgpActivePeerConfig extends BgpPeerConfig {
       Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @Nullable EvpnAddressFamily evpnAddressFamily,
       boolean replaceNonLocalAsesOnExport,
-      @Nullable String sessionVrf) {
+      @Nullable SessionVrfScope sessionVrf) {
     super(
         appliedRibGroup,
         authenticationSettings,

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.SessionVrfScope;
 import org.batfish.datamodel.dataplane.rib.RibGroup;
 
 /**
@@ -44,7 +45,7 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
       @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport,
-      @JsonProperty(PROP_SESSION_VRF) @Nullable String sessionVrf) {
+      @JsonProperty(PROP_SESSION_VRF) @Nullable SessionVrfScope sessionVrf) {
     return new BgpPassivePeerConfig(
         appliedRibGroup,
         authenticationSettings,
@@ -86,7 +87,7 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @Nullable EvpnAddressFamily evpnAddressFamily,
       boolean replaceNonLocalAsesOnExport,
-      @Nullable String sessionVrf) {
+      @Nullable SessionVrfScope sessionVrf) {
     super(
         appliedRibGroup,
         authenticationSettings,

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -19,6 +19,8 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.bgp.AddressFamily;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.SessionVrfScope;
+import org.batfish.datamodel.bgp.SessionVrfScope.OwnVrf;
 import org.batfish.datamodel.dataplane.rib.RibGroup;
 
 /** Represents a configured BGP peering, at the control plane level */
@@ -96,13 +98,11 @@ public abstract class BgpPeerConfig implements Serializable {
   private final boolean _replaceNonLocalAsesOnExport;
 
   /**
-   * The VRF from which this peer's BGP TCP session is sourced, if different from the VRF in which
-   * the peer is configured. When {@code null}, the session is sourced from the peer's own VRF.
-   *
-   * <p>For example, Junos {@code forwarding-context master} causes a BGP session in a VRF to source
-   * its TCP connection from the default routing instance.
+   * Which ingress VRF(s) this peer's BGP TCP session accepts from, and which VRF it sources an
+   * outbound connection from. Defaults to {@link OwnVrf} (the peer's own VRF). See {@link
+   * SessionVrfScope}.
    */
-  private final @Nullable String _sessionVrf;
+  private final @Nonnull SessionVrfScope _sessionVrf;
 
   protected BgpPeerConfig(
       @Nullable RibGroup appliedRibGroup,
@@ -122,7 +122,7 @@ public abstract class BgpPeerConfig implements Serializable {
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @Nullable EvpnAddressFamily evpnAddressFamily,
       boolean replaceNonLocalAsesOnExport,
-      @Nullable String sessionVrf) {
+      @Nullable SessionVrfScope sessionVrf) {
     _appliedRibGroup = appliedRibGroup;
     _authenticationSettings = authenticationSettings;
     _checkLocalIpOnAccept = firstNonNull(checkLocalIpOnAccept, true);
@@ -140,7 +140,7 @@ public abstract class BgpPeerConfig implements Serializable {
     _ipv4UnicastAddressFamily = ipv4UnicastAddressFamily;
     _evpnAddressFamily = evpnAddressFamily;
     _replaceNonLocalAsesOnExport = replaceNonLocalAsesOnExport;
-    _sessionVrf = sessionVrf;
+    _sessionVrf = firstNonNull(sessionVrf, OwnVrf.instance());
   }
 
   /** Return the {@link RibGroup} applied to this config */
@@ -294,12 +294,21 @@ public abstract class BgpPeerConfig implements Serializable {
   }
 
   /**
-   * The VRF in which this peer's BGP TCP session takes place, if different from the VRF in which
-   * the peer is configured. When {@code null}, the session uses the peer's own VRF.
+   * Which ingress VRF(s) this peer's BGP TCP session accepts from, and which VRF it sources an
+   * outbound connection from. Never {@code null}; defaults to {@link OwnVrf}.
+   */
+  @JsonIgnore
+  public @Nonnull SessionVrfScope getSessionVrf() {
+    return _sessionVrf;
+  }
+
+  /**
+   * JSON view of {@link #getSessionVrf()}: {@code null} (omitted) for {@link OwnVrf}, so the common
+   * case adds nothing to serialized output.
    */
   @JsonProperty(PROP_SESSION_VRF)
-  public @Nullable String getSessionVrf() {
-    return _sessionVrf;
+  private @Nullable SessionVrfScope getSessionVrfJson() {
+    return _sessionVrf instanceof OwnVrf ? null : _sessionVrf;
   }
 
   @Override
@@ -401,7 +410,7 @@ public abstract class BgpPeerConfig implements Serializable {
     protected @Nullable String _hostname;
 
     protected boolean _replaceNonLocalAsesOnExport;
-    protected @Nullable String _sessionVrf;
+    protected @Nonnull SessionVrfScope _sessionVrf = OwnVrf.instance();
 
     protected Builder() {
       _remoteAsns = LongSpace.EMPTY;
@@ -521,7 +530,7 @@ public abstract class BgpPeerConfig implements Serializable {
       return getThis();
     }
 
-    public S setSessionVrf(@Nullable String sessionVrf) {
+    public S setSessionVrfScope(@Nonnull SessionVrfScope sessionVrf) {
       _sessionVrf = sessionVrf;
       return getThis();
     }

--- a/projects/common/src/main/java/org/batfish/datamodel/BgpUnnumberedPeerConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/BgpUnnumberedPeerConfig.java
@@ -12,6 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.SessionVrfScope;
 import org.batfish.datamodel.dataplane.rib.RibGroup;
 
 /**
@@ -96,7 +97,7 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
           Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @JsonProperty(PROP_EVPN_ADDRESS_FAMILY) @Nullable EvpnAddressFamily evpnAddressFamily,
       @JsonProperty(PROP_REPLACE_NON_LOCAL_ASES_ON_EXPORT) boolean replaceNonLocalAsesOnExport,
-      @JsonProperty(PROP_SESSION_VRF) @Nullable String sessionVrf) {
+      @JsonProperty(PROP_SESSION_VRF) @Nullable SessionVrfScope sessionVrf) {
     checkArgument(peerInterface != null, "Missing %s", PROP_PEER_INTERFACE);
     return new BgpUnnumberedPeerConfig(
         appliedRibGroup,
@@ -139,7 +140,7 @@ public final class BgpUnnumberedPeerConfig extends BgpPeerConfig {
       @Nullable Ipv4UnicastAddressFamily ipv4UnicastAddressFamily,
       @Nullable EvpnAddressFamily evpnAddressFamily,
       boolean replaceNonLocalAsesOnExport,
-      @Nullable String sessionVrf) {
+      @Nullable SessionVrfScope sessionVrf) {
     super(
         appliedRibGroup,
         authenticationSettings,

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel.bgp;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.MoreObjects;
@@ -153,8 +152,8 @@ public final class BgpTopologyUtils {
             localIpsBuilder.put(neighborId, config.getLocalIp());
           } else {
             // No explicitly configured local IP. Check for dynamically resolvable local IPs.
-            // If sessionVrf is set, resolve from that VRF's FIB instead.
-            String sourceVrfName = firstNonNull(config.getSessionVrf(), vrfName);
+            // Resolve from the VRF the session originates from (own VRF unless overridden).
+            String sourceVrfName = config.getSessionVrf().originVrf(vrfName);
             Vrf sourceVrf = sourceVrfName.equals(vrfName) ? vrf : node.getVrfs().get(sourceVrfName);
             Fib sourceFib =
                 sourceVrfName.equals(vrfName)
@@ -199,14 +198,23 @@ public final class BgpTopologyUtils {
       }
       Multimap<String, BgpPeerConfigId> hostReceivers =
           receivers.computeIfAbsent(peer.getHostname(), name -> LinkedListMultimap.create());
-      // Register under sessionVrf if set (the VRF where the TCP session lives), otherwise
-      // the peer's own VRF.
+      // Register the peer under each VRF its listening socket accepts from. Normally just the
+      // peer's own VRF (or a specific sessionVrf), but an AnyVrf listener (tcp_l3mdev_accept)
+      // registers under every VRF on the node so initiators whose peer address is owned in a
+      // non-config VRF can still find it.
       BgpPeerConfig peerConfig = networkConfigurations.getBgpPeerConfig(peer);
-      String receiverVrf =
+      Set<String> nodeVrfs =
+          networkConfigurations
+              .get(peer.getHostname())
+              .map(c -> c.getVrfs().keySet())
+              .orElse(ImmutableSet.of(peer.getVrfName()));
+      Set<String> receiverVrfs =
           peerConfig != null
-              ? firstNonNull(peerConfig.getSessionVrf(), peer.getVrfName())
-              : peer.getVrfName();
-      hostReceivers.put(receiverVrf, peer);
+              ? peerConfig.getSessionVrf().listenVrfs(peer.getVrfName(), nodeVrfs)
+              : ImmutableSet.of(peer.getVrfName());
+      for (String receiverVrf : receiverVrfs) {
+        hostReceivers.put(receiverVrf, peer);
+      }
     }
     SetMultimap<BgpPeerConfigId, Ip> localIps = localIpsBuilder.build();
 
@@ -430,7 +438,7 @@ public final class BgpTopologyUtils {
     }
 
     Ip localIp = config.getLocalIp();
-    String sourceVrf = firstNonNull(config.getSessionVrf(), vrfName);
+    String sourceVrf = config.getSessionVrf().originVrf(vrfName);
     return localIp == null
         || (ipOwners.containsKey(localIp)
             && ipOwners.get(localIp).getOrDefault(hostname, ImmutableSet.of()).contains(sourceVrf));
@@ -591,7 +599,7 @@ public final class BgpTopologyUtils {
             .setIpProtocol(IpProtocol.TCP)
             .setTcpFlagsSyn(true)
             .setIngressNode(initiatorId.getHostname())
-            .setIngressVrf(firstNonNull(initiator.getSessionVrf(), initiatorId.getVrfName()))
+            .setIngressVrf(initiator.getSessionVrf().originVrf(initiatorId.getVrfName()))
             .setSrcIp(initiatorLocalIp)
             .setDstIp(initiator.getPeerAddress())
             .setSrcPort(NamedPort.EPHEMERAL_LOWEST.number())
@@ -621,11 +629,11 @@ public final class BgpTopologyUtils {
               Flow reverseFlow = traceAndReverseFlow.getReverseFlow();
               assert traceAndReverseFlow.getReverseFlow() != null; // success implies return flow
               assert reverseFlow.getIngressVrf() != null; // accepted
-              String listenerSessionVrf =
-                  firstNonNull(listener.getSessionVrf(), listenerId.getVrfName());
               if (!reverseFlow.getIngressNode().equals(listenerId.getHostname())
-                  || !reverseFlow.getIngressVrf().equals(listenerSessionVrf)) {
-                // This trace is success at the wrong device or in the wrong VRF.
+                  || !listener
+                      .getSessionVrf()
+                      .acceptsIngressVrf(reverseFlow.getIngressVrf(), listenerId.getVrfName())) {
+                // This trace is success at the wrong device or in a VRF the listener won't accept.
                 return false;
               } else if (listener.getCheckLocalIpOnAccept() && listener.getLocalIp() != null) {
                 // The destination IP must match the listener's local IP, otherwise the listener

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/SessionVrfScope.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/SessionVrfScope.java
@@ -1,0 +1,155 @@
+package org.batfish.datamodel.bgp;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Describes which ingress VRF(s) a BGP listener's TCP socket will accept connections from, and
+ * which VRF an initiator sources its outbound connection from.
+ *
+ * <p>The three states are mutually-exclusive answers to "which VRF is this peer's session in":
+ *
+ * <ul>
+ *   <li>{@link OwnVrf}: the session uses the peer's own (configured) VRF. This is the default.
+ *   <li>{@link SpecificVrf}: the session uses a specific, possibly different, VRF. For example,
+ *       Junos {@code forwarding-context master} causes a BGP session in a VRF to source its TCP
+ *       connection from the default routing instance.
+ *   <li>{@link AnyVrf}: the listener's global socket accepts connections arriving on any VRF, as on
+ *       Linux-based NOSes (FRR/Cumulus/SONiC) with the kernel sysctl {@code tcp_l3mdev_accept=1}.
+ *       This is a listener-side concept only: an outbound (initiated) connection is still bound to
+ *       one VRF, so origination collapses to the peer's own/config VRF.
+ * </ul>
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = SessionVrfScope.OwnVrf.class, name = "OwnVrf"),
+  @JsonSubTypes.Type(value = SessionVrfScope.SpecificVrf.class, name = "SpecificVrf"),
+  @JsonSubTypes.Type(value = SessionVrfScope.AnyVrf.class, name = "AnyVrf"),
+})
+public sealed interface SessionVrfScope extends Serializable
+    permits SessionVrfScope.OwnVrf, SessionVrfScope.SpecificVrf, SessionVrfScope.AnyVrf {
+
+  /** The concrete VRF an outbound (initiated) connection is sourced from. */
+  @Nonnull
+  String originVrf(String configVrf);
+
+  /** The VRFs this listener registers under to accept inbound connections. */
+  @Nonnull
+  Set<String> listenVrfs(String configVrf, Set<String> allNodeVrfs);
+
+  /**
+   * Whether an inbound connection arriving on {@code ingressVrf} is acceptable by this listener.
+   */
+  boolean acceptsIngressVrf(String ingressVrf, String configVrf);
+
+  /**
+   * Value to display for the {@code Session_VRF} answer column / peer property. {@code null} for
+   * {@link OwnVrf} (i.e., no override of the peer's own VRF).
+   */
+  @Nullable
+  String displayString();
+
+  /** The session uses the peer's own (configured) VRF. */
+  record OwnVrf() implements SessionVrfScope {
+    private static final OwnVrf INSTANCE = new OwnVrf();
+
+    public static @Nonnull OwnVrf instance() {
+      return INSTANCE;
+    }
+
+    @Override
+    public @Nonnull String originVrf(String configVrf) {
+      return configVrf;
+    }
+
+    @Override
+    public @Nonnull Set<String> listenVrfs(String configVrf, Set<String> allNodeVrfs) {
+      return ImmutableSet.of(configVrf);
+    }
+
+    @Override
+    public boolean acceptsIngressVrf(String ingressVrf, String configVrf) {
+      return ingressVrf.equals(configVrf);
+    }
+
+    @Override
+    public @Nullable String displayString() {
+      return null;
+    }
+  }
+
+  /**
+   * The session uses a specific, possibly different, VRF (e.g. Junos {@code forwarding-context}).
+   */
+  record SpecificVrf(@Nonnull String vrf) implements SessionVrfScope {
+    @JsonCreator
+    public SpecificVrf(@JsonProperty("vrf") @Nonnull String vrf) {
+      this.vrf = vrf;
+    }
+
+    @Override
+    @JsonProperty("vrf")
+    public @Nonnull String vrf() {
+      return vrf;
+    }
+
+    @Override
+    public @Nonnull String originVrf(String configVrf) {
+      return vrf;
+    }
+
+    @Override
+    public @Nonnull Set<String> listenVrfs(String configVrf, Set<String> allNodeVrfs) {
+      return ImmutableSet.of(vrf);
+    }
+
+    @Override
+    public boolean acceptsIngressVrf(String ingressVrf, String configVrf) {
+      return ingressVrf.equals(vrf);
+    }
+
+    @Override
+    public @Nonnull String displayString() {
+      return vrf;
+    }
+  }
+
+  /**
+   * The listener's global socket accepts connections arriving on any VRF ({@code
+   * tcp_l3mdev_accept=1}). As an initiator, origination collapses to the peer's own/config VRF.
+   */
+  record AnyVrf() implements SessionVrfScope {
+    private static final AnyVrf INSTANCE = new AnyVrf();
+
+    public static @Nonnull AnyVrf instance() {
+      return INSTANCE;
+    }
+
+    @Override
+    public @Nonnull String originVrf(String configVrf) {
+      return configVrf;
+    }
+
+    @Override
+    public @Nonnull Set<String> listenVrfs(String configVrf, Set<String> allNodeVrfs) {
+      return ImmutableSet.copyOf(allNodeVrfs);
+    }
+
+    @Override
+    public boolean acceptsIngressVrf(String ingressVrf, String configVrf) {
+      return true;
+    }
+
+    @Override
+    public @Nonnull String displayString() {
+      return "*";
+    }
+  }
+}

--- a/projects/common/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
@@ -153,7 +153,7 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
           .put(
               SESSION_VRF,
               new PropertyDescriptor<>(
-                  BgpPeerConfig::getSessionVrf,
+                  p -> p.getSessionVrf().displayString(),
                   Schema.STRING,
                   "The VRF in which the BGP TCP session takes place, if different from VRF"))
           .build();

--- a/projects/common/src/test/java/org/batfish/datamodel/BgpUnnumberedPeerConfigTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/BgpUnnumberedPeerConfigTest.java
@@ -14,6 +14,7 @@ import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.SessionVrfScope.SpecificVrf;
 import org.batfish.datamodel.dataplane.rib.RibGroup;
 import org.batfish.datamodel.dataplane.rib.RibId;
 import org.junit.Test;
@@ -90,7 +91,7 @@ public final class BgpUnnumberedPeerConfigTest {
             builder.setEvpnAddressFamily(
                 EvpnAddressFamily.builder().setPropagateUnmatched(true).build()))
         .addEqualityGroup(builder.setReplaceNonLocalAsesOnExport(true).build())
-        .addEqualityGroup(builder.setSessionVrf("default").build())
+        .addEqualityGroup(builder.setSessionVrfScope(new SpecificVrf("default")).build())
         .testEquals();
   }
 
@@ -125,7 +126,7 @@ public final class BgpUnnumberedPeerConfigTest {
             .setLocalIp(Ip.FIRST_CLASS_A_PRIVATE_IP)
             .setPeerInterface("eth0")
             .setRemoteAsns(LongSpace.of(11L))
-            .setSessionVrf("default")
+            .setSessionVrfScope(new SpecificVrf("default"))
             .build();
 
     assertThat(
@@ -165,7 +166,7 @@ public final class BgpUnnumberedPeerConfigTest {
             .setLocalIp(Ip.FIRST_CLASS_A_PRIVATE_IP)
             .setPeerInterface("eth0")
             .setRemoteAsns(LongSpace.of(11L))
-            .setSessionVrf("default")
+            .setSessionVrfScope(new SpecificVrf("default"))
             .build();
 
     assertThat(SerializationUtils.clone(bgpUnnumberedPeerConfig), equalTo(bgpUnnumberedPeerConfig));

--- a/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
@@ -112,7 +112,7 @@ public class BgpTopologyUtilsTest {
             .setLocalAs(1L)
             .setPeerAddress(ip2)
             .setRemoteAs(2L)
-            .setSessionVrf(DEFAULT_VRF_NAME)
+            .setSessionVrfScope(new SessionVrfScope.SpecificVrf(DEFAULT_VRF_NAME))
             .setIpv4UnicastAddressFamily(
                 Ipv4UnicastAddressFamily.builder()
                     .setAddressFamilyCapabilities(AddressFamilyCapabilities.builder().build())
@@ -135,6 +135,89 @@ public class BgpTopologyUtilsTest {
     ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
         initBgpTopology(_configs, ipOwners, false, null).getGraph();
     assertThat(bgpTopology.nodes(), hasSize(1));
+  }
+
+  /**
+   * Builds a two-node network where an initiator in the default VRF dials an address that the
+   * listener owns in its <i>default</i> VRF, while the listener's BGP process lives in VRF "blue".
+   * The listener's {@link SessionVrfScope} is the variable under test.
+   */
+  private static ValueGraph<BgpPeerConfigId, BgpSessionProperties> initAnyVrfScenario(
+      SessionVrfScope listenerScope) {
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    // Initiator i1: default VRF, active peer dialing ip2.
+    Configuration ci = cb.setHostname("i1").build();
+    Vrf vi = new Vrf(DEFAULT_VRF_NAME);
+    BgpProcess bpi = BgpProcess.testBgpProcess(Ip.parse("0.0.0.1"));
+    vi.setBgpProcess(bpi);
+    ci.setVrfs(ImmutableMap.of(DEFAULT_VRF_NAME, vi));
+    BgpActivePeerConfig initiator =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip1)
+            .setLocalAs(1L)
+            .setPeerAddress(ip2)
+            .setRemoteAs(2L)
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder()
+                    .setAddressFamilyCapabilities(AddressFamilyCapabilities.builder().build())
+                    .build())
+            .build();
+    bpi.setNeighbors(ImmutableSortedMap.of(ip2, initiator));
+
+    // Listener l2: BGP process in VRF "blue", passive peer with the scope under test.
+    Configuration cl = cb.setHostname("l2").build();
+    BgpProcess bpl = BgpProcess.testBgpProcess(Ip.parse("0.0.0.2"));
+    Vrf vlBlue = new Vrf("blue");
+    vlBlue.setBgpProcess(bpl);
+    cl.setVrfs(ImmutableMap.of(DEFAULT_VRF_NAME, new Vrf(DEFAULT_VRF_NAME), "blue", vlBlue));
+    Prefix listenRange = Prefix.create(ip1, 24);
+    BgpPassivePeerConfig listener =
+        BgpPassivePeerConfig.builder()
+            .setLocalAs(2L)
+            .setRemoteAs(1L)
+            .setPeerPrefix(listenRange)
+            .setSessionVrfScope(listenerScope)
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder()
+                    .setAddressFamilyCapabilities(AddressFamilyCapabilities.builder().build())
+                    .build())
+            .build();
+    bpl.setPassiveNeighbors(ImmutableSortedMap.of(listenRange, listener));
+
+    // ip2 is owned by l2 in the DEFAULT VRF, not "blue".
+    Map<Ip, Map<String, Set<String>>> ipOwners =
+        ImmutableMap.of(
+            ip1,
+            ImmutableMap.of("i1", ImmutableSet.of(DEFAULT_VRF_NAME)),
+            ip2,
+            ImmutableMap.of("l2", ImmutableSet.of(DEFAULT_VRF_NAME)));
+
+    return initBgpTopology(ImmutableMap.of("i1", ci, "l2", cl), ipOwners, true, null).getGraph();
+  }
+
+  /**
+   * An {@link SessionVrfScope.AnyVrf} listener registers under every VRF on its node, so an
+   * initiator whose dialed address is owned in a non-config VRF still finds it.
+   */
+  @Test
+  public void testInitTopologyAnyVrfRegistersUnderAllNodeVrfs() {
+    assertThat(initAnyVrfScenario(SessionVrfScope.AnyVrf.instance()).edges(), hasSize(2));
+  }
+
+  /**
+   * Contrast with {@link #testInitTopologyAnyVrfRegistersUnderAllNodeVrfs()}: a default-scoped
+   * listener registers only under its own (config) VRF, so the same dialed address owned in a
+   * different VRF does not match.
+   */
+  @Test
+  public void testInitTopologyOwnVrfDoesNotRegisterUnderOtherVrfs() {
+    assertThat(initAnyVrfScenario(SessionVrfScope.OwnVrf.instance()).edges(), empty());
   }
 
   /**

--- a/projects/common/src/test/java/org/batfish/datamodel/bgp/SessionVrfScopeTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/bgp/SessionVrfScopeTest.java
@@ -1,0 +1,80 @@
+package org.batfish.datamodel.bgp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.bgp.SessionVrfScope.AnyVrf;
+import org.batfish.datamodel.bgp.SessionVrfScope.OwnVrf;
+import org.batfish.datamodel.bgp.SessionVrfScope.SpecificVrf;
+import org.junit.Test;
+
+/** Tests of {@link SessionVrfScope}. */
+public class SessionVrfScopeTest {
+
+  private static final ImmutableSet<String> NODE_VRFS = ImmutableSet.of("default", "blue", "green");
+
+  @Test
+  public void testOriginVrf() {
+    assertThat(OwnVrf.instance().originVrf("blue"), equalTo("blue"));
+    assertThat(new SpecificVrf("default").originVrf("blue"), equalTo("default"));
+    // AnyVrf collapses to the config VRF for origination.
+    assertThat(AnyVrf.instance().originVrf("blue"), equalTo("blue"));
+  }
+
+  @Test
+  public void testListenVrfs() {
+    assertThat(OwnVrf.instance().listenVrfs("blue", NODE_VRFS), contains("blue"));
+    assertThat(new SpecificVrf("default").listenVrfs("blue", NODE_VRFS), contains("default"));
+    // AnyVrf registers under every VRF on the node.
+    assertThat(
+        AnyVrf.instance().listenVrfs("blue", NODE_VRFS),
+        containsInAnyOrder("default", "blue", "green"));
+  }
+
+  @Test
+  public void testAcceptsIngressVrf() {
+    assertTrue(OwnVrf.instance().acceptsIngressVrf("blue", "blue"));
+    assertFalse(OwnVrf.instance().acceptsIngressVrf("green", "blue"));
+
+    assertTrue(new SpecificVrf("default").acceptsIngressVrf("default", "blue"));
+    assertFalse(new SpecificVrf("default").acceptsIngressVrf("blue", "blue"));
+
+    // AnyVrf accepts from any ingress VRF.
+    assertTrue(AnyVrf.instance().acceptsIngressVrf("default", "blue"));
+    assertTrue(AnyVrf.instance().acceptsIngressVrf("green", "blue"));
+  }
+
+  @Test
+  public void testDisplayString() {
+    assertThat(OwnVrf.instance().displayString(), nullValue());
+    assertThat(new SpecificVrf("default").displayString(), equalTo("default"));
+    assertThat(AnyVrf.instance().displayString(), equalTo("*"));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(OwnVrf.instance(), new OwnVrf())
+        .addEqualityGroup(AnyVrf.instance(), new AnyVrf())
+        .addEqualityGroup(new SpecificVrf("blue"), new SpecificVrf("blue"))
+        .addEqualityGroup(new SpecificVrf("green"))
+        .testEquals();
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    for (SessionVrfScope scope :
+        new SessionVrfScope[] {OwnVrf.instance(), new SpecificVrf("blue"), AnyVrf.instance()}) {
+      assertThat(BatfishObjectMapper.clone(scope, SessionVrfScope.class), equalTo(scope));
+    }
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtils.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtils.java
@@ -1,7 +1,5 @@
 package org.batfish.question.bgpsessionstatus;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -66,7 +64,9 @@ public final class BgpSessionAnswererUtils {
     Ip localIp = activePeerConfig.getLocalIp();
     Ip remoteIp = activePeerConfig.getPeerAddress();
 
-    String sourceVrf = firstNonNull(activePeerConfig.getSessionVrf(), peerId.getVrfName());
+    // INVALID_LOCAL_IP is an initiator-side check: the active peer originates from its config VRF
+    // (AnyVrf collapses to it), so this stays per-VRF.
+    String sourceVrf = activePeerConfig.getSessionVrf().originVrf(peerId.getVrfName());
     if (!ipVrfOwners
         .getOrDefault(localIp, ImmutableMap.of())
         .getOrDefault(peerId.getHostname(), ImmutableSet.of())

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
@@ -210,7 +210,7 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
         .put(COL_REMOTE_NODE, remoteNode)
         .put(COL_REMOTE_INTERFACE, null)
         .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, activePeer.getPeerAddress()))
-        .put(COL_SESSION_VRF, activePeer.getSessionVrf())
+        .put(COL_SESSION_VRF, activePeer.getSessionVrf().displayString())
         .put(COL_SESSION_TYPE, getSessionType(activePeer))
         .put(COL_VRF, activeId.getVrfName())
         .build();
@@ -238,7 +238,7 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
             .put(
                 COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, passivePeer.getPeerPrefix()))
             .put(COL_ADDRESS_FAMILIES, ImmutableSet.of())
-            .put(COL_SESSION_VRF, passivePeer.getSessionVrf())
+            .put(COL_SESSION_VRF, passivePeer.getSessionVrf().displayString())
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, passiveId.getVrfName());
 
@@ -316,7 +316,7 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
         .put(COL_REMOTE_INTERFACE, remoteInterface)
         .put(COL_REMOTE_IP, null)
         .put(COL_ADDRESS_FAMILIES, addressFamilies)
-        .put(COL_SESSION_VRF, unnumPeer.getSessionVrf())
+        .put(COL_SESSION_VRF, unnumPeer.getSessionVrf().displayString())
         .put(COL_SESSION_TYPE, getSessionType(unnumPeer))
         .put(COL_VRF, unnumId.getVrfName())
         .build();

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -247,7 +247,7 @@ public class BgpSessionStatusAnswerer extends Answerer {
         .put(COL_REMOTE_NODE, remoteNode)
         .put(COL_REMOTE_INTERFACE, null)
         .put(COL_REMOTE_IP, new SelfDescribingObject(Schema.IP, remoteIp))
-        .put(COL_SESSION_VRF, activePeer.getSessionVrf())
+        .put(COL_SESSION_VRF, activePeer.getSessionVrf().displayString())
         .put(COL_SESSION_TYPE, getSessionType(activePeer))
         .put(COL_VRF, activeId.getVrfName())
         .build();
@@ -308,7 +308,7 @@ public class BgpSessionStatusAnswerer extends Answerer {
             .put(COL_REMOTE_AS, passivePeer.getRemoteAsns().toString())
             .put(
                 COL_REMOTE_IP, new SelfDescribingObject(Schema.PREFIX, passivePeer.getPeerPrefix()))
-            .put(COL_SESSION_VRF, passivePeer.getSessionVrf())
+            .put(COL_SESSION_VRF, passivePeer.getSessionVrf().displayString())
             .put(COL_SESSION_TYPE, SessionType.UNSET)
             .put(COL_VRF, passiveId.getVrfName());
 
@@ -416,7 +416,7 @@ public class BgpSessionStatusAnswerer extends Answerer {
         .put(COL_REMOTE_NODE, remoteNode)
         .put(COL_REMOTE_INTERFACE, remoteInterface)
         .put(COL_REMOTE_IP, null)
-        .put(COL_SESSION_VRF, unnumPeer.getSessionVrf())
+        .put(COL_SESSION_VRF, unnumPeer.getSessionVrf().displayString())
         .put(COL_SESSION_TYPE, getSessionType(unnumPeer))
         .put(COL_VRF, unnumId.getVrfName())
         .build();

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswererTest.java
@@ -43,6 +43,7 @@ import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.answers.SelfDescribingObject;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.SessionVrfScope.SpecificVrf;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.questions.BgpPeerPropertySpecifier;
 import org.batfish.datamodel.table.Row;
@@ -68,7 +69,7 @@ public final class BgpPeerConfigurationAnswererTest {
             .setConfederation(1L)
             .setDescription("desc1")
             .setGroup("g1")
-            .setSessionVrf("otherVrf")
+            .setSessionVrfScope(new SpecificVrf("otherVrf"))
             .setIpv4UnicastAddressFamily(
                 Ipv4UnicastAddressFamily.builder()
                     .setImportPolicySources(ImmutableSortedSet.of("p1"))

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtilsTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtilsTest.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.SessionVrfScope.SpecificVrf;
 import org.batfish.datamodel.questions.ConfiguredSessionStatus;
 import org.junit.Before;
 import org.junit.Test;
@@ -182,7 +183,7 @@ public final class BgpSessionAnswererUtilsTest {
             .setPeerAddress(remoteIp)
             .setLocalAs(1L)
             .setRemoteAs(2L)
-            .setSessionVrf("default")
+            .setSessionVrfScope(new SpecificVrf("default"))
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
             .build();
 


### PR DESCRIPTION
Linux-based NOSes (FRR, Cumulus, SONiC) run BGP over a listening socket
that is not bound to a particular VRF and rely on the kernel sysctl
tcp_l3mdev_accept=1 to accept connections arriving on any VRF. Batfish
modeled BGP acceptance as strictly per-ingress-VRF, so it reported
legitimate VRF-BGP sessions on these platforms as not establishing.

Generalize BgpPeerConfig's nullable String sessionVrf into a sealed
SessionVrfScope tri-state:

  OwnVrf        - the peer's own (configured) VRF (was: null)
  SpecificVrf   - a specific VRF, e.g. Junos forwarding-context (was: non-null)
  AnyVrf        - accept from any VRF (tcp_l3mdev_accept)

The three states are mutually-exclusive answers to "which VRF is this
peer's session in", so a sealed type unifies them. Role behavior lives on
the type as resolver methods (originVrf/listenVrfs/acceptsIngressVrf), so
call sites in BgpTopologyUtils use the methods rather than pattern-matching:

  - originVrf: outbound connections source from the config VRF; AnyVrf
    collapses to the config VRF (the outbound socket is bound to one VRF).
  - listenVrfs: AnyVrf registers the listener under every VRF on the node
    so an initiator whose peer address is owned in a non-config VRF finds
    it; others register under one VRF.
  - acceptsIngressVrf: AnyVrf accepts any ingress VRF; others require equality.

AnyVrf only relaxes socket selection. The checkReachability path still
requires the end-to-end forward+reverse traceroute to succeed, so local
delivery stays per-VRF and the localIp guard is unchanged.

Default AnyVrf for all FRR/Cumulus/SONiC peers (SONiC delegates to the
FRR conversion). The listening socket is not bound to a particular VRF,
so a peer accepts a connection regardless of the VRF the BGP process is
configured in: a default-VRF process still accepts a connection whose
local IP is delivered on a non-default VRF. Junos forwarding-context now
produces SpecificVrf. Sysctl-file extraction for finer fidelity is
deferred.

OwnVrf serializes as null (omitted), so existing peer JSON is unchanged;
SpecificVrf and AnyVrf serialize as structured objects. The vimodel ref
gains AnyVrf objects on the affected peers.

Fixes batfish/batfish#10010.

----

Prompt:
```
Implement https://github.com/batfish/batfish/issues/10010
```

During implementation the user confirmed: encode the scopes as
structured JSON objects (not a "*" sentinel), migrate all callers to a
scope-typed setter (no String overload), and that polluting reference
test outputs with the new objects is acceptable.

