### PR TITLE
tools: disable implicit __init__.py creation for py_binary targets

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -47,6 +47,7 @@ java_binary(
 py_binary(
     name = "generate_pan_apps",
     srcs = ["generate_pan_apps.py"],
+    legacy_create_init = 0,
     deps = [
         requirement("xmltodict"),
     ],

--- a/tools/profiling/BUILD.bazel
+++ b/tools/profiling/BUILD.bazel
@@ -65,5 +65,6 @@ filegroup(
 py_binary(
     name = "analyze_profile",
     srcs = ["analyze_profile.py"],
+    legacy_create_init = 0,
     python_version = "PY3",
 )


### PR DESCRIPTION
rules_python warns that legacy_create_init defaults to true and will
be flipped to false in a future release. Neither generate_pan_apps
nor analyze_profile is part of a Python package tree, so no
__init__.py files are needed.

----

Prompt:
```
Run bazel build //... and fix all the warnings about implicit
__init__.py creation in this repo (not the ones where python rules
are used from external places)
```
