### PR TITLE
comparePeerGroupPolicies: skip peers with no group

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
@@ -15,6 +15,7 @@ import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.questions.BgpRoute;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesAnswerer;
@@ -124,47 +125,53 @@ public final class ComparePeerGroupPoliciesUtils {
             if (bgp != null) {
               // If there is a BGP process on the device in the current snapshot.
               for (BgpPeerConfig peer : bgp.getAllPeerConfigs()) {
+                String group = peer.getGroup();
+                // This question compares policies per peer group. A peer with no group (e.g. a
+                // directly-configured neighbor that does not inherit a peer template) has no group
+                // identity to match or deduplicate on, so it is skipped.
+                if (group == null) {
+                  continue;
+                }
                 // If we have already covered this peerGroup then we do not to compare policies
                 // again.
-                if (!peerGroupsSeen.contains(peer.getGroup())) {
-                  // Find the config for the same peer in the reference snapshot.
+                if (!peerGroupsSeen.contains(group)) {
+                  // Find the config for the same peer group in the reference snapshot.
                   Optional<BgpPeerConfig> refPeer =
                       refVrf
                           .getBgpProcess()
                           .allPeerConfigsStream()
-                          .filter(
-                              p -> {
-                                assert p.getGroup() != null;
-                                return p.getGroup().equals(peer.getGroup());
-                              })
+                          .filter(p -> group.equals(p.getGroup()))
                           .findFirst();
 
                   if (refPeer.isPresent()) {
-                    // The peer is in both snapshots. Check if the export policy used in both
-                    // snapshots is syntactically
-                    // the same.
-                    if ((peer.getIpv4UnicastAddressFamily().getExportPolicy() != null)
-                        && (refPeer.get().getIpv4UnicastAddressFamily().getExportPolicy()
-                            != null)) {
-                      trackDifference(
-                          router,
-                          peer.getIpv4UnicastAddressFamily().getExportPolicy(),
-                          refPeer.get().getIpv4UnicastAddressFamily().getExportPolicy(),
-                          syntacticCompare,
-                          candidates);
+                    Ipv4UnicastAddressFamily currentAf = peer.getIpv4UnicastAddressFamily();
+                    Ipv4UnicastAddressFamily refAf = refPeer.get().getIpv4UnicastAddressFamily();
+                    // Only IPv4 unicast policies are compared; a peer that does not exchange IPv4
+                    // unicast routes (e.g. an EVPN-only peer) has no such address family.
+                    if (currentAf != null && refAf != null) {
+                      // The peer is in both snapshots. Check if the export policy used in both
+                      // snapshots is syntactically the same.
+                      if ((currentAf.getExportPolicy() != null)
+                          && (refAf.getExportPolicy() != null)) {
+                        trackDifference(
+                            router,
+                            currentAf.getExportPolicy(),
+                            refAf.getExportPolicy(),
+                            syntacticCompare,
+                            candidates);
+                      }
+                      // Likewise for the import policy.
+                      if ((currentAf.getImportPolicy() != null)
+                          && (refAf.getImportPolicy() != null)) {
+                        trackDifference(
+                            router,
+                            currentAf.getImportPolicy(),
+                            refAf.getImportPolicy(),
+                            syntacticCompare,
+                            candidates);
+                      }
                     }
-                    // Likewise for the import policy.
-                    if ((peer.getIpv4UnicastAddressFamily().getImportPolicy() != null)
-                        && (refPeer.get().getIpv4UnicastAddressFamily().getImportPolicy()
-                            != null)) {
-                      trackDifference(
-                          router,
-                          peer.getIpv4UnicastAddressFamily().getImportPolicy(),
-                          refPeer.get().getIpv4UnicastAddressFamily().getImportPolicy(),
-                          syntacticCompare,
-                          candidates);
-                    }
-                    peerGroupsSeen.add(peer.getGroup());
+                    peerGroupsSeen.add(group);
                   }
                 }
               }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
@@ -232,6 +232,115 @@ public class ComparePeerGroupPoliciesAnswererTest {
     assertThat("the two are equivalent", answer.getRows().getData().isEmpty());
   }
 
+  /**
+   * Adds an active peer with no group (a "standalone" peer, e.g. an NX-OS neighbor that does not
+   * inherit a peer template) with the given export policy to both snapshots at {@code peerIp}.
+   */
+  private void addStandalonePeer(Ip peerIp, String exportPolicy) {
+    Configuration currentConfig =
+        _batfish.getProcessedConfigurations(_batfish.getSnapshot()).get().get(HOSTNAME);
+    Configuration referenceConfig =
+        _batfish.getProcessedConfigurations(_batfish.getReferenceSnapshot()).get().get(HOSTNAME);
+
+    BgpActivePeerConfig noGroupPeer =
+        BgpActivePeerConfig.builder()
+            .setPeerAddress(peerIp)
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder().setExportPolicy(exportPolicy).build())
+            .build();
+
+    SortedMap<Ip, BgpActivePeerConfig> baseBgpPeers =
+        new TreeMap<>(currentConfig.getDefaultVrf().getBgpProcess().getActiveNeighbors());
+    baseBgpPeers.put(peerIp, noGroupPeer);
+    currentConfig.getDefaultVrf().getBgpProcess().setNeighbors(baseBgpPeers);
+
+    SortedMap<Ip, BgpActivePeerConfig> deltaBgpPeers =
+        new TreeMap<>(referenceConfig.getDefaultVrf().getBgpProcess().getActiveNeighbors());
+    deltaBgpPeers.put(peerIp, noGroupPeer);
+    referenceConfig.getDefaultVrf().getBgpProcess().setNeighbors(deltaBgpPeers);
+  }
+
+  /**
+   * Reproduces batfish/batfish#10106: a peer with no group (e.g. an NX-OS neighbor that does not
+   * inherit a peer template) has a null group. {@code getGroup()} is nullable, but
+   * findDifferenceCandidates asserted it non-null, crashing on any topology containing such a peer.
+   * Such peers are now skipped: even when the group-less peer's policy differs across snapshots,
+   * the question runs without crashing and reports nothing for it.
+   */
+  @Test
+  public void testNullPeerGroupSkipped() {
+    // The shared group peer's policy (POLICY_NAME) is unchanged.
+    _policyBuilderDelta.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+    _policyBuilderBase.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+
+    // RM2 is referenced only by the group-less peer, and differs across snapshots.
+    _policyBuilderBase
+        .setName("RM2")
+        .setStatements(ImmutableList.of(new Statements.StaticStatement(Statements.ExitReject)))
+        .build();
+    _policyBuilderDelta
+        .setName("RM2")
+        .setStatements(ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept)))
+        .build();
+
+    // Add a directly-configured peer with no group (null) to both snapshots.
+    addStandalonePeer(Ip.FIRST_CLASS_B_PRIVATE_IP, "RM2");
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    // The group-less peer's RM2 difference is not reported; the grouped peer is unchanged.
+    assertThat("the group-less peer is skipped", answer.getRows().getData().isEmpty());
+  }
+
+  /**
+   * Skipping group-less peers is targeted: a grouped peer whose policy differs is still compared
+   * even when the same device also has a group-less peer with a differing policy.
+   */
+  @Test
+  public void testGroupedPeerComparedAlongsideNullPeerGroup() {
+    // The grouped peer's policy (POLICY_NAME) differs across snapshots.
+    _policyBuilderBase.addStatement(new Statements.StaticStatement(Statements.ExitReject)).build();
+    _policyBuilderDelta.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+
+    // RM2 is referenced only by the group-less peer, and also differs across snapshots.
+    _policyBuilderBase
+        .setName("RM2")
+        .setStatements(ImmutableList.of(new Statements.StaticStatement(Statements.ExitReject)))
+        .build();
+    _policyBuilderDelta
+        .setName("RM2")
+        .setStatements(ImmutableList.of(new Statements.StaticStatement(Statements.ExitAccept)))
+        .build();
+
+    addStandalonePeer(Ip.FIRST_CLASS_B_PRIVATE_IP, "RM2");
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion();
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    // Only the grouped peer's POLICY_NAME difference is reported; RM2 (group-less) is skipped.
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(COL_REFERENCE_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(
+                    deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING))));
+  }
+
   /** Tests route-map diff when the action differs. */
   @Test
   public void testActionDifference() {


### PR DESCRIPTION
findDifferenceCandidates matched peers across snapshots by peer group
name and asserted the group was non-null. BgpPeerConfig.getGroup() is
nullable: a directly-configured neighbor that does not inherit a peer
template (common on Cisco NX-OS, including EVPN route-reflector nodes)
has a null group. Any snapshot containing such a peer crashed the
question with an AssertionError, and because the question takes no
node/policy parameters there was no way to exclude the offending nodes.

This question compares policies per peer group, so a peer with no group
has no group identity to match or deduplicate on. Skip such peers
instead of asserting. Grouped peers on the same device are still
compared. Policy changes on group-less peers are not flagged by this
question.

Also guard the IPv4 unicast address-family dereferences: a peer whose
group is set but that exchanges only EVPN routes has no IPv4 unicast
address family, which would otherwise NPE.

Fixes batfish/batfish#10106.

----

Prompt:
```
Investigate https://github.com/batfish/batfish/issues/10106
```

Investigation found the crash was a null peer group (line 137 assert),
not the AutoAs limitation the issue title proposed. After weighing
whether to skip group-less peers or compare them by peer identity, the
decision was to skip them, keeping the fix aligned with the question's
per-peer-group semantics.
