### PR TITLE
Updated com.ibm.icu:icu4j to 78.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ BATFISH_MAVEN_ARTIFACTS = [
     "com.google.guava:guava",
     "com.google.guava:guava-testlib",
     "com.google.re2j:re2j:1.8",
-    "com.ibm.icu:icu4j:76.1",
+    "com.ibm.icu:icu4j:78.3",
     "com.puppycrawl.tools:checkstyle:13.8.0",
     "commons-beanutils:commons-beanutils:1.11.0",
     "commons-cli:commons-cli:1.11.0",

--- a/maven_install.json
+++ b/maven_install.json
@@ -27,7 +27,7 @@
     "com.google.guava:guava-testlib": 279911981,
     "com.google.j2objc:j2objc-annotations": 2003271689,
     "com.google.re2j:re2j": 1525409503,
-    "com.ibm.icu:icu4j": 304238961,
+    "com.ibm.icu:icu4j": 1685361909,
     "com.puppycrawl.tools:checkstyle": -1817917266,
     "commons-beanutils:commons-beanutils": 332733947,
     "commons-cli:commons-cli": 1754587837,
@@ -128,8 +128,8 @@
     "com.google.j2objc:j2objc-annotations:jar:sources": -1518668002,
     "com.google.re2j:re2j": -1688126233,
     "com.google.re2j:re2j:jar:sources": 485338798,
-    "com.ibm.icu:icu4j": 1483821939,
-    "com.ibm.icu:icu4j:jar:sources": 400701553,
+    "com.ibm.icu:icu4j": -1667183492,
+    "com.ibm.icu:icu4j:jar:sources": 1011748514,
     "com.puppycrawl.tools:checkstyle": 1538301535,
     "com.puppycrawl.tools:checkstyle:jar:sources": -1415230263,
     "com.vaadin.external.google:android-json": -815169796,
@@ -546,10 +546,10 @@
     },
     "com.ibm.icu:icu4j": {
       "shasums": {
-        "jar": "732cdf18121b1642899da1f5e37e52cc7f48e3ec07fa737105d4603976781b33",
-        "sources": "3ab527e55dae77dd6fad6d8d397605f8b3fac1162191bc871cc87594e111d109"
+        "jar": "e962c1758d9659ea1e1fbab99c58683f654d304e1126ace19aaabfe39e0edb25",
+        "sources": "b8458be1c296aec6c52ea8f195f27e833c5d6030fa15a4b361a0e83030c3c3fe"
       },
-      "version": "76.1"
+      "version": "78.3"
     },
     "com.puppycrawl.tools:checkstyle": {
       "shasums": {
@@ -1857,6 +1857,7 @@
       "com.google.re2j"
     ],
     "com.ibm.icu:icu4j": [
+      "com.ibm.icu.dev.tool.docs",
       "com.ibm.icu.impl",
       "com.ibm.icu.impl.breakiter",
       "com.ibm.icu.impl.coll",
@@ -1874,6 +1875,7 @@
       "com.ibm.icu.math",
       "com.ibm.icu.message2",
       "com.ibm.icu.number",
+      "com.ibm.icu.segmenter",
       "com.ibm.icu.text",
       "com.ibm.icu.util"
     ],

--- a/projects/batfish/src/test/java/org/batfish/main/StreamDecoderTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/StreamDecoderTest.java
@@ -1,0 +1,37 @@
+package org.batfish.main;
+
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.main.StreamDecoder.decodeStreamAndAppendNewline;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.primitives.Bytes;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.apache.commons.io.ByteOrderMark;
+import org.junit.Test;
+
+/** Tests of {@link StreamDecoder}. */
+public final class StreamDecoderTest {
+
+  @Test
+  public void testDecodeStreamAndAppendNewlineEmpty() throws IOException {
+    assertThat(decodeStreamAndAppendNewline(new ByteArrayInputStream(new byte[0])), equalTo(""));
+  }
+
+  @Test
+  public void testDecodeStreamAndAppendNewlineUtf8() throws IOException {
+    String text = "café";
+    assertThat(
+        decodeStreamAndAppendNewline(new ByteArrayInputStream(text.getBytes(UTF_8))),
+        equalTo(text + "\n"));
+  }
+
+  @Test
+  public void testDecodeStreamAndAppendNewlineUtf16LeBom() throws IOException {
+    String text = "café";
+    byte[] bytes = Bytes.concat(ByteOrderMark.UTF_16LE.getBytes(), text.getBytes(UTF_16LE));
+    assertThat(decodeStreamAndAppendNewline(new ByteArrayInputStream(bytes)), equalTo(text + "\n"));
+  }
+}

--- a/projects/common/src/test/java/org/batfish/common/util/CommonUtilTest.java
+++ b/projects/common/src/test/java/org/batfish/common/util/CommonUtilTest.java
@@ -1,0 +1,35 @@
+package org.batfish.common.util;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.CommonUtil.readFile;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests of {@link CommonUtil}. */
+public final class CommonUtilTest {
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  @Test
+  public void testDetectCharsetUtf8RoundTrip() {
+    String text = "snowman ☃";
+    byte[] bytes = text.getBytes(UTF_8);
+    assertThat(new String(bytes, CommonUtil.detectCharset(bytes)), equalTo(text));
+  }
+
+  @Test
+  public void testReadFileIso88591RoundTrip() throws IOException {
+    String text = "café piñata";
+    Path file = _folder.getRoot().toPath().resolve("latin1.txt");
+    Files.write(file, text.getBytes(ISO_8859_1));
+    assertThat(readFile(file), equalTo(text));
+  }
+}


### PR DESCRIPTION
Bump icu4j to 78.3 and regenerate maven_install.json.
Add direct charset-decoding regression tests for CommonUtil and
StreamDecoder.

----

Prompt:
```
Upgrade icu4j after discussing the implications of the bump, and add
charset regression coverage so the upgrade is guarded by direct
tests.
```
