### PR TITLE
feat(cisco): extract ASA syslog logging attributes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_logging.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLegacy_logging.g4
@@ -65,7 +65,7 @@ logging_common
    | logging_archive
    | logging_asdm_buffer_size_null
    | logging_asdm_null
-   | logging_buffer_size_null
+   | logging_buffer_size
    | logging_buffered
    | logging_cmts_null
    | logging_console
@@ -77,7 +77,7 @@ logging_common
    | logging_esm_null
    | logging_event_null
    | logging_events_null
-   | logging_facility_null
+   | logging_facility
    | logging_format
    | logging_history_null
    | logging_host
@@ -163,30 +163,29 @@ logging_format
 
 logging_host
 :
-   HOST iname = variable? hostname = variable
+   HOST iface = variable hostname =
    (
-      VRF vrf = variable
+      IP_ADDRESS
+      | IPV6_ADDRESS
+   ) transport = logging_host_transport?
+   (
+      FORMAT EMBLEM
    )?
    (
-      DISCRIMINATOR descr = variable
-   )?
-   (
-      TRANSPORT
+      SECURE
       (
-         TCP
-         | UDP
-      )
-   )?
-   (
-      PORT
-      (
-         DEFAULT
-         | dec
-      )
-   )?
-   (
-      FACILITY name = variable
+         REFERENCE_IDENTITY refid = variable
+      )?
    )? NEWLINE
+;
+
+// The transport/port pair is either a bare keyword (tcp | udp) or, when a port
+// is present, a single token such as 'tcp/1500' or 'udp/1026'
+logging_host_transport
+:
+   TCP
+   | UDP
+   | VARIABLE
 ;
 
 logging_message
@@ -206,9 +205,9 @@ logging_asdm_buffer_size_null
 :
    ASDM_BUFFER_SIZE null_rest_of_line
 ;
-logging_buffer_size_null
+logging_buffer_size
 :
-   BUFFER_SIZE null_rest_of_line
+   BUFFER_SIZE bytes = dec NEWLINE
 ;
 logging_count_null
 :
@@ -238,9 +237,9 @@ logging_events_null
 :
    EVENTS null_rest_of_line
 ;
-logging_facility_null
+logging_facility
 :
-   FACILITY null_rest_of_line
+   FACILITY num = dec NEWLINE
 ;
 logging_history_null
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_asa/AsaLexer.g4
@@ -1697,6 +1697,8 @@ EMAIL_CONTACT
    'email-contact' -> pushMode ( M_Description )
 ;
 
+EMBLEM: 'emblem';
+
 EMERGENCIES: 'emergencies';
 
 EMPTY: 'empty';
@@ -4492,6 +4494,8 @@ REDUNDANCY_GROUP: 'redundancy-group';
 
 REFERENCE_BANDWIDTH: 'reference-bandwidth';
 
+REFERENCE_IDENTITY: 'reference-identity';
+
 REFLECT: 'reflect';
 
 REFLECTION: 'reflection';
@@ -4859,6 +4863,8 @@ SECONDARY: 'secondary';
 SECONDARY_DIALTONE: 'secondary-dialtone';
 
 SECRET: 'secret';
+
+SECURE: 'secure';
 
 SECUREID_UDP: 'secureid-udp';
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
@@ -283,6 +283,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Range;
+import com.google.common.primitives.Ints;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -663,8 +664,10 @@ import org.batfish.grammar.cisco_asa.AsaParser.L_login_authenticationContext;
 import org.batfish.grammar.cisco_asa.AsaParser.L_transportContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Local_as_bgp_tailContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Logging_addressContext;
+import org.batfish.grammar.cisco_asa.AsaParser.Logging_buffer_sizeContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Logging_bufferedContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Logging_consoleContext;
+import org.batfish.grammar.cisco_asa.AsaParser.Logging_facilityContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Logging_hostContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Logging_onContext;
 import org.batfish.grammar.cisco_asa.AsaParser.Logging_serverContext;
@@ -1120,6 +1123,7 @@ import org.batfish.representation.cisco_asa.StandardIpv6AccessListLine;
 import org.batfish.representation.cisco_asa.StaticRoute;
 import org.batfish.representation.cisco_asa.StubSettings;
 import org.batfish.representation.cisco_asa.SubnetNetworkObject;
+import org.batfish.representation.cisco_asa.SyslogTransportProtocol;
 import org.batfish.representation.cisco_asa.TcpServiceObjectGroupLine;
 import org.batfish.representation.cisco_asa.TcpUdpServiceObjectGroupLine;
 import org.batfish.representation.cisco_asa.Tunnel;
@@ -1139,6 +1143,9 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
   private static final IntegerSpace PROTOCOL_DISTANCE_RANGE = IntegerSpace.of(Range.closed(1, 255));
 
   private static final LongSpace NTP_KEY_RANGE = LongSpace.of(Range.closed(1L, 4294967295L));
+
+  private static final IntegerSpace LOGGING_HOST_PORT_RANGE =
+      IntegerSpace.of(Range.closed(1025, 65535));
 
   @VisibleForTesting static final String SERIAL_LINE = "serial";
 
@@ -6117,6 +6124,9 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
     buffered.setSeverity(severity);
     buffered.setSeverityNum(severityNum);
     buffered.setSize(size);
+    // Vendor-specific ASA model: record the internal buffer severity by name and level.
+    _configuration.getAsaLogging().setBufferedSeverity(severity);
+    _configuration.getAsaLogging().setBufferedSeverityNum(severityNum);
   }
 
   @Override
@@ -6145,10 +6155,82 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
     if (_no) {
       return;
     }
-    Logging logging = _configuration.getCf().getLogging();
     String hostname = ctx.hostname.getText();
-    LoggingHost host = new LoggingHost(hostname);
-    logging.getHosts().put(hostname, host);
+    // Preserve shared-model behavior (used for the VI loggingServers set).
+    Logging logging = _configuration.getCf().getLogging();
+    logging.getHosts().put(hostname, new LoggingHost(hostname));
+
+    // Vendor-specific ASA model: capture interface, transport, and port
+    org.batfish.representation.cisco_asa.LoggingHost syslogHost =
+        new org.batfish.representation.cisco_asa.LoggingHost(ctx.iface.getText(), hostname);
+
+    // Transport defaults to UDP on ASA. The transport clause is either a bare
+    // keyword (tcp | udp) or a combined 'protocol/port' token (e.g. 'tcp/1500').
+    SyslogTransportProtocol transport = SyslogTransportProtocol.UDP;
+    Integer explicitPort = null;
+    if (ctx.transport != null) {
+      if (ctx.transport.TCP() != null) {
+        transport = SyslogTransportProtocol.TCP;
+      } else if (ctx.transport.UDP() != null) {
+        transport = SyslogTransportProtocol.UDP;
+      } else {
+        String text = ctx.transport.getText();
+        int slash = text.indexOf('/');
+        String protocol = (slash < 0 ? text : text.substring(0, slash)).toLowerCase();
+        if (protocol.equals("tcp")) {
+          transport = SyslogTransportProtocol.TCP;
+        } else if (protocol.equals("udp")) {
+          transport = SyslogTransportProtocol.UDP;
+        } else {
+          warn(ctx, String.format("Unrecognized logging host transport protocol: '%s'", text));
+          return;
+        }
+        if (slash >= 0) {
+          Optional<Integer> maybePort = toLoggingHostPort(ctx, text.substring(slash + 1));
+          if (!maybePort.isPresent()) {
+            return;
+          }
+          explicitPort = maybePort.get();
+        }
+      }
+    }
+    syslogHost.setTransport(transport);
+    syslogHost.setPort(explicitPort != null ? explicitPort : transport.getDefaultPort());
+    _configuration.getAsaLogging().getHosts().put(hostname, syslogHost);
+  }
+
+  private @Nonnull Optional<Integer> toLoggingHostPort(
+      ParserRuleContext messageCtx, String portText) {
+    Integer port = Ints.tryParse(portText.trim());
+    if (port == null) {
+      warn(messageCtx, String.format("Invalid logging host port: '%s'", portText));
+      return Optional.empty();
+    }
+    if (!LOGGING_HOST_PORT_RANGE.contains(port)) {
+      warn(
+          messageCtx,
+          String.format(
+              "Expected logging host port in range %s, but got '%s'",
+              LOGGING_HOST_PORT_RANGE, portText));
+      return Optional.empty();
+    }
+    return Optional.of(port);
+  }
+
+  @Override
+  public void exitLogging_facility(Logging_facilityContext ctx) {
+    if (_no) {
+      return;
+    }
+    _configuration.getAsaLogging().setFacility(toInteger(ctx.num));
+  }
+
+  @Override
+  public void exitLogging_buffer_size(Logging_buffer_sizeContext ctx) {
+    if (_no) {
+      return;
+    }
+    _configuration.getAsaLogging().setBufferSize(toInteger(ctx.bytes));
   }
 
   @Override
@@ -6197,6 +6279,9 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
     }
     trap.setSeverity(severity);
     trap.setSeverityNum(severityNum);
+    // Vendor-specific ASA model: record the global trap severity by name and level.
+    _configuration.getAsaLogging().setTrapSeverity(severity);
+    _configuration.getAsaLogging().setTrapSeverityNum(severityNum);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -424,6 +424,8 @@ public final class AsaConfiguration extends VendorConfiguration {
 
   private final CiscoFamily _cf;
 
+  private final Logging _logging;
+
   private final Map<String, CryptoMapSet> _cryptoMapSets;
 
   private final Map<String, NamedRsaPubKey> _cryptoNamedRsaPubKeys;
@@ -561,6 +563,7 @@ public final class AsaConfiguration extends VendorConfiguration {
   public AsaConfiguration() {
     _asPathAccessLists = new TreeMap<>();
     _cf = new CiscoFamily();
+    _logging = new Logging();
     _cryptoNamedRsaPubKeys = new TreeMap<>();
     _cryptoMapSets = new HashMap<>();
     _dhcpRelayServers = new ArrayList<>();
@@ -710,6 +713,11 @@ public final class AsaConfiguration extends VendorConfiguration {
 
   public CiscoFamily getCf() {
     return _cf;
+  }
+
+  /** Vendor-specific ASA syslog/logging settings. */
+  public Logging getAsaLogging() {
+    return _logging;
   }
 
   public Map<String, CryptoMapSet> getCryptoMapSets() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/Logging.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/Logging.java
@@ -1,0 +1,86 @@
+package org.batfish.representation.cisco_asa;
+
+import java.io.Serializable;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Vendor-specific ASA syslog/logging settings.
+ *
+ * <p>Captures ASA logging attributes that are not represented by the shared {@link
+ * org.batfish.datamodel.vendor_family.cisco.Logging} model: per-host transport/port, the global
+ * logging facility, the global trap severity, and the internal log buffer size/severity.
+ *
+ * <p>Severities are captured both by name (e.g. {@code errors}) and by numeric level (0-7), since
+ * the ASA CLI accepts either form.
+ */
+@ParametersAreNonnullByDefault
+public final class Logging implements Serializable {
+
+  private final @Nonnull SortedMap<String, LoggingHost> _hosts;
+  private @Nullable Integer _facility;
+  private @Nullable String _trapSeverity;
+  private @Nullable Integer _trapSeverityNum;
+  private @Nullable Integer _bufferSize;
+  private @Nullable String _bufferedSeverity;
+  private @Nullable Integer _bufferedSeverityNum;
+
+  public Logging() {
+    _hosts = new TreeMap<>();
+  }
+
+  public @Nonnull SortedMap<String, LoggingHost> getHosts() {
+    return _hosts;
+  }
+
+  public @Nullable Integer getFacility() {
+    return _facility;
+  }
+
+  public void setFacility(@Nullable Integer facility) {
+    _facility = facility;
+  }
+
+  public @Nullable String getTrapSeverity() {
+    return _trapSeverity;
+  }
+
+  public void setTrapSeverity(@Nullable String trapSeverity) {
+    _trapSeverity = trapSeverity;
+  }
+
+  public @Nullable Integer getTrapSeverityNum() {
+    return _trapSeverityNum;
+  }
+
+  public void setTrapSeverityNum(@Nullable Integer trapSeverityNum) {
+    _trapSeverityNum = trapSeverityNum;
+  }
+
+  public @Nullable Integer getBufferSize() {
+    return _bufferSize;
+  }
+
+  public void setBufferSize(@Nullable Integer bufferSize) {
+    _bufferSize = bufferSize;
+  }
+
+  public @Nullable String getBufferedSeverity() {
+    return _bufferedSeverity;
+  }
+
+  public void setBufferedSeverity(@Nullable String bufferedSeverity) {
+    _bufferedSeverity = bufferedSeverity;
+  }
+
+  public @Nullable Integer getBufferedSeverityNum() {
+    return _bufferedSeverityNum;
+  }
+
+  public void setBufferedSeverityNum(@Nullable Integer bufferedSeverityNum) {
+    _bufferedSeverityNum = bufferedSeverityNum;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/LoggingHost.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/LoggingHost.java
@@ -1,0 +1,51 @@
+package org.batfish.representation.cisco_asa;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * A syslog server configured via {@code logging host interface_name syslog_ip [tcp[/port] |
+ * udp[/port]]}.
+ *
+ * <p>The host is stored as its literal text so that both IPv4 and IPv6 syslog servers are
+ * supported.
+ */
+@ParametersAreNonnullByDefault
+public final class LoggingHost implements Serializable {
+
+  private final @Nonnull String _interfaceName;
+  private final @Nonnull String _host;
+  private @Nullable SyslogTransportProtocol _transport;
+  private @Nullable Integer _port;
+
+  public LoggingHost(String interfaceName, String host) {
+    _interfaceName = interfaceName;
+    _host = host;
+  }
+
+  public @Nonnull String getInterfaceName() {
+    return _interfaceName;
+  }
+
+  public @Nonnull String getHost() {
+    return _host;
+  }
+
+  public @Nullable SyslogTransportProtocol getTransport() {
+    return _transport;
+  }
+
+  public void setTransport(@Nullable SyslogTransportProtocol transport) {
+    _transport = transport;
+  }
+
+  public @Nullable Integer getPort() {
+    return _port;
+  }
+
+  public void setPort(@Nullable Integer port) {
+    _port = port;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/SyslogTransportProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/SyslogTransportProtocol.java
@@ -1,0 +1,17 @@
+package org.batfish.representation.cisco_asa;
+
+/** The transport protocol used to send syslog messages to a syslog server. */
+public enum SyslogTransportProtocol {
+  TCP(1470),
+  UDP(514);
+
+  private final int _defaultPort;
+
+  SyslogTransportProtocol(int defaultPort) {
+    _defaultPort = defaultPort;
+  }
+
+  public int getDefaultPort() {
+    return _defaultPort;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_asa/CiscoAsaGrammarTest.java
@@ -196,6 +196,8 @@ import org.batfish.representation.cisco_asa.BgpAggregateIpv4Network;
 import org.batfish.representation.cisco_asa.EigrpProcess;
 import org.batfish.representation.cisco_asa.ExpandedCommunityList;
 import org.batfish.representation.cisco_asa.ExpandedCommunityListLine;
+import org.batfish.representation.cisco_asa.Logging;
+import org.batfish.representation.cisco_asa.LoggingHost;
 import org.batfish.representation.cisco_asa.NetworkObject;
 import org.batfish.representation.cisco_asa.NetworkObjectAddressSpecifier;
 import org.batfish.representation.cisco_asa.NetworkObjectGroupAddressSpecifier;
@@ -209,6 +211,7 @@ import org.batfish.representation.cisco_asa.RouteMapSetAdditiveCommunityLine;
 import org.batfish.representation.cisco_asa.RouteMapSetCommunityLine;
 import org.batfish.representation.cisco_asa.StandardCommunityList;
 import org.batfish.representation.cisco_asa.StandardCommunityListLine;
+import org.batfish.representation.cisco_asa.SyslogTransportProtocol;
 import org.batfish.representation.cisco_asa.WildcardAddressSpecifier;
 import org.junit.Rule;
 import org.junit.Test;
@@ -274,6 +277,62 @@ public final class CiscoAsaGrammarTest {
   public void testHumanName() throws IOException {
     Configuration c = parseConfig("asa-humanname");
     assertThat(c.getHumanName(), equalTo("ASA-humanname"));
+  }
+
+  @Test
+  public void testLoggingExtraction() {
+    AsaConfiguration c = parseVendorConfig("asa-logging");
+    Logging logging = c.getAsaLogging();
+
+    assertThat(logging.getFacility(), equalTo(21));
+    assertThat(logging.getTrapSeverity(), equalTo("errors"));
+    assertThat(logging.getTrapSeverityNum(), equalTo(3));
+    assertThat(logging.getBufferedSeverity(), equalTo("warnings"));
+    assertThat(logging.getBufferedSeverityNum(), equalTo(4));
+    assertThat(logging.getBufferSize(), equalTo(16384));
+
+    Map<String, LoggingHost> hosts = logging.getHosts();
+    assertThat(
+        hosts.keySet(),
+        containsInAnyOrder(
+            "10.0.0.1", "192.168.1.5", "172.16.0.9", "10.0.0.4", "192.168.1.7", "2001::1:1"));
+
+    LoggingHost tcpHost = hosts.get("10.0.0.1");
+    assertThat(tcpHost.getInterfaceName(), equalTo("inside"));
+    assertThat(tcpHost.getTransport(), equalTo(SyslogTransportProtocol.TCP));
+    assertThat(tcpHost.getPort(), equalTo(1500));
+
+    LoggingHost udpHost = hosts.get("192.168.1.5");
+    assertThat(udpHost.getInterfaceName(), equalTo("dmz"));
+    assertThat(udpHost.getTransport(), equalTo(SyslogTransportProtocol.UDP));
+    assertThat(udpHost.getPort(), equalTo(1026));
+
+    LoggingHost defaultHost = hosts.get("172.16.0.9");
+    assertThat(defaultHost.getInterfaceName(), equalTo("mgmt"));
+    assertThat(defaultHost.getTransport(), equalTo(SyslogTransportProtocol.UDP));
+    assertThat(defaultHost.getPort(), equalTo(514));
+
+    LoggingHost bareTcpHost = hosts.get("10.0.0.4");
+    assertThat(bareTcpHost.getInterfaceName(), equalTo("outside"));
+    assertThat(bareTcpHost.getTransport(), equalTo(SyslogTransportProtocol.TCP));
+    assertThat(bareTcpHost.getPort(), equalTo(1470));
+
+    LoggingHost bareUdpHost = hosts.get("192.168.1.7");
+    assertThat(bareUdpHost.getInterfaceName(), equalTo("dmz"));
+    assertThat(bareUdpHost.getTransport(), equalTo(SyslogTransportProtocol.UDP));
+    assertThat(bareUdpHost.getPort(), equalTo(514));
+
+    LoggingHost ipv6Host = hosts.get("2001::1:1");
+    assertThat(ipv6Host.getInterfaceName(), equalTo("inside"));
+    assertThat(ipv6Host.getTransport(), equalTo(SyslogTransportProtocol.UDP));
+    assertThat(ipv6Host.getPort(), equalTo(2020));
+  }
+
+  @Test
+  public void testLoggingBadPort() {
+    AsaConfiguration c = parseVendorConfig("asa-logging-bad-port");
+    // An out-of-range port is warned about, and the host is not stored in the vendor model.
+    assertTrue(c.getAsaLogging().getHosts().isEmpty());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-logging
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-logging
@@ -1,0 +1,17 @@
+! This is an ASA device.
+ASA Version 9.9
+!
+hostname asa-logging
+!
+logging enable
+logging host inside 10.0.0.1 tcp/1500
+logging host dmz 192.168.1.5 udp/1026
+logging host mgmt 172.16.0.9
+logging host outside 10.0.0.4 tcp
+logging host dmz 192.168.1.7 udp
+logging host inside 2001::1:1 udp/2020
+logging facility 21
+logging trap errors
+logging buffered warnings
+logging buffer-size 16384
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-logging-bad-port
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_asa/testconfigs/asa-logging-bad-port
@@ -1,0 +1,7 @@
+! This is an ASA device.
+ASA Version 9.9
+!
+hostname asa-logging-bad-port
+!
+logging host inside 10.0.0.2 udp/500
+!


### PR DESCRIPTION
## Summary

Add extraction for the Cisco ASA `logging host`, `logging facility`, `logging trap`, `logging buffered`, and `logging buffer-size` commands to capture per-host syslog server attributes (interface, IPv4/IPv6 address, transport protocol, and port) and global logging attributes (facility, trap severity, and internal log buffer size/severity). This is captured in new vendor-specific `cisco_asa` model classes; the shared `vendor_family.cisco.Logging` model is intentionally left untouched.

## Changes

- Add `EMBLEM`, `SECURE`, and `REFERENCE_IDENTITY` lexer tokens. ASA already had `HOST`, `FACILITY`, `TRAP`, `BUFFER_SIZE`, `TCP`/`UDP`, `PORT`, `FORWARD_SLASH`, and all severity-name tokens, so no other lexer changes were needed.

- Rewrite the `logging_host` grammar rule to real ASA syntax (`logging host interface_name syslog_ip [tcp[/port] | udp[/port]] [format emblem] [secure [reference-identity name]]`). Because the lexer folds the slash form (`tcp/1500`) into a single `VARIABLE` token the transport/port pair is captured via a `logging_host_transport` subrule (bare `tcp`/`udp` keyword or the combined token) and split in the extractor.

- Promote `logging_facility` and `logging_buffer_size` from ignored `_null` rules to value-capturing rules and wire them into `logging_common`.

- Add new VS model classes in `representation/cisco_asa`: `LoggingHost.java` (interface name and host in the constructor, host stored as a `String` so both IPv4 and IPv6 servers are supported, plus transport and port), `SyslogTransportProtocol.java` (enum `TCP`/`UDP` carrying its default port), and `Logging.java` (host map keyed by server IP literal, plus global facility, trap severity, and buffer size/severity). Trap and buffer severities are each captured by name and numeric level to mirror the shared model. Transport defaults to `UDP`; port defaults to `514` (UDP) / `1470` (TCP), sourced from the enum rather than the extractor.

- Add a `_logging` field to `AsaConfiguration.java` with a `getAsaLogging()` accessor (named to distinguish it from the shared `getCf().getLogging()`). The existing shared-model host write is preserved so the vendor-independent `loggingServers` behavior is unchanged.

- Populate `exitLogging_host` and add `exitLogging_facility` and `exitLogging_buffer_size` in `AsaControlPlaneExtractor.java`. The host port is range-validated (`1025-65535`), with out-of-range or non-numeric values warned and the host dropped; port parsing uses `Ints.tryParse` to avoid overflow on a malformed value. Facility and severities are captured via the existing `toLoggingSeverity`/`toLoggingSeverityNum` helpers, which canonicalize either the numeric or named form. IPv6 hosts are accepted and modeled the same as IPv4.

## Testing

- Extend the new `asa-logging` testconfig with `logging host` variations across servers (tcp/port, udp/port, bare host, bare `tcp`, bare `udp`, and an IPv6 server), plus `logging facility`, `logging trap`, `logging buffered`, and `logging buffer-size` lines. Add an `asa-logging-bad-port` testconfig for the out-of-range case.

- Add unit tests confirming extraction works correctly: per-host interface/transport/port including the correct default ports, IPv6 modeling, and the global facility/trap/buffer attributes by both name and level and a negative test confirming an out-of-range port is warned and the host is dropped.

- All tests pass locally.
