### PR TITLE
Pin bazel-steward to v1.8.0

### DIFF
--- a/.github/workflows/bazel-steward.yml
+++ b/.github/workflows/bazel-steward.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: VirtusLab/bazel-steward@latest
+      - uses: VirtusLab/bazel-steward@v1.8.0
         with:
           configuration-path: "./.bazel-steward.yaml"


### PR DESCRIPTION
## Summary
- pin the Bazel Steward GitHub Action to v1.8.0 instead of using the literal latest ref

## Testing
- not run (GitHub Actions workflow version bump only)