### PR TITLE
feat(cisco): parse NXOS ip domain-lookup and DNS source-interface

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosLexer.g4
@@ -578,7 +578,16 @@ DISTRIBUTE_LIST: 'distribute-list';
 
 DNS
 :
-  'dns' -> pushMode(M_Words)
+  'dns'
+  {
+    // In "[no] ip dns ..." the preceding token is IP, and we want the remainder of the line to be
+    // tokenized normally (e.g. source-interface, interface names, vrf). Everywhere else (notably
+    // the "dns <hostname>" line inside an "ip sla" block), push M_Words so arbitrary text such as
+    // hostnames is consumed as words.
+    if (lastTokenType() != IP) {
+      pushMode(M_Words);
+    }
+  }
 ;
 
 DNSIX: 'dnsix';

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosParser.g4
@@ -216,8 +216,9 @@ s_ip
     | ip_as_path_access_list
     | ip_community_list
     | ip_dhcp
+    | ip_dns
     | ip_domain_list_null
-    | ip_domain_lookup_null
+    | ip_domain_lookup
     | ip_domain_name
     | ip_name_server
     | ip_pim
@@ -241,13 +242,27 @@ domain_name
 
 ip_name_server
 :
-  NAME_SERVER servers += name_server+ (USE_VRF vrf = vrf_name)? NEWLINE
+  NAME_SERVER servers += name_server+
+  (
+    SOURCE_INTERFACE source_interface = interface_name
+    | USE_VRF vrf = vrf_name
+  )* NEWLINE
 ;
 
 name_server
 :
   ip_address
   | ipv6_address
+;
+
+ip_dns
+:
+  DNS ip_dns_source_interface
+;
+
+ip_dns_source_interface
+:
+  SOURCE_INTERFACE source_interface = interface_name (VRF vrf = vrf_name)? NEWLINE
 ;
 
 ip_arp_null
@@ -258,9 +273,9 @@ ip_domain_list_null
 :
    DOMAIN_LIST null_rest_of_line
 ;
-ip_domain_lookup_null
+ip_domain_lookup
 :
-   DOMAIN_LOOKUP null_rest_of_line
+   DOMAIN_LOOKUP NEWLINE
 ;
 
 ip_pim
@@ -455,7 +470,7 @@ no_ip_adjacency_null
 | no_ip_auto_discard_null
 | no_ip_dns_null
 | no_ip_domain_list_null
-| no_ip_domain_lookup_null
+| no_ip_domain_lookup
 | no_ip_dscp_lop_null
 | no_ip_extcommunity_list_null
 | no_ip_host_null
@@ -502,9 +517,9 @@ no_ip_domain_list_null
 :
    DOMAIN_LIST null_rest_of_line
 ;
-no_ip_domain_lookup_null
+no_ip_domain_lookup
 :
-   DOMAIN_LOOKUP null_rest_of_line
+   DOMAIN_LOOKUP NEWLINE
 ;
 no_ip_dscp_lop_null
 :

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosControlPlaneExtractor.java
@@ -135,6 +135,8 @@ import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsa
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_ACCESS_LIST_LINE_SELF_REFERENCE;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_ACCESS_LIST_SOURCE_ADDRGROUP;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_ACCESS_LIST_SOURCE_PORTGROUP;
+import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_DNS_SOURCE_INTERFACE;
+import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_NAME_SERVER_SOURCE_INTERFACE;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_PIM_RP_ADDRESS_PREFIX_LIST;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_PIM_RP_ADDRESS_ROUTE_MAP;
 import static org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage.IP_PIM_RP_CANDIDATE_INTERFACE;
@@ -448,6 +450,8 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_as_path_access_l
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_as_path_access_list_seqContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_community_list_nameContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_community_list_seqContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_dns_source_interfaceContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_domain_lookupContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_domain_nameContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_name_serverContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Ip_prefixContext;
@@ -487,6 +491,7 @@ import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Monitor_session_des
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Monitor_session_source_interfaceContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Monitor_session_source_vlanContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.Name_serverContext;
+import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.No_ip_domain_lookupContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.No_ip_route_networkContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.No_sysds_shutdownContext;
 import org.batfish.vendor.cisco_nxos.grammar.CiscoNxosParser.No_sysds_switchportContext;
@@ -794,6 +799,7 @@ import org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage;
 import org.batfish.vendor.cisco_nxos.representation.DefaultVrfOspfProcess;
 import org.batfish.vendor.cisco_nxos.representation.DistributeList;
 import org.batfish.vendor.cisco_nxos.representation.DistributeList.DistributeListFilterType;
+import org.batfish.vendor.cisco_nxos.representation.DnsSourceInterface;
 import org.batfish.vendor.cisco_nxos.representation.EigrpMetric;
 import org.batfish.vendor.cisco_nxos.representation.EigrpProcessConfiguration;
 import org.batfish.vendor.cisco_nxos.representation.EigrpVrfConfiguration;
@@ -2206,6 +2212,36 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
+  public void exitIp_domain_lookup(Ip_domain_lookupContext ctx) {
+    _c.setDnsLookupEnabled(true);
+  }
+
+  @Override
+  public void exitNo_ip_domain_lookup(No_ip_domain_lookupContext ctx) {
+    _c.setDnsLookupEnabled(false);
+  }
+
+  @Override
+  public void exitIp_dns_source_interface(Ip_dns_source_interfaceContext ctx) {
+    Optional<String> inameOrError = toString(ctx, ctx.source_interface);
+    if (!inameOrError.isPresent()) {
+      return;
+    }
+    String name = inameOrError.get();
+    String vrf = null;
+    if (ctx.vrf != null) {
+      Optional<String> vrfOrErr = toString(ctx, ctx.vrf);
+      if (!vrfOrErr.isPresent()) {
+        return;
+      }
+      vrf = vrfOrErr.get();
+    }
+    _c.addDnsSourceInterface(new DnsSourceInterface(name, vrf));
+    _c.referenceStructure(
+        INTERFACE, name, IP_DNS_SOURCE_INTERFACE, ctx.source_interface.getStart().getLine());
+  }
+
+  @Override
   public void exitIp_name_server(Ip_name_serverContext ctx) {
     String useVrf = null;
     if (ctx.vrf != null) {
@@ -2215,8 +2251,21 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       }
       useVrf = vrfOrErr.get();
     }
+    String sourceInterface = null;
+    if (ctx.source_interface != null) {
+      Optional<String> inameOrError = toString(ctx, ctx.source_interface);
+      if (!inameOrError.isPresent()) {
+        return;
+      }
+      sourceInterface = inameOrError.get();
+      _c.referenceStructure(
+          INTERFACE,
+          sourceInterface,
+          IP_NAME_SERVER_SOURCE_INTERFACE,
+          ctx.source_interface.getStart().getLine());
+    }
     for (Name_serverContext server : ctx.servers) {
-      _currentVrf.addNameServer(new NameServer(getFullText(server), useVrf));
+      _currentVrf.addNameServer(new NameServer(getFullText(server), useVrf, sourceInterface));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosConfiguration.java
@@ -61,6 +61,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Streams;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -435,6 +436,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   private final @Nonnull Map<String, IpAsPathAccessList> _ipAsPathAccessLists;
   private final @Nonnull Map<String, IpCommunityList> _ipCommunityLists;
   private @Nullable String _ipDomainName;
+  private @Nullable Boolean _dnsLookupEnabled;
+  private final @Nonnull List<DnsSourceInterface> _dnsSourceInterfaces;
   private final @Nonnull Map<String, IpPrefixList> _ipPrefixLists;
   private final @Nonnull Map<String, Ipv6AccessList> _ipv6AccessLists;
   private final @Nonnull Map<String, Ipv6PrefixList> _ipv6PrefixLists;
@@ -470,6 +473,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   public CiscoNxosConfiguration() {
     _bgpGlobalConfiguration = new BgpGlobalConfiguration();
+    _dnsSourceInterfaces = new ArrayList<>();
     _eigrpProcesses = new HashMap<>();
     _interfaces = new HashMap<>();
     _ipAccessLists = new HashMap<>();
@@ -1831,6 +1835,37 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   public @Nullable String getIpDomainName() {
     return _ipDomainName;
+  }
+
+  public @Nullable Boolean getDnsLookupEnabled() {
+    return _dnsLookupEnabled;
+  }
+
+  public void setDnsLookupEnabled(@Nullable Boolean dnsLookupEnabled) {
+    _dnsLookupEnabled = dnsLookupEnabled;
+  }
+
+  public @Nonnull List<DnsSourceInterface> getDnsSourceInterfaces() {
+    return _dnsSourceInterfaces;
+  }
+
+  public void addDnsSourceInterface(DnsSourceInterface dnsSourceInterface) {
+    if (_dnsSourceInterfaces.contains(dnsSourceInterface)) {
+      return;
+    }
+    _dnsSourceInterfaces.add(dnsSourceInterface);
+  }
+
+  public @Nonnull Set<String> getAllDnsSourceInterfaces() {
+    ImmutableSet.Builder<String> interfaces = ImmutableSet.builder();
+    _dnsSourceInterfaces.forEach(
+        dnsSourceInterface -> interfaces.add(dnsSourceInterface.getInterface()));
+    _vrfs.values().stream()
+        .flatMap(vrf -> vrf.getNameServers().stream())
+        .map(NameServer::getSourceInterface)
+        .filter(Objects::nonNull)
+        .forEach(interfaces::add);
+    return interfaces.build();
   }
 
   public @Nonnull Map<String, IpPrefixList> getIpPrefixLists() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/CiscoNxosStructureUsage.java
@@ -88,6 +88,8 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   IP_ACCESS_LIST_SOURCE_ADDRGROUP("ip access-list source addrgroup"),
   IP_ACCESS_LIST_SOURCE_PORTGROUP("ip access-list source portgroup"),
   IP_ACCESS_LIST_LINE_SELF_REFERENCE("ip access-list line"),
+  IP_DNS_SOURCE_INTERFACE("ip dns source-interface"),
+  IP_NAME_SERVER_SOURCE_INTERFACE("ip name-server source-interface"),
   IP_PIM_RP_ADDRESS_PREFIX_LIST("ip pim rp-address prefix-list"),
   IP_PIM_RP_ADDRESS_ROUTE_MAP("ip pim rp-address route-map"),
   IP_PIM_RP_CANDIDATE_INTERFACE("ip pim rp-candidate interface"),

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/DnsSourceInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/DnsSourceInterface.java
@@ -1,0 +1,60 @@
+package org.batfish.vendor.cisco_nxos.representation;
+
+import com.google.common.base.MoreObjects;
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Global DNS source interface configuration, corresponding to the {@code ip dns source-interface
+ * <interface> [vrf <vrf>]} command. Determines the interface used to source DNS packets when the
+ * device acts as a DNS client/resolver.
+ */
+@ParametersAreNonnullByDefault
+public final class DnsSourceInterface implements Serializable {
+
+  public DnsSourceInterface(String iface, @Nullable String vrf) {
+    _interface = iface;
+    _vrf = vrf;
+  }
+
+  /** Interface used to source DNS packets. */
+  public @Nonnull String getInterface() {
+    return _interface;
+  }
+
+  /** VRF associated with the source interface, or {@code null} if none is configured. */
+  public @Nullable String getVrf() {
+    return _vrf;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DnsSourceInterface)) {
+      return false;
+    }
+    DnsSourceInterface that = (DnsSourceInterface) o;
+    return _interface.equals(that._interface) && Objects.equals(_vrf, that._vrf);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_interface, _vrf);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("interface", _interface)
+        .add("vrf", _vrf)
+        .toString();
+  }
+
+  private final @Nonnull String _interface;
+  private final @Nullable String _vrf;
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/NameServer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/cisco_nxos/representation/NameServer.java
@@ -8,15 +8,16 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
- * Name server configuration. Contains ipv4 or ipv6 address of the nameserver, and what VRF to use
- * for fallback name resolution.
+ * Name server configuration. Contains ipv4 or ipv6 address of the nameserver, what VRF to use for
+ * fallback name resolution, and an optional source interface used to reach the name server.
  */
 @ParametersAreNonnullByDefault
 public final class NameServer implements Serializable {
 
-  public NameServer(String name, @Nullable String useVrf) {
+  public NameServer(String name, @Nullable String useVrf, @Nullable String sourceInterface) {
     _ip = name;
     _useVrf = useVrf;
+    _sourceInterface = sourceInterface;
   }
 
   public String getName() {
@@ -28,6 +29,11 @@ public final class NameServer implements Serializable {
     return _useVrf;
   }
 
+  /** Source interface used to reach the name server, or {@code null} if none is configured. */
+  public @Nullable String getSourceInterface() {
+    return _sourceInterface;
+  }
+
   @Override
   public boolean equals(@Nullable Object o) {
     if (this == o) {
@@ -37,19 +43,26 @@ public final class NameServer implements Serializable {
       return false;
     }
     NameServer that = (NameServer) o;
-    return _ip.equals(that._ip) && Objects.equals(_useVrf, that._useVrf);
+    return _ip.equals(that._ip)
+        && Objects.equals(_useVrf, that._useVrf)
+        && Objects.equals(_sourceInterface, that._sourceInterface);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_ip, _useVrf);
+    return Objects.hash(_ip, _useVrf, _sourceInterface);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("ip", _ip).add("useVrf", _useVrf).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("ip", _ip)
+        .add("useVrf", _useVrf)
+        .add("sourceInterface", _sourceInterface)
+        .toString();
   }
 
   private final @Nonnull String _ip;
   private final @Nullable String _useVrf;
+  private final @Nullable String _sourceInterface;
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/cisco_nxos/grammar/CiscoNxosGrammarTest.java
@@ -347,6 +347,7 @@ import org.batfish.vendor.cisco_nxos.representation.CiscoNxosStructureUsage;
 import org.batfish.vendor.cisco_nxos.representation.DefaultVrfOspfProcess;
 import org.batfish.vendor.cisco_nxos.representation.DistributeList;
 import org.batfish.vendor.cisco_nxos.representation.DistributeList.DistributeListFilterType;
+import org.batfish.vendor.cisco_nxos.representation.DnsSourceInterface;
 import org.batfish.vendor.cisco_nxos.representation.EigrpProcessConfiguration;
 import org.batfish.vendor.cisco_nxos.representation.EigrpVrfConfiguration;
 import org.batfish.vendor.cisco_nxos.representation.EigrpVrfIpv4AddressFamilyConfiguration;
@@ -5037,16 +5038,112 @@ public final class CiscoNxosGrammarTest {
     assertThat(
         vc.getDefaultVrf().getNameServers(),
         contains(
-            new NameServer("192.0.2.2", null),
-            new NameServer("192.0.2.1", null),
-            new NameServer("dead:beef::1", null),
-            new NameServer("192.0.2.3", MANAGEMENT_VRF_NAME)));
+            new NameServer("192.0.2.2", null, null),
+            new NameServer("192.0.2.1", null, null),
+            new NameServer("dead:beef::1", null, null),
+            new NameServer("192.0.2.3", MANAGEMENT_VRF_NAME, null)));
     assertThat(
         vc.getVrfs().get("other_vrf").getNameServers(),
         contains(
-            new NameServer("192.0.2.99", MANAGEMENT_VRF_NAME),
-            new NameServer("192.0.2.100", null)));
+            new NameServer("192.0.2.99", MANAGEMENT_VRF_NAME, null),
+            new NameServer("192.0.2.100", null, null)));
     assertThat(vc.getVrfs().get(MANAGEMENT_VRF_NAME).getNameServers(), empty());
+
+    assertThat(vc.getDnsLookupEnabled(), nullValue());
+    assertThat(vc.getDnsSourceInterfaces(), empty());
+  }
+
+  @Test
+  public void testIpDnsExtraction() {
+    String hostname = "nxos_ip_dns";
+    CiscoNxosConfiguration vc = parseVendorConfig(hostname);
+
+    assertThat(vc.getDnsLookupEnabled(), equalTo(Boolean.TRUE));
+
+    assertThat(
+        vc.getDnsSourceInterfaces(),
+        contains(
+            new DnsSourceInterface("loopback0", "Corp"),
+            new DnsSourceInterface("loopback3", "Mgmt"),
+            new DnsSourceInterface("loopback4", "Client")));
+
+    assertThat(
+        vc.getDefaultVrf().getNameServers(),
+        contains(
+            new NameServer("192.0.2.11", "Client", null),
+            new NameServer("192.0.2.12", "Client", null),
+            new NameServer("198.51.100.11", null, "loopback5")));
+  }
+
+  @Test
+  public void testIpDnsReferences() throws IOException {
+    String hostname = "nxos_ip_dns";
+    String filename = String.format("configs/%s", hostname);
+    Batfish bf = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ans =
+        bf.loadConvertConfigurationAnswerElementOrReparse(bf.getSnapshot());
+
+    assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.INTERFACE, "loopback0", 2));
+    assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.INTERFACE, "loopback3", 2));
+    assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.INTERFACE, "loopback4", 2));
+    assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.INTERFACE, "loopback5", 2));
+  }
+
+  @Test
+  public void testIpDomainLookupDisabledExtraction() {
+    String hostname = "nxos_ip_domain_lookup_disabled";
+    CiscoNxosConfiguration vc = parseVendorConfig(hostname);
+
+    assertThat(vc.getDnsLookupEnabled(), equalTo(Boolean.FALSE));
+  }
+
+  @Test
+  public void testIpDnsMultiVrfExtraction() {
+    String hostname = "nxos_ip_dns_multi_vrf";
+    CiscoNxosConfiguration vc = parseVendorConfig(hostname);
+
+    assertThat(vc.getDnsLookupEnabled(), equalTo(Boolean.TRUE));
+
+    assertThat(
+        vc.getDnsSourceInterfaces(),
+        contains(
+            new DnsSourceInterface("loopback0", "Corp"),
+            new DnsSourceInterface("loopback3", "Mgmt"),
+            new DnsSourceInterface("loopback4", "Client"),
+            new DnsSourceInterface("loopback5", "Infra")));
+
+    List<NameServer> defaultNs = vc.getDefaultVrf().getNameServers();
+    assertThat(defaultNs, hasSize(15));
+    assertThat(
+        defaultNs,
+        containsInAnyOrder(
+            new NameServer("192.0.2.11", "Client", "loopback6"),
+            new NameServer("192.0.2.12", "Client", "loopback6"),
+            new NameServer("192.0.2.13", "Client", "loopback6"),
+            new NameServer("192.0.2.14", "Client", "loopback6"),
+            new NameServer("192.0.2.15", "Client", "loopback6"),
+            new NameServer("192.0.2.16", "Client", "loopback6"),
+            new NameServer("198.51.100.11", "Infra", "loopback7"),
+            new NameServer("198.51.100.12", "Infra", "loopback7"),
+            new NameServer("198.51.100.13", "Infra", "loopback7"),
+            new NameServer("198.51.100.14", "Infra", "loopback7"),
+            new NameServer("198.51.100.15", "Infra", "loopback7"),
+            new NameServer("198.51.100.16", "Infra", "loopback7"),
+            new NameServer("203.0.113.11", "Mgmt", null),
+            new NameServer("203.0.113.12", "Mgmt", null),
+            new NameServer("203.0.113.13", "Mgmt", null)));
+
+    assertThat(
+        vc.getVrfs().get("Corp").getNameServers(),
+        contains(new NameServer("192.0.2.4", null, null)));
+    assertThat(vc.getVrfs().get("Client").getNameServers(), hasSize(6));
+    assertThat(vc.getVrfs().get("Infra").getNameServers(), hasSize(6));
+    assertThat(vc.getVrfs().get("Mgmt").getNameServers(), hasSize(3));
+
+    assertThat(
+        vc.getAllDnsSourceInterfaces(),
+        containsInAnyOrder(
+            "loopback0", "loopback3", "loopback4", "loopback5", "loopback6", "loopback7"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ip_dns
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ip_dns
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_ip_dns
+!
+interface loopback0
+!
+interface loopback3
+!
+interface loopback4
+!
+interface loopback5
+!
+ip domain-lookup
+ip name-server 192.0.2.11 192.0.2.12 use-vrf Client
+ip name-server 198.51.100.11 source-interface loopback5
+ip dns source-interface loopback0 vrf Corp
+ip dns source-interface loopback3 vrf Mgmt
+ip dns source-interface loopback4 vrf Client

--- a/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ip_dns_multi_vrf
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ip_dns_multi_vrf
@@ -1,0 +1,41 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_ip_dns_multi_vrf
+!
+ip domain-lookup
+ip domain-name example.com
+ip name-server 192.0.2.11 192.0.2.12 192.0.2.13 192.0.2.14 192.0.2.15 192.0.2.16 use-vrf Client source-interface loopback6
+ip name-server 198.51.100.11 198.51.100.12 198.51.100.13 198.51.100.14 198.51.100.15 198.51.100.16 use-vrf Infra source-interface loopback7
+ip name-server 203.0.113.11 203.0.113.12 203.0.113.13 use-vrf Mgmt
+ip dns source-interface loopback0 vrf Corp
+ip dns source-interface loopback3 vrf Mgmt
+ip dns source-interface loopback4 vrf Client
+ip dns source-interface loopback5 vrf Infra
+!
+vrf context Client
+  ip name-server 192.0.2.11 192.0.2.12 192.0.2.13 192.0.2.14 192.0.2.15 192.0.2.16
+vrf context Corp
+  ip domain-name example.com
+  ip name-server 192.0.2.4
+vrf context Infra
+  ip name-server 198.51.100.11 198.51.100.12 198.51.100.13 198.51.100.14 198.51.100.15 198.51.100.16
+vrf context Mgmt
+  ip name-server 203.0.113.11 203.0.113.12 203.0.113.13
+!
+interface loopback0
+  vrf member Corp
+!
+interface loopback3
+  vrf member Mgmt
+!
+interface loopback4
+  vrf member Client
+!
+interface loopback5
+  vrf member Infra
+!
+interface loopback6
+  vrf member Client
+!
+interface loopback7
+  vrf member Infra

--- a/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ip_domain_lookup_disabled
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/cisco_nxos/grammar/testconfigs/nxos_ip_domain_lookup_disabled
@@ -1,0 +1,5 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_ip_domain_lookup_disabled
+!
+no ip domain-lookup


### PR DESCRIPTION
## Summary

Add extraction for the Cisco NX-OS `ip domain-lookup`, `ip dns source-interface`, and the per-name-server `source-interface` forms to capture DNS-resolver state: whether name lookup is enabled, the global DNS source interface(s) (with optional VRF), and the source interface used to reach each configured name server. This is captured in the vendor-specific `cisco_nxos` model; interface references are recorded so DNS source interfaces are not reported as unused.

## Changes

- Guard the `DNS` lexer token so it only pushes `M_Words` when it does not follow `IP`. This lets `ip dns ...` and `no ip dns ...` tokenize normally (so `source-interface`, interface names, and `vrf` are real tokens) while preserving the existing  behavior for `dns <hostname>` inside an `ip sla` block.

- Add the `ip_dns` grammar rule (`DNS ip_dns_source_interface`) and `ip_dns_source_interface` (`source-interface <intf> [vrf <vrf>]`) under `s_ip`. Widen `ip_name_server` from `(use-vrf <vrf>)?` to `(source-interface <intf> | use-vrf <vrf>)*` so a name-server line may carry a source interface, a fallback VRF, or both in any order. Promote `ip_domain_lookup` and `no_ip_domain_lookup` from ignored `_null` rules to value-capturing rules (strict `NEWLINE`, since the command takes no arguments) and wire them into `s_ip`.

- Add a new VS model class in `representation/cisco_nxos`: `DnsSourceInterface.java` (source interface plus optional VRF for the global `ip dns source-interface` command). Extend `NameServer.java` with an optional `sourceInterface` field (nullable, included in `equals`/`hashCode`/`toString`) alongside the existing `useVrf`.

- Add DNS state to `CiscoNxosConfiguration.java`: a tri-state `Boolean _dnsLookupEnabled` (null = unconfigured), an ordered `_dnsSourceInterfaces` list with a dedup-on-add setter, and a `getAllDnsSourceInterfaces()` accessor that merges both source-interface forms (global `ip dns source-interface` and per-name-server `source-interface`).

- Add `IP_DNS_SOURCE_INTERFACE` and `IP_NAME_SERVER_SOURCE_INTERFACE` structure usages. Populate `exitIp_domain_lookup`/`exitNo_ip_domain_lookup`, `exitIp_dns_source_interface`, and extend `exitIp_name_server` in `CiscoNxosControlPlaneExtractor.java`. Both source-interface forms record an `INTERFACE` structure reference (matching the existing `logging source-interface` pattern), so interfaces used only as a DNS source are counted as referenced. Name servers configured at global scope remain under the default VRF with `use-vrf` stored as a fallback-resolution attribute rather than as VRF ownership.

## Testing

- Add three `cisco_nxos` testconfigs: `nxos_ip_dns` (domain-lookup enabled, mixed `use-vrf` and per-name-server `source-interface` name servers, and multiple global `ip dns source-interface` lines), `nxos_ip_dns_multi_vrf` (a multi-VRF aggregation-router shape with per-VRF and global name servers, one `ip dns source-interface` per VRF, and per-name-server `source-interface` combined with `use-vrf` on two global lines), and `nxos_ip_domain_lookup_disabled` (`no ip domain-lookup`).

- Add unit tests confirming extraction works correctly: the tri-state lookup flag (enabled/disabled/unset), ordered global source interfaces with VRF, name servers under the correct VRF with their `use-vrf` and `source-interface` attributes, the merge of both source-interface forms via `getAllDnsSourceInterfaces()`, and a reference test asserting each DNS source interface carries the expected referrer count.

- All tests pass locally, formatting (`google-java-format`) passes, and the full `cisco_nxos` grammar suite runs clean.
