### PR TITLE
ci: bump CI JDK to 25 and document JDK 21 minimum

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
       - name: Checkstyle
         run: tools/run_checkstyle.sh
   bazel_build_test_and_pmd:
@@ -86,14 +86,14 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.cache/bazel"
-          key: ${{runner.os}}-bazel-17-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-test-${{ needs.get_date.outputs.ymd }}
+          key: ${{runner.os}}-bazel-25-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-test-${{ needs.get_date.outputs.ymd }}
           restore-keys: |
-            ${{runner.os}}-bazel-17-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-test-
-            ${{runner.os}}-bazel-17-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-
+            ${{runner.os}}-bazel-25-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-test-
+            ${{runner.os}}-bazel-25-${{ hashFiles('.bazelversion', 'WORKSPACE', 'maven_install.json') }}-
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
       - name: Bazel build and test
         run: |
           # Stop on first test failure for PRs; keep going for scheduled runs to see all failures
@@ -110,7 +110,7 @@ jobs:
       - name: Save JAR
         uses: actions/upload-artifact@v7
         with:
-          name: allinone_jar_17
+          name: allinone_jar_25
           path: workspace/allinone.jar
   code_cov:
     needs:
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
       - name: Bazel Junit Tests and Coverage
         run: |
           bazel coverage //projects/... \

--- a/docs/building_and_running/README.md
+++ b/docs/building_and_running/README.md
@@ -8,7 +8,7 @@ or can be [set up separately](https://github.com/batfish/pybatfish#how-do-i-get-
 
 ## Prerequisites
 
-- Java 17 JDK
+- Java JDK 21 (minimum) or 25 (preferred)
 - Python 3.10 or later (for Pybatfish)
 - git
 - [`bazelisk`](https://github.com/bazelbuild/bazelisk#installation)
@@ -32,11 +32,11 @@ Do the following before doing anything
 
 1. Open a fresh terminal to ensure the utilities are correctly picked up.
 
-1. If you don't already have the Java 17 JDK installed, first install homebrew cask and then Java 17
-   using the following commands.
+1. If you don't already have a suitable Java JDK installed, first install homebrew cask and then Java
+   using the following commands. Batfish requires JDK 21 at a minimum; JDK 25 is preferred.
 
    - `brew tap homebrew/cask-versions`
-   - `brew install --cask temurin17`
+   - `brew install --cask temurin@25`
 
 1. If you don't already have it, install Bazelisk.
    - `brew install bazelisk`
@@ -45,9 +45,10 @@ Do the following before doing anything
 
 Do the following before doing anything
 
-1. Install Java 17 and corresponding debug symbols
+1. Install a Java JDK and corresponding debug symbols. Batfish requires JDK 21 at a minimum;
+   JDK 25 is preferred.
 
-   - `sudo apt install openjdk-17-jdk openjdk-17-dbg`
+   - `sudo apt install openjdk-21-jdk openjdk-21-dbg`
 
 1. If you don't already have it, install `wget`:
 
@@ -73,20 +74,20 @@ Do the following before doing anything
 ### Note: multiple versions of Java
 
 If you have multiple versions of Java installed on your machine, the default `java`/`javac` commands may still not be
-using JVM 17. In that case, you can force the version of Java in use by setting `JAVA_HOME`. @dhalperi has these aliases
+using a supported JVM. In that case, you can force the version of Java in use by setting `JAVA_HOME`. @dhalperi has these aliases
 in his `.zshrc` to control which Java is running in a given shell on macOS:
 
 ```sh
 # Java options
-# j11q switches to Java 11, quietly. Could make a loud version that runs `java -version` after.
-function j11q() {
-    export JAVA_HOME=`/usr/libexec/java_home -v 11`
+# j21q switches to Java 21, quietly. Could make a loud version that runs `java -version` after.
+function j21q() {
+    export JAVA_HOME=`/usr/libexec/java_home -v 21`
 }
-function j17q() {
-    export JAVA_HOME=`/usr/libexec/java_home -v 17`
+function j25q() {
+    export JAVA_HOME=`/usr/libexec/java_home -v 25`
 }
-# Default to Java 17.
-j17q
+# Default to Java 25.
+j25q
 ```
 
 ## Installation steps

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -24,7 +24,7 @@ This section provides information about the Batfish development environment, tec
 
 ### Prerequisites
 
-- Java 17 or later
+- Java JDK 21 (minimum) or 25 (preferred)
 - [Bazelisk](https://github.com/bazelbuild/bazelisk#installation)
 - Python 3.10 or later (for Pybatfish)
 - Docker (for containerized deployment)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,7 +105,7 @@ REPIN=1 bazel run @maven//:pin
 **Diagnosis**:
 ```bash
 # Check Java version
-java -version  # Should be Java 17
+java -version  # Should be JDK 21 (minimum) or 25 (preferred)
 
 # Check what Bazel is using
 bazel info --jvmopt
@@ -114,11 +114,10 @@ bazel info --jvmopt
 **Solutions**:
 ```bash
 # Set JAVA_HOME explicitly
-export JAVA_HOME=/path/to/java17
+export JAVA_HOME=/path/to/java25
 
-# Or use Bazel config
-echo "build --java_language_version=17" >> ~/.bazelrc
-echo "build --tool_java_language_version=17" >> ~/.bazelrc
+# Or use Bazel config to pin the runtime
+echo "build --java_runtime_version=remotejdk_25" >> ~/.bazelrc
 ```
 
 ---

--- a/docs/tutorials/adding_vendor_support.md
+++ b/docs/tutorials/adding_vendor_support.md
@@ -45,7 +45,7 @@ re-running the pipeline for each newly-exercised feature. SR-OS was built this w
 1. **ANTLR4 basics**: lexer/parser concepts. New to it? Read the
    [example code](../example_code/new_vendor/) (the "CoolNOS" scaffold) and
    [ANTLR4 tips](../parsing/antlr4_tips.md) first.
-2. **Java 17**, and comfort reading existing vendor code.
+2. **Java JDK 21 or later** (25 preferred), and comfort reading existing vendor code.
 3. **Read the canonical docs first.** Read [Parsing](../parsing/README.md), the
    [Implementation Guide](../parsing/implementation_guide.md), and
    [Extraction](../extraction/README.md) before writing code — the steps below assume

--- a/docs/tutorials/contributing_first_pr.md
+++ b/docs/tutorials/contributing_first_pr.md
@@ -25,7 +25,7 @@ You'll make a simple documentation fix or improvement to Batfish. This could be:
 Before starting, ensure you have:
 
 1. **Git installed**: `git --version`
-2. **Java 17 JDK**: `java -version` (should show 17.x.x)
+2. **Java JDK**: `java -version` (should show 21.x.x or later; 25 preferred)
 3. **Bazelisk**: `bazelisk version`
 4. **GitHub account**: [Create one here](https://github.com/signup)
 


### PR DESCRIPTION
Batfish now requires a minimum of JDK 21 to run and prefers JDK 25.

- pre-commit.yml: bump the three setup-java Temurin steps 17 -> 25,
  update the matching bazel-17 cache-key labels to bazel-25, and rename
  the built-JAR artifact allinone_jar_17 -> allinone_jar_25. The
  artifact has no consumers in batfish, pybatfish, or lab-validation.
- Developer docs (building_and_running, development, troubleshooting,
  and the two tutorials): state the JDK 21 minimum / 25 preferred
  policy and update install commands and the multi-JDK JAVA_HOME notes.

Leaves .bazelrc untouched: it already runs on remotejdk_25, and the
java_language_version/tool_java_runtime_version=17 settings are the
bytecode-target floor (17 bytecode runs on 21+), separate from the
runtime-version policy.

----

Prompt:
```
now do ../batfish - the big one. Make sure the CI, cache keys, and
developer docs are updated.
```
