### PR TITLE
Junos: allow '>' in config object names

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3675,6 +3675,8 @@ F_NameChar
   | ','
   | '.'
   | ':'
+  // Junos allows '>' in names, e.g. LSP name "WASH->ATLA".
+  | '>'
 ;
 
 // Any number of newlines, allowing whitespace in between

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/JunosMplsLspTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/JunosMplsLspTest.java
@@ -57,4 +57,17 @@ public class JunosMplsLspTest {
     // Verify undefined path reference
     assertThat(ccae, hasUndefinedReference(filename, MPLS_PATH, "SEC", MPLS_LSP_SECONDARY_PATH));
   }
+
+  /** Names containing {@code >}, e.g. LSP name "WASH->ATLA", lex so the LSP body parses. */
+  @Test
+  public void testLspNameWithArrowParsing() throws IOException {
+    String hostname = "junos-lsp-name-with-arrow";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    assertThat(ccae, hasDefinedStructure(filename, MPLS_PATH, "PRI"));
+    assertThat(ccae, hasReferencedStructure(filename, MPLS_PATH, "PRI", MPLS_LSP_PRIMARY_PATH));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/junos-lsp-name-with-arrow
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/junos-lsp-name-with-arrow
@@ -1,0 +1,12 @@
+#
+# Junos config object names may contain '>', e.g. MPLS LSP names like "WASH->ATLA".
+#
+
+set system host-name junos-lsp-name-with-arrow
+
+set protocols mpls label-switched-path WASH->ATLA to 64.57.28.243
+set protocols mpls label-switched-path WASH->ATLA admin-group exclude RED
+set protocols mpls label-switched-path WASH->ATLA primary PRI
+
+set protocols mpls path PRI
+set protocols mpls admin-groups RED 1


### PR DESCRIPTION
Junos permits '>' in config object names, e.g. MPLS LSP names like
"WASH->ATLA". The lexer's F_NameChar fragment did not include '>', so
such a name failed to lex as a single NAME token and the entire
enclosing block (its "to", "admin-group exclude", etc.) was dropped as
unrecognized. Add '>' to F_NameChar.

This cannot conflict with F_Wildcard, which is anchored by a leading
'<' (F_WildcardInner: '<' ~'>'* '>') and self-terminates at its first
'>'; the WILDCARD alternative is also declared before NAME in every
lexer mode. The only existing '>' token, GREATER_THAN, is referenced by
no parser rule.

----

Prompt:
```
I was told that there are issues parsing ~/oss/internet2 configurations.
Figure out what the issues are and recommend fixes
```

Then, after diagnosing the issues and confirming the wildcard analysis:
implement the first fix (allow '>' in F_NameChar) with a regression test
that also guards against wildcard interference.
