### PR TITLE
Replace Jettison with Jackson and drop the dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -50,7 +50,6 @@ BATFISH_MAVEN_ARTIFACTS = [
     "org.apache.logging.log4j:log4j-api:2.26.1",
     "org.apache.logging.log4j:log4j-core:2.26.1",
     "org.apache.logging.log4j:log4j-slf4j-impl:2.26.1",
-    "org.codehaus.jettison:jettison:1.5.7",
     "org.glassfish.grizzly:grizzly-framework:2.4.4",
     "org.glassfish.grizzly:grizzly-http-server:2.4.4",
     "org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.48",

--- a/maven_install.json
+++ b/maven_install.json
@@ -52,7 +52,6 @@
     "org.apache.logging.log4j:log4j-api": -1004697821,
     "org.apache.logging.log4j:log4j-core": 260343140,
     "org.apache.logging.log4j:log4j-slf4j-impl": 1608875535,
-    "org.codehaus.jettison:jettison": 888911119,
     "org.glassfish.grizzly:grizzly-framework": 1869934097,
     "org.glassfish.grizzly:grizzly-http-server": -292995845,
     "org.glassfish.jersey.containers:jersey-container-grizzly2-http": 711949421,
@@ -223,8 +222,6 @@
     "org.apiguardian:apiguardian-api:jar:sources": 729595858,
     "org.checkerframework:checker-qual": -2134103876,
     "org.checkerframework:checker-qual:jar:sources": 11073524,
-    "org.codehaus.jettison:jettison": 1811238688,
-    "org.codehaus.jettison:jettison:jar:sources": 591354675,
     "org.codehaus.plexus:plexus-classworlds": 830297444,
     "org.codehaus.plexus:plexus-classworlds:jar:sources": -2122083127,
     "org.codehaus.plexus:plexus-component-annotations": -599131582,
@@ -875,13 +872,6 @@
         "sources": "cd0abd821e0672baba7c3f1af7001056afcc79b7d975e774726a395c7ed12908"
       },
       "version": "4.2.0"
-    },
-    "org.codehaus.jettison:jettison": {
-      "shasums": {
-        "jar": "0fa0f1144fe37925e3568f8f5413ba5c0a551a243c47ec2d1885505e76a7b186",
-        "sources": "ecfce2b3915faf1d3e95c12a25227c47db623328452772de824db24dd66b2e18"
-      },
-      "version": "1.5.7"
     },
     "org.codehaus.plexus:plexus-classworlds": {
       "shasums": {
@@ -2664,13 +2654,6 @@
       "org.checkerframework.dataflow.qual",
       "org.checkerframework.framework.qual"
     ],
-    "org.codehaus.jettison:jettison": [
-      "org.codehaus.jettison",
-      "org.codehaus.jettison.badgerfish",
-      "org.codehaus.jettison.json",
-      "org.codehaus.jettison.mapped",
-      "org.codehaus.jettison.util"
-    ],
     "org.codehaus.plexus:plexus-classworlds": [
       "org.codehaus.classworlds",
       "org.codehaus.plexus.classworlds",
@@ -3417,8 +3400,6 @@
       "org.apiguardian:apiguardian-api:jar:sources",
       "org.checkerframework:checker-qual",
       "org.checkerframework:checker-qual:jar:sources",
-      "org.codehaus.jettison:jettison",
-      "org.codehaus.jettison:jettison:jar:sources",
       "org.codehaus.plexus:plexus-classworlds",
       "org.codehaus.plexus:plexus-classworlds:jar:sources",
       "org.codehaus.plexus:plexus-component-annotations",

--- a/projects/batfish/src/main/java/org/batfish/BUILD.bazel
+++ b/projects/batfish/src/main/java/org/batfish/BUILD.bazel
@@ -72,7 +72,6 @@ java_library(
         "@maven//:org_apache_commons_commons_configuration2",
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_apache_logging_log4j_log4j_api",
-        "@maven//:org_codehaus_jettison_jettison",
         "@maven//:org_glassfish_grizzly_grizzly_http_server",
         "@maven//:org_glassfish_jersey_containers_jersey_container_grizzly2_http",
         "@maven//:org_glassfish_jersey_core_jersey_server",

--- a/projects/batfish/src/main/java/org/batfish/main/CoordinatorClient.java
+++ b/projects/batfish/src/main/java/org/batfish/main/CoordinatorClient.java
@@ -1,5 +1,6 @@
 package org.batfish.main;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Throwables;
 import java.util.Map;
 import javax.net.ssl.SSLHandshakeException;
@@ -11,8 +12,8 @@ import javax.ws.rs.core.Response;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.CoordConsts;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
-import org.codehaus.jettison.json.JSONArray;
 
 /** Helper class that implements (some) communication between Batfish worker and coordinator */
 public final class CoordinatorClient {
@@ -26,7 +27,7 @@ public final class CoordinatorClient {
       for (Map.Entry<String, String> entry : params.entrySet()) {
         webTarget = webTarget.queryParam(entry.getKey(), entry.getValue());
       }
-      JSONArray array;
+      JsonNode array;
       try (Response response = webTarget.request(MediaType.APPLICATION_JSON).get()) {
 
         logger.debug(
@@ -38,11 +39,11 @@ public final class CoordinatorClient {
         }
 
         String sobj = response.readEntity(String.class);
-        array = new JSONArray(sobj);
+        array = BatfishObjectMapper.mapper().readTree(sobj);
       }
       logger.debugf("BF: response: %s [%s] [%s]\n", array, array.get(0), array.get(1));
 
-      if (!array.get(0).equals(CoordConsts.SVC_KEY_SUCCESS)) {
+      if (!array.get(0).asText().equals(CoordConsts.SVC_KEY_SUCCESS)) {
         logger.errorf(
             "BF: got error while talking to coordinator: %s %s\n", array.get(0), array.get(1));
         return null;

--- a/projects/client/src/main/java/org/batfish/client/BUILD.bazel
+++ b/projects/client/src/main/java/org/batfish/client/BUILD.bazel
@@ -23,7 +23,6 @@ java_library(
         "@maven//:io_github_java_diff_utils_java_diff_utils",
         "@maven//:jakarta_ws_rs_jakarta_ws_rs_api",
         "@maven//:org_apache_commons_commons_lang3",
-        "@maven//:org_codehaus_jettison_jettison",
     ],
 )
 

--- a/projects/client/src/main/java/org/batfish/client/Client.java
+++ b/projects/client/src/main/java/org/batfish/client/Client.java
@@ -7,6 +7,7 @@ import static org.batfish.specifier.NameRegexRoutingPolicySpecifier.ALL_ROUTING_
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.difflib.DiffUtils;
 import com.github.difflib.UnifiedDiffUtils;
 import com.github.difflib.patch.Patch;
@@ -52,6 +53,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.batfish.client.BfCoordWorkHelper.WorkResult;
 import org.batfish.client.Command.CommandUsage;
 import org.batfish.client.Command.TestComparisonMode;
+import org.batfish.client.LenientJsonParser.LenientJsonException;
 import org.batfish.client.answer.LoadQuestionAnswerElement;
 import org.batfish.client.config.Settings;
 import org.batfish.common.BatfishException;
@@ -94,9 +96,6 @@ import org.batfish.specifier.AllNodesNodeSpecifier;
 import org.batfish.specifier.RoutingProtocolSpecifier;
 import org.batfish.specifier.SpecifierFactories;
 import org.batfish.specifier.parse.ParsedIpSpaceSpecifier;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
-import org.codehaus.jettison.json.JSONTokener;
 
 public class Client extends AbstractClient implements IClient {
 
@@ -775,10 +774,10 @@ public class Client extends AbstractClient implements IClient {
       throw new BatfishException("Invalid question template name: '" + questionTemplateName + "'");
     }
     Map<String, JsonNode> parameters = parseParams(paramsLine);
-    JSONObject questionJson;
+    ObjectNode questionJson;
     try {
-      questionJson = new JSONObject(questionContentUnmodified);
-    } catch (JSONException e) {
+      questionJson = (ObjectNode) BatfishObjectMapper.mapper().readTree(questionContentUnmodified);
+    } catch (IOException | ClassCastException e) {
       throw new BatfishException("Question content is not valid JSON", e);
     }
     String questionName = DEFAULT_QUESTION_PREFIX + "_" + UUID.randomUUID();
@@ -800,19 +799,13 @@ public class Client extends AbstractClient implements IClient {
     }
     try {
       questionJson = QuestionHelper.fillTemplate(questionJson, parameters, questionName);
-    } catch (IOException | JSONException e) {
+    } catch (IOException e) {
       throw new BatfishException("Could not fill template: ", e);
     }
     String modifiedQuestionStr = questionJson.toString();
 
-    boolean questionJsonDifferential;
-    try {
-      questionJsonDifferential =
-          questionJson.has(BfConsts.PROP_DIFFERENTIAL)
-              && questionJson.getBoolean(BfConsts.PROP_DIFFERENTIAL);
-    } catch (JSONException e) {
-      throw new BatfishException("Could not find whether question is explicitly differential", e);
-    }
+    boolean questionJsonDifferential =
+        questionJson.path(BfConsts.PROP_DIFFERENTIAL).asBoolean(false);
     if (questionJsonDifferential && _currDeltaTestrig == null) {
       _logger.output(DIFF_NOT_READY_MSG);
       return false;
@@ -885,30 +878,18 @@ public class Client extends AbstractClient implements IClient {
   }
 
   private boolean answerType(String questionType, String paramsLine, FileWriter outWriter) {
-    JSONObject questionJson;
+    ObjectNode questionJson;
     try {
       String questionString = QuestionHelper.getQuestionString(questionType, _questions, false);
-      questionJson = new JSONObject(questionString);
+      questionJson = (ObjectNode) BatfishObjectMapper.mapper().readTree(questionString);
 
       Map<String, JsonNode> parameters = parseParams(paramsLine);
       for (Entry<String, JsonNode> e : parameters.entrySet()) {
         String parameterName = e.getKey();
-        String parameterValue = e.getValue().toString();
-        Object parameterObj;
-        try {
-          parameterObj = new JSONTokener(parameterValue).nextValue();
-          questionJson.put(parameterName, parameterObj);
-        } catch (JSONException e1) {
-          throw new BatfishException(
-              "Failed to apply parameter: '"
-                  + parameterName
-                  + "' with value: '"
-                  + parameterValue
-                  + "' to question JSON",
-              e1);
-        }
+        // The parameter value is already a JsonNode produced by parseParams; set it directly.
+        questionJson.set(parameterName, e.getValue());
       }
-    } catch (JSONException e) {
+    } catch (IOException | ClassCastException e) {
       throw new BatfishException("Failed to convert unmodified question string to JSON", e);
     } catch (BatfishException e) {
       _logger.errorf("Could not construct a question: %s\n", e.getMessage());
@@ -1074,25 +1055,18 @@ public class Client extends AbstractClient implements IClient {
    * @return name of question
    * @throws if any of instance or instanceName not found in question
    */
-  static String getQuestionName(JSONObject question, String questionIdentifier) {
+  static String getQuestionName(ObjectNode question, String questionIdentifier) {
     if (!question.has(BfConsts.PROP_INSTANCE)) {
       throw new BatfishException(
           String.format("question %s does not have instance field", questionIdentifier));
     }
-    try {
-      if (!question.getJSONObject(BfConsts.PROP_INSTANCE).has(BfConsts.PROP_INSTANCE_NAME)) {
-        throw new BatfishException(
-            String.format(
-                "question %s does not have instanceName field in instance", questionIdentifier));
-      } else {
-        return question
-            .getJSONObject(BfConsts.PROP_INSTANCE)
-            .getString(BfConsts.PROP_INSTANCE_NAME);
-      }
-    } catch (JSONException e) {
+    JsonNode instance = question.get(BfConsts.PROP_INSTANCE);
+    if (!instance.isObject() || !instance.has(BfConsts.PROP_INSTANCE_NAME)) {
       throw new BatfishException(
-          String.format("Failure in extracting instanceName from question %s", questionIdentifier));
+          String.format(
+              "question %s does not have instanceName field in instance", questionIdentifier));
     }
+    return instance.get(BfConsts.PROP_INSTANCE_NAME).asText();
   }
 
   public Settings getSettings() {
@@ -1297,10 +1271,10 @@ public class Client extends AbstractClient implements IClient {
    * Loads question from a given file
    *
    * @param questionFile File containing the question JSON
-   * @return question loaded as a {@link JSONObject}
+   * @return question loaded as an {@link ObjectNode}
    * @throws BatfishException if question does not have instanceName or question cannot be parsed
    */
-  static JSONObject loadQuestionFromFile(Path questionFile) {
+  static ObjectNode loadQuestionFromFile(Path questionFile) {
     String questionText = CommonUtil.readFile(questionFile);
     return loadQuestionFromText(questionText, questionFile.toString());
   }
@@ -1310,14 +1284,18 @@ public class Client extends AbstractClient implements IClient {
    *
    * @param questionText Question JSON Text
    * @param questionSource JSON key of question or file path of JSON
-   * @return question loaded as a {@link JSONObject}
+   * @return question loaded as an {@link ObjectNode}
    * @throws BatfishException if question does not have instanceName or question cannot be parsed
    */
-  static JSONObject loadQuestionFromText(String questionText, String questionSource) {
+  static ObjectNode loadQuestionFromText(String questionText, String questionSource) {
     try {
-      JSONObject questionObj = new JSONObject(questionText);
-      if (questionObj.has(BfConsts.PROP_INSTANCE) && !questionObj.isNull(BfConsts.PROP_INSTANCE)) {
-        JSONObject instanceDataObj = questionObj.getJSONObject(BfConsts.PROP_INSTANCE);
+      JsonNode parsed = BatfishObjectMapper.mapper().readTree(questionText);
+      if (!(parsed instanceof ObjectNode)) {
+        throw new BatfishException("Failed to process question");
+      }
+      ObjectNode questionObj = (ObjectNode) parsed;
+      if (questionObj.hasNonNull(BfConsts.PROP_INSTANCE)) {
+        JsonNode instanceDataObj = questionObj.get(BfConsts.PROP_INSTANCE);
         String instanceDataStr = instanceDataObj.toString();
         InstanceData instanceData =
             BatfishObjectMapper.mapper()
@@ -1328,7 +1306,7 @@ public class Client extends AbstractClient implements IClient {
         throw new BatfishException(
             String.format("Question in %s has no instance data", questionSource));
       }
-    } catch (JSONException | IOException e) {
+    } catch (IOException e) {
       throw new BatfishException("Failed to process question", e);
     }
   }
@@ -1401,7 +1379,7 @@ public class Client extends AbstractClient implements IClient {
     Multimap<String, String> loadedQuestions = HashMultimap.create();
     for (Path jsonQuestionFile : jsonQuestionFiles) {
       try {
-        JSONObject questionJSON = loadQuestionFromFile(jsonQuestionFile);
+        ObjectNode questionJSON = loadQuestionFromFile(jsonQuestionFile);
         loadedQuestions.put(
             getQuestionName(questionJSON, jsonQuestionFile.toString()), questionJSON.toString());
       } catch (Exception e) {
@@ -1473,15 +1451,13 @@ public class Client extends AbstractClient implements IClient {
 
   private Map<String, JsonNode> parseParams(String paramsLine) {
     String jsonParamsStr = "{ " + paramsLine + " }";
-    Map<String, JsonNode> parameters;
     try {
-      parameters =
-          BatfishObjectMapper.mapper()
-              .readValue(
-                  new JSONObject(jsonParamsStr).toString(),
-                  new TypeReference<Map<String, JsonNode>>() {});
-      return parameters;
-    } catch (JSONException | IOException e) {
+      // The CLI accepts a lenient, org.json-flavored parameter syntax (unquoted keys, '='
+      // separators, etc.); normalize it to strict JSON before binding to a map.
+      JsonNode params = LenientJsonParser.parse(jsonParamsStr);
+      return BatfishObjectMapper.mapper()
+          .readValue(params.toString(), new TypeReference<Map<String, JsonNode>>() {});
+    } catch (LenientJsonException | IOException e) {
       throw new BatfishException(
           "Failed to parse parameters. (Are all key-value pairs separated by commas? Are all "
               + "values valid JSON?)",
@@ -2107,7 +2083,7 @@ public class Client extends AbstractClient implements IClient {
 
   /**
    * Template validation extracts the question template text and parameters, and then relies on
-   * {@link QuestionHelper#validateTemplate(JSONObject, Map)}
+   * {@link QuestionHelper#validateTemplate(ObjectNode, Map)}
    *
    * @param words The array of command words that led to this function being called
    * @param outWriter The parsed question is written to this FileWriter
@@ -2135,11 +2111,11 @@ public class Client extends AbstractClient implements IClient {
         parseParams(String.join(" ", Arrays.copyOfRange(words, 2 + options.size(), words.length)));
 
     try {
-      Question question =
-          QuestionHelper.validateTemplate(
-              new JSONObject(questionContentUnmodified), parsedParameters);
+      ObjectNode questionJson =
+          (ObjectNode) BatfishObjectMapper.mapper().readTree(questionContentUnmodified);
+      Question question = QuestionHelper.validateTemplate(questionJson, parsedParameters);
       logOutput(outWriter, BatfishObjectMapper.writePrettyString(question));
-    } catch (IOException | JSONException e) {
+    } catch (IOException | ClassCastException e) {
       throw new BatfishException(
           "Could not create or write question template: " + e.getMessage(), e);
     }

--- a/projects/client/src/main/java/org/batfish/client/LenientJsonParser.java
+++ b/projects/client/src/main/java/org/batfish/client/LenientJsonParser.java
@@ -1,0 +1,362 @@
+package org.batfish.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.math.BigDecimal;
+
+/**
+ * Parses the lenient, {@code org.json}-flavored JSON that the Batfish client CLI historically
+ * accepted for question parameters. This is <b>not</b> strict JSON: it tolerates the same
+ * non-standard forms the CLI relied on when it used Jettison to parse parameter lines, namely
+ *
+ * <ul>
+ *   <li>unquoted object keys (e.g. {@code {nodes: "as1.*"}}),
+ *   <li>{@code =} and {@code =>} as key/value separators in addition to {@code :},
+ *   <li>{@code ;} as a pair separator in addition to {@code ,},
+ *   <li>single-quoted strings,
+ *   <li>case-insensitive {@code true}/{@code false}/{@code null},
+ *   <li>bare unquoted scalar values, and
+ *   <li>slash-slash, slash-star, and {@code #} comments.
+ * </ul>
+ *
+ * <p>The grammar is ported from Jettison's {@code JSONTokener}/{@code JSONObject}/{@code JSONArray}
+ * so that CLI parameter parsing behaves identically after removing that dependency. The result is
+ * emitted as Jackson {@link JsonNode}s.
+ */
+final class LenientJsonParser {
+
+  /** Thrown on malformed lenient-JSON input. */
+  static final class LenientJsonException extends Exception {
+    LenientJsonException(String message) {
+      super(message);
+    }
+  }
+
+  private static final JsonNodeFactory NF = JsonNodeFactory.instance;
+
+  private final String _source;
+  private int _index;
+
+  private LenientJsonParser(String source) {
+    _source = source.trim();
+    _index = 0;
+  }
+
+  /** Parses {@code text} as a single lenient-JSON value. */
+  static JsonNode parse(String text) throws LenientJsonException {
+    return new LenientJsonParser(text).nextValue();
+  }
+
+  private boolean more() {
+    return _index < _source.length();
+  }
+
+  private char next() {
+    if (more()) {
+      return _source.charAt(_index++);
+    }
+    return 0;
+  }
+
+  private void back() {
+    if (_index > 0) {
+      _index -= 1;
+    }
+  }
+
+  private String next(int n) throws LenientJsonException {
+    int i = _index;
+    int j = i + n;
+    if (j >= _source.length()) {
+      throw error("Substring bounds error");
+    }
+    _index += n;
+    return _source.substring(i, j);
+  }
+
+  /** Get the next char, skipping whitespace and comments (slash-slash, slash-star, and hash). */
+  private char nextClean() throws LenientJsonException {
+    for (; ; ) {
+      char c = next();
+      if (c == '/') {
+        switch (next()) {
+          case '/':
+            do {
+              c = next();
+            } while (c != '\n' && c != '\r' && c != 0);
+            break;
+          case '*':
+            for (; ; ) {
+              c = next();
+              if (c == 0) {
+                throw error("Unclosed comment.");
+              }
+              if (c == '*') {
+                if (next() == '/') {
+                  break;
+                }
+              }
+            }
+            break;
+          default:
+            if (!more()) {
+              throw error("The JSON text is malformed");
+            }
+            back();
+            return '/';
+        }
+      } else if (c == '#') {
+        do {
+          c = next();
+        } while (c != '\n' && c != '\r' && c != 0);
+      } else if (c == 0 || c > ' ') {
+        return c;
+      }
+    }
+  }
+
+  /** Return the characters up to the next close quote character, with backslash processing. */
+  private String nextString(char quote) throws LenientJsonException {
+    char c;
+    StringBuilder sb = new StringBuilder();
+    for (; ; ) {
+      c = next();
+      switch (c) {
+        case 0:
+        case '\n':
+        case '\r':
+          throw error("Unterminated string");
+        case '\\':
+          c = next();
+          switch (c) {
+            case 'b':
+              sb.append('\b');
+              break;
+            case 't':
+              sb.append('\t');
+              break;
+            case 'n':
+              sb.append('\n');
+              break;
+            case 'f':
+              sb.append('\f');
+              break;
+            case 'r':
+              sb.append('\r');
+              break;
+            case 'u':
+              try {
+                sb.append((char) Integer.parseInt(next(4), 16));
+              } catch (NumberFormatException e) {
+                throw error("Illegal escape.");
+              }
+              break;
+            default:
+              sb.append(c);
+          }
+          break;
+        default:
+          if (c == quote) {
+            return sb.toString();
+          }
+          sb.append(c);
+      }
+    }
+  }
+
+  /** Get the next value: an object, array, string, boolean, null, number, or bare string. */
+  private JsonNode nextValue() throws LenientJsonException {
+    char c = nextClean();
+    switch (c) {
+      case '"':
+      case '\'':
+        return NF.textNode(nextString(c));
+      case '{':
+        back();
+        return parseObject();
+      case '[':
+        back();
+        return parseArray();
+      default:
+        break;
+    }
+
+    // Handle unquoted text: true/false/null, a number, or a bare string. Accumulate characters
+    // until we reach the end of the text or a formatting character.
+    StringBuilder sb = new StringBuilder();
+    char b = c;
+    while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
+      sb.append(c);
+      c = next();
+    }
+    back();
+
+    String s = sb.toString().trim();
+    if (s.isEmpty()) {
+      throw error("Missing value.");
+    }
+    return toValueNode(s, b);
+  }
+
+  /** Convert an unquoted token to the appropriate {@link JsonNode}, mirroring Jettison. */
+  private static JsonNode toValueNode(String s, char firstChar) {
+    if (s.equalsIgnoreCase("true")) {
+      return NF.booleanNode(true);
+    }
+    if (s.equalsIgnoreCase("false")) {
+      return NF.booleanNode(false);
+    }
+    if (s.equalsIgnoreCase("null")) {
+      return NF.nullNode();
+    }
+
+    // If it might be a number, try converting it. We support the 0- (octal) and 0x- (hex)
+    // conventions, matching Jettison. If a number cannot be produced, the value is a string.
+    if ((firstChar >= '0' && firstChar <= '9')
+        || firstChar == '.'
+        || firstChar == '-'
+        || firstChar == '+') {
+      if (firstChar == '0') {
+        if (s.length() > 2 && (s.charAt(1) == 'x' || s.charAt(1) == 'X')) {
+          try {
+            return NF.numberNode(Integer.parseInt(s.substring(2), 16));
+          } catch (NumberFormatException e) {
+            // fall through
+          }
+        } else {
+          try {
+            return NF.numberNode(Integer.parseInt(s, 8));
+          } catch (NumberFormatException e) {
+            // fall through
+          }
+        }
+      }
+      try {
+        return NF.numberNode(Integer.parseInt(s));
+      } catch (NumberFormatException e) {
+        try {
+          return NF.numberNode(Long.parseLong(s));
+        } catch (NumberFormatException f) {
+          try {
+            return NF.numberNode(new BigDecimal(s));
+          } catch (NumberFormatException g) {
+            return NF.textNode(s);
+          }
+        }
+      }
+    }
+    return NF.textNode(s);
+  }
+
+  /**
+   * Parse a lenient object, tolerating {@code =}/{@code =>} and {@code :}, and {@code ;}/{@code ,}.
+   */
+  private ObjectNode parseObject() throws LenientJsonException {
+    ObjectNode object = NF.objectNode();
+    char c;
+    String key;
+
+    if (nextClean() != '{') {
+      throw error("A JSONObject text must begin with '{'");
+    }
+    for (; ; ) {
+      c = nextClean();
+      switch (c) {
+        case 0:
+          throw error("A JSONObject text must end with '}'");
+        case '}':
+          return object;
+        case '{':
+        case '[':
+          throw error("Expected a key");
+        default:
+          back();
+          key = nextValueAsKey();
+      }
+
+      // The key is followed by ':'. We also tolerate '=' or '=>'.
+      c = nextClean();
+      if (c == '=') {
+        if (next() != '>') {
+          back();
+        }
+      } else if (c != ':') {
+        throw error("Expected a ':' after a key");
+      }
+      object.set(key, nextValue());
+
+      // Pairs are separated by ','. We also tolerate ';'.
+      switch (nextClean()) {
+        case ';':
+        case ',':
+          if (nextClean() == '}') {
+            return object;
+          }
+          back();
+          break;
+        case '}':
+          return object;
+        default:
+          throw error("Expected a ',' or '}'");
+      }
+    }
+  }
+
+  /**
+   * Reads the next value as an object key. Jettison stringifies whatever {@code nextValue} returns;
+   * for a key that is a bare token or quoted string that is the token's text.
+   */
+  private String nextValueAsKey() throws LenientJsonException {
+    JsonNode node = nextValue();
+    return node.isValueNode() ? node.asText() : node.toString();
+  }
+
+  /** Parse a lenient array, tolerating {@code ;}/{@code ,} separators and holes. */
+  private ArrayNode parseArray() throws LenientJsonException {
+    ArrayNode array = NF.arrayNode();
+    if (nextClean() != '[') {
+      throw error("A JSONArray text must start with '['");
+    }
+    char c = nextClean();
+    if (c == 0) {
+      throw error("JSONArray text must end with ']'");
+    } else if (c == ',') {
+      throw error("JSONArray text has a trailing ','");
+    }
+    if (c == ']') {
+      return array;
+    }
+    back();
+    for (; ; ) {
+      if (nextClean() == ',') {
+        back();
+        array.add(NF.nullNode());
+      } else {
+        back();
+        array.add(nextValue());
+      }
+      switch (nextClean()) {
+        case ';':
+        case ',':
+          char nextClean = nextClean();
+          if (nextClean == 0) {
+            throw error("JSONArray text has a trailing ','");
+          } else if (nextClean == ']') {
+            return array;
+          }
+          back();
+          break;
+        case ']':
+          return array;
+        default:
+          throw error("Expected a ',' or ']'");
+      }
+    }
+  }
+
+  private LenientJsonException error(String message) {
+    return new LenientJsonException(message + " at character " + _index + " of " + _source);
+  }
+}

--- a/projects/client/src/main/java/org/batfish/client/QuestionHelper.java
+++ b/projects/client/src/main/java/org/batfish/client/QuestionHelper.java
@@ -2,6 +2,7 @@ package org.batfish.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Map;
@@ -13,8 +14,6 @@ import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.InstanceData;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.questions.Variable;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 
 public class QuestionHelper {
 
@@ -26,14 +25,14 @@ public class QuestionHelper {
    * @param questionJson The question template to modify
    * @param parameters The parameters and values to fill
    * @param questionName The name to embed in the template
-   * @return A JSONObject representation of the filled out template
+   * @return An {@link ObjectNode} representation of the filled out template
    */
-  public static JSONObject fillTemplate(
-      JSONObject questionJson, Map<String, JsonNode> parameters, String questionName)
-      throws JSONException, IOException {
-    JSONObject clonedQuestionJson = new JSONObject(questionJson.toString()); // deep copy
+  public static ObjectNode fillTemplate(
+      ObjectNode questionJson, Map<String, JsonNode> parameters, String questionName)
+      throws IOException {
+    ObjectNode clonedQuestionJson = questionJson.deepCopy();
 
-    JSONObject instanceJson = clonedQuestionJson.getJSONObject(BfConsts.PROP_INSTANCE);
+    ObjectNode instanceJson = (ObjectNode) clonedQuestionJson.get(BfConsts.PROP_INSTANCE);
     instanceJson.put(BfConsts.PROP_INSTANCE_NAME, questionName);
     String instanceDataStr = instanceJson.toString();
     InstanceData instanceData =
@@ -44,9 +43,9 @@ public class QuestionHelper {
     Client.validateAndSet(parameters, variables);
     Client.checkVariableState(variables);
 
-    JSONObject modifiedInstanceData =
-        new JSONObject(BatfishObjectMapper.writePrettyString(instanceData));
-    clonedQuestionJson.put(BfConsts.PROP_INSTANCE, modifiedInstanceData);
+    JsonNode modifiedInstanceData =
+        BatfishObjectMapper.mapper().readTree(BatfishObjectMapper.writePrettyString(instanceData));
+    clonedQuestionJson.set(BfConsts.PROP_INSTANCE, modifiedInstanceData);
 
     return clonedQuestionJson;
   }
@@ -74,20 +73,19 @@ public class QuestionHelper {
   /**
    * Validates templates. It first checks if all the variables in template are being exercised by
    * validation (see reason below), and all variable in the templates are used somplace. Then, it
-   * checks if the output of {@link #fillTemplate(JSONObject, Map, String)} can be parsed into a
+   * checks if the output of {@link #fillTemplate(ObjectNode, Map, String)} can be parsed into a
    * valid Question.
    *
-   * @param questionJson The {@link JSONObject} that represents the question
+   * @param questionJson The {@link ObjectNode} that represents the question
    * @param parsedParameters The map of parameter name to value
    * @return The {@link Question} after parameter filling
-   * @throws JSONException If instance data cannot be read from the template or {@link
-   *     #fillTemplate(JSONObject, Map, String)} throws an exception
-   * @throws IOException If {@link #fillTemplate(JSONObject, Map, String)} throws an exception
+   * @throws IOException If instance data cannot be read from the template or {@link
+   *     #fillTemplate(ObjectNode, Map, String)} throws an exception
    */
-  static Question validateTemplate(JSONObject questionJson, Map<String, JsonNode> parsedParameters)
-      throws JSONException, IOException {
+  static Question validateTemplate(ObjectNode questionJson, Map<String, JsonNode> parsedParameters)
+      throws IOException {
 
-    JSONObject instanceJson = questionJson.getJSONObject(BfConsts.PROP_INSTANCE);
+    ObjectNode instanceJson = (ObjectNode) questionJson.get(BfConsts.PROP_INSTANCE);
     InstanceData instanceData =
         BatfishObjectMapper.mapper()
             .readValue(instanceJson.toString(), new TypeReference<InstanceData>() {});

--- a/projects/client/src/test/java/BUILD.bazel
+++ b/projects/client/src/test/java/BUILD.bazel
@@ -40,7 +40,6 @@ junit_tests(
         "@maven//:io_github_java_diff_utils_java_diff_utils",
         "@maven//:junit_junit",
         "@maven//:org_apache_commons_commons_lang3",
-        "@maven//:org_codehaus_jettison_jettison",
         "@maven//:org_hamcrest_hamcrest",
     ],
 )

--- a/projects/client/src/test/java/org/batfish/client/ClientTest.java
+++ b/projects/client/src/test/java/org/batfish/client/ClientTest.java
@@ -74,6 +74,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -100,8 +102,6 @@ import org.batfish.datamodel.answers.Answer;
 import org.batfish.datamodel.questions.AllowedValue;
 import org.batfish.datamodel.questions.Variable;
 import org.batfish.datamodel.questions.Variable.Type;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -228,11 +228,12 @@ public final class ClientTest {
   }
 
   @Test
-  public void testGetQuestionName() throws JSONException {
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+  public void testGetQuestionName() {
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", "testQuestionName")
             .put("description", "test question description"));
 
@@ -241,9 +242,11 @@ public final class ClientTest {
   }
 
   @Test
-  public void testGetQuestionNameInvalid1() throws JSONException {
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put("instance", new JSONObject().put("description", "test question description"));
+  public void testGetQuestionNameInvalid1() {
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
+        "instance",
+        JsonNodeFactory.instance.objectNode().put("description", "test question description"));
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage("question testquestion does not have instanceName field in instance");
 
@@ -253,7 +256,7 @@ public final class ClientTest {
 
   @Test
   public void testGetQuestionNameInvalid2() {
-    JSONObject testQuestion = new JSONObject();
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage("question testquestion does not have instance field");
 
@@ -742,69 +745,75 @@ public final class ClientTest {
 
   @Test
   public void testLoadQuestionFromFile() throws Exception {
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", "testQuestionName")
             .put("description", "test question description"));
     Path questionJsonPath = _folder.newFile("testquestion.json").toPath();
     CommonUtil.writeFile(questionJsonPath, testQuestion.toString());
-    JSONObject question = Client.loadQuestionFromFile(questionJsonPath);
+    ObjectNode question = Client.loadQuestionFromFile(questionJsonPath);
 
     // checking if actual and loaded JSONs are same
     assertEquals(
         "testQuestionName",
-        question.getJSONObject(BfConsts.PROP_INSTANCE).getString(BfConsts.PROP_INSTANCE_NAME));
+        question.get(BfConsts.PROP_INSTANCE).get(BfConsts.PROP_INSTANCE_NAME).asText());
     assertEquals(
         "test question description",
-        question.getJSONObject(BfConsts.PROP_INSTANCE).getString(BfConsts.PROP_DESCRIPTION));
+        question.get(BfConsts.PROP_INSTANCE).get(BfConsts.PROP_DESCRIPTION).asText());
   }
 
   @Test
   public void testLoadQuestionFromText() throws Exception {
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", "testQuestionName")
             .put("description", "test question description")
-            .put(
+            .set(
                 "variables",
-                new JSONObject()
-                    .put(
+                JsonNodeFactory.instance
+                    .objectNode()
+                    .set(
                         "var1",
-                        new JSONObject()
+                        JsonNodeFactory.instance
+                            .objectNode()
                             .put("description", "test var1 description")
                             .put("longDescription", "test var1 long description"))));
-    JSONObject question = Client.loadQuestionFromText(testQuestion.toString(), "testquestion");
+    ObjectNode question = Client.loadQuestionFromText(testQuestion.toString(), "testquestion");
 
     // checking if actual and loaded JSONs are same
     assertEquals(
         "testQuestionName",
-        question.getJSONObject(BfConsts.PROP_INSTANCE).getString(BfConsts.PROP_INSTANCE_NAME));
+        question.get(BfConsts.PROP_INSTANCE).get(BfConsts.PROP_INSTANCE_NAME).asText());
     assertEquals(
         "test question description",
-        question.getJSONObject(BfConsts.PROP_INSTANCE).getString(BfConsts.PROP_DESCRIPTION));
+        question.get(BfConsts.PROP_INSTANCE).get(BfConsts.PROP_DESCRIPTION).asText());
     assertEquals(
         "test var1 description",
         question
-            .getJSONObject(BfConsts.PROP_INSTANCE)
-            .getJSONObject(BfConsts.PROP_VARIABLES)
-            .getJSONObject("var1")
-            .getString(BfConsts.PROP_DESCRIPTION));
+            .get(BfConsts.PROP_INSTANCE)
+            .get(BfConsts.PROP_VARIABLES)
+            .get("var1")
+            .get(BfConsts.PROP_DESCRIPTION)
+            .asText());
     assertEquals(
         "test var1 long description",
         question
-            .getJSONObject(BfConsts.PROP_INSTANCE)
-            .getJSONObject(BfConsts.PROP_VARIABLES)
-            .getJSONObject("var1")
-            .getString(BfConsts.PROP_LONG_DESCRIPTION));
+            .get(BfConsts.PROP_INSTANCE)
+            .get(BfConsts.PROP_VARIABLES)
+            .get("var1")
+            .get(BfConsts.PROP_LONG_DESCRIPTION)
+            .asText());
   }
 
   @Test
   public void testLoadQuestionFromTextInvalid() {
-    JSONObject testQuestion = new JSONObject();
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
 
     // checking if exception thrown for instance missing
     _thrown.expect(BatfishException.class);
@@ -816,10 +825,11 @@ public final class ClientTest {
   public void testLoadQuestionsNames() throws Exception {
     Path dummyCmdFile = _folder.newFile("dummy.cmd").toPath();
     Client client = new Client(new String[] {"-cmdfile", dummyCmdFile.toString()});
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", "testQuestionName")
             .put("description", "test question description"));
     Path questionJsonPath = _folder.newFile("testquestion.json").toPath();
@@ -841,10 +851,11 @@ public final class ClientTest {
 
   @Test
   public void testLoadQuestionsFromDir() throws Exception {
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", "testQuestionName")
             .put("description", "test question description"));
     Path questionJsonPath = _folder.newFile("testquestion.json").toPath();

--- a/projects/client/src/test/java/org/batfish/client/LenientJsonParserTest.java
+++ b/projects/client/src/test/java/org/batfish/client/LenientJsonParserTest.java
@@ -1,0 +1,116 @@
+package org.batfish.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.batfish.client.LenientJsonParser.LenientJsonException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of {@link LenientJsonParser}. */
+@RunWith(JUnit4.class)
+public class LenientJsonParserTest {
+
+  private static JsonNode parse(String text) throws LenientJsonException {
+    return LenientJsonParser.parse(text);
+  }
+
+  @Test
+  public void testUnquotedKey() throws Exception {
+    JsonNode node = parse("{ nodes: \"as2.*\" }");
+    assertThat(node.get("nodes").textValue(), equalTo("as2.*"));
+  }
+
+  @Test
+  public void testEqualsSeparator() throws Exception {
+    // The CLI historically passed params as {key=value}, relying on '=' as a separator.
+    JsonNode node = parse("{ verbose=True }");
+    assertTrue(node.get("verbose").isBoolean());
+    assertThat(node.get("verbose").booleanValue(), equalTo(true));
+  }
+
+  @Test
+  public void testFatArrowSeparator() throws Exception {
+    JsonNode node = parse("{ k => 3 }");
+    assertThat(node.get("k").intValue(), equalTo(3));
+  }
+
+  @Test
+  public void testSemicolonPairSeparator() throws Exception {
+    JsonNode node = parse("{ a: 1; b: 2 }");
+    assertThat(node.get("a").intValue(), equalTo(1));
+    assertThat(node.get("b").intValue(), equalTo(2));
+  }
+
+  @Test
+  public void testCaseInsensitiveLiterals() throws Exception {
+    JsonNode node = parse("{ t: TRUE, f: False, n: NULL }");
+    assertThat(node.get("t").booleanValue(), equalTo(true));
+    assertThat(node.get("f").booleanValue(), equalTo(false));
+    assertTrue(node.get("n").isNull());
+  }
+
+  @Test
+  public void testNestedObjectAndArray() throws Exception {
+    JsonNode node = parse("{ headers={\"dstIps\": \"1.1.1.1\"}, nodes=\"host.*\" }");
+    assertThat(node.get("headers").get("dstIps").textValue(), equalTo("1.1.1.1"));
+    assertThat(node.get("nodes").textValue(), equalTo("host.*"));
+  }
+
+  @Test
+  public void testArrayValue() throws Exception {
+    JsonNode node = parse("{ xs: [1, 2, 3] }");
+    assertThat(node.get("xs").size(), equalTo(3));
+    assertThat(node.get("xs").get(2).intValue(), equalTo(3));
+  }
+
+  @Test
+  public void testSingleQuotedString() throws Exception {
+    JsonNode node = parse("{ 'a': 'b' }");
+    assertThat(node.get("a").textValue(), equalTo("b"));
+  }
+
+  @Test
+  public void testNumberTypes() throws Exception {
+    JsonNode node = parse("{ i: 5, l: 5000000000, d: 1.5 }");
+    assertThat(node.get("i").intValue(), equalTo(5));
+    assertThat(node.get("l").longValue(), equalTo(5000000000L));
+    assertThat(node.get("d").doubleValue(), equalTo(1.5));
+  }
+
+  @Test
+  public void testBareUnquotedStringValue() throws Exception {
+    JsonNode node = parse("{ a: passive }");
+    assertThat(node.get("a").textValue(), equalTo("passive"));
+  }
+
+  @Test
+  public void testTrailingComma() throws Exception {
+    JsonNode node = parse("{ a: 1, }");
+    assertThat(node.get("a").intValue(), equalTo(1));
+    assertThat(node.size(), equalTo(1));
+  }
+
+  @Test
+  public void testEmptyObject() throws Exception {
+    JsonNode node = parse("{ }");
+    assertThat(node.size(), equalTo(0));
+    assertTrue(node.isObject());
+  }
+
+  @Test
+  public void testInvalidMissingSeparator() {
+    LenientJsonException e = assertThrows(LenientJsonException.class, () -> parse("{ a 1 }"));
+    assertThat(e, instanceOf(LenientJsonException.class));
+  }
+
+  @Test
+  public void testInvalidMissingValue() {
+    assertThrows(LenientJsonException.class, () -> parse("{ a: }"));
+  }
+}

--- a/projects/client/src/test/java/org/batfish/client/QuestionHelperTest.java
+++ b/projects/client/src/test/java/org/batfish/client/QuestionHelperTest.java
@@ -6,12 +6,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableSortedMap;
 import java.io.IOException;
 import org.batfish.common.BatfishException;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.Question;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -21,10 +21,12 @@ public class QuestionHelperTest {
   @Rule public ExpectedException _thrown = ExpectedException.none();
 
   @Test
-  public void fillTemplate() throws JSONException, IOException {
-    JSONObject template =
-        new JSONObject(readResource("org/batfish/client/goodTemplate.json", UTF_8));
-    JSONObject filledTempate =
+  public void fillTemplate() throws IOException {
+    ObjectNode template =
+        (ObjectNode)
+            BatfishObjectMapper.mapper()
+                .readTree(readResource("org/batfish/client/goodTemplate.json", UTF_8));
+    ObjectNode filledTempate =
         QuestionHelper.fillTemplate(
             template, ImmutableSortedMap.of("parameter1", new IntNode(2)), "qname");
     QuestionHelperTestQuestion question =
@@ -36,9 +38,11 @@ public class QuestionHelperTest {
   }
 
   @Test
-  public void validateTemplateExtraParameter() throws JSONException, IOException {
-    JSONObject template =
-        new JSONObject(readResource("org/batfish/client/extraParameter.json", UTF_8));
+  public void validateTemplateExtraParameter() throws IOException {
+    ObjectNode template =
+        (ObjectNode)
+            BatfishObjectMapper.mapper()
+                .readTree(readResource("org/batfish/client/extraParameter.json", UTF_8));
 
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage("Unrecognized field");
@@ -49,9 +53,11 @@ public class QuestionHelperTest {
   }
 
   @Test
-  public void validateTemplateExtraVariable() throws JSONException, IOException {
-    JSONObject template =
-        new JSONObject(readResource("org/batfish/client/extraVariable.json", UTF_8));
+  public void validateTemplateExtraVariable() throws IOException {
+    ObjectNode template =
+        (ObjectNode)
+            BatfishObjectMapper.mapper()
+                .readTree(readResource("org/batfish/client/extraVariable.json", UTF_8));
 
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage("Unused variable");
@@ -62,9 +68,11 @@ public class QuestionHelperTest {
   }
 
   @Test
-  public void validateTemplateSuccess() throws JSONException, IOException {
-    JSONObject template =
-        new JSONObject(readResource("org/batfish/client/goodTemplate.json", UTF_8));
+  public void validateTemplateSuccess() throws IOException {
+    ObjectNode template =
+        (ObjectNode)
+            BatfishObjectMapper.mapper()
+                .readTree(readResource("org/batfish/client/goodTemplate.json", UTF_8));
 
     QuestionHelperTestQuestion question =
         (QuestionHelperTestQuestion)
@@ -77,9 +85,11 @@ public class QuestionHelperTest {
   }
 
   @Test
-  public void validateTemplateUnexercisedVariable() throws JSONException, IOException {
-    JSONObject template =
-        new JSONObject(readResource("org/batfish/client/goodTemplate.json", UTF_8));
+  public void validateTemplateUnexercisedVariable() throws IOException {
+    ObjectNode template =
+        (ObjectNode)
+            BatfishObjectMapper.mapper()
+                .readTree(readResource("org/batfish/client/goodTemplate.json", UTF_8));
 
     _thrown.expect(BatfishException.class);
     _thrown.expectMessage("Template validation should exercise all variables");

--- a/projects/common/src/main/java/BUILD.bazel
+++ b/projects/common/src/main/java/BUILD.bazel
@@ -182,7 +182,6 @@ java_library(
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_apache_commons_commons_text",
         "@maven//:org_apache_logging_log4j_log4j_api",
-        "@maven//:org_codehaus_jettison_jettison",
         "@maven//:org_glassfish_grizzly_grizzly_framework",
         "@maven//:org_glassfish_grizzly_grizzly_http_server",
         "@maven//:org_glassfish_jersey_containers_jersey_container_grizzly2_http",

--- a/projects/common/src/main/java/org/batfish/datamodel/questions/Question.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/questions/Question.java
@@ -7,18 +7,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.re2j.Pattern;
 import java.io.IOException;
-import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BfConsts;
 import org.batfish.common.util.BatfishObjectMapper;
-import org.codehaus.jettison.json.JSONArray;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public abstract class Question implements IQuestion {
@@ -116,9 +115,14 @@ public abstract class Question implements IQuestion {
 
   private static String preprocessQuestion(String rawQuestionText) {
     try {
-      JSONObject jobj = new JSONObject(rawQuestionText);
-      if (jobj.has(BfConsts.PROP_INSTANCE) && !jobj.isNull(BfConsts.PROP_INSTANCE)) {
-        String instanceDataStr = jobj.getString(BfConsts.PROP_INSTANCE);
+      JsonNode parsed = BatfishObjectMapper.mapper().readTree(rawQuestionText);
+      if (!(parsed instanceof ObjectNode)) {
+        throw new BatfishException(
+            String.format("Question text [%s] is not a JSON object", rawQuestionText));
+      }
+      ObjectNode jobj = (ObjectNode) parsed;
+      if (jobj.hasNonNull(BfConsts.PROP_INSTANCE)) {
+        String instanceDataStr = jobj.get(BfConsts.PROP_INSTANCE).toString();
         InstanceData instanceData =
             BatfishObjectMapper.mapper()
                 .readValue(instanceDataStr, new TypeReference<InstanceData>() {});
@@ -139,15 +143,17 @@ public abstract class Question implements IQuestion {
               if (!value.isArray()) {
                 throw new IllegalArgumentException("Expecting JSON array for array type");
               }
-              JSONArray arr = new JSONArray();
+              ArrayNode arr = jobj.arrayNode();
               for (int i = 0; i < value.size(); i++) {
                 String valueJsonString = new ObjectMapper().writeValueAsString(value.get(i));
-                arr.put(i, new JSONObject(preprocessQuestion(valueJsonString)));
+                arr.add(BatfishObjectMapper.mapper().readTree(preprocessQuestion(valueJsonString)));
               }
-              jobj.put(varName, arr);
+              jobj.set(varName, arr);
             } else {
               String valueJsonString = new ObjectMapper().writeValueAsString(value);
-              jobj.put(varName, new JSONObject(preprocessQuestion(valueJsonString)));
+              jobj.set(
+                  varName,
+                  BatfishObjectMapper.mapper().readTree(preprocessQuestion(valueJsonString)));
             }
           }
         }
@@ -167,7 +173,9 @@ public abstract class Question implements IQuestion {
             if (stringType && !setType) {
               inlineReplacement = valueJsonString.substring(1, valueJsonString.length() - 1);
             } else {
-              String quotedValueJsonString = JSONObject.quote(valueJsonString);
+              // Escape the JSON text so it can be embedded inline as a JSON string, then strip the
+              // surrounding quotes that Jackson adds.
+              String quotedValueJsonString = new ObjectMapper().writeValueAsString(valueJsonString);
               inlineReplacement =
                   quotedValueJsonString.substring(1, quotedValueJsonString.length() - 1);
             }
@@ -180,7 +188,7 @@ public abstract class Question implements IQuestion {
         return questionText;
       }
       return rawQuestionText;
-    } catch (JSONException | IOException e) {
+    } catch (IOException e) {
       throw new BatfishException(
           String.format("Could not convert raw question text [%s] to JSON", rawQuestionText), e);
     }
@@ -191,23 +199,23 @@ public abstract class Question implements IQuestion {
    * Is this fragile? To be doubly sure, we do this only for keys with a sibling key "class" that is
    * a Question class
    */
-  private static void recursivelyRemoveOptionalVar(JSONObject questionObject, String varName)
-      throws JSONException {
-    Iterator<?> iter = questionObject.keys();
-    while (iter.hasNext()) {
-      String key = (String) iter.next();
-      Object value = questionObject.get(key);
-      if (value instanceof String) {
-        if (value.equals("${" + varName + "}")) {
-          iter.remove();
+  private static void recursivelyRemoveOptionalVar(ObjectNode questionObject, String varName) {
+    // Collect keys first to avoid mutating the node while iterating over its field names.
+    List<String> keys = new ArrayList<>();
+    questionObject.fieldNames().forEachRemaining(keys::add);
+    for (String key : keys) {
+      JsonNode value = questionObject.get(key);
+      if (value.isTextual()) {
+        if (value.textValue().equals("${" + varName + "}")) {
+          questionObject.remove(key);
         }
-      } else if (value instanceof JSONObject) {
-        JSONObject childObject = (JSONObject) value;
-        if (childObject.has("class")) {
-          Object classValue = childObject.get("class");
-          if (classValue instanceof String && isQuestionClass((String) classValue)) {
-            recursivelyRemoveOptionalVar(childObject, varName);
-          }
+      } else if (value instanceof ObjectNode) {
+        ObjectNode childObject = (ObjectNode) value;
+        JsonNode classValue = childObject.get("class");
+        if (classValue != null
+            && classValue.isTextual()
+            && isQuestionClass(classValue.textValue())) {
+          recursivelyRemoveOptionalVar(childObject, varName);
         }
       }
     }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/BUILD.bazel
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/BUILD.bazel
@@ -26,7 +26,6 @@ java_library(
         "@maven//:jakarta_annotation_jakarta_annotation_api",
         "@maven//:jakarta_ws_rs_jakarta_ws_rs_api",
         "@maven//:org_apache_logging_log4j_log4j_api",
-        "@maven//:org_codehaus_jettison_jettison",
         "@maven//:org_glassfish_grizzly_grizzly_http_server",
         "@maven//:org_glassfish_jersey_containers_jersey_container_grizzly2_http",
         "@maven//:org_glassfish_jersey_core_jersey_common",

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -3,6 +3,8 @@ package org.batfish.coordinator;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -36,8 +38,6 @@ import org.batfish.coordinator.config.Settings;
 import org.batfish.coordinator.id.StorageBasedIdManager;
 import org.batfish.datamodel.questions.InstanceData;
 import org.batfish.storage.FileBasedStorage;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -96,12 +96,15 @@ public class Main {
   }
 
   @VisibleForTesting
-  static String readQuestionTemplate(Path file, Map<String, String> templates)
-      throws JSONException, IOException {
+  static String readQuestionTemplate(Path file, Map<String, String> templates) throws IOException {
     String questionText = CommonUtil.readFile(file);
-    JSONObject questionObj = new JSONObject(questionText);
-    if (questionObj.has(BfConsts.PROP_INSTANCE) && !questionObj.isNull(BfConsts.PROP_INSTANCE)) {
-      JSONObject instanceDataObj = questionObj.getJSONObject(BfConsts.PROP_INSTANCE);
+    JsonNode parsed = BatfishObjectMapper.mapper().readTree(questionText);
+    if (!(parsed instanceof ObjectNode)) {
+      throw new BatfishException(String.format("Question in file:%s has no instance name", file));
+    }
+    ObjectNode questionObj = (ObjectNode) parsed;
+    if (questionObj.hasNonNull(BfConsts.PROP_INSTANCE)) {
+      JsonNode instanceDataObj = questionObj.get(BfConsts.PROP_INSTANCE);
       String instanceDataStr = instanceDataObj.toString();
       InstanceData instanceData =
           BatfishObjectMapper.mapper().readValue(instanceDataStr, InstanceData.class);

--- a/projects/coordinator/src/test/java/BUILD.bazel
+++ b/projects/coordinator/src/test/java/BUILD.bazel
@@ -56,7 +56,6 @@ junit_tests(
         "@maven//:commons_io_commons_io",
         "@maven//:jakarta_ws_rs_jakarta_ws_rs_api",
         "@maven//:junit_junit",
-        "@maven//:org_codehaus_jettison_jettison",
         "@maven//:org_glassfish_jersey_core_jersey_client",
         "@maven//:org_glassfish_jersey_core_jersey_server",
         "@maven//:org_glassfish_jersey_test_framework_jersey_test_framework_core",

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/MainTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/MainTest.java
@@ -9,6 +9,8 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import java.io.File;
@@ -17,7 +19,6 @@ import java.nio.file.Paths;
 import java.util.Map;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.util.CommonUtil;
-import org.codehaus.jettison.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -39,10 +40,11 @@ public class MainTest {
     // already existing question template with key duplicate_template
     questionTemplates.put(DUPLICATE_TEMPLATE_NAME, "template_body");
 
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", DUPLICATE_TEMPLATE_NAME)
             .put("description", "test question description"));
     Path questionJsonPath = _folder.newFile("testquestion.json").toPath();
@@ -65,10 +67,11 @@ public class MainTest {
     Map<String, String> questionTemplates = Maps.newHashMap();
     questionTemplates.put(DUPLICATE_TEMPLATE_NAME, "template_body");
 
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", DUPLICATE_TEMPLATE_NAME.toUpperCase())
             .put("description", "test question description"));
     Path questionJsonPath = _folder.newFile("testquestion.json").toPath();
@@ -92,10 +95,11 @@ public class MainTest {
     Map<String, String> questionTemplates = Maps.newHashMap();
     questionTemplates.put(DUPLICATE_TEMPLATE_NAME, "template_body");
 
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", NEW_TEMPLATE_NAME)
             .put("description", "test question description"));
     Path questionJsonPath = _folder.newFile("testquestion.json").toPath();
@@ -117,19 +121,21 @@ public class MainTest {
 
   @Test
   public void testReadQuestionTemplatesRecursive() throws Exception {
-    JSONObject testQuestion1 = new JSONObject();
-    testQuestion1.put(
+    ObjectNode testQuestion1 = JsonNodeFactory.instance.objectNode();
+    testQuestion1.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", "testQuestion1")
             .put("description", "test question one description"));
     Path question1JsonPath = _folder.newFile("testquestion1.json").toPath();
     CommonUtil.writeFile(question1JsonPath, testQuestion1.toString());
 
-    JSONObject testQuestion2 = new JSONObject();
-    testQuestion2.put(
+    ObjectNode testQuestion2 = JsonNodeFactory.instance.objectNode();
+    testQuestion2.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", "testQuestion2")
             .put("description", "test question two description"));
     File nestedFolder = _folder.newFolder("nestedFolder");
@@ -156,10 +162,11 @@ public class MainTest {
 
   @Test
   public void testEmptyQuestionTemplateDir() throws Exception {
-    JSONObject testQuestion = new JSONObject();
-    testQuestion.put(
+    ObjectNode testQuestion = JsonNodeFactory.instance.objectNode();
+    testQuestion.set(
         "instance",
-        new JSONObject()
+        JsonNodeFactory.instance
+            .objectNode()
             .put("instanceName", "testQuestion")
             .put("description", "test question description"));
     Path questionJsonPath = _folder.newFile("testquestion.json").toPath();


### PR DESCRIPTION
Jettison was used only for its lenient, org.json-style mutable tree API in
two places: question-template preprocessing and CLI parameter parsing.

Question preprocessing (Question.java), QuestionHelper, Client,
coordinator Main, and CoordinatorClient now build and traverse Jackson
JsonNode/ObjectNode trees via BatfishObjectMapper. These paths always saw
strict JSON, so the mapping is direct.

The CLI parameter path is the exception: it historically accepted
Jettison's relaxed grammar (=/=> and : key separators, ;/, pair
separators, unquoted keys, single-quoted and bare values,
case-insensitive true/false/null, octal/hex numbers, trailing commas,
and comments). To preserve that behavior without Jettison, add
LenientJsonParser, a focused port of Jettison's
JSONTokener/JSONObject/JSONArray grammar that emits Jackson nodes.
Client.parseParams is its only caller. LenientJsonParserTest covers the
non-standard forms; existing unit and reference tests cover the strict
paths.

Removes org.codehaus.jettison:jettison from MODULE.bazel and the six
BUILD.bazel deps, and re-pins.

----

Prompt:
```
Remind me why we use Jettison in this project? Can we replace it with
something else, like Jackson?
```

Follow-up: after confirming Jettison was used only for its lenient tree
API, the instruction was to do the full migration to Jackson and drop the
dependency. For the CLI parameter path, which relied on Jettison's
lenient parser, the chosen approach was to add a small lenient normalizer
that accepts the historical CLI grammar and emits strict Jackson nodes,
covered by reference tests plus new unit tests.
