### PR TITLE
BDDInteger: add firstBitsEqual for symbolic subnet comparison

### DIFF
--- a/projects/common/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/common/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -239,9 +239,22 @@ public abstract class BDDInteger implements Serializable {
    * must have the same width.
    */
   public BDD eq(BDDInteger other) {
+    return firstBitsEqual(other, _bitvec.length);
+  }
+
+  /**
+   * The set of assignments under which this integer and {@code other} agree on their first {@code
+   * numBits} (most-significant) bits, ignoring the lower bits. For an IP-valued integer this is
+   * "the two addresses are in the same {@code /numBits} subnet". {@code numBits == } the width
+   * reduces to {@link #eq}; {@code numBits == 0} is unconstrained ({@code one}). Both integers must
+   * have the same width.
+   */
+  public BDD firstBitsEqual(BDDInteger other, int numBits) {
     checkArgument(_bitvec.length == other._bitvec.length, "operands must have equal width");
+    checkArgument(numBits >= 0 && numBits <= _bitvec.length, "numBits out of range: %s", numBits);
+    // _bitvec is most-significant-bit first, so the first numBits entries are the high bits.
     BDD acc = _factory.one();
-    for (int i = 0; i < _bitvec.length; i++) {
+    for (int i = 0; i < numBits; i++) {
       // bit-i equal: biimp is the xnor, computed directly and preserving both operands.
       acc = acc.andWith(_bitvec[i].biimp(other._bitvec[i]));
     }

--- a/projects/common/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/common/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -128,6 +128,31 @@ public class BDDIntegerTest {
   }
 
   @Test
+  public void testFirstBitsEqual() {
+    // Two independent 4-bit integers; firstBitsEqual(n) holds iff the top n (most-significant) bits
+    // match. Exhaustive over every (a, b) and every n in [0, 4].
+    BDDFactory factory = BDDUtils.bddFactory(8);
+    ImmutableBDDInteger x = ImmutableBDDInteger.makeFromIndex(factory, 4, 0);
+    ImmutableBDDInteger y = ImmutableBDDInteger.makeFromIndex(factory, 4, 4);
+    for (int a = 0; a < 16; a++) {
+      for (int b = 0; b < 16; b++) {
+        BDD assignment = x.value(a).and(y.value(b));
+        for (int n = 0; n <= 4; n++) {
+          // The top n of 4 bits are the value shifted right by (4 - n).
+          boolean topNMatch = (a >> (4 - n)) == (b >> (4 - n));
+          assertThat(
+              "x=" + a + " firstBits" + n + " y=" + b,
+              x.firstBitsEqual(y, n).restrict(assignment).isOne(),
+              equalTo(topNMatch));
+        }
+      }
+    }
+    // n == width reduces to eq; n == 0 is unconstrained.
+    assertThat(x.firstBitsEqual(y, 4), equalTo(x.eq(y)));
+    assertThat(x.firstBitsEqual(y, 0).isOne(), equalTo(true));
+  }
+
+  @Test
   public void testSymbolicComparisonsAgainstConstantForm() {
     // For a fixed constant c, comparing the symbolic var against a constant-valued BDDInteger must
     // agree with the existing constant-comparison methods.


### PR DESCRIPTION
Add firstBitsEqual(BDDInteger other, int numBits): the set of
assignments under which two symbolic integers of equal width agree on
their first (most-significant) numBits bits, ignoring the rest. For an
IP-valued integer this is "the two addresses are in the same /numBits
subnet". numBits == width reduces to eq, which now delegates to it;
numBits == 0 is unconstrained.

Tested exhaustively over all (a, b) pairs and bit-lengths, and against
eq at the boundary widths.
