### PR TITLE
Junos: allow empty input/output-vlan-map blocks

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -217,7 +217,8 @@ i_gigether_options
 
 i_input_vlan_map
 :
-   INPUT_VLAN_MAP i_vlan_action
+   // The rewrite action is optional; Junos accepts an empty "input-vlan-map {}" block.
+   INPUT_VLAN_MAP i_vlan_action?
 ;
 
 i_link_mode
@@ -265,7 +266,8 @@ i_null
 
 i_output_vlan_map
 :
-   OUTPUT_VLAN_MAP i_vlan_action
+   // The rewrite action is optional; Junos accepts an empty "output-vlan-map {}" block.
+   OUTPUT_VLAN_MAP i_vlan_action?
 ;
 
 i_peer_unit

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-vlan-map
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-vlan-map
@@ -4,3 +4,8 @@ set system host-name interfaces-vlan-map
 set interfaces ae1 unit 1000 output-vlan-map pop
 #
 set interfaces ae2 unit 1000 input-vlan-map push
+#
+# Empty "input-vlan-map {}" / "output-vlan-map {}" blocks flatten to a bare statement with no
+# rewrite action.
+set interfaces ae3 unit 507 input-vlan-map
+set interfaces ae3 unit 507 output-vlan-map


### PR DESCRIPTION
interfaces X unit Y input-vlan-map (an empty "input-vlan-map {}" block,
flattened to a bare statement) was unrecognized: the rule required a
rewrite action. Per the Juniper CLI reference, the action and all other
sub-statements of input-vlan-map/output-vlan-map are optional, so an
empty block is valid. Make i_vlan_action optional for both. Extend
interfaces-vlan-map.

----

Prompt:
```
Continue clearing internet2 Junos parse warnings in separate orthogonal
PRs. Next: empty interfaces input-vlan-map blocks. Ground in Juniper docs.
```
