### PR TITLE
Junos: parse and track class-of-service classifier/rewrite-rule import

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
@@ -50,11 +50,8 @@ scoscl_dscp
 
 scoscld_import
 :
-    IMPORT
-    (
-        DEFAULT
-        | name = junos_name
-    )
+    // "import" enters policy-expression lexer mode, so "default" arrives as a name.
+    IMPORT name = junos_name
 ;
 
 scoscld_forwarding_class
@@ -187,7 +184,14 @@ scoscl_exp
     EXP name = junos_name
     (
         scoscle_forwarding_class
+        | scoscle_import
     )
+;
+
+scoscle_import
+:
+    // "import" enters policy-expression lexer mode, so "default" arrives as a name.
+    IMPORT name = junos_name
 ;
 
 scoscl_ieee_802_1
@@ -532,7 +536,14 @@ scosrr_exp
     EXP name = junos_name
     (
         scosrre_forwarding_class
+        | scosrre_import
     )
+;
+
+scosrre_import
+:
+    // "import" enters policy-expression lexer mode, so "default" arrives as a name.
+    IMPORT name = junos_name
 ;
 
 scosrre_forwarding_class

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -81,10 +81,12 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.BRIDGE_DO
 import static org.batfish.representation.juniper.JuniperStructureUsage.BRIDGE_DOMAIN_SELF_REF;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_DSCP_CODE_POINTS;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_DSCP_FORWARDING_CLASS;
+import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IPV6_CODE_POINTS;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IPV6_FORWARDING_CLASS;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_EXP_CODE_POINTS;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_EXP_FORWARDING_CLASS;
+import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_EXP_IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_IEEE_802_1_CODE_POINTS;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_IEEE_802_1_FORWARDING_CLASS;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_CLASSIFIERS_INET_PRECEDENCE_CODE_POINTS;
@@ -111,6 +113,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_DSCP_SELF_REFERENCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_EXP_CODE_POINT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_EXP_FORWARDING_CLASS;
+import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_EXP_IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_EXP_SELF_REFERENCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_CODE_POINT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_FORWARDING_CLASS;
@@ -821,8 +824,10 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscl_inet_precedenceC
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscld6_forwarding_classContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscld6fc_loss_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscld_forwarding_classContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscld_importContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscldfc_loss_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscle_forwarding_classContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscle_importContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosclefc_loss_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scoscli_forwarding_classContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosclifc_loss_priorityContext;
@@ -859,6 +864,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrrd6fc_loss_priorit
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrrd_forwarding_classContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrrdfc_loss_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrre_forwarding_classContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrre_importContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrrefc_loss_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrri_forwarding_classContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrrifc_loss_priorityContext;
@@ -8140,6 +8146,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
+  public void exitScoscld_import(Scoscld_importContext ctx) {
+    // The imported name may be "default", which is a built-in classifier.
+    referenceBuiltIn(
+        ctx.name, CLASS_OF_SERVICE_CLASSIFIER, CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IMPORT);
+  }
+
+  @Override
   public void exitScoscld6_forwarding_class(Scoscld6_forwarding_classContext ctx) {
     referenceBuiltIn(
         ctx.fc,
@@ -8153,6 +8166,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
         ctx.fc,
         CLASS_OF_SERVICE_FORWARDING_CLASS,
         CLASS_OF_SERVICE_CLASSIFIERS_EXP_FORWARDING_CLASS);
+  }
+
+  @Override
+  public void exitScoscle_import(Scoscle_importContext ctx) {
+    // The imported name may be "default", which is a built-in classifier.
+    referenceBuiltIn(
+        ctx.name, CLASS_OF_SERVICE_CLASSIFIER, CLASS_OF_SERVICE_CLASSIFIERS_EXP_IMPORT);
   }
 
   @Override
@@ -8193,6 +8213,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
         ctx.fc,
         CLASS_OF_SERVICE_FORWARDING_CLASS,
         CLASS_OF_SERVICE_REWRITE_RULES_EXP_FORWARDING_CLASS);
+  }
+
+  @Override
+  public void exitScosrre_import(Scosrre_importContext ctx) {
+    // The imported name may be "default", which is a built-in rewrite-rule.
+    referenceBuiltIn(
+        ctx.name, CLASS_OF_SERVICE_REWRITE_RULE, CLASS_OF_SERVICE_REWRITE_RULES_EXP_IMPORT);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -19,6 +19,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   CLASS_OF_SERVICE_CLASSIFIERS_DSCP_FORWARDING_CLASS(
       "class-of-service classifiers dscp forwarding-class"),
   CLASS_OF_SERVICE_CLASSIFIERS_DSCP_CODE_POINTS("class-of-service classifiers dscp code-points"),
+  CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IMPORT("class-of-service classifiers dscp import"),
   CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IPV6_FORWARDING_CLASS(
       "class-of-service classifiers dscp-ipv6 forwarding-class"),
   CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IPV6_CODE_POINTS(
@@ -26,6 +27,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   CLASS_OF_SERVICE_CLASSIFIERS_EXP_FORWARDING_CLASS(
       "class-of-service classifiers exp forwarding-class"),
   CLASS_OF_SERVICE_CLASSIFIERS_EXP_CODE_POINTS("class-of-service classifiers exp code-points"),
+  CLASS_OF_SERVICE_CLASSIFIERS_EXP_IMPORT("class-of-service classifiers exp import"),
   CLASS_OF_SERVICE_CLASSIFIERS_IEEE_802_1_FORWARDING_CLASS(
       "class-of-service classifiers ieee-802.1 forwarding-class"),
   CLASS_OF_SERVICE_CLASSIFIERS_IEEE_802_1_CODE_POINTS(
@@ -70,6 +72,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   CLASS_OF_SERVICE_REWRITE_RULES_EXP_FORWARDING_CLASS(
       "class-of-service rewrite-rules exp forwarding-class"),
   CLASS_OF_SERVICE_REWRITE_RULES_EXP_CODE_POINT("class-of-service rewrite-rules exp code-point"),
+  CLASS_OF_SERVICE_REWRITE_RULES_EXP_IMPORT("class-of-service rewrite-rules exp import"),
   CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_FORWARDING_CLASS(
       "class-of-service rewrite-rules ieee-802.1 forwarding-class"),
   CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_CODE_POINT(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1068,6 +1068,42 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testClassOfServiceImport() throws IOException {
+    // "import default" under a dscp/exp classifier and exp rewrite-rule references the built-in
+    // "default" classifier/rewrite-rule.
+    String hostname = "class-of-service-comprehensive";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename,
+            org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_CLASSIFIER,
+            "default",
+            org.batfish.representation.juniper.JuniperStructureUsage
+                .CLASS_OF_SERVICE_CLASSIFIERS_DSCP_IMPORT));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename,
+            org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_CLASSIFIER,
+            "default",
+            org.batfish.representation.juniper.JuniperStructureUsage
+                .CLASS_OF_SERVICE_CLASSIFIERS_EXP_IMPORT));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename,
+            org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_REWRITE_RULE,
+            "default",
+            org.batfish.representation.juniper.JuniperStructureUsage
+                .CLASS_OF_SERVICE_REWRITE_RULES_EXP_IMPORT));
+  }
+
+  @Test
   public void testClassOfServiceBuiltinForwardingClasses() throws IOException {
     String hostname = "class-of-service-builtin-forwarding-classes";
     String filename = "configs/" + hostname;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
@@ -11,6 +11,7 @@ set class-of-service classifiers dscp DSCP-BA forwarding-class FC-CLASS3 loss-pr
 set class-of-service classifiers dscp DSCP-BA import default
 set class-of-service classifiers dscp-ipv6 DSCP-IPV6-BA forwarding-class FC-CLASS2 loss-priority high code-points 000000
 set class-of-service classifiers dscp-ipv6 DSCP-IPV6-BA forwarding-class FC-CLASS1 loss-priority low code-points ALIAS2
+set class-of-service classifiers exp EXP-BA import default
 set class-of-service classifiers exp EXP-BA forwarding-class FC-CLASS3 loss-priority high code-points 000
 set class-of-service classifiers exp EXP-BA forwarding-class FC-CLASS1 loss-priority low code-points ALIAS3
 set class-of-service classifiers exp EXP-BA forwarding-class FC-CLASS2 loss-priority high code-points be
@@ -36,6 +37,7 @@ set class-of-service rewrite-rules dscp REWRITE-DSCP forwarding-class FC-CLASS2 
 set class-of-service rewrite-rules dscp REWRITE-DSCP forwarding-class FC-CLASS3 loss-priority high code-point af11
 set class-of-service rewrite-rules dscp-ipv6 REWRITE-DSCP-IPV6 forwarding-class FC-CLASS2 loss-priority low code-point ALIAS2
 set class-of-service rewrite-rules dscp-ipv6 REWRITE-DSCP-IPV6 forwarding-class FC-CLASS1 loss-priority high code-point 000000
+set class-of-service rewrite-rules exp REWRITE-EXP import default
 set class-of-service rewrite-rules exp REWRITE-EXP forwarding-class FC-CLASS3 loss-priority low code-point ALIAS3
 set class-of-service rewrite-rules exp REWRITE-EXP forwarding-class FC-CLASS1 loss-priority high code-point 001
 set class-of-service rewrite-rules exp REWRITE-EXP forwarding-class FC-CLASS2 loss-priority low code-point be


### PR DESCRIPTION
class-of-service classifiers exp X import (default | name) and
rewrite-rules exp X import (default | name) were unrecognized. The
Juniper CLI reference defines import for both the exp classifier and the
exp rewrite rule, the same as for dscp. Add the import alternative to
scoscl_exp and scosrr_exp. Extend class-of-service-comprehensive.

----

Prompt:
```
Continue clearing internet2 Junos parse warnings in separate orthogonal
PRs. Next: class-of-service "exp" classifiers/rewrite-rules. Ground the
syntax in the Juniper docs (working/junos-cli-reference.txt).
```
