### PR TITLE
feat(cisco): extract Cisco ASA NTP authentication

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_ntp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_ntp.g4
@@ -58,6 +58,20 @@ ntp_authentication
    AUTHENTICATION NEWLINE
 ;
 
+ntp_authentication_key
+:
+   AUTHENTICATION_KEY key_num = ntp_key hash_algorithm = ntp_hash_algorithm key = variable NEWLINE
+;
+
+ntp_hash_algorithm
+:
+   CMAC
+   | MD5
+   | SHA1
+   | SHA256
+   | SHA512
+;
+
 ntp_clock_period
 :
    CLOCK_PERIOD null_rest_of_line
@@ -74,7 +88,7 @@ ntp_common
    | ntp_allow_null
    | ntp_authenticate
    | ntp_authentication
-   | ntp_authentication_key_null
+   | ntp_authentication_key
    | ntp_clock_period
    | ntp_commit
    | ntp_distribute
@@ -116,10 +130,6 @@ ntp_allow_null
 :
    ALLOW null_rest_of_line
 ;
-ntp_authentication_key_null
-:
-   AUTHENTICATION_KEY null_rest_of_line
-;
 ntp_interface_null
 :
    INTERFACE null_rest_of_line
@@ -145,7 +155,7 @@ ntp_server
    hostname = variable
    (
       IBURST
-      | KEY key = dec
+      | KEY key = ntp_key
       | MAXPOLL dec
       | MINPOLL dec
       | prefer = PREFER
@@ -172,7 +182,7 @@ ntp_source_interface
 
 ntp_trusted_key
 :
-   TRUSTED_KEY dec NEWLINE
+   TRUSTED_KEY key = ntp_key NEWLINE
 ;
 
 ntp_update_calendar

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLexer.g4
@@ -956,6 +956,8 @@ CLUSTER_ID: 'cluster-id';
 
 CLUSTER_LIST_LENGTH: 'cluster-list-length';
 
+CMAC: 'cmac';
+
 CMD: 'cmd';
 
 CMTS: 'cmts';
@@ -5001,10 +5003,17 @@ SHA: 'sha';
 
 SHA1
 :
-   'sha1' -> pushMode ( M_SHA1 )
+   'sha1'
+   {
+     if (secondToLastTokenType() != AUTHENTICATION_KEY) {
+       pushMode(M_SHA1);
+     }
+   }
 ;
 
 SHA2_256_128: 'sha2-256-128';
+
+SHA256: 'sha256';
 
 SHA512: 'sha512';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/Asa_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/Asa_common.g4
@@ -598,6 +598,11 @@ uint32
   | UINT32
 ;
 
+ntp_key
+:
+  uint32
+;
+
 variable
 :
    ~NEWLINE

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
@@ -342,6 +342,7 @@ import org.batfish.datamodel.IsoAddress;
 import org.batfish.datamodel.Line;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LineType;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
@@ -697,8 +698,13 @@ import org.batfish.grammar.cisco_asa.AsaParser.No_neighbor_shutdown_rb_stanzaCon
 import org.batfish.grammar.cisco_asa.AsaParser.No_redistribute_connected_rb_stanzaContext;
 import org.batfish.grammar.cisco_asa.AsaParser.No_route_map_stanzaContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Ntp_access_groupContext;
+import org.batfish.grammar.cisco_asa.AsaParser.Ntp_authenticateContext;
+import org.batfish.grammar.cisco_asa.AsaParser.Ntp_authentication_keyContext;
+import org.batfish.grammar.cisco_asa.AsaParser.Ntp_hash_algorithmContext;
+import org.batfish.grammar.cisco_asa.AsaParser.Ntp_keyContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Ntp_serverContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Ntp_source_interfaceContext;
+import org.batfish.grammar.cisco_asa.AsaParser.Ntp_trusted_keyContext;
 import org.batfish.grammar.cisco_asa.AsaParser.O_networkContext;
 import org.batfish.grammar.cisco_asa.AsaParser.O_serviceContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Og_icmp_typeContext;
@@ -1052,6 +1058,7 @@ import org.batfish.representation.cisco_asa.NetworkObjectGroup;
 import org.batfish.representation.cisco_asa.NetworkObjectGroupAddressSpecifier;
 import org.batfish.representation.cisco_asa.NetworkObjectInfo;
 import org.batfish.representation.cisco_asa.NssaSettings;
+import org.batfish.representation.cisco_asa.NtpAuthenticationKey;
 import org.batfish.representation.cisco_asa.OspfNetwork;
 import org.batfish.representation.cisco_asa.OspfNetworkType;
 import org.batfish.representation.cisco_asa.OspfProcess;
@@ -1130,6 +1137,8 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
     implements SilentSyntaxListener, ControlPlaneExtractor {
   private static final String INLINE_SERVICE_OBJECT_NAME = "~INLINE_SERVICE_OBJECT~";
   private static final IntegerSpace PROTOCOL_DISTANCE_RANGE = IntegerSpace.of(Range.closed(1, 255));
+
+  private static final LongSpace NTP_KEY_RANGE = LongSpace.of(Range.closed(1L, 4294967295L));
 
   @VisibleForTesting static final String SERIAL_LINE = "serial";
 
@@ -1248,6 +1257,25 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
 
   private static long toLong(DecContext ctx) {
     return Long.parseLong(ctx.getText());
+  }
+
+  /**
+   * Convert a {@link ParserRuleContext} whose text is guaranteed to represent a valid signed 64-bit
+   * decimal integer to a {@link Long} if it is contained in the provided {@code space}, or else
+   * {@link Optional#empty}.
+   */
+  private @Nonnull Optional<Long> toLongInSpace(
+      ParserRuleContext messageCtx, ParserRuleContext ctx, LongSpace space, String name) {
+    long num = Long.parseLong(ctx.getText());
+    if (!space.contains(num)) {
+      warn(messageCtx, String.format("Expected %s in range %s, but got '%d'", name, space, num));
+      return Optional.empty();
+    }
+    return Optional.of(num);
+  }
+
+  private @Nonnull Optional<Long> toLong(ParserRuleContext messageCtx, Ntp_keyContext ctx) {
+    return toLongInSpace(messageCtx, ctx, NTP_KEY_RANGE, "NTP key number");
   }
 
   private static List<SubRange> toRange(RangeContext ctx) {
@@ -6817,6 +6845,46 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
   }
 
   @Override
+  public void exitNtp_authenticate(Ntp_authenticateContext ctx) {
+    _configuration.setNtpAuthenticate(true);
+  }
+
+  @Override
+  public void exitNtp_authentication_key(Ntp_authentication_keyContext ctx) {
+    Optional<Long> maybeKeyNum = toLong(ctx, ctx.key_num);
+    if (!maybeKeyNum.isPresent()) {
+      return;
+    }
+    NtpAuthenticationKey key =
+        _configuration
+            .getNtpAuthenticationKeys()
+            .computeIfAbsent(maybeKeyNum.get(), NtpAuthenticationKey::new);
+    key.setHashAlgorithm(toHashAlgorithm(ctx.hash_algorithm));
+    key.setValue(ctx.key.getText());
+  }
+
+  private NtpAuthenticationKey.HashAlgorithm toHashAlgorithm(Ntp_hash_algorithmContext ctx) {
+    if (ctx.CMAC() != null) {
+      return NtpAuthenticationKey.HashAlgorithm.CMAC;
+    } else if (ctx.MD5() != null) {
+      return NtpAuthenticationKey.HashAlgorithm.MD5;
+    } else if (ctx.SHA1() != null) {
+      return NtpAuthenticationKey.HashAlgorithm.SHA1;
+    } else if (ctx.SHA256() != null) {
+      return NtpAuthenticationKey.HashAlgorithm.SHA256;
+    } else if (ctx.SHA512() != null) {
+      return NtpAuthenticationKey.HashAlgorithm.SHA512;
+    } else {
+      throw convError(NtpAuthenticationKey.HashAlgorithm.class, ctx);
+    }
+  }
+
+  @Override
+  public void exitNtp_trusted_key(Ntp_trusted_keyContext ctx) {
+    toLong(ctx, ctx.key).ifPresent(_configuration.getNtpTrustedKeys()::add);
+  }
+
+  @Override
   public void exitNtp_server(Ntp_serverContext ctx) {
     Ntp ntp = _configuration.getCf().getNtp();
     String hostname = ctx.hostname.getText();
@@ -6825,6 +6893,13 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
       String vrfName = ctx.vrf.getText();
       server.setVrf(vrfName);
       initVrf(vrfName);
+    }
+    org.batfish.representation.cisco_asa.NtpServer vsServer =
+        _configuration
+            .getNtpServers()
+            .computeIfAbsent(hostname, org.batfish.representation.cisco_asa.NtpServer::new);
+    if (ctx.key != null) {
+      toLong(ctx, ctx.key).ifPresent(vsServer::setKey);
     }
     if (ctx.PREFER() != null) {
       // TODO: implement

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -497,6 +497,14 @@ public final class AsaConfiguration extends VendorConfiguration {
 
   private String _ntpSourceInterface;
 
+  private boolean _ntpAuthenticate;
+
+  private final Map<Long, NtpAuthenticationKey> _ntpAuthenticationKeys;
+
+  private final Set<Long> _ntpTrustedKeys;
+
+  private final Map<String, NtpServer> _ntpServers;
+
   private final Map<String, ObjectGroup> _objectGroups;
 
   private final Map<String, Prefix6List> _prefix6Lists;
@@ -579,6 +587,9 @@ public final class AsaConfiguration extends VendorConfiguration {
     _networkObjectGroups = new TreeMap<>();
     _networkObjectInfos = new TreeMap<>();
     _networkObjects = new TreeMap<>();
+    _ntpAuthenticationKeys = new TreeMap<>();
+    _ntpTrustedKeys = new TreeSet<>();
+    _ntpServers = new TreeMap<>();
     _objectGroups = new TreeMap<>();
     _prefixLists = new TreeMap<>();
     _prefix6Lists = new TreeMap<>();
@@ -829,6 +840,40 @@ public final class AsaConfiguration extends VendorConfiguration {
 
   public String getNtpSourceInterface() {
     return _ntpSourceInterface;
+  }
+
+  public boolean getNtpAuthenticate() {
+    return _ntpAuthenticate;
+  }
+
+  public void setNtpAuthenticate(boolean ntpAuthenticate) {
+    _ntpAuthenticate = ntpAuthenticate;
+  }
+
+  public Map<Long, NtpAuthenticationKey> getNtpAuthenticationKeys() {
+    return _ntpAuthenticationKeys;
+  }
+
+  public Set<Long> getNtpTrustedKeys() {
+    return _ntpTrustedKeys;
+  }
+
+  public Map<String, NtpServer> getNtpServers() {
+    return _ntpServers;
+  }
+
+  /**
+   * Whether the NTP server with the given hostname is authenticated: NTP authentication is enabled,
+   * the server references a key, and that key is both defined via {@code ntp authentication-key}
+   * and trusted via {@code ntp trusted-key}.
+   */
+  public boolean isNtpServerAuthenticated(String hostname) {
+    NtpServer server = _ntpServers.get(hostname);
+    if (server == null || !_ntpAuthenticate) {
+      return false;
+    }
+    Long key = server.getKey();
+    return key != null && _ntpAuthenticationKeys.containsKey(key) && _ntpTrustedKeys.contains(key);
   }
 
   public Map<String, Prefix6List> getPrefix6Lists() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/NtpAuthenticationKey.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/NtpAuthenticationKey.java
@@ -1,0 +1,51 @@
+package org.batfish.representation.cisco_asa;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/**
+ * A Cisco ASA NTP authentication key defined via {@code ntp authentication-key <key-id> {md5 | sha1
+ * | sha256 | sha512 | cmac} <value>}.
+ */
+public class NtpAuthenticationKey implements Serializable {
+
+  /** The hashing algorithm used to authenticate with an NTP key. */
+  public enum HashAlgorithm {
+    CMAC,
+    MD5,
+    SHA1,
+    SHA256,
+    SHA512
+  }
+
+  private final long _keyNumber;
+  private @Nullable HashAlgorithm _hashAlgorithm;
+  private @Nullable String _value;
+
+  public NtpAuthenticationKey(long keyNumber) {
+    _keyNumber = keyNumber;
+  }
+
+  /** The key number this authentication key is identified by. */
+  public long getKeyNumber() {
+    return _keyNumber;
+  }
+
+  /** The hashing algorithm used with this key. */
+  public @Nullable HashAlgorithm getHashAlgorithm() {
+    return _hashAlgorithm;
+  }
+
+  public void setHashAlgorithm(@Nullable HashAlgorithm hashAlgorithm) {
+    _hashAlgorithm = hashAlgorithm;
+  }
+
+  /** The key value. */
+  public @Nullable String getValue() {
+    return _value;
+  }
+
+  public void setValue(@Nullable String value) {
+    _value = value;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/NtpServer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/NtpServer.java
@@ -1,0 +1,31 @@
+package org.batfish.representation.cisco_asa;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** An NTP server configured via {@code ntp server}. */
+@ParametersAreNonnullByDefault
+public final class NtpServer implements Serializable {
+
+  private final @Nonnull String _host;
+  private @Nullable Long _key;
+
+  public NtpServer(String host) {
+    _host = host;
+  }
+
+  public @Nonnull String getHost() {
+    return _host;
+  }
+
+  /** The key number referenced by this server's {@code key} statement, if any. */
+  public @Nullable Long getKey() {
+    return _key;
+  }
+
+  public void setKey(@Nullable Long key) {
+    _key = key;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
@@ -199,6 +199,8 @@ import org.batfish.representation.cisco_asa.ExpandedCommunityListLine;
 import org.batfish.representation.cisco_asa.NetworkObject;
 import org.batfish.representation.cisco_asa.NetworkObjectAddressSpecifier;
 import org.batfish.representation.cisco_asa.NetworkObjectGroupAddressSpecifier;
+import org.batfish.representation.cisco_asa.NtpAuthenticationKey;
+import org.batfish.representation.cisco_asa.NtpAuthenticationKey.HashAlgorithm;
 import org.batfish.representation.cisco_asa.OspfNetworkType;
 import org.batfish.representation.cisco_asa.RouteMap;
 import org.batfish.representation.cisco_asa.RouteMapClause;
@@ -2893,5 +2895,79 @@ public final class CiscoAsaGrammarTest {
           containsInAnyOrder(
               StandardCommunity.of(1, 1), StandardCommunity.of(2, 2), StandardCommunity.of(3, 3)));
     }
+  }
+
+  @Test
+  public void testAsaNtpExtraction() {
+    AsaConfiguration vc = parseVendorConfig("asa-ntp");
+
+    assertTrue(vc.getNtpAuthenticate());
+
+    assertThat(vc.getNtpAuthenticationKeys(), hasKeys(1L, 2L, 3L, 42L, 100L, 4294967295L));
+
+    NtpAuthenticationKey key1 = vc.getNtpAuthenticationKeys().get(1L);
+    assertThat(key1.getHashAlgorithm(), equalTo(HashAlgorithm.MD5));
+    assertThat(key1.getValue(), equalTo("aNiceKey"));
+
+    NtpAuthenticationKey key2 = vc.getNtpAuthenticationKeys().get(2L);
+    assertThat(key2.getHashAlgorithm(), equalTo(HashAlgorithm.CMAC));
+    assertThat(key2.getValue(), equalTo("aCmacKey"));
+
+    NtpAuthenticationKey key3 = vc.getNtpAuthenticationKeys().get(3L);
+    assertThat(key3.getHashAlgorithm(), equalTo(HashAlgorithm.SHA1));
+    assertThat(key3.getValue(), equalTo("aSha1Key"));
+
+    NtpAuthenticationKey key42 = vc.getNtpAuthenticationKeys().get(42L);
+    assertThat(key42.getHashAlgorithm(), equalTo(HashAlgorithm.SHA256));
+    assertThat(key42.getValue(), equalTo("aSha256Key"));
+
+    NtpAuthenticationKey key100 = vc.getNtpAuthenticationKeys().get(100L);
+    assertThat(key100.getHashAlgorithm(), equalTo(HashAlgorithm.SHA512));
+    assertThat(key100.getValue(), equalTo("aSha512Key"));
+
+    // Largest valid uint32 key ID
+    NtpAuthenticationKey keyMax = vc.getNtpAuthenticationKeys().get(4294967295L);
+    assertThat(keyMax.getHashAlgorithm(), equalTo(HashAlgorithm.MD5));
+    assertThat(keyMax.getValue(), equalTo("aBigKey"));
+
+    // `ntp trusted-key 0` parses as a uint32 but is out of the valid NTP key range
+    // (1-4294967295), so it is dropped with a warning and never added to the trusted-key set.
+    assertThat(vc.getNtpTrustedKeys(), equalTo(ImmutableSet.of(1L, 10L, 4294967295L)));
+
+    assertThat(vc.getNtpServers(), hasKeys("10.1.1.10", "10.1.1.11", "10.1.1.12", "10.1.1.13"));
+
+    assertThat(vc.getNtpServers().get("10.1.1.10").getKey(), equalTo(1L));
+    assertThat(vc.getNtpServers().get("10.1.1.11").getKey(), nullValue());
+    assertThat(vc.getNtpServers().get("10.1.1.12").getKey(), equalTo(42L));
+    assertThat(vc.getNtpServers().get("10.1.1.13").getKey(), equalTo(4294967295L));
+
+    // key 1 is defined, trusted, and authentication is enabled.
+    assertTrue(vc.isNtpServerAuthenticated("10.1.1.10"));
+    // no key referenced.
+    assertFalse(vc.isNtpServerAuthenticated("10.1.1.11"));
+    // key 42 is defined but not trusted.
+    assertFalse(vc.isNtpServerAuthenticated("10.1.1.12"));
+    // key 4294967295 is defined and trusted, and authentication is enabled.
+    assertTrue(vc.isNtpServerAuthenticated("10.1.1.13"));
+  }
+
+  @Test
+  public void testAsaNtpNoAuthenticateExtraction() {
+    AsaConfiguration vc = parseVendorConfig("asa-ntp-no-authenticate");
+
+    assertFalse(vc.getNtpAuthenticate());
+
+    assertThat(vc.getNtpTrustedKeys(), equalTo(ImmutableSet.of(6L)));
+
+    assertThat(vc.getNtpServers(), hasKeys("10.1.1.20", "10.1.1.21"));
+
+    assertThat(vc.getNtpServers().get("10.1.1.20").getKey(), equalTo(6L));
+    assertThat(vc.getNtpServers().get("10.1.1.21").getKey(), equalTo(9L));
+
+    // Key 6 is defined and trusted, but `ntp authenticate` is off, so the server is not
+    // authenticated.
+    assertFalse(vc.isNtpServerAuthenticated("10.1.1.20"));
+    // Key 9 is undefined and untrusted.
+    assertFalse(vc.isNtpServerAuthenticated("10.1.1.21"));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-ntp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-ntp
@@ -1,0 +1,21 @@
+! This is an ASA device.
+ASA Version 9.9
+!
+hostname asa-ntp
+!
+ntp authenticate
+ntp authentication-key 1 md5 aNiceKey
+ntp authentication-key 2 cmac aCmacKey
+ntp authentication-key 3 sha1 aSha1Key
+ntp authentication-key 42 sha256 aSha256Key
+ntp authentication-key 100 sha512 aSha512Key
+ntp authentication-key 4294967295 md5 aBigKey
+ntp trusted-key 1
+ntp trusted-key 10
+ntp trusted-key 4294967295
+ntp trusted-key 0
+ntp server 10.1.1.10 key 1
+ntp server 10.1.1.11
+ntp server 10.1.1.12 key 42
+ntp server 10.1.1.13 key 4294967295
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-ntp-no-authenticate
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-ntp-no-authenticate
@@ -1,0 +1,10 @@
+! This is an ASA device.
+ASA Version 9.9
+!
+hostname asa-ntp-no-authenticate
+!
+ntp authentication-key 6 md5 aKey
+ntp trusted-key 6
+ntp server 10.1.1.20 key 6
+ntp server 10.1.1.21 key 9
+!


### PR DESCRIPTION
## Summary
Add support for `ntp authenticate`, `ntp authentication-key`, `ntp trusted-key`, and `ntp server <> key` for determining whether an ASA NTP server is configured for authentication.

## Changes
- Add ```CMAC```, ```SHA256``` tokens and rework ```SHA1``` token to only push ```M_SHA1``` if not parsing ```ntp authentication-key``` statements
- Add ```ntp_key``` common grammar rule
- Add ```ntp_authentication_key``` and ```ntp_trusted_key``` grammar rules
- Create ```NtpServer.java``` and ```NtpAuthenticationKey.java``` VS model classes
- Add ```_ntpAuthenticate```, ```_ntpAuthenticationKeys```, ```_ntpTrustedKeys```, and ```_ntpServers``` fields to ```AsaConfiguration.java``` with getters and setters
- Add ```enter*/exit*``` methods in ```AsaControlPlaneExtractor.java``` to extract NTP authentication attributes into VS model

## Testing
- Add ```asa-ntp``` and ```asa-ntp-no-authenticate``` testconfigs
- Add unit tests confirming extraction works correctly and handles ```key-id``` ranges correctly as well as the ```ntp authenticate``` command
- All tests pass locally
- No ref files touched 