### PR TITLE
Arista: honor aggregate-address advertise-only (do not install in main RIB)

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -373,6 +373,10 @@ public final class BgpProtocolHelper {
             .setNextHop(NextHopDiscard.instance())
             .setNetwork(aggregate.getNetwork())
             .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
+            // When the aggregate should not be installed in the main RIB (e.g. Arista EOS
+            // advertise-only), mark it non-routing so it remains in the BGP RIB for advertisement
+            // but is excluded from the main RIB.
+            .setNonRouting(!aggregate.getInstallInMainRib())
             .setOriginatorIp(routerId)
             .setOriginMechanism(GENERATED)
             // TODO: confirm default is IGP for all devices initializing aggregates from BGP RIB

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -201,7 +201,6 @@ final class AristaConversions {
 
   static @Nonnull BgpAggregate toBgpAggregate(
       Prefix prefix, AristaBgpAggregateNetwork vsAggregate, Configuration c, Warnings w) {
-    // TODO: handle advertise-only
     // TODO: handle as-set
     // TODO: handle match-map
     // TODO: verify undefined attribute-map can be treated as omitted
@@ -211,12 +210,16 @@ final class AristaConversions {
       attributeMap = null;
     }
     String attributePolicy = generateAggregateAttributePolicy(attributeMap, c);
+    // advertise-only generates the aggregate for advertisement to peers but does not install it in
+    // the main RIB.
+    boolean installInMainRib = !Boolean.TRUE.equals(vsAggregate.getAdvertiseOnly());
     return BgpAggregate.of(
         prefix,
         generateSuppressionPolicy(vsAggregate.getSummaryOnlyEffective(), c),
         // TODO: put match-map here
         null,
-        attributePolicy);
+        attributePolicy,
+        installInMainRib);
   }
 
   static @Nonnull Map<Ip, BgpActivePeerConfig> getNeighbors(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -43,6 +43,7 @@ import org.batfish.datamodel.ReceivedFromSelf;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.AddressFamily;
 import org.batfish.datamodel.bgp.AllowRemoteAsOutMode;
+import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.BgpTopologyUtils.ConfedSessionType;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
@@ -791,5 +792,23 @@ public class BgpProtocolHelperTest {
 
     // ReceivedFromSelf: never matches
     assertFalse(receivedFromPeer(ReceivedFromSelf.instance(), peerIp));
+  }
+
+  @Test
+  public void testToBgpv4RouteFromAggregate() {
+    Prefix network = Prefix.parse("1.0.0.0/8");
+    Ip routerId = Ip.parse("1.1.1.1");
+
+    // installInMainRib=true => routing (installed in main RIB)
+    Bgpv4Route routing =
+        BgpProtocolHelper.toBgpv4Route(
+            BgpAggregate.of(network, null, null, null), null, 200, routerId);
+    assertFalse(routing.getNonRouting());
+
+    // installInMainRib=false (e.g. advertise-only) => non-routing
+    Bgpv4Route nonRouting =
+        BgpProtocolHelper.toBgpv4Route(
+            BgpAggregate.of(network, null, null, null, false), null, 200, routerId);
+    assertTrue(nonRouting.getNonRouting());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -1608,12 +1608,14 @@ public class AristaGrammarTest {
         defaultVrfAggs,
         hasEntry(
             Prefix.parse("1.2.33.0/24"),
-            // TODO: Support advertise-only, as-set, and match-map
+            // advertise-only => installInMainRib=false
+            // TODO: Support as-set and match-map
             BgpAggregate.of(
                 Prefix.parse("1.2.33.0/24"),
                 SUMMARY_ONLY_SUPPRESSION_POLICY_NAME,
                 null,
-                "~BGP_AGGREGATE_ATTRIBUTE_MAP:ATTR_MAP~")));
+                "~BGP_AGGREGATE_ATTRIBUTE_MAP:ATTR_MAP~",
+                false)));
     assertThat(
         defaultVrfAggs,
         hasEntry(
@@ -1785,6 +1787,36 @@ public class AristaGrammarTest {
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix1)));
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix2)));
     assertThat(mainRibRoutes, hasItem(hasPrefix(aggPrefix4General)));
+  }
+
+  @Test
+  public void testBgpAggregateAdvertiseOnly() throws IOException {
+    /*
+     * Config has static routes 1.1.1.0/24 and 2.2.2.0/24 redistributed into BGP, and aggregates:
+     * - 1.1.0.0/16 advertise-only
+     * - 2.2.0.0/16 summary-only advertise-only
+     *
+     * advertise-only means each aggregate is generated in the BGP RIB (for advertisement to peers)
+     * but is NOT installed in the main RIB.
+     */
+    String hostname = "bgp_aggregate_advertise_only";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+
+    Prefix aggPrefix1 = Prefix.parse("1.1.0.0/16");
+    Prefix aggPrefix2 = Prefix.parse("2.2.0.0/16");
+
+    // Both aggregates are generated in the BGP RIB.
+    Set<Bgpv4Route> bgpRibRoutes = dp.getBgpRoutes().get(hostname, Configuration.DEFAULT_VRF_NAME);
+    assertThat(bgpRibRoutes, hasItem(hasPrefix(aggPrefix1)));
+    assertThat(bgpRibRoutes, hasItem(hasPrefix(aggPrefix2)));
+
+    // Neither aggregate is installed in the main RIB (advertise-only).
+    Set<AbstractRoute> mainRibRoutes =
+        dp.getRibs().get(hostname, Configuration.DEFAULT_VRF_NAME).getRoutes();
+    assertThat(mainRibRoutes, not(hasItem(hasPrefix(aggPrefix1))));
+    assertThat(mainRibRoutes, not(hasItem(hasPrefix(aggPrefix2))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/bgp_aggregate_advertise_only
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/bgp_aggregate_advertise_only
@@ -1,0 +1,12 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname bgp_aggregate_advertise_only
+!
+ip route 1.1.1.0 255.255.255.0 Null0
+ip route 2.2.2.0 255.255.255.0 Null0
+!
+router bgp 1
+  router-id 1.1.1.1
+  aggregate-address 1.1.0.0 255.255.0.0 advertise-only
+  aggregate-address 2.2.0.0 255.255.0.0 summary-only advertise-only
+  redistribute static

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpAggregate.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpAggregate.java
@@ -24,7 +24,17 @@ public final class BgpAggregate implements Serializable {
       @Nullable String suppressionPolicy,
       @Nullable String generationPolicy,
       @Nullable String attributePolicy) {
-    return new BgpAggregate(attributePolicy, generationPolicy, network, suppressionPolicy);
+    return of(network, suppressionPolicy, generationPolicy, attributePolicy, true);
+  }
+
+  public static @Nonnull BgpAggregate of(
+      Prefix network,
+      @Nullable String suppressionPolicy,
+      @Nullable String generationPolicy,
+      @Nullable String attributePolicy,
+      boolean installInMainRib) {
+    return new BgpAggregate(
+        attributePolicy, generationPolicy, network, suppressionPolicy, installInMainRib);
   }
 
   /**
@@ -90,6 +100,18 @@ public final class BgpAggregate implements Serializable {
     return _suppressionPolicy;
   }
 
+  /**
+   * Whether the generated aggregate should be installed in the main RIB once activated. If {@code
+   * false}, the aggregate is generated in the BGP RIB (and thus advertised to peers) but not
+   * installed in the main RIB. This models {@code advertise-only} on Arista EOS.
+   *
+   * <p>Defaults to {@code true}.
+   */
+  @JsonProperty(PROP_INSTALL_IN_MAIN_RIB)
+  public boolean getInstallInMainRib() {
+    return _installInMainRib;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -101,12 +123,14 @@ public final class BgpAggregate implements Serializable {
     return Objects.equals(_attributePolicy, that._attributePolicy)
         && Objects.equals(_generationPolicy, that._generationPolicy)
         && _network.equals(that._network)
-        && Objects.equals(_suppressionPolicy, that._suppressionPolicy);
+        && Objects.equals(_suppressionPolicy, that._suppressionPolicy)
+        && _installInMainRib == that._installInMainRib;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_attributePolicy, _generationPolicy, _network, _suppressionPolicy);
+    return Objects.hash(
+        _attributePolicy, _generationPolicy, _network, _suppressionPolicy, _installInMainRib);
   }
 
   @Override
@@ -117,6 +141,7 @@ public final class BgpAggregate implements Serializable {
         .add(PROP_GENERATION_POLICY, _generationPolicy)
         .add(PROP_NETWORK, _network)
         .add(PROP_SUPPRESSION_POLICY, _suppressionPolicy)
+        .add(PROP_INSTALL_IN_MAIN_RIB, _installInMainRib)
         .toString();
   }
 
@@ -124,30 +149,41 @@ public final class BgpAggregate implements Serializable {
   private static final String PROP_GENERATION_POLICY = "generationPolicy";
   private static final String PROP_NETWORK = "network";
   private static final String PROP_SUPPRESSION_POLICY = "suppressionPolicy";
+  private static final String PROP_INSTALL_IN_MAIN_RIB = "installInMainRib";
 
   private final @Nullable String _attributePolicy;
   private final @Nullable String _generationPolicy;
   private final @Nonnull Prefix _network;
   private final @Nullable String _suppressionPolicy;
+  private final boolean _installInMainRib;
 
   @JsonCreator
   private static @Nonnull BgpAggregate create(
       @JsonProperty(PROP_ATTRIBUTE_POLICY) @Nullable String attributePolicy,
       @JsonProperty(PROP_GENERATION_POLICY) @Nullable String generationPolicy,
       @JsonProperty(PROP_NETWORK) @Nullable Prefix network,
-      @JsonProperty(PROP_SUPPRESSION_POLICY) @Nullable String suppressionPolicy) {
+      @JsonProperty(PROP_SUPPRESSION_POLICY) @Nullable String suppressionPolicy,
+      @JsonProperty(PROP_INSTALL_IN_MAIN_RIB) @Nullable Boolean installInMainRib) {
     checkArgument(network != null, "Missing %s", PROP_NETWORK);
-    return of(network, suppressionPolicy, generationPolicy, attributePolicy);
+    return of(
+        network,
+        suppressionPolicy,
+        generationPolicy,
+        attributePolicy,
+        // Default to true for backward compatibility with older serialized aggregates.
+        installInMainRib == null || installInMainRib);
   }
 
   private BgpAggregate(
       @Nullable String attributePolicy,
       @Nullable String generationPolicy,
       Prefix network,
-      @Nullable String suppressionPolicy) {
+      @Nullable String suppressionPolicy,
+      boolean installInMainRib) {
     _attributePolicy = attributePolicy;
     _generationPolicy = generationPolicy;
     _network = network;
     _suppressionPolicy = suppressionPolicy;
+    _installInMainRib = installInMainRib;
   }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpAggregateTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpAggregateTest.java
@@ -14,14 +14,19 @@ public final class BgpAggregateTest {
 
   @Test
   public void testJavaSerialization() {
-    BgpAggregate obj = BgpAggregate.of(Prefix.ZERO, "a", "b", "c");
+    BgpAggregate obj = BgpAggregate.of(Prefix.ZERO, "a", "b", "c", false);
     assertThat(SerializationUtils.clone(obj), equalTo(obj));
   }
 
   @Test
   public void testJsonSerialization() {
-    BgpAggregate obj = BgpAggregate.of(Prefix.ZERO, "a", "b", "c");
+    BgpAggregate obj = BgpAggregate.of(Prefix.ZERO, "a", "b", "c", false);
     assertThat(BatfishObjectMapper.clone(obj, BgpAggregate.class), equalTo(obj));
+  }
+
+  @Test
+  public void testDefaultInstallInMainRib() {
+    assertThat(BgpAggregate.of(Prefix.ZERO, null, null, null).getInstallInMainRib(), equalTo(true));
   }
 
   @Test
@@ -32,6 +37,7 @@ public final class BgpAggregateTest {
         .addEqualityGroup(BgpAggregate.of(Prefix.ZERO, "a", null, null))
         .addEqualityGroup(BgpAggregate.of(Prefix.ZERO, "a", "b", null))
         .addEqualityGroup(BgpAggregate.of(Prefix.ZERO, "a", "b", "c"))
+        .addEqualityGroup(BgpAggregate.of(Prefix.ZERO, "a", "b", "c", false))
         .addEqualityGroup(BgpAggregate.of(Prefix.MULTICAST, "a", "b", "c"))
         .testEquals();
   }

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -5435,6 +5435,7 @@
               "routerId" : "2.1.1.1",
               "aggregates" : [
                 {
+                  "installInMainRib" : true,
                   "network" : "2.128.0.0/16",
                   "suppressionPolicy" : "~suppress~rp~summary-only~"
                 }
@@ -7100,6 +7101,7 @@
               "routerId" : "2.1.1.2",
               "aggregates" : [
                 {
+                  "installInMainRib" : true,
                   "network" : "2.128.0.0/16",
                   "suppressionPolicy" : "~suppress~rp~summary-only~"
                 }


### PR DESCRIPTION
On Arista EOS, `aggregate-address <prefix> advertise-only` generates the
aggregate for advertisement to BGP neighbors but does not install it in
the local main RIB. Batfish extracted advertise-only but ignored it in
conversion, so the aggregate was always installed in the main RIB.

Add an `installInMainRib` flag to the vendor-neutral BgpAggregate
(defaults to true; JSON creator treats a missing value as true for
backward compatibility). When false, BgpProtocolHelper.toBgpv4Route
marks the generated aggregate non-routing so it stays in the BGP RIB
(and is still advertised to peers) but is excluded from the main RIB.
AristaConversions sets installInMainRib=false for advertise-only
aggregates.

Fixes batfish/batfish#10095.

----

Prompt:
```
  - batfish/batfish#10095 (filed) — advertise-only aggregate wrongly
    installed in main RIB (the conversion TODO named in #10093).

Can you take a look at this issue and see if we can fix it?
```
