### PR TITLE
pre-commit: run buildifier.check in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -42,6 +42,8 @@ jobs:
             ${{runner.os}}-bazel-format-
       - name: Java Formatting
         run: bazel run //tools/format:format.check
+      - name: Buildifier
+        run: bazel run //:buildifier.check
   json_template:
     runs-on: ubuntu-latest
     steps:

--- a/projects/allinone/BUILD.bazel
+++ b/projects/allinone/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_java//java:defs.bzl", "java_binary")
 load("@batfish//skylark:thin_jar.bzl", "thin_jar")
+load("@rules_java//java:defs.bzl", "java_binary")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
The buildifier.check target existed in //BUILD.bazel but no workflow
invoked it, so Bazel file formatting was never enforced in CI. Add a
Buildifier step to the existing format job, which already configures
Bazel caching. Also reorder loads in projects/allinone/BUILD.bazel,
which the check flags.

----

Prompt:
```
Is buildifer running in github CI? If not, add it
```
