### PR TITLE
feat(cisco): extract Cisco NX-OS NTP authentication

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosLexer.g4
@@ -2460,6 +2460,8 @@ TRUST: 'trust';
 
 TRUSTED: 'trusted';
 
+TRUSTED_KEY: 'trusted-key';
+
 TRUSTPOINT: 'trustpoint';
 
 TTL: 'ttl';

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_ntp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_ntp.g4
@@ -24,6 +24,7 @@ s_ntp
     | ntp_peer
     | ntp_server
     | ntp_source_interface
+    | ntp_trusted_key
   )
 ;
 
@@ -148,4 +149,9 @@ ntps_use_vrf
 ntp_source_interface
 :
   SOURCE_INTERFACE name = interface_name NEWLINE
+;
+
+ntp_trusted_key
+:
+  TRUSTED_KEY key = ntp_authentication_key_number NEWLINE
 ;

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosControlPlaneExtractor.java
@@ -488,12 +488,17 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Name_serverContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.No_ip_route_networkContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.No_sysds_shutdownContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.No_sysds_switchportContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntp_authenticateContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntp_authentication_keyContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntp_authentication_key_numberContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntp_serverContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntp_source_interfaceContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntp_trusted_keyContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntpag_peerContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntpag_query_onlyContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntpag_serveContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntpag_serve_onlyContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntps_keyContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntps_preferContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ntps_use_vrfContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Nve_host_reachabilityContext;
@@ -825,6 +830,7 @@ import org.batfish.vendor.cisco_nxos.representation.LiteralIpAddressSpec;
 import org.batfish.vendor.cisco_nxos.representation.LiteralPortSpec;
 import org.batfish.vendor.cisco_nxos.representation.LoggingServer;
 import org.batfish.vendor.cisco_nxos.representation.NameServer;
+import org.batfish.vendor.cisco_nxos.representation.NtpAuthenticationKey;
 import org.batfish.vendor.cisco_nxos.representation.NtpServer;
 import org.batfish.vendor.cisco_nxos.representation.Nve;
 import org.batfish.vendor.cisco_nxos.representation.Nve.HostReachabilityProtocol;
@@ -917,6 +923,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   private static final IntegerSpace BGP_EBGP_MULTIHOP_TTL_RANGE =
       IntegerSpace.of(Range.closed(2, 255));
   private static final IntegerSpace BGP_INHERIT_RANGE = IntegerSpace.of(Range.closed(1, 65535));
+  private static final IntegerSpace NTP_KEY_RANGE = IntegerSpace.of(Range.closed(1, 65535));
   private static final IntegerSpace BGP_MAXAS_LIMIT_RANGE = IntegerSpace.of(Range.closed(1, 512));
   private static final IntegerSpace BGP_MAXIMUM_PATHS_RANGE = IntegerSpace.of(Range.closed(1, 64));
   private static final IntegerSpace BGP_NEIGHBOR_DESCRIPTION_LENGTH_RANGE =
@@ -2805,6 +2812,32 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   @Override
   public void exitNtp_server(Ntp_serverContext ctx) {
     _currentNtpServer = null;
+  }
+
+  @Override
+  public void exitNtps_key(Ntps_keyContext ctx) {
+    toInteger(ctx, ctx.ntp_authentication_key_number()).ifPresent(_currentNtpServer::setKey);
+  }
+
+  @Override
+  public void exitNtp_authenticate(Ntp_authenticateContext ctx) {
+    _c.setNtpAuthenticate(true);
+  }
+
+  @Override
+  public void exitNtp_authentication_key(Ntp_authentication_keyContext ctx) {
+    Optional<Integer> maybeKeyNum = toInteger(ctx, ctx.num);
+    if (!maybeKeyNum.isPresent()) {
+      return;
+    }
+    NtpAuthenticationKey key =
+        _c.getNtpAuthenticationKeys().computeIfAbsent(maybeKeyNum.get(), NtpAuthenticationKey::new);
+    key.setMd5Value(ctx.md5.getText());
+  }
+
+  @Override
+  public void exitNtp_trusted_key(Ntp_trusted_keyContext ctx) {
+    toInteger(ctx, ctx.key).ifPresent(_c.getNtpTrustedKeys()::add);
   }
 
   @Override
@@ -7284,6 +7317,11 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
 
   private @Nonnull Optional<Integer> toInteger(ParserRuleContext messageCtx, Eigrp_asnContext ctx) {
     return toIntegerInSpace(messageCtx, ctx, EIGRP_ASN_RANGE, "EIGRP autonomous-system number");
+  }
+
+  private @Nonnull Optional<Integer> toInteger(
+      ParserRuleContext messageCtx, Ntp_authentication_key_numberContext ctx) {
+    return toIntegerInSpace(messageCtx, ctx, NTP_KEY_RANGE, "NTP key number");
   }
 
   private @Nonnull Optional<Integer> toInteger(

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
@@ -443,6 +443,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   private @Nullable String _loggingSourceInterface;
   private @Nonnull NxosMajorVersion _majorVersion;
   private boolean _nonSwitchportDefaultShutdown;
+  private boolean _ntpAuthenticate;
+  private final @Nonnull Map<Integer, NtpAuthenticationKey> _ntpAuthenticationKeys;
+  private final @Nonnull Set<Integer> _ntpTrustedKeys;
   private final @Nonnull Map<String, NtpServer> _ntpServers;
   private @Nullable String _ntpSourceInterface;
   private final @Nonnull Map<Integer, Nve> _nves;
@@ -477,6 +480,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     _isisProcesses = new HashMap<>();
     _loggingServers = new HashMap<>();
     _majorVersion = NxosMajorVersion.UNKNOWN;
+    _ntpAuthenticationKeys = new HashMap<>();
+    _ntpTrustedKeys = new HashSet<>();
     _ntpServers = new HashMap<>();
     _nves = new HashMap<>();
     _objectGroups = new HashMap<>();
@@ -1853,6 +1858,36 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   public @Nonnull Map<String, NtpServer> getNtpServers() {
     return _ntpServers;
+  }
+
+  public boolean getNtpAuthenticate() {
+    return _ntpAuthenticate;
+  }
+
+  public void setNtpAuthenticate(boolean ntpAuthenticate) {
+    _ntpAuthenticate = ntpAuthenticate;
+  }
+
+  public @Nonnull Map<Integer, NtpAuthenticationKey> getNtpAuthenticationKeys() {
+    return _ntpAuthenticationKeys;
+  }
+
+  public @Nonnull Set<Integer> getNtpTrustedKeys() {
+    return _ntpTrustedKeys;
+  }
+
+  /**
+   * Whether the NTP server with the given hostname is authenticated: NTP authentication is enabled,
+   * the server references a key, and that key is both defined via {@code ntp authentication-key}
+   * and trusted via {@code ntp trusted-key}.
+   */
+  public boolean isNtpServerAuthenticated(String hostname) {
+    NtpServer server = _ntpServers.get(hostname);
+    if (server == null || !_ntpAuthenticate) {
+      return false;
+    }
+    Integer key = server.getKey();
+    return key != null && _ntpAuthenticationKeys.containsKey(key) && _ntpTrustedKeys.contains(key);
   }
 
   public @Nullable String getNtpSourceInterface() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/NtpAuthenticationKey.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/NtpAuthenticationKey.java
@@ -1,0 +1,30 @@
+package org.batfish.vendor.cisco_nxos.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/**
+ * A Cisco NX-OS NTP authentication key defined via {@code ntp authentication-key <number> md5
+ * <value> [<type>]}.
+ */
+public final class NtpAuthenticationKey implements Serializable {
+
+  public NtpAuthenticationKey(int keyNumber) {
+    _keyNumber = keyNumber;
+  }
+
+  public int getKeyNumber() {
+    return _keyNumber;
+  }
+
+  public @Nullable String getMd5Value() {
+    return _md5Value;
+  }
+
+  public void setMd5Value(@Nullable String md5Value) {
+    _md5Value = md5Value;
+  }
+
+  private final int _keyNumber;
+  private @Nullable String _md5Value;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/NtpServer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/NtpServer.java
@@ -31,7 +31,16 @@ public final class NtpServer implements Serializable {
     _useVrf = useVrf;
   }
 
+  public @Nullable Integer getKey() {
+    return _key;
+  }
+
+  public void setKey(@Nullable Integer key) {
+    _key = key;
+  }
+
   private final @Nonnull String _host;
   private boolean _prefer;
   private @Nullable String _useVrf;
+  private @Nullable Integer _key;
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
@@ -381,6 +381,7 @@ import org.batfish.vendor.cisco_nxos.representation.Layer3Options;
 import org.batfish.vendor.cisco_nxos.representation.LiteralIpAddressSpec;
 import org.batfish.vendor.cisco_nxos.representation.LiteralPortSpec;
 import org.batfish.vendor.cisco_nxos.representation.NameServer;
+import org.batfish.vendor.cisco_nxos.representation.NtpAuthenticationKey;
 import org.batfish.vendor.cisco_nxos.representation.NtpServer;
 import org.batfish.vendor.cisco_nxos.representation.Nve;
 import org.batfish.vendor.cisco_nxos.representation.Nve.HostReachabilityProtocol;
@@ -5471,29 +5472,71 @@ public final class CiscoNxosGrammarTest {
   public void testNtpExtraction() {
     CiscoNxosConfiguration vc = parseVendorConfig("nxos_ntp");
 
+    assertTrue(vc.getNtpAuthenticate());
+
+    assertThat(vc.getNtpAuthenticationKeys(), hasKeys(1, 12345));
+    {
+      NtpAuthenticationKey key = vc.getNtpAuthenticationKeys().get(1);
+      assertThat(key.getMd5Value(), equalTo("012345678Abz"));
+    }
+    {
+      NtpAuthenticationKey key = vc.getNtpAuthenticationKeys().get(12345);
+      assertThat(key.getMd5Value(), equalTo("aSecondKey"));
+    }
+
+    assertThat(vc.getNtpTrustedKeys(), containsInAnyOrder(1, 12345));
+
     assertThat(vc.getNtpServers(), hasKeys("192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4"));
     {
       NtpServer ntpServer = vc.getNtpServers().get("192.0.2.1");
       assertFalse(ntpServer.getPrefer());
       assertThat(ntpServer.getUseVrf(), nullValue());
+      assertThat(ntpServer.getKey(), nullValue());
     }
     {
       NtpServer ntpServer = vc.getNtpServers().get("192.0.2.2");
       assertFalse(ntpServer.getPrefer());
       assertThat(ntpServer.getUseVrf(), nullValue());
+      assertThat(ntpServer.getKey(), equalTo(12345));
     }
     {
       NtpServer ntpServer = vc.getNtpServers().get("192.0.2.3");
       assertFalse(ntpServer.getPrefer());
       assertThat(ntpServer.getUseVrf(), equalTo("management"));
+      assertThat(ntpServer.getKey(), equalTo(12345));
     }
     {
       NtpServer ntpServer = vc.getNtpServers().get("192.0.2.4");
       assertTrue(ntpServer.getPrefer());
       assertThat(ntpServer.getUseVrf(), nullValue());
+      assertThat(ntpServer.getKey(), nullValue());
     }
 
+    assertTrue(vc.isNtpServerAuthenticated("192.0.2.2"));
+    assertTrue(vc.isNtpServerAuthenticated("192.0.2.3"));
+    assertFalse(vc.isNtpServerAuthenticated("192.0.2.1"));
+    assertFalse(vc.isNtpServerAuthenticated("192.0.2.4"));
+
     assertThat(vc.getNtpSourceInterface(), equalTo("mgmt0"));
+  }
+
+  @Test
+  public void testNtpNoAuthenticateExtraction() {
+    CiscoNxosConfiguration vc = parseVendorConfig("nxos_ntp_no_authenticate");
+
+    assertFalse(vc.getNtpAuthenticate());
+
+    assertThat(vc.getNtpAuthenticationKeys(), hasKeys(1));
+    assertThat(vc.getNtpAuthenticationKeys().get(1).getMd5Value(), equalTo("012345678Abz"));
+
+    assertThat(vc.getNtpTrustedKeys(), containsInAnyOrder(1));
+
+    assertThat(vc.getNtpServers(), hasKeys("192.0.2.1", "192.0.2.2"));
+    assertThat(vc.getNtpServers().get("192.0.2.1").getKey(), equalTo(1));
+    assertThat(vc.getNtpServers().get("192.0.2.2").getKey(), nullValue());
+
+    assertFalse(vc.isNtpServerAuthenticated("192.0.2.1"));
+    assertFalse(vc.isNtpServerAuthenticated("192.0.2.2"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ntp
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ntp
@@ -16,6 +16,9 @@ ntp access-group serve-only acl_serve_only
 
 ntp authenticate
 ntp authentication-key 1 md5 012345678Abz 7
+ntp authentication-key 12345 md5 aSecondKey
+ntp trusted-key 1
+ntp trusted-key 12345
 
 ntp commit
 ntp distribute

--- a/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ntp_no_authenticate
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ntp_no_authenticate
@@ -1,0 +1,10 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_ntp_no_authenticate
+!
+
+ntp authentication-key 1 md5 012345678Abz 7
+ntp trusted-key 1
+
+ntp server 192.0.2.1 key 1
+ntp server 192.0.2.2

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -64269,7 +64269,7 @@
             "          USE_VRF:'use-vrf'",
             "          vrf = (vrf_name*",
             "            WORD:'management'  <== mode:M_Word))",
-            "        (ntps_key*",
+            "        (ntps_key",
             "          KEY:'key'",
             "          (ntp_authentication_key_number*",
             "            (uint16*",


### PR DESCRIPTION
## Summary

Add support for `ntp authenticate`, `ntp authentication-key`, `ntp trusted-key`, and `ntp server <> key` for determining whether a NX-OS NTP server is configured for authentication.

## Changes

- Add `TRUSTED_KEY` lexer token (NX-OS already had `AUTHENTICATION_KEY`, `KEY`, and `MD5` tokens with the correct mode predicates, so no other lexer changes were needed)

- Add `ntp_trusted_key` grammar rule and wire it into `s_ntp` (the `ntp_authenticate`, `ntp_authentication_key`, and `ntps_key` rules already existed

- Add a `_key` field to the existing `NtpServer.java` VS model class and create `NtpAuthenticationKey.java`

- Add `_ntpAuthenticate`, `_ntpAuthenticationKeys`, and `_ntpTrustedKeys` fields to `CiscoNxosConfiguration.java` with accessors, plus an `isNtpServerAuthenticated` helper (`_ntpServers` already existed). Trusted keys are stored as a `Set<Integer>` rather than an `IntegerSpace`, since NX-OS `trusted-key` takes exactly one key ID per line with no range support

- Add `exit*` methods in `CiscoNxosControlPlaneExtractor.java` to extract NTP authentication attributes into the VS model, with the server key captured in the existing `ntps_key` rule via `exitNtps_key`

## Testing

- Extend the existing `nxos_ntp` testconfig and add a new `nxos_ntp_no_authenticate` testconfig

- Add unit tests confirming extraction works correctly, that keys are validated against the `1-65535` (uint16) range, and that a server is only reported authenticated when `ntp authenticate` is enabled

- All tests pass locally

- Regenerated `tests/parsing-tests/unit-tests.ref` via `./tools/update_refs.sh` (a one-line parse-tree rendering change for the `nxos_ntp` config due to regenerating the parser after the grammar change)
