### PR TITLE
Junos: parse and track ieee-802.1 rewrite-rules import

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_class_of_service.g4
@@ -564,7 +564,14 @@ scosrr_ieee_802_1
     IEEE_802_1 name = junos_name
     (
         scosrri_forwarding_class
+        | scosrri_import
     )
+;
+
+scosrri_import
+:
+    // "import" enters policy-expression lexer mode, so "default" arrives as a name.
+    IMPORT name = junos_name
 ;
 
 scosrri_forwarding_class

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -117,6 +117,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_EXP_SELF_REFERENCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_CODE_POINT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_FORWARDING_CLASS;
+import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_SELF_REFERENCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_INET_PRECEDENCE_CODE_POINT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_SERVICE_REWRITE_RULES_INET_PRECEDENCE_FORWARDING_CLASS;
@@ -869,6 +870,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrre_forwarding_clas
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrre_importContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrrefc_loss_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrri_forwarding_classContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrri_importContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrrifc_loss_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrrip_forwarding_classContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Scosrripfc_loss_priorityContext;
@@ -8251,6 +8253,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     // The imported name may be "default", which is a built-in rewrite-rule.
     referenceBuiltIn(
         ctx.name, CLASS_OF_SERVICE_REWRITE_RULE, CLASS_OF_SERVICE_REWRITE_RULES_EXP_IMPORT);
+  }
+
+  @Override
+  public void exitScosrri_import(Scosrri_importContext ctx) {
+    // The imported name may be "default", which is a built-in rewrite-rule.
+    referenceBuiltIn(
+        ctx.name, CLASS_OF_SERVICE_REWRITE_RULE, CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_IMPORT);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -77,6 +77,8 @@ public enum JuniperStructureUsage implements StructureUsage {
       "class-of-service rewrite-rules ieee-802.1 forwarding-class"),
   CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_CODE_POINT(
       "class-of-service rewrite-rules ieee-802.1 code-point"),
+  CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_IMPORT(
+      "class-of-service rewrite-rules ieee-802.1 import"),
   CLASS_OF_SERVICE_REWRITE_RULES_INET_PRECEDENCE_FORWARDING_CLASS(
       "class-of-service rewrite-rules inet-precedence forwarding-class"),
   CLASS_OF_SERVICE_REWRITE_RULES_INET_PRECEDENCE_CODE_POINT(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1104,6 +1104,14 @@ public final class FlatJuniperGrammarTest {
             "default",
             org.batfish.representation.juniper.JuniperStructureUsage
                 .CLASS_OF_SERVICE_REWRITE_RULES_EXP_IMPORT));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename,
+            org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_REWRITE_RULE,
+            "default",
+            org.batfish.representation.juniper.JuniperStructureUsage
+                .CLASS_OF_SERVICE_REWRITE_RULES_IEEE_802_1_IMPORT));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/class-of-service-comprehensive
@@ -41,6 +41,7 @@ set class-of-service rewrite-rules exp REWRITE-EXP import default
 set class-of-service rewrite-rules exp REWRITE-EXP forwarding-class FC-CLASS3 loss-priority low code-point ALIAS3
 set class-of-service rewrite-rules exp REWRITE-EXP forwarding-class FC-CLASS1 loss-priority high code-point 001
 set class-of-service rewrite-rules exp REWRITE-EXP forwarding-class FC-CLASS2 loss-priority low code-point be
+set class-of-service rewrite-rules ieee-802.1 REWRITE-8021P import default
 set class-of-service rewrite-rules ieee-802.1 REWRITE-8021P forwarding-class FC-CLASS1 loss-priority high code-point ALIAS-8021P
 set class-of-service rewrite-rules ieee-802.1 REWRITE-8021P forwarding-class FC-CLASS2 loss-priority low code-point 010
 set class-of-service rewrite-rules ieee-802.1 REWRITE-8021P forwarding-class FC-CLASS3 loss-priority high code-point be


### PR DESCRIPTION
class-of-service rewrite-rules ieee-802.1 <name> accepts "import
<rule>" (commonly "import default"), like the dscp/exp variants. Accept
it and track the imported rule as a built-in reference.

----

Prompt:
```
let's do the c-o-s one and then do the next-hop one
```
