### PR TITLE
cisco_asa: split catch-all _null rules into per-token rules

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_cable.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_cable.g4
@@ -30,10 +30,21 @@ c_load_balance
 :
    LOAD_BALANCE
    (
-      clb_docsis_group
+      clb_d20_ggrp_default_null
+      | clb_d30_ggrp_default_null
+      | clb_docsis30_enable_null
+      | clb_docsis_enable_null
+      | clb_docsis_group
       | clb_docsis_policy
-      | clb_null
+      | clb_downstream_start_threshold_null
+      | clb_exclude_null
+      | clb_failed_list_null
+      | clb_general_group_defaults_null
+      | clb_method_utilization_null
+      | clb_modem_null
       | clb_rule
+      | clb_tcs_load_balance_null
+      | clb_upstream_start_threshold_null
    )
 ;
 
@@ -51,31 +62,89 @@ c_modulation_profile_single
    MODULATION_PROFILE dec ~NEWLINE+ NEWLINE
 ;
 
-c_null
+c_acfe_null
 :
-   (
-      ACFE
-      | ADMISSION_CONTROL
-      | CLOCK
-      | DEFAULT_TOS_QOS10
-      | DS_MAX_BURST
-      | DSG
-      | FLAP_LIST
-      | GLOBAL
-      | INTERCEPT
-      | IPV6
-      | LOGGING
-      | METERING
-      | MODEM
-      | MULTICAST
-      | PRE_EQUALIZATION
-      | SHARED_SECONDARY_SECRET
-      | SHARED_SECRET
-      | SNMP
-      | SUBMGMT
-      | UTIL_INTERVAL
-      | WIDEBAND
-   ) null_rest_of_line
+   ACFE null_rest_of_line
+;
+c_admission_control_null
+:
+   ADMISSION_CONTROL null_rest_of_line
+;
+c_clock_null
+:
+   CLOCK null_rest_of_line
+;
+c_default_tos_qos10_null
+:
+   DEFAULT_TOS_QOS10 null_rest_of_line
+;
+c_ds_max_burst_null
+:
+   DS_MAX_BURST null_rest_of_line
+;
+c_dsg_null
+:
+   DSG null_rest_of_line
+;
+c_flap_list_null
+:
+   FLAP_LIST null_rest_of_line
+;
+c_global_null
+:
+   GLOBAL null_rest_of_line
+;
+c_intercept_null
+:
+   INTERCEPT null_rest_of_line
+;
+c_ipv6_null
+:
+   IPV6 null_rest_of_line
+;
+c_logging_null
+:
+   LOGGING null_rest_of_line
+;
+c_metering_null
+:
+   METERING null_rest_of_line
+;
+c_modem_null
+:
+   MODEM null_rest_of_line
+;
+c_multicast_null
+:
+   MULTICAST null_rest_of_line
+;
+c_pre_equalization_null
+:
+   PRE_EQUALIZATION null_rest_of_line
+;
+c_shared_secondary_secret_null
+:
+   SHARED_SECONDARY_SECRET null_rest_of_line
+;
+c_shared_secret_null
+:
+   SHARED_SECRET null_rest_of_line
+;
+c_snmp_null
+:
+   SNMP null_rest_of_line
+;
+c_submgmt_null
+:
+   SUBMGMT null_rest_of_line
+;
+c_util_interval_null
+:
+   UTIL_INTERVAL null_rest_of_line
+;
+c_wideband_null
+:
+   WIDEBAND null_rest_of_line
 ;
 
 c_qos
@@ -83,7 +152,8 @@ c_qos
    QOS
    (
       cq_enforce_rule
-      | cq_null
+      | cq_permission_null
+      | cq_profile_null
    )
 ;
 
@@ -91,8 +161,9 @@ c_service
 :
    SERVICE
    (
-      cs_class
-      | cs_null
+      cs_attribute_null
+      | cs_class
+      | cs_flow_null
    )
 ;
 
@@ -142,22 +213,53 @@ clb_docsis_policy
    ) policy = dec RULE rulenum = dec NEWLINE
 ;
 
-clb_null
+clb_d20_ggrp_default_null
 :
-   (
-      D20_GGRP_DEFAULT
-      | D30_GGRP_DEFAULT
-      | DOCSIS_ENABLE
-      | DOCSIS30_ENABLE
-      | DOWNSTREAM_START_THRESHOLD
-      | EXCLUDE
-      | FAILED_LIST
-      | GENERAL_GROUP_DEFAULTS
-      | METHOD_UTILIZATION
-      | MODEM
-      | TCS_LOAD_BALANCE
-      | UPSTREAM_START_THRESHOLD
-   ) null_rest_of_line
+   D20_GGRP_DEFAULT null_rest_of_line
+;
+clb_d30_ggrp_default_null
+:
+   D30_GGRP_DEFAULT null_rest_of_line
+;
+clb_docsis_enable_null
+:
+   DOCSIS_ENABLE null_rest_of_line
+;
+clb_docsis30_enable_null
+:
+   DOCSIS30_ENABLE null_rest_of_line
+;
+clb_downstream_start_threshold_null
+:
+   DOWNSTREAM_START_THRESHOLD null_rest_of_line
+;
+clb_exclude_null
+:
+   EXCLUDE null_rest_of_line
+;
+clb_failed_list_null
+:
+   FAILED_LIST null_rest_of_line
+;
+clb_general_group_defaults_null
+:
+   GENERAL_GROUP_DEFAULTS null_rest_of_line
+;
+clb_method_utilization_null
+:
+   METHOD_UTILIZATION null_rest_of_line
+;
+clb_modem_null
+:
+   MODEM null_rest_of_line
+;
+clb_tcs_load_balance_null
+:
+   TCS_LOAD_BALANCE null_rest_of_line
+;
+clb_upstream_start_threshold_null
+:
+   UPSTREAM_START_THRESHOLD null_rest_of_line
 ;
 
 clb_rule
@@ -255,12 +357,13 @@ cq_enforce_rule
    )*
 ;
 
-cq_null
+cq_permission_null
 :
-   (
-      PERMISSION
-      | PROFILE
-   ) null_rest_of_line
+   PERMISSION null_rest_of_line
+;
+cq_profile_null
+:
+   PROFILE null_rest_of_line
 ;
 
 cqer_null
@@ -287,17 +390,28 @@ cs_class
 :
    CLASS num = dec
    (
-      csc_name
-      | csc_null
+      csc_downstream_null
+      | csc_max_burst_null
+      | csc_max_concat_burst_null
+      | csc_max_rate_null
+      | csc_min_packet_size_null
+      | csc_min_rate_null
+      | csc_name
+      | csc_priority_null
+      | csc_req_trans_policy_null
+      | csc_sched_type_null
+      | csc_tos_overwrite_null
+      | csc_upstream_null
    )
 ;
 
-cs_null
+cs_attribute_null
 :
-   (
-      ATTRIBUTE
-      | FLOW
-   ) null_rest_of_line
+   ATTRIBUTE null_rest_of_line
+;
+cs_flow_null
+:
+   FLOW null_rest_of_line
 ;
 
 csc_name
@@ -305,21 +419,49 @@ csc_name
    NAME name = variable NEWLINE
 ;
 
-csc_null
+csc_downstream_null
 :
-   (
-      DOWNSTREAM
-      | MAX_BURST
-      | MAX_CONCAT_BURST
-      | MAX_RATE
-      | MIN_PACKET_SIZE
-      | MIN_RATE
-      | PRIORITY
-      | REQ_TRANS_POLICY
-      | SCHED_TYPE
-      | TOS_OVERWRITE
-      | UPSTREAM
-   ) null_rest_of_line
+   DOWNSTREAM null_rest_of_line
+;
+csc_max_burst_null
+:
+   MAX_BURST null_rest_of_line
+;
+csc_max_concat_burst_null
+:
+   MAX_CONCAT_BURST null_rest_of_line
+;
+csc_max_rate_null
+:
+   MAX_RATE null_rest_of_line
+;
+csc_min_packet_size_null
+:
+   MIN_PACKET_SIZE null_rest_of_line
+;
+csc_min_rate_null
+:
+   MIN_RATE null_rest_of_line
+;
+csc_priority_null
+:
+   PRIORITY null_rest_of_line
+;
+csc_req_trans_policy_null
+:
+   REQ_TRANS_POLICY null_rest_of_line
+;
+csc_sched_type_null
+:
+   SCHED_TYPE null_rest_of_line
+;
+csc_tos_overwrite_null
+:
+   TOS_OVERWRITE null_rest_of_line
+;
+csc_upstream_null
+:
+   UPSTREAM null_rest_of_line
 ;
 
 ct_name
@@ -371,15 +513,35 @@ s_cable
 :
    NO? CABLE
    (
-      c_fiber_node
+      c_acfe_null
+      | c_admission_control_null
+      | c_clock_null
+      | c_default_tos_qos10_null
+      | c_ds_max_burst_null
+      | c_dsg_null
+      | c_fiber_node
       | c_filter
+      | c_flap_list_null
+      | c_global_null
+      | c_intercept_null
+      | c_ipv6_null
       | c_load_balance
+      | c_logging_null
+      | c_metering_null
+      | c_modem_null
       | c_modulation_profile_block
       | c_modulation_profile_single
-      | c_null
+      | c_multicast_null
+      | c_pre_equalization_null
       | c_qos
       | c_service
+      | c_shared_secondary_secret_null
+      | c_shared_secret_null
+      | c_snmp_null
+      | c_submgmt_null
       | c_tag
+      | c_util_interval_null
+      | c_wideband_null
    )
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_crypto.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_crypto.g4
@@ -141,21 +141,26 @@ certificate
    ~QUIT+
 ;
 
-cg_null
+cg_identity_null
 :
-   (
-      IDENTITY
-      | SERVER
-   ) null_rest_of_line
+   IDENTITY null_rest_of_line
+;
+cg_server_null
+:
+   SERVER null_rest_of_line
 ;
 
-ci1_null
+ci1_am_disable_null
 :
-   (
-      AM_DISABLE
-      | ENABLE
-      | IPSEC_OVER_TCP
-   ) null_rest_of_line
+   AM_DISABLE null_rest_of_line
+;
+ci1_enable_null
+:
+   ENABLE null_rest_of_line
+;
+ci1_ipsec_over_tcp_null
+:
+   IPSEC_OVER_TCP null_rest_of_line
 ;
 
 ci1_policy
@@ -186,12 +191,13 @@ ci2_keyring
    )*
 ;
 
-ci2_null
+ci2_enable_null
 :
-   (
-      ENABLE
-      | REMOTE_ACCESS
-   ) null_rest_of_line
+   ENABLE null_rest_of_line
+;
+ci2_remote_access_null
+:
+   REMOTE_ACCESS null_rest_of_line
 ;
 
 ci2_policy
@@ -273,15 +279,25 @@ cip_ikev2
    IKEV2 cipi2_ipsec_proposal
 ;
 
-cip_null
+cip_df_bit_null
 :
-   (
-      DF_BIT
-      | FRAGMENTATION
-      | IKEV1
-      | NAT_TRANSPARENCY
-      | SECURITY_ASSOCIATION
-   ) null_rest_of_line
+   DF_BIT null_rest_of_line
+;
+cip_fragmentation_null
+:
+   FRAGMENTATION null_rest_of_line
+;
+cip_ikev1_null
+:
+   IKEV1 null_rest_of_line
+;
+cip_nat_transparency_null
+:
+   NAT_TRANSPARENCY null_rest_of_line
+;
+cip_security_association_null
+:
+   SECURITY_ASSOCIATION null_rest_of_line
 ;
 
 cip_profile
@@ -325,9 +341,10 @@ cipprf_set
 :
    SET
    (
-      cipprf_set_isakmp_profile
-      | cipprf_set_null
+      cipprf_set_ikev2_profile_null
+      | cipprf_set_isakmp_profile
       | cipprf_set_pfs
+      | cipprf_set_security_association_null
       | cipprf_set_transform_set
    )
 ;
@@ -337,12 +354,13 @@ cipprf_set_isakmp_profile
     ISAKMP_PROFILE name = variable NEWLINE
 ;
 
-cipprf_set_null
+cipprf_set_ikev2_profile_null
 :
-   (
-      IKEV2_PROFILE
-      | SECURITY_ASSOCIATION
-   ) null_rest_of_line
+   IKEV2_PROFILE null_rest_of_line
+;
+cipprf_set_security_association_null
+:
+   SECURITY_ASSOCIATION null_rest_of_line
 ;
 
 cipprf_set_pfs
@@ -372,17 +390,33 @@ cis_key
    KEY dec? key = VARIABLE ADDRESS ip_address = IP_ADDRESS (wildcard_mask = IP_ADDRESS)? NEWLINE
 ;
 
-cis_null
+cis_eap_passthrough_null
 :
-   (
-      EAP_PASSTHROUGH
-      | ENABLE
-      | IDENTITY
-      | INVALID_SPI_RECOVERY
-      | KEEPALIVE
-      | NAT
-      | NAT_TRAVERSAL
-   ) null_rest_of_line
+   EAP_PASSTHROUGH null_rest_of_line
+;
+cis_enable_null
+:
+   ENABLE null_rest_of_line
+;
+cis_identity_null
+:
+   IDENTITY null_rest_of_line
+;
+cis_invalid_spi_recovery_null
+:
+   INVALID_SPI_RECOVERY null_rest_of_line
+;
+cis_keepalive_null
+:
+   KEEPALIVE null_rest_of_line
+;
+cis_nat_null
+:
+   NAT null_rest_of_line
+;
+cis_nat_traversal_null
+:
+   NAT_TRAVERSAL null_rest_of_line
 ;
 
 cis_policy
@@ -498,12 +532,13 @@ cisprf_self_identity
 ;
 
 
-ck_null
+ck_generate_null
 :
-   (
-      GENERATE
-      | PARAM
-   ) null_rest_of_line
+   GENERATE null_rest_of_line
+;
+ck_param_null
+:
+   PARAM null_rest_of_line
 ;
 
 ck_pubkey_chain
@@ -666,7 +701,7 @@ crypto_gdoi
 :
    GDOI null_rest_of_line
    (
-      cg_null
+      ( cg_identity_null | cg_server_null )
    )*
 ;
 
@@ -674,7 +709,9 @@ crypto_ikev1
 :
    IKEV1
    (
-      ci1_null
+      ci1_am_disable_null
+      | ci1_enable_null
+      | ci1_ipsec_over_tcp_null
       | ci1_policy
    )
 ;
@@ -683,11 +720,12 @@ crypto_ikev2
 :
    IKEV2
    (
-      ci2_keyring
-      | ci2_null
+      ci2_enable_null
+      | ci2_keyring
       | ci2_policy
       | ci2_profile
       | ci2_proposal
+      | ci2_remote_access_null
    )
 ;
 
@@ -695,9 +733,13 @@ crypto_ipsec
 :
    IPSEC
    (
-      cip_ikev2
-      | cip_null
+      cip_df_bit_null
+      | cip_fragmentation_null
+      | cip_ikev1_null
+      | cip_ikev2
+      | cip_nat_transparency_null
       | cip_profile
+      | cip_security_association_null
       | cip_transform_set
    )
 ;
@@ -706,8 +748,14 @@ crypto_isakmp
 :
    ISAKMP
    (
-      cis_key
-      | cis_null
+      cis_eap_passthrough_null
+      | cis_enable_null
+      | cis_identity_null
+      | cis_invalid_spi_recovery_null
+      | cis_keepalive_null
+      | cis_key
+      | cis_nat_null
+      | cis_nat_traversal_null
       | cis_policy
       | cis_profile
    )
@@ -717,7 +765,8 @@ crypto_key
 :
    KEY
    (
-      ck_null
+      ck_generate_null
+      | ck_param_null
       | ck_pubkey_chain
    )
 ;
@@ -735,28 +784,31 @@ crypto_map
 :
    MAP name = variable
    (
-      crypto_map_null
+      ( crypto_map_interface_null | crypto_map_local_address_null | crypto_map_redundancy_null )
       | seq_num = dec crypto_map_tail
    )
 ;
 
-crypto_map_null
+crypto_map_interface_null
 :
-   (
-      INTERFACE
-      | LOCAL_ADDRESS
-      | REDUNDANCY
-   ) null_rest_of_line
+   INTERFACE null_rest_of_line
+;
+crypto_map_local_address_null
+:
+   LOCAL_ADDRESS null_rest_of_line
+;
+crypto_map_redundancy_null
+:
+   REDUNDANCY null_rest_of_line
 ;
 
 crypto_map_tail
 :
-   (
-      crypto_map_t_gdoi
-      | crypto_map_t_ipsec_isakmp
-      | crypto_map_t_match
-      | crypto_map_t_null
-   )
+   crypto_map_t_gdoi
+   | crypto_map_t_ipsec_isakmp
+   | crypto_map_t_ipsec_manual_null
+   | crypto_map_t_match
+   | crypto_map_t_set_null
 ;
 
 crypto_map_t_g_null
@@ -855,12 +907,13 @@ crypto_map_t_match_address
    ADDRESS name = variable NEWLINE
 ;
 
-crypto_map_t_null
+crypto_map_t_ipsec_manual_null
 :
-   (
-      IPSEC_MANUAL
-      | SET
-   ) null_rest_of_line
+   IPSEC_MANUAL null_rest_of_line
+;
+crypto_map_t_set_null
+:
+   SET null_rest_of_line
 ;
 
 crypto_pki

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_eigrp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_eigrp.g4
@@ -17,15 +17,26 @@ re_classic_tail
    re_distribute_list
    | re_eigrp
    | rec_address_family
+   | rec_auto_summary_null
+   | rec_bfd_null
+   | rec_default_information_null
+   | rec_hello_interval_null
+   | rec_maximum_paths_null
    | rec_metric
+   | rec_neighbor_null
    | rec_no
-   | rec_null
    | re_default_metric
    | re_network
    | re_passive_interface_default
    | re_passive_interface
    | re_redistribute
    | re_shutdown
+   | rec_nsf_null
+   | rec_offset_list_null
+   | rec_split_horizon_null
+   | rec_timers_null
+   | rec_traffic_share_null
+   | rec_variance_null
 ;
 
 re_default_metric
@@ -51,20 +62,30 @@ re_eigrp
 :
    EIGRP
    (
-      re_eigrp_null
+      re_eigrp_default_route_tag_null
+      | re_eigrp_event_log_size_null
+      | re_eigrp_log_neighbor_changes_null
+      | re_eigrp_log_neighbor_warnings_null
       | re_eigrp_stub
       | re_eigrp_router_id
    )
 ;
 
-re_eigrp_null
+re_eigrp_default_route_tag_null
 :
-   (
-      DEFAULT_ROUTE_TAG
-      | EVENT_LOG_SIZE
-      | LOG_NEIGHBOR_CHANGES
-      | LOG_NEIGHBOR_WARNINGS
-   ) null_rest_of_line
+   DEFAULT_ROUTE_TAG null_rest_of_line
+;
+re_eigrp_event_log_size_null
+:
+   EVENT_LOG_SIZE null_rest_of_line
+;
+re_eigrp_log_neighbor_changes_null
+:
+   LOG_NEIGHBOR_CHANGES null_rest_of_line
+;
+re_eigrp_log_neighbor_warnings_null
+:
+   LOG_NEIGHBOR_WARNINGS null_rest_of_line
 ;
 
 re_eigrp_router_id
@@ -260,7 +281,10 @@ reaf_interface_tail
 reaf_topology_tail
 :
    re_default_metric
-   | re_eigrp_null
+   | re_eigrp_default_route_tag_null
+   | re_eigrp_event_log_size_null
+   | re_eigrp_log_neighbor_changes_null
+   | re_eigrp_log_neighbor_warnings_null
    | re_redistribute
    | reaf_topology_null
 ;
@@ -371,8 +395,19 @@ rec_no
 :
    NO
    (
-     recno_eigrp
-     | rec_null
+     rec_auto_summary_null
+     | rec_bfd_null
+     | rec_default_information_null
+     | rec_hello_interval_null
+     | rec_maximum_paths_null
+     | rec_neighbor_null
+     | rec_nsf_null
+     | rec_offset_list_null
+     | rec_split_horizon_null
+     | rec_timers_null
+     | rec_traffic_share_null
+     | rec_variance_null
+     | recno_eigrp
      | reno_shutdown
    )
 ;
@@ -388,22 +423,53 @@ recno_eigrp_router_id
   ROUTER_ID NEWLINE
 ;
 
-rec_null
+rec_auto_summary_null
 :
-   (
-      AUTO_SUMMARY
-      | BFD
-      | DEFAULT_INFORMATION
-      | HELLO_INTERVAL
-      | MAXIMUM_PATHS
-      | NEIGHBOR
-      | NSF
-      | OFFSET_LIST
-      | SPLIT_HORIZON
-      | TIMERS
-      | TRAFFIC_SHARE
-      | VARIANCE
-   ) null_rest_of_line
+   AUTO_SUMMARY null_rest_of_line
+;
+rec_bfd_null
+:
+   BFD null_rest_of_line
+;
+rec_default_information_null
+:
+   DEFAULT_INFORMATION null_rest_of_line
+;
+rec_hello_interval_null
+:
+   HELLO_INTERVAL null_rest_of_line
+;
+rec_maximum_paths_null
+:
+   MAXIMUM_PATHS null_rest_of_line
+;
+rec_neighbor_null
+:
+   NEIGHBOR null_rest_of_line
+;
+rec_nsf_null
+:
+   NSF null_rest_of_line
+;
+rec_offset_list_null
+:
+   OFFSET_LIST null_rest_of_line
+;
+rec_split_horizon_null
+:
+   SPLIT_HORIZON null_rest_of_line
+;
+rec_timers_null
+:
+   TIMERS null_rest_of_line
+;
+rec_traffic_share_null
+:
+   TRAFFIC_SHARE null_rest_of_line
+;
+rec_variance_null
+:
+   VARIANCE null_rest_of_line
 ;
 
 re_shutdown
@@ -600,7 +666,10 @@ resf_null
 
 resf_topology_tail
 :
-   re_eigrp_null
+   re_eigrp_default_route_tag_null
+   | re_eigrp_event_log_size_null
+   | re_eigrp_log_neighbor_changes_null
+   | re_eigrp_log_neighbor_warnings_null
    | resf_topology_null
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_interface.g4
@@ -317,8 +317,9 @@ if_ip_dhcp
 :
    NO? IP DHCP
    (
-      ifdhcp_null
-      | ifdhcp_relay
+      ifdhcp_relay
+      | ifdhcp_smart_relay_null
+      | ifdhcp_snooping_null
    )
 ;
 
@@ -360,11 +361,27 @@ if_ip_igmp
 :
    NO? IP IGMP
    (
-      NEWLINE
-      | ifigmp_access_group
+      ifigmp_access_group
+      | ifigmp_group_timeout_null
       | ifigmp_host_proxy
-      | ifigmp_null
+      | ifigmp_join_group_null
+      | ifigmp_last_member_query_count_null
+      | ifigmp_last_member_query_interval_null
+      | ifigmp_last_member_query_response_time_null
+      | ifigmp_multicast_static_only_null
+      | ifigmp_query_interval_null
+      | ifigmp_query_max_response_time_null
+      | ifigmp_query_timeout_null
+      | ifigmp_robustness_variable_null
+      | ifigmp_router_alert_null
+      | ifigmp_snooping_null
+      | ifigmp_startup_query_count_null
+      | ifigmp_startup_query_interval_null
       | ifigmp_static_group
+      | ifigmp_tcn_null
+      | ifigmp_v3_query_max_response_time_null
+      | ifigmp_version_null
+      | NEWLINE
    )
 ;
 
@@ -1203,8 +1220,19 @@ if_spanning_tree
 :
    NO? SPANNING_TREE
    (
-      if_st_null
+      if_st_bpdufilter_null
+      | if_st_bpduguard_null
+      | if_st_cost_null
+      | if_st_guard_null
+      | if_st_link_type_null
+      | if_st_mst_null
+      | if_st_port_null
+      | if_st_port_priority_null
       | if_st_portfast
+      | if_st_priority_null
+      | if_st_protect_null
+      | if_st_rstp_null
+      | if_st_vlan_null
       | NEWLINE
    )
 ;
@@ -1264,22 +1292,53 @@ if_speed_ios_dot11radio
    )* NEWLINE
 ;
 
-if_st_null
+if_st_bpdufilter_null
 :
-   (
-      BPDUFILTER
-      | BPDUGUARD
-      | COST
-      | GUARD
-      | LINK_TYPE
-      | MST
-      | PORT
-      | PORT_PRIORITY
-      | PRIORITY
-      | PROTECT
-      | RSTP
-      | VLAN
-   ) null_rest_of_line
+   BPDUFILTER null_rest_of_line
+;
+if_st_bpduguard_null
+:
+   BPDUGUARD null_rest_of_line
+;
+if_st_cost_null
+:
+   COST null_rest_of_line
+;
+if_st_guard_null
+:
+   GUARD null_rest_of_line
+;
+if_st_link_type_null
+:
+   LINK_TYPE null_rest_of_line
+;
+if_st_mst_null
+:
+   MST null_rest_of_line
+;
+if_st_port_null
+:
+   PORT null_rest_of_line
+;
+if_st_port_priority_null
+:
+   PORT_PRIORITY null_rest_of_line
+;
+if_st_priority_null
+:
+   PRIORITY null_rest_of_line
+;
+if_st_protect_null
+:
+   PROTECT null_rest_of_line
+;
+if_st_rstp_null
+:
+   RSTP null_rest_of_line
+;
+if_st_vlan_null
+:
+   VLAN null_rest_of_line
 ;
 
 if_st_portfast
@@ -1563,12 +1622,13 @@ if_security_level
    SECURITY_LEVEL level = dec NEWLINE
 ;
 
-ifdhcp_null
+ifdhcp_smart_relay_null
 :
-   (
-      SMART_RELAY
-      | SNOOPING
-   ) null_rest_of_line
+   SMART_RELAY null_rest_of_line
+;
+ifdhcp_snooping_null
+:
+   SNOOPING null_rest_of_line
 ;
 
 ifdhcp_relay
@@ -1577,7 +1637,8 @@ ifdhcp_relay
    (
       ifdhcpr_address
       | ifdhcpr_client
-      | ifdhcpr_null
+      | ifdhcpr_information_null
+      | ifdhcpr_subnet_broadcast_null
    )
 ;
 
@@ -1591,12 +1652,13 @@ ifdhcpr_client
    CLIENT NEWLINE
 ;
 
-ifdhcpr_null
+ifdhcpr_information_null
 :
-   (
-      INFORMATION
-      | SUBNET_BROADCAST
-   ) null_rest_of_line
+   INFORMATION null_rest_of_line
+;
+ifdhcpr_subnet_broadcast_null
+:
+   SUBNET_BROADCAST null_rest_of_line
 ;
 
 ifigmp_access_group
@@ -1608,7 +1670,11 @@ ifigmp_host_proxy
 :
    HOST_PROXY (
        ifigmphp_access_list
-       | ifigmphp_null
+       | ifigmphp_exclude_null
+       | ifigmphp_include_null
+       | ifigmphp_ip_address_null
+       | ifigmphp_report_interval_null
+       | ifigmphp_version_null
    )
 ;
 
@@ -1617,39 +1683,94 @@ ifigmphp_access_list
    ACCESS_LIST name = variable NEWLINE
 ;
 
-ifigmphp_null
+ifigmphp_exclude_null
 :
-   (
-      EXCLUDE
-      | INCLUDE
-      | IP_ADDRESS
-      | REPORT_INTERVAL
-      | VERSION
-   ) null_rest_of_line
-
+   EXCLUDE null_rest_of_line
+;
+ifigmphp_include_null
+:
+   INCLUDE null_rest_of_line
+;
+ifigmphp_ip_address_null
+:
+   IP_ADDRESS null_rest_of_line
+;
+ifigmphp_report_interval_null
+:
+   REPORT_INTERVAL null_rest_of_line
+;
+ifigmphp_version_null
+:
+   VERSION null_rest_of_line
 ;
 
-ifigmp_null
+ifigmp_group_timeout_null
 :
-   (
-      GROUP_TIMEOUT
-      | JOIN_GROUP
-      | LAST_MEMBER_QUERY_COUNT
-      | LAST_MEMBER_QUERY_INTERVAL
-      | LAST_MEMBER_QUERY_RESPONSE_TIME
-      | MULTICAST_STATIC_ONLY
-      | QUERY_INTERVAL
-      | QUERY_MAX_RESPONSE_TIME
-      | QUERY_TIMEOUT
-      | ROBUSTNESS_VARIABLE
-      | ROUTER_ALERT
-      | SNOOPING
-      | STARTUP_QUERY_COUNT
-      | STARTUP_QUERY_INTERVAL
-      | TCN
-      | V3_QUERY_MAX_RESPONSE_TIME
-      | VERSION
-   ) null_rest_of_line
+   GROUP_TIMEOUT null_rest_of_line
+;
+ifigmp_join_group_null
+:
+   JOIN_GROUP null_rest_of_line
+;
+ifigmp_last_member_query_count_null
+:
+   LAST_MEMBER_QUERY_COUNT null_rest_of_line
+;
+ifigmp_last_member_query_interval_null
+:
+   LAST_MEMBER_QUERY_INTERVAL null_rest_of_line
+;
+ifigmp_last_member_query_response_time_null
+:
+   LAST_MEMBER_QUERY_RESPONSE_TIME null_rest_of_line
+;
+ifigmp_multicast_static_only_null
+:
+   MULTICAST_STATIC_ONLY null_rest_of_line
+;
+ifigmp_query_interval_null
+:
+   QUERY_INTERVAL null_rest_of_line
+;
+ifigmp_query_max_response_time_null
+:
+   QUERY_MAX_RESPONSE_TIME null_rest_of_line
+;
+ifigmp_query_timeout_null
+:
+   QUERY_TIMEOUT null_rest_of_line
+;
+ifigmp_robustness_variable_null
+:
+   ROBUSTNESS_VARIABLE null_rest_of_line
+;
+ifigmp_router_alert_null
+:
+   ROUTER_ALERT null_rest_of_line
+;
+ifigmp_snooping_null
+:
+   SNOOPING null_rest_of_line
+;
+ifigmp_startup_query_count_null
+:
+   STARTUP_QUERY_COUNT null_rest_of_line
+;
+ifigmp_startup_query_interval_null
+:
+   STARTUP_QUERY_INTERVAL null_rest_of_line
+;
+ifigmp_tcn_null
+:
+   TCN null_rest_of_line
+;
+ifigmp_v3_query_max_response_time_null
+:
+   V3_QUERY_MAX_RESPONSE_TIME null_rest_of_line
+;
+ifigmp_version_null
+:
+   VERSION null_rest_of_line
 ;
 
 ifigmp_static_group
@@ -1657,7 +1778,8 @@ ifigmp_static_group
    STATIC_GROUP
    (
       ifigmpsg_acl
-      | ifigmpsg_null
+      | ifigmpsg_ip_address_null
+      | ifigmpsg_range_null
    )
 ;
 
@@ -1666,12 +1788,13 @@ ifigmpsg_acl
    ACL name = variable NEWLINE
 ;
 
-ifigmpsg_null
+ifigmpsg_ip_address_null
 :
-   (
-      IP_ADDRESS
-      | RANGE
-   ) null_rest_of_line
+   IP_ADDRESS null_rest_of_line
+;
+ifigmpsg_range_null
+:
+   RANGE null_rest_of_line
 ;
 
 iftunnel_bandwidth

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_line.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_line.g4
@@ -147,20 +147,45 @@ l_transport
    ) prot += variable+ NEWLINE
 ;
 
-lc_null
+lc_accounting_null
 :
-   (
-      ACCOUNTING
-      | AUTHENTICATION
-      | AUTHORIZATION
-      | ENABLE_AUTHENTICATION
-      | IDLE_TIMEOUT
-      | LENGTH
-      | LOGIN_AUTHENTICATION
-      | PASSWORD
-      | SESSION_TIMEOUT
-      | SPEED
-   ) null_rest_of_line
+   ACCOUNTING null_rest_of_line
+;
+lc_authentication_null
+:
+   AUTHENTICATION null_rest_of_line
+;
+lc_authorization_null
+:
+   AUTHORIZATION null_rest_of_line
+;
+lc_enable_authentication_null
+:
+   ENABLE_AUTHENTICATION null_rest_of_line
+;
+lc_idle_timeout_null
+:
+   IDLE_TIMEOUT null_rest_of_line
+;
+lc_length_null
+:
+   LENGTH null_rest_of_line
+;
+lc_login_authentication_null
+:
+   LOGIN_AUTHENTICATION null_rest_of_line
+;
+lc_password_null
+:
+   PASSWORD null_rest_of_line
+;
+lc_session_timeout_null
+:
+   SESSION_TIMEOUT null_rest_of_line
+;
+lc_speed_null
+:
+   SPEED null_rest_of_line
 ;
 
 s_line

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_logging.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_logging.g4
@@ -61,21 +61,54 @@ logging_buffered
 logging_common
 :
    logging_address
+   | logging_alarm_null
    | logging_archive
+   | logging_asdm_buffer_size_null
+   | logging_asdm_null
+   | logging_buffer_size_null
    | logging_buffered
+   | logging_cmts_null
    | logging_console
+   | logging_count_null
+   | logging_debug_trace_null
    | logging_device_id
+   | logging_discriminator_null
    | logging_enable
+   | logging_esm_null
+   | logging_event_null
+   | logging_events_null
+   | logging_facility_null
    | logging_format
+   | logging_history_null
    | logging_host
+   | logging_hostnameprefix_null
+   | logging_ip_null
+   | logging_level_null
+   | logging_linecard_null
+   | logging_local_volatile_null
+   | logging_logfile_null
    | logging_message
-   | logging_null
+   | logging_message_counter_null
+   | logging_monitor_null
    | logging_on
+   | logging_origin_id_null
+   | logging_override_null
+   | logging_permit_hostdown_null
+   | logging_proprietary_null
    | logging_queue
+   | logging_queue_limit_null
+   | logging_rate_limit_null
+   | logging_sequence_nums_null
    | logging_server
+   | logging_server_arp_null
+   | logging_snmp_authfail_null
    | logging_source_interface
    | logging_suppress
+   | logging_synchronous_null
+   | logging_syslog_null
+   | logging_timestamp_null
    | logging_trap
+   | logging_userinfo_null
 ;
 
 logging_console
@@ -161,45 +194,141 @@ logging_message
    MESSAGE (syslog_id = dec) (LEVEL level = variable)? STANDBY? NEWLINE
 ;
 
-logging_null
+logging_alarm_null
 :
-   (
-      ALARM
-      | ASDM
-      | ASDM_BUFFER_SIZE
-      | BUFFER_SIZE
-      | COUNT
-      | CMTS
-      | DEBUG_TRACE
-      | DISCRIMINATOR
-      | ESM
-      | EVENT
-      | EVENTS
-      | FACILITY
-      | HISTORY
-      | HOSTNAMEPREFIX
-      | IP
-      | LEVEL
-      | LINECARD
-      | LOCAL_VOLATILE
-      | LOGFILE
-      | MESSAGE_COUNTER
-      | MONITOR
-      | ORIGIN_ID
-      | PERMIT_HOSTDOWN
-      | PROPRIETARY
-      | ORIGIN_ID
-      | OVERRIDE
-      | QUEUE_LIMIT
-      | RATE_LIMIT
-      | SEQUENCE_NUMS
-      | SERVER_ARP
-      | SNMP_AUTHFAIL
-      | SYNCHRONOUS
-      | SYSLOG
-      | TIMESTAMP
-      | USERINFO
-   ) null_rest_of_line
+   ALARM null_rest_of_line
+;
+logging_asdm_null
+:
+   ASDM null_rest_of_line
+;
+logging_asdm_buffer_size_null
+:
+   ASDM_BUFFER_SIZE null_rest_of_line
+;
+logging_buffer_size_null
+:
+   BUFFER_SIZE null_rest_of_line
+;
+logging_count_null
+:
+   COUNT null_rest_of_line
+;
+logging_cmts_null
+:
+   CMTS null_rest_of_line
+;
+logging_debug_trace_null
+:
+   DEBUG_TRACE null_rest_of_line
+;
+logging_discriminator_null
+:
+   DISCRIMINATOR null_rest_of_line
+;
+logging_esm_null
+:
+   ESM null_rest_of_line
+;
+logging_event_null
+:
+   EVENT null_rest_of_line
+;
+logging_events_null
+:
+   EVENTS null_rest_of_line
+;
+logging_facility_null
+:
+   FACILITY null_rest_of_line
+;
+logging_history_null
+:
+   HISTORY null_rest_of_line
+;
+logging_hostnameprefix_null
+:
+   HOSTNAMEPREFIX null_rest_of_line
+;
+logging_ip_null
+:
+   IP null_rest_of_line
+;
+logging_level_null
+:
+   LEVEL null_rest_of_line
+;
+logging_linecard_null
+:
+   LINECARD null_rest_of_line
+;
+logging_local_volatile_null
+:
+   LOCAL_VOLATILE null_rest_of_line
+;
+logging_logfile_null
+:
+   LOGFILE null_rest_of_line
+;
+logging_message_counter_null
+:
+   MESSAGE_COUNTER null_rest_of_line
+;
+logging_monitor_null
+:
+   MONITOR null_rest_of_line
+;
+logging_origin_id_null
+:
+   ORIGIN_ID null_rest_of_line
+;
+logging_permit_hostdown_null
+:
+   PERMIT_HOSTDOWN null_rest_of_line
+;
+logging_proprietary_null
+:
+   PROPRIETARY null_rest_of_line
+;
+logging_override_null
+:
+   OVERRIDE null_rest_of_line
+;
+logging_queue_limit_null
+:
+   QUEUE_LIMIT null_rest_of_line
+;
+logging_rate_limit_null
+:
+   RATE_LIMIT null_rest_of_line
+;
+logging_sequence_nums_null
+:
+   SEQUENCE_NUMS null_rest_of_line
+;
+logging_server_arp_null
+:
+   SERVER_ARP null_rest_of_line
+;
+logging_snmp_authfail_null
+:
+   SNMP_AUTHFAIL null_rest_of_line
+;
+logging_synchronous_null
+:
+   SYNCHRONOUS null_rest_of_line
+;
+logging_syslog_null
+:
+   SYSLOG null_rest_of_line
+;
+logging_timestamp_null
+:
+   TIMESTAMP null_rest_of_line
+;
+logging_userinfo_null
+:
+   USERINFO null_rest_of_line
 ;
 
 logging_on

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_ntp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_ntp.g4
@@ -71,15 +71,19 @@ ntp_commit
 ntp_common
 :
    ntp_access_group
+   | ntp_allow_null
    | ntp_authenticate
    | ntp_authentication
+   | ntp_authentication_key_null
    | ntp_clock_period
    | ntp_commit
    | ntp_distribute
+   | ntp_interface_null
+   | ntp_log_internal_sync_null
    | ntp_logging
    | ntp_max_associations
    | ntp_master
-   | ntp_null
+   | ntp_passive_null
    | ntp_peer
    | ntp_server
    | ntp_source
@@ -108,15 +112,25 @@ ntp_master
    MASTER NEWLINE
 ;
 
-ntp_null
+ntp_allow_null
 :
-   (
-      ALLOW
-      | AUTHENTICATION_KEY
-      | INTERFACE
-      | LOG_INTERNAL_SYNC
-      | PASSIVE
-   ) null_rest_of_line
+   ALLOW null_rest_of_line
+;
+ntp_authentication_key_null
+:
+   AUTHENTICATION_KEY null_rest_of_line
+;
+ntp_interface_null
+:
+   INTERFACE null_rest_of_line
+;
+ntp_log_internal_sync_null
+:
+   LOG_INTERNAL_SYNC null_rest_of_line
+;
+ntp_passive_null
+:
+   PASSIVE null_rest_of_line
 ;
 
 ntp_peer

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_ospf.g4
@@ -607,42 +607,152 @@ rov3_address_family
 
 rov3_common
 :
-   rov3_null
+   rov3_area_null
+   | rov3_auto_cost_null
+   | rov3_bfd_null
+   | rov3_cost_null
+   | rov3_dead_interval_null
+   | rov3_default_information_null
+   | rov3_discard_route_null
+   | rov3_distance_null
+   | rov3_fast_reroute_null
+   | rov3_graceful_restart_null
+   | rov3_hello_interval_null
+   | rov3_interface_null
+   | rov3_log_adjacency_changes_null
+   | rov3_log_null
+   | rov3_max_metric_null
+   | rov3_maximum_null
+   | rov3_maximum_paths_null
+   | rov3_mtu_ignore_null
+   | rov3_network_null
+   | rov3_nsr_null
+   | rov3_nssa_null
+   | rov3_ospfv3_null
+   | rov3_passive_interface_null
+   | rov3_passive_null
+   | rov3_priority_null
+   | rov3_range_null
+   | rov3_redistribute_null
+   | rov3_router_id_null
+   | rov3_timers_null
 ;
 
-rov3_null
+rov3_area_null
 :
-   (
-      AREA
-      | AUTO_COST
-      | BFD
-      | COST
-      | DEAD_INTERVAL
-      | DEFAULT_INFORMATION
-      | DISCARD_ROUTE
-      | DISTANCE
-      | FAST_REROUTE
-      | GRACEFUL_RESTART
-      | HELLO_INTERVAL
-      | INTERFACE
-      | LOG
-      | LOG_ADJACENCY_CHANGES
-      | MAX_METRIC
-      | MAXIMUM
-      | MAXIMUM_PATHS
-      | MTU_IGNORE
-      | NETWORK
-      | NSSA
-      | NSR
-      | OSPFV3
-      | PASSIVE
-      | PASSIVE_INTERFACE
-      | PRIORITY
-      | RANGE
-      | REDISTRIBUTE
-      | ROUTER_ID
-      | TIMERS
-   ) null_rest_of_line
+   AREA null_rest_of_line
+;
+rov3_auto_cost_null
+:
+   AUTO_COST null_rest_of_line
+;
+rov3_bfd_null
+:
+   BFD null_rest_of_line
+;
+rov3_cost_null
+:
+   COST null_rest_of_line
+;
+rov3_dead_interval_null
+:
+   DEAD_INTERVAL null_rest_of_line
+;
+rov3_default_information_null
+:
+   DEFAULT_INFORMATION null_rest_of_line
+;
+rov3_discard_route_null
+:
+   DISCARD_ROUTE null_rest_of_line
+;
+rov3_distance_null
+:
+   DISTANCE null_rest_of_line
+;
+rov3_fast_reroute_null
+:
+   FAST_REROUTE null_rest_of_line
+;
+rov3_graceful_restart_null
+:
+   GRACEFUL_RESTART null_rest_of_line
+;
+rov3_hello_interval_null
+:
+   HELLO_INTERVAL null_rest_of_line
+;
+rov3_interface_null
+:
+   INTERFACE null_rest_of_line
+;
+rov3_log_null
+:
+   LOG null_rest_of_line
+;
+rov3_log_adjacency_changes_null
+:
+   LOG_ADJACENCY_CHANGES null_rest_of_line
+;
+rov3_max_metric_null
+:
+   MAX_METRIC null_rest_of_line
+;
+rov3_maximum_null
+:
+   MAXIMUM null_rest_of_line
+;
+rov3_maximum_paths_null
+:
+   MAXIMUM_PATHS null_rest_of_line
+;
+rov3_mtu_ignore_null
+:
+   MTU_IGNORE null_rest_of_line
+;
+rov3_network_null
+:
+   NETWORK null_rest_of_line
+;
+rov3_nssa_null
+:
+   NSSA null_rest_of_line
+;
+rov3_nsr_null
+:
+   NSR null_rest_of_line
+;
+rov3_ospfv3_null
+:
+   OSPFV3 null_rest_of_line
+;
+rov3_passive_null
+:
+   PASSIVE null_rest_of_line
+;
+rov3_passive_interface_null
+:
+   PASSIVE_INTERFACE null_rest_of_line
+;
+rov3_priority_null
+:
+   PRIORITY null_rest_of_line
+;
+rov3_range_null
+:
+   RANGE null_rest_of_line
+;
+rov3_redistribute_null
+:
+   REDISTRIBUTE null_rest_of_line
+;
+rov3_router_id_null
+:
+   ROUTER_ID null_rest_of_line
+;
+rov3_timers_null
+:
+   TIMERS null_rest_of_line
 ;
 
 s_ipv6_router_ospf

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_pim.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_pim.g4
@@ -10,13 +10,29 @@ ip_pim_tail
 :
    pim_accept_register
    | pim_accept_rp
-   | pim_null
+   | pim_autorp_null
+   | pim_bidir_enable_null
+   | pim_bidir_offer_interval_null
+   | pim_bidir_offer_limit_null
+   | pim_bidir_rp_limit_null
+   | pim_bsr_candidate_null
+   | pim_dm_fallback_null
+   | pim_event_history_null
+   | pim_log_neighbor_changes_null
+   | pim_mtu_null
+   | pim_register_rate_limit_null
+   | pim_register_source_null
    | pim_rp_address
    | pim_rp_announce_filter
    | pim_rp_candidate
+   | pim_rpf_vector_null
    | pim_send_rp_announce
+   | pim_send_rp_discovery_null
+   | pim_sg_expiry_timer_null
+   | pim_snooping_null
    | pim_spt_threshold
    | pim_ssm
+   | pim_v1_rp_reachability_null
 ;
 
 pim_accept_register
@@ -45,27 +61,73 @@ pim_accept_rp
    )? NEWLINE
 ;
 
-pim_null
+pim_autorp_null
 :
-   (
-      AUTORP
-      | BIDIR_ENABLE
-      | BIDIR_OFFER_INTERVAL
-      | BIDIR_OFFER_LIMIT
-      | BIDIR_RP_LIMIT
-      | BSR_CANDIDATE
-      | DM_FALLBACK
-      | EVENT_HISTORY
-      | LOG_NEIGHBOR_CHANGES
-      | MTU
-      | REGISTER_RATE_LIMIT
-      | REGISTER_SOURCE
-      | RPF_VECTOR
-      | SEND_RP_DISCOVERY
-      | SG_EXPIRY_TIMER
-      | SNOOPING
-      | V1_RP_REACHABILITY
-   ) null_rest_of_line
+   AUTORP null_rest_of_line
+;
+pim_bidir_enable_null
+:
+   BIDIR_ENABLE null_rest_of_line
+;
+pim_bidir_offer_interval_null
+:
+   BIDIR_OFFER_INTERVAL null_rest_of_line
+;
+pim_bidir_offer_limit_null
+:
+   BIDIR_OFFER_LIMIT null_rest_of_line
+;
+pim_bidir_rp_limit_null
+:
+   BIDIR_RP_LIMIT null_rest_of_line
+;
+pim_bsr_candidate_null
+:
+   BSR_CANDIDATE null_rest_of_line
+;
+pim_dm_fallback_null
+:
+   DM_FALLBACK null_rest_of_line
+;
+pim_event_history_null
+:
+   EVENT_HISTORY null_rest_of_line
+;
+pim_log_neighbor_changes_null
+:
+   LOG_NEIGHBOR_CHANGES null_rest_of_line
+;
+pim_mtu_null
+:
+   MTU null_rest_of_line
+;
+pim_register_rate_limit_null
+:
+   REGISTER_RATE_LIMIT null_rest_of_line
+;
+pim_register_source_null
+:
+   REGISTER_SOURCE null_rest_of_line
+;
+pim_rpf_vector_null
+:
+   RPF_VECTOR null_rest_of_line
+;
+pim_send_rp_discovery_null
+:
+   SEND_RP_DISCOVERY null_rest_of_line
+;
+pim_sg_expiry_timer_null
+:
+   SG_EXPIRY_TIMER null_rest_of_line
+;
+pim_snooping_null
+:
+   SNOOPING null_rest_of_line
+;
+pim_v1_rp_reachability_null
+:
+   V1_RP_REACHABILITY null_rest_of_line
 ;
 
 pim_rp_address

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_snmp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_snmp.g4
@@ -19,19 +19,47 @@ s_snmp_server
 :
    SNMP_SERVER
    (
-      NEWLINE
+      ss_aaa_null
+      | ss_aaa_user_null
+      | ss_card_trap_inh_null
+      | ss_chassis_id_null
       | ss_community
+      | ss_community_map_null
+      | ss_contact_null
+      | ss_context_null
       | ss_enable_mib_null
       | ss_enable_trap
       | ss_enable_traps
+      | ss_engineid_null
       | ss_file_transfer
+      | ss_globalenforcepriv_null
       | ss_group
       | ss_host
+      | ss_ifindex_null
+      | ss_ifmib_null
+      | ss_location_null
+      | ss_logging_null
+      | ss_manager_null
+      | ss_max_ifindex_per_module_null
       | ss_mib
-      | ss_null
+      | ss_notify_filter_null
+      | ss_overload_control_null
+      | ss_packetsize_null
+      | ss_priority_null
+      | ss_protocol_null
+      | ss_queue_length_null
       | ss_source_interface
+      | ss_system_shutdown_null
+      | ss_tcp_session_null
       | ss_tftp_server_list
+      | ss_trap_null
       | ss_trap_source
+      | ss_trap_timeout_null
+      | ss_traps_null
+      | ss_user_null
+      | ss_view_null
+      | ss_vrf_null
+      | NEWLINE
    )
 ;
 
@@ -86,14 +114,19 @@ ss_group
 :
   GROUP name = variable
   (
-    ss_group_null
+    ss_group_v1_null
+    | ss_group_v2c_null
     | ss_group_v3
   )
 ;
 
-ss_group_null
+ss_group_v1_null
 :
-  (V1 | V2C) null_rest_of_line
+   V1 null_rest_of_line
+;
+ss_group_v2c_null
+:
+   V2C null_rest_of_line
 ;
 
 ss_view_name
@@ -140,39 +173,121 @@ ss_mib
    MIB COMMUNITY_MAP (community_string = variable) CONTEXT (context_name = variable) NEWLINE
 ;
 
-ss_null
+ss_aaa_null
 :
-   (
-      AAA
-      | AAA_USER
-      | CARD_TRAP_INH
-      | CHASSIS_ID
-      | COMMUNITY_MAP
-      | CONTACT
-      | CONTEXT
-      | ENGINEID
-      | GLOBALENFORCEPRIV
-      | IFINDEX
-      | IFMIB
-      | LOCATION
-      | LOGGING
-      | MANAGER
-      | MAX_IFINDEX_PER_MODULE
-      | NOTIFY_FILTER
-      | OVERLOAD_CONTROL
-      | PACKETSIZE
-      | PRIORITY
-      | PROTOCOL
-      | QUEUE_LENGTH
-      | SYSTEM_SHUTDOWN
-      | TCP_SESSION
-      | TRAP
-      | TRAP_TIMEOUT
-      | TRAPS
-      | USER
-      | VIEW
-      | VRF
-   ) null_rest_of_line
+   AAA null_rest_of_line
+;
+ss_aaa_user_null
+:
+   AAA_USER null_rest_of_line
+;
+ss_card_trap_inh_null
+:
+   CARD_TRAP_INH null_rest_of_line
+;
+ss_chassis_id_null
+:
+   CHASSIS_ID null_rest_of_line
+;
+ss_community_map_null
+:
+   COMMUNITY_MAP null_rest_of_line
+;
+ss_contact_null
+:
+   CONTACT null_rest_of_line
+;
+ss_context_null
+:
+   CONTEXT null_rest_of_line
+;
+ss_engineid_null
+:
+   ENGINEID null_rest_of_line
+;
+ss_globalenforcepriv_null
+:
+   GLOBALENFORCEPRIV null_rest_of_line
+;
+ss_ifindex_null
+:
+   IFINDEX null_rest_of_line
+;
+ss_ifmib_null
+:
+   IFMIB null_rest_of_line
+;
+ss_location_null
+:
+   LOCATION null_rest_of_line
+;
+ss_logging_null
+:
+   LOGGING null_rest_of_line
+;
+ss_manager_null
+:
+   MANAGER null_rest_of_line
+;
+ss_max_ifindex_per_module_null
+:
+   MAX_IFINDEX_PER_MODULE null_rest_of_line
+;
+ss_notify_filter_null
+:
+   NOTIFY_FILTER null_rest_of_line
+;
+ss_overload_control_null
+:
+   OVERLOAD_CONTROL null_rest_of_line
+;
+ss_packetsize_null
+:
+   PACKETSIZE null_rest_of_line
+;
+ss_priority_null
+:
+   PRIORITY null_rest_of_line
+;
+ss_protocol_null
+:
+   PROTOCOL null_rest_of_line
+;
+ss_queue_length_null
+:
+   QUEUE_LENGTH null_rest_of_line
+;
+ss_system_shutdown_null
+:
+   SYSTEM_SHUTDOWN null_rest_of_line
+;
+ss_tcp_session_null
+:
+   TCP_SESSION null_rest_of_line
+;
+ss_trap_null
+:
+   TRAP null_rest_of_line
+;
+ss_trap_timeout_null
+:
+   TRAP_TIMEOUT null_rest_of_line
+;
+ss_traps_null
+:
+   TRAPS null_rest_of_line
+;
+ss_user_null
+:
+   USER null_rest_of_line
+;
+ss_view_null
+:
+   VIEW null_rest_of_line
+;
+ss_vrf_null
+:
+   VRF null_rest_of_line
 ;
 
 ss_source_interface

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaParser.g4
@@ -616,14 +616,21 @@ eh_null
    ) null_rest_of_line
 ;
 
-enable_null
+enable_encrypted_password_null
 :
-   (
-      ENCRYPTED_PASSWORD
-      | READ_ONLY_PASSWORD
-      | SUPER_USER_PASSWORD
-      | TELNET
-   ) null_rest_of_line
+   ENCRYPTED_PASSWORD null_rest_of_line
+;
+enable_read_only_password_null
+:
+   READ_ONLY_PASSWORD null_rest_of_line
+;
+enable_super_user_password_null
+:
+   SUPER_USER_PASSWORD null_rest_of_line
+;
+enable_telnet_null
+:
+   TELNET null_rest_of_line
 ;
 
 enable_password
@@ -1037,15 +1044,25 @@ ip_as_path_regex_mode_stanza
    ) NEWLINE
 ;
 
-ip_dhcp_null
+ip_dhcp_excluded_address_null
 :
-   (
-      EXCLUDED_ADDRESS
-      | PACKET
-      | SMART_RELAY
-      | SNOOPING
-      | USE
-   ) null_rest_of_line
+   EXCLUDED_ADDRESS null_rest_of_line
+;
+ip_dhcp_packet_null
+:
+   PACKET null_rest_of_line
+;
+ip_dhcp_smart_relay_null
+:
+   SMART_RELAY null_rest_of_line
+;
+ip_dhcp_snooping_null
+:
+   SNOOPING null_rest_of_line
+;
+ip_dhcp_use_null
+:
+   USE null_rest_of_line
 ;
 
 ip_dhcp_pool
@@ -1080,23 +1097,45 @@ ip_dhcp_relay
 :
    RELAY
    (
-      NEWLINE
-      | ip_dhcp_relay_null
+      ip_dhcp_relay_always_on_null
+      | ip_dhcp_relay_information_null
+      | ip_dhcp_relay_option_null
       | ip_dhcp_relay_server
+      | ip_dhcp_relay_source_address_null
+      | ip_dhcp_relay_source_interface_null
+      | ip_dhcp_relay_sub_option_null
+      | ip_dhcp_relay_use_link_address_null
+      | NEWLINE
    )
 ;
 
-ip_dhcp_relay_null
+ip_dhcp_relay_always_on_null
 :
-   (
-      ALWAYS_ON
-      | INFORMATION
-      | OPTION
-      | SOURCE_ADDRESS
-      | SOURCE_INTERFACE
-      | SUB_OPTION
-      | USE_LINK_ADDRESS
-   ) null_rest_of_line
+   ALWAYS_ON null_rest_of_line
+;
+ip_dhcp_relay_information_null
+:
+   INFORMATION null_rest_of_line
+;
+ip_dhcp_relay_option_null
+:
+   OPTION null_rest_of_line
+;
+ip_dhcp_relay_source_address_null
+:
+   SOURCE_ADDRESS null_rest_of_line
+;
+ip_dhcp_relay_source_interface_null
+:
+   SOURCE_INTERFACE null_rest_of_line
+;
+ip_dhcp_relay_sub_option_null
+:
+   SUB_OPTION null_rest_of_line
+;
+ip_dhcp_relay_use_link_address_null
+:
+   USE_LINK_ADDRESS null_rest_of_line
 ;
 
 ip_dhcp_relay_server
@@ -2361,9 +2400,12 @@ s_enable
 :
    ENABLE
    (
-      enable_null
+      enable_encrypted_password_null
       | enable_password
+      | enable_read_only_password_null
       | enable_secret
+      | enable_super_user_password_null
+      | enable_telnet_null
    )
 ;
 
@@ -2541,9 +2583,13 @@ s_ip_dhcp
       | IPV6
    ) DHCP
    (
-      ip_dhcp_null
+      ip_dhcp_excluded_address_null
+      | ip_dhcp_packet_null
       | ip_dhcp_pool
       | ip_dhcp_relay
+      | ip_dhcp_smart_relay_null
+      | ip_dhcp_snooping_null
+      | ip_dhcp_use_null
    )
 ;
 
@@ -2645,8 +2691,12 @@ s_ip_wccp
       VRF vrf = variable
    )?
    (
-      wccp_id
-      | wccp_null
+      wccp_check_null
+      | wccp_id
+      | wccp_outbound_acl_check_null
+      | wccp_source_interface_null
+      | wccp_version_null
+      | wccp_web_cache_null
    )
 ;
 
@@ -2949,10 +2999,26 @@ s_spanning_tree
 :
    NO? SPANNING_TREE
    (
-      spanning_tree_mst
+      spanning_tree_backbonefast_null
+      | spanning_tree_bpdufilter_null
+      | spanning_tree_bridge_null
+      | spanning_tree_cost_null
+      | spanning_tree_dispute_null
+      | spanning_tree_etherchannel_null
+      | spanning_tree_extend_null
+      | spanning_tree_fcoe_null
+      | spanning_tree_guard_null
+      | spanning_tree_logging_null
+      | spanning_tree_loopguard_null
+      | spanning_tree_mode_null
+      | spanning_tree_mst
+      | spanning_tree_optimize_null
+      | spanning_tree_pathcost_null
+      | spanning_tree_port_null
       | spanning_tree_portfast
       | spanning_tree_pseudo_information
-      | spanning_tree_null
+      | spanning_tree_uplinkfast_null
+      | spanning_tree_vlan_null
       | NEWLINE
    )
 ;
@@ -2963,9 +3029,15 @@ s_ssh
    (
       ssh_access_group
       | ssh_client
-      | ssh_null
+      | ssh_ip_address_null
+      | ssh_key_exchange_null
+      | ssh_key_null
+      | ssh_login_attempts_null
+      | ssh_mgmt_auth_null
       | ssh_server
+      | ssh_stricthostkeycheck_null
       | ssh_timeout
+      | ssh_version_null
    )
 ;
 
@@ -3005,9 +3077,21 @@ s_system
 :
    NO? SYSTEM
    (
-      system_default
-      | system_null
+      system_admin_vdc_null
+      | system_auto_upgrade_null
+      | system_default
+      | system_fabric_mode_null
+      | system_fabric_null
+      | system_flowcontrol_null
+      | system_interface_null
+      | system_jumbomtu_null
+      | system_mode_null
+      | system_module_type_null
+      | system_mtu_null
       | system_qos
+      | system_routing_null
+      | system_urpf_null
+      | system_vlan_null
    )
    s_system_inner*
 ;
@@ -3026,7 +3110,8 @@ s_tacacs
 :
    TACACS
    (
-      t_null
+      t_group_null
+      | t_host_null
       | t_server
       | t_source_interface
    )
@@ -3130,7 +3215,7 @@ s_username_attributes
 :
    USERNAME user = variable ATTRIBUTES NEWLINE
    (
-      ua_null
+      ( ua_group_lock_null | ua_vpn_group_policy_null )
    )*
 ;
 
@@ -3143,9 +3228,19 @@ s_voice
 :
    NO? VOICE
    (
-      voice_class
-      | voice_null
+      voice_alg_based_cac_null
+      | voice_call_null
+      | voice_class
+      | voice_dialplan_profile_null
+      | voice_hunt_null
+      | voice_iec_null
+      | voice_logging_null
+      | voice_real_time_config_null
+      | voice_rtcp_inactivity_null
+      | voice_rtp_null
       | voice_service
+      | voice_sip_midcall_req_timeout_null
+      | voice_sip_null
       | voice_translation_profile
       | voice_translation_rule
    )
@@ -3268,13 +3363,17 @@ sccp_null
    ) null_rest_of_line
 ;
 
-sd_null
+sd_dce_mode_null
 :
-   (
-      DCE_MODE
-      | INTERFACE
-      | LINK_FAIL
-   ) null_rest_of_line
+   DCE_MODE null_rest_of_line
+;
+sd_interface_null
+:
+   INTERFACE null_rest_of_line
+;
+sd_link_fail_null
+:
+   LINK_FAIL null_rest_of_line
 ;
 
 sd_switchport
@@ -3282,7 +3381,8 @@ sd_switchport
    SWITCHPORT
    (
       sd_switchport_blank
-      | sd_switchport_null
+      | sd_switchport_fabricpath_null
+      | sd_switchport_monitor_null
       | sd_switchport_shutdown
    )
 ;
@@ -3292,12 +3392,13 @@ sd_switchport_blank
    NEWLINE
 ;
 
-sd_switchport_null
+sd_switchport_fabricpath_null
 :
-   (
-      FABRICPATH
-      | MONITOR
-   ) null_rest_of_line
+   FABRICPATH null_rest_of_line
+;
+sd_switchport_monitor_null
+:
+   MONITOR null_rest_of_line
 ;
 
 sd_switchport_shutdown
@@ -3359,27 +3460,73 @@ spanning_tree_pseudo_information
    )*
 ;
 
-spanning_tree_null
+spanning_tree_backbonefast_null
 :
-   (
-      BACKBONEFAST
-      | BPDUFILTER
-      | BRIDGE
-      | COST
-      | DISPUTE
-      | ETHERCHANNEL
-      | EXTEND
-      | FCOE
-      | GUARD
-      | LOGGING
-      | LOOPGUARD
-      | MODE
-      | OPTIMIZE
-      | PATHCOST
-      | PORT
-      | UPLINKFAST
-      | VLAN
-   ) null_rest_of_line
+   BACKBONEFAST null_rest_of_line
+;
+spanning_tree_bpdufilter_null
+:
+   BPDUFILTER null_rest_of_line
+;
+spanning_tree_bridge_null
+:
+   BRIDGE null_rest_of_line
+;
+spanning_tree_cost_null
+:
+   COST null_rest_of_line
+;
+spanning_tree_dispute_null
+:
+   DISPUTE null_rest_of_line
+;
+spanning_tree_etherchannel_null
+:
+   ETHERCHANNEL null_rest_of_line
+;
+spanning_tree_extend_null
+:
+   EXTEND null_rest_of_line
+;
+spanning_tree_fcoe_null
+:
+   FCOE null_rest_of_line
+;
+spanning_tree_guard_null
+:
+   GUARD null_rest_of_line
+;
+spanning_tree_logging_null
+:
+   LOGGING null_rest_of_line
+;
+spanning_tree_loopguard_null
+:
+   LOOPGUARD null_rest_of_line
+;
+spanning_tree_mode_null
+:
+   MODE null_rest_of_line
+;
+spanning_tree_optimize_null
+:
+   OPTIMIZE null_rest_of_line
+;
+spanning_tree_pathcost_null
+:
+   PATHCOST null_rest_of_line
+;
+spanning_tree_port_null
+:
+   PORT null_rest_of_line
+;
+spanning_tree_uplinkfast_null
+:
+   UPLINKFAST null_rest_of_line
+;
+spanning_tree_vlan_null
+:
+   VLAN null_rest_of_line
 ;
 
 spti_null
@@ -3415,17 +3562,33 @@ ssh_client
    CLIENT null_rest_of_line
 ;
 
-ssh_null
+ssh_ip_address_null
 :
-   (
-      IP_ADDRESS
-      | KEY
-      | KEY_EXCHANGE
-      | LOGIN_ATTEMPTS
-      | MGMT_AUTH
-      | STRICTHOSTKEYCHECK
-      | VERSION
-   ) null_rest_of_line
+   IP_ADDRESS null_rest_of_line
+;
+ssh_key_null
+:
+   KEY null_rest_of_line
+;
+ssh_key_exchange_null
+:
+   KEY_EXCHANGE null_rest_of_line
+;
+ssh_login_attempts_null
+:
+   LOGIN_ATTEMPTS null_rest_of_line
+;
+ssh_mgmt_auth_null
+:
+   MGMT_AUTH null_rest_of_line
+;
+ssh_stricthostkeycheck_null
+:
+   STRICTHOSTKEYCHECK null_rest_of_line
+;
+ssh_version_null
+:
+   VERSION null_rest_of_line
 ;
 
 ssh_server
@@ -3680,28 +3843,64 @@ system_default
 :
    DEFAULT
    (
-      sd_null
+      sd_dce_mode_null
+      | sd_interface_null
+      | sd_link_fail_null
       | sd_switchport
    )
 ;
 
-system_null
+system_admin_vdc_null
 :
-   (
-      ADMIN_VDC
-      | AUTO_UPGRADE
-      | FABRIC
-      | FABRIC_MODE
-      | FLOWCONTROL
-      | INTERFACE
-      | JUMBOMTU
-      | MODE
-      | MODULE_TYPE
-      | MTU
-      | ROUTING
-      | URPF
-      | VLAN
-   ) null_rest_of_line
+   ADMIN_VDC null_rest_of_line
+;
+system_auto_upgrade_null
+:
+   AUTO_UPGRADE null_rest_of_line
+;
+system_fabric_null
+:
+   FABRIC null_rest_of_line
+;
+system_fabric_mode_null
+:
+   FABRIC_MODE null_rest_of_line
+;
+system_flowcontrol_null
+:
+   FLOWCONTROL null_rest_of_line
+;
+system_interface_null
+:
+   INTERFACE null_rest_of_line
+;
+system_jumbomtu_null
+:
+   JUMBOMTU null_rest_of_line
+;
+system_mode_null
+:
+   MODE null_rest_of_line
+;
+system_module_type_null
+:
+   MODULE_TYPE null_rest_of_line
+;
+system_mtu_null
+:
+   MTU null_rest_of_line
+;
+system_routing_null
+:
+   ROUTING null_rest_of_line
+;
+system_urpf_null
+:
+   URPF null_rest_of_line
+;
+system_vlan_null
+:
+   VLAN null_rest_of_line
 ;
 
 system_qos
@@ -3721,12 +3920,13 @@ system_qos_null
    ) null_rest_of_line
 ;
 
-t_null
+t_group_null
 :
-   (
-      GROUP
-      | HOST
-   ) null_rest_of_line
+   GROUP null_rest_of_line
+;
+t_host_null
+:
+   HOST null_rest_of_line
 ;
 
 t_server
@@ -3858,15 +4058,16 @@ track_interface
 
 track_ip
 :
-  IP null_rest_of_line track_ip_null*
+  IP null_rest_of_line ( track_ip_default_null | track_ip_delay_null )*
 ;
 
-track_ip_null
+track_ip_default_null
 :
-  (
-    DEFAULT
-    | DELAY
-  ) null_rest_of_line
+   DEFAULT null_rest_of_line
+;
+track_ip_delay_null
+:
+   DELAY null_rest_of_line
 ;
 
 track_list
@@ -3957,7 +4158,12 @@ tltw_object_tail
 
 ts_common
 :
-   ts_null
+   ts_deadtime_null
+   | ts_directed_request_null
+   | ts_key_null
+   | ts_retransmit_null
+   | ts_test_null
+   | ts_timeout_null
 ;
 
 ts_host
@@ -3969,16 +4175,29 @@ ts_host
    ) null_rest_of_line t_key?
 ;
 
-ts_null
+ts_deadtime_null
 :
-   (
-      DEADTIME
-      | DIRECTED_REQUEST
-      | KEY
-      | RETRANSMIT
-      | TEST
-      | TIMEOUT
-   ) null_rest_of_line
+   DEADTIME null_rest_of_line
+;
+ts_directed_request_null
+:
+   DIRECTED_REQUEST null_rest_of_line
+;
+ts_key_null
+:
+   KEY null_rest_of_line
+;
+ts_retransmit_null
+:
+   RETRANSMIT null_rest_of_line
+;
+ts_test_null
+:
+   TEST null_rest_of_line
+;
+ts_timeout_null
+:
+   TIMEOUT null_rest_of_line
 ;
 
 u
@@ -4039,12 +4258,13 @@ u_role
    ) role = variable
 ;
 
-ua_null
+ua_group_lock_null
 :
-   (
-      GROUP_LOCK
-      | VPN_GROUP_POLICY
-   ) null_rest_of_line
+   GROUP_LOCK null_rest_of_line
+;
+ua_vpn_group_policy_null
+:
+   VPN_GROUP_POLICY null_rest_of_line
 ;
 
 up_cisco
@@ -4248,21 +4468,49 @@ voice_class_uri
     )
 ;
 
-voice_null
+voice_alg_based_cac_null
 :
-   (
-      ALG_BASED_CAC
-      | CALL
-      | DIALPLAN_PROFILE
-      | HUNT
-      | IEC
-      | LOGGING
-      | REAL_TIME_CONFIG
-      | RTCP_INACTIVITY
-      | RTP
-      | SIP
-      | SIP_MIDCALL_REQ_TIMEOUT
-   ) null_rest_of_line
+   ALG_BASED_CAC null_rest_of_line
+;
+voice_call_null
+:
+   CALL null_rest_of_line
+;
+voice_dialplan_profile_null
+:
+   DIALPLAN_PROFILE null_rest_of_line
+;
+voice_hunt_null
+:
+   HUNT null_rest_of_line
+;
+voice_iec_null
+:
+   IEC null_rest_of_line
+;
+voice_logging_null
+:
+   LOGGING null_rest_of_line
+;
+voice_real_time_config_null
+:
+   REAL_TIME_CONFIG null_rest_of_line
+;
+voice_rtcp_inactivity_null
+:
+   RTCP_INACTIVITY null_rest_of_line
+;
+voice_rtp_null
+:
+   RTP null_rest_of_line
+;
+voice_sip_null
+:
+   SIP null_rest_of_line
+;
+voice_sip_midcall_req_timeout_null
+:
+   SIP_MIDCALL_REQ_TIMEOUT null_rest_of_line
 ;
 
 voice_service
@@ -4557,15 +4805,25 @@ wccp_id
    )* NEWLINE
 ;
 
-wccp_null
+wccp_check_null
 :
-   (
-      CHECK
-      | OUTBOUND_ACL_CHECK
-      | SOURCE_INTERFACE
-      | VERSION
-      | WEB_CACHE
-   ) null_rest_of_line
+   CHECK null_rest_of_line
+;
+wccp_outbound_acl_check_null
+:
+   OUTBOUND_ACL_CHECK null_rest_of_line
+;
+wccp_source_interface_null
+:
+   SOURCE_INTERFACE null_rest_of_line
+;
+wccp_version_null
+:
+   VERSION null_rest_of_line
+;
+wccp_web_cache_null
+:
+   WEB_CACHE null_rest_of_line
 ;
 
 web_server_null


### PR DESCRIPTION
Rewrite catch-all _null rules into per-token leaf rules. Each token
that shared a many-token _null rule now has its own
<prefix>_<token>_null: TOKEN null_rest_of_line; leaf. Leaf names are
matched to their sibling alternatives' prefix and merged alphabetically
among the pre-existing parent alternatives without reordering those
alternatives. Inline/quantified references are wrapped in a
parse-tree-neutral group. This restores LL(1) and the naming
conventions described in docs/parsing. The parse tree shape is
unchanged; only leaf rule names change. Only simple catch-alls are
handled; NO?-prefixed, leading-token, and ambiguous cases are punted.

----

Prompt:
```
In many of our older grammars, we have a bad pattern where we had rules like

bgp:
   bgp_abc
   | bgp_def
   | bgp_null
;

bgp_null:
   (SOMETOKEN
   | OTHER_TOKEN
   | OTHER_TOKEN
   ...
   ) null_rest_of_line;

(with other variants, like null_filler, etc.) This many-token-null-rule is
no longer acceptable. Rewrite all of these, vendor by vendor, in an
idiomatic way: bgp_sometoken_null: SOMETOKEN null_rest_of_line;, getting rid
of the catch-all bgp_null. Punt on the NO?-prefixed cases; one vendor per
commit; fan out across vendors in parallel worktrees. Leaf rule names should
match sibling alternatives, and be interleaved alphabetically into the parent.
```
