### PR TITLE
minesweeper: add veccompose for functional composition of symbolic routes

### DIFF
--- a/projects/common/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
+++ b/projects/common/src/main/java/org/batfish/common/bdd/MutableBDDInteger.java
@@ -251,6 +251,22 @@ public final class MutableBDDInteger extends BDDInteger {
   }
 
   /**
+   * Produces a new bitvector by composing each bit's formula through the given pairing (see {@link
+   * BDD#veccompose(BDDPairing)}). Used to functionally compose this integer, viewed as a function
+   * of some input variables, with another symbolic route that supplies those variables.
+   *
+   * @param pairing a pairing from input variables to their replacement formulas
+   * @return the composed bitvector
+   */
+  public MutableBDDInteger veccompose(BDDPairing pairing) {
+    BDD[] newBitvec = new BDD[_bitvec.length];
+    for (int i = 0; i < _bitvec.length; i++) {
+      newBitvec[i] = _bitvec[i].veccompose(pairing);
+    }
+    return new MutableBDDInteger(_factory, newBitvec);
+  }
+
+  /**
    * Produces a BDD whose models represent all possible differences between the two BDDIntegers --
    * valuations of the BDD variables that cause the two BDDIntegers to have different values. The
    * two BDDIntegers are assumed to have the same length.

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -101,6 +101,16 @@ public final class BDDDomain<T> {
     _integer.augmentPairing(other._integer, pairing);
   }
 
+  /**
+   * Produces a new domain by composing this one's underlying integer through the given pairing (see
+   * {@link BDD#veccompose(BDDPairing)}), for functional composition of symbolic routes.
+   */
+  public BDDDomain<T> veccompose(BDDPairing pairing) {
+    BDDDomain<T> result = new BDDDomain<>(this);
+    result._integer = _integer.veccompose(pairing);
+    return result;
+  }
+
   /** Produces a BDD that represents the support (i.e., the set of BDD variables) of this domain. */
   public BDD support() {
     return _integer.support();

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -429,6 +429,52 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     _tunnelEncapsulationAttribute = route._tunnelEncapsulationAttribute.and(pred);
   }
 
+  /**
+   * Constructs a new BDDRoute by composing every attribute formula of the given route through the
+   * given pairing (see {@link BDD#veccompose(BDDPairing)}). Used to functionally compose two
+   * symbolic routes; see {@link #veccompose(BDDPairing)}. Concrete (non-BDD) state is carried over
+   * unchanged.
+   *
+   * @param pairing a pairing from input variables to their replacement formulas
+   * @param route the symbolic route to compose
+   */
+  public BDDRoute(BDDPairing pairing, BDDRoute route) {
+    _factory = route._factory;
+
+    BDD[] communityAtomicPredicates = new BDD[route._communityAtomicPredicates.length];
+    for (int i = 0; i < communityAtomicPredicates.length; i++) {
+      communityAtomicPredicates[i] = route._communityAtomicPredicates[i].veccompose(pairing);
+    }
+    _communityAtomicPredicates = communityAtomicPredicates;
+    _asPathRegexAtomicPredicates = route._asPathRegexAtomicPredicates.veccompose(pairing);
+    _clusterListLength = route._clusterListLength.veccompose(pairing);
+    _prefixLength = route._prefixLength.veccompose(pairing);
+    _prefix = route._prefix.veccompose(pairing);
+    _nextHop = route._nextHop.veccompose(pairing);
+    _adminDist = route._adminDist.veccompose(pairing);
+    _med = route._med.veccompose(pairing);
+    _tag = route._tag.veccompose(pairing);
+    _localPref = route._localPref.veccompose(pairing);
+    _weight = route._weight.veccompose(pairing);
+    _protocolHistory = route._protocolHistory.veccompose(pairing);
+    _originType = route._originType.veccompose(pairing);
+    _ospfMetric = route._ospfMetric.veccompose(pairing);
+    _nextHopInterfaces = route._nextHopInterfaces.veccompose(pairing);
+    _peerAddress = route._peerAddress.veccompose(pairing);
+    _sourceVrfs = route._sourceVrfs.veccompose(pairing);
+    _tunnelEncapsulationAttribute = route._tunnelEncapsulationAttribute.veccompose(pairing);
+    BDD[] tracks = new BDD[route._tracks.length];
+    for (int i = 0; i < tracks.length; i++) {
+      tracks[i] = route._tracks[i].veccompose(pairing);
+    }
+    _tracks = tracks;
+    _bitNames = route._bitNames;
+    _nextHopSet = route._nextHopSet;
+    _nextHopType = route._nextHopType;
+    _unsupported = route._unsupported;
+    _prependedASes = new ArrayList<>(route._prependedASes);
+  }
+
   /*
    * Helper function that builds a map from BDD variable index
    * to some more meaningful name. Helpful for debugging.
@@ -537,6 +583,25 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     _sourceVrfs.augmentPairing(other._sourceVrfs, pairing);
     pairing.set(other._tracks, _tracks);
     _tunnelEncapsulationAttribute.augmentPairing(other._tunnelEncapsulationAttribute, pairing);
+  }
+
+  /**
+   * Produces a new {@link BDDRoute} by composing every attribute formula through the given pairing
+   * (see {@link BDD#veccompose(BDDPairing)}). This route is viewed as a function of some input
+   * variables; composing it through a pairing that maps those input variables to the formulas of
+   * another symbolic route yields the functional composition of the two -- the route that results
+   * from feeding the other route's output as this route's input.
+   *
+   * <p>The pairing is typically built by {@link TransferBDDUtils#makeRoutePairing} from the route
+   * supplying the inputs. Concrete (non-BDD) state -- the prepended-AS list, next-hop type/set
+   * flags, and the unsupported flag -- is carried over unchanged; callers that compose chains of
+   * routes are responsible for combining those (e.g. concatenating prepended ASes).
+   *
+   * @param pairing a pairing from input variables to their replacement formulas
+   * @return the composed route
+   */
+  public BDDRoute veccompose(BDDPairing pairing) {
+    return new BDDRoute(pairing, this);
   }
 
   /*

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttribute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttribute.java
@@ -120,6 +120,14 @@ public final class BDDTunnelEncapsulationAttribute {
     return new BDDTunnelEncapsulationAttribute(new BDDDomain<>(pred, _domain));
   }
 
+  /**
+   * Produces a new attribute by composing the underlying domain through the given pairing (see
+   * {@link BDD#veccompose(BDDPairing)}), for functional composition of symbolic routes.
+   */
+  public @Nonnull BDDTunnelEncapsulationAttribute veccompose(BDDPairing pairing) {
+    return new BDDTunnelEncapsulationAttribute(_domain.veccompose(pairing));
+  }
+
   public @Nonnull Value satAssignmentToValue(BDD model) {
     return _domain.satAssignmentToValue(model);
   }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
@@ -353,4 +353,46 @@ public class BDDRouteTest {
     pairing.reset();
     attrPairing.reset();
   }
+
+  @Test
+  public void testVeccomposeIdentity() {
+    // Composing any route through an identity pairing (each input variable mapped to itself) leaves
+    // the route unchanged.
+    BDDFactory factory = JFactory.init(10000, 1000);
+    BDDRoute orig = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    // Build a non-trivial route by setting some attributes to constants.
+    BDDRoute route = new BDDRoute(orig);
+    route.getLocalPref().setValue(300);
+    route.getOriginType().setValue(OriginType.EGP);
+
+    // A fresh route's formulas are just the canonical input variables, so pairing it with itself
+    // yields the identity pairing.
+    BDDPairing pairing = factory.makePair();
+    BDDRoute fresh = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    fresh.augmentPairing(fresh, pairing);
+
+    assertEquals(route, route.veccompose(pairing));
+  }
+
+  @Test
+  public void testVeccomposeSubstitutesInput() {
+    // veccompose feeds one route's attribute formulas in as another's input variables: composing a
+    // route whose local-pref is its input variable through a pairing that pins local-pref to a
+    // constant yields that constant.
+    BDDFactory factory = JFactory.init(10000, 1000);
+
+    // The "input" route fixes local-pref to 250.
+    BDDRoute input = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    input.getLocalPref().setValue(250);
+
+    // Pair the canonical variables (from a fresh route) with the input's formulas.
+    BDDPairing pairing = factory.makePair();
+    BDDRoute fresh = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    input.augmentPairing(fresh, pairing);
+
+    // The fresh route is the identity on the canonical input variables, so composing it through the
+    // pairing simply substitutes the input route's formulas: the result equals the input route.
+    BDDRoute composed = fresh.veccompose(pairing);
+    assertEquals(input, composed);
+  }
 }


### PR DESCRIPTION
A BDDRoute can be viewed as a function from its input variables to its
output attribute formulas. Composing one route through a pairing that maps
those input variables to a second route's output formulas yields the
functional composition of the two -- the route that results from feeding the
second route's output as the first's input.

Add veccompose to BDDRoute (and the supporting BDDDomain,
BDDTunnelEncapsulationAttribute, and MutableBDDInteger) to perform this
composition over every attribute formula. Concrete (non-BDD) state is carried
over unchanged; callers composing chains of routes combine those separately.

---
**Stack**:
- #10048 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*