### PR TITLE
minesweeper: BDDRoute support for relational image computation

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDDomain.java
@@ -116,6 +116,11 @@ public final class BDDDomain<T> {
     return _integer.support();
   }
 
+  /** The relation {@code this} equals {@code other}. */
+  public BDD eq(BDDDomain<T> other) {
+    return _integer.eq(other._integer);
+  }
+
   /**
    * Frees every BDD backing this domain's underlying integer; see {@link MutableBDDInteger#free}.
    */

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRoute.java
@@ -1,5 +1,6 @@
 package org.batfish.minesweeper.bdd;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.minesweeper.bdd.BDDDomain.numBits;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -59,6 +60,10 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     allMetricTypes.add(OspfType.E1);
     allMetricTypes.add(OspfType.E2);
   }
+
+  // need 6 bits for prefix length because there are 33 possible values, 0 - 32
+  static final int PREFIX_LENGTH_BITS = 6;
+  static final int PREFIX_BITS = 32;
 
   private final BDDFactory _factory;
 
@@ -169,11 +174,71 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
   private boolean _unsupported;
 
   /**
+   * Every {@link Field} of this route: every {@link Attribute} plus every community/track cell.
+   * Fixed once and for all at construction, since {@link #_communityAtomicPredicates}/{@link
+   * #_tracks}' lengths never change afterward.
+   */
+  private final ImmutableSet<Field> _allFields;
+
+  /**
    * The routing protocols allowed in a BGP route announcement (see {@link
    * org.batfish.datamodel.BgpRoute}).
    */
   public static final Set<RoutingProtocol> ALL_BGP_PROTOCOLS =
       ImmutableSet.of(RoutingProtocol.AGGREGATE, RoutingProtocol.BGP, RoutingProtocol.IBGP);
+
+  /**
+   * The number of non-prefix BDD variables a {@link BDDRoute} for {@code aps} needs -- i.e. how
+   * many contiguous indices {@code startIdx} must leave room for in the constructor below. Does NOT
+   * include the shared prefix/prefix-length block, since that is never per-route (see {@link
+   * BDDRouteFactory}).
+   */
+  static int numNonPrefixVars(ConfigAtomicPredicates aps) {
+    return numNonPrefixVars(
+        aps.getStandardCommunityAtomicPredicates().getNumAtomicPredicates()
+            + aps.getNonStandardCommunityLiterals().size(),
+        aps.getAsPathRegexAtomicPredicates().getNumAtomicPredicates(),
+        aps.getNextHopInterfaces().size(),
+        aps.getPeerAddresses().size(),
+        aps.getSourceVrfs().size(),
+        aps.getTracks().size(),
+        aps.getTunnelEncapsulationAttributes());
+  }
+
+  private static int numNonPrefixVars(
+      int numCommAtomicPredicates,
+      int numAsPathRegexAtomicPredicates,
+      int numNextHopInterfaces,
+      int numPeerAddresses,
+      int numSourceVrfs,
+      int numTracks,
+      List<TunnelEncapsulationAttribute> tunnelEncapsulationAttributes) {
+    int bitsToRepresentAdmin =
+        LongMath.log2(AbstractRoute.MAX_ADMIN_DISTANCE, RoundingMode.CEILING);
+    // or else we need to do tricks in the BDDInteger.
+    assert LongMath.isPowerOfTwo(1L + AbstractRoute.MAX_ADMIN_DISTANCE);
+    return
+    // med, nextHop, tag, localPref, clusterListLength (32 bits each; prefix is separate,
+    // allocated/re-derived at prefixStartIdx instead)
+    32 * 5
+        + 16
+        + bitsToRepresentAdmin
+        + numCommAtomicPredicates
+        + numBits(numAsPathRegexAtomicPredicates)
+        // we track one extra value for the next-hop interfaces and source VRFs, to represent
+        // "none", since these are optional parts of a route
+        + numBits(numNextHopInterfaces + 1)
+        + numBits(numSourceVrfs + 1)
+        // we track one extra value for the peer address to represent the case where the
+        // address is something other than the ones that are specifically matched upon in
+        // route policies
+        + numBits(numPeerAddresses + 1)
+        + numTracks
+        + BDDTunnelEncapsulationAttribute.numBitsFor(tunnelEncapsulationAttributes)
+        + numBits(OriginType.values().length)
+        + numBits(RoutingProtocol.values().length)
+        + numBits(allMetricTypes.size());
+  }
 
   /**
    * A constructor that obtains the number of atomic predicates for community and AS-path regexes
@@ -208,38 +273,85 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
       int numSourceVrfs,
       int numTracks,
       List<TunnelEncapsulationAttribute> tunnelEncapsulationAttributes) {
+    this(
+        factory,
+        numCommAtomicPredicates,
+        numAsPathRegexAtomicPredicates,
+        numNextHopInterfaces,
+        numPeerAddresses,
+        numSourceVrfs,
+        numTracks,
+        tunnelEncapsulationAttributes,
+        /* prefixStartIdx= */ 0,
+        /* startIdx= */ PREFIX_LENGTH_BITS + PREFIX_BITS);
+  }
+
+  /**
+   * Like the constructor above, but the destination prefix/prefix-length are allocated starting at
+   * BDD variable index {@code prefixStartIdx}, and the "other" (non-prefix) attribute formulas at
+   * {@code startIdx}, rather than both being implicitly at index 0. Every {@link BDDRoute} built in
+   * the same factory must be given the same {@code prefixStartIdx} (whether freshly allocating
+   * those variables there, for the very first {@link BDDRoute} built in a factory, or re-deriving
+   * the ones already allocated there by an earlier one), so every {@link BDDRoute} sharing a
+   * factory shares the literal same prefix/prefix-length variables: no route policy can ever change
+   * a route's destination, so there is nothing to distinguish per block. Used by {@link
+   * BDDRouteFactory} to build additional, disjoint (except for prefix/prefix-length) routes in the
+   * same factory, and optionally to offset {@code prefixStartIdx} itself past a block of
+   * caller-defined shared bits allocated before it.
+   */
+  BDDRoute(
+      BDDFactory factory,
+      int numCommAtomicPredicates,
+      int numAsPathRegexAtomicPredicates,
+      int numNextHopInterfaces,
+      int numPeerAddresses,
+      int numSourceVrfs,
+      int numTracks,
+      List<TunnelEncapsulationAttribute> tunnelEncapsulationAttributes,
+      int prefixStartIdx,
+      int startIdx) {
+    checkArgument(prefixStartIdx >= 0, "prefixStartIdx must be non-negative");
+    checkArgument(
+        startIdx >= prefixStartIdx + PREFIX_LENGTH_BITS + PREFIX_BITS,
+        "startIdx must be at or past the end of the prefix/prefix-length block");
     _factory = factory;
 
     int bitsToRepresentAdmin =
         LongMath.log2(AbstractRoute.MAX_ADMIN_DISTANCE, RoundingMode.CEILING);
     // or else we need to do tricks in the BDDInteger.
     assert LongMath.isPowerOfTwo(1L + AbstractRoute.MAX_ADMIN_DISTANCE);
-    int numVars = factory.varNum();
+    // startIdx is always at or past prefixStartIdx + PREFIX_LENGTH_BITS + PREFIX_BITS (every
+    // caller places the OTHER fields after the prefix/prefix-length block), so sizing off startIdx
+    // alone already accounts for the prefix/prefix-length variables too.
     int numNeeded =
-        32 * 6
-            + 16
-            + bitsToRepresentAdmin
-            + 6
-            + numCommAtomicPredicates
-            + numBits(numAsPathRegexAtomicPredicates)
-            // we track one extra value for the next-hop interfaces and source VRFs, to represent
-            // "none", since these are optional parts of a route
-            + numBits(numNextHopInterfaces + 1)
-            + numBits(numSourceVrfs + 1)
-            // we track one extra value for the peer address to represent the case where the address
-            // is something other than the ones that are specifically matched upon in route policies
-            + numBits(numPeerAddresses + 1)
-            + numTracks
-            + BDDTunnelEncapsulationAttribute.numBitsFor(tunnelEncapsulationAttributes)
-            + numBits(OriginType.values().length)
-            + numBits(RoutingProtocol.values().length)
-            + numBits(allMetricTypes.size());
-    if (numVars < numNeeded) {
+        startIdx
+            + numNonPrefixVars(
+                numCommAtomicPredicates,
+                numAsPathRegexAtomicPredicates,
+                numNextHopInterfaces,
+                numPeerAddresses,
+                numSourceVrfs,
+                numTracks,
+                tunnelEncapsulationAttributes);
+    if (factory.varNum() < numNeeded) {
       factory.setVarNum(numNeeded);
     }
     _bitNames = new HashMap<>();
 
-    int idx = 0;
+    // No route policy can ever change a route's destination (there is no setPrefix on this
+    // class), so every BDDRoute built in this factory is given the SAME prefixStartIdx, whether
+    // this is the very first one (freshly allocating the variables there) or a later one
+    // re-deriving them -- either way this is the same call, just possibly a repeat of an earlier
+    // one at that index. See BDDRouteFactory. startIdx (where the OTHER fields begin) is separate
+    // and always its own fresh allocation.
+    _prefixLength =
+        MutableBDDInteger.makeFromIndex(factory, PREFIX_LENGTH_BITS, prefixStartIdx, true);
+    addBitNames("pfxLen", PREFIX_LENGTH_BITS, prefixStartIdx, true);
+    _prefix =
+        MutableBDDInteger.makeFromIndex(
+            factory, PREFIX_BITS, prefixStartIdx + PREFIX_LENGTH_BITS, true);
+    addBitNames("pfx", PREFIX_BITS, prefixStartIdx + PREFIX_LENGTH_BITS, true);
+    int idx = startIdx;
     // Initialize one BDD per community atomic predicate, each of which has a corresponding
     // BDD variable
     _communityAtomicPredicates = new BDD[numCommAtomicPredicates];
@@ -280,13 +392,6 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     idx += 32;
     _clusterListLength = MutableBDDInteger.makeFromIndex(factory, 32, idx, false);
     addBitNames("clusterListLength", 32, idx, false);
-    idx += 32;
-    // need 6 bits for prefix length because there are 33 possible values, 0 - 32
-    _prefixLength = MutableBDDInteger.makeFromIndex(factory, 6, idx, true);
-    addBitNames("pfxLen", 6, idx, true);
-    idx += 6;
-    _prefix = MutableBDDInteger.makeFromIndex(factory, 32, idx, true);
-    addBitNames("pfx", 32, idx, true);
     idx += 32;
 
     _asPathRegexAtomicPredicates =
@@ -350,7 +455,22 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     // Initially there are no unsupported statements encountered
     _unsupported = false;
 
+    _allFields = computeAllFields(numCommAtomicPredicates, numTracks);
+
     assert idx != 0; // unnecessary, but needed to avoid unused comment
+  }
+
+  /** Every {@link Field} of a route with this many community/track cells. */
+  private static ImmutableSet<Field> computeAllFields(int numCommAtomicPredicates, int numTracks) {
+    ImmutableSet.Builder<Field> fields = ImmutableSet.builder();
+    fields.add(Attribute.values());
+    for (int i = 0; i < numCommAtomicPredicates; i++) {
+      fields.add(community(i));
+    }
+    for (int i = 0; i < numTracks; i++) {
+      fields.add(track(i));
+    }
+    return fields.build();
   }
 
   /** A copy constructor. Every field of the copy is independently owned. */
@@ -388,6 +508,7 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     _tunnelEncapsulationAttribute =
         BDDTunnelEncapsulationAttribute.copyOf(other._tunnelEncapsulationAttribute);
     _unsupported = other._unsupported;
+    _allFields = other._allFields;
   }
 
   /*
@@ -430,6 +551,7 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     _sourceVrfs = new BDDDomain<>(pred, route._sourceVrfs);
     _tracks = route.getTracks();
     _tunnelEncapsulationAttribute = route._tunnelEncapsulationAttribute.and(pred);
+    _allFields = route._allFields;
   }
 
   /**
@@ -476,6 +598,7 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
     _nextHopType = route._nextHopType;
     _unsupported = route._unsupported;
     _prependedASes = new ArrayList<>(route._prependedASes);
+    _allFields = route._allFields;
   }
 
   /*
@@ -561,31 +684,32 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
 
   /**
    * Augments a given pairing to pair corresponding BDDs from the given BDDRoute with this one. The
-   * BDDs in the given BDDRoute should all be variables.
+   * BDDs in the given BDDRoute must all be variables -- i.e. {@code identity} must be a route of
+   * pure identity-variable formulas (see {@link #touchedFields}), not an arbitrary route.
    *
-   * @param other the BDDRoute of variables
+   * @param identity the BDDRoute of variables
    * @param pairing the existing pairing
    */
-  public void augmentPairing(BDDRoute other, BDDPairing pairing) {
-    _asPathRegexAtomicPredicates.augmentPairing(other._asPathRegexAtomicPredicates, pairing);
-    _clusterListLength.augmentPairing(other._clusterListLength, pairing);
-    pairing.set(other._communityAtomicPredicates, _communityAtomicPredicates);
-    _prefixLength.augmentPairing(other._prefixLength, pairing);
-    _prefix.augmentPairing(other._prefix, pairing);
-    _nextHop.augmentPairing(other._nextHop, pairing);
-    _adminDist.augmentPairing(other._adminDist, pairing);
-    _med.augmentPairing(other._med, pairing);
-    _tag.augmentPairing(other._tag, pairing);
-    _weight.augmentPairing(other._weight, pairing);
-    _localPref.augmentPairing(other._localPref, pairing);
-    _protocolHistory.augmentPairing(other._protocolHistory, pairing);
-    _originType.augmentPairing(other._originType, pairing);
-    _ospfMetric.augmentPairing(other._ospfMetric, pairing);
-    _nextHopInterfaces.augmentPairing(other._nextHopInterfaces, pairing);
-    _peerAddress.augmentPairing(other._peerAddress, pairing);
-    _sourceVrfs.augmentPairing(other._sourceVrfs, pairing);
-    pairing.set(other._tracks, _tracks);
-    _tunnelEncapsulationAttribute.augmentPairing(other._tunnelEncapsulationAttribute, pairing);
+  public void augmentPairing(BDDRoute identity, BDDPairing pairing) {
+    _asPathRegexAtomicPredicates.augmentPairing(identity._asPathRegexAtomicPredicates, pairing);
+    _clusterListLength.augmentPairing(identity._clusterListLength, pairing);
+    pairing.set(identity._communityAtomicPredicates, _communityAtomicPredicates);
+    _prefixLength.augmentPairing(identity._prefixLength, pairing);
+    _prefix.augmentPairing(identity._prefix, pairing);
+    _nextHop.augmentPairing(identity._nextHop, pairing);
+    _adminDist.augmentPairing(identity._adminDist, pairing);
+    _med.augmentPairing(identity._med, pairing);
+    _tag.augmentPairing(identity._tag, pairing);
+    _weight.augmentPairing(identity._weight, pairing);
+    _localPref.augmentPairing(identity._localPref, pairing);
+    _protocolHistory.augmentPairing(identity._protocolHistory, pairing);
+    _originType.augmentPairing(identity._originType, pairing);
+    _ospfMetric.augmentPairing(identity._ospfMetric, pairing);
+    _nextHopInterfaces.augmentPairing(identity._nextHopInterfaces, pairing);
+    _peerAddress.augmentPairing(identity._peerAddress, pairing);
+    _sourceVrfs.augmentPairing(identity._sourceVrfs, pairing);
+    pairing.set(identity._tracks, _tracks);
+    _tunnelEncapsulationAttribute.augmentPairing(identity._tunnelEncapsulationAttribute, pairing);
   }
 
   /**
@@ -605,6 +729,474 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
    */
   public BDDRoute veccompose(BDDPairing pairing) {
     return new BDDRoute(pairing, this);
+  }
+
+  /** The set of BDD variables that appear in any attribute formula of this route. */
+  public BDD support() {
+    return _factory.andAllAndFree(
+        ImmutableList.of(_prefixLength.support(), _prefix.support(), mutableSupport()));
+  }
+
+  /**
+   * Like {@link #support}, but excludes the destination prefix/prefix-length variables. Since no
+   * route policy can ever change a route's destination, every {@link BDDRoute} built alongside a
+   * given one shares those variables rather than getting its own copy (see {@link BDDRouteFactory})
+   * -- so a caller existentially quantifying a whole block away (e.g. to eliminate an original,
+   * pre-image route once a relation over it is built) must use this, not {@link #support}:
+   * quantifying out the full support would erase the prefix/prefix-length variables from every
+   * other formula that mentions them too, not just this block's copy.
+   */
+  public BDD mutableSupport() {
+    ImmutableList.Builder<BDD> supports = ImmutableList.builder();
+    for (Attribute attribute : Attribute.values()) {
+      supports.add(attribute.support(this));
+    }
+    // COMMUNITIES/TRACKS have no Attribute of their own -- each cell is independently addressed
+    // via Field.Community/Field.Track instead (see Field's doc) -- so they're covered here
+    // per-cell rather than by a single Attribute member.
+    Arrays.stream(_communityAtomicPredicates).map(BDD::support).forEach(supports::add);
+    Arrays.stream(_tracks).map(BDD::support).forEach(supports::add);
+    return _factory.andAllAndFree(supports.build());
+  }
+
+  /**
+   * Every scalar attribute of a {@link BDDRoute} -- every composable attribute other than
+   * prefix/prefix-length (which every {@link BDDRoute} in the same variable domain shares as the
+   * literal same BDD variables, see {@link #makeAt}, since no route policy can ever change a
+   * route's destination) and other than {@code COMMUNITIES}/{@code TRACKS} (each many independent
+   * BDD variables -- one per atomic predicate / tracked name -- addressed instead by {@link
+   * Field.Community}/{@link Field.Track}, since e.g. a policy term that adds one community out of
+   * many touches only that community's {@link Field}, not the whole array; see {@link Field}'s
+   * doc). Used to name which fields a step actually WRITES (see {@link #touchedFields}), so a
+   * caller can scope both the relation it builds (see {@link #equalsRelationOn}) and the push that
+   * composes it (the exist-set and relabel pairing) to exactly those fields -- a field a step never
+   * writes is never mentioned by the relation, never quantified, and never relabeled, so it passes
+   * through the incoming route's correlation with the origin completely unconstrained by this step
+   * (not equated to anything -- there is nothing to model).
+   */
+  public enum Attribute implements Field {
+    AS_PATH_REGEX {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._asPathRegexAtomicPredicates.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._asPathRegexAtomicPredicates.augmentPairing(
+            identity._asPathRegexAtomicPredicates, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route
+            ._asPathRegexAtomicPredicates
+            .getInteger()
+            .eq(other._asPathRegexAtomicPredicates.getInteger());
+      }
+    },
+    CLUSTER_LIST_LENGTH {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._clusterListLength.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._clusterListLength.augmentPairing(identity._clusterListLength, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._clusterListLength.eq(other._clusterListLength);
+      }
+    },
+    NEXT_HOP {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._nextHop.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._nextHop.augmentPairing(identity._nextHop, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._nextHop.eq(other._nextHop);
+      }
+    },
+    ADMIN_DIST {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._adminDist.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._adminDist.augmentPairing(identity._adminDist, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._adminDist.eq(other._adminDist);
+      }
+    },
+    MED {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._med.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._med.augmentPairing(identity._med, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._med.eq(other._med);
+      }
+    },
+    TAG {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._tag.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._tag.augmentPairing(identity._tag, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._tag.eq(other._tag);
+      }
+    },
+    WEIGHT {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._weight.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._weight.augmentPairing(identity._weight, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._weight.eq(other._weight);
+      }
+    },
+    LOCAL_PREF {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._localPref.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._localPref.augmentPairing(identity._localPref, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._localPref.eq(other._localPref);
+      }
+    },
+    PROTOCOL_HISTORY {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._protocolHistory.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._protocolHistory.augmentPairing(identity._protocolHistory, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._protocolHistory.eq(other._protocolHistory);
+      }
+    },
+    ORIGIN_TYPE {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._originType.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._originType.augmentPairing(identity._originType, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._originType.eq(other._originType);
+      }
+    },
+    OSPF_METRIC {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._ospfMetric.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._ospfMetric.augmentPairing(identity._ospfMetric, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._ospfMetric.eq(other._ospfMetric);
+      }
+    },
+    NEXT_HOP_INTERFACES {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._nextHopInterfaces.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._nextHopInterfaces.augmentPairing(identity._nextHopInterfaces, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._nextHopInterfaces.eq(other._nextHopInterfaces);
+      }
+    },
+    PEER_ADDRESS {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._peerAddress.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._peerAddress.augmentPairing(identity._peerAddress, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._peerAddress.eq(other._peerAddress);
+      }
+    },
+    SOURCE_VRFS {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._sourceVrfs.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._sourceVrfs.augmentPairing(identity._sourceVrfs, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._sourceVrfs.eq(other._sourceVrfs);
+      }
+    },
+    TUNNEL_ENCAPSULATION_ATTRIBUTE {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._tunnelEncapsulationAttribute.support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        route._tunnelEncapsulationAttribute.augmentPairing(
+            identity._tunnelEncapsulationAttribute, pairing);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route
+            ._tunnelEncapsulationAttribute
+            .allDifferences(other._tunnelEncapsulationAttribute)
+            .notEq();
+      }
+    };
+  }
+
+  /**
+   * A single independently-touchable/scopable BDD-variable-bearing piece of a {@link BDDRoute}:
+   * either a whole {@link Attribute} (every scalar attribute is indivisible -- e.g. {@code MED} is
+   * always one 32-bit integer, so writing it always touches all 32 bits together), or one single
+   * community atomic predicate / tracked name -- see {@link #community}/{@link #track}.
+   *
+   * <p>This finer granularity than a whole {@code COMMUNITIES}/{@code TRACKS} attribute matters for
+   * a policy like a tag-dispatch export policy where every term does {@code community add SELF}
+   * plus one term-specific community: at whole-attribute granularity, every term touches "some
+   * community", so every term's relation (and the push it feeds) must constrain/quantify ALL ~30+
+   * community atomic predicates, even the ~28 neither this term nor most others ever mention. At
+   * per-community granularity, each term touches only the 2-3 {@link Field}s it actually writes, so
+   * the relation, the OR across terms, and the push are all narrower by the same factor. {@link
+   * Attribute} has no such array to index into, so it implements {@link Field} directly rather than
+   * needing an indexed sibling of its own.
+   */
+  public sealed interface Field permits Attribute, Field.Community, Field.Track {
+    /** The support (BDD variable set) of this field on {@code route}. */
+    BDD support(BDDRoute route);
+
+    /**
+     * Augments {@code pairing} to map {@code identity}'s variable(s) for this field to {@code
+     * route}'s corresponding variable(s). {@code identity} must be a route of pure
+     * identity-variable formulas -- see {@link #touchedFields}.
+     */
+    void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing);
+
+    /** The relation {@code route}'s formula for this field equals {@code other}'s. */
+    BDD eq(BDDRoute route, BDDRoute other);
+
+    /** The {@code index}-th community atomic predicate. */
+    record Community(int index) implements Field {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._communityAtomicPredicates[index].support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        pairing.set(
+            identity._communityAtomicPredicates[index].var(),
+            route._communityAtomicPredicates[index]);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._communityAtomicPredicates[index].biimp(
+            other._communityAtomicPredicates[index]);
+      }
+    }
+
+    /** The {@code index}-th tracked name. */
+    record Track(int index) implements Field {
+      @Override
+      public BDD support(BDDRoute route) {
+        return route._tracks[index].support();
+      }
+
+      @Override
+      public void augmentPairing(BDDRoute route, BDDRoute identity, BDDPairing pairing) {
+        pairing.set(identity._tracks[index].var(), route._tracks[index]);
+      }
+
+      @Override
+      public BDD eq(BDDRoute route, BDDRoute other) {
+        return route._tracks[index].biimp(other._tracks[index]);
+      }
+    }
+  }
+
+  /** {@link Field.Community} for {@code index}. Convenience constructor. */
+  public static Field community(int index) {
+    return new Field.Community(index);
+  }
+
+  /** {@link Field.Track} for {@code index}. Convenience constructor. */
+  public static Field track(int index) {
+    return new Field.Track(index);
+  }
+
+  /**
+   * The support (BDD variable set) of a single {@link Field} of this route. Used to build a push's
+   * exist-set/relabel-pairing scoped to only the fields a step relation actually writes -- see
+   * {@link Field}'s javadoc.
+   */
+  public BDD fieldSupport(Field field) {
+    return field.support(this);
+  }
+
+  /** The union of {@link #fieldSupport} over each of {@code fields}. */
+  public BDD fieldSupportOn(Set<Field> fields) {
+    return _factory.andAllAndFree(fields.stream().map(this::fieldSupport).toList());
+  }
+
+  /**
+   * Augments {@code pairing} to map {@code identity}'s variable(s) for a single {@link Field} to
+   * this route's corresponding variable(s). Same contract as {@link #augmentPairing}, scoped to one
+   * field -- see {@link Field}'s javadoc.
+   */
+  public void augmentPairingOn(BDDRoute identity, Field field, BDDPairing pairing) {
+    field.augmentPairing(this, identity, pairing);
+  }
+
+  /**
+   * The fields on which this route's formulas differ from {@code identity}'s -- i.e. the fields a
+   * step's output function actually WRITES, as opposed to leaving as the identity (which a route
+   * policy achieves simply by never mentioning/setting that field). See {@link Field}'s javadoc for
+   * why this matters: a caller building a step's relation should constrain and push only these
+   * fields, leaving every other field of the incoming route to pass through unconstrained -- not
+   * equated to itself, just never touched.
+   *
+   * @param identity a route of pure identity-variable formulas over the same domain as this route
+   *     (e.g. a fresh block from {@link BDDRouteFactory}, itself)
+   */
+  public Set<Field> touchedFields(BDDRoute identity) {
+    Set<Field> touched = new HashSet<>();
+    if (!_asPathRegexAtomicPredicates.equals(identity._asPathRegexAtomicPredicates)) {
+      touched.add(Attribute.AS_PATH_REGEX);
+    }
+    if (!_clusterListLength.equals(identity._clusterListLength)) {
+      touched.add(Attribute.CLUSTER_LIST_LENGTH);
+    }
+    for (int i = 0; i < _communityAtomicPredicates.length; i++) {
+      if (!_communityAtomicPredicates[i].equals(identity._communityAtomicPredicates[i])) {
+        touched.add(community(i));
+      }
+    }
+    if (!_nextHop.equals(identity._nextHop)) {
+      touched.add(Attribute.NEXT_HOP);
+    }
+    if (!_adminDist.equals(identity._adminDist)) {
+      touched.add(Attribute.ADMIN_DIST);
+    }
+    if (!_med.equals(identity._med)) {
+      touched.add(Attribute.MED);
+    }
+    if (!_tag.equals(identity._tag)) {
+      touched.add(Attribute.TAG);
+    }
+    if (!_weight.equals(identity._weight)) {
+      touched.add(Attribute.WEIGHT);
+    }
+    if (!_localPref.equals(identity._localPref)) {
+      touched.add(Attribute.LOCAL_PREF);
+    }
+    if (!_protocolHistory.equals(identity._protocolHistory)) {
+      touched.add(Attribute.PROTOCOL_HISTORY);
+    }
+    if (!_originType.equals(identity._originType)) {
+      touched.add(Attribute.ORIGIN_TYPE);
+    }
+    if (!_ospfMetric.equals(identity._ospfMetric)) {
+      touched.add(Attribute.OSPF_METRIC);
+    }
+    if (!_nextHopInterfaces.equals(identity._nextHopInterfaces)) {
+      touched.add(Attribute.NEXT_HOP_INTERFACES);
+    }
+    if (!_peerAddress.equals(identity._peerAddress)) {
+      touched.add(Attribute.PEER_ADDRESS);
+    }
+    if (!_sourceVrfs.equals(identity._sourceVrfs)) {
+      touched.add(Attribute.SOURCE_VRFS);
+    }
+    for (int i = 0; i < _tracks.length; i++) {
+      if (!_tracks[i].equals(identity._tracks[i])) {
+        touched.add(track(i));
+      }
+    }
+    if (!_tunnelEncapsulationAttribute.equals(identity._tunnelEncapsulationAttribute)) {
+      touched.add(Attribute.TUNNEL_ENCAPSULATION_ATTRIBUTE);
+    }
+    return touched;
   }
 
   /**
@@ -635,6 +1227,33 @@ public final class BDDRoute implements IDeepCopy<BDDRoute> {
       track.free();
     }
     _tunnelEncapsulationAttribute.free();
+  }
+
+  /**
+   * Produces the relation {@code this == other}: a BDD over the union of this route's and {@code
+   * other}'s variables that holds exactly when every attribute formula of this route agrees with
+   * the corresponding formula of {@code other}. Combined with a guard and existential
+   * quantification, this turns a {@code (BDDRoute, BDD guard)} pair -- a function plus a path
+   * condition -- into a flat BDD describing the set of possible outputs (a relational image
+   * computation).
+   *
+   * @param other a route over the same or a disjoint set of variables
+   */
+  public BDD equalsRelation(BDDRoute other) {
+    return equalsRelationOn(other, _allFields);
+  }
+
+  /**
+   * Like {@link #equalsRelation}, but constrains only {@code fields}; every other field is left
+   * completely unmentioned (not merely "unconstrained" via a trivial term -- genuinely absent from
+   * the returned BDD's support). Pairing this with a push whose exist-set/relabel pairing are
+   * scoped to the same {@code fields} means a field this step doesn't write is never quantified and
+   * never relabeled, so it passes through the incoming relation's correlation with the origin
+   * completely untouched -- no equality term is needed to model "preserved", because omission from
+   * both the relation and the push's scope already achieves it. See {@link Field}'s javadoc.
+   */
+  public BDD equalsRelationOn(BDDRoute other, Set<Field> fields) {
+    return _factory.andAllAndFree(fields.stream().map(f -> f.eq(this, other)).toList());
   }
 
   /*

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRouteFactory.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDRouteFactory.java
@@ -1,0 +1,198 @@
+package org.batfish.minesweeper.bdd;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import net.sf.javabdd.BDDFactory;
+import net.sf.javabdd.JFactory;
+import org.batfish.minesweeper.ConfigAtomicPredicates;
+
+/**
+ * Builds {@code numRoutes} {@link BDDRoute}s of identity-variable formulas over a {@link
+ * BDDFactory}, each disjoint from every other's and all mutually interleaved (variable {@code v} of
+ * one route immediately followed by its counterpart in every other route), all in a single
+ * constructor call. Interleaving matches the pattern {@link
+ * org.batfish.common.bdd.BDDPacket#allocatePrimedBDDInteger} uses for primed/unprimed variable
+ * pairs, and is required for tractability: pairwise-comparing two routes (e.g. via {@link
+ * BDDRoute#equalsRelation}) builds one BDD level per bit-pair, and if a bit and its counterpart sit
+ * at opposite ends of the variable order, every level in between must be represented, giving a
+ * relation exponential in the route width instead of linear.
+ *
+ * <p>By convention (not a mechanical distinction -- every route this class builds is otherwise
+ * interchangeable), {@link #identityRoute} index {@code 0} is the one a caller should also hand to
+ * {@link TransferBDD#TransferBDD(BDDFactory, BDDRoute, ConfigAtomicPredicates)} to reuse as that
+ * analysis' own canonical route, per that constructor's contract.
+ *
+ * <p>Every route shares the literal same destination prefix/prefix-length variables rather than
+ * each getting a fresh copy: no route policy can ever change a route's destination (there is no
+ * {@code setPrefix} on {@link BDDRoute}), so every accepted path's output already agrees with its
+ * input on those bits, and relating "two copies, then constrain equal" would just be relating a
+ * variable to itself at extra BDD-node cost. Optionally, this class can also reserve a block of
+ * {@link #numSharedBits} shared the same way, for caller-defined state that isn't part of {@link
+ * BDDRoute} at all (e.g. tracking which snapshot a route's underlying config came from) but that
+ * every route should be able to refer to identically. The caller owns what those bits mean -- this
+ * class only guarantees indices {@code [0, numSharedBits())} are reserved and untouched by every
+ * {@link BDDRoute}, and builds nothing over them itself.
+ *
+ * <p>Building every route together, in one call, matters because interleaving requires that each
+ * new route be built while {@code factory} holds only the previously-built routes from this same
+ * call and nothing else -- building them as separate steps would leave a window in which that
+ * precondition could be silently violated (e.g. by other code allocating factory variables in
+ * between, or by building a route twice).
+ */
+public final class BDDRouteFactory {
+  private final BDDFactory _factory;
+  private final ImmutableList<BDDRoute> _routes;
+  private final int _numSharedBits;
+
+  /**
+   * Like {@link #BDDRouteFactory(BDDFactory, ConfigAtomicPredicates, int, int)}, with no shared
+   * bits.
+   */
+  public BDDRouteFactory(ConfigAtomicPredicates aps, int numRoutes) {
+    this(aps, numRoutes, 0);
+  }
+
+  /**
+   * Like {@link #BDDRouteFactory(BDDFactory, ConfigAtomicPredicates, int, int)}, in a fresh
+   * factory.
+   */
+  public BDDRouteFactory(ConfigAtomicPredicates aps, int numRoutes, int numSharedBits) {
+    this(JFactory.init(100000, 10000), aps, numRoutes, numSharedBits);
+  }
+
+  /**
+   * Like {@link #BDDRouteFactory(BDDFactory, ConfigAtomicPredicates, int, int)}, with no shared
+   * bits.
+   */
+  public BDDRouteFactory(BDDFactory factory, ConfigAtomicPredicates aps, int numRoutes) {
+    this(factory, aps, numRoutes, 0);
+  }
+
+  /**
+   * Builds {@code numRoutes} mutually-interleaved {@link BDDRoute}s of identity-variable formulas,
+   * plus (at the very front, before even the prefix/prefix-length variables) {@code numSharedBits}
+   * reserved bits for the caller's own use -- see {@link #numSharedBits}.
+   *
+   * @param factory must not yet hold any {@link BDDRoute} variables.
+   */
+  public BDDRouteFactory(
+      BDDFactory factory, ConfigAtomicPredicates aps, int numRoutes, int numSharedBits) {
+    checkArgument(numRoutes >= 1, "numRoutes must be at least 1, got %s", numRoutes);
+    _factory = factory;
+    // The shared bits, if any, go at the very front (indices [0, numSharedBits)), ahead of even
+    // the prefix/prefix-length variables -- see numSharedBits()'s doc. Reserving them first, before
+    // building any BDDRoute, means prefixStartIdx below is fixed once and for all for this
+    // factory's lifetime.
+    if (numSharedBits > 0) {
+      factory.setVarNum(numSharedBits);
+    }
+    _numSharedBits = numSharedBits;
+    int prefixStartIdx = numSharedBits;
+    _routes = makeRoutes(factory, aps, numRoutes, prefixStartIdx);
+  }
+
+  private static final int PREFIX_WIDTH = BDDRoute.PREFIX_LENGTH_BITS + BDDRoute.PREFIX_BITS;
+
+  public BDDFactory getFactory() {
+    return _factory;
+  }
+
+  /**
+   * The {@code i}-th of the {@code numRoutes} mutually-interleaved identity-variable {@link
+   * BDDRoute}s requested via the constructor -- see {@link BDDRoute#touchedFields} for what an
+   * identity-variable route means. This is the live, shared-by-reference route, not a copy; callers
+   * must treat it as read-only -- mutate a {@link #mutableRoute} of it instead, since setting
+   * fields directly would corrupt every other holder's view of the identity route.
+   */
+  public BDDRoute identityRoute(int i) {
+    return _routes.get(i);
+  }
+
+  /** Every identity route requested via the constructor's {@code numRoutes}, in order. */
+  public ImmutableList<BDDRoute> identityRoutes() {
+    return _routes;
+  }
+
+  /**
+   * A fresh {@link BDDRoute#deepCopy} of {@link #identityRoute}, safe for the caller to mutate
+   * (e.g. via its {@code setXxx} methods) without affecting the shared identity route or any other
+   * caller's copy of it.
+   */
+  public BDDRoute mutableRoute(int i) {
+    return _routes.get(i).deepCopy();
+  }
+
+  /**
+   * The number of BDD variables reserved at indices {@code [0, numSharedBits())}, for
+   * caller-defined state that isn't part of {@link BDDRoute} at all -- this class only reserves the
+   * indices and builds nothing over them. Unlike {@link #identityRoute}, there is only one copy of
+   * these variables -- every route refers to the exact same variables, the same way every route
+   * shares the same prefix/prefix-length. Fits state that isn't compared or rewritten per-route the
+   * way a route attribute is (e.g. which snapshot a route's underlying config came from is a
+   * property of the route, not of which symbolic variable route currently represents it) -- the
+   * caller is free to wrap {@code getFactory().ithVar(i)} for {@code i} in this range in whatever
+   * type fits (a single flag, a {@link org.batfish.common.bdd.MutableBDDInteger}, ...).
+   */
+  public int numSharedBits() {
+    return _numSharedBits;
+  }
+
+  /**
+   * Builds {@code numRoutes} mutually-interleaved {@link BDDRoute}s, each disjoint from every
+   * other's non-prefix variables, all sharing the same prefix/prefix-length variables starting at
+   * {@code prefixStartIdx}.
+   */
+  private static ImmutableList<BDDRoute> makeRoutes(
+      BDDFactory factory, ConfigAtomicPredicates aps, int numRoutes, int prefixStartIdx) {
+    int fixedWidth = prefixStartIdx + PREFIX_WIDTH;
+    int width = BDDRoute.numNonPrefixVars(aps);
+    ImmutableList.Builder<BDDRoute> routes = ImmutableList.builderWithExpectedSize(numRoutes);
+    for (int r = 0; r < numRoutes; r++) {
+      routes.add(makeAt(factory, aps, prefixStartIdx, fixedWidth + r * width));
+    }
+    interleave(factory, fixedWidth, width, numRoutes);
+    return routes.build();
+  }
+
+  private static BDDRoute makeAt(
+      BDDFactory factory, ConfigAtomicPredicates aps, int prefixStartIdx, int startIdx) {
+    return new BDDRoute(
+        factory,
+        aps.getStandardCommunityAtomicPredicates().getNumAtomicPredicates()
+            + aps.getNonStandardCommunityLiterals().size(),
+        aps.getAsPathRegexAtomicPredicates().getNumAtomicPredicates(),
+        aps.getNextHopInterfaces().size(),
+        aps.getPeerAddresses().size(),
+        aps.getSourceVrfs().size(),
+        aps.getTracks().size(),
+        aps.getTunnelEncapsulationAttributes(),
+        prefixStartIdx,
+        startIdx);
+  }
+
+  /**
+   * Reorders {@code factory}'s variables so that each of the {@code width} non-prefix variables of
+   * every one of the {@code numRoutes} routes (built contiguously at indices {@code [fixedWidth,
+   * fixedWidth + numRoutes*width)}) is immediately followed by its counterpart(s) in every other
+   * route (preserving each route's relative order otherwise, and leaving the shared prefix/prefix-
+   * length variables at the very front, before {@code fixedWidth}, untouched). Needed for
+   * tractability whenever a computation relates more than two of the routes at once (see this
+   * class's javadoc for why non-adjacent variables blow up).
+   */
+  private static void interleave(BDDFactory factory, int fixedWidth, int width, int numRoutes) {
+    int[] oldOrder = factory.getVarOrder();
+    int[] newOrder = new int[fixedWidth + numRoutes * width];
+    int pos = 0;
+    for (int var : oldOrder) {
+      if (var < fixedWidth) {
+        newOrder[pos++] = var;
+      } else if (var < fixedWidth + width) {
+        for (int r = 0; r < numRoutes; r++) {
+          newOrder[pos++] = fixedWidth + r * width + (var - fixedWidth);
+        }
+      }
+    }
+    factory.setVarOrder(newOrder);
+  }
+}

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -191,13 +191,27 @@ public class TransferBDD {
   }
 
   public TransferBDD(BDDFactory factory, ConfigAtomicPredicates aps) {
+    this(factory, new BDDRoute(factory, aps), aps);
+  }
+
+  /**
+   * Like {@link #TransferBDD(BDDFactory, ConfigAtomicPredicates)}, but reuses an already-built
+   * {@code originalRoute} (over {@code factory}'s canonical input variables) instead of building
+   * its own. Useful for a caller that also needs fresh {@link BDDRoute} blocks interleaved with the
+   * canonical route (see {@link BDDRouteFactory}), since those must be built from the same
+   * canonical route this analysis operates over.
+   *
+   * @param originalRoute must be a {@code new BDDRoute(factory, aps)} over the same {@code factory}
+   *     and {@code aps} given here.
+   */
+  public TransferBDD(BDDFactory factory, BDDRoute originalRoute, ConfigAtomicPredicates aps) {
     _configAtomicPredicates = aps;
     _unsupportedAlreadyWarned = new HashSet<>();
 
     _factory = factory;
     _factory.setCacheRatio(64);
 
-    _originalRoute = new BDDRoute(_factory, aps);
+    _originalRoute = originalRoute;
     RegexAtomicPredicates<CommunityVar> standardCommAPs =
         _configAtomicPredicates.getStandardCommunityAtomicPredicates();
     _communityAtomicPredicates = new HashMap<>(standardCommAPs.getRegexAtomicPredicates());

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteFactoryTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteFactoryTest.java
@@ -1,0 +1,174 @@
+package org.batfish.minesweeper.bdd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import net.sf.javabdd.JFactory;
+import org.batfish.minesweeper.CommunityVar;
+import org.batfish.minesweeper.ConfigAtomicPredicates;
+import org.junit.Test;
+
+/** Tests for {@link BDDRouteFactory}. */
+public class BDDRouteFactoryTest {
+  private static final ConfigAtomicPredicates CONFIG_APS =
+      new ConfigAtomicPredicates(
+          ImmutableList.of(),
+          ImmutableSet.of(CommunityVar.from("30:30"), CommunityVar.from("40:40")),
+          ImmutableSet.of());
+
+  @Test
+  public void testZeroRoutesRejected() {
+    assertThrows(IllegalArgumentException.class, () -> new BDDRouteFactory(CONFIG_APS, 0));
+  }
+
+  @Test
+  public void testSingleRouteIsCanonical() {
+    // With a single route requested, identityRoute(0) must be the same as building a BDDRoute
+    // directly against a fresh factory for the same aps.
+    BDDRouteFactory routeFactory = new BDDRouteFactory(CONFIG_APS, 1);
+    BDDRoute direct = new BDDRoute(routeFactory.getFactory(), CONFIG_APS);
+    assertThat(routeFactory.identityRoute(0), equalTo(direct));
+  }
+
+  @Test
+  public void testRoutesAreMutuallyInterleaved() {
+    // The routes must be pairwise interleaved, not contiguous: each of the first route's
+    // non-prefix variables' level must be immediately followed, in the factory's variable order,
+    // by its counterpart in the second and then in the third.
+    BDDRouteFactory routeFactory = new BDDRouteFactory(CONFIG_APS, 3);
+    BDDRoute first = routeFactory.identityRoute(0);
+    BDDRoute second = routeFactory.identityRoute(1);
+    BDDRoute third = routeFactory.identityRoute(2);
+
+    int[] firstLevels = sortedLevels(first.mutableSupport());
+    int[] secondLevels = sortedLevels(second.mutableSupport());
+    int[] thirdLevels = sortedLevels(third.mutableSupport());
+    assertThat(secondLevels.length, equalTo(firstLevels.length));
+    assertThat(thirdLevels.length, equalTo(firstLevels.length));
+    for (int i = 0; i < firstLevels.length; i++) {
+      assertThat(secondLevels[i], equalTo(firstLevels[i] + 1));
+      assertThat(thirdLevels[i], equalTo(firstLevels[i] + 2));
+    }
+
+    // A blown-up (non-interleaved) relation over hundreds of bits would have astronomically more
+    // nodes than this; a generous but finite bound catches a regression without being brittle.
+    BDD firstVsSecond = first.equalsRelation(second);
+    BDD firstVsThird = first.equalsRelation(third);
+    BDD secondVsThird = second.equalsRelation(third);
+    assertThat(firstVsSecond.nodeCount(), lessThan(10_000));
+    assertThat(firstVsThird.nodeCount(), lessThan(10_000));
+    assertThat(secondVsThird.nodeCount(), lessThan(10_000));
+
+    assertThat(routeFactory.identityRoutes(), equalTo(ImmutableList.of(first, second, third)));
+  }
+
+  /**
+   * The factory-order levels of every BDD variable in {@code support}'s support, sorted ascending.
+   */
+  private static int[] sortedLevels(BDD support) {
+    int[] vars = support.scanSet();
+    BDDFactory factory = support.getFactory();
+    int[] levels = new int[vars.length];
+    for (int i = 0; i < vars.length; i++) {
+      levels[i] = factory.var2Level(vars[i]);
+    }
+    Arrays.sort(levels);
+    return levels;
+  }
+
+  @Test
+  public void testExplicitFactoryWithNoSharedBits() {
+    // The (BDDFactory, ConfigAtomicPredicates, int) overload -- a caller-supplied factory, no
+    // shared bits -- must build the same shape as passing numSharedBits=0 explicitly.
+    BDDFactory factory = JFactory.init(100000, 10000);
+    BDDRouteFactory routeFactory = new BDDRouteFactory(factory, CONFIG_APS, 3);
+    assertThat(routeFactory.getFactory(), equalTo(factory));
+    assertThat(routeFactory.numSharedBits(), equalTo(0));
+    assertThat(routeFactory.identityRoutes().size(), equalTo(3));
+  }
+
+  @Test
+  public void testTransferBDDCanReuseIdentityRoute() {
+    // A caller that needs both a TransferBDD and other routes interleaved with its canonical route
+    // must build the canonical route once, via BDDRouteFactory, and hand it to the
+    // TransferBDD(factory, originalRoute, aps) overload -- which stores it as-is -- rather than to
+    // TransferBDD(factory, aps), which builds its OWN second canonical route that
+    // BDDRouteFactory's other routes are not interleaved with (a hazard distinct from object
+    // equality: for the same aps, that second route happens to allocate the identical variable
+    // range and so is .equals() to routeFactory's, since BDDRoute equality is purely structural --
+    // it is the interleaving, not the identity, that TransferBDD(factory, aps) would get wrong).
+    BDDRouteFactory routeFactory = new BDDRouteFactory(CONFIG_APS, 2);
+    TransferBDD tbdd =
+        new TransferBDD(routeFactory.getFactory(), routeFactory.identityRoute(0), CONFIG_APS);
+    assertThat(tbdd.getOriginalRoute(), equalTo(routeFactory.identityRoute(0)));
+  }
+
+  @Test
+  public void testMutableRouteIsIndependentCopy() {
+    // mutableRoute(i) must be a genuinely independent deep copy: mutating it must not affect
+    // identityRoute(i) or any other mutableRoute(i) call's result.
+    BDDRouteFactory routeFactory = new BDDRouteFactory(CONFIG_APS, 1);
+    BDDRoute identity = routeFactory.identityRoute(0);
+    BDDRoute mutableA = routeFactory.mutableRoute(0);
+    BDDRoute mutableB = routeFactory.mutableRoute(0);
+    assertThat(mutableA, equalTo(identity));
+
+    mutableA.getLocalPref().setValue(100);
+    assertThat(mutableA, not(equalTo(identity)));
+    assertThat(mutableB, equalTo(identity));
+    assertThat(routeFactory.identityRoute(0), equalTo(identity));
+  }
+
+  @Test
+  public void testSharedBitsAreReservedAndDisjointFromEveryRoute() {
+    // numSharedBits() only reserves indices [0, numSharedBits()) -- it's the caller's job to build
+    // something over them, e.g. a MutableBDDInteger. Those reserved variables sit at the very front
+    // of the var order; the shared prefix/prefix-length variables (which support() includes, and
+    // every route shares the SAME instance of, unlike its own non-prefix variables) come right
+    // after, so every route's support -- not just its own non-prefix portion -- has its lowest
+    // (top) level exactly at numSharedBits(), never lower: the reserved range is never touched.
+    BDDRouteFactory routeFactory = new BDDRouteFactory(CONFIG_APS, 2, 4);
+    assertThat(routeFactory.numSharedBits(), equalTo(4));
+
+    assertThat(routeFactory.identityRoute(0).support().level(), equalTo(4));
+    assertThat(routeFactory.identityRoute(1).support().level(), equalTo(4));
+  }
+
+  @Test
+  public void testSharedBitsDoNotPerturbInterleaving() {
+    // Requesting shared bits must not change the interleaving/width math for the routes: each of
+    // the first route's non-prefix variables' level must still be immediately followed by its
+    // counterpart in the second, exactly as without shared bits.
+    BDDRouteFactory routeFactory = new BDDRouteFactory(CONFIG_APS, 2, 4);
+    BDDRoute first = routeFactory.identityRoute(0);
+    BDDRoute second = routeFactory.identityRoute(1);
+
+    int[] firstLevels = sortedLevels(first.mutableSupport());
+    int[] secondLevels = sortedLevels(second.mutableSupport());
+    assertThat(secondLevels.length, equalTo(firstLevels.length));
+    for (int i = 0; i < firstLevels.length; i++) {
+      assertThat(secondLevels[i], equalTo(firstLevels[i] + 1));
+    }
+
+    BDD firstVsSecond = first.equalsRelation(second);
+    assertThat(firstVsSecond.nodeCount(), lessThan(10_000));
+  }
+
+  @Test
+  public void testNoSharedBitsRequestedIsZero() {
+    // With no shared bits requested, numSharedBits() is 0, and the first route is allocated
+    // exactly as if BDDRouteFactory had no shared-bits support at all.
+    BDDRouteFactory routeFactory = new BDDRouteFactory(CONFIG_APS, 1);
+    assertThat(routeFactory.numSharedBits(), equalTo(0));
+    BDDRoute direct = new BDDRoute(routeFactory.getFactory(), CONFIG_APS);
+    assertThat(routeFactory.identityRoute(0), equalTo(direct));
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/BDDRouteTest.java
@@ -3,12 +3,15 @@ package org.batfish.minesweeper.bdd;
 import static org.batfish.common.bdd.BDDMatchers.isZero;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
+import java.util.function.Consumer;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
@@ -18,6 +21,8 @@ import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.TunnelEncapsulationAttribute;
 import org.batfish.minesweeper.OspfType;
+import org.batfish.minesweeper.bdd.BDDRoute.Attribute;
+import org.batfish.minesweeper.bdd.BDDRoute.Field;
 import org.batfish.minesweeper.bdd.BDDRoute.NextHopType;
 import org.batfish.minesweeper.bdd.BDDTunnelEncapsulationAttribute.Value;
 import org.junit.Test;
@@ -419,5 +424,190 @@ public class BDDRouteTest {
 
     copy.free();
     original.free();
+  }
+
+  @Test
+  public void testNegativePrefixStartIdxRejected() {
+    BDDFactory factory = JFactory.init(10000, 1000);
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new BDDRoute(
+                factory,
+                3,
+                4,
+                5,
+                6,
+                7,
+                2,
+                ImmutableList.of(),
+                /* prefixStartIdx= */ -1,
+                /* startIdx= */ 38));
+  }
+
+  @Test
+  public void testStartIdxBeforeEndOfPrefixBlockRejected() {
+    BDDFactory factory = JFactory.init(10000, 1000);
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new BDDRoute(
+                factory,
+                3,
+                4,
+                5,
+                6,
+                7,
+                2,
+                ImmutableList.of(),
+                /* prefixStartIdx= */ 0,
+                /* startIdx= */ 37));
+  }
+
+  @Test
+  public void testStartIdxAtEndOfPrefixBlockAccepted() {
+    // 38 == PREFIX_LENGTH_BITS + PREFIX_BITS (6 + 32) -- the boundary case immediately at the end
+    // of the prefix/prefix-length block, one past the rejected 37 above -- must not throw.
+    BDDFactory factory = JFactory.init(10000, 1000);
+    new BDDRoute(
+        factory, 3, 4, 5, 6, 7, 2, ImmutableList.of(), /* prefixStartIdx= */ 0, /* startIdx= */ 38);
+  }
+
+  @Test
+  public void testEqualsRelationDoesNotLeak() {
+    BDDFactory factory = JFactory.init(10000, 1000);
+    BDDRoute route = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    BDDRoute other = new BDDRoute(route);
+    // Mutate other so every attribute actually differs from route's, rather than leaking on an
+    // exact self-comparison -- in particular this exercises the TUNNEL_ENCAPSULATION_ATTRIBUTE
+    // .allDifferences(...).notEq() path (see Attribute#eq) on a real, non-degenerate difference.
+    other.getLocalPref().setValue(100);
+    other.getTunnelEncapsulationAttribute().setValue(Value.absent());
+    long baseline = factory.numOutstandingBDDs();
+
+    BDD relation = route.equalsRelation(other);
+    relation.free();
+
+    assertEquals(baseline, factory.numOutstandingBDDs());
+  }
+
+  @Test
+  public void testEqualsRelationOnDoesNotLeak() {
+    BDDFactory factory = JFactory.init(10000, 1000);
+    BDDRoute route = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    BDDRoute other = new BDDRoute(route);
+    long baseline = factory.numOutstandingBDDs();
+
+    BDD relation =
+        route.equalsRelationOn(
+            other, ImmutableSet.of(BDDRoute.Attribute.TUNNEL_ENCAPSULATION_ATTRIBUTE));
+    relation.free();
+
+    assertEquals(baseline, factory.numOutstandingBDDs());
+  }
+
+  /**
+   * For each scalar {@link Attribute}, mutates exactly that attribute on a copy of the identity
+   * route and checks {@link BDDRoute#touchedFields}/{@link BDDRoute#fieldSupport}/{@link
+   * BDDRoute#augmentPairingOn}/{@link Field#eq} all agree it -- and only it -- was touched.
+   */
+  @Test
+  public void testTouchedFieldsAndFieldOperationsPerAttribute() {
+    BDDFactory factory = JFactory.init(1000, 1000);
+    BDDRoute identity =
+        new BDDRoute(
+            factory,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            ImmutableList.of(new TunnelEncapsulationAttribute(Ip.create(1))));
+
+    ImmutableList<Consumer<BDDRoute>> mutators =
+        ImmutableList.of(
+            x -> x.getAdminDist().setValue(1),
+            x -> x.getAsPathRegexAtomicPredicates().setValue(1),
+            x -> x.getClusterListLength().setValue(3),
+            x -> x.getLocalPref().setValue(100),
+            x -> x.getMed().setValue(50),
+            x -> x.getNextHop().setValue(12345),
+            x -> x.getNextHopInterfaces().setValue(1),
+            x -> x.getOriginType().setValue(OriginType.IGP),
+            x -> x.getOspfMetric().setValue(OspfType.E1),
+            x -> x.getPeerAddress().setValue(1),
+            x -> x.getProtocolHistory().setValue(RoutingProtocol.BGP),
+            x -> x.getSourceVrfs().setValue(1),
+            x -> x.getTag().setValue(300),
+            x ->
+                x.getTunnelEncapsulationAttribute()
+                    .setValue(Value.literal(new TunnelEncapsulationAttribute(Ip.create(1)))),
+            x -> x.getWeight().setValue(200));
+
+    for (Consumer<BDDRoute> mutator : mutators) {
+      BDDRoute mutated = new BDDRoute(identity);
+      mutator.accept(mutated);
+
+      assertEquals(1, mutated.touchedFields(identity).size());
+      Field touched = mutated.touchedFields(identity).iterator().next();
+
+      // identity's field is a free variable, so its support/fieldSupportOn are nonzero (mutated's
+      // field is now a fixed value, so its own support would trivially be one()).
+      BDD identitySupport = identity.fieldSupport(touched);
+      assertEquals(identitySupport, identity.fieldSupportOn(ImmutableSet.of(touched)));
+      assertThat(identitySupport.isOne(), equalTo(false));
+
+      // augmentPairingOn(identity, touched, ...), applied to just the touched field, must agree
+      // with the full-route augmentPairing on that same field's variables -- checked by composing
+      // the same probe (identity's touched-field support) through both.
+      BDDPairing pairingOnField = factory.makePair();
+      mutated.augmentPairingOn(identity, touched, pairingOnField);
+      BDDPairing fullPairing = factory.makePair();
+      mutated.augmentPairing(identity, fullPairing);
+      assertEquals(
+          identitySupport.veccompose(pairingOnField), identitySupport.veccompose(fullPairing));
+
+      // mutated's field is a fixed value but identity's is a free variable, so eq between them is
+      // not the tautology it is between a route and itself.
+      assertThat(touched.eq(mutated, identity).isOne(), equalTo(false));
+      assertEquals(factory.one(), touched.eq(mutated, mutated));
+    }
+  }
+
+  @Test
+  public void testTouchedFieldsAndFieldOperationsPerCommunityAndTrack() {
+    BDDFactory factory = JFactory.init(1000, 1000);
+    BDDRoute identity = new BDDRoute(factory, 3, 2, 2, 2, 2, 3, ImmutableList.of());
+
+    BDDRoute community = new BDDRoute(identity);
+    community.getCommunityAtomicPredicates()[1] = factory.one();
+    assertEquals(ImmutableSet.of(BDDRoute.community(1)), community.touchedFields(identity));
+
+    // identity's cell is a free variable, so its support/fieldSupportOn are nonzero (community's
+    // cell is now the constant true, so its own support would trivially be one()).
+    BDD identityCommunitySupport = identity.fieldSupport(BDDRoute.community(1));
+    assertEquals(
+        identityCommunitySupport, identity.fieldSupportOn(ImmutableSet.of(BDDRoute.community(1))));
+    assertThat(identityCommunitySupport.isOne(), equalTo(false));
+    assertThat(BDDRoute.community(1).eq(community, identity).isOne(), equalTo(false));
+    assertEquals(factory.one(), BDDRoute.community(1).eq(community, community));
+
+    BDDRoute track = new BDDRoute(identity);
+    track.getTracks()[2] = factory.one();
+    assertEquals(ImmutableSet.of(BDDRoute.track(2)), track.touchedFields(identity));
+
+    BDD identityTrackSupport = identity.fieldSupport(BDDRoute.track(2));
+    assertEquals(identityTrackSupport, identity.fieldSupportOn(ImmutableSet.of(BDDRoute.track(2))));
+    assertThat(identityTrackSupport.isOne(), equalTo(false));
+    assertThat(BDDRoute.track(2).eq(track, identity).isOne(), equalTo(false));
+    assertEquals(factory.one(), BDDRoute.track(2).eq(track, track));
+  }
+
+  @Test
+  public void testTouchedFieldsIsEmptyForIdentity() {
+    BDDFactory factory = JFactory.init(1000, 1000);
+    BDDRoute identity = new BDDRoute(factory, 3, 4, 5, 6, 7, 2, ImmutableList.of());
+    assertEquals(ImmutableSet.of(), identity.touchedFields(identity));
   }
 }


### PR DESCRIPTION
Add infrastructure for treating a BDDRoute as one side of a relation
rather than only a function of implicit input variables:

- BDDRouteFactory builds a factory's canonical BDDRoute together
  with any number of additional fresh, mutually-interleaved blocks,
  all in a single constructor call -- interleaving requires that the
  factory hold exactly one previously-built BDDRoute and nothing
  else, and building the canonical route and its extra blocks as
  separate steps would leave a window in which that precondition
  could be silently violated (e.g. by other code allocating factory
  variables in between, or by building the extra blocks twice).
  Blocks share the destination prefix/prefix-length variables, since
  no route policy can ever change a route's destination; comparing
  two blocks bit-by-bit stays linear in route width only if each bit
  sits next to its counterpart in the variable order, so the extra
  blocks are interleaved with the canonical route rather than
  appended contiguously.
- BDDRouteFactory can also allocate a block of caller-defined shared
  bits (e.g. tracking which snapshot a route's underlying config
  came from), at the very front of the variable order, ahead of even
  prefix/prefix-length. Unlike the extra blocks, these are shared the
  same way prefix/prefix-length is: one copy that every block refers
  to identically, since this state is a property of the route rather
  than of which symbolic variable block currently represents it.
- A new TransferBDD(BDDFactory, BDDRoute, ConfigAtomicPredicates)
  constructor lets a caller that also needs BDDRouteFactory's extra
  blocks hand in the same canonical route TransferBDD operates over,
  instead of TransferBDD building a second, un-interleaved one.
- support()/mutableSupport() expose a route's BDD variable set, the
  latter excluding the shared prefix/prefix-length variables (needed
  when quantifying out one block's variables must not erase another
  block's copy of the same shared variables).
- equalsRelation(other)/equalsRelationOn(other, fields) build the BDD
  relation "this route's attributes equal other's," in whole or
  restricted to a subset of fields; the latter leaves every other
  field completely unmentioned rather than adding a trivial equality
  term, so it composes cleanly with a caller that only cares about
  the fields actually written.
- Attribute (a per-attribute strategy enum) and the Field sealed
  interface (Scalar/Community/Track) give per-attribute, and for
  COMMUNITIES/TRACKS per-index, granularity for naming which piece of
  a route a computation touches, via fieldSupport(On)/
  augmentPairingOn/touchedFields.
