### PR TITLE
Arista: exclude non-BGP contributors from aggregate AS_PATH

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -78,6 +78,7 @@ import org.batfish.datamodel.EvpnType3Route;
 import org.batfish.datamodel.EvpnType5Route;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.GenericRibReadOnly;
+import org.batfish.datamodel.HasReadableAsPath;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.KernelRoute;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
@@ -1473,23 +1474,27 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
               Optional.ofNullable(aggregate.getGenerationPolicy())
                   .map(_c.getRoutingPolicies()::get)
                   .orElse(null);
-          // Collect the AS_PATHs of all contributors that activate the aggregate. Used below to
-          // derive the aggregate's AS_PATH per its AsPathMode. Non-BGP contributors (e.g. a locally
-          // redistributed static route) contribute an empty AS_PATH.
+          // Any contributor that passes the generation policy activates the aggregate. Only
+          // contributors that carry an AS_PATH inform the aggregate's AS_PATH: routes without one
+          // (e.g. connected routes that fall under a 0.0.0.0/0 aggregate) are not in the BGP table
+          // and do not contribute an AS_PATH on the device. Locally-originated BGP contributors
+          // (e.g. redistributed statics) carry an empty AS_PATH, which correctly collapses the
+          // common sequence to empty.
+          boolean activated = false;
           List<AsPath> contributorAsPaths = new ArrayList<>();
           for (AbstractRoute potentialContributor : potentialContributors) {
             // TODO: apply suppressionPolicy
             // TODO: apply and merge transformations of generationPolicy
             if (generationPolicy == null
                 || generationPolicy.processReadOnly(potentialContributor)) {
-              contributorAsPaths.add(
-                  potentialContributor instanceof BgpRoute
-                      ? ((BgpRoute<?, ?>) potentialContributor).getAsPath()
-                      : AsPath.empty());
+              activated = true;
+              if (potentialContributor instanceof HasReadableAsPath) {
+                contributorAsPaths.add(((HasReadableAsPath) potentialContributor).getAsPath());
+              }
             }
           }
           Bgpv4Route activatedAggregate = null;
-          if (!contributorAsPaths.isEmpty()) {
+          if (activated) {
             AsPath asPath =
                 aggregate.getAsPathMode() == BgpAggregate.AsPathMode.COMMON_SEQUENCE
                     ? AsPath.aggregateContributors(contributorAsPaths)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -896,6 +896,51 @@ public class BgpRoutingProcessTest {
                     hasAsPath(equalTo(AsPath.ofSingletonAsSets(65000L)))))));
   }
 
+  /**
+   * When generating aggregates from the main RIB (Arista), a non-BGP contributor (e.g. a connected
+   * route that falls under a 0.0.0.0/0 aggregate) must not zero out the AS_PATH derived from the
+   * BGP contributors. Regression for batfish/batfish#10094: the device only aggregates BGP-table
+   * routes, so connected routes carry no AS_PATH into the aggregate.
+   */
+  @Test
+  public void testInitBgpAggregateRoutesCommonSequenceIgnoresNonBgpContributors() {
+    _c.setGenerateBgpAggregatesFromMainRib(true);
+    _bgpProcess.addAggregate(
+        BgpAggregate.of(
+            Prefix.ZERO, null, null, null, true, BgpAggregate.AsPathMode.COMMON_SEQUENCE));
+    Rib mainRib = new Rib();
+    // A connected route and a BGP route both fall under the 0.0.0.0/0 aggregate.
+    mainRib.mergeRoute(
+        new AnnotatedRoute<>(
+            ConnectedRoute.builder()
+                .setNetwork(Prefix.strict("10.10.10.0/24"))
+                .setNextHop(NextHopInterface.of("Ethernet1"))
+                .build(),
+            DEFAULT_VRF_NAME));
+    mainRib.mergeRoute(
+        new AnnotatedRoute<>(
+            aggregateContributorRoute(
+                Prefix.strict("10.1.1.0/24"), AsPath.ofSingletonAsSets(65001L)),
+            DEFAULT_VRF_NAME));
+    _routingProcess =
+        new BgpRoutingProcess(
+            _bgpProcess, _c, DEFAULT_VRF_NAME, mainRib, BgpTopology.EMPTY, new PrefixTracer());
+
+    RibDelta<Bgpv4Route> delta = _routingProcess.initBgpAggregateRoutes();
+
+    // The connected route's (empty) AS_PATH must not drag the aggregate path to empty.
+    assertThat(
+        delta
+            .getRoutesStream()
+            .filter(r -> r.getNetwork().equals(Prefix.ZERO))
+            .collect(ImmutableList.toImmutableList()),
+        contains(
+            isBgpv4RouteThat(
+                allOf(
+                    hasPrefix(Prefix.ZERO),
+                    hasAsPath(equalTo(AsPath.ofSingletonAsSets(65001L)))))));
+  }
+
   /** With the default {@link BgpAggregate.AsPathMode#NONE}, the aggregate's AS_PATH is empty. */
   @Test
   public void testInitBgpAggregateRoutesNoneAsPath() {


### PR DESCRIPTION
The common-leading-sequence AS_PATH added in batfish/batfish#10098 was
computed over every activating contributor, including non-BGP main-RIB
routes. For an aggregate like 0.0.0.0/0 (or any prefix covering a
connected/static route), those non-BGP contributors carry an empty
AS_PATH, which collapsed the common leading sequence to empty even when
all BGP contributors shared a leading AS.

On the device the aggregate is formed from BGP-table routes only;
connected routes are not in the BGP table and contribute no AS_PATH.
Restrict the AS_PATH computation to BGP contributors while still letting
any contributor (BGP or not) activate the aggregate. Locally-originated
BGP contributors (e.g. redistributed statics) still carry an empty
AS_PATH and correctly collapse the sequence to empty.

Regression test covers a 0.0.0.0/0 aggregate generated from the main RIB
with a connected contributor alongside a BGP contributor: the connected
route no longer zeroes the aggregate's AS_PATH.

Fixes batfish/batfish#10094 follow-up surfaced by the eos_bgp_agg_vrf
lab-validation labs (default-route aggregate).

----

Prompt:
```
221 is not green, figure out why?
```

The lab-validation PR failed after #10098 merged: the eos_bgp_agg_vrf
labs use a 0.0.0.0/0 advertise-only aggregate, whose contributor set
includes the device's connected interfaces. Those non-BGP contributors
zeroed the computed AS_PATH, so the aggregate still diverged from the
device.
