### PR TITLE
Extended community: accept any type octet; fix signed-byte parsing

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -5,12 +5,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import java.math.BigInteger;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -24,9 +22,6 @@ import org.batfish.datamodel.Ip;
 public final class ExtendedCommunity extends Community {
   /** The max value that can be stored in 6 bytes. */
   private static final long VALUE_MAX = 0xFFFF_FFFF_FFFFL;
-
-  private static final Set<Integer> VALID_TYPES =
-      ImmutableSet.of(0x00, 0x01, 0x02, 0x03, 0x40, 0x41, 0x43);
 
   /** See: https://datatracker.ietf.org/doc/html/rfc8097.html#section-2 */
   public static final ExtendedCommunity ORIGIN_VALIDATION_STATE_VALID =
@@ -54,9 +49,15 @@ public final class ExtendedCommunity extends Community {
   private transient @Nullable String _regexStr;
 
   private ExtendedCommunity(int type, int subType, long value) {
-    checkArgument(VALID_TYPES.contains(type), "Not a valid BGP extended community type: %s", type);
+    // Type and subtype are each a single byte. We do not restrict the type to
+    // the IANA-assigned values we recognize: extended communities observed on
+    // real devices may use experimental or vendor-specific types (e.g. Junos
+    // accepts a generic "type:ga:la" literal with an arbitrary type octet),
+    // and we model them as opaque values. The type-specific predicates
+    // (isRouteTarget, isRouteOrigin, etc.) return false for unrecognized types.
+    checkArgument(type >= 0 && type <= 0xFF, "Type not within accepted 0-0xFF range: %s", type);
     checkArgument(
-        subType >= 0 && type <= 0xFF, "Subtype not within accepted 0-0xFF range: %s", type);
+        subType >= 0 && subType <= 0xFF, "Subtype not within accepted 0-0xFF range: %s", subType);
     checkArgument(
         value >= 0 && value <= VALUE_MAX, "Value %s is not within the accepted range", value);
 
@@ -174,7 +175,10 @@ public final class ExtendedCommunity extends Community {
         }
       }
     }
-    return of((int) typeByte << 8 | (int) subTypeByte, gaLong, laLong);
+    // Mask each byte to its unsigned value: typeByte/subTypeByte are signed
+    // bytes, so a type or subtype octet >= 0x80 would otherwise sign-extend to
+    // a negative int and be rejected (e.g. Junos "65000:..." has type 0xFD).
+    return of((typeByte & 0xFF) << 8 | (subTypeByte & 0xFF), gaLong, laLong);
   }
 
   public static @Nonnull Optional<ExtendedCommunity> tryParse(String text) {
@@ -190,7 +194,7 @@ public final class ExtendedCommunity extends Community {
         type >= 0 && type <= 0xFFFF,
         "Extended community type %s is not within the allowed range",
         type);
-    byte typeByte = (byte) (type >> 8);
+    int typeByte = (type >> 8) & 0xFF;
     checkArgument(
         globalAdministrator >= 0 && localAdministrator >= 0,
         "Administrator values must be positive");

--- a/projects/common/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
@@ -87,9 +87,46 @@ public final class ExtendedCommunityTest {
   }
 
   @Test
-  public void testOfWithInvalidType() {
+  public void testParseHighTypeOctet() {
+    // A bare numeric first field whose type octet has the high bit set must
+    // parse as an opaque/unknown extended community rather than being rejected
+    // by signed-byte arithmetic. Junos emits these via the generic
+    // "type:ga:la" literal, e.g. "65000:672277L:36867" -> type 0xFD, subtype
+    // 0xE8, 4-byte GA 672277 (L suffix), 2-byte LA 36867.
+    ExtendedCommunity ec = ExtendedCommunity.parse("65000:672277L:36867");
+    assertThat(ec, equalTo(ExtendedCommunity.of(0xFDE8, 672277L, 36867L)));
+    assertThat(ec.getGlobalAdministrator(), equalTo(672277L));
+    assertThat(ec.getLocalAdministrator(), equalTo(36867L));
+    // Unknown type: none of the type-specific predicates should match.
+    assertFalse(ec.isRouteTarget());
+    assertFalse(ec.isRouteOrigin());
+    // Round-trips through string form.
+    assertThat(ExtendedCommunity.parse(ec.toString()), equalTo(ec));
+  }
+
+  @Test
+  public void testOfHighTypeOctet() {
+    // of() must not reject a type octet >= 0x80 via signed-byte arithmetic.
+    ExtendedCommunity ec = ExtendedCommunity.of(0xFDE8, 672277L, 36867L);
+    assertThat(ec.getSubtype(), equalTo(0xE8));
+    assertThat(ec.getGlobalAdministrator(), equalTo(672277L));
+    assertThat(ec.getLocalAdministrator(), equalTo(36867L));
+  }
+
+  @Test
+  public void testOfTypeOutOfRange() {
+    // A combined type+subtype must fit in 2 bytes (0-0xFFFF).
     thrown.expect(IllegalArgumentException.class);
-    ExtendedCommunity.of(4 << 8, 1, 1);
+    ExtendedCommunity.of(0x10000, 1, 1);
+  }
+
+  @Test
+  public void testOfUnknownTypeAccepted() {
+    // Type octets we do not specifically recognize (e.g. 0x04) are modeled as
+    // opaque values rather than rejected.
+    ExtendedCommunity ec = ExtendedCommunity.of(4 << 8, 1, 1);
+    assertThat(ec.getGlobalAdministrator(), equalTo(1L));
+    assertThat(ec.getLocalAdministrator(), equalTo(1L));
   }
 
   @Test
@@ -141,10 +178,11 @@ public final class ExtendedCommunityTest {
   }
 
   @Test
-  public void testInvalidType() {
-    thrown.expect(IllegalArgumentException.class);
-    // this will make typeByte 0x04
-    ExtendedCommunity.parse("1024:1:1");
+  public void testParseUnknownTypeAccepted() {
+    // "1024" makes type octet 0x04, which we do not specifically recognize;
+    // it is modeled as an opaque value rather than rejected.
+    ExtendedCommunity ec = ExtendedCommunity.parse("1024:1:1");
+    assertThat(ec, equalTo(ExtendedCommunity.of(0x0400, 1L, 1L)));
   }
 
   @Test


### PR DESCRIPTION
A generic extended-community literal whose type octet has the high bit
set -- e.g. Junos "65000:672277L:36867" (type octet 0xFD) -- failed to
parse and was silently dropped. Two causes:

- parse() and of() assembled the type via signed-byte arithmetic, so a
  type or subtype octet >= 0x80 sign-extended to a negative int and was
  rejected. Mask each byte to its unsigned value.
- the constructor's VALID_TYPES allowlist rejected any type it did not
  specifically recognize. Extended communities observed on real devices
  may use experimental or vendor-specific types; model them as opaque
  values and let the type-specific predicates (isRouteTarget,
  isRouteOrigin, etc.) return false for unrecognized types. Only the
  single-byte type/subtype range is enforced now.

The Junos flatjuniper path previously fell back to a regex community
member for such literals, producing a FATAL convert warning on
"community add". It now parses as a literal extended community.

For batfish/batfish#10018.

----

Prompt:
```
now fix batfish (~/batfish/batfish), re-test the lab (rerunning the
server of course), and send a batfish PR
```
