### PR TITLE
checkstyle: drive via bazel target, mirror format.check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -60,17 +60,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Checkstyle cache
+      - name: Bazelisk cache
         uses: actions/cache@v6
         with:
-          path: "~/.cache/checkstyle"
-          key: checkstyle-${{ hashFiles('tools/run_checkstyle.sh') }}
-      - uses: actions/setup-java@v5
+          path: "~/.cache/bazelisk"
+          key: ${{runner.os}}-bazelisk-${{ hashFiles('.bazelversion') }}
+      - name: Bazel cache
+        uses: actions/cache@v6
         with:
-          distribution: "temurin"
-          java-version: "25"
+          path: "~/.cache/bazel"
+          key: ${{runner.os}}-bazel-checkstyle-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'maven_install.json') }}
+          restore-keys: |
+            ${{runner.os}}-bazel-checkstyle-
       - name: Checkstyle
-        run: tools/run_checkstyle.sh
+        run: bazel run //tools/checkstyle:checkstyle.check
   bazel_build_test_and_pmd:
     needs:
       - get_date

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,7 @@ BATFISH_MAVEN_ARTIFACTS = [
     "com.google.guava:guava-testlib",
     "com.google.re2j:re2j:1.8",
     "com.ibm.icu:icu4j:76.1",
+    "com.puppycrawl.tools:checkstyle:10.12.3",
     "commons-beanutils:commons-beanutils:1.11.0",
     "commons-cli:commons-cli:1.11.0",
     "commons-io:commons-io:2.22.0",

--- a/maven_install.json
+++ b/maven_install.json
@@ -28,6 +28,7 @@
     "com.google.j2objc:j2objc-annotations": 2003271689,
     "com.google.re2j:re2j": 1525409503,
     "com.ibm.icu:icu4j": 304238961,
+    "com.puppycrawl.tools:checkstyle": -1889222151,
     "commons-beanutils:commons-beanutils": 332733947,
     "commons-cli:commons-cli": 1754587837,
     "commons-io:commons-io": 1305681826,
@@ -113,6 +114,8 @@
     "com.google.code.findbugs:jsr305:jar:sources": -935881202,
     "com.google.code.gson:gson": -1663769307,
     "com.google.code.gson:gson:jar:sources": 935710753,
+    "com.google.collections:google-collections": 323138836,
+    "com.google.collections:google-collections:jar:sources": -1702686057,
     "com.google.errorprone:error_prone_annotations": 652227016,
     "com.google.errorprone:error_prone_annotations:jar:sources": -507624312,
     "com.google.googlejavaformat:google-java-format:jar:all-deps": 1824641929,
@@ -130,6 +133,8 @@
     "com.google.re2j:re2j:jar:sources": 485338798,
     "com.ibm.icu:icu4j": 1483821939,
     "com.ibm.icu:icu4j:jar:sources": 400701553,
+    "com.puppycrawl.tools:checkstyle": 1876617571,
+    "com.puppycrawl.tools:checkstyle:jar:sources": -481512718,
     "com.vaadin.external.google:android-json": -815169796,
     "com.vaadin.external.google:android-json:jar:sources": -241719183,
     "commons-beanutils:commons-beanutils": -882775588,
@@ -204,6 +209,16 @@
     "org.apache.logging.log4j:log4j-core:jar:sources": -625900064,
     "org.apache.logging.log4j:log4j-slf4j-impl": 731614719,
     "org.apache.logging.log4j:log4j-slf4j-impl:jar:sources": 670996594,
+    "org.apache.maven.doxia:doxia-core": -301526020,
+    "org.apache.maven.doxia:doxia-core:jar:sources": -552924920,
+    "org.apache.maven.doxia:doxia-logging-api": 1075845517,
+    "org.apache.maven.doxia:doxia-logging-api:jar:sources": -2045371637,
+    "org.apache.maven.doxia:doxia-module-xdoc": 1248806483,
+    "org.apache.maven.doxia:doxia-module-xdoc:jar:sources": 178270329,
+    "org.apache.maven.doxia:doxia-sink-api": -429838471,
+    "org.apache.maven.doxia:doxia-sink-api:jar:sources": 812584004,
+    "org.apache.xbean:xbean-reflect": -780502532,
+    "org.apache.xbean:xbean-reflect:jar:sources": 1604927661,
     "org.apfloat:apfloat": -1689392346,
     "org.apfloat:apfloat:jar:sources": -1889003084,
     "org.apiguardian:apiguardian-api": 1279798469,
@@ -212,6 +227,14 @@
     "org.checkerframework:checker-qual:jar:sources": 11073524,
     "org.codehaus.jettison:jettison": -1830180768,
     "org.codehaus.jettison:jettison:jar:sources": -1639170826,
+    "org.codehaus.plexus:plexus-classworlds": 830297444,
+    "org.codehaus.plexus:plexus-classworlds:jar:sources": -2122083127,
+    "org.codehaus.plexus:plexus-component-annotations": -599131582,
+    "org.codehaus.plexus:plexus-component-annotations:jar:sources": -1567582380,
+    "org.codehaus.plexus:plexus-container-default": -930299307,
+    "org.codehaus.plexus:plexus-container-default:jar:sources": 1495289637,
+    "org.codehaus.plexus:plexus-utils": -2106813517,
+    "org.codehaus.plexus:plexus-utils:jar:sources": -1133546446,
     "org.glassfish.grizzly:grizzly-framework": -880099071,
     "org.glassfish.grizzly:grizzly-framework:jar:sources": -1312844390,
     "org.glassfish.grizzly:grizzly-http": -1102587462,
@@ -294,6 +317,8 @@
     "org.ow2.asm:asm:jar:sources": 1372783843,
     "org.pcollections:pcollections": -311488717,
     "org.pcollections:pcollections:jar:sources": 238016638,
+    "org.reflections:reflections": 1275425251,
+    "org.reflections:reflections:jar:sources": -1998345296,
     "org.skyscreamer:jsonassert": -852848867,
     "org.skyscreamer:jsonassert:jar:sources": 1419411400,
     "org.slf4j:jul-to-slf4j": -1066646556,
@@ -469,6 +494,13 @@
       },
       "version": "2.14.0"
     },
+    "com.google.collections:google-collections": {
+      "shasums": {
+        "jar": "81b8d638af0083c4b877099d56aa0fee714485cd2ace1b6a09cab867cadb375d",
+        "sources": "dbb1a31cbbbaf5596cd7431a551cada2c329bba53b2f76900af35ab17d307f21"
+      },
+      "version": "1.0"
+    },
     "com.google.errorprone:error_prone_annotations": {
       "shasums": {
         "jar": "4667724877f1d37a689202da191e23efa7657c62eef93ccdac406eccfe5cdd0a",
@@ -530,6 +562,13 @@
         "sources": "3ab527e55dae77dd6fad6d8d397605f8b3fac1162191bc871cc87594e111d109"
       },
       "version": "76.1"
+    },
+    "com.puppycrawl.tools:checkstyle": {
+      "shasums": {
+        "jar": "04bf90a71ebf31a863a7cdeb0de04fd1f776085b2c6b3be58f5a67cb443da3ee",
+        "sources": "e6fb698775497e6bfe7efa46b5b92116dc797d6713e511aef4004c7707f2fe4b"
+      },
+      "version": "10.12.3"
     },
     "com.vaadin.external.google:android-json": {
       "shasums": {
@@ -790,6 +829,41 @@
       },
       "version": "2.26.1"
     },
+    "org.apache.maven.doxia:doxia-core": {
+      "shasums": {
+        "jar": "5e49cd827bebbcea5829d3b3883d17ad1ce15ebd6394aeb50ad50d7dfd939fcd",
+        "sources": "dda664b7207c3cb136ea981491fa9d568eb0869ffafff448544aad4d6856ebee"
+      },
+      "version": "1.12.0"
+    },
+    "org.apache.maven.doxia:doxia-logging-api": {
+      "shasums": {
+        "jar": "985306162c0a9f4c309d46109447f30f02bf6fc9bc16a3e039d59e1dabd0192f",
+        "sources": "184a5d645c92233365f732acfc596c54aff9fdccc582adde98987d65569add28"
+      },
+      "version": "1.12.0"
+    },
+    "org.apache.maven.doxia:doxia-module-xdoc": {
+      "shasums": {
+        "jar": "e8731ba00a4edd34b20eff9e4a729c2045c62cb796c3e491692607de4476ab01",
+        "sources": "41ad1b3fdecd0b0f50dc1299678835c23d29b043a01e77d8230622726de63164"
+      },
+      "version": "1.12.0"
+    },
+    "org.apache.maven.doxia:doxia-sink-api": {
+      "shasums": {
+        "jar": "5dca6aaaa9e70d8a0766e143ddcf9db09de5fde0fbcc78cb635d74e764dfcca5",
+        "sources": "747968d879494167ce3d393dc43ec6ec47d00df3addf1e1f2351f5aa76e8974a"
+      },
+      "version": "1.12.0"
+    },
+    "org.apache.xbean:xbean-reflect": {
+      "shasums": {
+        "jar": "104e5e9bb5a669f86722f32281960700f7ec8e3209ef51b23eb9b6d23d1629cb",
+        "sources": "ed59780db1ee258d806c6da541d74ef23fb9b05a5c96cc7f28e6fb203d2d4f9e"
+      },
+      "version": "3.7"
+    },
     "org.apfloat:apfloat": {
       "shasums": {
         "jar": "14fa3dee487b9d8de6d0ff7c39526159405c0879a65c817f959c9575e4b14820",
@@ -817,6 +891,34 @@
         "sources": "412f5e7f526cd8d34b824097e6c301c851a9610a3988ab7e731b2dfad2ce7a77"
       },
       "version": "1.5.6"
+    },
+    "org.codehaus.plexus:plexus-classworlds": {
+      "shasums": {
+        "jar": "52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549",
+        "sources": "a9dc469d6d1ad442d6661e677614bd102b5fcf30a27d55533ef05af7807cab89"
+      },
+      "version": "2.6.0"
+    },
+    "org.codehaus.plexus:plexus-component-annotations": {
+      "shasums": {
+        "jar": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac",
+        "sources": "3896689e1df0a4e2707ecdce4946e37c3037fbebbb3d730873c4d9dfb6d25174"
+      },
+      "version": "2.1.0"
+    },
+    "org.codehaus.plexus:plexus-container-default": {
+      "shasums": {
+        "jar": "6dceb1246b188153bdcb6f962d543d51ddb672cca07cad94a78fbabc9edf0a39",
+        "sources": "46f5a62b34ed74daec875416e4405702f9d2d313e5bbffe0e7e08582d0b2f24b"
+      },
+      "version": "2.1.0"
+    },
+    "org.codehaus.plexus:plexus-utils": {
+      "shasums": {
+        "jar": "76d174792540e2775af94d03d10fb2d3c776e2cd0ac0ebf427d3e570072bb9ce",
+        "sources": "a955fb73bd949cbf0bbdfe76e17a054a8180a82f16038d0c8c719cdbecc8504b"
+      },
+      "version": "3.3.0"
     },
     "org.glassfish.grizzly:grizzly-framework": {
       "shasums": {
@@ -1105,6 +1207,13 @@
       },
       "version": "4.0.2"
     },
+    "org.reflections:reflections": {
+      "shasums": {
+        "jar": "938a2d08fe54050d7610b944d8ddc3a09355710d9e6be0aac838dbc04e9a2825",
+        "sources": "7c8f0b91e298556ac8eebcbbb33de537baa146d80a7e5a6500e44cd8f76a91f4"
+      },
+      "version": "0.10.2"
+    },
     "org.skyscreamer:jsonassert": {
       "shasums": {
         "jar": "719095c07d4203961320da593441d8b3b643c18eb1d81aa98ea933bb7eb351ba",
@@ -1226,6 +1335,17 @@
       "com.google.j2objc:j2objc-annotations",
       "org.jspecify:jspecify"
     ],
+    "com.puppycrawl.tools:checkstyle": [
+      "com.google.guava:guava",
+      "commons-beanutils:commons-beanutils",
+      "info.picocli:picocli",
+      "net.sf.saxon:Saxon-HE",
+      "org.antlr:antlr4-runtime",
+      "org.apache.maven.doxia:doxia-core",
+      "org.apache.maven.doxia:doxia-module-xdoc",
+      "org.checkerframework:checker-qual",
+      "org.reflections:reflections"
+    ],
     "commons-beanutils:commons-beanutils": [
       "commons-collections:commons-collections",
       "commons-logging:commons-logging"
@@ -1290,6 +1410,35 @@
       "org.apache.logging.log4j:log4j-api",
       "org.apache.logging.log4j:log4j-core",
       "org.slf4j:slf4j-api"
+    ],
+    "org.apache.maven.doxia:doxia-core": [
+      "org.apache.commons:commons-lang3",
+      "org.apache.commons:commons-text",
+      "org.apache.httpcomponents:httpclient",
+      "org.apache.httpcomponents:httpcore",
+      "org.apache.maven.doxia:doxia-logging-api",
+      "org.apache.maven.doxia:doxia-sink-api",
+      "org.codehaus.plexus:plexus-component-annotations",
+      "org.codehaus.plexus:plexus-container-default",
+      "org.codehaus.plexus:plexus-utils"
+    ],
+    "org.apache.maven.doxia:doxia-logging-api": [
+      "org.codehaus.plexus:plexus-container-default"
+    ],
+    "org.apache.maven.doxia:doxia-module-xdoc": [
+      "org.apache.maven.doxia:doxia-core",
+      "org.apache.maven.doxia:doxia-sink-api",
+      "org.codehaus.plexus:plexus-component-annotations",
+      "org.codehaus.plexus:plexus-utils"
+    ],
+    "org.apache.maven.doxia:doxia-sink-api": [
+      "org.apache.maven.doxia:doxia-logging-api"
+    ],
+    "org.codehaus.plexus:plexus-container-default": [
+      "com.google.collections:google-collections",
+      "org.apache.xbean:xbean-reflect",
+      "org.codehaus.plexus:plexus-classworlds",
+      "org.codehaus.plexus:plexus-utils"
     ],
     "org.glassfish.grizzly:grizzly-http": [
       "org.glassfish.grizzly:grizzly-framework"
@@ -1436,6 +1585,11 @@
     ],
     "org.mockito:mockito-inline": [
       "org.mockito:mockito-core"
+    ],
+    "org.reflections:reflections": [
+      "com.google.code.findbugs:jsr305",
+      "org.javassist:javassist",
+      "org.slf4j:slf4j-api"
     ],
     "org.skyscreamer:jsonassert": [
       "com.vaadin.external.google:android-json"
@@ -1623,6 +1777,12 @@
       "com.google.gson.reflect",
       "com.google.gson.stream"
     ],
+    "com.google.collections:google-collections": [
+      "com.google.common.annotations",
+      "com.google.common.base",
+      "com.google.common.base.internal",
+      "com.google.common.collect"
+    ],
     "com.google.errorprone:error_prone_annotations": [
       "com.google.errorprone.annotations",
       "com.google.errorprone.annotations.concurrent"
@@ -1753,6 +1913,38 @@
       "com.ibm.icu.number",
       "com.ibm.icu.text",
       "com.ibm.icu.util"
+    ],
+    "com.puppycrawl.tools:checkstyle": [
+      "com.puppycrawl.tools.checkstyle",
+      "com.puppycrawl.tools.checkstyle.ant",
+      "com.puppycrawl.tools.checkstyle.api",
+      "com.puppycrawl.tools.checkstyle.checks",
+      "com.puppycrawl.tools.checkstyle.checks.annotation",
+      "com.puppycrawl.tools.checkstyle.checks.blocks",
+      "com.puppycrawl.tools.checkstyle.checks.coding",
+      "com.puppycrawl.tools.checkstyle.checks.design",
+      "com.puppycrawl.tools.checkstyle.checks.header",
+      "com.puppycrawl.tools.checkstyle.checks.imports",
+      "com.puppycrawl.tools.checkstyle.checks.indentation",
+      "com.puppycrawl.tools.checkstyle.checks.javadoc",
+      "com.puppycrawl.tools.checkstyle.checks.javadoc.utils",
+      "com.puppycrawl.tools.checkstyle.checks.metrics",
+      "com.puppycrawl.tools.checkstyle.checks.modifier",
+      "com.puppycrawl.tools.checkstyle.checks.naming",
+      "com.puppycrawl.tools.checkstyle.checks.regexp",
+      "com.puppycrawl.tools.checkstyle.checks.sizes",
+      "com.puppycrawl.tools.checkstyle.checks.whitespace",
+      "com.puppycrawl.tools.checkstyle.filefilters",
+      "com.puppycrawl.tools.checkstyle.filters",
+      "com.puppycrawl.tools.checkstyle.grammar",
+      "com.puppycrawl.tools.checkstyle.grammar.java",
+      "com.puppycrawl.tools.checkstyle.grammar.javadoc",
+      "com.puppycrawl.tools.checkstyle.gui",
+      "com.puppycrawl.tools.checkstyle.meta",
+      "com.puppycrawl.tools.checkstyle.site",
+      "com.puppycrawl.tools.checkstyle.utils",
+      "com.puppycrawl.tools.checkstyle.xpath",
+      "com.puppycrawl.tools.checkstyle.xpath.iterators"
     ],
     "com.vaadin.external.google:android-json": [
       "org.json"
@@ -2415,6 +2607,36 @@
       "org.apache.logging.slf4j.message",
       "org.slf4j.impl"
     ],
+    "org.apache.maven.doxia:doxia-core": [
+      "org.apache.maven.doxia",
+      "org.apache.maven.doxia.document",
+      "org.apache.maven.doxia.document.io.xpp3",
+      "org.apache.maven.doxia.index",
+      "org.apache.maven.doxia.macro",
+      "org.apache.maven.doxia.macro.manager",
+      "org.apache.maven.doxia.macro.snippet",
+      "org.apache.maven.doxia.macro.toc",
+      "org.apache.maven.doxia.markup",
+      "org.apache.maven.doxia.parser",
+      "org.apache.maven.doxia.parser.manager",
+      "org.apache.maven.doxia.parser.module",
+      "org.apache.maven.doxia.sink.impl",
+      "org.apache.maven.doxia.util"
+    ],
+    "org.apache.maven.doxia:doxia-logging-api": [
+      "org.apache.maven.doxia.logging"
+    ],
+    "org.apache.maven.doxia:doxia-module-xdoc": [
+      "org.apache.maven.doxia.module.xdoc"
+    ],
+    "org.apache.maven.doxia:doxia-sink-api": [
+      "org.apache.maven.doxia.sink",
+      "org.codehaus.doxia.sink"
+    ],
+    "org.apache.xbean:xbean-reflect": [
+      "org.apache.xbean.propertyeditor",
+      "org.apache.xbean.recipe"
+    ],
     "org.apfloat:apfloat": [
       "org.apfloat",
       "org.apfloat.internal",
@@ -2463,6 +2685,59 @@
       "org.codehaus.jettison.json",
       "org.codehaus.jettison.mapped",
       "org.codehaus.jettison.util"
+    ],
+    "org.codehaus.plexus:plexus-classworlds": [
+      "org.codehaus.classworlds",
+      "org.codehaus.plexus.classworlds",
+      "org.codehaus.plexus.classworlds.launcher",
+      "org.codehaus.plexus.classworlds.realm",
+      "org.codehaus.plexus.classworlds.strategy"
+    ],
+    "org.codehaus.plexus:plexus-component-annotations": [
+      "org.codehaus.plexus.component.annotations"
+    ],
+    "org.codehaus.plexus:plexus-container-default": [
+      "org.codehaus.plexus",
+      "org.codehaus.plexus.component",
+      "org.codehaus.plexus.component.builder",
+      "org.codehaus.plexus.component.collections",
+      "org.codehaus.plexus.component.composition",
+      "org.codehaus.plexus.component.configurator",
+      "org.codehaus.plexus.component.configurator.converters",
+      "org.codehaus.plexus.component.configurator.converters.basic",
+      "org.codehaus.plexus.component.configurator.converters.composite",
+      "org.codehaus.plexus.component.configurator.converters.lookup",
+      "org.codehaus.plexus.component.configurator.converters.special",
+      "org.codehaus.plexus.component.configurator.expression",
+      "org.codehaus.plexus.component.discovery",
+      "org.codehaus.plexus.component.factory",
+      "org.codehaus.plexus.component.factory.java",
+      "org.codehaus.plexus.component.manager",
+      "org.codehaus.plexus.component.repository",
+      "org.codehaus.plexus.component.repository.exception",
+      "org.codehaus.plexus.component.repository.io",
+      "org.codehaus.plexus.configuration",
+      "org.codehaus.plexus.configuration.io",
+      "org.codehaus.plexus.configuration.source",
+      "org.codehaus.plexus.configuration.xml",
+      "org.codehaus.plexus.container.initialization",
+      "org.codehaus.plexus.context",
+      "org.codehaus.plexus.lifecycle",
+      "org.codehaus.plexus.lifecycle.phase",
+      "org.codehaus.plexus.logging",
+      "org.codehaus.plexus.logging.console",
+      "org.codehaus.plexus.personality.plexus.lifecycle.phase"
+    ],
+    "org.codehaus.plexus:plexus-utils": [
+      "org.codehaus.plexus.util",
+      "org.codehaus.plexus.util.cli",
+      "org.codehaus.plexus.util.cli.shell",
+      "org.codehaus.plexus.util.dag",
+      "org.codehaus.plexus.util.introspection",
+      "org.codehaus.plexus.util.io",
+      "org.codehaus.plexus.util.reflection",
+      "org.codehaus.plexus.util.xml",
+      "org.codehaus.plexus.util.xml.pull"
     ],
     "org.glassfish.grizzly:grizzly-framework": [
       "org.glassfish.grizzly",
@@ -2933,6 +3208,13 @@
     "org.pcollections:pcollections": [
       "org.pcollections"
     ],
+    "org.reflections:reflections": [
+      "org.reflections",
+      "org.reflections.scanners",
+      "org.reflections.serializers",
+      "org.reflections.util",
+      "org.reflections.vfs"
+    ],
     "org.skyscreamer:jsonassert": [
       "org.json",
       "org.skyscreamer.jsonassert",
@@ -3041,6 +3323,8 @@
       "com.google.code.findbugs:jsr305:jar:sources",
       "com.google.code.gson:gson",
       "com.google.code.gson:gson:jar:sources",
+      "com.google.collections:google-collections",
+      "com.google.collections:google-collections:jar:sources",
       "com.google.errorprone:error_prone_annotations",
       "com.google.errorprone:error_prone_annotations:jar:sources",
       "com.google.googlejavaformat:google-java-format:jar:all-deps",
@@ -3058,6 +3342,8 @@
       "com.google.re2j:re2j:jar:sources",
       "com.ibm.icu:icu4j",
       "com.ibm.icu:icu4j:jar:sources",
+      "com.puppycrawl.tools:checkstyle",
+      "com.puppycrawl.tools:checkstyle:jar:sources",
       "com.vaadin.external.google:android-json",
       "com.vaadin.external.google:android-json:jar:sources",
       "commons-beanutils:commons-beanutils",
@@ -3132,6 +3418,16 @@
       "org.apache.logging.log4j:log4j-core:jar:sources",
       "org.apache.logging.log4j:log4j-slf4j-impl",
       "org.apache.logging.log4j:log4j-slf4j-impl:jar:sources",
+      "org.apache.maven.doxia:doxia-core",
+      "org.apache.maven.doxia:doxia-core:jar:sources",
+      "org.apache.maven.doxia:doxia-logging-api",
+      "org.apache.maven.doxia:doxia-logging-api:jar:sources",
+      "org.apache.maven.doxia:doxia-module-xdoc",
+      "org.apache.maven.doxia:doxia-module-xdoc:jar:sources",
+      "org.apache.maven.doxia:doxia-sink-api",
+      "org.apache.maven.doxia:doxia-sink-api:jar:sources",
+      "org.apache.xbean:xbean-reflect",
+      "org.apache.xbean:xbean-reflect:jar:sources",
       "org.apfloat:apfloat",
       "org.apfloat:apfloat:jar:sources",
       "org.apiguardian:apiguardian-api",
@@ -3140,6 +3436,14 @@
       "org.checkerframework:checker-qual:jar:sources",
       "org.codehaus.jettison:jettison",
       "org.codehaus.jettison:jettison:jar:sources",
+      "org.codehaus.plexus:plexus-classworlds",
+      "org.codehaus.plexus:plexus-classworlds:jar:sources",
+      "org.codehaus.plexus:plexus-component-annotations",
+      "org.codehaus.plexus:plexus-component-annotations:jar:sources",
+      "org.codehaus.plexus:plexus-container-default",
+      "org.codehaus.plexus:plexus-container-default:jar:sources",
+      "org.codehaus.plexus:plexus-utils",
+      "org.codehaus.plexus:plexus-utils:jar:sources",
       "org.glassfish.grizzly:grizzly-framework",
       "org.glassfish.grizzly:grizzly-framework:jar:sources",
       "org.glassfish.grizzly:grizzly-http",
@@ -3222,6 +3526,8 @@
       "org.ow2.asm:asm:jar:sources",
       "org.pcollections:pcollections",
       "org.pcollections:pcollections:jar:sources",
+      "org.reflections:reflections",
+      "org.reflections:reflections:jar:sources",
       "org.skyscreamer:jsonassert",
       "org.skyscreamer:jsonassert:jar:sources",
       "org.slf4j:jul-to-slf4j",

--- a/tools/checkstyle/BUILD.bazel
+++ b/tools/checkstyle/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+# checkstyle launcher using Bazel's hermetic JDK.
+java_binary(
+    name = "checkstyle",
+    main_class = "com.puppycrawl.tools.checkstyle.Main",
+    runtime_deps = ["@maven//:com_puppycrawl_tools_checkstyle"],
+)
+
+sh_binary(
+    name = "checkstyle.check",
+    srcs = ["checkstyle.sh"],
+    data = [":checkstyle"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/tools/checkstyle/checkstyle.sh
+++ b/tools/checkstyle/checkstyle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Runs checkstyle against the Java sources.
+#
+# Invoked via `bazel run //tools/checkstyle:checkstyle.check`. Any extra
+# arguments are passed through to checkstyle as additional paths to check;
+# with no arguments the default source trees are scanned.
+
+set -o pipefail
+
+# --- begin runfiles.bash initialization v2 ---
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }
+# --- end runfiles.bash initialization v2 ---
+
+CHECKSTYLE="$(rlocation _main/tools/checkstyle/checkstyle)"
+if [ -z "${CHECKSTYLE}" ] || [ ! -x "${CHECKSTYLE}" ]; then
+  echo "ERROR: cannot locate checkstyle launcher in runfiles" >&2
+  exit 1
+fi
+# The java_binary launcher looks for its own runfiles tree next to its
+# script, which doesn't exist when nested inside another binary's
+# runfiles. Point it at ours.
+if [ -n "${RUNFILES_DIR:-}" ]; then
+  export JAVA_RUNFILES="${RUNFILES_DIR}"
+elif [ -d "${0}.runfiles" ]; then
+  export JAVA_RUNFILES="${0}.runfiles"
+fi
+
+# checkstyle reads its config and the source trees from the workspace, not
+# from runfiles. `bazel run` sets BUILD_WORKSPACE_DIRECTORY to the workspace
+# root; fall back to the current directory otherwise.
+WORKSPACE="${BUILD_WORKSPACE_DIRECTORY:-$(pwd)}"
+cd "${WORKSPACE}"
+
+if [ "$#" -gt 0 ]; then
+  PATHS=("$@")
+else
+  PATHS=(projects)
+fi
+
+"${CHECKSTYLE}" -c projects/checkstyle.xml "${PATHS[@]}" --exclude projects/bdd

--- a/tools/run_checkstyle.sh
+++ b/tools/run_checkstyle.sh
@@ -2,17 +2,7 @@
 
 set -euo pipefail
 
-CHECKSTYLE_VERSION=10.12.3
-JAR_NAME="checkstyle-${CHECKSTYLE_VERSION}-all.jar"
-JAR_URL="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/${JAR_NAME}"
-
-# Check cache, and and download+cache jar if not present.
-JAR_DIR="${HOME}/.cache/checkstyle"
-JAR="${JAR_DIR}/${JAR_NAME}"
-if [ ! -f ${JAR} ]; then
-  mkdir -p "${JAR_DIR}"
-  wget "${JAR_URL}" -O "${JAR}"
-fi
-
-# Run the check
-java -jar ${JAR} -c projects/checkstyle.xml projects --exclude projects/bdd
+# Checkstyle runs as a Bazel target so the jar is resolved via Maven rather
+# than downloaded ad hoc. Any extra arguments are passed through as
+# additional paths to check.
+exec bazel run //tools/checkstyle:checkstyle.check -- "$@"


### PR DESCRIPTION
Resolve checkstyle through @maven and run it from a java_binary on
bazel's hermetic JDK, replacing the tools/run_checkstyle.sh that
fetched the jar from GitHub with wget and shelled out to system
`java`. run_checkstyle.sh now invokes //tools/checkstyle:checkstyle.check,
and the pre-commit GitHub workflow's checkstyle job builds and runs
that target instead of doing its own setup-java plus jar caching,
matching the existing format job.

This lets checkstyle run in environments without network access to
GitHub, since the jar is resolved via Maven and cached like every
other dependency.

----

Prompt:
```
Make checkstyle a bazel-native target mirroring
//tools/format:format.check so the jar resolves via @maven (and works
in environments without network access to GitHub) rather than being
downloaded at runtime.
```

