### PR TITLE
TransferBDD: build symbolic routes over the analysis's canonical route

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/ModelGeneration.java
@@ -237,12 +237,22 @@ public class ModelGeneration {
    */
   public static AbstractRoute satAssignmentToInputRoute(
       BDD model, ConfigAtomicPredicates configAPs) {
-    BDDRoute bddRoute = new BDDRoute(model.getFactory(), configAPs);
-    RoutingProtocol p = bddRoute.getProtocolHistory().satAssignmentToValue(model);
+    return satAssignmentToInputRoute(model, new BDDRoute(model.getFactory(), configAPs), configAPs);
+  }
+
+  /**
+   * As {@link #satAssignmentToInputRoute(BDD, ConfigAtomicPredicates)}, but takes the analysis's
+   * canonical route explicitly. {@code model}'s variables must be those of {@code identityRoute};
+   * pass the {@link TransferBDD#getOriginalRoute()} the model was produced over so decoding is
+   * correct even when that route is not at the default variable positions.
+   */
+  public static AbstractRoute satAssignmentToInputRoute(
+      BDD model, BDDRoute identityRoute, ConfigAtomicPredicates configAPs) {
+    RoutingProtocol p = identityRoute.getProtocolHistory().satAssignmentToValue(model);
     if (p == RoutingProtocol.STATIC) {
-      return satAssignmentToStaticInputRoute(model, configAPs);
+      return satAssignmentToStaticInputRoute(model, identityRoute, configAPs);
     } else if (BDDRoute.ALL_BGP_PROTOCOLS.contains(p)) {
-      return satAssignmentToBgpInputRoute(model, configAPs);
+      return satAssignmentToBgpRoute(model, identityRoute, configAPs).build();
     } else {
       throw new IllegalArgumentException("Unexpected routing protocol " + p);
     }
@@ -258,8 +268,18 @@ public class ModelGeneration {
    */
   public static Bgpv4Route satAssignmentToBgpInputRoute(
       BDD model, ConfigAtomicPredicates configAPs) {
-    return satAssignmentToBgpRoute(model, new BDDRoute(model.getFactory(), configAPs), configAPs)
-        .build();
+    return satAssignmentToBgpInputRoute(
+        model, new BDDRoute(model.getFactory(), configAPs), configAPs);
+  }
+
+  /**
+   * As {@link #satAssignmentToBgpInputRoute(BDD, ConfigAtomicPredicates)}, but takes the analysis's
+   * canonical route explicitly (see {@link #satAssignmentToInputRoute(BDD, BDDRoute,
+   * ConfigAtomicPredicates)}).
+   */
+  public static Bgpv4Route satAssignmentToBgpInputRoute(
+      BDD model, BDDRoute identityRoute, ConfigAtomicPredicates configAPs) {
+    return satAssignmentToBgpRoute(model, identityRoute, configAPs).build();
   }
 
   /**
@@ -271,18 +291,16 @@ public class ModelGeneration {
    * @return a static route
    */
   private static StaticRoute satAssignmentToStaticInputRoute(
-      BDD model, ConfigAtomicPredicates configAPs) {
-
-    BDDRoute bddRoute = new BDDRoute(model.getFactory(), configAPs);
+      BDD model, BDDRoute identityRoute, ConfigAtomicPredicates configAPs) {
 
     StaticRoute.Builder builder = StaticRoute.builder();
     // dummy value
     builder.setAdministrativeCost(0);
-    Ip ip = Ip.create(bddRoute.getPrefix().satAssignmentToLong(model));
-    long len = bddRoute.getPrefixLength().satAssignmentToLong(model);
+    Ip ip = Ip.create(identityRoute.getPrefix().satAssignmentToLong(model));
+    long len = identityRoute.getPrefixLength().satAssignmentToLong(model);
     builder.setNetwork(Prefix.create(ip, (int) len));
-    builder.setNextHop(satAssignmentToNextHop(model, bddRoute, configAPs));
-    builder.setTag(bddRoute.getTag().satAssignmentToLong(model));
+    builder.setNextHop(satAssignmentToNextHop(model, identityRoute, configAPs));
+    builder.setTag(identityRoute.getTag().satAssignmentToLong(model));
 
     return builder.build();
   }
@@ -492,15 +510,26 @@ public class ModelGeneration {
    */
   public static RouteMapEnvironment satAssignmentToEnvironment(
       BDD model, ConfigAtomicPredicates configAPs) {
+    return satAssignmentToEnvironment(
+        model, new BDDRoute(model.getFactory(), configAPs), configAPs);
+  }
 
-    BDDRoute r = new BDDRoute(model.getFactory(), configAPs);
+  /**
+   * As {@link #satAssignmentToEnvironment(BDD, ConfigAtomicPredicates)}, but takes the analysis's
+   * canonical route explicitly (see {@link #satAssignmentToInputRoute(BDD, BDDRoute,
+   * ConfigAtomicPredicates)}).
+   */
+  public static RouteMapEnvironment satAssignmentToEnvironment(
+      BDD model, BDDRoute identityRoute, ConfigAtomicPredicates configAPs) {
 
-    List<String> successfulTracks = allSatisfyingItems(configAPs.getTracks(), r.getTracks(), model);
+    List<String> successfulTracks =
+        allSatisfyingItems(configAPs.getTracks(), identityRoute.getTracks(), model);
 
     // get the optional (and hence possibly null) source VRF
-    String sourceVrf = optionalSatisfyingItem(configAPs.getSourceVrfs(), r.getSourceVrfs(), model);
+    String sourceVrf =
+        optionalSatisfyingItem(configAPs.getSourceVrfs(), identityRoute.getSourceVrfs(), model);
 
-    Ip remoteIp = satAssignmentToPeerAddress(model, r, configAPs);
+    Ip remoteIp = satAssignmentToPeerAddress(model, identityRoute, configAPs);
 
     return new RouteMapEnvironment(successfulTracks::contains, sourceVrf, remoteIp);
   }
@@ -555,32 +584,41 @@ public class ModelGeneration {
   // like the prefix, if they are consistent with the constraints. Note that the model is a partial
   // assignment -- variables that don't matter are not assigned a truth value.
   public static BDD constraintsToModel(BDD constraints, ConfigAtomicPredicates configAPs) {
-    BDDRoute route = new BDDRoute(constraints.getFactory(), configAPs);
+    return constraintsToModel(constraints, new BDDRoute(constraints.getFactory(), configAPs));
+  }
+
+  /**
+   * As {@link #constraintsToModel(BDD, ConfigAtomicPredicates)}, but takes the analysis's canonical
+   * route explicitly. {@code constraints}'s variables must be those of {@code identityRoute}; pass
+   * the {@link TransferBDD#getOriginalRoute()} the constraints were produced over so this is
+   * correct even when that route is not at the default variable positions.
+   */
+  public static BDD constraintsToModel(BDD constraints, BDDRoute identityRoute) {
     // set the protocol field to BGP if it is consistent with the constraints
-    BDD isBGP = route.getProtocolHistory().value(RoutingProtocol.BGP);
-    BDD defaultLP = route.getLocalPref().value(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE);
+    BDD isBGP = identityRoute.getProtocolHistory().value(RoutingProtocol.BGP);
+    BDD defaultLP = identityRoute.getLocalPref().value(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE);
 
     // Set the prefixes to one of the well-known ones
     BDD googlePrefix =
-        route
+        identityRoute
             .getPrefix()
             .value(Ip.parse("8.8.8.0").asLong())
-            .and(route.getPrefixLength().value(24));
+            .and(identityRoute.getPrefixLength().value(24));
     BDD amazonPrefix =
-        route
+        identityRoute
             .getPrefix()
             .value(Ip.parse("52.0.0.0").asLong())
-            .and(route.getPrefixLength().value(10));
+            .and(identityRoute.getPrefixLength().value(10));
     BDD rfc1918 =
-        route
+        identityRoute
             .getPrefix()
             .value(Ip.parse("10.0.0.0").asLong())
-            .and(route.getPrefixLength().value(8));
+            .and(identityRoute.getPrefixLength().value(8));
     BDD prefixes = googlePrefix.or(amazonPrefix).or(rfc1918);
     // Alternatively, if the above fails set the prefix to something >= 10.0.0.0 and the length to
     // something >= 16.
     BDD lessPreferredPrefixes =
-        route.getPrefix().geq(167772160).and(route.getPrefixLength().geq(16));
+        identityRoute.getPrefix().geq(167772160).and(identityRoute.getPrefixLength().geq(16));
     BDD augmentedConstraints = tryAddingConstraint(isBGP, constraints);
     augmentedConstraints = tryAddingConstraint(defaultLP, augmentedConstraints);
     augmentedConstraints = tryAddingConstraint(prefixes, augmentedConstraints);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -1580,7 +1580,7 @@ public class TransferBDD {
    */
   public List<TransferReturn> computePaths(
       List<Statement> statements, Context context, boolean retainAllPaths) {
-    BDDRoute o = new BDDRoute(_factory, _configAtomicPredicates);
+    BDDRoute o = _originalRoute.deepCopy();
     TransferParam p = new TransferParam(false);
     TransferBDDState state = new TransferBDDState(p, new TransferResult(o));
     return computePaths(state, statements, context, retainAllPaths).stream()

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDDUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDDUtils.java
@@ -7,7 +7,6 @@ import java.util.stream.Stream;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
 import net.sf.javabdd.BDDPairing;
-import org.batfish.minesweeper.ConfigAtomicPredicates;
 
 /**
  * Various utility methods for working with the results of the symbolic routing analysis {@link
@@ -74,14 +73,8 @@ public class TransferBDDUtils {
    */
   public static BDDPairing makeRoutePairing(BDDRoute route, TransferBDD tbdd) {
     BDDFactory factory = tbdd.getFactory();
-    ConfigAtomicPredicates configAPs = tbdd.getConfigAtomicPredicates();
-
-    // create a fresh BDDRoute to pair with the given one
-    BDDRoute freshRoute = new BDDRoute(factory, configAPs);
     BDDPairing pairing = factory.makePair();
-
-    route.augmentPairing(freshRoute, pairing);
-
+    route.augmentPairing(tbdd.getOriginalRoute(), pairing);
     return pairing;
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/compareroutepolicies/CompareRoutePoliciesUtils.java
@@ -444,7 +444,7 @@ public final class CompareRoutePoliciesUtils {
     TransferBDD tBDD = new TransferBDD(configAPs);
 
     // Generate well-formedness constraints
-    BDD wf = new BDDRoute(tBDD.getFactory(), configAPs).wellFormednessConstraints(true);
+    BDD wf = tBDD.getOriginalRoute().wellFormednessConstraints(true);
 
     // The set of paths for the current policy
     List<TransferReturn> paths = computePaths(tBDD, referencePolicy);
@@ -577,51 +577,65 @@ public final class CompareRoutePoliciesUtils {
    */
   public static List<Result.RouteAttributeType> relevantAttributesFor(
       BDD constraint, ConfigAtomicPredicates configAPs) {
+    return relevantAttributesFor(constraint, new BDDRoute(constraint.getFactory(), configAPs));
+  }
+
+  /**
+   * As {@link #relevantAttributesFor(BDD, ConfigAtomicPredicates)}, but takes the analysis's
+   * canonical route explicitly. {@code constraint}'s variables must be those of {@code
+   * identityRoute}; pass the {@link TransferBDD#getOriginalRoute()} the constraint was produced
+   * over so this is correct even when that route is not at the default variable positions.
+   *
+   * @param constraint predicate that represents the input space leading to a particular difference
+   * @param identityRoute the analysis's canonical route, whose variables {@code constraint} is over
+   * @return a list of route attributes that are relevant for this difference
+   */
+  public static List<Result.RouteAttributeType> relevantAttributesFor(
+      BDD constraint, BDDRoute identityRoute) {
     ImmutableList.Builder<Result.RouteAttributeType> result = new ImmutableList.Builder<>();
 
     BDDFactory factory = constraint.getFactory();
-    BDDRoute origRoute = new BDDRoute(factory, configAPs);
 
     BDD support = constraint.support();
 
-    if (support.testsVars(origRoute.getAdminDist().support())) {
+    if (support.testsVars(identityRoute.getAdminDist().support())) {
       result.add(ADMINISTRATIVE_DISTANCE);
     }
-    if (support.testsVars(origRoute.getAsPathRegexAtomicPredicates().support())) {
+    if (support.testsVars(identityRoute.getAsPathRegexAtomicPredicates().support())) {
       result.add(AS_PATH);
     }
-    if (support.testsVars(origRoute.getClusterListLength().support())) {
+    if (support.testsVars(identityRoute.getClusterListLength().support())) {
       result.add(CLUSTER_LIST);
     }
-    if (support.testsVars(factory.andAll(origRoute.getCommunityAtomicPredicates()))) {
+    if (support.testsVars(factory.andAll(identityRoute.getCommunityAtomicPredicates()))) {
       result.add(COMMUNITIES);
     }
-    if (support.testsVars(origRoute.getLocalPref().support())) {
+    if (support.testsVars(identityRoute.getLocalPref().support())) {
       result.add(LOCAL_PREFERENCE);
     }
-    if (support.testsVars(origRoute.getMed().support())) {
+    if (support.testsVars(identityRoute.getMed().support())) {
       result.add(METRIC);
     }
     if (support.testsVars(
-        origRoute.getPrefix().support().and(origRoute.getPrefixLength().support()))) {
+        identityRoute.getPrefix().support().and(identityRoute.getPrefixLength().support()))) {
       result.add(NETWORK);
     }
-    if (support.testsVars(origRoute.getNextHop().support())) {
+    if (support.testsVars(identityRoute.getNextHop().support())) {
       result.add(NEXT_HOP);
     }
-    if (support.testsVars(origRoute.getOriginType().support())) {
+    if (support.testsVars(identityRoute.getOriginType().support())) {
       result.add(ORIGIN_TYPE);
     }
-    if (support.testsVars(origRoute.getProtocolHistory().support())) {
+    if (support.testsVars(identityRoute.getProtocolHistory().support())) {
       result.add(PROTOCOL);
     }
-    if (support.testsVars(origRoute.getTag().support())) {
+    if (support.testsVars(identityRoute.getTag().support())) {
       result.add(TAG);
     }
-    if (support.testsVars(origRoute.getTunnelEncapsulationAttribute().support())) {
+    if (support.testsVars(identityRoute.getTunnelEncapsulationAttribute().support())) {
       result.add(TUNNEL_ENCAPSULATION_ATTRIBUTE);
     }
-    if (support.testsVars(origRoute.getWeight().support())) {
+    if (support.testsVars(identityRoute.getWeight().support())) {
       result.add(WEIGHT);
     }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -529,8 +529,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     relevantPaths.addAll(pathMap.get(true));
     Set<PrefixSpace> blockedPrefixes = new HashSet<>();
     BDD inConstraints =
-        routeConstraintsToBDD(
-            _inputConstraints, new BDDRoute(tbdd.getFactory(), configAPs), false, tbdd, context);
+        routeConstraintsToBDD(_inputConstraints, tbdd.getOriginalRoute(), false, tbdd, context);
     ImmutableList.Builder<Row> builder = ImmutableList.builder();
     for (TransferReturn path : relevantPaths) {
       BDD pathAnnouncements = path.getInputConstraints();

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -357,6 +357,33 @@ public class TransferBDDTest {
     assertTrue(validatePaths(policy, paths, tbdd.getFactory()));
   }
 
+  /**
+   * When constructed with an {@code originalRoute} whose variables are not at the default
+   * positions, {@code computePaths} must express its output routes over THAT route's variables, not
+   * a fresh default-layout {@link BDDRoute}'s. Here the route is allocated past a block of reserved
+   * shared bits (via {@link BDDRouteFactory}), so a default-layout output route would sit on
+   * entirely different variables and the accept path's output would not equal the supplied route.
+   */
+  @Test
+  public void testComputePathsHonorsOriginalRouteVariables() {
+    RoutingPolicy policy =
+        _policyBuilder.addStatement(new StaticStatement(Statements.ExitAccept)).build();
+    _configAPs = forDevice(_batfish, _batfish.getSnapshot(), HOSTNAME);
+
+    // originalRoute allocated after 10 reserved shared bits => non-default variable positions.
+    BDDRouteFactory routeFactory =
+        new BDDRouteFactory(_configAPs, /* numRoutes= */ 1, /* numSharedBits= */ 10);
+    BDDRoute originalRoute = routeFactory.identityRoute(0);
+    TransferBDD tbdd = new TransferBDD(routeFactory.getFactory(), originalRoute, _configAPs);
+
+    List<TransferReturn> paths = tbdd.computePaths(policy, true);
+
+    assertThat(paths, hasSize(1));
+    // The accepted path is the identity: its output route must be the supplied originalRoute (same
+    // variables), not a fresh default-layout route.
+    assertEquals(originalRoute, paths.get(0).getOutputRoute());
+  }
+
   @Test
   public void testEmptyPolicy() {
 


### PR DESCRIPTION
Several places in the symbolic route analysis built a fresh
new BDDRoute(factory, configAtomicPredicates) at the default variable
positions and then related it against routes/constraints the analysis
produces, which are expressed over the _originalRoute the TransferBDD was
constructed with. The two agree only when _originalRoute is itself at the
default positions; a caller that supplies an _originalRoute elsewhere --
e.g. one built by BDDRouteFactory interleaved with other routes, or offset
past reserved leading variables -- gets a variable mismatch, yielding wrong
results or large BDD blowups. With the default _originalRoute the two are
identical, so this is a no-op for existing callers.

Fixed the sites where the analysis's canonical route is directly in scope:
- TransferBDD.computePaths seeds from _originalRoute rather than a fresh
  route.
- TransferBDDUtils.makeRoutePairing pairs with getOriginalRoute() rather
  than a fresh route.
- SearchRoutePoliciesAnswerer / CompareRoutePoliciesUtils build the
  input-constraint / well-formedness route from getOriginalRoute().

For the decoder helpers that are reached from other pipelines and only had
a ConfigAtomicPredicates (ModelGeneration.satAssignmentTo*/constraintsToModel
and CompareRoutePoliciesUtils.relevantAttributesFor), added an overload that
takes the canonical identityRoute explicitly; the existing
ConfigAtomicPredicates overload builds the default-position route and
delegates, so current callers are unchanged while a non-default caller can
now decode correctly.

Adds a regression test that runs computePaths with an originalRoute placed
past reserved shared bits and checks the accept path's output route is over
that route's variables.