### PR TITLE
Junos: recognize the discard (dsc) interface

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3884,6 +3884,8 @@ F_InterfaceName
     // optional channel  
     (':' F_Digit+)?
   )
+  // Fixed-name internal interfaces.
+  | 'dsc'
   | 'irb'
   | 'vlan'
   | 'vme'

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -9918,6 +9918,16 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfacesDsc() {
+    // The fixed-name discard (dsc) interface parses and converts like any other interface.
+    Configuration c = parseConfig("interfaces-dsc");
+    assertThat(
+        c,
+        hasInterface(
+            "dsc.0", hasAllAddresses(contains(ConcreteInterfaceAddress.parse("198.32.11.6/32")))));
+  }
+
+  @Test
   public void testIsisImport() {
     // Should not crash.
     parseConfig("isis-import");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-dsc
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-dsc
@@ -1,0 +1,7 @@
+#
+# The discard (dsc) interface is a fixed-name internal interface, like irb/vlan/vme.
+#
+set system host-name interfaces-dsc
+
+set interfaces dsc unit 0 description "Discard Interface"
+set interfaces dsc unit 0 family inet address 198.32.11.6/32


### PR DESCRIPTION
interfaces dsc { ... } was unrecognized: "dsc" did not lex as an
interface name, so the whole block (description, family inet address)
was dropped. dsc is a fixed-name internal interface, like irb/vlan/vme;
add it to F_InterfaceName. It then parses and converts like any other
interface.

----

Prompt:
```
Continue clearing internet2 Junos parse warnings in separate orthogonal
PRs. Next: the discard (dsc) interface. Ground in Juniper docs.
```
