### PR TITLE
ios-xr: test route-target extraction with 4-byte asplain ASN (#10062)

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -18,9 +19,11 @@ import org.batfish.config.Settings;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
 import org.batfish.main.Batfish;
 import org.batfish.representation.cisco_xr.CiscoXrConfiguration;
+import org.batfish.representation.cisco_xr.VrfAddressFamily;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -88,5 +91,23 @@ public final class GitHub10062Test {
     assertThat(c.getVrfs().get("bad_ip_admin").getRouteDistinguisher(), nullValue());
     // invalid: 4-byte ASN administrator requires a 2-byte assigned number
     assertThat(c.getVrfs().get("bad_asn4_val4").getRouteDistinguisher(), nullValue());
+  }
+
+  @Test
+  public void testVrfRouteTargetExtraction() {
+    // Route-targets under router bgp / vrf / address-family, including a 4-byte asplain
+    // ASN administrator (the extcommunity/RT half of GH-10062). The 4-byte forms must both
+    // parse cleanly and be extracted onto the VRF address-family import/export sets.
+    CiscoXrConfiguration c = parseVendorConfig("gh10062rt");
+    assertThat(c.getVrfs(), hasKeys("default", "rt_test"));
+    VrfAddressFamily af = c.getVrfs().get("rt_test").getIpv4UnicastAddressFamily();
+    assertThat(
+        af.getRouteTargetImport(),
+        containsInAnyOrder(
+            ExtendedCommunity.target(65000L, 100L),
+            ExtendedCommunity.target(4200000001L, 200L)));
+    assertThat(
+        af.getRouteTargetExport(),
+        containsInAnyOrder(ExtendedCommunity.target(4200000001L, 300L)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
@@ -104,10 +104,8 @@ public final class GitHub10062Test {
     assertThat(
         af.getRouteTargetImport(),
         containsInAnyOrder(
-            ExtendedCommunity.target(65000L, 100L),
-            ExtendedCommunity.target(4200000001L, 200L)));
+            ExtendedCommunity.target(65000L, 100L), ExtendedCommunity.target(4200000001L, 200L)));
     assertThat(
-        af.getRouteTargetExport(),
-        containsInAnyOrder(ExtendedCommunity.target(4200000001L, 300L)));
+        af.getRouteTargetExport(), containsInAnyOrder(ExtendedCommunity.target(4200000001L, 300L)));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh10062rt
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh10062rt
@@ -1,0 +1,17 @@
+hostname gh10062rt
+vrf rt_test
+!
+router bgp 4200000001
+ vrf rt_test
+  address-family ipv4 unicast
+   import route-target
+    65000:100
+    4200000001:200
+   !
+   export route-target
+    4200000001:300
+   !
+  !
+ !
+!
+end


### PR DESCRIPTION
Adds regression coverage for the extcommunity/route-target half of #10062.

A 4-byte asplain ASN administrator in `import`/`export route-target` under
`router bgp / vrf / address-family ipv4 unicast` now parses cleanly and is
extracted onto the VRF address-family route-target import/export sets. This
complements the `rd` fix in #10066 (which handled the route-distinguisher half).

New test `GitHub10062Test.testVrfRouteTargetExtraction` + `testconfigs/gh10062rt`:
asserts the import set contains `65000:100` and `4200000001:200`, and the export
set contains `4200000001:300`, as `ExtendedCommunity.target(asn, value)`.

Verified: `bazel test //projects/batfish/src/test/java/org/batfish/grammar/cisco_xr:tests` passes.