### PR TITLE
Junos: parse host-outbound-traffic ieee-802.1 block

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -507,7 +507,18 @@ DEAD_PEER_DETECTION: 'dead-peer-detection';
 
 DECAPSULATE: 'decapsulate';
 
-DEFAULT: 'default';
+DEFAULT
+:
+  'default'
+  {
+    // Under host-outbound-traffic ieee-802.1, "default" takes a 3-bit code point or alias. In
+    // classifier/rewrite contexts ieee-802.1 pushes M_Name, so "default" lexes as NAME there, not
+    // as this DEFAULT token; a DEFAULT directly after IEEE_802_1 only occurs in that block.
+    if (lastTokenType() == IEEE_802_1) {
+      pushMode(M_CodePointOrAlias);
+    }
+  }
+;
 
 DEFAULT_ACTION: 'default-action';
 
@@ -1007,6 +1018,8 @@ IEEE_802_1
   {
     if (lastTokenType() == CODE_POINT_ALIASES) {
       pushMode(M_CodePointAlias3Bit);
+    } else if (lastTokenType() == HOST_OUTBOUND_TRAFFIC) {
+      // Under host-outbound-traffic, ieee-802.1 is a block of keywords, not a named reference.
     } else {
       pushMode(M_Name);
     }
@@ -2128,6 +2141,7 @@ OUTPUT_TRAFFIC_CONTROL_PROFILE: 'output-traffic-control-profile' -> pushMode(M_N
 OUTPUT_VLAN_MAP: 'output-vlan-map';
 OVERLAY_ECMP: 'overlay-ecmp';
 OVERLOAD: 'overload';
+OVERRIDE_FIREWALL: 'override-firewall';
 OVERRIDE_METRIC: 'override-metric';
 OVERRIDES: 'overrides';
 P2MP: 'p2mp';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
@@ -285,12 +285,40 @@ scos_host_outbound_traffic
     HOST_OUTBOUND_TRAFFIC
     (
         scoshob_forwarding_class
+        | scoshob_ieee_802_1
     )
 ;
 
 scoshob_forwarding_class
 :
     FORWARDING_CLASS name = junos_name
+;
+
+// IEEE 802.1p marking of host (Routing Engine) outbound traffic.
+scoshob_ieee_802_1
+:
+    IEEE_802_1
+    (
+        scoshobi_default
+        | scoshobi_override_firewall
+        | scoshobi_rewrite_rules
+    )
+;
+
+scoshobi_default
+:
+    // Doc: three-bit binary number (000 through 111) or code-point alias.
+    DEFAULT value = ieee_802_1_code_point_or_alias
+;
+
+scoshobi_override_firewall
+:
+    OVERRIDE_FIREWALL
+;
+
+scoshobi_rewrite_rules
+:
+    REWRITE_RULES
 ;
 
 scos_interfaces

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
@@ -24,6 +24,9 @@ set class-of-service forwarding-classes class FC-CLASS1 queue-num 0
 set class-of-service forwarding-classes class FC-CLASS2 queue-num 1
 set class-of-service forwarding-classes queue 3 FC-CLASS3
 set class-of-service host-outbound-traffic forwarding-class FC-CLASS1
+set class-of-service host-outbound-traffic ieee-802.1 default 111
+set class-of-service host-outbound-traffic ieee-802.1 rewrite-rules
+set class-of-service host-outbound-traffic ieee-802.1 override-firewall
 set class-of-service interfaces ae1 scheduler-map SCHED-MAP1
 set class-of-service interfaces ae1 unit 0 forwarding-class FC-CLASS1
 set class-of-service interfaces ae1 unit 0 classifiers dscp DSCP-BA


### PR DESCRIPTION
class-of-service host-outbound-traffic ieee-802.1 { default <value>;
rewrite-rules; override-firewall; } was unrecognized: only
forwarding-class was accepted. The Juniper CLI reference documents the
ieee-802.1 block (and its default/rewrite-rules/override-firewall
options) for marking Routing Engine outbound traffic.

Add the ieee-802.1 alternative under scos_host_outbound_traffic and an
OVERRIDE_FIREWALL token. ieee-802.1 normally pushes a name lexer mode for
its classifier/rewrite-rule reference; under host-outbound-traffic it is
a keyword block, so suppress the mode push in that context. Extend
class-of-service-comprehensive.

----

Prompt:
```
Continue clearing internet2 Junos parse warnings in separate orthogonal
PRs. Next: class-of-service host-outbound-traffic ieee-802.1. Ground the
syntax in the Juniper docs.
```
