### PR TITLE
Hierarchy: skip error-recovery when re-parsing generated set-lines

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
@@ -785,7 +785,11 @@ final class Hierarchy {
       return new GrammarSettings() {
         @Override
         public boolean getDisableUnrecognized() {
-          return false;
+          // The lines re-parsed here are set-lines generated from an already-parsed tree, so they
+          // are always valid. Disabling unrecognized-line recovery avoids installing the recovery
+          // strategy, ATN-simulator override, and per-parser whole-text regex split for each
+          // generated line; parser/lexer errors still throw via the error listeners.
+          return true;
         }
 
         @Override


### PR DESCRIPTION
When applying apply-groups and apply-path, the preprocessor generates
set-lines from an already-parsed hierarchy tree and re-parses each one with
a fresh FlatJuniperCombinedParser. These generated lines are always valid,
but the parser was constructed with unrecognized-line recovery enabled, so
each one installed the recovery error strategy (which splits the whole
input text with a freshly compiled regex), the recovery-mode parser ATN
simulator, and the lexer recovery strategy -- all unused overhead for a
single valid line.

Disable unrecognized-line recovery for these parsers. Parser and lexer
errors still throw via the error listeners, so a malformed generated line
would still fail loudly. Flattened output is byte-for-byte unchanged.
