### PR TITLE
BDDInteger: add symbolic integer-vs-integer comparisons

### DIFF
--- a/projects/common/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/common/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -194,4 +194,81 @@ public abstract class BDDInteger implements Serializable {
   public BDDFactory getFactory() {
     return _factory;
   }
+
+  // ---- symbolic (integer-vs-integer) comparisons ------------------------------------------------
+  //
+  // The above leq/geq/range compare this integer against a *constant*. The methods below compare
+  // this integer against another *symbolic* BDDInteger, producing a BDD over both operands'
+  // variables: the set of assignments under which the relation holds. Both integers must have the
+  // same bit width. These are unsigned comparisons; _bitvec is most-significant-bit first.
+
+  /**
+   * The set of assignments under which this integer is strictly less than {@code other} (unsigned).
+   * Both integers must have the same width.
+   */
+  public BDD lt(BDDInteger other) {
+    return ltImpl(other, /* orEqual= */ false);
+  }
+
+  /**
+   * The set of assignments under which this integer is less than or equal to {@code other}
+   * (unsigned). Both integers must have the same width.
+   */
+  public BDD leq(BDDInteger other) {
+    return ltImpl(other, /* orEqual= */ true);
+  }
+
+  /**
+   * The set of assignments under which this integer is strictly greater than {@code other}
+   * (unsigned). Both integers must have the same width.
+   */
+  public BDD gt(BDDInteger other) {
+    return other.ltImpl(this, /* orEqual= */ false);
+  }
+
+  /**
+   * The set of assignments under which this integer is greater than or equal to {@code other}
+   * (unsigned). Both integers must have the same width.
+   */
+  public BDD geq(BDDInteger other) {
+    return other.ltImpl(this, /* orEqual= */ true);
+  }
+
+  /**
+   * The set of assignments under which this integer equals {@code other} bit-for-bit. Both integers
+   * must have the same width.
+   */
+  public BDD eq(BDDInteger other) {
+    checkArgument(_bitvec.length == other._bitvec.length, "operands must have equal width");
+    BDD acc = _factory.one();
+    for (int i = 0; i < _bitvec.length; i++) {
+      // bit-i equal: biimp is the xnor, computed directly and preserving both operands.
+      acc = acc.andWith(_bitvec[i].biimp(other._bitvec[i]));
+    }
+    return acc;
+  }
+
+  /**
+   * Unsigned "this {@code <} other" (or {@code <=} when {@code orEqual}), as a
+   * most-significant-bit- first lexicographic comparison: scanning from the high bit, the result is
+   * determined at the first differing bit (this has 0, other has 1 => less). Implemented with a
+   * single backward sweep: {@code acc} is the relation on the suffix already processed; at each
+   * more-significant bit {@code acc' = (a < b) OR (a == b AND acc)}.
+   */
+  private BDD ltImpl(BDDInteger other, boolean orEqual) {
+    checkArgument(_bitvec.length == other._bitvec.length, "operands must have equal width");
+    // Base case on the empty suffix: equal (so <= is true, < is false).
+    BDD acc = orEqual ? _factory.one() : _factory.zero();
+    // Scan least-significant to most-significant (high index to low index).
+    for (int i = _bitvec.length - 1; i >= 0; i--) {
+      BDD a = _bitvec[i];
+      BDD b = other._bitvec[i];
+      // thisBitLess = !a & b ; bitsEqual = a <-> b.
+      BDD thisBitLess = b.diff(a); // b AND NOT a
+      BDD bitsEqual = a.biimp(b);
+      // acc = thisBitLess OR (bitsEqual AND acc)
+      acc = thisBitLess.orWith(bitsEqual.andWith(acc));
+    }
+    return acc;
+  }
 }

--- a/projects/common/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/common/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -106,6 +106,75 @@ public class BDDIntegerTest {
   }
 
   @Test
+  public void testSymbolicComparisons() {
+    // Two independent 4-bit integers over disjoint variables; exhaustively check every (a, b).
+    BDDFactory factory = BDDUtils.bddFactory(8);
+    ImmutableBDDInteger x = ImmutableBDDInteger.makeFromIndex(factory, 4, 0);
+    ImmutableBDDInteger y = ImmutableBDDInteger.makeFromIndex(factory, 4, 4);
+    for (int a = 0; a < 16; a++) {
+      for (int b = 0; b < 16; b++) {
+        // Restricting every variable to this concrete assignment collapses the comparison to a
+        // terminal: it is one iff the relation holds.
+        BDD assignment = x.value(a).and(y.value(b));
+        assertThat("x=" + a + " lt y=" + b, x.lt(y).restrict(assignment).isOne(), equalTo(a < b));
+        assertThat(
+            "x=" + a + " leq y=" + b, x.leq(y).restrict(assignment).isOne(), equalTo(a <= b));
+        assertThat("x=" + a + " gt y=" + b, x.gt(y).restrict(assignment).isOne(), equalTo(a > b));
+        assertThat(
+            "x=" + a + " geq y=" + b, x.geq(y).restrict(assignment).isOne(), equalTo(a >= b));
+        assertThat("x=" + a + " eq y=" + b, x.eq(y).restrict(assignment).isOne(), equalTo(a == b));
+      }
+    }
+  }
+
+  @Test
+  public void testSymbolicComparisonsAgainstConstantForm() {
+    // For a fixed constant c, comparing the symbolic var against a constant-valued BDDInteger must
+    // agree with the existing constant-comparison methods.
+    BDDFactory factory = BDDUtils.bddFactory(10);
+    ImmutableBDDInteger x = ImmutableBDDInteger.makeFromIndex(factory, 5, 0);
+    ImmutableBDDInteger y = ImmutableBDDInteger.makeFromIndex(factory, 5, 5);
+    for (int c = 0; c < 32; c++) {
+      BDD yIsC = y.value(c);
+      assertThat(x.lt(y).and(yIsC), equalTo(x.leq(c).and(x.value(c).not()).and(yIsC)));
+      assertThat(x.leq(y).and(yIsC), equalTo(x.leq(c).and(yIsC)));
+      assertThat(x.geq(y).and(yIsC), equalTo(x.geq(c).and(yIsC)));
+      assertThat(x.eq(y).and(yIsC), equalTo(x.value(c).and(yIsC)));
+    }
+  }
+
+  @Test
+  public void testSymbolicComparisonsMutable() {
+    // Same exhaustive check as testSymbolicComparisons, but over MutableBDDIntegers whose bits are
+    // compound formulas (sums) rather than plain variables, to exercise the general case.
+    BDDFactory factory = BDDUtils.bddFactory(8);
+    MutableBDDInteger p = MutableBDDInteger.makeFromIndex(factory, 4, 0, false);
+    MutableBDDInteger q = MutableBDDInteger.makeFromIndex(factory, 4, 4, false);
+    MutableBDDInteger one = MutableBDDInteger.makeFromValue(factory, 4, 1);
+    // x = p + 1 (mod 16) and y = q + 1 (mod 16); each bit is an adder formula, not a variable.
+    MutableBDDInteger x = p.add(one);
+    MutableBDDInteger y = q.add(one);
+    for (int a = 0; a < 16; a++) {
+      for (int b = 0; b < 16; b++) {
+        // Restrict the underlying variables p=a, q=b; x and y then take the values (a+1) and (b+1).
+        BDD assignment = p.value(a).and(q.value(b));
+        int xv = (a + 1) % 16;
+        int yv = (b + 1) % 16;
+        assertThat(
+            "x=" + xv + " lt y=" + yv, x.lt(y).restrict(assignment).isOne(), equalTo(xv < yv));
+        assertThat(
+            "x=" + xv + " leq y=" + yv, x.leq(y).restrict(assignment).isOne(), equalTo(xv <= yv));
+        assertThat(
+            "x=" + xv + " gt y=" + yv, x.gt(y).restrict(assignment).isOne(), equalTo(xv > yv));
+        assertThat(
+            "x=" + xv + " geq y=" + yv, x.geq(y).restrict(assignment).isOne(), equalTo(xv >= yv));
+        assertThat(
+            "x=" + xv + " eq y=" + yv, x.eq(y).restrict(assignment).isOne(), equalTo(xv == yv));
+      }
+    }
+  }
+
+  @Test
   public void testRangeBounds() {
     {
       BDDFactory factory = BDDUtils.bddFactory(32);


### PR DESCRIPTION
The existing leq/geq/range compare against a constant. Add lt/leq/gt/geq/eq
that compare against another symbolic BDDInteger of equal width, producing a
BDD over both operands' variables: the assignments under which the relation
holds. Comparisons are unsigned, implemented as an MSB-first lexicographic
sweep. Tested exhaustively over all (a, b) pairs and cross-checked against the
constant-comparison forms.

---
**Stack**:
- #10048
- #10047 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*