### PR TITLE
Junos: parse forwarding-table traceoptions

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -539,6 +539,7 @@ rof_null
    (
       INDIRECT_NEXT_HOP
       | INDIRECT_NEXT_HOP_CHANGE_ACKNOWLEDGEMENTS
+      | TRACEOPTIONS
    ) null_filler
 ;
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -9975,9 +9975,9 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testInterfacesEthernetSwitchProfile() {
-    // gigether-options ethernet-switch-profile (empty and with nested children) should not crash.
-    parseConfig("interfaces-ethernet-switch-profile");
+  public void testForwardingTableTraceoptions() {
+    // routing-options forwarding-table traceoptions should not crash.
+    parseConfig("forwarding-table-traceoptions");
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/forwarding-table-traceoptions
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/forwarding-table-traceoptions
@@ -1,0 +1,7 @@
+#
+# routing-options forwarding-table traceoptions (ignored).
+#
+set system host-name forwarding-table-traceoptions
+
+set routing-options forwarding-table traceoptions file fib-trace
+set routing-options forwarding-table traceoptions flag all


### PR DESCRIPTION
Accept traceoptions under routing-options forwarding-table as an
ignored stanza, alongside the other rof_null entries.

----

Prompt:
```
merged all open CRs. keep going
```
