### PR TITLE
maven: upgrade Jackson and Guava BOMs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,8 +74,8 @@ BATFISH_MAVEN_ARTIFACTS = [
 ]
 
 BATFISH_MAVEN_BOMS = [
-    "com.fasterxml.jackson:jackson-bom:2.20.1",
-    "com.google.guava:guava-bom:33.5.0-jre",
+    "com.fasterxml.jackson:jackson-bom:2.22.1",
+    "com.google.guava:guava-bom:33.6.0-jre",
 ]
 
 JOL_MAVEN_ARTIFACTS = [

--- a/maven_install.json
+++ b/maven_install.json
@@ -12,7 +12,7 @@
     "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": -578085414,
     "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": -182968498,
     "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": 1548616537,
-    "com.fasterxml.jackson:jackson-bom": -374984083,
+    "com.fasterxml.jackson:jackson-bom": -317725781,
     "com.github.ben-manes.caffeine:caffeine": 1815596219,
     "com.google.auto.service:auto-service": -1729498094,
     "com.google.auto.service:auto-service-annotations": -843120535,
@@ -23,7 +23,7 @@
     "com.google.errorprone:error_prone_annotations": 911823543,
     "com.google.googlejavaformat:google-java-format": -1003676123,
     "com.google.guava:guava": -692456693,
-    "com.google.guava:guava-bom": -1581455824,
+    "com.google.guava:guava-bom": -1777969329,
     "com.google.guava:guava-testlib": 279911981,
     "com.google.j2objc:j2objc-annotations": 2003271689,
     "com.google.re2j:re2j": 1525409503,
@@ -77,29 +77,29 @@
     "at.yawk.lz4:lz4-java:jar:sources": 1101932966,
     "com.carrotsearch:hppc": 1515426128,
     "com.carrotsearch:hppc:jar:sources": 704007767,
-    "com.fasterxml.jackson.core:jackson-annotations": -85510638,
-    "com.fasterxml.jackson.core:jackson-annotations:jar:sources": 467665637,
-    "com.fasterxml.jackson.core:jackson-core": 347333998,
-    "com.fasterxml.jackson.core:jackson-core:jar:sources": 1597076141,
-    "com.fasterxml.jackson.core:jackson-databind": -1900032447,
-    "com.fasterxml.jackson.core:jackson-databind:jar:sources": 572042403,
-    "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": -1170460245,
-    "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:sources": 1325780484,
-    "com.fasterxml.jackson.datatype:jackson-datatype-guava": -222930394,
-    "com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:sources": -1768749306,
-    "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": -754611385,
-    "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:sources": -225328574,
-    "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": 1279145438,
-    "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:sources": -212458373,
-    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": 980357790,
-    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:sources": -1626348069,
-    "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": -1678436642,
-    "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:sources": 1810676120,
+    "com.fasterxml.jackson.core:jackson-annotations": -1012223496,
+    "com.fasterxml.jackson.core:jackson-annotations:jar:sources": -164405597,
+    "com.fasterxml.jackson.core:jackson-core": 789964708,
+    "com.fasterxml.jackson.core:jackson-core:jar:sources": -616277826,
+    "com.fasterxml.jackson.core:jackson-databind": 1075068690,
+    "com.fasterxml.jackson.core:jackson-databind:jar:sources": 779577142,
+    "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": 1100236561,
+    "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:sources": 597390101,
+    "com.fasterxml.jackson.datatype:jackson-datatype-guava": -405148898,
+    "com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:sources": -321409313,
+    "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": -1222179274,
+    "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:sources": 2125434031,
+    "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": 1674025786,
+    "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:sources": -1994626552,
+    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": -903910001,
+    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:sources": -1077897804,
+    "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": 374736092,
+    "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:sources": 1497034834,
     "com.github.ben-manes.caffeine:caffeine": 139651916,
     "com.github.ben-manes.caffeine:caffeine:jar:sources": -57104877,
     "com.github.oowekyala.ooxml:nice-xml-messages": -1242718147,
     "com.github.oowekyala.ooxml:nice-xml-messages:jar:sources": 923999346,
-    "com.google.auto.service:auto-service": -771255207,
+    "com.google.auto.service:auto-service": 1941444422,
     "com.google.auto.service:auto-service-annotations": 262983930,
     "com.google.auto.service:auto-service-annotations:jar:sources": -1392999316,
     "com.google.auto.service:auto-service:jar:sources": -1296332334,
@@ -107,7 +107,7 @@
     "com.google.auto.value:auto-value-annotations": 641752776,
     "com.google.auto.value:auto-value-annotations:jar:sources": -2083311588,
     "com.google.auto.value:auto-value:jar:sources": -30292358,
-    "com.google.auto:auto-common": -921224917,
+    "com.google.auto:auto-common": 1746224209,
     "com.google.auto:auto-common:jar:sources": -542679945,
     "com.google.code.findbugs:jsr305": 870839855,
     "com.google.code.findbugs:jsr305:jar:sources": -935881202,
@@ -115,14 +115,14 @@
     "com.google.code.gson:gson:jar:sources": 935710753,
     "com.google.errorprone:error_prone_annotations": 652227016,
     "com.google.errorprone:error_prone_annotations:jar:sources": -507624312,
-    "com.google.googlejavaformat:google-java-format:jar:all-deps": 1824641929,
+    "com.google.googlejavaformat:google-java-format:jar:all-deps": 197123759,
     "com.google.googlejavaformat:google-java-format:jar:sources": 863436563,
     "com.google.guava:failureaccess": 1715931538,
     "com.google.guava:failureaccess:jar:sources": 1303858893,
-    "com.google.guava:guava": 895055937,
-    "com.google.guava:guava-testlib": 967689317,
-    "com.google.guava:guava-testlib:jar:sources": 1351030420,
-    "com.google.guava:guava:jar:sources": 1246910673,
+    "com.google.guava:guava": 951060859,
+    "com.google.guava:guava-testlib": 1429289549,
+    "com.google.guava:guava-testlib:jar:sources": -1659445038,
+    "com.google.guava:guava:jar:sources": 129808367,
     "com.google.guava:listenablefuture": 1079558157,
     "com.google.j2objc:j2objc-annotations": -1008747351,
     "com.google.j2objc:j2objc-annotations:jar:sources": -1518668002,
@@ -130,7 +130,7 @@
     "com.google.re2j:re2j:jar:sources": 485338798,
     "com.ibm.icu:icu4j": 1483821939,
     "com.ibm.icu:icu4j:jar:sources": 400701553,
-    "com.puppycrawl.tools:checkstyle": -1564757191,
+    "com.puppycrawl.tools:checkstyle": 1538301535,
     "com.puppycrawl.tools:checkstyle:jar:sources": -1415230263,
     "com.vaadin.external.google:android-json": -815169796,
     "com.vaadin.external.google:android-json:jar:sources": -241719183,
@@ -270,7 +270,7 @@
     "org.glassfish.jersey.inject:jersey-hk2:jar:sources": -955988821,
     "org.glassfish.jersey.media:jersey-media-jaxb": 460526446,
     "org.glassfish.jersey.media:jersey-media-jaxb:jar:sources": -273605230,
-    "org.glassfish.jersey.media:jersey-media-json-jackson": 1768377442,
+    "org.glassfish.jersey.media:jersey-media-json-jackson": -518666610,
     "org.glassfish.jersey.media:jersey-media-json-jackson:jar:sources": -1661795504,
     "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2": -335164412,
     "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:jar:sources": -1806408383,
@@ -334,18 +334,18 @@
     "tools.profiler:async-profiler:jar:sources": 1066933666
   },
   "conflict_resolution": {
-    "com.fasterxml.jackson.core:jackson-annotations": "com.fasterxml.jackson.core:jackson-annotations:2.20",
-    "com.fasterxml.jackson.core:jackson-core": "com.fasterxml.jackson.core:jackson-core:2.20.1",
-    "com.fasterxml.jackson.core:jackson-databind": "com.fasterxml.jackson.core:jackson-databind:2.20.1",
-    "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.1",
-    "com.fasterxml.jackson.datatype:jackson-datatype-guava": "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.20.1",
-    "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.20.1",
-    "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.1",
-    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.20.1",
-    "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.20.1",
-    "com.google.guava:guava": "com.google.guava:guava:33.5.0-jre",
-    "com.google.guava:guava-testlib": "com.google.guava:guava-testlib:33.5.0-jre",
-    "com.google.guava:guava:32.0.1-jre": "com.google.guava:guava:33.5.0-jre",
+    "com.fasterxml.jackson.core:jackson-annotations": "com.fasterxml.jackson.core:jackson-annotations:2.22",
+    "com.fasterxml.jackson.core:jackson-core": "com.fasterxml.jackson.core:jackson-core:2.22.1",
+    "com.fasterxml.jackson.core:jackson-databind": "com.fasterxml.jackson.core:jackson-databind:2.22.1",
+    "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.1",
+    "com.fasterxml.jackson.datatype:jackson-datatype-guava": "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.22.1",
+    "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.22.1",
+    "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.1",
+    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.22.1",
+    "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.22.1",
+    "com.google.guava:guava": "com.google.guava:guava:33.6.0-jre",
+    "com.google.guava:guava-testlib": "com.google.guava:guava-testlib:33.6.0-jre",
+    "com.google.guava:guava:32.0.1-jre": "com.google.guava:guava:33.6.0-jre",
     "com.google.j2objc:j2objc-annotations:2.8": "com.google.j2objc:j2objc-annotations:3.1"
   },
   "artifacts": {
@@ -365,66 +365,66 @@
     },
     "com.fasterxml.jackson.core:jackson-annotations": {
       "shasums": {
-        "jar": "959a2ffb2d591436f51f183c6a521fc89347912f711bf0cae008cdf045d95319",
-        "sources": "6bdceeb142be2dc19f8ada2e7be1f028e47d94716d4b9ea8bd2c14b3cec0bca8"
+        "jar": "21ddb598807d3a51a876704eb979d9296e1c6a6f47ab1826ff88c6d6a127a2d0",
+        "sources": "f5375c756ee3c585808f9937eb087d074743fd3f05f6aeff9b183cf19230c9f7"
       },
-      "version": "2.20"
+      "version": "2.22"
     },
     "com.fasterxml.jackson.core:jackson-core": {
       "shasums": {
-        "jar": "ffab4d957daa2796cf24cb66d0b78a7090f1bcbe17c3a4578f09affaaf137089",
-        "sources": "30265c51a834ab4620efb8d1b30c0b9d9b47761781e14f53dcc12bcb0ea8a841"
+        "jar": "941ff029bcdb93e83d209ce516c1a7fb8bbac07d0a2fa122f5bf194b2cd7b4f4",
+        "sources": "f08c6bcea73ec33dcc18861a9c56e2ecb7c124619f5de46e1de89c02e4f65283"
       },
-      "version": "2.20.1"
+      "version": "2.22.1"
     },
     "com.fasterxml.jackson.core:jackson-databind": {
       "shasums": {
-        "jar": "34bbeb4526fff4f8565b12106bf85a6afcbae858966d489b54214ac46b2e26e8",
-        "sources": "a2512473d90c5ee7845970f7956f97820a34367af3d2b4d3b68644c15715fd87"
+        "jar": "7dcd7e53bec1f56c7ad278bd1ca0840bebcc595d61ce44d6a8439abb75b965b2",
+        "sources": "4e7160e0e90a844ae12ac3c73b70ea3855d29425890d3c5aed40723bca5bce52"
       },
-      "version": "2.20.1"
+      "version": "2.22.1"
     },
     "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
       "shasums": {
-        "jar": "030f1d91f7df278e86e1ba3e129fb520871ac16ce53017c735f708823be970db",
-        "sources": "cb01c1f4ccb2e1453304d999aae42a888353c09a30be6cf0c930a71dbca29e0c"
+        "jar": "cc3a0e540791a9a1cbcd7584767b84572ffda0b72823856558f47dea69ae8ed1",
+        "sources": "09425e7d5a89546558263f18fd97492a6d045df1dd2a6ff575d0ed85b6d7b81e"
       },
-      "version": "2.20.1"
+      "version": "2.22.1"
     },
     "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
       "shasums": {
-        "jar": "6da48c97ed7c5e2fb3ac11bd618d95eacad525c88b8d16e2a6ce561ddc402b29",
-        "sources": "ef9d187bb95e03deaa28fd9f6bb067d4a94f4e7fa8fa4ca34344f6d0f365f79c"
+        "jar": "2133e75851972acce8cc63a279d47db551cced55b649cda31c625d0059ad3c60",
+        "sources": "87a2227ef759b247a401bb25760ac89b0755a7be91e778bd0f3bdb744e336f13"
       },
-      "version": "2.20.1"
+      "version": "2.22.1"
     },
     "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
       "shasums": {
-        "jar": "6821cdd695e95c4e6853ec855a7432c71f2f4be318b3ca190fbbf8a2e5f981f2",
-        "sources": "ebce33af64c010e20ecf61c3bb6846cfacd8a56bf01b2dc6318e78707483fce0"
+        "jar": "2d5ee03fcaa017db0c947a5921ede8b39481d1d637af39079840a87d55e907eb",
+        "sources": "d227df8338e113094c065c34f84523f4872bd4359637cb6d86f612ee1bb885a8"
       },
-      "version": "2.20.1"
+      "version": "2.22.1"
     },
     "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
       "shasums": {
-        "jar": "692be83c7e2eebb53b995c11d813c603a7d716d60c9d2d4fb9486ecb105f9291",
-        "sources": "39249d56fe22e63e52167c59013f1501a6535709fd05b43d3263efb4c3794c26"
+        "jar": "85da45b7e5e565418963ff8f0dcb184365b0557c15468933f4318dde5c3ce845",
+        "sources": "a7ad98f51575c04073ce99f7eec64fbda91d853628a0abde0eaf4a014d74bebd"
       },
-      "version": "2.20.1"
+      "version": "2.22.1"
     },
     "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base": {
       "shasums": {
-        "jar": "d34944bd5666bd4db02882185c43551dbde0801286fe7c2c5b43a5b5dcca1d1e",
-        "sources": "725103c12bf0c0bbbc1f4b2686bd41cddc8b5cfc90bdcd17de27d06a38b8152f"
+        "jar": "3182df7eba804dd56aa8208222de500b51d21a55e6bea846aa322d9ad88e6caa",
+        "sources": "96e6bd120c9e21a59f26366b1d5e70a9ec972ff42442877e7bcc0a3ed192fc74"
       },
-      "version": "2.20.1"
+      "version": "2.22.1"
     },
     "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
       "shasums": {
-        "jar": "0b4c0cf84bb9e5251d29743fc0488d5414b0ac6e20fa4ac87d0754b8d4d78a05",
-        "sources": "2924aea4d1b742dc47176e413b6c4105a3919ed862b104add9792a09faa0f5dd"
+        "jar": "b80b2d3701efd1bc0e72eb9cd56f64c8b8558555edbee7b7a3011a34cb6db7fd",
+        "sources": "93787a7bd128bf97a5f0db1ea09bf0f6a59b4735ee88435088911509b6e9ef52"
       },
-      "version": "2.20.1"
+      "version": "2.22.1"
     },
     "com.github.ben-manes.caffeine:caffeine": {
       "shasums": {
@@ -512,17 +512,17 @@
     },
     "com.google.guava:guava": {
       "shasums": {
-        "jar": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
-        "sources": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb"
+        "jar": "dc573e1fca4fd5454f4a5fd3d7da2df03002876a4175bafc14a95980dd7713b3",
+        "sources": "eff31867dd63a92d63ca856127a424a6836418d8bfa044162cac20430abd3500"
       },
-      "version": "33.5.0-jre"
+      "version": "33.6.0-jre"
     },
     "com.google.guava:guava-testlib": {
       "shasums": {
-        "jar": "d98a26c3c32803007ca4a1126f36d66cc0ba4b4471eb650ed2e329a2b49b285b",
-        "sources": "b535fa90b57f7b44167383e5c60d73f4086c6cbab474fb6cadb29df9d241b321"
+        "jar": "61796b530b22fc45e94f808ac954bd437e605335995a3bfeaf8452dbfc9e26df",
+        "sources": "e9935f2d18622cb3d9c77f063bb61d65bccda7ee6d5f6f09ad88172ffd3695ee"
       },
-      "version": "33.5.0-jre"
+      "version": "33.6.0-jre"
     },
     "com.google.guava:listenablefuture": {
       "shasums": {
@@ -1606,9 +1606,7 @@
       "com.fasterxml.jackson.core.exc",
       "com.fasterxml.jackson.core.filter",
       "com.fasterxml.jackson.core.format",
-      "com.fasterxml.jackson.core.internal.shaded.fdp.v2_20_1",
-      "com.fasterxml.jackson.core.internal.shaded.fdp.v2_20_1.bte",
-      "com.fasterxml.jackson.core.internal.shaded.fdp.v2_20_1.chr",
+      "com.fasterxml.jackson.core.internal.shaded.fdp.v2_22_1",
       "com.fasterxml.jackson.core.io",
       "com.fasterxml.jackson.core.io.schubfach",
       "com.fasterxml.jackson.core.json",
@@ -1700,20 +1698,12 @@
       "autovalue.shaded.com.google.auto.service",
       "autovalue.shaded.com.google.common.annotations",
       "autovalue.shaded.com.google.common.base",
-      "autovalue.shaded.com.google.common.cache",
       "autovalue.shaded.com.google.common.collect",
-      "autovalue.shaded.com.google.common.escape",
-      "autovalue.shaded.com.google.common.eventbus",
-      "autovalue.shaded.com.google.common.graph",
       "autovalue.shaded.com.google.common.hash",
-      "autovalue.shaded.com.google.common.html",
       "autovalue.shaded.com.google.common.io",
       "autovalue.shaded.com.google.common.math",
-      "autovalue.shaded.com.google.common.net",
       "autovalue.shaded.com.google.common.primitives",
       "autovalue.shaded.com.google.common.reflect",
-      "autovalue.shaded.com.google.common.util.concurrent",
-      "autovalue.shaded.com.google.common.xml",
       "autovalue.shaded.com.google.errorprone.annotations",
       "autovalue.shaded.com.google.errorprone.annotations.concurrent",
       "autovalue.shaded.com.google.escapevelocity",
@@ -1855,7 +1845,6 @@
       "com.google.common.collect.testing",
       "com.google.common.collect.testing.features",
       "com.google.common.collect.testing.google",
-      "com.google.common.collect.testing.suites",
       "com.google.common.collect.testing.testers",
       "com.google.common.escape.testing",
       "com.google.common.testing",
@@ -2199,7 +2188,6 @@
       "net.sourceforge.pmd",
       "net.sourceforge.pmd.annotation",
       "net.sourceforge.pmd.benchmark",
-      "net.sourceforge.pmd.cache",
       "net.sourceforge.pmd.cache.internal",
       "net.sourceforge.pmd.cpd",
       "net.sourceforge.pmd.cpd.impl",


### PR DESCRIPTION
Bump jackson-bom to 2.22.1 and guava-bom to 33.6.0-jre, then
regenerate maven_install.json with the resolved dependency graph.

----

Prompt:
```
Run @maven//:outdated, make recommendations if we should update any
of them, and then update the Jackson and Guava BOMs first.
```
