### PR TITLE
Arista: model aggregate AS_PATH as contributors' common leading sequence

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -31,6 +31,7 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.graph.ValueGraph;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -57,6 +58,7 @@ import org.apache.logging.log4j.Logger;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.BgpAdvertisement.BgpAdvertisementType;
@@ -1467,28 +1469,40 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
           BgpAggregate aggregate = Iterables.getOnlyElement(aggregatesAtNode);
           Collection<AbstractRoute> potentialContributors =
               potentialContributorsByAggregatePrefix.get(aggNet);
-          Bgpv4Route activatedAggregate = null;
+          RoutingPolicy generationPolicy =
+              Optional.ofNullable(aggregate.getGenerationPolicy())
+                  .map(_c.getRoutingPolicies()::get)
+                  .orElse(null);
+          // Collect the AS_PATHs of all contributors that activate the aggregate. Used below to
+          // derive the aggregate's AS_PATH per its AsPathMode. Non-BGP contributors (e.g. a locally
+          // redistributed static route) contribute an empty AS_PATH.
+          List<AsPath> contributorAsPaths = new ArrayList<>();
           for (AbstractRoute potentialContributor : potentialContributors) {
             // TODO: apply suppressionPolicy
             // TODO: apply and merge transformations of generationPolicy
-            RoutingPolicy generationPolicy =
-                Optional.ofNullable(aggregate.getGenerationPolicy())
-                    .map(_c.getRoutingPolicies()::get)
-                    .orElse(null);
             if (generationPolicy == null
                 || generationPolicy.processReadOnly(potentialContributor)) {
-              // When merging is supported, the aggregate should be updated by each contributor
-              // instead of just the first one.
-              activatedAggregate =
-                  toBgpv4Route(
-                      aggregate,
-                      Optional.ofNullable(aggregate.getAttributePolicy())
-                          .map(_c.getRoutingPolicies()::get)
-                          .orElse(null),
-                      admin,
-                      _process.getRouterId());
-              break;
+              contributorAsPaths.add(
+                  potentialContributor instanceof BgpRoute
+                      ? ((BgpRoute<?, ?>) potentialContributor).getAsPath()
+                      : AsPath.empty());
             }
+          }
+          Bgpv4Route activatedAggregate = null;
+          if (!contributorAsPaths.isEmpty()) {
+            AsPath asPath =
+                aggregate.getAsPathMode() == BgpAggregate.AsPathMode.COMMON_SEQUENCE
+                    ? AsPath.aggregateContributors(contributorAsPaths)
+                    : AsPath.empty();
+            activatedAggregate =
+                toBgpv4Route(
+                    aggregate,
+                    Optional.ofNullable(aggregate.getAttributePolicy())
+                        .map(_c.getRoutingPolicies()::get)
+                        .orElse(null),
+                    admin,
+                    _process.getRouterId(),
+                    asPath);
           }
 
           // If generating aggregates from main RIB routes, the aggregate should only be generated

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -357,14 +357,22 @@ public final class BgpProtocolHelper {
         .setNonRouting(nonRouting);
   }
 
-  /** Create a BGP route from an activated aggregate. */
+  /**
+   * Create a BGP route from an activated aggregate.
+   *
+   * @param asPath the AS_PATH to assign to the generated aggregate, derived from its contributors
+   *     according to the aggregate's {@link BgpAggregate.AsPathMode} (empty for {@code NONE})
+   */
   public static @Nonnull Bgpv4Route toBgpv4Route(
-      BgpAggregate aggregate, @Nullable RoutingPolicy attributePolicy, int admin, Ip routerId) {
+      BgpAggregate aggregate,
+      @Nullable RoutingPolicy attributePolicy,
+      int admin,
+      Ip routerId,
+      AsPath asPath) {
     Bgpv4Route.Builder builder =
         Bgpv4Route.builder()
             .setAdmin(admin)
-            // TODO: support merging as-path from contributors via generationPolicy
-            .setAsPath(AsPath.empty())
+            .setAsPath(asPath)
             // TODO: support merging communities from contributors via generationPolicy
             .setCommunities(CommunitySet.empty())
             .setMetric(0L)

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -201,7 +201,6 @@ final class AristaConversions {
 
   static @Nonnull BgpAggregate toBgpAggregate(
       Prefix prefix, AristaBgpAggregateNetwork vsAggregate, Configuration c, Warnings w) {
-    // TODO: handle as-set
     // TODO: handle match-map
     // TODO: verify undefined attribute-map can be treated as omitted
     String attributeMap = vsAggregate.getAttributeMap();
@@ -213,13 +212,18 @@ final class AristaConversions {
     // advertise-only generates the aggregate for advertisement to peers but does not install it in
     // the main RIB.
     boolean installInMainRib = !Boolean.TRUE.equals(vsAggregate.getAdvertiseOnly());
+    // EOS builds the aggregate's AS_PATH from the common leading AS_SEQUENCE of its contributors,
+    // with or without the as-set keyword.
+    // TODO: when as-set is set, model the divergent tail as an AS_SET segment (AsPathMode.AS_SET)
+    // instead of dropping it. Needs a device-observed lab to confirm the as-set rendering.
     return BgpAggregate.of(
         prefix,
         generateSuppressionPolicy(vsAggregate.getSummaryOnlyEffective(), c),
         // TODO: put match-map here
         null,
         attributePolicy,
-        installInMainRib);
+        installInMainRib,
+        BgpAggregate.AsPathMode.COMMON_SEQUENCE);
   }
 
   static @Nonnull Map<Ip, BgpActivePeerConfig> getNeighbors(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -11,6 +11,7 @@ import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasP
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasProtocol;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasTag;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.isNonRouting;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasAsPath;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasOriginType;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasWeight;
@@ -846,6 +847,86 @@ public class BgpRoutingProcessTest {
             .map(RouteAdvertisement::getRoute)
             .collect(ImmutableList.toImmutableList()),
         containsInAnyOrder(hasPrefix((Prefix.strict("1.0.0.0/24")))));
+  }
+
+  /**
+   * With {@link BgpAggregate.AsPathMode#COMMON_SEQUENCE}, the aggregate's AS_PATH is the longest
+   * common leading AS_SEQUENCE of its contributors, with the divergent tail dropped. Models Arista
+   * EOS (batfish/batfish#10094).
+   */
+  @Test
+  public void testInitBgpAggregateRoutesCommonSequenceAsPath() {
+    // Two contributors to 10.1.0.0/16 with divergent AS_PATHs sharing a leading 65000.
+    _routingProcess._bgpv4Rib.mergeRoute(
+        aggregateContributorRoute(
+            Prefix.strict("10.1.1.0/24"), AsPath.ofSingletonAsSets(65000L, 65001L)));
+    _routingProcess._bgpv4Rib.mergeRoute(
+        aggregateContributorRoute(
+            Prefix.strict("10.1.2.0/24"), AsPath.ofSingletonAsSets(65000L, 65003L)));
+    _bgpProcess.addAggregate(
+        BgpAggregate.of(
+            Prefix.strict("10.1.0.0/16"),
+            null,
+            null,
+            null,
+            true,
+            BgpAggregate.AsPathMode.COMMON_SEQUENCE));
+    // Re-init routing process to pick up the aggregate.
+    _routingProcess =
+        new BgpRoutingProcess(
+            _bgpProcess, _c, DEFAULT_VRF_NAME, new Rib(), BgpTopology.EMPTY, new PrefixTracer());
+    _routingProcess._bgpv4Rib.mergeRoute(
+        aggregateContributorRoute(
+            Prefix.strict("10.1.1.0/24"), AsPath.ofSingletonAsSets(65000L, 65001L)));
+    _routingProcess._bgpv4Rib.mergeRoute(
+        aggregateContributorRoute(
+            Prefix.strict("10.1.2.0/24"), AsPath.ofSingletonAsSets(65000L, 65003L)));
+
+    RibDelta<Bgpv4Route> delta = _routingProcess.initBgpAggregateRoutes();
+
+    assertThat(
+        delta
+            .getRoutesStream()
+            .filter(r -> r.getNetwork().equals(Prefix.strict("10.1.0.0/16")))
+            .collect(ImmutableList.toImmutableList()),
+        contains(
+            isBgpv4RouteThat(
+                allOf(
+                    hasPrefix(Prefix.strict("10.1.0.0/16")),
+                    hasAsPath(equalTo(AsPath.ofSingletonAsSets(65000L)))))));
+  }
+
+  /** With the default {@link BgpAggregate.AsPathMode#NONE}, the aggregate's AS_PATH is empty. */
+  @Test
+  public void testInitBgpAggregateRoutesNoneAsPath() {
+    _bgpProcess.addAggregate(BgpAggregate.of(Prefix.strict("10.1.0.0/16"), null, null, null));
+    _routingProcess =
+        new BgpRoutingProcess(
+            _bgpProcess, _c, DEFAULT_VRF_NAME, new Rib(), BgpTopology.EMPTY, new PrefixTracer());
+    _routingProcess._bgpv4Rib.mergeRoute(
+        aggregateContributorRoute(
+            Prefix.strict("10.1.1.0/24"), AsPath.ofSingletonAsSets(65000L, 65001L)));
+
+    RibDelta<Bgpv4Route> delta = _routingProcess.initBgpAggregateRoutes();
+
+    assertThat(
+        delta
+            .getRoutesStream()
+            .filter(r -> r.getNetwork().equals(Prefix.strict("10.1.0.0/16")))
+            .collect(ImmutableList.toImmutableList()),
+        contains(
+            isBgpv4RouteThat(
+                allOf(
+                    hasPrefix(Prefix.strict("10.1.0.0/16")), hasAsPath(equalTo(AsPath.empty()))))));
+  }
+
+  private static @Nonnull Bgpv4Route aggregateContributorRoute(Prefix network, AsPath asPath) {
+    return Bgpv4Route.testBuilder()
+        .setNetwork(network)
+        .setAsPath(asPath)
+        .setProtocol(RoutingProtocol.BGP)
+        .setSrcProtocol(RoutingProtocol.BGP)
+        .build();
   }
 
   /*

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -798,17 +798,39 @@ public class BgpProtocolHelperTest {
   public void testToBgpv4RouteFromAggregate() {
     Prefix network = Prefix.parse("1.0.0.0/8");
     Ip routerId = Ip.parse("1.1.1.1");
+    AsPath asPath = AsPath.ofSingletonAsSets(65000L);
 
     // installInMainRib=true => routing (installed in main RIB)
     Bgpv4Route routing =
         BgpProtocolHelper.toBgpv4Route(
-            BgpAggregate.of(network, null, null, null), null, 200, routerId);
+            BgpAggregate.of(network, null, null, null), null, 200, routerId, asPath);
     assertFalse(routing.getNonRouting());
 
     // installInMainRib=false (e.g. advertise-only) => non-routing
     Bgpv4Route nonRouting =
         BgpProtocolHelper.toBgpv4Route(
-            BgpAggregate.of(network, null, null, null, false), null, 200, routerId);
+            BgpAggregate.of(network, null, null, null, false), null, 200, routerId, asPath);
     assertTrue(nonRouting.getNonRouting());
+  }
+
+  @Test
+  public void testToBgpv4RouteFromAggregateAsPath() {
+    Prefix network = Prefix.parse("1.0.0.0/8");
+    Ip routerId = Ip.parse("1.1.1.1");
+
+    // The AS_PATH passed in is assigned to the generated aggregate verbatim.
+    Bgpv4Route withAsPath =
+        BgpProtocolHelper.toBgpv4Route(
+            BgpAggregate.of(network, null, null, null),
+            null,
+            200,
+            routerId,
+            AsPath.ofSingletonAsSets(65000L));
+    assertThat(withAsPath.getAsPath(), equalTo(AsPath.ofSingletonAsSets(65000L)));
+
+    Bgpv4Route emptyAsPath =
+        BgpProtocolHelper.toBgpv4Route(
+            BgpAggregate.of(network, null, null, null), null, 200, routerId, AsPath.empty());
+    assertThat(emptyAsPath.getAsPath(), equalTo(AsPath.empty()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -1615,7 +1615,8 @@ public class AristaGrammarTest {
                 SUMMARY_ONLY_SUPPRESSION_POLICY_NAME,
                 null,
                 "~BGP_AGGREGATE_ATTRIBUTE_MAP:ATTR_MAP~",
-                false)));
+                false,
+                BgpAggregate.AsPathMode.COMMON_SEQUENCE)));
     assertThat(
         defaultVrfAggs,
         hasEntry(
@@ -1624,13 +1625,20 @@ public class AristaGrammarTest {
                 Prefix.parse("1.2.44.0/24"),
                 SUMMARY_ONLY_SUPPRESSION_POLICY_NAME,
                 null,
-                "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~")));
+                "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~",
+                true,
+                BgpAggregate.AsPathMode.COMMON_SEQUENCE)));
     assertThat(
         defaultVrfAggs,
         hasEntry(
             Prefix.parse("1.2.55.0/24"),
             BgpAggregate.of(
-                Prefix.parse("1.2.55.0/24"), null, null, "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~")));
+                Prefix.parse("1.2.55.0/24"),
+                null,
+                null,
+                "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~",
+                true,
+                BgpAggregate.AsPathMode.COMMON_SEQUENCE)));
 
     // vrf FOO
     Map<Prefix, BgpAggregate> vrfFooAggs = c.getVrfs().get("FOO").getBgpProcess().getAggregates();
@@ -1641,7 +1649,12 @@ public class AristaGrammarTest {
             Prefix.parse("5.6.7.0/24"),
             // TODO Support as-set
             BgpAggregate.of(
-                Prefix.parse("5.6.7.0/24"), null, null, "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~")));
+                Prefix.parse("5.6.7.0/24"),
+                null,
+                null,
+                "~BGP_AGGREGATE_ATTRIBUTE_MAP:null~",
+                true,
+                BgpAggregate.AsPathMode.COMMON_SEQUENCE)));
   }
 
   @Test

--- a/projects/common/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/AsPath.java
@@ -46,6 +46,57 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
     return of(Arrays.asList(asSets));
   }
 
+  /**
+   * Returns the longest common leading AS_SEQUENCE shared by all the given contributor paths, as a
+   * new {@link AsPath} of singleton AS_SEQUENCE segments, dropping the divergent tail.
+   *
+   * <p>This models how Arista EOS (and RFC 4271 aggregation without {@code as-set}) forms the
+   * AS_PATH of a locally-generated aggregate from its contributors: it keeps the ASes shared, in
+   * order, as a leading run of singleton segments by every contributor and drops everything from
+   * the first point of divergence onward. A single contributor yields its own leading AS_SEQUENCE
+   * (up to any AS_SET segment). An empty collection yields the empty path.
+   *
+   * <p>The common-prefix traversal is factored into {@link #commonLeadingAsns} so an {@code as-set}
+   * variant (which would instead append the union of divergent ASes as a single AS_SET segment) can
+   * reuse it.
+   */
+  public static @Nonnull AsPath aggregateContributors(Collection<AsPath> contributors) {
+    return AsPath.ofSingletonAsSets(commonLeadingAsns(contributors));
+  }
+
+  /**
+   * Returns the ASNs of the longest run of leading segments for which every path in {@code
+   * contributors} has the same single (non-confederation) ASN. Stops at the first index where the
+   * paths diverge, any path is exhausted, or any path has a non-singleton (AS_SET) or confederation
+   * segment.
+   */
+  private static @Nonnull List<Long> commonLeadingAsns(Collection<AsPath> contributors) {
+    if (contributors.isEmpty()) {
+      return ImmutableList.of();
+    }
+    ImmutableList.Builder<Long> common = ImmutableList.builder();
+    for (int i = 0; ; i++) {
+      Long asnAtI = null;
+      for (AsPath path : contributors) {
+        List<AsSet> asSets = path.getAsSets();
+        if (i >= asSets.size()) {
+          return common.build();
+        }
+        AsSet asSet = asSets.get(i);
+        if (asSet.size() != 1 || asSet.isConfederationAsSet()) {
+          return common.build();
+        }
+        long asn = asSet.getAsns().first();
+        if (asnAtI == null) {
+          asnAtI = asn;
+        } else if (asnAtI != asn) {
+          return common.build();
+        }
+      }
+      common.add(asnAtI);
+    }
+  }
+
   private final List<AsSet> _asSets;
 
   // Soft values: let it be garbage collected in times of pressure.

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpAggregate.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/BgpAggregate.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.bgp;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,12 +20,29 @@ import org.batfish.datamodel.Prefix;
 @ParametersAreNonnullByDefault
 public final class BgpAggregate implements Serializable {
 
+  /**
+   * How the AS_PATH of a locally-generated aggregate is derived from its contributing routes.
+   *
+   * <p>The default {@link #NONE} matches vendors that generate an empty AS_PATH for aggregates
+   * (e.g. Cisco IOS/NX-OS/XR without {@code as-set}). Arista EOS includes the contributors' common
+   * leading AS_SEQUENCE, modeled by {@link #COMMON_SEQUENCE}.
+   */
+  public enum AsPathMode {
+    /** Empty AS_PATH. */
+    NONE,
+    /**
+     * Longest common leading AS_SEQUENCE of the contributors, with the divergent tail dropped
+     * (matching Arista EOS and RFC 4271 aggregation without {@code as-set}).
+     */
+    COMMON_SEQUENCE,
+  }
+
   public static @Nonnull BgpAggregate of(
       Prefix network,
       @Nullable String suppressionPolicy,
       @Nullable String generationPolicy,
       @Nullable String attributePolicy) {
-    return of(network, suppressionPolicy, generationPolicy, attributePolicy, true);
+    return of(network, suppressionPolicy, generationPolicy, attributePolicy, true, AsPathMode.NONE);
   }
 
   public static @Nonnull BgpAggregate of(
@@ -33,8 +51,29 @@ public final class BgpAggregate implements Serializable {
       @Nullable String generationPolicy,
       @Nullable String attributePolicy,
       boolean installInMainRib) {
+    return of(
+        network,
+        suppressionPolicy,
+        generationPolicy,
+        attributePolicy,
+        installInMainRib,
+        AsPathMode.NONE);
+  }
+
+  public static @Nonnull BgpAggregate of(
+      Prefix network,
+      @Nullable String suppressionPolicy,
+      @Nullable String generationPolicy,
+      @Nullable String attributePolicy,
+      boolean installInMainRib,
+      AsPathMode asPathMode) {
     return new BgpAggregate(
-        attributePolicy, generationPolicy, network, suppressionPolicy, installInMainRib);
+        attributePolicy,
+        generationPolicy,
+        network,
+        suppressionPolicy,
+        installInMainRib,
+        asPathMode);
   }
 
   /**
@@ -112,6 +151,15 @@ public final class BgpAggregate implements Serializable {
     return _installInMainRib;
   }
 
+  /**
+   * How the AS_PATH of the generated aggregate is derived from its contributors. See {@link
+   * AsPathMode}. Defaults to {@link AsPathMode#NONE}.
+   */
+  @JsonProperty(PROP_AS_PATH_MODE)
+  public @Nonnull AsPathMode getAsPathMode() {
+    return _asPathMode;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -124,13 +172,19 @@ public final class BgpAggregate implements Serializable {
         && Objects.equals(_generationPolicy, that._generationPolicy)
         && _network.equals(that._network)
         && Objects.equals(_suppressionPolicy, that._suppressionPolicy)
-        && _installInMainRib == that._installInMainRib;
+        && _installInMainRib == that._installInMainRib
+        && _asPathMode == that._asPathMode;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        _attributePolicy, _generationPolicy, _network, _suppressionPolicy, _installInMainRib);
+        _attributePolicy,
+        _generationPolicy,
+        _network,
+        _suppressionPolicy,
+        _installInMainRib,
+        _asPathMode.ordinal());
   }
 
   @Override
@@ -142,6 +196,7 @@ public final class BgpAggregate implements Serializable {
         .add(PROP_NETWORK, _network)
         .add(PROP_SUPPRESSION_POLICY, _suppressionPolicy)
         .add(PROP_INSTALL_IN_MAIN_RIB, _installInMainRib)
+        .add(PROP_AS_PATH_MODE, _asPathMode)
         .toString();
   }
 
@@ -150,12 +205,14 @@ public final class BgpAggregate implements Serializable {
   private static final String PROP_NETWORK = "network";
   private static final String PROP_SUPPRESSION_POLICY = "suppressionPolicy";
   private static final String PROP_INSTALL_IN_MAIN_RIB = "installInMainRib";
+  private static final String PROP_AS_PATH_MODE = "asPathMode";
 
   private final @Nullable String _attributePolicy;
   private final @Nullable String _generationPolicy;
   private final @Nonnull Prefix _network;
   private final @Nullable String _suppressionPolicy;
   private final boolean _installInMainRib;
+  private final @Nonnull AsPathMode _asPathMode;
 
   @JsonCreator
   private static @Nonnull BgpAggregate create(
@@ -163,7 +220,8 @@ public final class BgpAggregate implements Serializable {
       @JsonProperty(PROP_GENERATION_POLICY) @Nullable String generationPolicy,
       @JsonProperty(PROP_NETWORK) @Nullable Prefix network,
       @JsonProperty(PROP_SUPPRESSION_POLICY) @Nullable String suppressionPolicy,
-      @JsonProperty(PROP_INSTALL_IN_MAIN_RIB) @Nullable Boolean installInMainRib) {
+      @JsonProperty(PROP_INSTALL_IN_MAIN_RIB) @Nullable Boolean installInMainRib,
+      @JsonProperty(PROP_AS_PATH_MODE) @Nullable AsPathMode asPathMode) {
     checkArgument(network != null, "Missing %s", PROP_NETWORK);
     return of(
         network,
@@ -171,7 +229,9 @@ public final class BgpAggregate implements Serializable {
         generationPolicy,
         attributePolicy,
         // Default to true for backward compatibility with older serialized aggregates.
-        installInMainRib == null || installInMainRib);
+        installInMainRib == null || installInMainRib,
+        // Default to NONE for backward compatibility with older serialized aggregates.
+        firstNonNull(asPathMode, AsPathMode.NONE));
   }
 
   private BgpAggregate(
@@ -179,11 +239,13 @@ public final class BgpAggregate implements Serializable {
       @Nullable String generationPolicy,
       Prefix network,
       @Nullable String suppressionPolicy,
-      boolean installInMainRib) {
+      boolean installInMainRib,
+      AsPathMode asPathMode) {
     _attributePolicy = attributePolicy;
     _generationPolicy = generationPolicy;
     _network = network;
     _suppressionPolicy = suppressionPolicy;
     _installInMainRib = installInMainRib;
+    _asPathMode = asPathMode;
   }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/AsPathTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/AsPathTest.java
@@ -40,4 +40,60 @@ public class AsPathTest {
     assertThat(path.length(), equalTo(1));
     assertThat(path.size(), equalTo(3));
   }
+
+  @Test
+  public void testAggregateContributorsEmpty() {
+    assertThat(AsPath.aggregateContributors(ImmutableList.of()), equalTo(AsPath.empty()));
+  }
+
+  @Test
+  public void testAggregateContributorsSingle() {
+    // A single contributor yields its own leading AS_SEQUENCE.
+    AsPath path = AsPath.ofSingletonAsSets(65000L, 65001L);
+    assertThat(AsPath.aggregateContributors(ImmutableList.of(path)), equalTo(path));
+  }
+
+  @Test
+  public void testAggregateContributorsIdentical() {
+    AsPath path = AsPath.ofSingletonAsSets(65000L, 65001L);
+    assertThat(
+        AsPath.aggregateContributors(ImmutableList.of(path, path)),
+        equalTo(AsPath.ofSingletonAsSets(65000L, 65001L)));
+  }
+
+  @Test
+  public void testAggregateContributorsCommonPrefixThenDiverge() {
+    // The lab case: "65000 65001" and "65000 65003" share the leading 65000, then diverge; the
+    // divergent tail is dropped.
+    AsPath a = AsPath.ofSingletonAsSets(65000L, 65001L);
+    AsPath b = AsPath.ofSingletonAsSets(65000L, 65003L);
+    assertThat(
+        AsPath.aggregateContributors(ImmutableList.of(a, b)),
+        equalTo(AsPath.ofSingletonAsSets(65000L)));
+  }
+
+  @Test
+  public void testAggregateContributorsNoCommonPrefix() {
+    AsPath a = AsPath.ofSingletonAsSets(65001L);
+    AsPath b = AsPath.ofSingletonAsSets(65002L);
+    assertThat(AsPath.aggregateContributors(ImmutableList.of(a, b)), equalTo(AsPath.empty()));
+  }
+
+  @Test
+  public void testAggregateContributorsEmptyContributorPath() {
+    // A contributor with an empty path (e.g. a locally redistributed route) shares no prefix.
+    AsPath a = AsPath.ofSingletonAsSets(65000L);
+    assertThat(
+        AsPath.aggregateContributors(ImmutableList.of(a, AsPath.empty())), equalTo(AsPath.empty()));
+  }
+
+  @Test
+  public void testAggregateContributorsStopsAtAsSet() {
+    // A non-singleton (AS_SET) segment cannot extend the common AS_SEQUENCE.
+    AsPath a = AsPath.of(ImmutableList.of(AsSet.of(65000L), AsSet.of(65001L, 65002L)));
+    AsPath b = AsPath.of(ImmutableList.of(AsSet.of(65000L), AsSet.of(65001L, 65002L)));
+    assertThat(
+        AsPath.aggregateContributors(ImmutableList.of(a, b)),
+        equalTo(AsPath.ofSingletonAsSets(65000L)));
+  }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpAggregateTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/bgp/BgpAggregateTest.java
@@ -14,19 +14,28 @@ public final class BgpAggregateTest {
 
   @Test
   public void testJavaSerialization() {
-    BgpAggregate obj = BgpAggregate.of(Prefix.ZERO, "a", "b", "c", false);
+    BgpAggregate obj =
+        BgpAggregate.of(Prefix.ZERO, "a", "b", "c", false, BgpAggregate.AsPathMode.COMMON_SEQUENCE);
     assertThat(SerializationUtils.clone(obj), equalTo(obj));
   }
 
   @Test
   public void testJsonSerialization() {
-    BgpAggregate obj = BgpAggregate.of(Prefix.ZERO, "a", "b", "c", false);
+    BgpAggregate obj =
+        BgpAggregate.of(Prefix.ZERO, "a", "b", "c", false, BgpAggregate.AsPathMode.COMMON_SEQUENCE);
     assertThat(BatfishObjectMapper.clone(obj, BgpAggregate.class), equalTo(obj));
   }
 
   @Test
   public void testDefaultInstallInMainRib() {
     assertThat(BgpAggregate.of(Prefix.ZERO, null, null, null).getInstallInMainRib(), equalTo(true));
+  }
+
+  @Test
+  public void testDefaultAsPathMode() {
+    assertThat(
+        BgpAggregate.of(Prefix.ZERO, null, null, null).getAsPathMode(),
+        equalTo(BgpAggregate.AsPathMode.NONE));
   }
 
   @Test
@@ -38,6 +47,9 @@ public final class BgpAggregateTest {
         .addEqualityGroup(BgpAggregate.of(Prefix.ZERO, "a", "b", null))
         .addEqualityGroup(BgpAggregate.of(Prefix.ZERO, "a", "b", "c"))
         .addEqualityGroup(BgpAggregate.of(Prefix.ZERO, "a", "b", "c", false))
+        .addEqualityGroup(
+            BgpAggregate.of(
+                Prefix.ZERO, "a", "b", "c", false, BgpAggregate.AsPathMode.COMMON_SEQUENCE))
         .addEqualityGroup(BgpAggregate.of(Prefix.MULTICAST, "a", "b", "c"))
         .testEquals();
   }

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -5435,6 +5435,7 @@
               "routerId" : "2.1.1.1",
               "aggregates" : [
                 {
+                  "asPathMode" : "NONE",
                   "installInMainRib" : true,
                   "network" : "2.128.0.0/16",
                   "suppressionPolicy" : "~suppress~rp~summary-only~"
@@ -7101,6 +7102,7 @@
               "routerId" : "2.1.1.2",
               "aggregates" : [
                 {
+                  "asPathMode" : "NONE",
                   "installInMainRib" : true,
                   "network" : "2.128.0.0/16",
                   "suppressionPolicy" : "~suppress~rp~summary-only~"


### PR DESCRIPTION
On Arista EOS, a locally-generated BGP aggregate carries an AS_PATH
derived from its contributors: the longest common leading AS_SEQUENCE,
with the divergent tail dropped. Batfish modeled the aggregate with an
empty AS_PATH, which changed route selection and defeated the AS-path
loop check on upstream routers, so they wrongly installed the aggregate.

Ground truth captured on cEOS 4.36.0.1F (no as-set): two contributors
"65000 65001 ?" and "65000 65003 ?" produce aggregate "65000 ?" with
atomic-aggregate. EOS does not build an AS_SET union; it keeps only the
shared leading sequence. This matches RFC 4271 aggregation without
as-set, and is consistent with the single-origin case (whole shared path
kept, nothing dropped).

Add an AsPathMode enum to the vendor-neutral BgpAggregate (NONE default,
COMMON_SEQUENCE). NONE preserves the empty-AS_PATH behavior of
Cisco/NX-OS/XR; AristaConversions sets COMMON_SEQUENCE. In the dataplane,
initBgpAggregateRoutes now collects the AS_PATHs of all activating
contributors (rather than stopping at the first) and BgpProtocolHelper
.toBgpv4Route assigns the derived AS_PATH. The new
AsPath.aggregateContributors helper computes the common leading
AS_SEQUENCE; it is factored around commonLeadingAsns so an as-set variant
can reuse the same traversal. The existing on-import loop check then
rejects the aggregate on the contributor/transit ASes with no additional
code.

Recompute-per-round already reflects contributor-set changes: AS_PATH is
part of Bgpv4Route identity, so a changed aggregate produces a real
withdraw/add delta and quiesces once contributors stabilize. No
dependency tracking needed.

Not modeled (no bearing on this issue, deferred): the as-set keyword's
AS_SET form (needs a device-observed lab) and the ATOMIC_AGGREGATE /
AGGREGATOR attributes (non-transitive, large ref-test churn).

Fixes batfish/batfish#10094.

----

Prompt:
```
Read batfish/batfish#10094 ... I don't think we've taken this on before
in Batfish, can you think about it?
```

Built a divergent-contributor lab (eos_bgp_agg_as_path) to capture how
EOS combines contributors on different AS_PATHs, then planned and
implemented the fix scoped to the common-leading-sequence behavior the
lab proved.
