### PR TITLE
minesweeper: add free() to BDDDomain and BDDTunnelEncapsulationAttribute

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -116,6 +116,13 @@ public final class BDDDomain<T> {
     return _integer.support();
   }
 
+  /**
+   * Frees every BDD backing this domain's underlying integer; see {@link MutableBDDInteger#free}.
+   */
+  public void free() {
+    _integer.free();
+  }
+
   public MutableBDDInteger getInteger() {
     return _integer;
   }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttribute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDTunnelEncapsulationAttribute.java
@@ -140,6 +140,11 @@ public final class BDDTunnelEncapsulationAttribute {
     return _domain.getIsValidConstraint();
   }
 
+  /** Frees every BDD backing this attribute's underlying domain; see {@link BDDDomain#free}. */
+  public void free() {
+    _domain.free();
+  }
+
   public int getNumBits() {
     return _domain.getInteger().size();
   }


### PR DESCRIPTION
Both wrap a MutableBDDInteger but expose no way to free its BDDs
without reaching into internals. Add free(), delegating to the
underlying integer's (BDDTunnelEncapsulationAttribute's delegates
through its BDDDomain), for callers freeing a composite route's
fields individually.
