### PR TITLE
Junos: allow interface rewrite-rules exp without protocol

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
@@ -444,7 +444,9 @@ scosiiu_dscp_ipv6_rw
 
 scosiiu_exp_rw
 :
-    EXP name = junos_name PROTOCOL proto = scos_protocol_type
+    // The protocol clause is optional in practice: Junos accepts a bare "exp rewrite-name", even
+    // though the CLI reference lists protocol in the canonical syntax.
+    EXP name = junos_name (PROTOCOL proto = scos_protocol_type)?
 ;
 
 scos_protocol_type

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
@@ -43,6 +43,7 @@ set class-of-service rewrite-rules inet-precedence REWRITE-IPPREC forwarding-cla
 set class-of-service rewrite-rules inet-precedence REWRITE-IPPREC forwarding-class FC-CLASS2 loss-priority low code-point 010
 set class-of-service rewrite-rules inet-precedence REWRITE-IPPREC forwarding-class FC-CLASS3 loss-priority high code-point af11
 set class-of-service interfaces ae1 unit 0 rewrite-rules exp REWRITE-EXP protocol mpls-any
+set class-of-service interfaces ae2 unit 0 rewrite-rules exp REWRITE-EXP
 set class-of-service interfaces ae1 unit 0 classifiers dscp-ipv6 DSCP-IPV6-BA
 set class-of-service interfaces ae1 unit 0 classifiers ieee-802.1 IEEE-BA
 set class-of-service interfaces ae1 unit 0 classifiers inet-precedence IPPREC-BA


### PR DESCRIPTION
class-of-service interfaces X unit Y rewrite-rules exp <name> (no
protocol clause) was unrecognized: scosiiu_exp_rw required PROTOCOL. The
Juniper CLI reference lists protocol in the canonical syntax, but Junos
accepts a bare "exp rewrite-name" and defaults the protocol. Make the
protocol clause optional. Extend class-of-service-comprehensive.

----

Prompt:
```
Continue clearing internet2 Junos parse warnings in separate orthogonal
PRs. Next: interface class-of-service rewrite-rules "exp <name>" without
a protocol clause.
```
