### PR TITLE
Model interface-level IS-IS enable/passive (Arista EOS + Cisco)

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/Legacy_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/Legacy_interface.g4
@@ -711,7 +711,7 @@ if_isis_circuit_type
 
 if_isis_enable
 :
-   ENABLE num = dec NEWLINE
+   ENABLE name = variable NEWLINE
 ;
 
 if_isis_hello_interval

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -634,7 +634,9 @@ import org.batfish.grammar.cisco.CiscoParser.If_ip_verifyContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_vrf_forwardingContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_vrf_sitemapContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ipv6_traffic_filterContext;
+import org.batfish.grammar.cisco.CiscoParser.If_isis_enableContext;
 import org.batfish.grammar.cisco.CiscoParser.If_isis_metricContext;
+import org.batfish.grammar.cisco.CiscoParser.If_isis_passiveContext;
 import org.batfish.grammar.cisco.CiscoParser.If_member_interfaceContext;
 import org.batfish.grammar.cisco.CiscoParser.If_mtuContext;
 import org.batfish.grammar.cisco.CiscoParser.If_service_policyContext;
@@ -5702,6 +5704,20 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     long metric = toLong(ctx.metric);
     for (Interface iface : _currentInterfaces) {
       iface.setIsisCost(metric);
+    }
+  }
+
+  @Override
+  public void exitIf_isis_enable(If_isis_enableContext ctx) {
+    for (Interface iface : _currentInterfaces) {
+      iface.setIsisInterfaceMode(IsisInterfaceMode.ACTIVE);
+    }
+  }
+
+  @Override
+  public void exitIf_isis_passive(If_isis_passiveContext ctx) {
+    for (Interface iface : _currentInterfaces) {
+      iface.setIsisInterfaceMode(IsisInterfaceMode.PASSIVE);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -609,7 +609,9 @@ import org.batfish.vendor.arista.grammar.AristaParser.If_ip_inband_access_groupC
 import org.batfish.vendor.arista.grammar.AristaParser.If_ip_local_proxy_arp_eosContext;
 import org.batfish.vendor.arista.grammar.AristaParser.If_ip_virtual_routerContext;
 import org.batfish.vendor.arista.grammar.AristaParser.If_ipv6_traffic_filterContext;
+import org.batfish.vendor.arista.grammar.AristaParser.If_isis_enableContext;
 import org.batfish.vendor.arista.grammar.AristaParser.If_isis_metricContext;
+import org.batfish.vendor.arista.grammar.AristaParser.If_isis_passiveContext;
 import org.batfish.vendor.arista.grammar.AristaParser.If_member_interfaceContext;
 import org.batfish.vendor.arista.grammar.AristaParser.If_mtuContext;
 import org.batfish.vendor.arista.grammar.AristaParser.If_no_autostateContext;
@@ -5409,6 +5411,20 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
     long metric = toLong(ctx.metric);
     for (Interface iface : _currentInterfaces) {
       iface.setIsisCost(metric);
+    }
+  }
+
+  @Override
+  public void exitIf_isis_enable(If_isis_enableContext ctx) {
+    for (Interface iface : _currentInterfaces) {
+      iface.setIsisInterfaceMode(IsisInterfaceMode.ACTIVE);
+    }
+  }
+
+  @Override
+  public void exitIf_isis_passive(If_isis_passiveContext ctx) {
+    for (Interface iface : _currentInterfaces) {
+      iface.setIsisInterfaceMode(IsisInterfaceMode.PASSIVE);
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1882,6 +1882,10 @@ public final class CiscoGrammarTest {
 
     assertThat(c, hasInterface("Loopback0", hasIsis(hasLevel2(notNullValue()))));
     assertThat(c, hasInterface("Loopback100", hasIsis(nullValue())));
+    // interface-level "isis enable" makes the interface an active IS-IS interface
+    assertThat(c, hasInterface("Loopback101", hasIsis(hasLevel2(notNullValue()))));
+    // interface-level "isis passive" still models IS-IS on the interface (passive)
+    assertThat(c, hasInterface("Loopback102", hasIsis(hasLevel2(notNullValue()))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -50,6 +50,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasBandwidth;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasEncapsulationVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasIsis;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMlagId;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSpeed;
@@ -59,6 +60,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVrf;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isSwitchport;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
+import static org.batfish.datamodel.matchers.IsisInterfaceSettingsMatchers.hasLevel2;
 import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.datamodel.matchers.MlagMatchers.hasId;
 import static org.batfish.datamodel.matchers.MlagMatchers.hasPeerAddress;
@@ -668,6 +670,17 @@ public class AristaGrammarTest {
         c.getAllInterfaces().get("Ethernet1").getOspfSettings().getCost(),
         equalTo(OspfProcess.DEFAULT_INTERFACE_OSPF_COST));
     assertThat(c.getAllInterfaces().get("Ethernet2").getOspfSettings().getCost(), equalTo(42));
+  }
+
+  @Test
+  public void testIsisInterfaceEnable() throws IOException {
+    // Interface-level "isis enable" makes the interface an active IS-IS interface, and
+    // "isis passive" models it as passive. Both were previously dropped by the extractor.
+    Configuration c = parseConfig("arista-isis");
+    assertThat(c, hasInterface("Loopback0", hasIsis(hasLevel2(notNullValue()))));
+    assertThat(c, hasInterface("Loopback1", hasIsis(hasLevel2(notNullValue()))));
+    // Loopback2 has no interface-level IS-IS config, so it gets no IS-IS settings.
+    assertThat(c, hasInterface("Loopback2", hasIsis(nullValue())));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-isis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-isis
@@ -10,6 +10,14 @@ interface Loopback0
 interface Loopback100
   ip address 153.56.0.1 255.255.255.255
 !
+interface Loopback101
+  ip address 153.56.0.2 255.255.255.255
+  isis enable 1
+!
+interface Loopback102
+  ip address 153.56.0.3 255.255.255.255
+  isis passive
+!
 router isis CORE
   net 49.0001.1722.0020.0001.00
   is-type level-2-only

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista-isis
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista-isis
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista-isis
+!
+interface Loopback0
+   ip address 172.20.20.1/32
+   isis enable CORE
+!
+interface Loopback1
+   ip address 172.20.20.2/32
+   isis enable CORE
+   isis passive
+!
+interface Loopback2
+   ip address 172.20.20.3/32
+!
+router isis CORE
+   net 49.0001.1720.2002.0001.00
+   is-type level-2
+!


### PR DESCRIPTION
## Problem

Interface-level `isis enable` and `isis passive` parse but are silently dropped by the extractors, so the interface IS-IS mode is never set. The vendor-independent conversion only builds `IsisInterfaceSettings` when the mode is set, so Batfish cannot compute IS-IS adjacencies for interfaces that enable IS-IS at the interface level. This affects **Arista EOS** in particular, which enables IS-IS per-interface with `isis enable <instance>`.

## Changes

**Arista (`vendor/arista`):**
- Grammar: `isis enable` on EOS takes an IS-IS **instance name** (`isis enable CORE`), not a number. The rule was `ENABLE num = dec`, which fails to parse real configs. Changed to `ENABLE name = variable` (the same capture used for other instance-name references, e.g. `router isis <name>`). Verified against the Arista EOS User Manual (`isis enable <instance>`).
- Extractor: added `exitIf_isis_enable` (sets `IsisInterfaceMode.ACTIVE`) and `exitIf_isis_passive` (sets `PASSIVE`), mirroring the existing `exitIf_isis_metric`.

**Cisco (`grammar/cisco`, shared IOS path):**
- Extractor: added the same two handlers. `if_isis_enable` / `if_isis_passive` parsed but had no exit handler.

No conversion changes are needed in either vendor: the existing interface → VI IS-IS conversion already reads `getIsisInterfaceMode()` and builds `IsisInterfaceSettings` once the mode is set.

## Tests

- Arista: new `arista-isis` test config + `testIsisInterfaceEnable` — asserts an `isis enable` interface and an `isis passive` interface get IS-IS settings, and an unconfigured interface does not.
- Cisco: extended the `ios-isis` config + `testIosIsisConfigOnInterface` with `isis enable` and `isis passive` interfaces.

Both changes verified by reverting the extractor with the tests in place (tests fail), then restoring (tests pass). Full `cisco:tests` and `arista/grammar:tests` suites pass; `format.check` and checkstyle clean.
