### PR TITLE
flatvyos: split catch-all _null rules into per-token rules

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/FlatVyosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/FlatVyosParser.g4
@@ -27,8 +27,16 @@ s_system
 
 s_system_tail
 :
-   st_host_name
-   | st_null
+   st_config_management_null
+   | st_console_null
+   | st_flow_accounting_null
+   | st_host_name
+   | st_login_null
+   | st_ntp_null
+   | st_package_null
+   | st_syslog_null
+   | st_task_scheduler_null
+   | st_time_zone_null
 ;
 
 set_line
@@ -51,19 +59,41 @@ st_host_name
    HOST_NAME name = variable
 ;
 
-st_null
+st_config_management_null
 :
-   (
-      CONFIG_MANAGEMENT
-      | CONSOLE
-      | FLOW_ACCOUNTING
-      | LOGIN
-      | NTP
-      | PACKAGE
-      | SYSLOG
-      | TASK_SCHEDULER
-      | TIME_ZONE
-   ) null_filler
+   CONFIG_MANAGEMENT null_filler
+;
+st_console_null
+:
+   CONSOLE null_filler
+;
+st_flow_accounting_null
+:
+   FLOW_ACCOUNTING null_filler
+;
+st_login_null
+:
+   LOGIN null_filler
+;
+st_ntp_null
+:
+   NTP null_filler
+;
+st_package_null
+:
+   PACKAGE null_filler
+;
+st_syslog_null
+:
+   SYSLOG null_filler
+;
+st_task_scheduler_null
+:
+   TASK_SCHEDULER null_filler
+;
+st_time_zone_null
+:
+   TIME_ZONE null_filler
 ;
 
 statement

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/FlatVyos_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/FlatVyos_bgp.g4
@@ -11,12 +11,13 @@ bnt_nexthop_self
    NEXTHOP_SELF
 ;
 
-bnt_null
+bnt_soft_reconfiguration_null
 :
-   (
-      SOFT_RECONFIGURATION
-      | TIMERS
-   ) null_filler
+   SOFT_RECONFIGURATION null_filler
+;
+bnt_timers_null
+:
+   TIMERS null_filler
 ;
 
 bnt_remote_as
@@ -42,10 +43,11 @@ bt_neighbor
 bt_neighbor_tail
 :
    bnt_nexthop_self
-   | bnt_null
    | bnt_remote_as
    | bnt_route_map_export
    | bnt_route_map_import
+   | bnt_soft_reconfiguration_null
+   | bnt_timers_null
 ;
 
 s_protocols_bgp

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/FlatVyos_interfaces.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/FlatVyos_interfaces.g4
@@ -20,15 +20,25 @@ it_description
    description
 ;
 
-it_null
+it_duplex_null
 :
-   (
-      DUPLEX
-      | HW_ID
-      | MTU
-      | SMP_AFFINITY
-      | SPEED
-   ) null_filler
+   DUPLEX null_filler
+;
+it_hw_id_null
+:
+   HW_ID null_filler
+;
+it_mtu_null
+:
+   MTU null_filler
+;
+it_smp_affinity_null
+:
+   SMP_AFFINITY null_filler
+;
+it_speed_null
+:
+   SPEED null_filler
 ;
 
 s_interfaces
@@ -40,5 +50,9 @@ s_interfaces_tail
 :
    it_address
    | it_description
-   | it_null
+   | it_duplex_null
+   | it_hw_id_null
+   | it_mtu_null
+   | it_smp_affinity_null
+   | it_speed_null
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/FlatVyos_vpn.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/FlatVyos_vpn.g4
@@ -122,12 +122,13 @@ iket_lifetime
    LIFETIME seconds = DEC
 ;
 
-iket_null
+iket_dead_peer_detection_null
 :
-   (
-      DEAD_PEER_DETECTION
-      | IKEV2_REAUTH
-   ) null_filler
+   DEAD_PEER_DETECTION null_filler
+;
+iket_ikev2_reauth_null
+:
+   IKEV2_REAUTH null_filler
 ;
 
 iket_proposal
@@ -163,9 +164,10 @@ ivt_ike_group
 
 ivt_ike_group_tail
 :
-   iket_key_exchange
+   iket_dead_peer_detection_null
+   | iket_ikev2_reauth_null
+   | iket_key_exchange
    | iket_lifetime
-   | iket_null
    | iket_proposal
 ;
 


### PR DESCRIPTION
Rewrite the many-token catch-all `_null` rules (bnt_null, it_null,
st_null, iket_null) into one idiomatic `<prefix>_<token>_null` leaf per
token, delete the catch-alls, and expand every parent reference into the
corresponding list of leaf rules.

This restores LL(1) single-token advancement and the `<prefix>_next_token`
naming convention per docs/parsing/parser_rule_conventions.md and
docs/parsing/README.md. The parse tree shape is unchanged; only leaf rule
names change. Only simple catch-alls (single UPPERCASE token per
alternative, tail `null_rest_of_line`/`null_filler`) are handled;
NO?-prefixed cases are punted.

----

Prompt:
```
In many of our older grammars, we have a bad pattern where we had rules like

bgp:
   bgp_abc
   | bgp_def
   | bgp_null
;

bgp_null:
   (SOMETOKEN
   | OTHER_TOKEN
   | OTHER_TOKEN
   ...
   ) null_rest_of_line;

(with other variants, like null_filler, etc.) This many-token-null-rule is
no longer acceptable. Rewrite all of these, vendor by vendor, in an
idiomatic way: bgp_sometoken_null: SOMETOKEN null_rest_of_line;, getting rid
of the catch-all bgp_null. Punt on the NO?-prefixed cases; one vendor per
commit; fan out across vendors in parallel worktrees. Leaf rule names should
match sibling alternatives, and be interleaved alphabetically into the parent.
```
