### PR TITLE
Junos: parse isis per-level ipv6/ipv4 metric variants

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -1236,7 +1236,11 @@ IPSEC_POLICY: 'ipsec-policy' -> pushMode(M_Name);
 
 IPSEC_VPN: 'ipsec-vpn' -> pushMode(M_Name);
 
+IPV4_MULTICAST_METRIC: 'ipv4-multicast-metric';
+
 IPV6: 'ipv6';
+IPV6_MULTICAST_METRIC: 'ipv6-multicast-metric';
+IPV6_UNICAST_METRIC: 'ipv6-unicast-metric';
 IPV6_TUNNELING: 'ipv6-tunneling';
 
 IPV6_EXTENSION_HEADER: 'ipv6-extension-header';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
@@ -139,6 +139,9 @@ isi_level
     | isil_hello_authentication_type
     | isil_hello_interval
     | isil_hold_time
+    | isil_ipv4_multicast_metric
+    | isil_ipv6_multicast_metric
+    | isil_ipv6_unicast_metric
     | isil_metric
     | isil_passive
     | isil_priority
@@ -202,9 +205,30 @@ isil_hold_time
   HOLD_TIME dec
 ;
 
+isil_ipv4_multicast_metric
+:
+  IPV4_MULTICAST_METRIC isis_level_metric
+;
+
+isil_ipv6_multicast_metric
+:
+  IPV6_MULTICAST_METRIC isis_level_metric
+;
+
+isil_ipv6_unicast_metric
+:
+  IPV6_UNICAST_METRIC isis_level_metric
+;
+
+// IS-IS wide metric value, 1-16777215 (3 octets).
+isis_level_metric
+:
+  uint32
+;
+
 isil_metric
 :
-  METRIC dec
+  METRIC isis_level_metric
 ;
 
 isil_passive

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -543,6 +543,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_passiveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_priorityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_te_metricContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isis_level_metricContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isl_disableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isl_wide_metrics_onlyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Iso_addressContext;
@@ -1301,6 +1302,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   private static final IntegerSpace SRLG_COST_RANGE = IntegerSpace.of(new SubRange(1, 65535));
   private static final LongSpace SRLG_VALUE_RANGE = LongSpace.of(Range.closed(1L, 4294967295L));
   private static final IntegerSpace VNI_NUMBER_RANGE = IntegerSpace.of(new SubRange(0, 16777215));
+
+  // IS-IS wide metric: 1 through 16,777,215 (2^24 - 1).
+  private static final IntegerSpace ISIS_LEVEL_METRIC_RANGE =
+      IntegerSpace.of(new SubRange(1, 16777215));
 
   private static final IntegerSpace VLAN_RANGE = IntegerSpace.of(new SubRange(1, 4094));
 
@@ -6157,8 +6162,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
 
   @Override
   public void exitIsil_metric(Isil_metricContext ctx) {
-    int metric = toInt(ctx.dec());
-    _currentIsisInterfaceLevelSettings.setMetric(metric);
+    toInteger(ctx, ctx.isis_level_metric())
+        .ifPresent(metric -> _currentIsisInterfaceLevelSettings.setMetric(metric));
   }
 
   @Override
@@ -9196,6 +9201,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   private @Nonnull Optional<Integer> toInteger(
       ParserRuleContext messageCtx, Vlan_numberContext ctx) {
     return toIntegerInSpace(messageCtx, ctx, VLAN_RANGE, "vlan number");
+  }
+
+  private @Nonnull Optional<Integer> toInteger(
+      ParserRuleContext messageCtx, Isis_level_metricContext ctx) {
+    return toIntegerInSpace(messageCtx, ctx, ISIS_LEVEL_METRIC_RANGE, "isis level metric");
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -10078,6 +10078,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testIsisLevelIpv6Metric() {
+    // IS-IS per-level ipv6/ipv4 metric variants should not crash.
+    parseConfig("isis-level-ipv6-metric");
+  }
+
+  @Test
   public void testIsisImport() {
     // Should not crash.
     parseConfig("isis-import");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-level-ipv6-metric
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-level-ipv6-metric
@@ -1,0 +1,10 @@
+#
+# IS-IS per-level metric variants: ipv6-unicast-metric, ipv6-multicast-metric,
+# ipv4-multicast-metric (alongside the plain metric). Not modeled.
+#
+set system host-name isis-level-ipv6-metric
+
+set protocols isis interface et-5/0/0.81 level 2 metric 1
+set protocols isis interface et-5/0/0.81 level 2 ipv6-unicast-metric 99999
+set protocols isis interface et-5/0/0.81 level 2 ipv6-multicast-metric 1
+set protocols isis interface et-5/0/0.81 level 2 ipv4-multicast-metric 50


### PR DESCRIPTION
Under protocols isis interface <name> level <n>, accept
ipv6-unicast-metric, ipv6-multicast-metric, and ipv4-multicast-metric
alongside the existing metric/te-metric. Not modeled.

----

Prompt:
```
do em all
```
