### PR TITLE
BGP: drop non-transitive extended communities on eBGP export

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -41,6 +41,8 @@ import org.batfish.datamodel.bgp.AllowRemoteAsOutMode;
 import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.BgpTopologyUtils.ConfedSessionType;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
+import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
@@ -533,6 +535,14 @@ public final class BgpProtocolHelper {
       routeBuilder.setCommunities(routeBuilder.getCommunities().getStandardCommunities());
     } // else preserve all communities as-is.
 
+    // Non-transitive extended communities (Transitive bit set in the type octet; see RFC 4360
+    // section 2) do not cross AS boundaries. Drop them when exporting over a true eBGP session
+    // (outside a confederation), consistent with how weight / local-pref / tag are cleared above.
+    if (isEbgp && confedSessionType != ConfedSessionType.WITHIN_CONFED) {
+      routeBuilder.setCommunities(
+          removeNonTransitiveExtendedCommunities(routeBuilder.getCommunities()));
+    }
+
     // Skip setting our own next hop if it has already been set by the routing policy
     // TODO: When sending out a BGP route with a NextHopVtep, should that next hop be preserved?
     //  If so, this should step be skipped for such routes.
@@ -563,6 +573,39 @@ public final class BgpProtocolHelper {
     if (routeBuilder.getProtocol() == RoutingProtocol.AGGREGATE) {
       routeBuilder.setProtocol(isEbgp ? RoutingProtocol.BGP : RoutingProtocol.IBGP);
     }
+  }
+
+  /**
+   * Return a {@link CommunitySet} with any non-transitive extended communities removed. Standard
+   * and large communities, and transitive extended communities, are preserved. Returns the input
+   * {@code communities} instance when there is nothing to remove.
+   *
+   * <p>This runs on every BGP route export, so it avoids streams and allocates nothing on the
+   * common path: most routes carry no extended communities at all, and {@link
+   * CommunitySet#getExtendedCommunities()} caches its result, so it only builds a new set (the one
+   * case that must allocate) when a non-transitive extended community is found.
+   */
+  @VisibleForTesting
+  static @Nonnull CommunitySet removeNonTransitiveExtendedCommunities(CommunitySet communities) {
+    Set<ExtendedCommunity> extended = communities.getExtendedCommunities();
+    if (extended.isEmpty()) {
+      return communities;
+    }
+    for (ExtendedCommunity ec : extended) {
+      if (!ec.isTransitive()) {
+        // Found one to remove. Rebuild the set, keeping everything else.
+        Set<Community> all = communities.getCommunities();
+        ImmutableSet.Builder<Community> kept = ImmutableSet.builderWithExpectedSize(all.size() - 1);
+        for (Community keep : all) {
+          if (!(keep instanceof ExtendedCommunity keepEc) || keepEc.isTransitive()) {
+            kept.add(keep);
+          }
+        }
+        return CommunitySet.of(kept.build());
+      }
+    }
+    // No non-transitive extended communities: nothing to do, no allocation.
+    return communities;
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -11,6 +11,7 @@ import static org.batfish.dataplane.protocols.BgpProtocolHelper.allowAsPathOut;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.convertGeneratedRouteToBgp;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.isReflectable;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.receivedFromPeer;
+import static org.batfish.dataplane.protocols.BgpProtocolHelper.removeNonTransitiveExtendedCommunities;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRouteOnImport;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRoutePostExport;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -367,6 +368,106 @@ public class BgpProtocolHelperTest {
         null,
         false);
     assertThat("All communities", builder.getCommunities(), equalTo(mixedComms));
+  }
+
+  @Test
+  public void testRemoveNonTransitiveExtendedCommunities() {
+    StandardCommunity standard = StandardCommunity.of(5);
+    // Transitive bit clear (type octet high bit 0x40 == 0): crosses AS boundaries.
+    ExtendedCommunity transitiveExt = ExtendedCommunity.target(65000, 100);
+    assertTrue(transitiveExt.isTransitive());
+    // Transitive bit set (non-transitive): the generic Junos literal "65000:672277L:36867" whose
+    // type octet 0xFD has 0x40 set.
+    ExtendedCommunity nonTransitiveExt = ExtendedCommunity.parse("65000:672277L:36867");
+    assertFalse(nonTransitiveExt.isTransitive());
+
+    // Non-transitive extended community is removed; standard and transitive extended remain.
+    assertThat(
+        removeNonTransitiveExtendedCommunities(
+            CommunitySet.of(standard, transitiveExt, nonTransitiveExt)),
+        equalTo(CommunitySet.of(standard, transitiveExt)));
+
+    // No non-transitive extended communities: returns the same instance (no allocation).
+    CommunitySet allTransitive = CommunitySet.of(standard, transitiveExt);
+    assertThat(removeNonTransitiveExtendedCommunities(allTransitive), equalTo(allTransitive));
+
+    // Empty set is unchanged.
+    assertThat(
+        removeNonTransitiveExtendedCommunities(CommunitySet.empty()),
+        equalTo(CommunitySet.empty()));
+  }
+
+  @Test
+  public void testTransformPostExportNonTransitiveExtendedCommunities() {
+    ExtendedCommunity transitiveExt = ExtendedCommunity.target(65000, 100);
+    ExtendedCommunity nonTransitiveExt = ExtendedCommunity.parse("65000:672277L:36867");
+    CommunitySet comms = CommunitySet.of(StandardCommunity.of(5), transitiveExt, nonTransitiveExt);
+
+    // eBGP outside a confederation: non-transitive extended community is dropped.
+    Builder builder = _baseBgpRouteBuilder.setCommunities(comms).build().toBuilder();
+    transformBgpRoutePostExport(
+        builder,
+        true,
+        true,
+        true,
+        true,
+        ConfedSessionType.NO_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
+    assertThat(
+        builder.getCommunities(), equalTo(CommunitySet.of(StandardCommunity.of(5), transitiveExt)));
+
+    // eBGP within a confederation: all communities preserved.
+    builder = _baseBgpRouteBuilder.setCommunities(comms).build().toBuilder();
+    transformBgpRoutePostExport(
+        builder,
+        true,
+        true,
+        true,
+        true,
+        ConfedSessionType.WITHIN_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
+    assertThat(builder.getCommunities(), equalTo(comms));
+
+    // eBGP across a confederation border (true AS boundary): non-transitive dropped.
+    builder = _baseBgpRouteBuilder.setCommunities(comms).build().toBuilder();
+    transformBgpRoutePostExport(
+        builder,
+        true,
+        true,
+        true,
+        true,
+        ConfedSessionType.ACROSS_CONFED_BORDER,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
+    assertThat(
+        builder.getCommunities(), equalTo(CommunitySet.of(StandardCommunity.of(5), transitiveExt)));
+
+    // iBGP: all communities preserved.
+    builder = _baseBgpRouteBuilder.setCommunities(comms).build().toBuilder();
+    transformBgpRoutePostExport(
+        builder,
+        false,
+        true,
+        true,
+        true,
+        ConfedSessionType.NO_CONFED,
+        1,
+        DEST_IP,
+        Ip.ZERO,
+        null,
+        false);
+    assertThat(builder.getCommunities(), equalTo(comms));
   }
 
   @Test


### PR DESCRIPTION
An extended community's type octet carries the Transitive bit (RFC 4360
section 2: 0x40, value 1 = non-transitive across ASes). Real devices
drop such communities at the AS boundary, but the eBGP export path in
BgpProtocolHelper only cleared non-transitive attributes (weight,
local-preference, tag) -- it left non-transitive extended communities in
the community set, so they leaked across eBGP in the data plane model.

Filter them out on true eBGP export (outside a confederation), mirroring
the existing local-pref / MED clearing. Standard and large communities,
and transitive extended communities (including route targets), are
unaffected.

Fixes batfish/batfish#10019.

----

Prompt:
```
address https://github.com/batfish/batfish/issues/10019

design an elegant and efficient solution and, when done, send a PR
```
