### PR TITLE
Junos: parse unit-level vlan-tags outer/inner

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -305,6 +305,7 @@ i_unit
       | i_input_vlan_map
       | i_output_vlan_map
       | i_peer_unit
+      | i_vlan_tags_null
    )
 ;
 
@@ -326,6 +327,12 @@ i_vlan_id_list
 i_vlan_tagging
 :
    VLAN_TAGGING
+;
+
+// Dual-tagged (Q-in-Q) outer/inner VLAN IDs. Not modeled.
+i_vlan_tags_null
+:
+   VLAN_TAGS OUTER outer = vlan_number (INNER inner = vlan_number)?
 ;
 
 if_bridge

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -9994,6 +9994,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfacesVlanTags() {
+    // Q-in-Q vlan-tags outer/inner should not crash.
+    parseConfig("interfaces-vlan-tags");
+  }
+
+  @Test
   public void testIsisImport() {
     // Should not crash.
     parseConfig("isis-import");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-vlan-tags
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-vlan-tags
@@ -1,0 +1,12 @@
+#
+# Dual-tagged (Q-in-Q) unit with vlan-tags outer/inner. Tags are parsed and ignored.
+#
+set system host-name interfaces-vlan-tags
+
+set interfaces xe-0/1/2 flexible-vlan-tagging
+set interfaces xe-0/1/2 encapsulation flexible-ethernet-services
+set interfaces xe-0/1/2 unit 10898 encapsulation vlan-ccc
+set interfaces xe-0/1/2 unit 10898 vlan-tags outer 992 inner 898
+
+# outer-only form
+set interfaces xe-0/1/2 unit 10899 vlan-tags outer 993


### PR DESCRIPTION
Accept "vlan-tags outer <id> [inner <id>]" on a logical unit. The
Q-in-Q tags are parsed and ignored.

----

Prompt:
```
merged all open CRs. keep going
```
