### PR TITLE
feat(cisco): extract Cisco NX-OS syslog server and logfile attributes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosLexer.g4
@@ -1258,6 +1258,11 @@ LOG_BUFFER: 'log-buffer';
 
 LOG_NEIGHBOR_CHANGES: 'log-neighbor-changes';
 
+LOGFILE
+:
+  'logfile' -> pushMode ( M_Word )
+;
+
 LOGGING: 'logging';
 
 LOGIN: 'login';
@@ -1758,6 +1763,8 @@ PERIODIC: 'periodic';
 PERMIT: 'permit';
 
 PERMIT_ALL: 'permit-all';
+
+PERSISTENT: 'persistent';
 
 PIM: 'pim';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_logging.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxos_logging.g4
@@ -10,9 +10,27 @@ s_logging
 :
   LOGGING
   (
-    logging_server
+    logging_logfile
+    | logging_server
     | logging_source_interface
   )
+;
+
+logging_logfile
+:
+  LOGFILE name = WORD severity = logging_level ll_size? ll_persistent? NEWLINE
+;
+
+ll_size
+:
+// 4096-4194304
+  SIZE size = uint32
+;
+
+ll_persistent
+:
+// 0-99
+  PERSISTENT THRESHOLD threshold = uint8
 ;
 
 logging_server
@@ -56,7 +74,7 @@ trustpoint_name
 
 ls_facility
 :
-  FACILITY
+  FACILITY facility =
   (
     AUTH
     | AUTHPRIV

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosControlPlaneExtractor.java
@@ -144,6 +144,7 @@ import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsa
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_ROUTE_NEXT_HOP_VRF;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.LINE_VTY_ACCESS_CLASS_IN;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.LINE_VTY_ACCESS_CLASS_OUT;
+import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.LOGGING_SERVER_USE_VRF;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.LOGGING_SOURCE_INTERFACE;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.MONITOR_SESSION_DESTINATION_INTERFACE;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.MONITOR_SESSION_SOURCE_INTERFACE;
@@ -472,6 +473,7 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ispt_queuingContext
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Last_as_num_prependsContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Line_actionContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Literal_standard_communityContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Logging_logfileContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Logging_serverContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Logging_source_interfaceContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Lv6_access_classContext;
@@ -828,6 +830,7 @@ import org.batfish.vendor.cisco_nxos.representation.IsisVrfConfiguration;
 import org.batfish.vendor.cisco_nxos.representation.Layer3Options;
 import org.batfish.vendor.cisco_nxos.representation.LiteralIpAddressSpec;
 import org.batfish.vendor.cisco_nxos.representation.LiteralPortSpec;
+import org.batfish.vendor.cisco_nxos.representation.LoggingLogfile;
 import org.batfish.vendor.cisco_nxos.representation.LoggingServer;
 import org.batfish.vendor.cisco_nxos.representation.NameServer;
 import org.batfish.vendor.cisco_nxos.representation.NtpAuthenticationKey;
@@ -1013,6 +1016,13 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   private static final IntegerSpace ISIS_PROCESS_TAG_LENGTH_RANGE =
       IntegerSpace.of(Range.closed(1, 20));
   private static final IntegerSpace LACP_MIN_LINKS_RANGE = IntegerSpace.of(Range.closed(1, 32));
+  private static final LongSpace LOGGING_LOGFILE_SIZE_RANGE =
+      LongSpace.of(Range.closed(4096L, 4194304L));
+  private static final IntegerSpace LOGGING_LOGFILE_THRESHOLD_RANGE =
+      IntegerSpace.of(Range.closed(0, 99));
+  private static final IntegerSpace LOGGING_SERVER_PORT_RANGE =
+      IntegerSpace.of(Range.closed(1, 65535));
+  private static final IntegerSpace LOGGING_SEVERITY_RANGE = IntegerSpace.of(Range.closed(0, 7));
   private static final IntegerSpace NUM_AS_PATH_PREPENDS_RANGE =
       IntegerSpace.of(Range.closed(1, 10));
   private static final IntegerSpace OBJECT_GROUP_NAME_LENGTH_RANGE =
@@ -1386,7 +1396,6 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   private Ipv6PrefixList _currentIpv6PrefixList;
   private Layer3Options.Builder _currentLayer3OptionsBuilder;
 
-  @SuppressWarnings("unused")
   private LoggingServer _currentLoggingServer;
 
   private NtpServer _currentNtpServer;
@@ -2702,6 +2711,30 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
+  public void exitLogging_logfile(Logging_logfileContext ctx) {
+    Optional<Integer> severity =
+        toIntegerInSpace(
+            ctx, ctx.severity.uint8(), LOGGING_SEVERITY_RANGE, "logging logfile severity");
+    if (!severity.isPresent()) {
+      return;
+    }
+    LoggingLogfile logfile = new LoggingLogfile(ctx.name.getText(), severity.get());
+    if (ctx.ll_size() != null) {
+      toLongInSpace(ctx, ctx.ll_size().size, LOGGING_LOGFILE_SIZE_RANGE, "logging logfile size")
+          .ifPresent(size -> logfile.setSizeBytes(size.intValue()));
+    }
+    if (ctx.ll_persistent() != null) {
+      toIntegerInSpace(
+              ctx,
+              ctx.ll_persistent().threshold,
+              LOGGING_LOGFILE_THRESHOLD_RANGE,
+              "logging logfile persistent threshold")
+          .ifPresent(logfile::setPersistentThreshold);
+    }
+    _c.setLoggingLogfile(logfile);
+  }
+
+  @Override
   public void enterLogging_server(Logging_serverContext ctx) {
     _currentLoggingServer =
         _c.getLoggingServers().computeIfAbsent(ctx.host.getText(), LoggingServer::new);
@@ -2709,6 +2742,29 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
 
   @Override
   public void exitLogging_server(Logging_serverContext ctx) {
+    if (ctx.level != null) {
+      toIntegerInSpace(ctx, ctx.level.uint8(), LOGGING_SEVERITY_RANGE, "logging server severity")
+          .ifPresent(_currentLoggingServer::setSeverityLevel);
+    }
+    if (ctx.ls_port() != null) {
+      toIntegerInSpace(ctx, ctx.ls_port().port, LOGGING_SERVER_PORT_RANGE, "logging server port")
+          .ifPresent(_currentLoggingServer::setPort);
+    }
+    if (ctx.ls_facility() != null) {
+      _currentLoggingServer.setFacility(ctx.ls_facility().facility.getText());
+    }
+    if (ctx.ls_use_vrf() != null) {
+      Optional<String> vrfOrError = toString(ctx, ctx.ls_use_vrf().name);
+      if (vrfOrError.isPresent()) {
+        String vrf = vrfOrError.get();
+        _currentLoggingServer.setUseVrf(vrf);
+        _c.referenceStructure(
+            VRF, vrf, LOGGING_SERVER_USE_VRF, ctx.ls_use_vrf().name.getStart().getLine());
+      }
+    }
+    if (ctx.ls_secure() != null) {
+      _currentLoggingServer.setSecure(true);
+    }
     _currentLoggingServer = null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
@@ -440,6 +440,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   private final @Nonnull Map<String, Ipv6PrefixList> _ipv6PrefixLists;
   private final @Nonnull Map<String, IsisProcess> _isisProcesses;
   private final @Nonnull Map<String, LoggingServer> _loggingServers;
+  private @Nullable LoggingLogfile _loggingLogfile;
   private @Nullable String _loggingSourceInterface;
   private @Nonnull NxosMajorVersion _majorVersion;
   private boolean _nonSwitchportDefaultShutdown;
@@ -1846,6 +1847,14 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   public @Nonnull Map<String, LoggingServer> getLoggingServers() {
     return _loggingServers;
+  }
+
+  public @Nullable LoggingLogfile getLoggingLogfile() {
+    return _loggingLogfile;
+  }
+
+  public void setLoggingLogfile(@Nullable LoggingLogfile loggingLogfile) {
+    _loggingLogfile = loggingLogfile;
   }
 
   public @Nullable String getLoggingSourceInterface() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosStructureUsage.java
@@ -101,6 +101,7 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   IPV6_ROUTE_TRACK("ipv6 route track"),
   LINE_VTY_ACCESS_CLASS_IN("line vty access-class in"),
   LINE_VTY_ACCESS_CLASS_OUT("line vty access-class out"),
+  LOGGING_SERVER_USE_VRF("logging server use-vrf"),
   LOGGING_SOURCE_INTERFACE("logging source-interface"),
   MONITOR_SESSION_DESTINATION_INTERFACE("monitor session destination interface"),
   MONITOR_SESSION_SOURCE_INTERFACE("monitor session source interface"),

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/LoggingLogfile.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/LoggingLogfile.java
@@ -1,0 +1,46 @@
+package org.batfish.vendor.cisco_nxos.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Configuration for the local logging logfile, set via {@code logging logfile <name>
+ * <severity-level> [size <bytes>] [persistent threshold <percent>]}.
+ */
+public final class LoggingLogfile implements Serializable {
+
+  public LoggingLogfile(String name, int severityLevel) {
+    _name = name;
+    _severityLevel = severityLevel;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public int getSeverityLevel() {
+    return _severityLevel;
+  }
+
+  public @Nullable Integer getSizeBytes() {
+    return _sizeBytes;
+  }
+
+  public void setSizeBytes(@Nullable Integer sizeBytes) {
+    _sizeBytes = sizeBytes;
+  }
+
+  public @Nullable Integer getPersistentThreshold() {
+    return _persistentThreshold;
+  }
+
+  public void setPersistentThreshold(@Nullable Integer persistentThreshold) {
+    _persistentThreshold = persistentThreshold;
+  }
+
+  private final @Nonnull String _name;
+  private final int _severityLevel;
+  private @Nullable Integer _sizeBytes;
+  private @Nullable Integer _persistentThreshold;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/LoggingServer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/LoggingServer.java
@@ -2,6 +2,7 @@ package org.batfish.vendor.cisco_nxos.representation;
 
 import java.io.Serializable;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /** Configuration for a logging-server. */
 public final class LoggingServer implements Serializable {
@@ -10,9 +11,55 @@ public final class LoggingServer implements Serializable {
     _host = host;
   }
 
-  public String getHost() {
+  public @Nonnull String getHost() {
     return _host;
   }
 
+  public @Nullable Integer getSeverityLevel() {
+    return _severityLevel;
+  }
+
+  public void setSeverityLevel(@Nullable Integer level) {
+    _severityLevel = level;
+  }
+
+  public @Nullable Integer getPort() {
+    return _port;
+  }
+
+  public void setPort(@Nullable Integer port) {
+    _port = port;
+  }
+
+  public @Nullable String getFacility() {
+    return _facility;
+  }
+
+  public void setFacility(@Nullable String facility) {
+    _facility = facility;
+  }
+
+  public @Nullable String getUseVrf() {
+    return _useVrf;
+  }
+
+  public void setUseVrf(@Nullable String useVrf) {
+    _useVrf = useVrf;
+  }
+
+  /** Whether the {@code secure} option is configured for this logging server. */
+  public boolean getSecure() {
+    return _secure;
+  }
+
+  public void setSecure(boolean secure) {
+    _secure = secure;
+  }
+
   private final @Nonnull String _host;
+  private @Nullable Integer _severityLevel;
+  private @Nullable Integer _port;
+  private @Nullable String _facility;
+  private @Nullable String _useVrf;
+  private boolean _secure;
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
@@ -380,6 +380,8 @@ import org.batfish.vendor.cisco_nxos.representation.Lacp;
 import org.batfish.vendor.cisco_nxos.representation.Layer3Options;
 import org.batfish.vendor.cisco_nxos.representation.LiteralIpAddressSpec;
 import org.batfish.vendor.cisco_nxos.representation.LiteralPortSpec;
+import org.batfish.vendor.cisco_nxos.representation.LoggingLogfile;
+import org.batfish.vendor.cisco_nxos.representation.LoggingServer;
 import org.batfish.vendor.cisco_nxos.representation.NameServer;
 import org.batfish.vendor.cisco_nxos.representation.NtpAuthenticationKey;
 import org.batfish.vendor.cisco_nxos.representation.NtpServer;
@@ -5355,8 +5357,34 @@ public final class CiscoNxosGrammarTest {
     String hostname = "nxos_logging";
     Configuration c = parseConfig(hostname);
 
-    assertThat(c.getLoggingServers(), containsInAnyOrder("192.0.2.1", "192.0.2.2", "192.0.2.3"));
+    assertThat(
+        c.getLoggingServers(),
+        containsInAnyOrder("192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4"));
     assertThat(c.getLoggingSourceInterface(), equalTo("loopback0"));
+  }
+
+  @Test
+  public void testLoggingReferences() throws IOException {
+    String hostname = "nxos_logging";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename,
+            CiscoNxosStructureType.VRF,
+            "default",
+            CiscoNxosStructureUsage.LOGGING_SERVER_USE_VRF));
+    assertThat(
+        ccae,
+        hasReferencedStructure(
+            filename,
+            CiscoNxosStructureType.VRF,
+            "management",
+            CiscoNxosStructureUsage.LOGGING_SERVER_USE_VRF));
   }
 
   @Test
@@ -5364,8 +5392,43 @@ public final class CiscoNxosGrammarTest {
     String hostname = "nxos_logging";
     CiscoNxosConfiguration vc = parseVendorConfig(hostname);
 
-    assertThat(vc.getLoggingServers(), hasKeys("192.0.2.1", "192.0.2.2", "192.0.2.3"));
+    assertThat(vc.getLoggingServers(), hasKeys("192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4"));
     assertThat(vc.getLoggingSourceInterface(), equalTo("loopback0"));
+
+    LoggingServer server1 = vc.getLoggingServers().get("192.0.2.1");
+    assertThat(server1.getSeverityLevel(), equalTo(5));
+    assertThat(server1.getPort(), nullValue());
+    assertFalse(server1.getSecure());
+    assertThat(server1.getUseVrf(), equalTo("default"));
+    assertThat(server1.getFacility(), equalTo("local7"));
+
+    LoggingServer server2 = vc.getLoggingServers().get("192.0.2.2");
+    assertThat(server2.getSeverityLevel(), equalTo(3));
+    assertThat(server2.getPort(), equalTo(2025));
+    assertFalse(server2.getSecure());
+    assertThat(server2.getUseVrf(), equalTo("management"));
+    assertThat(server2.getFacility(), equalTo("kern"));
+
+    LoggingServer server3 = vc.getLoggingServers().get("192.0.2.3");
+    assertThat(server3.getSeverityLevel(), nullValue());
+    assertThat(server3.getPort(), nullValue());
+    assertFalse(server3.getSecure());
+    assertThat(server3.getUseVrf(), nullValue());
+    assertThat(server3.getFacility(), nullValue());
+
+    LoggingServer server4 = vc.getLoggingServers().get("192.0.2.4");
+    assertThat(server4.getSeverityLevel(), equalTo(2));
+    assertThat(server4.getPort(), equalTo(500));
+    assertTrue(server4.getSecure());
+    assertThat(server4.getUseVrf(), nullValue());
+    assertThat(server4.getFacility(), equalTo("local3"));
+
+    LoggingLogfile logfile = vc.getLoggingLogfile();
+    assertThat(logfile, notNullValue());
+    assertThat(logfile.getName(), equalTo("my_log"));
+    assertThat(logfile.getSeverityLevel(), equalTo(6));
+    assertThat(logfile.getSizeBytes(), equalTo(4194304));
+    assertThat(logfile.getPersistentThreshold(), equalTo(80));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_logging
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_logging
@@ -3,8 +3,11 @@
 hostname nxos_logging
 !
 
-logging server 192.0.2.1 5 use-vrf default facility kern
-logging server 192.0.2.2 5 port 2025 use-vrf management facility kern
+logging server 192.0.2.1 5 use-vrf default facility local7
+logging server 192.0.2.2 3 port 2025 use-vrf management facility kern
 logging server 192.0.2.3
+logging server 192.0.2.4 2 port 500 secure facility local3
+
+logging logfile my_log 6 size 4194304 persistent threshold 80
 
 logging source-interface loopback 0


### PR DESCRIPTION
## Summary

Add extraction for the NX-OS `logging server` and `logging logfile` commands to capture syslog server attributes (severity level, port, facility, VRF, and whether the secure/TLS option is enabled) and local logfile attributes (name, severity, size, and persistent threshold).

## Changes

- Add `LOGFILE` and `PERSISTENT` lexer tokens (`LOGFILE` pushes `M_Word` so the filename lexes as a `WORD`). NX-OS already had `SERVER`, `PORT`, `SECURE`, `FACILITY` (and all facility names), `USE_VRF`, `SIZE`, and `THRESHOLD` tokens, so no other lexer changes were needed

- Add the `logging_logfile` grammar rule with `ll_size` and `ll_persistent` child rules and wire it into `s_logging`. The `logging_server` rule already parsed `level`, `port`, `secure`, `facility`, and `use-vrf`, but the extractor discarded them; add a label to the facility alternative in `ls_facility` so it can be read

- Add `_severityLevel`, `_port`, `_facility`, `_useVrf`, and `_secure` fields to the existing `LoggingServer.java` VS model class and create `LoggingLogfile.java` (name, severity, size, persistent threshold). `secure` is stored as a boolean only — the transport protocol is not modeled since it is not stated explicitly in the device config

- Add a `_loggingLogfile` field to `CiscoNxosConfiguration.java` with accessors (`_loggingServers` already existed). A single logfile is retained since a later `logging logfile` command overrides the previous one. Add a `LOGGING_SERVER_USE_VRF` structure usage so `use-vrf` records a VRF reference (matching the existing AAA `use-vrf` pattern)

- Add `exitLogging_logfile` and populate `exitLogging_server` in `CiscoNxosControlPlaneExtractor.java`. Severity (`0-7`), port (`1-65535`), logfile size (`4096-4194304`), and persistent threshold (`0-99`) are range-validated, with out-of-range values warned and dropped. Logfile size is parsed as a long to avoid overflow on a malformed uint32

## Testing

- Extend the existing `nxos_logging` testconfig with severity/port/facility/use-vrf/secure variations across servers and a `logging logfile` line configuring both size and persistent threshold

- Add unit tests confirming extraction works correctly, that the attributes are validated against their documented ranges, and a reference test confirming `logging server ... use-vrf` records a VRF structure reference

- All tests pass locally