### PR TITLE
Junos: parse legacy security key-chain

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -458,6 +458,7 @@ s_security
       | se_certificates
       | se_ike
       | se_ipsec
+      | se_key_chain
       | se_nat
       | se_null
       | se_policies
@@ -493,6 +494,31 @@ se_certificates
    CERTIFICATES
    (
       sec_local
+   )
+;
+
+// Legacy form of "security authentication-key-chains key-chain". Mirrors
+// se_authentication_key_chain, but a key may be empty.
+se_key_chain
+:
+   KEY_CHAIN name = junos_name
+   (
+      apply
+      | sea_description
+      | sea_tolerance
+      | sekc_key
+   )
+;
+
+sekc_key
+:
+   KEY name = junos_name
+   (
+      apply
+      | seak_algorithm
+      | seak_options
+      | seak_secret
+      | seak_start_time
    )
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -875,6 +875,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrripfc_loss_priorit
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scossm_forwarding_classContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Se_address_bookContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Se_authentication_key_chainContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Se_key_chainContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Se_zonesContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sea_keyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sea_toleranceContext;
@@ -917,6 +918,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Seippr_protocolContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Seipv_bind_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Seipvi_gatewayContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Seipvi_ipsec_policyContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sekc_keyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sen_destinationContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sen_sourceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sen_staticContext;
@@ -4233,6 +4235,27 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
             .getKeys()
             .computeIfAbsent(name, JuniperAuthenticationKey::new);
     _currentAuthenticationKey = authenticationkey;
+  }
+
+  @Override
+  public void enterSe_key_chain(Se_key_chainContext ctx) {
+    // Legacy form of authentication-key-chains key-chain; same data model.
+    String name = toString(ctx.name);
+    int line = getLine(ctx.getStart());
+    _currentAuthenticationKeyChain =
+        _currentLogicalSystem
+            .getAuthenticationKeyChains()
+            .computeIfAbsent(name, n -> new JuniperAuthenticationKeyChain(n, line));
+    _configuration.defineFlattenedStructure(AUTHENTICATION_KEY_CHAIN, name, ctx, _parser);
+  }
+
+  @Override
+  public void enterSekc_key(Sekc_keyContext ctx) {
+    String name = toString(ctx.name);
+    _currentAuthenticationKey =
+        _currentAuthenticationKeyChain
+            .getKeys()
+            .computeIfAbsent(name, JuniperAuthenticationKey::new);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -453,6 +453,7 @@ import org.batfish.representation.juniper.InterfaceRangeMember;
 import org.batfish.representation.juniper.InterfaceRangeMemberRange;
 import org.batfish.representation.juniper.IpBgpGroup;
 import org.batfish.representation.juniper.IpUnknownProtocol;
+import org.batfish.representation.juniper.JuniperAuthenticationKeyChain;
 import org.batfish.representation.juniper.JuniperConfiguration;
 import org.batfish.representation.juniper.JuniperStructureType;
 import org.batfish.representation.juniper.JuniperStructureUsage;
@@ -9978,6 +9979,18 @@ public final class FlatJuniperGrammarTest {
   public void testForwardingTableTraceoptions() {
     // routing-options forwarding-table traceoptions should not crash.
     parseConfig("forwarding-table-traceoptions");
+  }
+
+  @Test
+  public void testSecurityKeyChain() {
+    // Legacy "security key-chain" form (pre authentication-key-chains) extracts the same
+    // JuniperAuthenticationKeyChain model, including empty keys.
+    JuniperConfiguration jc = parseJuniperConfig("security-key-chain");
+    Map<String, JuniperAuthenticationKeyChain> keyChains =
+        jc.getMasterLogicalSystem().getAuthenticationKeyChains();
+    assertThat(keyChains.keySet(), containsInAnyOrder("BFD-BGP-MERIT", "BFD-BGP-OARNET"));
+    assertThat(keyChains.get("BFD-BGP-MERIT").getTolerance(), equalTo(30));
+    assertThat(keyChains.get("BFD-BGP-OARNET").getKeys().keySet(), containsInAnyOrder("0", "1"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/security-key-chain
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/security-key-chain
@@ -1,0 +1,12 @@
+#
+# Legacy "security key-chain" (pre authentication-key-chains) with empty keys.
+#
+set system host-name security-key-chain
+
+set security key-chain BFD-BGP-MERIT key 0
+set security key-chain BFD-BGP-OARNET key 0
+
+# Key with attributes, plus chain-level options.
+set security key-chain BFD-BGP-MERIT tolerance 30
+set security key-chain BFD-BGP-OARNET key 1 algorithm md5
+set security key-chain BFD-BGP-OARNET key 1 start-time "2020-1-1.00:00:00 -0800"


### PR DESCRIPTION
Accept the pre-authentication-key-chains form "security key-chain
<name> { key <id> {...} }" and extract it into the same
JuniperAuthenticationKeyChain model. A key may be empty.

----

Prompt:
```
merged all open CRs. keep going
```
