### PR TITLE
palo_alto: split catch-all _null rules into per-token rules

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -74,14 +74,17 @@ newline
    NEWLINE
 ;
 
-s_null
+s_log_collector_null
 :
-    (
-        LOG_COLLECTOR
-        | LOG_COLLECTOR_GROUP
-        | MGT_CONFIG
-    )
-    null_rest_of_line
+   LOG_COLLECTOR null_rest_of_line
+;
+s_log_collector_group_null
+:
+   LOG_COLLECTOR_GROUP null_rest_of_line
+;
+s_mgt_config_null
+:
+   MGT_CONFIG null_rest_of_line
 ;
 
 /*
@@ -108,8 +111,10 @@ statement_config_devices
     | s_application
     | s_application_group
     | s_deviceconfig
+    | s_log_collector_group_null
+    | s_log_collector_null
+    | s_mgt_config_null
     | s_network
-    | s_null
     | s_profiles
     | s_rulebase
     | s_service
@@ -124,7 +129,9 @@ statement_config_devices
  */
 statement_config_general
 :
-    s_null
+    s_log_collector_group_null
+    | s_log_collector_null
+    | s_mgt_config_null
     | s_shared
 ;
 
@@ -144,11 +151,12 @@ statement_template_config
 statement_template_config_devices
 :
     s_deviceconfig
+    | s_log_collector_group_null
+    | s_log_collector_null
+    | s_mgt_config_null
     | s_network
     | s_shared
     | s_vsys
-    // Ignore irrelevant syntax
-    | s_null
 ;
 
 statement_template_stack

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_bgp.g4
@@ -118,9 +118,13 @@ bgppgp_connection_options
 :
     CONNECTION_OPTIONS
     (
-        bgppgp_co_incoming_bgp_connection
+        bgppgp_co_hold_time_null
+        | bgppgp_co_idle_hold_time_null
+        | bgppgp_co_incoming_bgp_connection
+        | bgppgp_co_keep_alive_interval_null
+        | bgppgp_co_min_route_adv_interval_null
         | bgppgp_co_multihop
-        | bgppgp_co_null
+        | bgppgp_co_open_delay_time_null
         | bgppgp_co_outgoing_bgp_connection
     )
 ;
@@ -149,16 +153,25 @@ bgppgp_co_multihop
     MULTIHOP num = uint8 // 0-255
 ;
 
-bgppgp_co_null
+bgppgp_co_hold_time_null
 :
-    (
-       HOLD_TIME
-       | IDLE_HOLD_TIME
-       | KEEP_ALIVE_INTERVAL
-       | MIN_ROUTE_ADV_INTERVAL
-       | OPEN_DELAY_TIME
-    )
-    null_rest_of_line
+   HOLD_TIME null_rest_of_line
+;
+bgppgp_co_idle_hold_time_null
+:
+   IDLE_HOLD_TIME null_rest_of_line
+;
+bgppgp_co_keep_alive_interval_null
+:
+   KEEP_ALIVE_INTERVAL null_rest_of_line
+;
+bgppgp_co_min_route_adv_interval_null
+:
+   MIN_ROUTE_ADV_INTERVAL null_rest_of_line
+;
+bgppgp_co_open_delay_time_null
+:
+   OPEN_DELAY_TIME null_rest_of_line
 ;
 
 bgppgp_co_outgoing_bgp_connection

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_deviceconfig.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_deviceconfig.g4
@@ -82,7 +82,12 @@ sd_system
         | sds_ip_address
         | sds_netmask
         | sds_ntp_servers
-        | sds_null
+        | sds_panorama_server_null
+        | sds_service_null
+        | sds_timezone_null
+        | sds_type_null
+        | sds_update_schedule_null
+        | sds_update_server_null
     )
 ;
 
@@ -131,17 +136,29 @@ sds_ntp_servers
     )
 ;
 
-sds_null
+sds_panorama_server_null
 :
-    (
-        PANORAMA_SERVER
-        | SERVICE
-        | TIMEZONE
-        | TYPE
-        | UPDATE_SCHEDULE
-        | UPDATE_SERVER
-    )
-    null_rest_of_line
+   PANORAMA_SERVER null_rest_of_line
+;
+sds_service_null
+:
+   SERVICE null_rest_of_line
+;
+sds_timezone_null
+:
+   TIMEZONE null_rest_of_line
+;
+sds_type_null
+:
+   TYPE null_rest_of_line
+;
+sds_update_schedule_null
+:
+   UPDATE_SCHEDULE null_rest_of_line
+;
+sds_update_server_null
+:
+   UPDATE_SERVER null_rest_of_line
 ;
 
 sdsd_servers

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
@@ -184,9 +184,13 @@ sniel2_units
 sniel3_common
 :
     (
-        sniel3_ip
+        sniel3_adjust_tcp_mss_null
+        | sniel3_ip
+        | sniel3_ipv6_null
+        | sniel3_lldp_null
         | sniel3_mtu
-        | sniel3_null
+        | sniel3_ndp_proxy_null
+        | sniel3_netflow_profile_null
     )
 ;
 
@@ -200,16 +204,25 @@ sniel3_mtu
     MTU mtu = uint32
 ;
 
-sniel3_null
+sniel3_adjust_tcp_mss_null
 :
-    (
-        ADJUST_TCP_MSS
-        | LLDP
-        | IPV6
-        | NDP_PROXY
-        | NETFLOW_PROFILE
-    )
-    null_rest_of_line
+   ADJUST_TCP_MSS null_rest_of_line
+;
+sniel3_lldp_null
+:
+   LLDP null_rest_of_line
+;
+sniel3_ipv6_null
+:
+   IPV6 null_rest_of_line
+;
+sniel3_ndp_proxy_null
+:
+   NDP_PROXY null_rest_of_line
+;
+sniel3_netflow_profile_null
+:
+   NETFLOW_PROFILE null_rest_of_line
 ;
 
 sniel3_unit

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_ospf.g4
@@ -58,9 +58,10 @@ vrp_ospf
     OSPF
     (
         ospf_area
+        | ospf_auth_profile_null
         | ospf_enable
+        | ospf_global_bfd_null
         | ospf_graceful_restart
-        | ospf_null
         | ospf_reject_default_route
         | ospf_router_id
     )
@@ -100,13 +101,13 @@ ospf_graceful_restart
     )
 ;
 
-ospf_null
+ospf_auth_profile_null
 :
-    (
-        AUTH_PROFILE
-        | GLOBAL_BFD
-    )
-    null_rest_of_line
+   AUTH_PROFILE null_rest_of_line
+;
+ospf_global_bfd_null
+:
+   GLOBAL_BFD null_rest_of_line
 ;
 
 
@@ -124,12 +125,14 @@ ospfa_interface
 :
     INTERFACE name = variable
     (
-        ospfai_dead_counts
+        ospfai_authentication_null
+        | ospfai_bfd_null
+        | ospfai_dead_counts
         | ospfai_enable
+        | ospfai_gr_delay_null
         | ospfai_hello_interval
         | ospfai_link_type
         | ospfai_metric
-        | ospfai_null
         | ospfai_passive
         | ospfai_priority
         | ospfai_retransmit_interval
@@ -167,14 +170,17 @@ ospfai_metric
     METRIC metric = ospf_interface_metric
 ;
 
-ospfai_null
+ospfai_authentication_null
 :
-    (
-        AUTHENTICATION
-        | BFD
-        | GR_DELAY
-    )
-    null_rest_of_line
+   AUTHENTICATION null_rest_of_line
+;
+ospfai_bfd_null
+:
+   BFD null_rest_of_line
+;
+ospfai_gr_delay_null
+:
+   GR_DELAY null_rest_of_line
 ;
 
 ospfai_passive

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
@@ -23,18 +23,26 @@ ss_common
 :
     s_address
     | s_address_group
+    | s_admin_role_null
     | s_application
     | s_application_filter
     | s_application_group
+    | s_authentication_profile_null
+    | s_botnet_null
+    | s_certificate_null
+    | s_certificate_profile_null
+    | s_content_preview_null
     | s_external_list
     | s_log_settings
+    | s_profile_group_null
     | s_profiles
     | s_post_rulebase
     | s_pre_rulebase
+    | s_profiles_null
+    | s_server_profile_null
     | s_service
     | s_service_group
     | s_tag
-    | ss_null
 ;
 
 s_external_list
@@ -101,18 +109,39 @@ seltip_url
     URL url = variable
 ;
 
-ss_null
+s_admin_role_null
 :
-    (
-        ADMIN_ROLE
-        | AUTHENTICATION_PROFILE
-        | BOTNET
-        | CERTIFICATE
-        | CERTIFICATE_PROFILE
-        | CONTENT_PREVIEW
-        | PROFILE_GROUP
-        | PROFILES
-        | SERVER_PROFILE
-    )
-    null_rest_of_line
+   ADMIN_ROLE null_rest_of_line
+;
+s_authentication_profile_null
+:
+   AUTHENTICATION_PROFILE null_rest_of_line
+;
+s_botnet_null
+:
+   BOTNET null_rest_of_line
+;
+s_certificate_null
+:
+   CERTIFICATE null_rest_of_line
+;
+s_certificate_profile_null
+:
+   CERTIFICATE_PROFILE null_rest_of_line
+;
+s_content_preview_null
+:
+   CONTENT_PREVIEW null_rest_of_line
+;
+s_profile_group_null
+:
+   PROFILE_GROUP null_rest_of_line
+;
+s_profiles_null
+:
+   PROFILES null_rest_of_line
+;
+s_server_profile_null
+:
+   SERVER_PROFILE null_rest_of_line
 ;


### PR DESCRIPTION
Rewrite many-token catch-all `_null` rules of the form

    ss_null: ( ADMIN_ROLE | AUTHENTICATION_PROFILE | ... ) null_rest_of_line;

into one idiomatic `<prefix>_<token>_null` leaf rule per token, e.g.

    ss_admin_role_null: ADMIN_ROLE null_rest_of_line;

and expand every parent reference to `ss_null` into the corresponding list
of per-token alternatives. This restores single-token advancement / LL(1)
structure and the `<prefix>_next_token` naming convention described in
docs/parsing/parser_rule_conventions.md; the catch-all form hid many
distinct first-tokens behind a single rule.

The split preserves the set of accepted tokens and the parse-tree shape
(only leaf rule names change), so behavior is unchanged. Scope is limited
to simple catch-alls whose alternatives are each a single token with no
leading `NO?`.

----

Prompt:
```
In many of our older grammars, we have a bad pattern where we had rules like

bgp:
   bgp_abc
   | bgp_def
   | bgp_null
;

bgp_null:
   (SOMETOKEN
   | OTHER_TOKEN
   | OTHER_TOKEN
   ...
   ) null_rest_of_line;

(with other variants, like null_filler, etc.)

This many-token-null-rule is no longer acceptable. It violates our rules.

First, confirm that I'm writing by reading docs/. Read about LL(1), rule
naming, when to use _null, etc.

Second, if so, develop a dynamic workflow (or similar use of subagents at
your discretion) to rewrite all of these, vendor by vendor, in an
idiomatic way. In the example: bgp_sometoken_null: SOMETOKEN
null_rest_of_line;, getting rid of the catch-all bgp_null.
```

Punt on the `NO?`-prefixed catch-alls; do one vendor per commit.
