### PR TITLE
Junos: parse interface family vpls

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -203,6 +203,7 @@ i_family
       | if_iso
       | if_primary
       | if_mpls
+      | if_vpls_null
    )
 ;
 
@@ -467,6 +468,12 @@ if_mpls
 if_primary
 :
    PRIMARY
+;
+
+// family vpls (Layer 2 pseudowire). Contents (filter, etc.) are not modeled.
+if_vpls_null
+:
+   VPLS null_filler
 ;
 
 if_storm_control

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -10000,6 +10000,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfacesFamilyVpls() {
+    // family vpls and empty family bridge should not crash.
+    parseConfig("interfaces-family-vpls");
+  }
+
+  @Test
   public void testIsisImport() {
     // Should not crash.
     parseConfig("isis-import");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-family-vpls
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-family-vpls
@@ -1,0 +1,11 @@
+#
+# Layer 2 interface families: family vpls, and empty family bridge.
+#
+set system host-name interfaces-family-vpls
+
+set interfaces xe-0/2/0 unit 2000 encapsulation vlan-vpls
+set interfaces xe-0/2/0 unit 2000 vlan-id 2000
+set interfaces xe-0/2/0 unit 2000 family vpls
+
+# Empty family bridge.
+set interfaces xe-0/2/1 unit 0 family bridge


### PR DESCRIPTION
Accept "family vpls" on a logical unit as an ignored stanza. The empty
"family bridge" block already parses via the existing if_bridge apply
alternative; both are covered by the new test.

----

Prompt:
```
merged all open CRs. keep going
```
