### PR TITLE
Junos: parse preference under protocols mpls

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
@@ -45,6 +45,7 @@ p_mpls
        | mpls_optimize_timer_null
        | mpls_path
        | mpls_path_mtu_null
+       | mpls_preference_null
        | mpls_record_null
        | mpls_smart_optimize_timer_null
        | mpls_statistics_null
@@ -378,6 +379,11 @@ mpls_optimize_timer_null
 mpls_path_mtu_null
 :
    PATH_MTU null_filler
+;
+
+mpls_preference_null
+:
+   PREFERENCE uint32
 ;
 
 mpls_record_null

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-mpls
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-mpls
@@ -21,6 +21,7 @@ set protocols mpls optimize-adaptive-teardown delay 360
 set protocols mpls optimize-aggressive
 set protocols mpls optimize-timer 300
 set protocols mpls path-mtu rsvp mtu-signaling
+set protocols mpls preference 7
 set protocols mpls record
 set protocols mpls smart-optimize-timer 100
 #


### PR DESCRIPTION
protocols mpls preference <n> was unrecognized. Add mpls_preference_null
to p_mpls. Extend juniper-mpls.

----

Prompt:
```
Implement the next fix for parsing ~/oss/internet2 Junos configs: add
support for "preference" directly under "protocols mpls".
```
