### PR TITLE
minesweeper: add free() to BDDRoute

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -604,6 +604,36 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     return new BDDRoute(pairing, this);
   }
 
+  /**
+   * Frees every BDD backing this route's attribute formulas. This route must not be used after this
+   * call.
+   */
+  public void free() {
+    _asPathRegexAtomicPredicates.free();
+    _clusterListLength.free();
+    _prefixLength.free();
+    _prefix.free();
+    for (BDD communityAtomicPredicate : _communityAtomicPredicates) {
+      communityAtomicPredicate.free();
+    }
+    _nextHop.free();
+    _adminDist.free();
+    _med.free();
+    _tag.free();
+    _weight.free();
+    _localPref.free();
+    _protocolHistory.free();
+    _originType.free();
+    _ospfMetric.free();
+    _nextHopInterfaces.free();
+    _peerAddress.free();
+    _sourceVrfs.free();
+    for (BDD track : _tracks) {
+      track.free();
+    }
+    _tunnelEncapsulationAttribute.free();
+  }
+
   /*
    * Converts a BDD to the graphviz DOT format for debugging.
    */

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
@@ -3,6 +3,7 @@ package org.batfish.minesweeper.bdd;
 import static org.batfish.common.bdd.BDDMatchers.isZero;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -394,5 +395,17 @@ public class BDDRouteTest {
     // pairing simply substitutes the input route's formulas: the result equals the input route.
     BDDRoute composed = fresh.veccompose(pairing);
     assertEquals(input, composed);
+  }
+
+  @Test
+  public void testFreeReturnsToBaselineOutstandingBDDs() {
+    BDDFactory factory = JFactory.init(10000, 1000);
+    long baseline = factory.numOutstandingBDDs();
+
+    BDDRoute route = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    assertThat(factory.numOutstandingBDDs(), greaterThan(baseline));
+
+    route.free();
+    assertEquals(baseline, factory.numOutstandingBDDs());
   }
 }


### PR DESCRIPTION
Frees every BDD backing a route's attribute formulas, for a route
built purely as scratch and then discarded.
