### PR TITLE
Junos: parse fast-reroute under MPLS label-switched-path

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -781,6 +781,8 @@ FAMILY: 'family';
 
 FAST_INTERVAL: 'fast-interval';
 
+FAST_REROUTE: 'fast-reroute';
+
 FASTETHER_OPTIONS: 'fastether-options';
 
 FILE: 'file';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
@@ -95,6 +95,7 @@ mpls_label_switched_path
       | mplslsp_bandwidth_null
       | mplslsp_conditional_metric_null
       | mplslsp_cross_credibility_cspf_null
+      | mplslsp_fast_reroute_null
       | mplslsp_hop_limit_null
       | mplslsp_in_place_lsp_bandwidth_update_null
       | mplslsp_install_null
@@ -263,6 +264,11 @@ mplslsp_bandwidth_null
 mplslsp_cross_credibility_cspf_null
 :
    CROSS_CREDIBILITY_CSPF null_filler
+;
+
+mplslsp_fast_reroute_null
+:
+   FAST_REROUTE null_filler
 ;
 
 mplslsp_hop_limit_null

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/mpls-lsp-comprehensive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/mpls-lsp-comprehensive
@@ -40,6 +40,10 @@ set protocols mpls label-switched-path no-decrement-ttl no-decrement-ttl
 set protocols mpls label-switched-path link-protection to 192.0.2.8
 set protocols mpls label-switched-path link-protection link-protection
 
+# Fast-reroute property
+set protocols mpls label-switched-path fast-reroute-lsp to 192.0.2.18
+set protocols mpls label-switched-path fast-reroute-lsp fast-reroute
+
 # Combinations of multiple properties
 set protocols mpls label-switched-path multi-property to 192.0.2.9
 set protocols mpls label-switched-path multi-property install 10.0.0.0/24


### PR DESCRIPTION
label-switched-path X fast-reroute was unrecognized. Add a FAST_REROUTE
token and a null sub-stanza under the LSP rule. null_filler covers both
the bare form and any sub-options. Extend mpls-lsp-comprehensive.

----

Prompt:
```
Implement the next fix for parsing ~/oss/internet2 Junos configs: add
support for "fast-reroute" under MPLS label-switched-path (110 of the
unrecognized lines across the configs).
```
