### PR TITLE
Junos: parse mpls path hops

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -1811,6 +1811,8 @@ LOGIN: 'login';
 
 LONGER: 'longer';
 
+LOOSE: 'loose';
+
 LOOPBACK: 'loopback';
 
 LOOPS: 'loops';
@@ -2850,6 +2852,7 @@ STP: 'stp';
 
 STREAM_ID: 'stream-id';
 STREAM_OPTION: 'stream-option';
+STRICT: 'strict';
 STRICT_HIGH: 'strict-high';
 STRICT_SOURCE_ROUTE: 'strict-source-route';
 STRICT_SOURCE_ROUTE_OPTION: 'strict-source-route-option';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_mpls.g4
@@ -63,6 +63,20 @@ mpls_admin_groups
 mpls_path
 :
    PATH name = junos_name
+   (
+      apply
+      | mplsp_hop_null
+   )
+;
+
+// A path hop: (address | hostname) <loose | strict>. Hops are not modeled.
+mplsp_hop_null
+:
+   (ip_address | ipv6_address)
+   (
+      LOOSE
+      | STRICT
+   )?
 ;
 
 mpls_interface

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/mpls-lsp-comprehensive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/mpls-lsp-comprehensive
@@ -109,6 +109,11 @@ set protocols mpls label-switched-path comprehensive-new-lsp auto-bandwidth maxi
 
 # Path definitions and references
 set protocols mpls path PRI
+# Path hops: address with optional strict/loose (and a bare-address hop).
+set protocols mpls path PRI 192.0.2.100 strict
+set protocols mpls path PRI 192.0.2.101 loose
+set protocols mpls path PRI 192.0.2.102
+set protocols mpls path PRI6 2001:db8::100 strict
 set protocols mpls label-switched-path path-lsp to 192.0.2.16
 set protocols mpls label-switched-path path-lsp primary PRI
 set protocols mpls label-switched-path path-lsp secondary SEC preference 8


### PR DESCRIPTION
protocols mpls path <name> takes hop entries of the form
"(address | hostname) <loose | strict>". Accept address hops (v4/v6)
with optional loose/strict; hops are not modeled.

----

Prompt:
```
do em all
```
(the remaining Internet2 parse gaps: mpls path strict/loose, family
bridge interface-mode/vlan-id, isis per-level ipv6 metrics, empty
gigether-options)
