### PR TITLE
Junos: allow empty ether-options/gigether-options block

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_interfaces.g4
@@ -69,7 +69,8 @@ eo8023ad_lacp
 
 ether_options
 :
-   eo_802_3ad
+   apply
+   | eo_802_3ad
    | eo_null
    | eo_redundant_parent
    | eo_speed

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -10042,6 +10042,12 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testInterfacesGigetherOptionsEmpty() {
+    // Empty gigether-options / ether-options blocks should not crash.
+    parseConfig("interfaces-gigether-options-empty");
+  }
+
+  @Test
   public void testForwardingTableTraceoptions() {
     // routing-options forwarding-table traceoptions should not crash.
     parseConfig("forwarding-table-traceoptions");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-gigether-options-empty
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interfaces-gigether-options-empty
@@ -1,0 +1,7 @@
+#
+# Empty gigether-options / ether-options blocks.
+#
+set system host-name interfaces-gigether-options-empty
+
+set interfaces xe-8/0/3 gigether-options
+set interfaces xe-8/0/4 ether-options


### PR DESCRIPTION
An interface can carry an empty "gigether-options {}" (or
"ether-options {}") block. Add the blank apply alternative to
ether_options so the empty block parses.

----

Prompt:
```
do em all
```
