### PR TITLE
Junos: track switch-options vrf-import/vrf-export policy references

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3089,9 +3089,9 @@ VPN_MONITOR: 'vpn-monitor';
 
 VRF: 'vrf';
 
-VRF_EXPORT: 'vrf-export' -> pushMode(M_Name);
+VRF_EXPORT: 'vrf-export' -> pushMode(M_NameList);
 
-VRF_IMPORT: 'vrf-import' -> pushMode(M_Name);
+VRF_IMPORT: 'vrf-import' -> pushMode(M_NameList);
 
 VRF_TABLE_LABEL: 'vrf-table-label';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_switch_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_switch_options.g4
@@ -61,12 +61,12 @@ sovt_import
 
 so_vrf_export
 :
-  VRF_EXPORT name = junos_name
+  VRF_EXPORT names = junos_name_list
 ;
 
 so_vrf_import
 :
-  VRF_IMPORT name = junos_name
+  VRF_IMPORT names = junos_name_list
 ;
 
 so_interface

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3989,18 +3989,24 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitSo_vrf_export(So_vrf_exportContext ctx) {
-    String policyName = toString(ctx.name);
-    _currentLogicalSystem.getOrInitSwitchOptions().setVrfExportPolicy(policyName);
-    _configuration.referenceStructure(
-        POLICY_STATEMENT, policyName, SWITCH_OPTIONS_VRF_EXPORT, getLine(ctx.start));
+    // vrf-export accepts a single policy or a bracketed list; reference each.
+    for (Junos_nameContext nameCtx : ctx.names.junos_name()) {
+      String policyName = toString(nameCtx);
+      _currentLogicalSystem.getOrInitSwitchOptions().setVrfExportPolicy(policyName);
+      _configuration.referenceStructure(
+          POLICY_STATEMENT, policyName, SWITCH_OPTIONS_VRF_EXPORT, getLine(nameCtx.getStart()));
+    }
   }
 
   @Override
   public void exitSo_vrf_import(So_vrf_importContext ctx) {
-    String policyName = toString(ctx.name);
-    _currentLogicalSystem.getOrInitSwitchOptions().setVrfImportPolicy(policyName);
-    _configuration.referenceStructure(
-        POLICY_STATEMENT, policyName, SWITCH_OPTIONS_VRF_IMPORT, getLine(ctx.start));
+    // vrf-import accepts a single policy or a bracketed list; reference each.
+    for (Junos_nameContext nameCtx : ctx.names.junos_name()) {
+      String policyName = toString(nameCtx);
+      _currentLogicalSystem.getOrInitSwitchOptions().setVrfImportPolicy(policyName);
+      _configuration.referenceStructure(
+          POLICY_STATEMENT, policyName, SWITCH_OPTIONS_VRF_IMPORT, getLine(nameCtx.getStart()));
+    }
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -197,6 +197,8 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_ST
 import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_STATEMENT_RTF_PREFIX_LIST;
 import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_STATEMENT_THEN_TUNNEL_ATTRIBUTE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SECURITY_POLICY_MATCH_APPLICATION;
+import static org.batfish.representation.juniper.JuniperStructureUsage.SWITCH_OPTIONS_VRF_EXPORT;
+import static org.batfish.representation.juniper.JuniperStructureUsage.SWITCH_OPTIONS_VRF_IMPORT;
 import static org.batfish.representation.juniper.RoutingInformationBase.RIB_IPV4_UNICAST;
 import static org.batfish.representation.juniper.RoutingInformationBase.RIB_IPV6_UNICAST;
 import static org.batfish.representation.juniper.RoutingInstance.OSPF_INTERNAL_SUMMARY_DISCARD_METRIC;
@@ -8706,6 +8708,55 @@ public final class FlatJuniperGrammarTest {
     assertThat(ipPrefixRoutes.getVni(), equalTo(1011));
     assertThat(ipPrefixRoutes.getImportPolicy(), equalTo("FOO-vrf-import"));
     assertThat(ipPrefixRoutes.getExportPolicy(), equalTo("FOO-vrf-export"));
+  }
+
+  @Test
+  public void testSwitchOptionsVrfImportExportReferences() throws IOException {
+    // GH-6305: policy-statements used by switch-options vrf-import/vrf-export must be marked as
+    // referenced (not orphans), for both the single-name and bracketed-list forms.
+    String hostname = "switch-options-vrf-import-list";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, POLICY_STATEMENT, "SINGLE_IMPORT", SWITCH_OPTIONS_VRF_IMPORT));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, POLICY_STATEMENT, "SINGLE_EXPORT", SWITCH_OPTIONS_VRF_EXPORT));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, POLICY_STATEMENT, "LIST_IMPORT_A", SWITCH_OPTIONS_VRF_IMPORT));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, POLICY_STATEMENT, "LIST_IMPORT_B", SWITCH_OPTIONS_VRF_IMPORT));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, POLICY_STATEMENT, "LIST_EXPORT_A", SWITCH_OPTIONS_VRF_EXPORT));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename, POLICY_STATEMENT, "LIST_EXPORT_B", SWITCH_OPTIONS_VRF_EXPORT));
+
+    // Every referenced policy is defined, so none are flagged as undefined references.
+    for (String policy :
+        new String[] {
+          "SINGLE_IMPORT",
+          "SINGLE_EXPORT",
+          "LIST_IMPORT_A",
+          "LIST_IMPORT_B",
+          "LIST_EXPORT_A",
+          "LIST_EXPORT_B"
+        }) {
+      assertThat(ccae, hasNumReferrers(filename, POLICY_STATEMENT, policy, 1));
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/switch-options-vrf-import-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/switch-options-vrf-import-list
@@ -1,0 +1,21 @@
+#
+# switch-options vrf-import/vrf-export reference policy-statements, both as a
+# single name (GH-6305) and as a bracketed list. Referenced policies must not be
+# flagged as orphans/undefined.
+#
+set system host-name switch-options-vrf-import-list
+
+set policy-options policy-statement SINGLE_IMPORT term t1 then accept
+set policy-options policy-statement SINGLE_EXPORT term t1 then accept
+set policy-options policy-statement LIST_IMPORT_A term t1 then accept
+set policy-options policy-statement LIST_IMPORT_B term t1 then accept
+set policy-options policy-statement LIST_EXPORT_A term t1 then accept
+set policy-options policy-statement LIST_EXPORT_B term t1 then accept
+
+# Single name (the case from the issue).
+set switch-options vrf-import SINGLE_IMPORT
+set switch-options vrf-export SINGLE_EXPORT
+
+# Bracketed list form, per the CLI reference: vrf-import (policy-name | [policy-names]).
+set switch-options vrf-import [ LIST_IMPORT_A LIST_IMPORT_B ]
+set switch-options vrf-export [ LIST_EXPORT_A LIST_EXPORT_B ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -41457,7 +41457,7 @@
             "              (ri_vrf_import",
             "                VRF_IMPORT:'vrf-import'",
             "                name = (junos_name*",
-            "                  NAME:'fabric'  <== mode:M_Name)))))))",
+            "                  NAME:'fabric'  <== mode:M_NameList)))))))",
             "    NEWLINE:'\\n')",
             "  (set_line*",
             "    SET:'set'",
@@ -68952,7 +68952,7 @@
             "              (ri_vrf_import",
             "                VRF_IMPORT:'vrf-import'",
             "                name = (junos_name*",
-            "                  NAME:'policy1'  <== mode:M_Name)))))))",
+            "                  NAME:'policy1'  <== mode:M_NameList)))))))",
             "    NEWLINE:'\\n')",
             "  EOF:<EOF>)"
           ]


### PR DESCRIPTION
switch-options vrf-import/vrf-export reference policy-statements. The
single-name form is already tracked, but the CLI reference also allows a
bracketed list of policies (vrf-import (policy-name | [policy-names]))
which previously failed to parse. Accept the list form via
junos_name_list and add a reference for every named policy so none are
flagged as orphan/undefined.

Fixes batfish/batfish#6305.

----

Prompt:
```
In the meantime can you take a look at
https://github.com/batfish/batfish/issues/6305 ? ground in real manual too
```
