### PR TITLE
Arista: parse `ipv6 unicast-routing`

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaLexer.g4
@@ -4678,6 +4678,8 @@ UNAUTHORIZED: 'unauthorized';
 
 UNAUTHORIZED_DEVICE_PROFILE: 'unauthorized-device-profile';
 
+UNICAST_ROUTING: 'unicast-routing';
+
 UNICAST: 'unicast';
 
 UNIDIRECTIONAL: 'unidirectional';

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/arista/grammar/AristaParser.g4
@@ -2598,12 +2598,21 @@ s_ipc
 s_ipv6
 :
   IPV6
-  ipv6_route
+  (
+    ipv6_route
+    | ipv6_unicast_routing
+  )
 ;
 
 ipv6_route
 :
   ROUTE prefix = ipv6_prefix null_rest_of_line
+;
+
+// Global IPv6 forwarding enable; modeled like `ip routing` (accepted, not converted).
+ipv6_unicast_routing
+:
+  UNICAST_ROUTING (VRF name = vrf_name)? NEWLINE
 ;
 
 s_ipsla

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -5258,4 +5258,11 @@ public class AristaGrammarTest {
 
     assertTrue(vc.getAristaBgp().getDefaultVrf().getRedistributionPolicies().isEmpty());
   }
+
+  @Test
+  public void testIpv6UnicastRoutingParsing() {
+    // Ensure "ipv6 unicast-routing" (bare and vrf-qualified) parses without warnings.
+    AristaConfiguration vc = parseVendorConfig("arista_ipv6_unicast_routing");
+    assertThat(vc.getWarnings().getParseWarnings(), empty());
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_ipv6_unicast_routing
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_ipv6_unicast_routing
@@ -1,0 +1,8 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_ipv6_unicast_routing
+!
+ip routing
+ipv6 unicast-routing
+ipv6 unicast-routing vrf TENANT
+!


### PR DESCRIPTION
Arista EOS `ipv6 unicast-routing` (the global IPv6 forwarding enable) is currently flagged as an unrecognized line. It is a global routing statement, and its sibling `ip routing` already parses via `s_ip_routing`, so this models it the same way.

Changes:
- Add the `UNICAST_ROUTING` lexer token (placed before `UNICAST` so maximal munch matches the longer literal).
- Add an `ipv6_unicast_routing` parser rule under `s_ipv6`, accepting the bare form and the `vrf <name>` form.
- Accepted, not converted, matching how `ip routing` is handled today.

Before this change, feeding a config with `ipv6 unicast-routing` produced `no viable alternative at input 'ipv6 unicast-routing'` (the `unicast-routing` string lexed as a bare identifier).

Adds a test fixture (`arista_ipv6_unicast_routing`) and a test asserting the config parses with no parse warnings. `//projects/batfish/src/test/java/org/batfish/vendor/arista/grammar:tests` passes; checkstyle and google-java-format are clean.