### PR TITLE
EVPN VNI configs: model multiple import/export route-targets

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -891,7 +891,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
               EvpnType3Route route =
                   initEvpnType3Route(
                       l2Vni,
-                      vniConfig.getRouteTarget(),
+                      vniConfig.getRouteTargets(),
                       vniConfig.getRouteDistinguisher(),
                       _process.getRouterId());
               initializationBuilder.from(_evpnType3Rib.mergeRouteGetDelta(route));
@@ -906,16 +906,16 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   @VisibleForTesting
   static @Nonnull EvpnType3Route initEvpnType3Route(
       Layer2Vni vni,
-      ExtendedCommunity routeTarget,
+      Set<ExtendedCommunity> routeTargets,
       RouteDistinguisher routeDistinguisher,
       Ip routerId) {
     checkArgument(
         vni.getSourceAddress() != null,
         "Cannot construct type 3 route for invalid VNI %s",
         vni.getVni());
-    // Locally all routes start as eBGP routes in our own RIB
+    // Locally all routes start as eBGP routes in our own RIB. Attach all export route targets.
     return EvpnType3Route.builder()
-        .setCommunities(CommunitySet.of(routeTarget))
+        .setCommunities(CommunitySet.of(routeTargets))
         .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
         // so that this route is not installed back in the main RIB of any of the VRFs
         .setOriginatorIp(routerId)

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/grammar/AristaControlPlaneExtractor.java
@@ -3591,10 +3591,10 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
   public void exitEos_rb_vlan_tail_route_target(Eos_rb_vlan_tail_route_targetContext ctx) {
     ExtendedCommunity rt = toRouteTarget(ctx.rt);
     if (ctx.IMPORT() != null || ctx.BOTH() != null) {
-      _currentAristaBgpVlan.setRtImport(rt);
+      _currentAristaBgpVlan.addRtImport(rt);
     }
     if (ctx.EXPORT() != null || ctx.BOTH() != null) {
-      _currentAristaBgpVlan.setRtExport(rt);
+      _currentAristaBgpVlan.addRtExport(rt);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/AristaConversions.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -61,6 +63,7 @@ import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
 import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.routing_policy.Common;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
@@ -124,6 +127,13 @@ import org.batfish.vendor.arista.representation.eos.AristaEosVxlan;
  */
 @ParametersAreNonnullByDefault
 final class AristaConversions {
+  /** Convert a set of import route targets to the community-match patterns used by VniConfig. */
+  private static @Nonnull SortedSet<String> toImportRtPatterns(Set<ExtendedCommunity> rts) {
+    return rts.stream()
+        .map(ExtendedCommunity::matchString)
+        .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+  }
+
   /** Computes the router ID. */
   static @Nonnull Ip getBgpRouterId(
       AristaBgpVrf vrfConfig, String vrfName, Map<String, Interface> vrfInterfaces, Warnings w) {
@@ -694,8 +704,8 @@ final class AristaConversions {
           vxlan == null ? ImmutableSortedMap.of() : vxlan.getVlanVnis();
       for (AristaBgpVlan vlanConfig : bgpConfig.getVlans().values()) {
         if (vlanConfig.getRd() == null
-            || vlanConfig.getRtImport() == null
-            || vlanConfig.getRtExport() == null) {
+            || vlanConfig.getRtImports().isEmpty()
+            || vlanConfig.getRtExports().isEmpty()) {
           continue;
         }
         Vrf vrfForVlan = getVrfForVlan(c, vlanConfig.getVlan()).orElse(null);
@@ -709,8 +719,8 @@ final class AristaConversions {
         l2vnis.add(
             Layer2VniConfig.builder()
                 .setVni(vni)
-                .setImportRouteTarget(vlanConfig.getRtImport().matchString())
-                .setRouteTarget(vlanConfig.getRtExport())
+                .setImportRouteTargets(toImportRtPatterns(vlanConfig.getRtImports()))
+                .setRouteTargets(ImmutableSortedSet.copyOf(vlanConfig.getRtExports()))
                 .setRouteDistinguisher(vlanConfig.getRd())
                 .setVrf(vrfForVlan.getName())
                 .build());
@@ -718,8 +728,8 @@ final class AristaConversions {
       for (AristaBgpVlanAwareBundle bundle : bgpConfig.getVlanAwareBundles().values()) {
         if (bundle.getVlans() == null
             || bundle.getRd() == null
-            || bundle.getRtExport() == null
-            || bundle.getRtImport() == null) {
+            || bundle.getRtExports().isEmpty()
+            || bundle.getRtImports().isEmpty()) {
           continue;
         }
         for (Integer vlan : bundle.getVlans().enumerate()) {
@@ -730,8 +740,8 @@ final class AristaConversions {
           l2vnis.add(
               Layer2VniConfig.builder()
                   .setVni(vni)
-                  .setImportRouteTarget(bundle.getRtImport().matchString())
-                  .setRouteTarget(bundle.getRtExport())
+                  .setImportRouteTargets(toImportRtPatterns(bundle.getRtImports()))
+                  .setRouteTargets(ImmutableSortedSet.copyOf(bundle.getRtExports()))
                   .setRouteDistinguisher(bundle.getRd())
                   // TODO: remove vrf from Layer2Vni
                   .setVrf(DEFAULT_VRF_NAME)
@@ -753,17 +763,12 @@ final class AristaConversions {
             || bgpVrf.getExportRouteTargets().isEmpty()) {
           continue;
         }
-        // TODO: Layer3VniConfig models a single import/export RT; a VRF may
-        // configure multiple. Report an arbitrary one of each until the VI
-        // model supports collections (batfish/batfish#10113). Functional
-        // import/export leaking uses all RTs (see toVendorIndependentConfiguration).
         l3vnis.add(
             Layer3VniConfig.builder()
                 .setAdvertiseV4Unicast(true)
                 .setVni(entry.getValue())
-                .setImportRouteTarget(
-                    bgpVrf.getImportRouteTargets().iterator().next().matchString())
-                .setRouteTarget(bgpVrf.getExportRouteTargets().iterator().next())
+                .setImportRouteTargets(toImportRtPatterns(bgpVrf.getImportRouteTargets()))
+                .setRouteTargets(ImmutableSortedSet.copyOf(bgpVrf.getExportRouteTargets()))
                 .setRouteDistinguisher(bgpVrf.getRouteDistinguisher())
                 .setVrf(vrfName)
                 .build());

--- a/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpVlanBase.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/arista/representation/eos/AristaBgpVlanBase.java
@@ -1,14 +1,22 @@
 package org.batfish.vendor.arista.representation.eos;
 
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 
 public abstract class AristaBgpVlanBase implements Serializable {
   private @Nullable RouteDistinguisher _rd;
-  private @Nullable ExtendedCommunity _rtImport;
-  private @Nullable ExtendedCommunity _rtExport;
+  private final @Nonnull Set<ExtendedCommunity> _rtImports;
+  private final @Nonnull Set<ExtendedCommunity> _rtExports;
+
+  protected AristaBgpVlanBase() {
+    _rtImports = new HashSet<>(0);
+    _rtExports = new HashSet<>(0);
+  }
 
   public @Nullable RouteDistinguisher getRd() {
     return _rd;
@@ -18,19 +26,21 @@ public abstract class AristaBgpVlanBase implements Serializable {
     _rd = rd;
   }
 
-  public @Nullable ExtendedCommunity getRtImport() {
-    return _rtImport;
+  /** EVPN import route targets. A VLAN may declare multiple {@code route-target import} lines. */
+  public @Nonnull Set<ExtendedCommunity> getRtImports() {
+    return _rtImports;
   }
 
-  public void setRtImport(@Nullable ExtendedCommunity rtImport) {
-    _rtImport = rtImport;
+  public void addRtImport(ExtendedCommunity rtImport) {
+    _rtImports.add(rtImport);
   }
 
-  public @Nullable ExtendedCommunity getRtExport() {
-    return _rtExport;
+  /** EVPN export route targets. A VLAN may declare multiple {@code route-target export} lines. */
+  public @Nonnull Set<ExtendedCommunity> getRtExports() {
+    return _rtExports;
   }
 
-  public void setRtExport(@Nullable ExtendedCommunity rtExport) {
-    _rtExport = rtExport;
+  public void addRtExport(ExtendedCommunity rtExport) {
+    _rtExports.add(rtExport);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -159,7 +159,7 @@ public class BgpRoutingProcessTest {
                 .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
                 .setSourceAddress(ip)
                 .build(),
-            routeTarget,
+            ImmutableSortedSet.of(routeTarget),
             routeDistinguisher,
             ip);
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/arista/grammar/AristaGrammarTest.java
@@ -2323,8 +2323,8 @@ public class AristaGrammarTest {
       AristaBgpVlanAwareBundle bundle = config.getAristaBgp().getVlanAwareBundles().get("Tenant_A");
       assertThat(bundle, notNullValue());
       assertThat(bundle.getRd(), equalTo(RouteDistinguisher.parse("192.168.255.8:10101")));
-      assertThat(bundle.getRtImport(), equalTo(ExtendedCommunity.target(10101, 10101)));
-      assertThat(bundle.getRtExport(), equalTo(ExtendedCommunity.target(10101, 10101)));
+      assertThat(bundle.getRtImports(), contains(ExtendedCommunity.target(10101, 10101)));
+      assertThat(bundle.getRtExports(), contains(ExtendedCommunity.target(10101, 10101)));
       assertThat(bundle.getVlans(), equalTo(IntegerSpace.builder().including(1, 110, 111).build()));
     }
 
@@ -2332,8 +2332,22 @@ public class AristaGrammarTest {
       AristaBgpVlan vlan = config.getAristaBgp().getVlans().get(300);
       assertThat(vlan, notNullValue());
       assertThat(vlan.getRd(), equalTo(RouteDistinguisher.parse("192.168.255.100:10103")));
-      assertThat(vlan.getRtImport(), equalTo(ExtendedCommunity.target(10101, 10103)));
-      assertThat(vlan.getRtExport(), equalTo(ExtendedCommunity.target(10101, 10103)));
+      assertThat(vlan.getRtImports(), contains(ExtendedCommunity.target(10101, 10103)));
+      assertThat(vlan.getRtExports(), contains(ExtendedCommunity.target(10101, 10103)));
+    }
+    {
+      // A VLAN may declare multiple import and export route targets; all are retained.
+      AristaBgpVlan vlan = config.getAristaBgp().getVlans().get(301);
+      assertThat(vlan, notNullValue());
+      assertThat(vlan.getRd(), equalTo(RouteDistinguisher.parse("192.168.255.100:10104")));
+      assertThat(
+          vlan.getRtImports(),
+          containsInAnyOrder(
+              ExtendedCommunity.target(65000, 100), ExtendedCommunity.target(65000, 200)));
+      assertThat(
+          vlan.getRtExports(),
+          containsInAnyOrder(
+              ExtendedCommunity.target(65000, 300), ExtendedCommunity.target(65000, 400)));
     }
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_vlans
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/arista/grammar/testconfigs/arista_bgp_vlans
@@ -9,6 +9,12 @@ router bgp 1
        redistribute learned
        redistribute router-mac
        redistribute static
+   vlan 301
+       rd 192.168.255.100:10104
+       route-target import 65000:100
+       route-target import 65000:200
+       route-target export 65000:300
+       route-target export 65000:400
    vlan-aware-bundle Tenant_A
        rd 192.168.255.8:10101
        route-target both 10101:10101

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/Layer2VniConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/Layer2VniConfig.java
@@ -1,14 +1,15 @@
 package org.batfish.datamodel.bgp;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.SortedSet;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
@@ -22,9 +23,9 @@ public class Layer2VniConfig extends VniConfig
       int vni,
       String vrf,
       RouteDistinguisher rd,
-      ExtendedCommunity routeTarget,
-      String importRouteTarget) {
-    super(vni, vrf, rd, routeTarget, importRouteTarget);
+      SortedSet<ExtendedCommunity> routeTargets,
+      SortedSet<String> importRouteTargets) {
+    super(vni, vrf, rd, routeTargets, importRouteTargets);
   }
 
   @JsonCreator
@@ -32,14 +33,20 @@ public class Layer2VniConfig extends VniConfig
       @JsonProperty(PROP_VNI) @Nullable Integer vni,
       @JsonProperty(PROP_VRF) @Nullable String vrf,
       @JsonProperty(PROP_ROUTE_DISTINGUISHER) @Nullable RouteDistinguisher rd,
-      @JsonProperty(PROP_ROUTE_TARGET) @Nullable ExtendedCommunity routeTarget,
-      @JsonProperty(PROP_IMPORT_ROUTE_TARGET) @Nullable String importRouteTarget) {
+      @JsonProperty(PROP_ROUTE_TARGETS) @Nullable SortedSet<ExtendedCommunity> routeTargets,
+      @JsonProperty(PROP_IMPORT_ROUTE_TARGETS) @Nullable SortedSet<String> importRouteTargets) {
     checkArgument(vni != null, "Missing %s", PROP_VNI);
     checkArgument(vrf != null, "Missing %s", PROP_VRF);
     checkArgument(rd != null, "Missing %s", PROP_ROUTE_DISTINGUISHER);
-    checkArgument(routeTarget != null, "Missing %s", PROP_ROUTE_TARGET);
-    checkArgument(importRouteTarget != null, "Missing %s", PROP_IMPORT_ROUTE_TARGET);
-    return new Layer2VniConfig(vni, vrf, rd, routeTarget, importRouteTarget);
+    checkArgument(routeTargets != null, "Missing %s", PROP_ROUTE_TARGETS);
+    checkArgument(importRouteTargets != null, "Missing %s", PROP_IMPORT_ROUTE_TARGETS);
+    return new Builder()
+        .setVni(vni)
+        .setVrf(vrf)
+        .setRouteDistinguisher(rd)
+        .setRouteTargets(routeTargets)
+        .setImportRouteTargets(importRouteTargets)
+        .build();
   }
 
   @Override
@@ -54,13 +61,13 @@ public class Layer2VniConfig extends VniConfig
     return _vni == vniConfig._vni
         && _vrf.equals(vniConfig._vrf)
         && _rd.equals(vniConfig._rd)
-        && _routeTarget.equals(vniConfig._routeTarget)
-        && _importRouteTarget.equals(vniConfig._importRouteTarget);
+        && _routeTargets.equals(vniConfig._routeTargets)
+        && _importRouteTargets.equals(vniConfig._importRouteTargets);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_vni, _vrf, _rd, _routeTarget, _importRouteTarget);
+    return Objects.hash(_vni, _vrf, _rd, _routeTargets, _importRouteTargets);
   }
 
   @Override
@@ -68,8 +75,8 @@ public class Layer2VniConfig extends VniConfig
     return Comparator.comparing(Layer2VniConfig::getVni)
         .thenComparing(Layer2VniConfig::getVrf)
         .thenComparing(Layer2VniConfig::getRouteDistinguisher)
-        .thenComparing(Layer2VniConfig::getRouteTarget)
-        .thenComparing(Layer2VniConfig::getImportRouteTarget)
+        .thenComparing(vc -> vc.getRouteTargets().toString())
+        .thenComparing(vc -> vc.getImportRouteTargets().toString())
         .compare(this, o);
   }
 
@@ -79,8 +86,8 @@ public class Layer2VniConfig extends VniConfig
         .add(PROP_VNI, _vni)
         .add(PROP_VRF, _vrf)
         .add(PROP_ROUTE_DISTINGUISHER, _rd)
-        .add(PROP_ROUTE_TARGET, _routeTarget)
-        .add(PROP_IMPORT_ROUTE_TARGET, _importRouteTarget)
+        .add(PROP_ROUTE_TARGETS, _routeTargets)
+        .add(PROP_IMPORT_ROUTE_TARGETS, _importRouteTargets)
         .toString();
   }
 
@@ -92,8 +99,8 @@ public class Layer2VniConfig extends VniConfig
     protected @Nullable Integer _vni;
     protected @Nullable String _vrf;
     protected @Nullable RouteDistinguisher _rd;
-    protected @Nullable ExtendedCommunity _routeTarget;
-    protected @Nullable String _importRouteTarget;
+    protected @Nullable SortedSet<ExtendedCommunity> _routeTargets;
+    protected @Nullable SortedSet<String> _importRouteTargets;
 
     private Builder() {}
 
@@ -112,13 +119,25 @@ public class Layer2VniConfig extends VniConfig
       return this;
     }
 
+    /** Set a single export route target. Convenience for the common single-RT case. */
     public Builder setRouteTarget(ExtendedCommunity routeTarget) {
-      _routeTarget = routeTarget;
+      _routeTargets = ImmutableSortedSet.of(routeTarget);
       return this;
     }
 
+    public Builder setRouteTargets(SortedSet<ExtendedCommunity> routeTargets) {
+      _routeTargets = ImmutableSortedSet.copyOf(routeTargets);
+      return this;
+    }
+
+    /** Set a single import route target pattern. Convenience for the common single-RT case. */
     public Builder setImportRouteTarget(String importRouteTarget) {
-      _importRouteTarget = importRouteTarget;
+      _importRouteTargets = ImmutableSortedSet.of(importRouteTarget);
+      return this;
+    }
+
+    public Builder setImportRouteTargets(SortedSet<String> importRouteTargets) {
+      _importRouteTargets = ImmutableSortedSet.copyOf(importRouteTargets);
       return this;
     }
 
@@ -126,13 +145,13 @@ public class Layer2VniConfig extends VniConfig
       checkArgument(_vni != null, "Missing %s", PROP_VNI);
       checkArgument(_vrf != null, "Missing %s", PROP_VRF);
       checkArgument(_rd != null, "Missing %s", PROP_ROUTE_DISTINGUISHER);
-      checkArgument(_routeTarget != null, "Missing %s", PROP_ROUTE_TARGET);
-      return new Layer2VniConfig(
-          _vni,
-          _vrf,
-          _rd,
-          _routeTarget,
-          firstNonNull(_importRouteTarget, importRtPatternForAnyAs(_vni)));
+      checkArgument(
+          _routeTargets != null && !_routeTargets.isEmpty(), "Missing %s", PROP_ROUTE_TARGETS);
+      SortedSet<String> importRts =
+          _importRouteTargets == null || _importRouteTargets.isEmpty()
+              ? ImmutableSortedSet.of(importRtPatternForAnyAs(_vni))
+              : _importRouteTargets;
+      return new Layer2VniConfig(_vni, _vrf, _rd, _routeTargets, importRts);
     }
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/Layer3VniConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/Layer3VniConfig.java
@@ -6,9 +6,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.SortedSet;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nullable;
@@ -28,10 +30,10 @@ public final class Layer3VniConfig extends VniConfig
       int vni,
       String vrf,
       RouteDistinguisher rd,
-      ExtendedCommunity routeTarget,
-      String importRouteTarget,
+      SortedSet<ExtendedCommunity> routeTargets,
+      SortedSet<String> importRouteTargets,
       boolean advertiseV4Unicast) {
-    super(vni, vrf, rd, routeTarget, importRouteTarget);
+    super(vni, vrf, rd, routeTargets, importRouteTargets);
     _advertiseV4Unicast = advertiseV4Unicast;
   }
 
@@ -40,20 +42,20 @@ public final class Layer3VniConfig extends VniConfig
       @JsonProperty(PROP_VNI) @Nullable Integer vni,
       @JsonProperty(PROP_VRF) @Nullable String vrf,
       @JsonProperty(PROP_ROUTE_DISTINGUISHER) @Nullable RouteDistinguisher rd,
-      @JsonProperty(PROP_ROUTE_TARGET) @Nullable ExtendedCommunity routeTarget,
-      @JsonProperty(PROP_IMPORT_ROUTE_TARGET) @Nullable String importRouteTarget,
+      @JsonProperty(PROP_ROUTE_TARGETS) @Nullable SortedSet<ExtendedCommunity> routeTargets,
+      @JsonProperty(PROP_IMPORT_ROUTE_TARGETS) @Nullable SortedSet<String> importRouteTargets,
       @JsonProperty(PROP_ADVERTISE_V4_UNICAST) @Nullable Boolean advertiseV4Unicast) {
     checkArgument(vni != null, "Missing %s", PROP_VNI);
     checkArgument(vrf != null, "Missing %s", PROP_VRF);
     checkArgument(rd != null, "Missing %s", PROP_ROUTE_DISTINGUISHER);
-    checkArgument(routeTarget != null, "Missing %s", PROP_ROUTE_TARGET);
-    checkArgument(importRouteTarget != null, "Missing %s", PROP_ROUTE_TARGET);
+    checkArgument(routeTargets != null, "Missing %s", PROP_ROUTE_TARGETS);
+    checkArgument(importRouteTargets != null, "Missing %s", PROP_IMPORT_ROUTE_TARGETS);
     return new Builder()
         .setVni(vni)
         .setVrf(vrf)
         .setRouteDistinguisher(rd)
-        .setRouteTarget(routeTarget)
-        .setImportRouteTarget(importRouteTarget)
+        .setRouteTargets(routeTargets)
+        .setImportRouteTargets(importRouteTargets)
         .setAdvertiseV4Unicast(firstNonNull(advertiseV4Unicast, Boolean.FALSE))
         .build();
   }
@@ -79,21 +81,21 @@ public final class Layer3VniConfig extends VniConfig
     return _vni == vniConfig._vni
         && Objects.equals(_vrf, vniConfig._vrf)
         && Objects.equals(_rd, vniConfig._rd)
-        && Objects.equals(_routeTarget, vniConfig._routeTarget)
-        && Objects.equals(_importRouteTarget, vniConfig._importRouteTarget)
+        && Objects.equals(_routeTargets, vniConfig._routeTargets)
+        && Objects.equals(_importRouteTargets, vniConfig._importRouteTargets)
         && _advertiseV4Unicast == vniConfig._advertiseV4Unicast;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_vni, _vrf, _rd, _routeTarget);
+    return Objects.hash(_vni, _vrf, _rd, _routeTargets, _importRouteTargets, _advertiseV4Unicast);
   }
 
   @Override
   public int compareTo(Layer3VniConfig o) {
     return Comparator.comparing(Layer3VniConfig::getVrf)
         .thenComparing(Layer3VniConfig::getRouteDistinguisher)
-        .thenComparing(Layer3VniConfig::getRouteTarget)
+        .thenComparing(vc -> vc.getRouteTargets().toString())
         .thenComparing(Layer3VniConfig::getAdvertiseV4Unicast)
         .compare(this, o);
   }
@@ -104,7 +106,7 @@ public final class Layer3VniConfig extends VniConfig
         .add(PROP_VNI, _vni)
         .add(PROP_VRF, _vrf)
         .add(PROP_ROUTE_DISTINGUISHER, _rd)
-        .add(PROP_ROUTE_TARGET, _routeTarget)
+        .add(PROP_ROUTE_TARGETS, _routeTargets)
         .add(PROP_ADVERTISE_V4_UNICAST, _advertiseV4Unicast)
         .toString();
   }
@@ -118,8 +120,8 @@ public final class Layer3VniConfig extends VniConfig
     private @Nullable Integer _vni;
     private @Nullable String _vrf;
     private @Nullable RouteDistinguisher _rd;
-    private @Nullable ExtendedCommunity _routeTarget;
-    private @Nullable String _importRouteTarget;
+    private @Nullable SortedSet<ExtendedCommunity> _routeTargets;
+    private @Nullable SortedSet<String> _importRouteTargets;
     private boolean _advertiseV4Unicast;
 
     private Builder() {}
@@ -139,13 +141,25 @@ public final class Layer3VniConfig extends VniConfig
       return this;
     }
 
+    /** Set a single export route target. Convenience for the common single-RT case. */
     public Builder setRouteTarget(ExtendedCommunity routeTarget) {
-      _routeTarget = routeTarget;
+      _routeTargets = ImmutableSortedSet.of(routeTarget);
       return this;
     }
 
+    public Builder setRouteTargets(SortedSet<ExtendedCommunity> routeTargets) {
+      _routeTargets = ImmutableSortedSet.copyOf(routeTargets);
+      return this;
+    }
+
+    /** Set a single import route target pattern. Convenience for the common single-RT case. */
     public Builder setImportRouteTarget(String importRouteTarget) {
-      _importRouteTarget = importRouteTarget;
+      _importRouteTargets = ImmutableSortedSet.of(importRouteTarget);
+      return this;
+    }
+
+    public Builder setImportRouteTargets(SortedSet<String> importRouteTargets) {
+      _importRouteTargets = ImmutableSortedSet.copyOf(importRouteTargets);
       return this;
     }
 
@@ -158,16 +172,22 @@ public final class Layer3VniConfig extends VniConfig
       checkArgument(_vni != null, "Missing %s", PROP_VNI);
       checkArgument(_vrf != null, "Missing %s", PROP_VRF);
       checkArgument(_rd != null, "Missing %s", PROP_ROUTE_DISTINGUISHER);
-      checkArgument(_routeTarget != null, "Missing %s", PROP_ROUTE_TARGET);
-      String importRt = firstNonNull(_importRouteTarget, importRtPatternForAnyAs(_vni));
-      // check pattern for validity
-      try {
-        Pattern.compile(importRt);
-      } catch (PatternSyntaxException e) {
-        throw new IllegalArgumentException(
-            String.format("Invalid patthern %s for %s", importRt, PROP_IMPORT_ROUTE_TARGET));
+      checkArgument(
+          _routeTargets != null && !_routeTargets.isEmpty(), "Missing %s", PROP_ROUTE_TARGETS);
+      SortedSet<String> importRts =
+          _importRouteTargets == null || _importRouteTargets.isEmpty()
+              ? ImmutableSortedSet.of(importRtPatternForAnyAs(_vni))
+              : _importRouteTargets;
+      // check patterns for validity
+      for (String importRt : importRts) {
+        try {
+          Pattern.compile(importRt);
+        } catch (PatternSyntaxException e) {
+          throw new IllegalArgumentException(
+              String.format("Invalid pattern %s for %s", importRt, PROP_IMPORT_ROUTE_TARGETS));
+        }
       }
-      return new Layer3VniConfig(_vni, _vrf, _rd, _routeTarget, importRt, _advertiseV4Unicast);
+      return new Layer3VniConfig(_vni, _vrf, _rd, _routeTargets, importRts, _advertiseV4Unicast);
     }
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/bgp/VniConfig.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/bgp/VniConfig.java
@@ -3,7 +3,9 @@ package org.batfish.datamodel.bgp;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
+import java.util.SortedSet;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -20,26 +22,26 @@ public abstract class VniConfig implements Serializable {
   public static final String PROP_VNI = "vni";
   public static final String PROP_VRF = "vrf";
   public static final String PROP_ROUTE_DISTINGUISHER = "routeDistinguisher";
-  public static final String PROP_ROUTE_TARGET = "routeTarget";
-  public static final String PROP_IMPORT_ROUTE_TARGET = "importRouteTarget";
+  public static final String PROP_ROUTE_TARGETS = "routeTargets";
+  public static final String PROP_IMPORT_ROUTE_TARGETS = "importRouteTargets";
 
   protected final int _vni;
   protected final @Nonnull String _vrf;
   protected final @Nonnull RouteDistinguisher _rd;
-  protected final @Nonnull ExtendedCommunity _routeTarget;
-  protected final @Nonnull String _importRouteTarget;
+  protected final @Nonnull ImmutableSortedSet<ExtendedCommunity> _routeTargets;
+  protected final @Nonnull ImmutableSortedSet<String> _importRouteTargets;
 
   protected VniConfig(
       int vni,
       String vrf,
       RouteDistinguisher rd,
-      ExtendedCommunity routeTarget,
-      String importRouteTarget) {
+      SortedSet<ExtendedCommunity> routeTargets,
+      SortedSet<String> importRouteTargets) {
     _vni = vni;
     _vrf = vrf;
     _rd = rd;
-    _routeTarget = routeTarget;
-    _importRouteTarget = importRouteTarget;
+    _routeTargets = ImmutableSortedSet.copyOf(routeTargets);
+    _importRouteTargets = ImmutableSortedSet.copyOf(importRouteTargets);
   }
 
   /** Return an import route target pattern equivalent to "*:VNI" */
@@ -65,15 +67,16 @@ public abstract class VniConfig implements Serializable {
     return _rd;
   }
 
-  /** Route target to use when advertising this VNI (i.e., the export route target) */
-  @JsonProperty(PROP_ROUTE_TARGET)
-  public @Nonnull ExtendedCommunity getRouteTarget() {
-    return _routeTarget;
+  /** Route targets to attach when advertising this VNI (i.e., the export route targets) */
+  @JsonProperty(PROP_ROUTE_TARGETS)
+  public @Nonnull SortedSet<ExtendedCommunity> getRouteTargets() {
+    return _routeTargets;
   }
 
-  /** The import route target pattern. Can be compiled into a {@link Pattern} */
-  public @Nonnull String getImportRouteTarget() {
-    return _importRouteTarget;
+  /** The import route target patterns. Each can be compiled into a {@link Pattern} */
+  @JsonProperty(PROP_IMPORT_ROUTE_TARGETS)
+  public @Nonnull SortedSet<String> getImportRouteTargets() {
+    return _importRouteTargets;
   }
 
   @Override

--- a/projects/question/src/main/java/org/batfish/question/evpnl3vniproperties/EvpnL3VniPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/evpnl3vniproperties/EvpnL3VniPropertiesAnswerer.java
@@ -20,6 +20,7 @@ import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.questions.DisplayHints;
 import org.batfish.datamodel.table.ColumnMetadata;
 import org.batfish.datamodel.table.Row;
@@ -35,8 +36,8 @@ public final class EvpnL3VniPropertiesAnswerer extends Answerer {
   public static final String COL_VRF = "VRF";
   public static final String COL_VNI = "VNI";
   public static final String COL_ROUTE_DISTINGUISHER = "Route_Distinguisher";
-  public static final String COL_IMPORT_ROUTE_TARGET = "Import_Route_Target";
-  public static final String COL_EXPORT_ROUTE_TARGET = "Export_Route_Target";
+  public static final String COL_IMPORT_ROUTE_TARGETS = "Import_Route_Targets";
+  public static final String COL_EXPORT_ROUTE_TARGETS = "Export_Route_Targets";
 
   public static final List<ColumnMetadata> COLUMN_METADATA =
       ImmutableList.<ColumnMetadata>builder()
@@ -48,10 +49,18 @@ public final class EvpnL3VniPropertiesAnswerer extends Answerer {
                   COL_ROUTE_DISTINGUISHER, Schema.STRING, "Route distinguisher", false, true))
           .add(
               new ColumnMetadata(
-                  COL_IMPORT_ROUTE_TARGET, Schema.STRING, "Import route target", false, true))
+                  COL_IMPORT_ROUTE_TARGETS,
+                  Schema.list(Schema.STRING),
+                  "Import route targets",
+                  false,
+                  true))
           .add(
               new ColumnMetadata(
-                  COL_EXPORT_ROUTE_TARGET, Schema.STRING, "Export route target", false, true))
+                  COL_EXPORT_ROUTE_TARGETS,
+                  Schema.list(Schema.STRING),
+                  "Export route targets",
+                  false,
+                  true))
           .build();
 
   /**
@@ -100,8 +109,12 @@ public final class EvpnL3VniPropertiesAnswerer extends Answerer {
         .put(COL_NODE, nodeName)
         .put(COL_VRF, vniConfig.getVrf())
         .put(COL_VNI, vniConfig.getVni())
-        .put(COL_EXPORT_ROUTE_TARGET, vniConfig.getRouteTarget().matchString())
-        .put(COL_IMPORT_ROUTE_TARGET, vniConfig.getImportRouteTarget())
+        .put(
+            COL_EXPORT_ROUTE_TARGETS,
+            vniConfig.getRouteTargets().stream()
+                .map(ExtendedCommunity::matchString)
+                .collect(ImmutableList.toImmutableList()))
+        .put(COL_IMPORT_ROUTE_TARGETS, ImmutableList.copyOf(vniConfig.getImportRouteTargets()))
         .put(COL_ROUTE_DISTINGUISHER, vniConfig.getRouteDistinguisher())
         .build();
   }

--- a/projects/question/src/test/java/org/batfish/question/evpnl3vniproperties/EvpnL3VniPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/evpnl3vniproperties/EvpnL3VniPropertiesAnswererTest.java
@@ -1,7 +1,7 @@
 package org.batfish.question.evpnl3vniproperties;
 
-import static org.batfish.question.evpnl3vniproperties.EvpnL3VniPropertiesAnswerer.COL_EXPORT_ROUTE_TARGET;
-import static org.batfish.question.evpnl3vniproperties.EvpnL3VniPropertiesAnswerer.COL_IMPORT_ROUTE_TARGET;
+import static org.batfish.question.evpnl3vniproperties.EvpnL3VniPropertiesAnswerer.COL_EXPORT_ROUTE_TARGETS;
+import static org.batfish.question.evpnl3vniproperties.EvpnL3VniPropertiesAnswerer.COL_IMPORT_ROUTE_TARGETS;
 import static org.batfish.question.evpnl3vniproperties.EvpnL3VniPropertiesAnswerer.COL_NODE;
 import static org.batfish.question.evpnl3vniproperties.EvpnL3VniPropertiesAnswerer.COL_ROUTE_DISTINGUISHER;
 import static org.batfish.question.evpnl3vniproperties.EvpnL3VniPropertiesAnswerer.COL_VNI;
@@ -13,9 +13,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collections;
 import java.util.Map;
 import org.batfish.datamodel.BgpActivePeerConfig;
@@ -26,6 +28,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
@@ -58,10 +61,45 @@ public class EvpnL3VniPropertiesAnswererTest {
                 .put(COL_NODE, node)
                 .put(COL_VRF, vniConfig.getVrf())
                 .put(COL_VNI, vniConfig.getVni())
-                .put(COL_EXPORT_ROUTE_TARGET, vniConfig.getRouteTarget().matchString())
-                .put(COL_IMPORT_ROUTE_TARGET, vniConfig.getImportRouteTarget())
+                .put(
+                    COL_EXPORT_ROUTE_TARGETS,
+                    ImmutableList.of(ExtendedCommunity.target(65500, vni).matchString()))
+                .put(
+                    COL_IMPORT_ROUTE_TARGETS,
+                    ImmutableList.of(ExtendedCommunity.target(65500, vni).matchString()))
                 .put(COL_ROUTE_DISTINGUISHER, vniConfig.getRouteDistinguisher())
                 .build()));
+  }
+
+  /** A VNI with multiple import/export route targets reports all of them, sorted. */
+  @Test
+  public void testGenerateRowMultipleRouteTargets() {
+    String node = "n";
+    int vni = 100001;
+    // Provide targets out of order; the answer must be sorted.
+    Layer3VniConfig vniConfig =
+        Layer3VniConfig.builder()
+            .setVni(vni)
+            .setVrf("vrf")
+            .setRouteDistinguisher(RouteDistinguisher.from(Ip.ZERO, 2))
+            .setRouteTargets(
+                ImmutableSortedSet.of(
+                    ExtendedCommunity.target(65500, 200), ExtendedCommunity.target(65500, 100)))
+            .setImportRouteTargets(ImmutableSortedSet.of("^\\d+:300$", "^\\d+:250$"))
+            .setAdvertiseV4Unicast(false)
+            .build();
+    Map<String, ColumnMetadata> columnMap =
+        createTableMetadata(new EvpnL3VniPropertiesQuestion(null)).toColumnMap();
+    Row row = generateRow(vniConfig, node, columnMap);
+    assertThat(
+        row.get(COL_EXPORT_ROUTE_TARGETS, Schema.list(Schema.STRING)),
+        equalTo(
+            ImmutableList.of(
+                ExtendedCommunity.target(65500, 100).matchString(),
+                ExtendedCommunity.target(65500, 200).matchString())));
+    assertThat(
+        row.get(COL_IMPORT_ROUTE_TARGETS, Schema.list(Schema.STRING)),
+        equalTo(ImmutableList.of("^\\d+:250$", "^\\d+:300$")));
   }
 
   /**
@@ -134,8 +172,12 @@ public class EvpnL3VniPropertiesAnswererTest {
                     .put(COL_NODE, c1.getHostname())
                     .put(COL_VRF, vniConfig.getVrf())
                     .put(COL_VNI, vniConfig.getVni())
-                    .put(COL_EXPORT_ROUTE_TARGET, vniConfig.getRouteTarget().matchString())
-                    .put(COL_IMPORT_ROUTE_TARGET, vniConfig.getImportRouteTarget())
+                    .put(
+                        COL_EXPORT_ROUTE_TARGETS,
+                        ImmutableList.of(ExtendedCommunity.target(65500, vni).matchString()))
+                    .put(
+                        COL_IMPORT_ROUTE_TARGETS,
+                        ImmutableList.of(ExtendedCommunity.target(65500, vni).matchString()))
                     .put(COL_ROUTE_DISTINGUISHER, vniConfig.getRouteDistinguisher())
                     .build())));
     assertThat(getRows(Collections.singleton("nonexistent"), nc, columnMap), empty());


### PR DESCRIPTION
VniConfig held a single export route target and a single import route
target pattern, so a VNI configured with several route targets in a
direction surfaced only one. Widen both to sorted sets across Layer2 and
Layer3 VNI configs.

Changes:
- VniConfig: _routeTarget/_importRouteTarget become sorted sets
  routeTargets/importRouteTargets. JSON properties go plural. Builders
  keep single-value convenience setters (setRouteTarget /
  setImportRouteTarget) alongside the new plural setters, so single-RT
  vendor conversions are unchanged.
- Layer2 Type-3 origination (BgpRoutingProcess.initEvpnType3Route) now
  attaches all export route targets to the route's community set,
  matching how the Layer3 BGPv4-to-EVPN leak already behaves.
- Arista: L2 vlan/vlan-aware-bundle extraction accumulates route targets
  (AristaBgpVlanBase, extractor) instead of overwriting, and conversion
  passes the full sets; L3 conversion passes the full sets (the vendor
  model already retained them).
- evpnL3VniProperties: Import_Route_Target / Export_Route_Target columns
  become Import_Route_Targets / Export_Route_Targets, typed
  list-of-string, emitting all values sorted.

For batfish/batfish#10113.

----

Prompt:
```
Implement PR2 for batfish/batfish#10113: widen the vendor-independent
VniConfig model so EVPN VNIs can carry multiple import and export route
targets, covering both Layer2 and Layer3 (L2 has the same
multiple-route-target bug and its export RT is used for Type-3
origination). Rename the evpnL3VniProperties columns to the plural
Route_Targets and emit the values sorted in the answer, keeping internal
storage a plain set.
```
