### PR TITLE
Junos: parse more label-switched-path statements

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2068,8 +2068,10 @@ NO_ADVERTISE: 'no-advertise';
 NO_ANTI_REPLAY: 'no-anti-replay';
 NO_ARP: 'no-arp';
 NO_AUTO_NEGOTIATION: 'no-auto-negotiation';
+NO_AUTO_POLICING: 'no-auto-policing';
 NO_CHALLENGE_RESPONSE: 'no-challenge-response';
 NO_CLIENT_REFLECT: 'no-client-reflect';
+NO_CSPF: 'no-cspf';
 NO_DECREMENT_TTL: 'no-decrement-ttl';
 NO_ECMP_FAST_REROUTE: 'no-ecmp-fast-reroute';
 NO_EXPORT: 'no-export';
@@ -2211,6 +2213,7 @@ POE: 'poe';
 POINT_TO_POINT: 'point-to-point';
 POLICER: 'policer' -> pushMode(M_Name);
 POLICIES: 'policies';
+POLICING: 'policing';
 POLICY
 :
   'policy'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
@@ -96,15 +96,20 @@ mpls_label_switched_path
       | mplslsp_bandwidth_null
       | mplslsp_conditional_metric_null
       | mplslsp_cross_credibility_cspf_null
+      | mplslsp_description_null
       | mplslsp_fast_reroute_null
+      | mplslsp_from_null
       | mplslsp_hop_limit_null
       | mplslsp_in_place_lsp_bandwidth_update_null
       | mplslsp_install_null
       | mplslsp_link_protection_null
+      | mplslsp_metric_null
+      | mplslsp_no_cspf_null
       | mplslsp_no_decrement_ttl_null
       | mplslsp_no_self_ping_null
       | mplslsp_optimize_hold_dead_delay_null
       | mplslsp_optimize_timer_null
+      | mplslsp_policing
       | mplslsp_primary
       | mplslsp_priority_null
       | mplslsp_random_null
@@ -265,6 +270,46 @@ mplslsp_bandwidth_null
 mplslsp_cross_credibility_cspf_null
 :
    CROSS_CREDIBILITY_CSPF null_filler
+;
+
+mplslsp_description_null
+:
+   DESCRIPTION null_filler
+;
+
+mplslsp_from_null
+:
+   FROM (ip_address | ipv6_address)
+;
+
+mplslsp_metric_null
+:
+   METRIC uint32
+;
+
+mplslsp_no_cspf_null
+:
+   NO_CSPF null_filler
+;
+
+// policing { filter <name>; no-auto-policing; }
+mplslsp_policing
+:
+   POLICING
+   (
+      mplslsppol_filter
+      | mplslsppol_no_auto_policing
+   )
+;
+
+mplslsppol_filter
+:
+   FILTER name = filter_name
+;
+
+mplslsppol_no_auto_policing
+:
+   NO_AUTO_POLICING
 ;
 
 mplslsp_fast_reroute_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -161,6 +161,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_INTE
 import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_ADMIN_GROUP_EXCLUDE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_ADMIN_GROUP_INCLUDE_ALL;
 import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_ADMIN_GROUP_INCLUDE_ANY;
+import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_POLICING_FILTER;
 import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_PRIMARY_PATH;
 import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_SECONDARY_ADMIN_GROUP_EXCLUDE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_SECONDARY_ADMIN_GROUP_INCLUDE_ALL;
@@ -561,6 +562,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Mplslsp_secondaryContex
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Mplslspag_excludeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Mplslspag_include_allContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Mplslspag_include_anyContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Mplslsppol_filterContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Mplslspsag_excludeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Mplslspsag_include_allContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Mplslspsag_include_anyContext;
@@ -9226,6 +9228,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
         name,
         MPLS_LSP_SECONDARY_ADMIN_GROUP_INCLUDE_ANY,
         getLine(ctx.name.getStart()));
+  }
+
+  @Override
+  public void exitMplslsppol_filter(Mplslsppol_filterContext ctx) {
+    String name = toString(ctx.name);
+    _configuration.referenceStructure(
+        FIREWALL_FILTER, name, MPLS_LSP_POLICING_FILTER, getLine(ctx.name.getStart()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -134,6 +134,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   MPLS_LSP_ADMIN_GROUP_EXCLUDE("mpls lsp admin-group exclude"),
   MPLS_LSP_ADMIN_GROUP_INCLUDE_ALL("mpls lsp admin-group include-all"),
   MPLS_LSP_ADMIN_GROUP_INCLUDE_ANY("mpls lsp admin-group include-any"),
+  MPLS_LSP_POLICING_FILTER("mpls lsp policing filter"),
   MPLS_LSP_PRIMARY_PATH("mpls lsp primary path"),
   MPLS_LSP_SECONDARY_ADMIN_GROUP_EXCLUDE("mpls lsp secondary admin-group exclude"),
   MPLS_LSP_SECONDARY_ADMIN_GROUP_INCLUDE_ALL("mpls lsp secondary admin-group include-all"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/JunosMplsLspTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/JunosMplsLspTest.java
@@ -3,7 +3,9 @@ package org.batfish.grammar.flatjuniper;
 import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.hasDefinedStructure;
 import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.hasReferencedStructure;
 import static org.batfish.datamodel.matchers.ConvertConfigurationAnswerElementMatchers.hasUndefinedReference;
+import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER;
 import static org.batfish.representation.juniper.JuniperStructureType.MPLS_PATH;
+import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_POLICING_FILTER;
 import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_PRIMARY_PATH;
 import static org.batfish.representation.juniper.JuniperStructureUsage.MPLS_LSP_SECONDARY_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -56,6 +58,12 @@ public class JunosMplsLspTest {
 
     // Verify undefined path reference
     assertThat(ccae, hasUndefinedReference(filename, MPLS_PATH, "SEC", MPLS_LSP_SECONDARY_PATH));
+
+    // LSP policing references a firewall filter.
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, FIREWALL_FILTER, "signaled-lsp-filter", MPLS_LSP_POLICING_FILTER));
   }
 
   /** Names containing {@code >}, e.g. LSP name "WASH->ATLA", lex so the LSP body parses. */

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/mpls-lsp-comprehensive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/mpls-lsp-comprehensive
@@ -121,4 +121,19 @@ set protocols mpls label-switched-path params-lsp hop-limit 3
 set protocols mpls label-switched-path params-lsp optimize-timer 65535
 set protocols mpls label-switched-path params-lsp revert-timer 900
 
+# from / no-cspf / description / metric / policing
+set protocols mpls label-switched-path signaled-lsp from 192.0.2.18
+set protocols mpls label-switched-path signaled-lsp to 192.0.2.19
+set protocols mpls label-switched-path signaled-lsp no-cspf
+set protocols mpls label-switched-path signaled-lsp description "TR-CPS to gigapop L2Circuit"
+set protocols mpls label-switched-path signaled-lsp metric 65535
+set protocols mpls label-switched-path signaled-lsp policing filter signaled-lsp-filter
+
+# from with an IPv6 source
+set protocols mpls label-switched-path v6-from from 2001:db8::18
+set protocols mpls label-switched-path v6-from to 2001:db8::19
+
+# Firewall filter referenced by the LSP policing statement above.
+set firewall filter signaled-lsp-filter term t1 then accept
+
 #


### PR DESCRIPTION
Accept from, no-cspf, description, metric, and policing under
protocols mpls label-switched-path as ignored stanzas, matching the
existing null treatment of the rest of the LSP block.

----

Prompt:
```
merged all open CRs. keep going
```
