### PR TITLE
comparePeerGroupPolicies: add nodes specifier

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswerer.java
@@ -27,8 +27,10 @@ public class ComparePeerGroupPoliciesAnswerer extends Answerer {
 
   @Override
   public AnswerElement answerDiff(NetworkSnapshot snapshot, NetworkSnapshot reference) {
+    ComparePeerGroupPoliciesQuestion question = (ComparePeerGroupPoliciesQuestion) _question;
     List<Row> answers =
-        ComparePeerGroupPoliciesUtils.getDifferencesStream(_batfish, snapshot, reference)
+        ComparePeerGroupPoliciesUtils.getDifferencesStream(
+                _batfish, snapshot, reference, question.getNodeSpecifier())
             .map(t -> TestRoutePoliciesAnswerer.toCompareRow(t.getFirst(), t.getSecond()))
             .collect(ImmutableList.toImmutableList());
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesQuestion.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesQuestion.java
@@ -1,18 +1,49 @@
 package org.batfish.minesweeper.question.comparepeergrouppolicies;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.questions.Question;
+import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.NodeSpecifier;
+import org.batfish.specifier.SpecifierFactories;
 
 public class ComparePeerGroupPoliciesQuestion extends Question {
 
-  public ComparePeerGroupPoliciesQuestion() {}
+  private static final String PROP_NODES = "nodes";
 
+  private final @Nullable String _nodes;
+
+  public ComparePeerGroupPoliciesQuestion() {
+    this(null);
+  }
+
+  @JsonCreator
+  public ComparePeerGroupPoliciesQuestion(@JsonProperty(PROP_NODES) @Nullable String nodes) {
+    _nodes = nodes;
+  }
+
+  @JsonIgnore
   @Override
   public boolean getDataPlane() {
     return false;
   }
 
+  @JsonIgnore
   @Override
   public String getName() {
     return "SemDiff";
+  }
+
+  @JsonProperty(PROP_NODES)
+  public @Nullable String getNodes() {
+    return _nodes;
+  }
+
+  @JsonIgnore
+  public @Nonnull NodeSpecifier getNodeSpecifier() {
+    return SpecifierFactories.getNodeSpecifierOrDefault(_nodes, AllNodesNodeSpecifier.INSTANCE);
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesUtils.java
@@ -22,6 +22,7 @@ import org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePolicie
 import org.batfish.minesweeper.question.compareroutepolicies.CompareRoutePoliciesQuestion;
 import org.batfish.minesweeper.utils.Tuple;
 import org.batfish.question.testroutepolicies.Result;
+import org.batfish.specifier.NodeSpecifier;
 
 public final class ComparePeerGroupPoliciesUtils {
 
@@ -29,6 +30,7 @@ public final class ComparePeerGroupPoliciesUtils {
    * @param batfish the batfish object
    * @param snapshot the current snapshot
    * @param reference the reference snapshot
+   * @param nodeSpecifier restricts the comparison to the nodes it resolves to (in both snapshots)
    * @return a stream of all the BGP policy semantic differences between the two snapshots. For
    *     every node in both snapshots, and for every peer group that appears in both snapshots we
    *     use CRP to compare their policies across the snapshots and add to the stream any pair of
@@ -36,10 +38,14 @@ public final class ComparePeerGroupPoliciesUtils {
    *     the comparison of two policies.
    */
   public static Stream<Tuple<Result<BgpRoute, BgpRoute>, Result<BgpRoute, BgpRoute>>>
-      getDifferencesStream(IBatfish batfish, NetworkSnapshot snapshot, NetworkSnapshot reference) {
+      getDifferencesStream(
+          IBatfish batfish,
+          NetworkSnapshot snapshot,
+          NetworkSnapshot reference,
+          NodeSpecifier nodeSpecifier) {
     // Find the candidate differences based on a syntactic check.
     Map<SyntacticDifference, SortedSet<String>> candidates =
-        findDifferenceCandidates(batfish, snapshot, reference);
+        findDifferenceCandidates(batfish, snapshot, reference, nodeSpecifier);
 
     Stream<Tuple<Result<BgpRoute, BgpRoute>, Result<BgpRoute, BgpRoute>>> answers =
         Stream.<Tuple<Result<BgpRoute, BgpRoute>, Result<BgpRoute, BgpRoute>>>builder().build();
@@ -91,14 +97,22 @@ public final class ComparePeerGroupPoliciesUtils {
    * @param batfish the batfish object
    * @param snapshot The current snapshot
    * @param reference The reference snapshot
+   * @param nodeSpecifier restricts the comparison to the nodes it resolves to (in both snapshots)
    * @return A map from potential differences to the devices they appear on.
    */
   private static SortedMap<SyntacticDifference, SortedSet<String>> findDifferenceCandidates(
-      IBatfish batfish, NetworkSnapshot snapshot, NetworkSnapshot reference) {
+      IBatfish batfish,
+      NetworkSnapshot snapshot,
+      NetworkSnapshot reference,
+      NodeSpecifier nodeSpecifier) {
     SortedMap<String, Configuration> currentConfigs =
         batfish.getProcessedConfigurations(snapshot).orElse(batfish.loadConfigurations(snapshot));
     SortedMap<String, Configuration> referenceConfigs =
         batfish.getProcessedConfigurations(reference).orElse(batfish.loadConfigurations(reference));
+
+    // Restrict to nodes that the specifier resolves to in both snapshots.
+    Set<String> currentNodes = nodeSpecifier.resolve(batfish.specifierContext(snapshot));
+    Set<String> referenceNodes = nodeSpecifier.resolve(batfish.specifierContext(reference));
 
     // Routing policies that are potentially different. Maps them to the devices they live on.
     SortedMap<SyntacticDifference, SortedSet<String>> candidates = new TreeMap<>();
@@ -106,6 +120,10 @@ public final class ComparePeerGroupPoliciesUtils {
     // Go through every device in the current snapshot
     for (Map.Entry<String, Configuration> current : currentConfigs.entrySet()) {
       String router = current.getKey();
+      // Skip nodes not selected by the specifier in both snapshots.
+      if (!currentNodes.contains(router) || !referenceNodes.contains(router)) {
+        continue;
+      }
       Configuration currentConfig = current.getValue();
       Configuration refConfig = referenceConfigs.get(current.getKey());
       // If the device is also present in the reference snapshot

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/comparepeergrouppolicies/ComparePeerGroupPoliciesAnswererTest.java
@@ -384,6 +384,49 @@ public class ComparePeerGroupPoliciesAnswererTest {
                 hasColumn(COL_DIFF, equalTo(diff), Schema.BGP_ROUTE_DIFFS))));
   }
 
+  /** A node specifier that matches the (only) node reports its differences. */
+  @Test
+  public void testNodesSpecifierMatches() {
+    _policyBuilderDelta.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+    _policyBuilderBase.addStatement(new Statements.StaticStatement(Statements.ExitReject)).build();
+
+    ComparePeerGroupPoliciesQuestion question = new ComparePeerGroupPoliciesQuestion(HOSTNAME);
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    assertThat(
+        answer.getRows().getData(),
+        Matchers.contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node(HOSTNAME)), Schema.NODE),
+                hasColumn(COL_POLICY_NAME, equalTo(POLICY_NAME), Schema.STRING),
+                hasColumn(baseColumnName(COL_ACTION), equalTo(DENY.toString()), Schema.STRING),
+                hasColumn(
+                    deltaColumnName(COL_ACTION), equalTo(PERMIT.toString()), Schema.STRING))));
+  }
+
+  /** A node specifier that excludes the node suppresses its differences. */
+  @Test
+  public void testNodesSpecifierExcludes() {
+    _policyBuilderDelta.addStatement(new Statements.StaticStatement(Statements.ExitAccept)).build();
+    _policyBuilderBase.addStatement(new Statements.StaticStatement(Statements.ExitReject)).build();
+
+    ComparePeerGroupPoliciesQuestion question =
+        new ComparePeerGroupPoliciesQuestion("someOtherNode");
+    ComparePeerGroupPoliciesAnswerer answerer =
+        new ComparePeerGroupPoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer =
+        (TableAnswerElement)
+            answerer.answerDiff(_batfish.getSnapshot(), _batfish.getReferenceSnapshot());
+
+    assertThat("the excluded node reports no differences", answer.getRows().getData().isEmpty());
+  }
+
   private MatchPrefixSet matchPrefixSet(List<PrefixRange> prList) {
     return new MatchPrefixSet(
         DestinationNetwork.instance(), new ExplicitPrefixSet(new PrefixSpace(prList)));

--- a/questions/experimental/comparePeerGroupPolicies.json
+++ b/questions/experimental/comparePeerGroupPolicies.json
@@ -1,15 +1,24 @@
 {
   "class": "org.batfish.minesweeper.question.comparepeergrouppolicies.ComparePeerGroupPoliciesQuestion",
   "differential": true,
+  "nodes": "${nodes}",
   "instance": {
     "description": "Compares the behavior of routing policies across a network change.",
     "instanceName": "comparePeerGroupPolicies",
     "longDescription": "This is a differential question that compares the behavior of routing policies across a network change.  For each peer group, the associated routing policy is semantically compared before and after the change using CRP.",
-    "orderedVariableNames": [],
+    "orderedVariableNames": [
+      "nodes"
+    ],
     "tags": [
       "routing"
     ],
     "variables": {
+      "nodes": {
+        "description": "Only examine policies on nodes matching this specifier",
+        "type": "nodeSpec",
+        "optional": true,
+        "displayName": "Nodes"
+      }
     }
   }
 }


### PR DESCRIPTION
The question took no parameters, so it always compared every node in
both snapshots. On a network containing a node that cannot be analyzed
(e.g. a BGP route reflector whose generated EVPN import policy uses
AutoAs, which minesweeper does not yet support), there was no way to
exclude that node from the comparison.

Add an optional `nodes` node specifier, matching the convention used by
compareRoutePolicies and bgpPeerConfiguration. When set, the comparison
is restricted to nodes the specifier resolves to in both snapshots;
unset, it defaults to all nodes, preserving existing behavior.

For batfish/batfish#10106.

----

Prompt:
```
Now also add a nodespecifier to the question
```

Followed up by choosing the specifier arguments to match existing BGP
and route-policy questions: a single optional `nodes` nodeSpec, resolved
via SpecifierFactories.getNodeSpecifierOrDefault with an all-nodes
default.
