### PR TITLE
xr: fix lexing of 32-bit ASNs after 'rd', extract rd under router bgp vrf

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -8046,7 +8046,7 @@ M_Rd_COLON: ':' -> type(COLON);
 M_Rd_IP_ADDRESS: F_IpAddress -> type(IP_ADDRESS);
 M_Rd_PERIOD: '.' -> type(PERIOD);
 M_Rd_UINT16: F_Uint16 -> type(UINT16);
-M_Rd_UINT32: F_Uint16 -> type(UINT16);
+M_Rd_UINT32: F_Uint32 -> type(UINT32);
 M_Rd_NEWLINE: F_Newline -> type(NEWLINE), popMode;
 M_Rd_WS: F_Whitespace+ -> channel(HIDDEN);
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -1204,6 +1204,8 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   private @Nullable RouteDistinguisher toRouteDistinguisher(
       ParserRuleContext messageCtx, Route_distinguisherContext ctx) {
+    // The M_Rd lexer mode produces at most UINT32 tokens, so both the ASN and the
+    // assigned number are guaranteed to fit in 32 bits here.
     long admin2 = toLong(ctx.uint_legacy());
     if (ctx.IP_ADDRESS() != null) {
       if (admin2 > 0xFFFFL) {
@@ -1213,10 +1215,12 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
       return RouteDistinguisher.from(toIp(ctx.IP_ADDRESS()), (int) admin2);
     }
     long asn = toAsNum(ctx.bgp_asn());
-    if (asn <= 0xFFFFL && admin2 <= 0xFFFFFFFFL) {
+    if (asn <= 0xFFFFL) {
+      // type 0: 2-byte ASN administrator, 4-byte assigned number
       return RouteDistinguisher.from((int) asn, admin2);
     }
-    if (asn <= 0xFFFFFFFFL && admin2 <= 0xFFFFL) {
+    if (admin2 <= 0xFFFFL) {
+      // type 2: 4-byte ASN administrator, 2-byte assigned number
       return RouteDistinguisher.from(asn, (int) admin2);
     }
     warn(messageCtx, "Invalid route distinguisher: " + ctx.getText());

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -284,6 +284,7 @@ import org.batfish.datamodel.SwitchportEncapsulationType;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.TcpFlags;
 import org.batfish.datamodel.TcpFlagsMatchConditions;
+import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.eigrp.ClassicMetric;
@@ -762,6 +763,7 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Rodl_route_policyContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Ror_routing_instanceContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Ror_routing_instance_nullContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Rorri_protocolContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Route_distinguisherContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Route_nexthopContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Route_policy_bgp_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Route_policy_nameContext;
@@ -1198,6 +1200,27 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     }
     String[] parts = ctx.asn4b.getText().split("\\.");
     return (Long.parseLong(parts[0]) << 16) + Long.parseLong(parts[1]);
+  }
+
+  private @Nullable RouteDistinguisher toRouteDistinguisher(
+      ParserRuleContext messageCtx, Route_distinguisherContext ctx) {
+    long admin2 = toLong(ctx.uint_legacy());
+    if (ctx.IP_ADDRESS() != null) {
+      if (admin2 > 0xFFFFL) {
+        warn(messageCtx, "Invalid route distinguisher: " + ctx.getText());
+        return null;
+      }
+      return RouteDistinguisher.from(toIp(ctx.IP_ADDRESS()), (int) admin2);
+    }
+    long asn = toAsNum(ctx.bgp_asn());
+    if (asn <= 0xFFFFL && admin2 <= 0xFFFFFFFFL) {
+      return RouteDistinguisher.from((int) asn, admin2);
+    }
+    if (asn <= 0xFFFFFFFFL && admin2 <= 0xFFFFL) {
+      return RouteDistinguisher.from(asn, (int) admin2);
+    }
+    warn(messageCtx, "Invalid route distinguisher: " + ctx.getText());
+    return null;
   }
 
   private static Ip toIp(TerminalNode t) {
@@ -2998,7 +3021,10 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitBgp_vrf_rd(Bgp_vrf_rdContext ctx) {
-    todo(ctx);
+    RouteDistinguisher rd = toRouteDistinguisher(ctx, ctx.route_distinguisher());
+    if (rd != null) {
+      currentVrf().setRouteDistinguisher(rd);
+    }
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
@@ -1,0 +1,78 @@
+package org.batfish.grammar.cisco_xr;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
+import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
+import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import javax.annotation.Nonnull;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
+import org.batfish.config.Settings;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.main.Batfish;
+import org.batfish.representation.cisco_xr.CiscoXrConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests for https://github.com/batfish/batfish/issues/10062. */
+public final class GitHub10062Test {
+
+  private static final String TESTCONFIGS_PREFIX = "org/batfish/grammar/cisco_xr/testconfigs/";
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private @Nonnull CiscoXrConfiguration parseVendorConfig(String hostname) {
+    String src = readResource(TESTCONFIGS_PREFIX + hostname, UTF_8);
+    Settings settings = new Settings();
+    configureBatfishTestSettings(settings);
+    CiscoXrCombinedParser ciscoXrParser = new CiscoXrCombinedParser(src, settings);
+    CiscoXrControlPlaneExtractor extractor =
+        new CiscoXrControlPlaneExtractor(
+            src,
+            ciscoXrParser,
+            ConfigurationFormat.CISCO_IOS_XR,
+            new Warnings(),
+            new SilentSyntaxCollection());
+    ParserRuleContext tree =
+        Batfish.parse(
+            ciscoXrParser, new BatfishLogger(BatfishLogger.LEVELSTR_FATAL, false), settings);
+    extractor.processParseTree(DUMMY_SNAPSHOT_1, tree);
+    CiscoXrConfiguration vendorConfiguration =
+        (CiscoXrConfiguration) extractor.getVendorConfiguration();
+    vendorConfiguration.setFilename(TESTCONFIGS_PREFIX + hostname);
+    // crash if not serializable
+    return SerializationUtils.clone(vendorConfiguration);
+  }
+
+  @Test
+  public void testBgpVrfRdExtraction() {
+    CiscoXrConfiguration c = parseVendorConfig("gh10062");
+    assertThat(c.getVrfs(), hasKeys("default", "two_byte", "four_byte", "dotted", "ip_admin"));
+    // type 0: 2-byte ASN administrator, 4-byte assigned number
+    assertThat(
+        c.getVrfs().get("two_byte").getRouteDistinguisher(),
+        equalTo(RouteDistinguisher.from(65000, 4294967295L)));
+    // type 2: 4-byte asplain ASN administrator, 2-byte assigned number
+    assertThat(
+        c.getVrfs().get("four_byte").getRouteDistinguisher(),
+        equalTo(RouteDistinguisher.from(4200000001L, 200)));
+    // type 2: 4-byte asdot ASN administrator (1.100 = 65636)
+    assertThat(
+        c.getVrfs().get("dotted").getRouteDistinguisher(),
+        equalTo(RouteDistinguisher.from((1L << 16) + 100, 200)));
+    // type 1: IP address administrator
+    assertThat(
+        c.getVrfs().get("ip_admin").getRouteDistinguisher(),
+        equalTo(RouteDistinguisher.from(Ip.parse("10.0.0.1"), 200)));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
@@ -7,6 +7,7 @@ import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -57,7 +58,16 @@ public final class GitHub10062Test {
   @Test
   public void testBgpVrfRdExtraction() {
     CiscoXrConfiguration c = parseVendorConfig("gh10062");
-    assertThat(c.getVrfs(), hasKeys("default", "two_byte", "four_byte", "dotted", "ip_admin"));
+    assertThat(
+        c.getVrfs(),
+        hasKeys(
+            "default",
+            "two_byte",
+            "four_byte",
+            "dotted",
+            "ip_admin",
+            "bad_ip_admin",
+            "bad_asn4_val4"));
     // type 0: 2-byte ASN administrator, 4-byte assigned number
     assertThat(
         c.getVrfs().get("two_byte").getRouteDistinguisher(),
@@ -74,5 +84,9 @@ public final class GitHub10062Test {
     assertThat(
         c.getVrfs().get("ip_admin").getRouteDistinguisher(),
         equalTo(RouteDistinguisher.from(Ip.parse("10.0.0.1"), 200)));
+    // invalid: IP administrator requires a 2-byte assigned number
+    assertThat(c.getVrfs().get("bad_ip_admin").getRouteDistinguisher(), nullValue());
+    // invalid: 4-byte ASN administrator requires a 2-byte assigned number
+    assertThat(c.getVrfs().get("bad_asn4_val4").getRouteDistinguisher(), nullValue());
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh10062
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh10062
@@ -7,6 +7,10 @@ vrf dotted
 !
 vrf ip_admin
 !
+vrf bad_ip_admin
+!
+vrf bad_asn4_val4
+!
 router bgp 65001
  vrf two_byte
   rd 65000:4294967295
@@ -19,6 +23,12 @@ router bgp 65001
  !
  vrf ip_admin
   rd 10.0.0.1:200
+ !
+ vrf bad_ip_admin
+  rd 10.0.0.1:70000
+ !
+ vrf bad_asn4_val4
+  rd 4200000001:70000
  !
 !
 end

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh10062
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh10062
@@ -1,0 +1,24 @@
+hostname gh10062
+vrf two_byte
+!
+vrf four_byte
+!
+vrf dotted
+!
+vrf ip_admin
+!
+router bgp 65001
+ vrf two_byte
+  rd 65000:4294967295
+ !
+ vrf four_byte
+  rd 4200000001:200
+ !
+ vrf dotted
+  rd 1.100:200
+ !
+ vrf ip_admin
+  rd 10.0.0.1:200
+ !
+!
+end


### PR DESCRIPTION
Partially addresses #10062 (the `rd` half; the `extcommunity-set rt` local-administrator half is a separate, larger change and I'll follow up on the issue with corrected analysis).

## Problem

The `M_Rd` lexer mode declares:

```
M_Rd_UINT32: F_Uint16 -> type(UINT16);
```

so an asplain 32-bit ASN administrator after `rd` can never tokenize. `rd 4200000001:100` shatters into a run of UINT16 fragments (`'42000' '0' '0' '0' '0' '1'`) and the whole line is reported as unrecognized, even though the `route_distinguisher` parser rule already accepts a 32-bit ASN via `bgp_asn`. Every VRF on a device whose backbone ASN is above 65535 hits this.

Separately, `rd` under `router bgp / vrf` was `todo()`, so even the 2-byte form reported "This feature is not currently supported" and nothing was extracted.

## Fix

* `M_Rd_UINT32` now uses `F_Uint32` and emits `UINT32` (one-line copy-paste fix).
* `exitBgp_vrf_rd` extracts the `RouteDistinguisher` onto the vendor-model `Vrf`, mirroring what `CiscoControlPlaneExtractor` already does for IOS. Handles type 0 (2-byte ASN admin, 4-byte value), type 1 (IP admin), and type 2 (4-byte asplain or asdot ASN admin, 2-byte value); out-of-range combinations produce a conversion warning instead of a crash.

## Testing

* New `GitHub10062Test` + `gh10062` testconfig covering all four RD administrator forms (2-byte ASN, 4-byte asplain, asdot, IP address), asserting the extracted `RouteDistinguisher` values.
* `//projects/batfish/src/test/java/org/batfish/grammar/cisco_xr:tests` passes; `bazel test //projects/...` run locally with only two pre-existing environment-dependent failures in `projects/common` (container runs as root, so the mkdir-permission test cannot fail as intended); `//tools/format:format.check` and `tools/run_checkstyle.sh` clean.
* Verified against a real ~1900-line IOS-XR 25.2.2 production config: the `rd` parse warnings disappear and the VRF RDs extract correctly.