### PR TITLE
Support SpecialCasesRendering in minesweeper community regex analysis

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDD.java
@@ -125,9 +125,18 @@ public class CommunityMatchExprToBDD implements CommunityMatchExprVisitor<BDD, A
 
   @Override
   public BDD visitCommunityMatchRegex(CommunityMatchRegex communityMatchRegex, Arg arg) {
-    return CommunitySetMatchExprToBDD.communityVarsToBDD(
-        communityMatchRegex.accept(new CommunityMatchExprVarCollector(), arg.getConfiguration()),
-        arg);
+    Set<CommunityVar> allVars =
+        communityMatchRegex.accept(new CommunityMatchExprVarCollector(), arg.getConfiguration());
+    BDD result = CommunitySetMatchExprToBDD.communityVarsToBDD(allVars, arg);
+
+    // Subtract communities whose colon form matches the regex but whose rendered name does not.
+    Set<CommunityVar> excluded =
+        CommunityMatchExprVarCollector.regexExcludedSpecialCases(
+            communityMatchRegex.getRegex(), communityMatchRegex.getCommunityRendering());
+    if (!excluded.isEmpty()) {
+      result = result.and(CommunitySetMatchExprToBDD.communityVarsToBDD(excluded, arg).not());
+    }
+    return result;
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollector.java
@@ -25,6 +25,7 @@ import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprRefere
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprVisitor;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
 import org.batfish.datamodel.routing_policy.communities.CommunityNot;
+import org.batfish.datamodel.routing_policy.communities.CommunityRendering;
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorHighMatch;
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorLowMatch;
 import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityGlobalAdministratorMatch;
@@ -32,6 +33,7 @@ import org.batfish.datamodel.routing_policy.communities.ExtendedCommunityLocalAd
 import org.batfish.datamodel.routing_policy.communities.OpaqueExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.RouteTargetExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.SiteOfOriginExtendedCommunities;
+import org.batfish.datamodel.routing_policy.communities.SpecialCasesRendering;
 import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighMatch;
 import org.batfish.datamodel.routing_policy.communities.StandardCommunityLowMatch;
 import org.batfish.datamodel.routing_policy.communities.VpnDistinguisherExtendedCommunities;
@@ -111,9 +113,24 @@ public class CommunityMatchExprVarCollector
   public Set<CommunityVar> visitCommunityMatchRegex(
       CommunityMatchRegex communityMatchRegex, Configuration arg) {
     checkArgument(
-        communityMatchRegex.getCommunityRendering().equals(ColonSeparatedRendering.instance()),
+        usesColonSeparatedRendering(communityMatchRegex.getCommunityRendering()),
         "Currently only supporting community regexes using the colon-separated rendering");
     return ImmutableSet.of(CommunityVar.from(communityMatchRegex.getRegex()));
+  }
+
+  /**
+   * Returns true if the given rendering is effectively colon-separated, either directly or as the
+   * fallback of a {@link SpecialCasesRendering}.
+   */
+  private static boolean usesColonSeparatedRendering(CommunityRendering rendering) {
+    if (rendering.equals(ColonSeparatedRendering.instance())) {
+      return true;
+    }
+    if (rendering instanceof SpecialCasesRendering) {
+      return usesColonSeparatedRendering(
+          ((SpecialCasesRendering) rendering).getFallbackRendering());
+    }
+    return false;
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollector.java
@@ -3,13 +3,17 @@ package org.batfish.minesweeper.communities;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.routing_policy.communities.AllExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.AllLargeCommunities;
 import org.batfish.datamodel.routing_policy.communities.AllStandardCommunities;
@@ -112,10 +116,22 @@ public class CommunityMatchExprVarCollector
   @Override
   public Set<CommunityVar> visitCommunityMatchRegex(
       CommunityMatchRegex communityMatchRegex, Configuration arg) {
+    CommunityRendering rendering = communityMatchRegex.getCommunityRendering();
     checkArgument(
-        usesColonSeparatedRendering(communityMatchRegex.getCommunityRendering()),
+        usesColonSeparatedRendering(rendering),
         "Currently only supporting community regexes using the colon-separated rendering");
-    return ImmutableSet.of(CommunityVar.from(communityMatchRegex.getRegex()));
+
+    String regex = communityMatchRegex.getRegex();
+    ImmutableSet.Builder<CommunityVar> vars = ImmutableSet.builder();
+    vars.add(CommunityVar.from(regex));
+    // For SpecialCasesRendering, also include exact community vars for any special-case
+    // communities whose rendered name is matched by the regex.
+    for (Map.Entry<Community, String> entry : getSpecialCases(rendering).entrySet()) {
+      if (Pattern.compile(regex).matcher(entry.getValue()).find()) {
+        vars.add(CommunityVar.from(entry.getKey()));
+      }
+    }
+    return vars.build();
   }
 
   /**
@@ -131,6 +147,17 @@ public class CommunityMatchExprVarCollector
           ((SpecialCasesRendering) rendering).getFallbackRendering());
     }
     return false;
+  }
+
+  /** Returns the map from community to rendered name for all special cases in the rendering. */
+  private static Map<Community, String> getSpecialCases(CommunityRendering rendering) {
+    if (rendering instanceof SpecialCasesRendering specialCases) {
+      ImmutableMap.Builder<Community, String> builder = ImmutableMap.builder();
+      builder.putAll(specialCases.getSpecialCases());
+      builder.putAll(getSpecialCases(specialCases.getFallbackRendering()));
+      return builder.buildOrThrow();
+    }
+    return ImmutableMap.of();
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollector.java
@@ -120,18 +120,47 @@ public class CommunityMatchExprVarCollector
     checkArgument(
         usesColonSeparatedRendering(rendering),
         "Currently only supporting community regexes using the colon-separated rendering");
+    return regexToCommunityVars(communityMatchRegex.getRegex(), rendering);
+  }
 
-    String regex = communityMatchRegex.getRegex();
+  /**
+   * Determines which community vars are needed for a regex under the given rendering.
+   *
+   * <p>Always includes a regex var for matching against the colon-separated universe. For
+   * SpecialCasesRendering, also includes exact vars for any special-case community whose rendered
+   * name or colon form interacts with the regex. This ensures atomic predicates are split finely
+   * enough for the BDD builder to correctly include/exclude individual communities.
+   */
+  public static Set<CommunityVar> regexToCommunityVars(String regex, CommunityRendering rendering) {
     ImmutableSet.Builder<CommunityVar> vars = ImmutableSet.builder();
     vars.add(CommunityVar.from(regex));
-    // For SpecialCasesRendering, also include exact community vars for any special-case
-    // communities whose rendered name is matched by the regex.
+    Pattern pattern = Pattern.compile(regex);
     for (Map.Entry<Community, String> entry : getSpecialCases(rendering).entrySet()) {
-      if (Pattern.compile(regex).matcher(entry.getValue()).find()) {
+      if (pattern.matcher(entry.getValue()).find()
+          || pattern.matcher(entry.getKey().matchString()).find()) {
         vars.add(CommunityVar.from(entry.getKey()));
       }
     }
     return vars.build();
+  }
+
+  /**
+   * Returns special-case communities whose colon form matches the regex but whose rendered name
+   * does not. These should be subtracted from the regex BDD because FRR evaluates the regex against
+   * the rendered name, not the colon form.
+   */
+  public static Set<CommunityVar> regexExcludedSpecialCases(
+      String regex, CommunityRendering rendering) {
+    ImmutableSet.Builder<CommunityVar> excluded = ImmutableSet.builder();
+    Pattern pattern = Pattern.compile(regex);
+    for (Map.Entry<Community, String> entry : getSpecialCases(rendering).entrySet()) {
+      boolean nameMatches = pattern.matcher(entry.getValue()).find();
+      boolean colonFormMatches = pattern.matcher(entry.getKey().matchString()).find();
+      if (colonFormMatches && !nameMatches) {
+        excluded.add(CommunityVar.from(entry.getKey()));
+      }
+    }
+    return excluded.build();
   }
 
   /**
@@ -149,8 +178,12 @@ public class CommunityMatchExprVarCollector
     return false;
   }
 
-  /** Returns the map from community to rendered name for all special cases in the rendering. */
-  private static Map<Community, String> getSpecialCases(CommunityRendering rendering) {
+  /**
+   * Returns the map from community to rendered name for all special cases in the rendering. For
+   * example, {NO_EXPORT -> "no-export", NO_ADVERTISE -> "no-advertise"}. Recurses through nested
+   * {@link SpecialCasesRendering} fallbacks.
+   */
+  public static Map<Community, String> getSpecialCases(CommunityRendering rendering) {
     if (rendering instanceof SpecialCasesRendering specialCases) {
       ImmutableMap.Builder<Community, String> builder = ImmutableMap.builder();
       builder.putAll(specialCases.getSpecialCases());

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDDTest.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.communities.OpaqueExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.RouteTargetExtendedCommunities;
 import org.batfish.datamodel.routing_policy.communities.SiteOfOriginExtendedCommunities;
+import org.batfish.datamodel.routing_policy.communities.SpecialCasesRendering;
 import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighMatch;
 import org.batfish.datamodel.routing_policy.communities.StandardCommunityLowMatch;
 import org.batfish.datamodel.routing_policy.communities.VpnDistinguisherExtendedCommunities;
@@ -265,6 +266,24 @@ public class CommunityMatchExprToBDDTest {
     CommunityVar cvar = CommunityVar.from("^20:");
 
     assertEquals(cvarToBDD(cvar), result);
+  }
+
+  @Test
+  public void testVisitCommunityMatchRegex_excludesSpecialCaseByName() {
+    // Regex "^20:" matches the colon form "20:30", but under SpecialCasesRendering where
+    // 20:30 is rendered as "foo", FRR would not match it. The BDD should exclude 20:30.
+    CommunityMatchRegex cmr =
+        new CommunityMatchRegex(
+            SpecialCasesRendering.of(
+                ColonSeparatedRendering.instance(),
+                ImmutableMap.of(StandardCommunity.parse("20:30"), "foo")),
+            "^20:");
+
+    BDD result = _communityMatchExprToBDD.visitCommunityMatchRegex(cmr, _arg);
+
+    CommunityVar regexVar = CommunityVar.from("^20:");
+    CommunityVar excludedVar = CommunityVar.from(StandardCommunity.parse("20:30"));
+    assertEquals(cvarToBDD(regexVar).and(cvarToBDD(excludedVar).not()), result);
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollectorTest.java
@@ -167,7 +167,8 @@ public class CommunityMatchExprVarCollectorTest {
   }
 
   @Test
-  public void testVisitCommunityMatchRegex_SpecialCasesRendering_matchesSpecialCase() {
+  public void testVisitCommunityMatchRegex_SpecialCasesRendering_nameMatches() {
+    // Regex matches the rendered name "no-export" — community should be included
     CommunityMatchRegex cmr =
         new CommunityMatchRegex(
             SpecialCasesRendering.of(
@@ -178,6 +179,24 @@ public class CommunityMatchExprVarCollectorTest {
     assertEquals(
         ImmutableSet.of(
             CommunityVar.from("no-export"), CommunityVar.from(StandardCommunity.NO_EXPORT)),
+        result);
+  }
+
+  @Test
+  public void testVisitCommunityMatchRegex_SpecialCasesRendering_colonFormMatchesButNotTheName() {
+    // Regex "^65535:" matches the colon form "65535:65281" but not the name "no-export".
+    // The community should still be emitted (for atomic predicate splitting), so that the
+    // BDD builder can correctly exclude it.
+    CommunityMatchRegex cmr =
+        new CommunityMatchRegex(
+            SpecialCasesRendering.of(
+                ColonSeparatedRendering.instance(),
+                ImmutableMap.of(StandardCommunity.NO_EXPORT, "no-export")),
+            "^65535:");
+    Set<CommunityVar> result = _varCollector.visitCommunityMatchRegex(cmr, _baseConfig);
+    assertEquals(
+        ImmutableSet.of(
+            CommunityVar.from("^65535:"), CommunityVar.from(StandardCommunity.NO_EXPORT)),
         result);
   }
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollectorTest.java
@@ -167,6 +167,21 @@ public class CommunityMatchExprVarCollectorTest {
   }
 
   @Test
+  public void testVisitCommunityMatchRegex_SpecialCasesRendering_matchesSpecialCase() {
+    CommunityMatchRegex cmr =
+        new CommunityMatchRegex(
+            SpecialCasesRendering.of(
+                ColonSeparatedRendering.instance(),
+                ImmutableMap.of(StandardCommunity.NO_EXPORT, "no-export")),
+            "no-export");
+    Set<CommunityVar> result = _varCollector.visitCommunityMatchRegex(cmr, _baseConfig);
+    assertEquals(
+        ImmutableSet.of(
+            CommunityVar.from("no-export"), CommunityVar.from(StandardCommunity.NO_EXPORT)),
+        result);
+  }
+
+  @Test
   public void testVisitCommunityMatchRegex_IntegerValueRendering() {
     CommunityMatchRegex cmr = new CommunityMatchRegex(IntegerValueRendering.instance(), "^20:");
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollectorTest.java
@@ -161,9 +161,9 @@ public class CommunityMatchExprVarCollectorTest {
         new CommunityMatchRegex(
             SpecialCasesRendering.of(ColonSeparatedRendering.instance(), ImmutableMap.of()),
             "^20:");
-    // TODO: support
-    _thrown.expect(IllegalArgumentException.class);
-    _varCollector.visitCommunityMatchRegex(cmr, _baseConfig);
+    Set<CommunityVar> result = _varCollector.visitCommunityMatchRegex(cmr, _baseConfig);
+    CommunityVar cvar = CommunityVar.from("^20:");
+    assertEquals(ImmutableSet.of(cvar), result);
   }
 
   @Test


### PR DESCRIPTION
FRR creates CommunityMatchRegex with a SpecialCasesRendering (wrapping ColonSeparatedRendering as fallback). The var collector previously rejected anything that wasn't exactly ColonSeparatedRendering.

Fixes:
1. Accept any rendering whose effective fallback is colon-separated.
2. For special-cased communities (i.e., Community -> String), resolve them to exact CommunityVars when the regex matches their rendered name. This is necessary because strings like "no-export" falls outside the `<num>:<num>` and would otherwise be invisible to the analysis.
3. Exclude special-cased communities whose colon form matches the regex but whose rendered name does not.  For example, regex [0-9]+:[0-9]+ would incorrectly match NO_EXPORT because 65535:65281 matches, even though FRR renders it as "no-export" which won't match.