### PR TITLE
Arista: honor `send-community extended` on EVPN neighbors

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -686,7 +686,7 @@ final class AristaConversions {
                   .setAllowRemoteAsOut(ALWAYS) // no outgoing remote-as check on Arista
                   .setSendCommunity(firstNonNull(neighbor.getSendCommunity(), Boolean.FALSE))
                   .setSendExtendedCommunity(
-                      firstNonNull(neighbor.getSendCommunity(), Boolean.FALSE))
+                      firstNonNull(neighbor.getSendExtendedCommunity(), Boolean.FALSE))
                   .build());
 
       ImmutableSet.Builder<Layer2VniConfig> l2vnis = ImmutableSet.builder();

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -201,6 +201,7 @@ import org.batfish.datamodel.VrrpGroup;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
+import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.BgpConfederation;
 import org.batfish.datamodel.bgp.BgpTopologyUtils;
@@ -3320,6 +3321,26 @@ public class AristaGrammarTest {
               hasIpv4UnicastAddressFamily(
                   hasAddressFamilyCapabilites(hasSendExtendedCommunity(true)))));
     }
+  }
+
+  /**
+   * `send-community extended` on an EVPN-activated neighbor must set send-extended-community (not
+   * send-community) on the converted EVPN address family. Otherwise route-target extended
+   * communities are stripped on EVPN export.
+   */
+  @Test
+  public void testEvpnSendExtendedCommunityConversion() {
+    Configuration config = parseConfig("arista_evpn_send_extended_community");
+    AddressFamilyCapabilities caps =
+        config
+            .getDefaultVrf()
+            .getBgpProcess()
+            .getActiveNeighbors()
+            .get(Ip.parse("192.168.255.2"))
+            .getEvpnAddressFamily()
+            .getAddressFamilyCapabilities();
+    assertFalse(caps.getSendCommunity());
+    assertTrue(caps.getSendExtendedCommunity());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_evpn_send_extended_community
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_evpn_send_extended_community
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_evpn_send_extended_community
+!
+interface Loopback0
+   ip address 192.168.255.1/32
+!
+interface Vxlan1
+   vxlan source-interface Loopback0
+!
+router bgp 65101
+   router-id 192.168.255.1
+   neighbor 192.168.255.2 remote-as 65102
+   neighbor 192.168.255.2 update-source Loopback0
+   neighbor 192.168.255.2 send-community extended
+   !
+   address-family evpn
+      neighbor 192.168.255.2 activate
+!


### PR DESCRIPTION
The EVPN address family set its send-extended-community capability from
the neighbor's send-community flag rather than its send-extended-community
flag. A neighbor configured with `send-community extended` (but not plain
`send-community`) therefore did not advertise extended communities on the
EVPN address family, stripping route targets from exported EVPN routes.
The IPv4 unicast family already used the correct flag.

Use getSendExtendedCommunity() for the EVPN family, matching IPv4.

----

Prompt:
```
While re-triaging the eos_evpn_multiple_rts lab against Batfish, EVPN
route targets were being stripped on export even though the config used
`send-community extended`. Fix the Arista EVPN address-family conversion
to honor send-community extended, and add a regression test.
```
