### PR TITLE
Junos: parse static ndp entry under interface family inet6 address

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2004,6 +2004,8 @@ NBMA: 'nbma';
 
 NEAREST: 'nearest';
 
+NDP: 'ndp';
+
 NEIGHBOR: 'neighbor';
 
 NEIGHBOR_ADVERTISEMENT: 'neighbor-advertisement';
@@ -2360,6 +2362,8 @@ PROTOCOL_VERSION: 'protocol-version';
 PROTOCOLS: 'protocols';
 
 PROVIDER_TUNNEL: 'provider-tunnel';
+
+PUBLISH: 'publish';
 
 PROXY_ARP: 'proxy-arp';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -403,9 +403,20 @@ ifi6_address
       | wildcard
    )
    (
-      ifi6a_preferred
+      ifi6a_ndp
+      | ifi6a_preferred
       | ifi6a_primary
    )?
+;
+
+// Static NDP entry: ndp <ip> (mac | multicast-mac) <mac> [publish]. Mirrors v4 static arp.
+ifi6a_ndp
+:
+   NDP ip = ipv6_address
+   (
+      MAC
+      | MULTICAST_MAC
+   ) MAC_ADDRESS PUBLISH?
 ;
 
 ifi6a_preferred: PREFERRED;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4547,6 +4547,17 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfaceInet6Ndp() {
+    // A static NDP entry under an inet6 address parses; the address still converts normally.
+    JuniperConfiguration jc = parseJuniperConfig("interfaces-inet6-ndp");
+    Map<String, org.batfish.representation.juniper.Interface> units =
+        jc.getMasterLogicalSystem().getInterfaces().get("xe-0/2/2").getUnits();
+    assertThat(
+        units.get("xe-0/2/2.80").getAllAddresses6(),
+        contains(ConcreteInterfaceAddress6.parse("2001:468:ff:909::1/64")));
+  }
+
+  @Test
   public void testIrbInterfaces() {
     String hostname = "irb-interfaces";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-inet6-ndp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-inet6-ndp
@@ -1,0 +1,6 @@
+#
+# Static NDP (IPv6 neighbor) entry under an interface family inet6 address.
+#
+set system host-name interfaces-inet6-ndp
+
+set interfaces xe-0/2/2 unit 80 family inet6 address 2001:468:ff:909::1/64 ndp 2001:468:ff:909::2 mac 00:de:ad:be:ef:00


### PR DESCRIPTION
interfaces X unit Y family inet6 address A/P ndp <ip> mac <mac> was
unrecognized: the inet6 address rule had no ndp alternative. Per the
Juniper CLI reference, family inet6 address takes
"ndp ip-address (mac | multicast-mac) mac-address <publish>", the IPv6
analog of static arp. Add ifi6a_ndp (mirroring v4 ifia_arp) and NDP /
PUBLISH tokens. Extend with interfaces-inet6-ndp.

----

Prompt:
```
Continue clearing internet2 Junos parse warnings in separate orthogonal
PRs. Next: static ndp entry under interface family inet6 address. Ground
in Juniper docs.
```
