### PR TITLE
Junos: lex next-hop in route-filter inline then

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -2042,8 +2042,17 @@ NEXT_HOP
 :
    'next-hop'
    {
-     if (lastTokenType() != THEN) {
-       pushMode(M_Interface);
+     // "next-hop" takes an interface name (M_Interface) only as a "then" action whose value can be
+     // an interface. In a policy "then" it follows THEN; in a route-filter inline action it follows
+     // the match type (exact/longer/orlonger), e.g. "route-filter 0.0.0.0/0 exact next-hop self".
+     switch (lastTokenType()) {
+       case THEN:
+       case EXACT:
+       case LONGER:
+       case ORLONGER:
+         break;
+       default:
+         pushMode(M_Interface);
      }
    }
 ;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -7357,6 +7357,13 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testRouteFilterThenNextHop() {
+    // route-filter "<prefix> <match-type> next-hop self": match type precedes next-hop, so "self"
+    // must lex as the keyword (not an interface name). Should not crash.
+    parseConfig("route-filter-then-next-hop");
+  }
+
+  @Test
   public void testRoutingInstanceType() {
     Configuration c = parseConfig("routing-instance-type");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/route-filter-then-next-hop
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/route-filter-then-next-hop
@@ -1,0 +1,11 @@
+#
+# route-filter with an inline "then" action of "next-hop self". The match type
+# (exact/longer/orlonger) precedes "next-hop", so the lexer must not treat
+# "self" as an interface name.
+#
+set system host-name route-filter-then-next-hop
+
+set policy-options policy-statement P term send-default from route-filter 0.0.0.0/0 exact next-hop self
+set policy-options policy-statement P term longer-route from route-filter 10.0.0.0/8 orlonger next-hop self
+set policy-options policy-statement P term longer-only from route-filter 10.0.0.0/8 longer next-hop self
+set policy-options policy-statement P term then-accept then accept


### PR DESCRIPTION
A route-filter can carry an inline action, e.g.
"route-filter 0.0.0.0/0 exact next-hop self". The match type (exact,
longer, orlonger) precedes "next-hop", so the lexer pushed M_Interface
and lexed "self" as an interface name, failing the parse. Suppress the
M_Interface push after those match-type tokens, like the existing THEN
case.

----

Prompt:
```
let's do the c-o-s one and then do the next-hop one
```
