### PR TITLE
bazel: target Java 21 source level

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,8 @@
 # Test targets are required to depend on our junit rather than using the one provided by Bazel
 build --explicit_java_test_deps
-build --java_language_version=17
+build --java_language_version=21
 build --java_runtime_version=remotejdk_25
-build --tool_java_runtime_version=17
+build --tool_java_runtime_version=21
 
 # Error Prone warnings to enforce
 build --javacopt "-Xep:WildcardImport:ERROR"

--- a/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
+++ b/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
@@ -96,6 +96,11 @@ public class BatfishJobExecutor {
    * @param <JobResultT> type of {@link BatfishJobResult} which will contain the result of the job
    * @param <OutputT> type of data structure to which job result will be applied
    */
+  // We call pool.shutdown() in a finally that spans everything after the pool is created, rather
+  // than using try-with-resources: ExecutorService.close() blocks awaiting termination, but on the
+  // error path we want the exception to propagate immediately without waiting for in-flight jobs.
+  // PMD's CloseResource only recognizes close()/try-with-resources, not shutdown(), so suppress it.
+  @SuppressWarnings("PMD.CloseResource")
   private <
           JobT extends BatfishJob<JobResultT>,
           AnswerElementT extends AnswerElement,
@@ -110,20 +115,21 @@ public class BatfishJobExecutor {
 
     // Initializing executors
     ExecutorService pool = createExecutorService();
-    ExecutorCompletionService<JobResultT> completionService = new ExecutorCompletionService<>(pool);
-
-    if (!_settings.getSequential() && _settings.getShuffleJobs()) {
-      Collections.shuffle(jobs);
-    }
-
-    for (JobT job : jobs) {
-      completionService.submit(job);
-    }
-
-    initializeJobsStats(jobs, description);
-    boolean processingError = false;
-    List<BatfishException> failureCauses = new ArrayList<>();
     try {
+      ExecutorCompletionService<JobResultT> completionService =
+          new ExecutorCompletionService<>(pool);
+
+      if (!_settings.getSequential() && _settings.getShuffleJobs()) {
+        Collections.shuffle(jobs);
+      }
+
+      for (JobT job : jobs) {
+        completionService.submit(job);
+      }
+
+      initializeJobsStats(jobs, description);
+      boolean processingError = false;
+      List<BatfishException> failureCauses = new ArrayList<>();
       for (int i = 0; i < jobs.size(); i++) {
 
         JobResultT result = null;
@@ -144,14 +150,14 @@ public class BatfishJobExecutor {
           processingError = true;
         }
       }
+
+      if (processingError) {
+        handleProcessingError(jobs, failureCauses, haltOnProcessingError);
+      } else if (!_logger.isActive(BatfishLogger.LEVEL_INFO)) {
+        _logger.info("All jobs executed successfully\n");
+      }
     } finally {
       pool.shutdown();
-    }
-
-    if (processingError) {
-      handleProcessingError(jobs, failureCauses, haltOnProcessingError);
-    } else if (!_logger.isActive(BatfishLogger.LEVEL_INFO)) {
-      _logger.info("All jobs executed successfully\n");
     }
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/SnapshotMetadataMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/SnapshotMetadataMgrTest.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -59,35 +58,35 @@ public class SnapshotMetadataMgrTest {
     // Start a background reader thread, which will do nothing but read continuously asserting
     // invariants over the read metadata.
     final AtomicBoolean done = new AtomicBoolean(false);
-    ExecutorService pollerService = Executors.newSingleThreadExecutor();
-    Future<Long> loops =
-        pollerService.submit(
-            () -> {
-              long count = 0;
-              Instant last = Instant.MIN;
-              while (!done.get()) {
-                ++count;
-                SnapshotMetadata meta = manager.readMetadata(net, ss);
-                assertThat(meta, notNullValue());
-                Instant cur = meta.getCreationTimestamp();
-                assertThat(cur, greaterThanOrEqualTo(last));
-                last = cur;
-              }
-              return count;
-            });
+    try (ExecutorService pollerService = Executors.newSingleThreadExecutor()) {
+      Future<Long> loops =
+          pollerService.submit(
+              () -> {
+                long count = 0;
+                Instant last = Instant.MIN;
+                while (!done.get()) {
+                  ++count;
+                  SnapshotMetadata meta = manager.readMetadata(net, ss);
+                  assertThat(meta, notNullValue());
+                  Instant cur = meta.getCreationTimestamp();
+                  assertThat(cur, greaterThanOrEqualTo(last));
+                  last = cur;
+                }
+                return count;
+              });
 
-    // Write continuously (in competition with the background reader).
-    for (int i = 0; i < writes; ++i) {
-      manager.writeMetadata(new SnapshotMetadata(Instant.now(), null), net, ss);
+      // Write continuously (in competition with the background reader).
+      for (int i = 0; i < writes; ++i) {
+        manager.writeMetadata(new SnapshotMetadata(Instant.now(), null), net, ss);
+      }
+
+      // Declare the test done so the reader stops.
+      done.set(true);
+      // 1. If there was an invariant violated in the reader thread, the loops.get() call will
+      // throw.
+      // 2. The loop must have run at least once. This mainly guards against an error in the test.
+      assertThat(loops.get(), greaterThanOrEqualTo(1L));
     }
-
-    // Declare the test done so the reader stops.
-    done.set(true);
-    // 1. If there was an invariant violated in the reader thread, the loops.get() call will throw.
-    // 2. The loop must have run at least once. This mainly guards against an error in the test.
-    assertThat(loops.get(), greaterThanOrEqualTo(1L));
-
-    // Shutdown cleanly.
-    pollerService.awaitTermination(1, TimeUnit.SECONDS);
+    // try-with-resources shuts down the executor and awaits termination on close.
   }
 }


### PR DESCRIPTION
Batfish's minimum supported runtime is now JDK 21, so raise the source
language level from 17 to 21 to allow use of Java 18-21 language
features. Bump tool_java_runtime_version to match; the build already
runs on remotejdk_25.

Raising the tool runtime to JDK 21 makes PMD run on a JDK where
ExecutorService implements AutoCloseable (Java 19+), so its CloseResource
rule now flags ExecutorService locals. Both flagged spots were real
leaks on some path:

- SnapshotMetadataMgrTest called awaitTermination without ever calling
  shutdown, so the executor and its thread were never reclaimed. Wrap it
  in try-with-resources, whose close() shuts down and awaits termination.
- BatfishJobExecutor shut the pool down in a finally, but the finally
  only spanned the result-collection loop; the pool was created earlier
  and the intervening setup (shuffle, submit, stats init) could throw and
  leak it. Widen the try/finally to cover everything after pool creation.
  Keep shutdown() rather than try-with-resources: close() blocks awaiting
  termination, but the error path intentionally propagates immediately
  without waiting for in-flight jobs, so CloseResource is suppressed here.
