### PR TITLE
Arista: retain all EVPN import/export route-targets per VRF

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -3640,10 +3640,10 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
       return;
     }
     if (ctx.EXPORT() != null) {
-      _currentAristaBgpVrf.setExportRouteTarget(toRouteTarget(ctx.rt));
+      _currentAristaBgpVrf.addExportRouteTarget(toRouteTarget(ctx.rt));
     }
     if (ctx.IMPORT() != null) {
-      _currentAristaBgpVrf.setImportRouteTarget(toRouteTarget(ctx.rt));
+      _currentAristaBgpVrf.addImportRouteTarget(toRouteTarget(ctx.rt));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConfiguration.java
@@ -160,6 +160,7 @@ import org.batfish.datamodel.ospf.StubType;
 import org.batfish.datamodel.routing_policy.Common;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.communities.CommunityIs;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchAny;
 import org.batfish.datamodel.routing_policy.communities.HasCommunity;
 import org.batfish.datamodel.routing_policy.communities.InputCommunities;
 import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
@@ -1030,29 +1031,34 @@ public final class AristaConfiguration extends VendorConfiguration {
     redistributionPolicy.addStatement(Statements.ExitReject.toStaticStatement()).build();
     newBgpProcess.setRedistributionPolicy(redistPolicyName);
 
-    if (bgpVrf.getExportRouteTarget() != null && bgpVrf.getRouteDistinguisher() != null) {
-      // This VRF exports BGPv4 into default VRF's EVPN. Create VRF leak config for default VRF
+    if (!bgpVrf.getExportRouteTargets().isEmpty() && bgpVrf.getRouteDistinguisher() != null) {
+      // This VRF exports BGPv4 into default VRF's EVPN. Create VRF leak config for default VRF.
+      // All export route targets are attached to the exported EVPN routes.
       Bgpv4ToEvpnVrfLeakConfig leakConfig =
           Bgpv4ToEvpnVrfLeakConfig.builder()
               .setImportFromVrf(vrfName)
               .setSrcVrfRouteDistinguisher(bgpVrf.getRouteDistinguisher())
-              .setAttachRouteTargets(bgpVrf.getExportRouteTarget())
+              .setAttachRouteTargets(bgpVrf.getExportRouteTargets())
               .build();
       org.batfish.datamodel.Vrf defaultVrf = c.getVrfs().get(DEFAULT_VRF_NAME);
       getOrInitVrfLeakConfig(defaultVrf).addBgpv4ToEvpnVrfLeakConfig(leakConfig);
     }
-    if (bgpVrf.getImportRouteTarget() != null) {
+    if (!bgpVrf.getImportRouteTargets().isEmpty()) {
       // This VRF imports default VRF's EVPN into its BGPv4. Create VRF leak config for it
       RoutingPolicy importPolicy =
           RoutingPolicy.builder()
               .setOwner(c)
               .setName(generatedEvpnToBgpv4VrfLeakPolicyName(bgpVrf.getName()))
               .addStatement(
-                  // Only import EVPN routes that match this VRF's import route target
+                  // Only import EVPN routes that match any of this VRF's import route targets
                   new If(
                       new MatchCommunities(
                           InputCommunities.instance(),
-                          new HasCommunity(new CommunityIs(bgpVrf.getImportRouteTarget()))),
+                          new HasCommunity(
+                              CommunityMatchAny.matchAny(
+                                  bgpVrf.getImportRouteTargets().stream()
+                                      .map(CommunityIs::new)
+                                      .collect(ImmutableList.toImmutableList())))),
                       ImmutableList.of(Statements.ReturnTrue.toStaticStatement())))
               .addStatement(Statements.ReturnFalse.toStaticStatement())
               .build();

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -749,16 +749,21 @@ final class AristaConversions {
         }
         AristaBgpVrf bgpVrf = bgpConfig.getVrfs().get(vrfName);
         if (bgpVrf.getRouteDistinguisher() == null
-            || bgpVrf.getImportRouteTarget() == null
-            || bgpVrf.getExportRouteTarget() == null) {
+            || bgpVrf.getImportRouteTargets().isEmpty()
+            || bgpVrf.getExportRouteTargets().isEmpty()) {
           continue;
         }
+        // TODO: Layer3VniConfig models a single import/export RT; a VRF may
+        // configure multiple. Report an arbitrary one of each until the VI
+        // model supports collections (batfish/batfish#10113). Functional
+        // import/export leaking uses all RTs (see toVendorIndependentConfiguration).
         l3vnis.add(
             Layer3VniConfig.builder()
                 .setAdvertiseV4Unicast(true)
                 .setVni(entry.getValue())
-                .setImportRouteTarget(bgpVrf.getImportRouteTarget().matchString())
-                .setRouteTarget(bgpVrf.getExportRouteTarget())
+                .setImportRouteTarget(
+                    bgpVrf.getImportRouteTargets().iterator().next().matchString())
+                .setRouteTarget(bgpVrf.getExportRouteTargets().iterator().next())
                 .setRouteDistinguisher(bgpVrf.getRouteDistinguisher())
                 .setVrf(vrfName)
                 .build());

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpVrf.java
@@ -3,7 +3,9 @@ package org.batfish.vendor.arista.representation.eos;
 import java.io.Serializable;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
@@ -30,9 +32,9 @@ public final class AristaBgpVrf implements Serializable {
   private @Nullable Long _defaultMetric;
   private @Nullable Integer _ebgpAdminDistance;
   private @Nullable Boolean _enforceFirstAs;
-  private @Nullable ExtendedCommunity _exportRouteTarget;
+  private final @Nonnull Set<ExtendedCommunity> _exportRouteTargets;
   private @Nullable Integer _ibgpAdminDistance;
-  private @Nullable ExtendedCommunity _importRouteTarget;
+  private final @Nonnull Set<ExtendedCommunity> _importRouteTargets;
   private @Nullable Integer _holdTimer;
   private @Nullable Integer _keepAliveTimer;
   private @Nullable Integer _listenLimit;
@@ -84,6 +86,8 @@ public final class AristaBgpVrf implements Serializable {
     _v4neighbors = new HashMap<>(0);
     _interfaceNeighbors = new HashMap<>(0);
     _redistributionPolicies = new EnumMap<>(AristaRedistributeType.class);
+    _exportRouteTargets = new HashSet<>(0);
+    _importRouteTargets = new HashSet<>(0);
   }
 
   public boolean getDefaultIpv4Unicast() {
@@ -206,12 +210,15 @@ public final class AristaBgpVrf implements Serializable {
     _localAdminDistance = localAdminDistance;
   }
 
-  public @Nullable ExtendedCommunity getExportRouteTarget() {
-    return _exportRouteTarget;
+  /**
+   * EVPN export route targets. A VRF may declare multiple {@code route-target export evpn} lines.
+   */
+  public @Nonnull Set<ExtendedCommunity> getExportRouteTargets() {
+    return _exportRouteTargets;
   }
 
-  public void setExportRouteTarget(@Nullable ExtendedCommunity exportRouteTarget) {
-    _exportRouteTarget = exportRouteTarget;
+  public void addExportRouteTarget(ExtendedCommunity exportRouteTarget) {
+    _exportRouteTargets.add(exportRouteTarget);
   }
 
   public @Nonnull AristaBgpVrfEvpnAddressFamily getOrCreateEvpnAf() {
@@ -251,12 +258,15 @@ public final class AristaBgpVrf implements Serializable {
     return _flowSpecV6Af;
   }
 
-  public @Nullable ExtendedCommunity getImportRouteTarget() {
-    return _importRouteTarget;
+  /**
+   * EVPN import route targets. A VRF may declare multiple {@code route-target import evpn} lines.
+   */
+  public @Nonnull Set<ExtendedCommunity> getImportRouteTargets() {
+    return _importRouteTargets;
   }
 
-  public void setImportRouteTarget(@Nullable ExtendedCommunity importRouteTarget) {
-    _importRouteTarget = importRouteTarget;
+  public void addImportRouteTarget(ExtendedCommunity importRouteTarget) {
+    _importRouteTargets.add(importRouteTarget);
   }
 
   /** Hold timer, in seconds */

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -12,6 +12,7 @@ import static org.batfish.datamodel.Names.bgpNeighborStructureName;
 import static org.batfish.datamodel.Names.generatedBgpPeerEvpnExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
+import static org.batfish.datamodel.Names.generatedEvpnToBgpv4VrfLeakPolicyName;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
@@ -160,6 +161,7 @@ import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Bgpv4Route.Builder;
+import org.batfish.datamodel.Bgpv4ToEvpnVrfLeakConfig;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
@@ -2618,7 +2620,8 @@ public class AristaGrammarTest {
     AristaConfiguration config = parseVendorConfig("arista_bgp_vrf");
     assertThat(config.getAristaBgp(), notNullValue());
     assertThat(
-        config.getAristaBgp().getVrfs().keySet(), containsInAnyOrder(DEFAULT_VRF, "FOO", "BAR"));
+        config.getAristaBgp().getVrfs().keySet(),
+        containsInAnyOrder(DEFAULT_VRF, "FOO", "BAR", "MULTI"));
     {
       AristaBgpVrf vrf = config.getAristaBgp().getDefaultVrf();
       assertThat(vrf.getBestpathAsPathMultipathRelax(), nullValue());
@@ -2629,8 +2632,8 @@ public class AristaGrammarTest {
       AristaBgpVrf vrf = config.getAristaBgp().getVrfs().get("FOO");
       assertThat(vrf.getBestpathAsPathMultipathRelax(), equalTo(Boolean.TRUE));
       assertThat(vrf.getRouteDistinguisher(), equalTo(RouteDistinguisher.parse("123:123")));
-      assertThat(vrf.getExportRouteTarget(), equalTo(ExtendedCommunity.target(1L, 1L)));
-      assertThat(vrf.getImportRouteTarget(), equalTo(ExtendedCommunity.target(2L, 2L)));
+      assertThat(vrf.getExportRouteTargets(), contains(ExtendedCommunity.target(1L, 1L)));
+      assertThat(vrf.getImportRouteTargets(), contains(ExtendedCommunity.target(2L, 2L)));
       assertThat(vrf.getLocalAs(), equalTo(65000L));
       assertThat(vrf.getBestpathTieBreaker(), equalTo(AristaBgpBestpathTieBreaker.ROUTER_ID));
       assertThat(vrf.getClusterId(), nullValue());
@@ -2642,12 +2645,25 @@ public class AristaGrammarTest {
           vrf.getBestpathTieBreaker(), equalTo(AristaBgpBestpathTieBreaker.CLUSTER_LIST_LENGTH));
       assertThat(vrf.getClusterId(), nullValue());
     }
+    {
+      // A VRF may declare multiple import and export EVPN route targets; all are retained.
+      AristaBgpVrf vrf = config.getAristaBgp().getVrfs().get("MULTI");
+      assertThat(vrf.getRouteDistinguisher(), equalTo(RouteDistinguisher.parse("123:456")));
+      assertThat(
+          vrf.getImportRouteTargets(),
+          containsInAnyOrder(
+              ExtendedCommunity.target(65000L, 100L), ExtendedCommunity.target(65000L, 200L)));
+      assertThat(
+          vrf.getExportRouteTargets(),
+          containsInAnyOrder(
+              ExtendedCommunity.target(65000L, 300L), ExtendedCommunity.target(65000L, 400L)));
+    }
   }
 
   @Test
   public void testVrfConversion() {
     Configuration c = parseConfig("arista_bgp_vrf");
-    assertThat(c.getVrfs().keySet(), containsInAnyOrder(DEFAULT_VRF, "FOO", "BAR"));
+    assertThat(c.getVrfs().keySet(), containsInAnyOrder(DEFAULT_VRF, "FOO", "BAR", "MULTI"));
     {
       BgpProcess proc = c.getDefaultVrf().getBgpProcess();
       assertThat(proc, notNullValue());
@@ -2671,6 +2687,43 @@ public class AristaGrammarTest {
           proc.getMultipathEquivalentAsPathMatchMode(),
           equalTo(MultipathEquivalentAsPathMatchMode.EXACT_PATH));
       assertThat(proc.getTieBreaker(), equalTo(BgpTieBreaker.CLUSTER_LIST_LENGTH));
+    }
+    {
+      // MULTI declares multiple import and export EVPN route targets. The export leak attaches
+      // all export RTs, and the import leak policy accepts a route carrying any import RT.
+      org.batfish.datamodel.Vrf multi = c.getVrfs().get("MULTI");
+      assertThat(multi.getBgpProcess(), notNullValue());
+      List<Bgpv4ToEvpnVrfLeakConfig> multiExportLeaks =
+          c.getDefaultVrf().getVrfLeakConfig().getBgpv4ToEvpnVrfLeakConfigs().stream()
+              .filter(leak -> leak.getImportFromVrf().equals("MULTI"))
+              .collect(ImmutableList.toImmutableList());
+      assertThat(multiExportLeaks, hasSize(1));
+      assertThat(
+          multiExportLeaks.get(0).getAttachRouteTargets(),
+          containsInAnyOrder(
+              ExtendedCommunity.target(65000L, 300L), ExtendedCommunity.target(65000L, 400L)));
+      assertThat(multi.getVrfLeakConfig().getEvpnToBgpv4VrfLeakConfigs(), hasSize(1));
+      RoutingPolicy importPolicy =
+          c.getRoutingPolicies().get(generatedEvpnToBgpv4VrfLeakPolicyName("MULTI"));
+      assertThat(importPolicy, notNullValue());
+      for (ExtendedCommunity rt :
+          ImmutableList.of(
+              ExtendedCommunity.target(65000L, 100L), ExtendedCommunity.target(65000L, 200L))) {
+        Bgpv4Route route =
+            Bgpv4Route.testBuilder()
+                .setNetwork(Prefix.parse("10.0.0.0/32"))
+                .setCommunities(CommunitySet.of(rt))
+                .build();
+        assertTrue(
+            "import policy should accept a route carrying " + rt,
+            importPolicy.process(route, route.toBuilder(), Direction.IN));
+      }
+      Bgpv4Route unmatched =
+          Bgpv4Route.testBuilder()
+              .setNetwork(Prefix.parse("10.0.0.0/32"))
+              .setCommunities(CommunitySet.of(ExtendedCommunity.target(65000L, 999L)))
+              .build();
+      assertFalse(importPolicy.process(unmatched, unmatched.toBuilder(), Direction.IN));
     }
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_vrf
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_vrf
@@ -16,6 +16,14 @@ router bgp 1
   vrf BAR
     no bgp bestpath as-path multipath-relax
     bgp bestpath tie-break cluster-list-length
+!
+  vrf MULTI
+    rd 123:456
+    route-target import evpn 65000:100
+    route-target import evpn 65000:200
+    route-target export evpn 65000:300
+    route-target export evpn 65000:400
 
 vrf instance FOO
 vrf instance BAR
+vrf instance MULTI


### PR DESCRIPTION
An Arista VRF may declare several `route-target import evpn` and
`route-target export evpn` lines. AristaBgpVrf stored a single import
and single export target, and the extractor overwrote on each line, so
only the last value per direction survived. A VRF whose matching target
was not listed last failed to import or export the affected EVPN routes.

Store the import and export route targets as insertion-ordered sets and
accumulate them in the extractor. In conversion, the BGPv4->EVPN export
leak now attaches all export targets, and the EVPN->BGPv4 import leak
policy accepts a route carrying any of the import targets rather than
only one.

The vendor-independent Layer3VniConfig still models a single import and
export target, so evpnL3VniProperties continues to report the first of
each; widening that model and the question output is left to a
follow-up. Functional import/export leaking uses the full sets.

For batfish/batfish#10113.

----

Prompt:
```
Now scope the Batfish fixes

Yes let's do PR1. Let's skip L2 widening.

When we do PR 2, let's also rename the columns (Route_Targets) and make
sure that in the answer they're sorted (but probably not in the internal
storage)
```
