### PR TITLE
Junos: parse and apply routing-options static defaults

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -332,6 +332,7 @@ ro_static
    STATIC
    (
       apply
+      | ros_defaults
       | ros_rib_group
       | ros_route4
    )
@@ -342,9 +343,17 @@ ro6_static
    STATIC
    (
       apply
+      | ros_defaults
       | ros_rib_group
       | ros_route6
    )
+;
+
+// Default attributes inherited by all static routes in this RIB. The attribute set matches that of
+// an individual static route; an empty "defaults {}" block matches via rosr_common -> apply.
+ros_defaults
+:
+   DEFAULTS rosr_common
 ;
 
 ro_validation

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -715,6 +715,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rib_nameContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Riv_communityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Riv_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Riv_importContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ro6_staticContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ro_autonomous_systemContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ro_confederationContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ro_instance_importContext;
@@ -758,6 +759,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ror_isoContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ror_mplsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Rores_ribContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roresr_importContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ros_defaultsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ros_route4Context;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ros_route6Context;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Roslrg_srlg_costContext;
@@ -3828,14 +3830,35 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void enterRos_route4(Ros_route4Context ctx) {
     Prefix prefix = toNormalizedPrefix(ctx.prefix, "Static route destination");
     Map<Prefix, StaticRouteV4> staticRoutes = _currentRib.getStaticRoutes();
-    _currentStaticRoute = staticRoutes.computeIfAbsent(prefix, StaticRouteV4::new);
+    // Each route points at this RIB's "static defaults" so unset fields resolve through it.
+    _currentStaticRoute =
+        staticRoutes.computeIfAbsent(
+            prefix, p -> new StaticRouteV4(p, _currentRib.getStaticRouteDefaults()));
   }
 
   @Override
   public void enterRos_route6(Ros_route6Context ctx) {
     Prefix6 prefix = toNormalizedPrefix6(ctx.prefix, "Static route destination");
     Map<Prefix6, StaticRouteV6> staticRoutes = _currentRib.getStaticRoutesV6();
-    _currentStaticRoute = staticRoutes.computeIfAbsent(prefix, StaticRouteV6::new);
+    _currentStaticRoute =
+        staticRoutes.computeIfAbsent(
+            prefix, p -> new StaticRouteV6(p, _currentRib.getStaticRouteDefaultsV6()));
+  }
+
+  @Override
+  public void enterRos_defaults(Ros_defaultsContext ctx) {
+    // The shared "DEFAULTS rosr_common" rule is reached from both the v4 ("static") and v6 ("rib
+    // inet6.0 { static }") paths; the parent rule tells them apart. The rosr_* attribute handlers
+    // populate _currentStaticRoute, so point it at this RIB's static-route defaults object.
+    _currentStaticRoute =
+        ctx.getParent() instanceof Ro6_staticContext
+            ? _currentRib.getStaticRouteDefaultsV6()
+            : _currentRib.getStaticRouteDefaults();
+  }
+
+  @Override
+  public void exitRos_defaults(Ros_defaultsContext ctx) {
+    _currentStaticRoute = null;
   }
 
   @Override
@@ -7419,7 +7442,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitRosr_community(Rosr_communityContext ctx) {
-    _currentStaticRoute.getCommunities().add(toStandardCommunity(ctx.standard_community()));
+    _currentStaticRoute.addCommunity(toStandardCommunity(ctx.standard_community()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3851,7 +3851,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
         _c.getSnmpTrapServers().addAll(snmpServer.getHosts().keySet());
       }
 
-      // static routes
+      // static routes. Each route's getters resolve "static defaults" inheritance on read, so no
+      // explicit inheritance step is needed here.
       for (StaticRouteV4 route : ri.getRibs().get(RIB_IPV4_UNICAST).getStaticRoutes().values()) {
         vrf.getStaticRoutes().addAll(toStaticRoutes(route));
       }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInformationBase.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInformationBase.java
@@ -22,6 +22,8 @@ public class RoutingInformationBase implements Serializable {
   private final String _name;
   private final Map<Prefix, StaticRouteV4> _staticRoutes;
   private final Map<Prefix6, StaticRouteV6> _staticRoutesV6;
+  private final StaticRouteV4 _staticRouteDefaults;
+  private final StaticRouteV6 _staticRouteDefaultsV6;
 
   public RoutingInformationBase(@Nonnull String name) {
     _name = name;
@@ -29,6 +31,10 @@ public class RoutingInformationBase implements Serializable {
     _generatedRoutes = new TreeMap<>();
     _staticRoutes = new TreeMap<>();
     _staticRoutesV6 = new TreeMap<>();
+    // Attributes from this RIB's "static defaults" block, inherited by its static routes. The
+    // defaults route has no parent defaults of its own.
+    _staticRouteDefaults = new StaticRouteV4(Prefix.ZERO, null);
+    _staticRouteDefaultsV6 = new StaticRouteV6(Prefix6.ZERO, null);
   }
 
   public @Nonnull Map<Prefix, AggregateRoute> getAggregateRoutes() {
@@ -49,5 +55,15 @@ public class RoutingInformationBase implements Serializable {
 
   public @Nonnull Map<Prefix6, StaticRouteV6> getStaticRoutesV6() {
     return _staticRoutesV6;
+  }
+
+  /** Default attributes inherited by IPv4 static routes in this RIB. */
+  public @Nonnull StaticRouteV4 getStaticRouteDefaults() {
+    return _staticRouteDefaults;
+  }
+
+  /** Default attributes inherited by IPv6 static routes in this RIB. */
+  public @Nonnull StaticRouteV6 getStaticRouteDefaultsV6() {
+    return _staticRouteDefaultsV6;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -16,13 +16,25 @@ public abstract class StaticRoute<T> implements Serializable {
   /* https://www.juniper.net/documentation/en_US/junos/topics/reference/general/routing-protocols-default-route-preference-values.html */
   private static final int DEFAULT_ADMIN_DISTANCE = 5;
 
-  private Set<Community> _communities;
+  private static final int DEFAULT_METRIC = 0;
 
-  private int _distance;
+  /**
+   * The enclosing {@code static {}} block's {@code defaults} route, whose attributes this route
+   * inherits for any field it does not set itself, or null if this route IS the defaults route.
+   * Resolving inheritance lazily in the getters (rather than copying fields in) keeps a route's own
+   * unset/explicit distinction intact and means callers need no separate inheritance step.
+   */
+  private final @Nullable StaticRoute<T> _defaults;
+
+  private final Set<Community> _communities;
+
+  // Null distinguishes "unset" (inherit from defaults) from an explicit value. An unset field with
+  // no defaults to inherit reads as the Junos default via the getter.
+  private @Nullable Integer _distance;
 
   private boolean _drop;
 
-  private int _metric;
+  private @Nullable Integer _metric;
 
   private @Nonnull Set<String> _nextHopInterface;
 
@@ -44,26 +56,45 @@ public abstract class StaticRoute<T> implements Serializable {
 
   private @Nullable Boolean _resolve;
 
-  private Long _tag;
+  private @Nullable Long _tag;
 
   private @Nullable Long _tag2;
 
-  public StaticRoute() {
+  public StaticRoute(@Nullable StaticRoute<T> defaults) {
+    _defaults = defaults;
     _communities = new TreeSet<>();
     _policies = new ArrayList<>();
-    // default admin costs for static routes in Juniper
-    _distance = DEFAULT_ADMIN_DISTANCE;
     _qualifiedNextHops = new HashMap<>();
     _nextHopInterface = new HashSet<>();
     _nextHopIp = new HashSet<>();
   }
 
+  /**
+   * The route's communities: its own if it sets any, otherwise those inherited from the {@code
+   * defaults} block. Junos replaces (does not merge) the defaults' communities when a route sets
+   * its own.
+   */
   public Set<Community> getCommunities() {
+    if (_communities.isEmpty() && _defaults != null) {
+      return _defaults.getCommunities();
+    }
     return _communities;
   }
 
+  /** Adds a community to this route's own set (used while parsing). */
+  public void addCommunity(Community community) {
+    _communities.add(community);
+  }
+
+  /**
+   * The route's administrative distance (Junos "preference"): its own if set, else inherited from
+   * the {@code defaults} block, else the Junos default.
+   */
   public int getDistance() {
-    return _distance;
+    if (_distance != null) {
+      return _distance;
+    }
+    return _defaults != null ? _defaults.getDistance() : DEFAULT_ADMIN_DISTANCE;
   }
 
   public boolean getDrop() {
@@ -71,15 +102,19 @@ public abstract class StaticRoute<T> implements Serializable {
   }
 
   public @Nullable Boolean getInstall() {
-    return _install;
+    return _install != null ? _install : (_defaults != null ? _defaults.getInstall() : null);
   }
 
   public void setInstall(@Nullable Boolean install) {
     _install = install;
   }
 
+  /** The route's metric: its own if set, else inherited from the {@code defaults} block, else 0. */
   public int getMetric() {
-    return _metric;
+    if (_metric != null) {
+      return _metric;
+    }
+    return _defaults != null ? _defaults.getMetric() : DEFAULT_METRIC;
   }
 
   public Set<String> getNextHopInterface() {
@@ -103,15 +138,17 @@ public abstract class StaticRoute<T> implements Serializable {
   }
 
   public @Nullable Boolean getReadvertise() {
-    return _readvertise;
+    return _readvertise != null
+        ? _readvertise
+        : (_defaults != null ? _defaults.getReadvertise() : null);
   }
 
   public void setReadvertise(@Nullable Boolean readvertise) {
     _readvertise = readvertise;
   }
 
-  public Long getTag() {
-    return _tag;
+  public @Nullable Long getTag() {
+    return _tag != null ? _tag : (_defaults != null ? _defaults.getTag() : null);
   }
 
   public void setTag(long tag) {
@@ -119,7 +156,7 @@ public abstract class StaticRoute<T> implements Serializable {
   }
 
   public @Nullable Long getTag2() {
-    return _tag2;
+    return _tag2 != null ? _tag2 : (_defaults != null ? _defaults.getTag2() : null);
   }
 
   public void setTag2(@Nullable Long tag2) {
@@ -155,7 +192,7 @@ public abstract class StaticRoute<T> implements Serializable {
   }
 
   public @Nullable Boolean getResolve() {
-    return _resolve;
+    return _resolve != null ? _resolve : (_defaults != null ? _defaults.getResolve() : null);
   }
 
   public void setResolve(@Nullable Boolean resolve) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRouteV4.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRouteV4.java
@@ -1,12 +1,14 @@
 package org.batfish.representation.juniper;
 
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 
 public final class StaticRouteV4 extends StaticRoute<Ip> {
   private Prefix _prefix;
 
-  public StaticRouteV4(Prefix prefix) {
+  public StaticRouteV4(Prefix prefix, @Nullable StaticRouteV4 defaults) {
+    super(defaults);
     _prefix = prefix;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRouteV6.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRouteV6.java
@@ -1,12 +1,14 @@
 package org.batfish.representation.juniper;
 
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.Prefix6;
 
 public final class StaticRouteV6 extends StaticRoute<Ip6> {
   private Prefix6 _prefix6;
 
-  public StaticRouteV6(Prefix6 prefix6) {
+  public StaticRouteV6(Prefix6 prefix6, @Nullable StaticRouteV6 defaults) {
+    super(defaults);
     _prefix6 = prefix6;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -7557,6 +7557,98 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testStaticRouteDefaultsExtraction() {
+    // "static defaults" attributes are captured per-RIB; inheritance into the routes happens at
+    // conversion. Defaults are scoped to the enclosing "static {}" block (per routing table and
+    // per routing-instance).
+    JuniperConfiguration c = parseJuniperConfig("junos-static-defaults");
+    Map<String, RoutingInstance> instances = c.getMasterLogicalSystem().getRoutingInstances();
+    Map<String, RoutingInformationBase> masterRibs = instances.get(DEFAULT_VRF_NAME).getRibs();
+
+    // Master inet.0 defaults.
+    StaticRouteV4 inet0Defaults = masterRibs.get(RIB_IPV4_UNICAST).getStaticRouteDefaults();
+    assertThat(inet0Defaults.getMetric(), equalTo(100));
+    assertThat(inet0Defaults.getDistance(), equalTo(50));
+    assertThat(inet0Defaults.getTag(), equalTo(1000L));
+    assertThat(inet0Defaults.getCommunities(), contains(StandardCommunity.of(65000, 1)));
+
+    // Master inet6.0 defaults are independent of inet.0 (different preference/tag, no community).
+    StaticRouteV6 inet6Defaults = masterRibs.get(RIB_IPV6_UNICAST).getStaticRouteDefaultsV6();
+    assertThat(inet6Defaults.getDistance(), equalTo(60));
+    assertThat(inet6Defaults.getTag(), equalTo(2000L));
+
+    // BLUE routing-instance has its own defaults, independent of the master instance.
+    StaticRouteV4 blueDefaults =
+        instances.get("BLUE").getRibs().get(RIB_IPV4_UNICAST).getStaticRouteDefaults();
+    assertThat(blueDefaults.getDistance(), equalTo(80));
+    assertThat(blueDefaults.getTag(), equalTo(3000L));
+
+    // RED routing-instance has no defaults block: its defaults object is empty (unset preference
+    // reads as the Junos system default 5).
+    StaticRouteV4 redDefaults =
+        instances.get("RED").getRibs().get(RIB_IPV4_UNICAST).getStaticRouteDefaults();
+    assertThat(redDefaults.getDistance(), equalTo(5));
+    assertThat(redDefaults.getTag(), nullValue());
+
+    // A route resolves inheritance through its getters (no separate inheritance step). The route
+    // that overrides only preference keeps its own preference but reads metric/tag/community from
+    // the inet.0 defaults.
+    StaticRouteV4 overridesPref =
+        masterRibs.get(RIB_IPV4_UNICAST).getStaticRoutes().get(Prefix.parse("10.200.2.0/24"));
+    assertThat(overridesPref.getDistance(), equalTo(7));
+    assertThat(overridesPref.getMetric(), equalTo(100));
+    assertThat(overridesPref.getTag(), equalTo(1000L));
+    assertThat(overridesPref.getCommunities(), contains(StandardCommunity.of(65000, 1)));
+  }
+
+  @Test
+  public void testStaticRouteDefaultsConversion() {
+    // At conversion, each static route inherits its RIB's "static defaults" for any field it does
+    // not set itself.
+    Configuration c = parseConfig("junos-static-defaults");
+    assertThat(
+        c,
+        hasDefaultVrf(
+            hasStaticRoutes(
+                containsInAnyOrder(
+                    // Inherits all of metric 100, preference 50, tag 1000.
+                    allOf(
+                        hasPrefix(Prefix.parse("10.200.1.0/24")),
+                        AbstractRouteDecoratorMatchers.hasMetric(100L),
+                        hasAdministrativeCost(50),
+                        hasTag(1000L)),
+                    // Overrides only preference (7); still inherits metric 100 and tag 1000.
+                    allOf(
+                        hasPrefix(Prefix.parse("10.200.2.0/24")),
+                        AbstractRouteDecoratorMatchers.hasMetric(100L),
+                        hasAdministrativeCost(7),
+                        hasTag(1000L))))));
+    // RED has no defaults: preference falls to the system default 5, and with no tag set the
+    // converted route carries Batfish's "no tag" sentinel (-1).
+    assertThat(
+        c,
+        hasVrf(
+            "RED",
+            hasStaticRoutes(
+                contains(
+                    allOf(
+                        hasPrefix(Prefix.parse("10.210.1.0/24")),
+                        hasAdministrativeCost(5),
+                        hasTag(-1L))))));
+    // BLUE inherits its own defaults, not the master instance's.
+    assertThat(
+        c,
+        hasVrf(
+            "BLUE",
+            hasStaticRoutes(
+                contains(
+                    allOf(
+                        hasPrefix(Prefix.parse("10.220.1.0/24")),
+                        hasAdministrativeCost(80),
+                        hasTag(3000L))))));
+  }
+
+  @Test
   public void testStaticRouteConversion() {
     Configuration c = parseConfig("static-routes");
     assertThat(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/junos-static-defaults
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/junos-static-defaults
@@ -1,0 +1,36 @@
+#
+# "static defaults" sets baseline attributes (preference/metric/tag/...)
+# inherited by every static route in the same "static {}" block, unless the
+# route overrides them per-field. Inheritance is scoped to the enclosing
+# block: no cascade between inet.0 and inet6.0, and no cascade from the master
+# instance into routing-instances. Mirrors lab junos_static_route_defaults.
+#
+set system host-name junos-static-defaults
+
+# Master instance, inet.0 defaults.
+set routing-options static defaults metric 100
+set routing-options static defaults preference 50
+set routing-options static defaults tag 1000
+set routing-options static defaults community 65000:1
+# Inherits all four defaults.
+set routing-options static route 10.200.1.0/24 discard
+# Overrides only preference; still inherits metric, tag, community.
+set routing-options static route 10.200.2.0/24 discard
+set routing-options static route 10.200.2.0/24 preference 7
+
+# Master instance, inet6.0 defaults: different values, proving per-table scope.
+set routing-options rib inet6.0 static defaults preference 60
+set routing-options rib inet6.0 static defaults tag 2000
+set routing-options rib inet6.0 static route 2001:db8:200::/48 discard
+
+# RED: routing-instance with a static route but NO defaults block. Its route
+# falls back to the system default preference (5), proving the master
+# instance's defaults do not cascade into a routing-instance.
+set routing-instances RED instance-type virtual-router
+set routing-instances RED routing-options static route 10.210.1.0/24 discard
+
+# BLUE: routing-instance with its own defaults, independent of the master.
+set routing-instances BLUE instance-type virtual-router
+set routing-instances BLUE routing-options static defaults preference 80
+set routing-instances BLUE routing-options static defaults tag 3000
+set routing-instances BLUE routing-options static route 10.220.1.0/24 discard


### PR DESCRIPTION
routing-options static defaults { ... } was unrecognized. It sets
baseline attributes (preference, metric, tag, community, etc.) that
every static route in the same "static {}" block inherits unless it
overrides them per-field. Inheritance is scoped to the enclosing block:
defaults do not cascade between inet.0 and inet6.0, nor from the master
instance into routing-instances (verified on vJunos-router 25.4R1.12).

Parse it as ros_defaults (DEFAULTS rosr_common), reusing the per-route
attribute rule so the defaults block accepts exactly what a route can,
mirroring the existing aggregate/generated roa_defaults/rog_defaults.
Each RIB owns a v4 and v6 "defaults" StaticRoute holding the block's
attributes.

Model inheritance on the route itself: a static route holds a pointer to
its RIB's defaults route (set at construction), and its getters return
the route's own value if set, else the inherited value, else the Junos
default. There is no separate inheritance pass and no field copying, so
both conversion and the BGP static-route community setters see inherited
values for free, and a route's own unset/explicit distinction is
preserved. StaticRoute's metric/distance become nullable internally;
getMetric/getDistance still return the Junos defaults (0 and 5) when
neither the route nor its defaults set a value.

For batfish/batfish#10017.

----

Prompt:
```
Implement the next fix for parsing ~/oss/internet2 Junos configs: add
support for "routing-options static defaults". Actually implement it in
extraction and test it (inheritance into the static routes), not just
parse-and-ignore.
```

Follow-up: refined the model so routes resolve "defaults" inheritance
lazily through a parent pointer in their getters rather than an explicit
inherit-and-copy step, and made the testconfig mirror the
junos_static_route_defaults lab (v6 inet6.0 scope, routing-instance
scope with RED/BLUE, preference-only override).
