### PR TITLE
Arista: test summary-only aggregate suppression in a VRF

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -1880,6 +1880,47 @@ public class AristaGrammarTest {
   }
 
   @Test
+  public void testBgpAggregateVrfSummaryOnly() throws IOException {
+    /*
+     * Snapshot contains c1, c2, and c3. All BGP sessions on c2 live in vrf vxlan_public under
+     * router bgp with an asdot AS (65166.10010 = 4270728986; c1 peers with it in asdot notation,
+     * c3 in asplain). c1 redistributes static routes 10.1.1.96/27 and 10.1.1.98/32 into BGP and
+     * advertises them to c2. c2 has `aggregate-address 0.0.0.0/0 summary-only advertise-only` in
+     * the vrf, so every learned route is a suppressed contributor of the default-route aggregate.
+     * c3 must receive ONLY the aggregate.
+     */
+    String snapshotName = "bgp-agg-vrf-summary-only";
+    String c1 = "c1";
+    String c2 = "c2";
+    String c3 = "c3";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(
+                    SNAPSHOTS_PREFIX + snapshotName, ImmutableList.of(c1, c2, c3))
+                .build(),
+            _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+
+    Prefix learnedPrefix1 = Prefix.parse("10.1.1.96/27");
+    Prefix learnedPrefix2 = Prefix.parse("10.1.1.98/32");
+    {
+      // c2's vrf BGP RIB has the learned contributors and the activated aggregate.
+      Set<Bgpv4Route> bgpRibRoutes = dp.getBgpRoutes().get(c2, "vxlan_public");
+      assertThat(
+          bgpRibRoutes,
+          containsInAnyOrder(
+              hasPrefix(learnedPrefix1), hasPrefix(learnedPrefix2), hasPrefix(Prefix.ZERO)));
+    }
+    {
+      // c3 receives only the aggregate; both contributors are suppressed VRF-wide.
+      Set<Bgpv4Route> bgpRibRoutes = dp.getBgpRoutes().get(c3, Configuration.DEFAULT_VRF_NAME);
+      assertThat(bgpRibRoutes, containsInAnyOrder(hasPrefix(Prefix.ZERO)));
+    }
+  }
+
+  @Test
   public void testAllowedVlans() throws IOException {
     Configuration c = parseConfig("eos-allowed-vlans");
 

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/snapshots/bgp-agg-vrf-summary-only/configs/c1
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/snapshots/bgp-agg-vrf-summary-only/configs/c1
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname c1
+!
+interface Ethernet1
+ no switchport
+ ip address 10.10.10.1 255.255.255.0
+!
+route-map ALLOW-ALL permit 10
+!
+ip route 10.1.1.96 255.255.255.224 Null0
+ip route 10.1.1.98 255.255.255.255 Null0
+!
+router bgp 65001
+  router-id 1.1.1.1
+  redistribute static
+  neighbor 10.10.10.2 remote-as 65166.10010
+  neighbor 10.10.10.2 route-map ALLOW-ALL in
+  neighbor 10.10.10.2 route-map ALLOW-ALL out
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/snapshots/bgp-agg-vrf-summary-only/configs/c2
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/snapshots/bgp-agg-vrf-summary-only/configs/c2
@@ -1,0 +1,31 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname c2
+!
+vrf instance vxlan_public
+!
+interface Ethernet1
+ no switchport
+ vrf vxlan_public
+ ip address 10.10.10.2 255.255.255.0
+!
+interface Ethernet2
+ no switchport
+ vrf vxlan_public
+ ip address 11.11.11.2 255.255.255.0
+!
+route-map ALLOW-ALL permit 10
+!
+router bgp 65166.10010
+  router-id 2.2.2.2
+  !
+  vrf vxlan_public
+    router-id 2.2.2.2
+    aggregate-address 0.0.0.0/0 summary-only advertise-only
+    neighbor 10.10.10.1 remote-as 65001
+    neighbor 10.10.10.1 route-map ALLOW-ALL in
+    neighbor 10.10.10.1 route-map ALLOW-ALL out
+    neighbor 11.11.11.1 remote-as 65002
+    neighbor 11.11.11.1 route-map ALLOW-ALL in
+    neighbor 11.11.11.1 route-map ALLOW-ALL out
+!

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/snapshots/bgp-agg-vrf-summary-only/configs/c3
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/snapshots/bgp-agg-vrf-summary-only/configs/c3
@@ -1,0 +1,16 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname c3
+!
+interface Ethernet1
+ no switchport
+ ip address 11.11.11.1 255.255.255.0
+!
+route-map ALLOW-ALL permit 10
+!
+router bgp 65002
+  router-id 3.3.3.3
+  neighbor 11.11.11.2 remote-as 4270728986
+  neighbor 11.11.11.2 route-map ALLOW-ALL in
+  neighbor 11.11.11.2 route-map ALLOW-ALL out
+!


### PR DESCRIPTION
Adds a dataplane regression test for `aggregate-address <prefix> summary-only` configured in a `vrf` stanza under `router bgp`.

Motivation: a production change on a pair of Arista border leafs applied `aggregate-address 0.0.0.0/0 summary-only advertise-only` inside a VRF. summary-only suppressed every contributing more-specific VRF-wide, collapsing a downstream router's received routes from 35 prefixes to 1 and causing a brief outage. Current master models this correctly (the downstream neighbor's computed BGP RIB shows only the aggregate), but existing coverage (`testBgpAggregateWithLearnedSuppressedRoutes`) only exercises the default VRF, an asplain AS, and a non-default aggregate prefix. This test locks in the VRF-context behavior with the exact shape of that change:

- sessions under `router bgp <asdot AS>` / `vrf <name>` (asdot `65166.10010`; one peer references it in asdot, the other in asplain)
- a `0.0.0.0/0` aggregate, so every learned route is a contributor
- `advertise-only` present (accepted and extracted; local-RIB-install semantics remain a conversion TODO and are not asserted here)
- contributors include a /27 and a covered /32 host route

Verified the test fails if `summary-only` is removed from the snapshot config.