### PR TITLE
BDDRoute: fix copy constructor to not alias COMMUNITIES/TRACKS

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -354,15 +354,19 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
   }
 
   /*
-   * Create a BDDRecord from another. Because BDDs are immutable,
-   * there is no need for a deep copy.
+   * Create a BDDRecord from another. Because BDDs are immutable, there is no need for a deep
+   * copy of any single BDD -- but every field must still get its own independently owned
+   * reference, matching MutableBDDInteger's own per-bit copy.
    */
   public BDDRoute(BDDRoute other) {
     _factory = other._factory;
 
     _asPathRegexAtomicPredicates = new BDDDomain<>(other._asPathRegexAtomicPredicates);
     _clusterListLength = new MutableBDDInteger(other._clusterListLength);
-    _communityAtomicPredicates = other._communityAtomicPredicates.clone();
+    _communityAtomicPredicates = new BDD[other._communityAtomicPredicates.length];
+    for (int i = 0; i < _communityAtomicPredicates.length; i++) {
+      _communityAtomicPredicates[i] = other._communityAtomicPredicates[i].id();
+    }
     _prefixLength = new MutableBDDInteger(other._prefixLength);
     _prefix = new MutableBDDInteger(other._prefix);
     _nextHop = new MutableBDDInteger(other._nextHop);
@@ -381,7 +385,10 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     _nextHopInterfaces = new BDDDomain<>(other._nextHopInterfaces);
     _peerAddress = new BDDDomain<>(other._peerAddress);
     _sourceVrfs = new BDDDomain<>(other._sourceVrfs);
-    _tracks = other._tracks.clone();
+    _tracks = new BDD[other._tracks.length];
+    for (int i = 0; i < _tracks.length; i++) {
+      _tracks[i] = other._tracks[i].id();
+    }
     _tunnelEncapsulationAttribute =
         BDDTunnelEncapsulationAttribute.copyOf(other._tunnelEncapsulationAttribute);
     _unsupported = other._unsupported;

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
@@ -408,4 +408,16 @@ public class BDDRouteTest {
     route.free();
     assertEquals(baseline, factory.numOutstandingBDDs());
   }
+
+  @Test
+  public void testCopyConstructorFieldsAreIndependentlyOwned() {
+    // If any field of the copy aliased the original's BDD object, free()-ing both routes would
+    // free that field's BDD twice -- an error JFactory throws on.
+    BDDFactory factory = JFactory.init(10000, 1000);
+    BDDRoute original = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    BDDRoute copy = new BDDRoute(original);
+
+    copy.free();
+    original.free();
+  }
 }


### PR DESCRIPTION
The copy constructor gave every scalar attribute an independently
owned copy (MutableBDDInteger re-id()'s each bit), but cloned the
COMMUNITIES and TRACKS arrays with a plain array clone: each cell of
the copy was the same BDD object as the corresponding cell of the
route it was copied from. Copy each cell via id() instead, so every
field of a copy is independently owned.
