### PR TITLE
Junos: parse family bridge interface-mode access and vlan-id

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -345,6 +345,7 @@ if_bridge
       | if_storm_control
       | ifbr_filter
       | ifbr_interface_mode
+      | ifbr_vlan_id
       | ifbr_vlan_id_list
    )
 ;
@@ -490,6 +491,11 @@ ifbr_filter
 ifbr_interface_mode
 :
    INTERFACE_MODE interface_mode
+;
+
+ifbr_vlan_id
+:
+   VLAN_ID id = vlan_number
 ;
 
 ifbr_vlan_id_list
@@ -786,7 +792,8 @@ int_null
 
 interface_mode
 :
-   TRUNK
+   ACCESS
+   | TRUNK
 ;
 
 intir_member

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -472,8 +472,11 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_vlan_taggingContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Icmp_codeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Icmp_typeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ieee_802_1_code_pointContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.If_bridgeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.If_ethernet_switchingContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.If_primaryContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifbr_interface_modeContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ifbr_vlan_idContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_filterContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_interface_modeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ife_native_vlan_idContext;
@@ -3086,6 +3089,33 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     _configuration.defineFlattenedStructure(INTERFACE, unitFullName, ctx, _parser);
     _configuration.referenceStructure(
         INTERFACE, unitFullName, INTERFACE_SELF_REFERENCE, getLine(ctx.num.start));
+  }
+
+  @Override
+  public void enterIf_bridge(If_bridgeContext ctx) {
+    _currentInterfaceOrRange.initBridgeSwitching();
+  }
+
+  @Override
+  public void exitIfbr_interface_mode(Ifbr_interface_modeContext ctx) {
+    if (ctx.interface_mode().ACCESS() != null) {
+      _currentInterfaceOrRange.getBridgeSwitching().setSwitchportMode(SwitchportMode.ACCESS);
+    } else {
+      assert ctx.interface_mode().TRUNK() != null;
+      _currentInterfaceOrRange.getBridgeSwitching().setSwitchportMode(SwitchportMode.TRUNK);
+    }
+  }
+
+  @Override
+  public void exitIfbr_vlan_id(Ifbr_vlan_idContext ctx) {
+    Optional<Integer> maybeVlan = toInteger(ctx, ctx.id);
+    if (!maybeVlan.isPresent()) {
+      return;
+    }
+    _currentInterfaceOrRange
+        .getBridgeSwitching()
+        .getVlanMembers()
+        .add(new VlanRange(IntegerSpace.of(maybeVlan.get())));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BridgeSwitching.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BridgeSwitching.java
@@ -1,0 +1,33 @@
+package org.batfish.representation.juniper;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.SwitchportMode;
+
+/** Interface settings for the {@code family bridge} L2 switching family. */
+@ParametersAreNonnullByDefault
+public final class BridgeSwitching implements Serializable {
+
+  public BridgeSwitching() {
+    _vlanMembers = new LinkedList<>();
+  }
+
+  public @Nullable SwitchportMode getSwitchportMode() {
+    return _switchportMode;
+  }
+
+  public void setSwitchportMode(SwitchportMode switchportMode) {
+    _switchportMode = switchportMode;
+  }
+
+  public @Nonnull List<VlanMember> getVlanMembers() {
+    return _vlanMembers;
+  }
+
+  private @Nullable SwitchportMode _switchportMode;
+  private final @Nonnull List<VlanMember> _vlanMembers;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -144,6 +144,16 @@ public class Interface implements Serializable {
     }
   }
 
+  public @Nullable BridgeSwitching getBridgeSwitching() {
+    return _bridgeSwitching;
+  }
+
+  public void initBridgeSwitching() {
+    if (_bridgeSwitching == null) {
+      _bridgeSwitching = new BridgeSwitching();
+    }
+  }
+
   private boolean _active;
   private Set<Ip> _additionalArpIps;
   private final Set<ConcreteInterfaceAddress> _allAddresses;
@@ -156,6 +166,7 @@ public class Interface implements Serializable {
   private double _bandwidth;
   private String _description;
   private boolean _defined;
+  private @Nullable BridgeSwitching _bridgeSwitching;
   private @Nullable EthernetSwitching _ethernetSwitching;
   private @Nullable String _incomingFilter;
   private @Nullable List<String> _incomingFilterList;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2104,6 +2104,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
       newIface.adminDown();
     }
     EthernetSwitching es = iface.getEthernetSwitching();
+    BridgeSwitching bs = iface.getBridgeSwitching();
+    // family ethernet-switching and family bridge are mutually exclusive L2 switching families;
+    // both map to the same VI switchport attributes.
+    SwitchportMode switchingMode =
+        es != null ? es.getSwitchportMode() : bs != null ? bs.getSwitchportMode() : null;
+    List<VlanMember> switchingVlanMembers =
+        es != null ? es.getVlanMembers() : bs != null ? bs.getVlanMembers() : ImmutableList.of();
+    Integer switchingNativeVlan = es != null ? es.getNativeVlan() : null;
     if (_indirectAccessPorts.containsKey(name)) {
       newIface.setSwitchport(true);
       newIface.setSwitchportMode(SwitchportMode.ACCESS);
@@ -2112,9 +2120,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
               .getNamedVlans()
               .get(_indirectAccessPorts.get(name).getName())
               .getVlanId());
-    } else if (es != null) {
-      if (es.getSwitchportMode() == null || es.getSwitchportMode() == SwitchportMode.ACCESS) {
-        Integer accessVlan = computeAccessVlan(iface.getName(), es.getVlanMembers());
+    } else if (es != null || bs != null) {
+      if (switchingMode == null || switchingMode == SwitchportMode.ACCESS) {
+        Integer accessVlan = computeAccessVlan(iface.getName(), switchingVlanMembers);
         newIface.setAccessVlan(accessVlan);
         if (accessVlan != null) {
           newIface.setSwitchport(true);
@@ -2124,12 +2132,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
           newIface.setSwitchportMode(SwitchportMode.NONE);
         }
       }
-      if (es.getSwitchportMode() == SwitchportMode.TRUNK) {
+      if (switchingMode == SwitchportMode.TRUNK) {
         newIface.setSwitchportTrunkEncapsulation(SwitchportEncapsulationType.DOT1Q);
-        newIface.setAllowedVlans(vlanMembersToIntegerSpace(es.getVlanMembers()));
+        newIface.setAllowedVlans(vlanMembersToIntegerSpace(switchingVlanMembers));
         // default is no native vlan, untagged are dropped.
         // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/native-vlan-id-edit-interfaces-qfx-series.html
-        newIface.setNativeVlan(es.getNativeVlan());
+        newIface.setNativeVlan(switchingNativeVlan);
         newIface.setSwitchport(true);
         newIface.setSwitchportMode(SwitchportMode.TRUNK);
       }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -532,6 +532,7 @@ import org.batfish.representation.juniper.TcpFinNoAck;
 import org.batfish.representation.juniper.TcpNoFlag;
 import org.batfish.representation.juniper.TcpSynFin;
 import org.batfish.representation.juniper.TunnelAttribute;
+import org.batfish.representation.juniper.VlanMember;
 import org.batfish.representation.juniper.VlanRange;
 import org.batfish.representation.juniper.VlanReference;
 import org.batfish.representation.juniper.VniOptions;
@@ -10081,6 +10082,31 @@ public final class FlatJuniperGrammarTest {
   public void testIsisLevelIpv6Metric() {
     // IS-IS per-level ipv6/ipv4 metric variants should not crash.
     parseConfig("isis-level-ipv6-metric");
+  }
+
+  @Test
+  public void testInterfacesFamilyBridgeSwitching() {
+    // family bridge interface-mode (access/trunk) and single vlan-id populate BridgeSwitching.
+    JuniperConfiguration c = parseJuniperConfig("interfaces-family-bridge-switching");
+    Map<String, org.batfish.representation.juniper.Interface> ifaces =
+        c.getMasterLogicalSystem().getInterfaces();
+
+    org.batfish.representation.juniper.Interface accessUnit =
+        ifaces.get("ge-10/1/0").getUnits().get("ge-10/1/0.0");
+    assertThat(accessUnit.getBridgeSwitching().getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
+    List<VlanMember> accessVlans = accessUnit.getBridgeSwitching().getVlanMembers();
+    assertThat(accessVlans, hasSize(1));
+    assertThat(((VlanRange) accessVlans.get(0)).getRange(), equalTo(IntegerSpace.of(620)));
+
+    org.batfish.representation.juniper.Interface trunkUnit =
+        ifaces.get("ge-10/1/1").getUnits().get("ge-10/1/1.0");
+    assertThat(trunkUnit.getBridgeSwitching().getSwitchportMode(), equalTo(SwitchportMode.TRUNK));
+
+    // Conversion: the access unit becomes a switchport access port on vlan 620.
+    Configuration vi = parseConfig("interfaces-family-bridge-switching");
+    org.batfish.datamodel.Interface viAccess = vi.getAllInterfaces().get("ge-10/1/0.0");
+    assertThat(viAccess.getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
+    assertThat(viAccess.getAccessVlan(), equalTo(620));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-family-bridge-switching
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-family-bridge-switching
@@ -1,0 +1,11 @@
+#
+# family bridge with switching attributes: interface-mode (access/trunk) and a
+# single vlan-id.
+#
+set system host-name interfaces-family-bridge-switching
+
+set interfaces ge-10/1/0 unit 0 family bridge interface-mode access
+set interfaces ge-10/1/0 unit 0 family bridge vlan-id 620
+
+set interfaces ge-10/1/1 unit 0 family bridge interface-mode trunk
+set interfaces ge-10/1/1 unit 0 family bridge vlan-id-list 100-200


### PR DESCRIPTION
A unit's family bridge accepts interface-mode (access or trunk) and a
single vlan-id, not just vlan-id-list. Accept "interface-mode access"
(interface_mode previously allowed only trunk) and a single
"vlan-id <n>".

----

Prompt:
```
do em all
```
