### PR TITLE
a10: split catch-all _null rules into per-token rules

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_router_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_router_bgp.g4
@@ -55,23 +55,33 @@ bgp_neighbor: ip_address;
 srbn
 :
    srbn_activate
+   | srbn_capability_null
    | srbn_description
+   | srbn_fall_over_null
    | srbn_maximum_prefix
    | srbn_remote_as
    | srbn_send_community
+   | srbn_soft_reconfiguration_null
+   | srbn_timers_null
    | srbn_weight
    | srbn_update_source
-   | srbn_null
 ;
 
-srbn_null
+srbn_capability_null
 :
-   (
-      CAPABILITY
-      | FALL_OVER
-      | SOFT_RECONFIGURATION
-      | TIMERS
-   ) null_rest_of_line
+   CAPABILITY null_rest_of_line
+;
+srbn_fall_over_null
+:
+   FALL_OVER null_rest_of_line
+;
+srbn_soft_reconfiguration_null
+:
+   SOFT_RECONFIGURATION null_rest_of_line
+;
+srbn_timers_null
+:
+   TIMERS null_rest_of_line
 ;
 
 srbn_activate: ACTIVATE NEWLINE;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_vrrp_a.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/a10/grammar/A10_vrrp_a.g4
@@ -10,11 +10,17 @@ s_vrrp_a
 :
   VRRP_A
   (
-    vrrpa_common
+    vrrpa_arp_retry_null
+    | vrrpa_common
+    | vrrpa_dead_timer_null
     | vrrpa_fail_over_policy_template
+    | vrrpa_get_ready_time_acos2_null
+    | vrrpa_hello_interval_null
     | vrrpa_interface
-    | vrrpa_null
     | vrrpa_peer_group
+    | vrrpa_preemption_delay_null
+    | vrrpa_session_sync_null
+    | vrrpa_track_event_delay_null
     | vrrpa_vrid
     | vrrpa_vrid_lead
   )
@@ -24,11 +30,17 @@ vrrpa_common: COMMON NEWLINE vrrpac*;
 
 vrrpac
 :
-  vrrpac_device_id
+  vrrpac_arp_retry_null
+  | vrrpac_dead_timer_null
+  | vrrpac_device_id
   | vrrpac_disable_default_vrid
   | vrrpac_enable
-  | vrrpac_null
+  | vrrpac_get_ready_time_null
+  | vrrpac_hello_interval_null
+  | vrrpac_preemption_delay_null
+  | vrrpac_restart_time_null
   | vrrpac_set_id
+  | vrrpac_track_event_delay_null
 ;
 
 vrrpac_device_id: DEVICE_ID vrrpa_device_id_number NEWLINE;
@@ -43,17 +55,33 @@ vrrpac_disable_default_vrid: DISABLE_DEFAULT_VRID NEWLINE;
 
 vrrpac_enable: ENABLE NEWLINE;
 
-vrrpac_null
+vrrpac_arp_retry_null
 :
-  (
-    ARP_RETRY
-    | DEAD_TIMER
-    | GET_READY_TIME
-    | HELLO_INTERVAL
-    | PREEMPTION_DELAY
-    | RESTART_TIME
-    | TRACK_EVENT_DELAY
-  ) null_rest_of_line
+   ARP_RETRY null_rest_of_line
+;
+vrrpac_dead_timer_null
+:
+   DEAD_TIMER null_rest_of_line
+;
+vrrpac_get_ready_time_null
+:
+   GET_READY_TIME null_rest_of_line
+;
+vrrpac_hello_interval_null
+:
+   HELLO_INTERVAL null_rest_of_line
+;
+vrrpac_preemption_delay_null
+:
+   PREEMPTION_DELAY null_rest_of_line
+;
+vrrpac_restart_time_null
+:
+   RESTART_TIME null_rest_of_line
+;
+vrrpac_track_event_delay_null
+:
+   TRACK_EVENT_DELAY null_rest_of_line
 ;
 
 vrrpac_set_id: SET_ID vrrpa_set_id_number NEWLINE;
@@ -87,17 +115,33 @@ vrrpaf_gateway_weight
 
 vrrpa_interface: INTERFACE ref = ethernet_or_trunk_reference NEWLINE;
 
-vrrpa_null
+vrrpa_arp_retry_null
 :
-  (
-    ARP_RETRY
-    | DEAD_TIMER
-    | GET_READY_TIME_ACOS2
-    | HELLO_INTERVAL
-    | PREEMPTION_DELAY
-    | SESSION_SYNC
-    | TRACK_EVENT_DELAY
-  ) null_rest_of_line
+   ARP_RETRY null_rest_of_line
+;
+vrrpa_dead_timer_null
+:
+   DEAD_TIMER null_rest_of_line
+;
+vrrpa_get_ready_time_acos2_null
+:
+   GET_READY_TIME_ACOS2 null_rest_of_line
+;
+vrrpa_hello_interval_null
+:
+   HELLO_INTERVAL null_rest_of_line
+;
+vrrpa_preemption_delay_null
+:
+   PREEMPTION_DELAY null_rest_of_line
+;
+vrrpa_session_sync_null
+:
+   SESSION_SYNC null_rest_of_line
+;
+vrrpa_track_event_delay_null
+:
+   TRACK_EVENT_DELAY null_rest_of_line
 ;
 
 vrrpa_peer_group: PEER_GROUP NEWLINE vrrpapg_peer*;


### PR DESCRIPTION
Rewrite the many-token catch-all `_null` rules into one idiomatic
per-token leaf rule each (prefix matched to sibling alternatives,
merged alphabetically into the parent alternation), delete the
catch-all, and wrap inline references in a parse-tree-neutral group.
This restores LL(1) single-token advancement and the
<prefix>_<token>_null naming convention described in docs/parsing.

The parse tree shape is unchanged aside from the leaf rule names; only
simple catch-alls (single uppercase token per alternative, tail
null_rest_of_line/null_filler) are handled. NO?-prefixed cases are
punted.

----

Prompt:
```
In many of our older grammars, we have a bad pattern where we had rules like

bgp:
   bgp_abc
   | bgp_def
   | bgp_null
;

bgp_null:
   (SOMETOKEN
   | OTHER_TOKEN
   | OTHER_TOKEN
   ...
   ) null_rest_of_line;

(with other variants, like null_filler, etc.) This many-token-null-rule is
no longer acceptable. Rewrite all of these, vendor by vendor, in an
idiomatic way: bgp_sometoken_null: SOMETOKEN null_rest_of_line;, getting rid
of the catch-all bgp_null. Punt on the NO?-prefixed cases; one vendor per
commit; fan out across vendors in parallel worktrees. Leaf rule names should
match sibling alternatives, and be interleaved alphabetically into the parent.
```
