### PR TITLE
cisco_xr: accept 4-byte local administrator in extcommunity-set rt

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_extcommunity_set.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_extcommunity_set.g4
@@ -45,6 +45,7 @@ extcommunity_set_rt_elem
 :
    extcommunity_set_rt_elem_as_dot_colon
    | extcommunity_set_rt_elem_colon
+   | extcommunity_set_rt_elem_colon_la32
 ;
 
 extcommunity_set_rt_elem_as_dot_colon
@@ -53,9 +54,19 @@ extcommunity_set_rt_elem_as_dot_colon
   extcommunity_set_rt_elem_16 COLON low = extcommunity_set_rt_elem_16
 ;
 
+// RFC 4360 type 2: 4-byte global administrator, 2-byte local administrator.
 extcommunity_set_rt_elem_colon
 :
   high = extcommunity_set_rt_elem_32 COLON low = extcommunity_set_rt_elem_16
+;
+
+// RFC 4360 type 0: 2-byte global administrator, 4-byte local administrator.
+// Ambiguous with extcommunity_set_rt_elem_colon when both halves fit in 16
+// bits; ANTLR resolves to that rule, which extracts to the same value. Only
+// one administrator may be 4 bytes, so neither rule accepts two 32-bit halves.
+extcommunity_set_rt_elem_colon_la32
+:
+  high = extcommunity_set_rt_elem_16 COLON low = extcommunity_set_rt_elem_32
 ;
 
 extcommunity_set_rt_elem_16

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -508,6 +508,7 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Extcommunity_set_rt_elem_16Con
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Extcommunity_set_rt_elem_32Context;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Extcommunity_set_rt_elem_as_dot_colonContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Extcommunity_set_rt_elem_colonContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Extcommunity_set_rt_elem_colon_la32Context;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Extcommunity_set_rt_elem_linesContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Extended_access_list_additional_featureContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Extended_access_list_tailContext;
@@ -7063,6 +7064,8 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
       return toExtcommunitySetRtElemExpr(ctx.extcommunity_set_rt_elem_as_dot_colon());
     } else if (ctx.extcommunity_set_rt_elem_colon() != null) {
       return toExtcommunitySetRtElemExpr(ctx.extcommunity_set_rt_elem_colon());
+    } else if (ctx.extcommunity_set_rt_elem_colon_la32() != null) {
+      return toExtcommunitySetRtElemExpr(ctx.extcommunity_set_rt_elem_colon_la32());
     } else {
       return convProblem(ExtcommunitySetRtElem.class, ctx, null);
     }
@@ -7071,12 +7074,27 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   private ExtcommunitySetRtElem toExtcommunitySetRtElemExpr(
       Extcommunity_set_rt_elem_colonContext ctx) {
     return new ExtcommunitySetRtElemAsColon(
-        toUint32RangeExpr(ctx.high), toUint16RangeExpr(ctx.low));
+        toUint32RangeExpr(ctx.high), toUint32RangeExpr(ctx.low));
+  }
+
+  private ExtcommunitySetRtElem toExtcommunitySetRtElemExpr(
+      Extcommunity_set_rt_elem_colon_la32Context ctx) {
+    return new ExtcommunitySetRtElemAsColon(
+        toUint32RangeExpr(ctx.high), toUint32RangeExpr(ctx.low));
   }
 
   private @Nonnull Uint32RangeExpr toUint32RangeExpr(Extcommunity_set_rt_elem_32Context ctx) {
     // TODO: support other 32-bit range expressions
     return new LiteralUint32(toLong(ctx.uint32()));
+  }
+
+  /**
+   * Widens a 16-bit administrator to a 32-bit range expression. The two administrators of a route
+   * target are modeled uniformly as 32-bit; only one of them may actually be 4 bytes wide.
+   */
+  private @Nonnull Uint32RangeExpr toUint32RangeExpr(Extcommunity_set_rt_elem_16Context ctx) {
+    // TODO: support other 32-bit range expressions
+    return new LiteralUint32(toInteger(ctx.uint16()));
   }
 
   private static @Nonnull ExtcommunitySetRtElem toExtcommunitySetRtElemExpr(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
@@ -159,6 +159,7 @@ import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.SelfNextHop;
 import org.batfish.datamodel.routing_policy.expr.Uint32HighLowExpr;
 import org.batfish.datamodel.routing_policy.expr.VarInt;
+import org.batfish.datamodel.routing_policy.expr.VarLong;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetEigrpMetric;
 import org.batfish.datamodel.routing_policy.statement.SetNextHop;
@@ -472,7 +473,7 @@ public class CiscoXrConversions {
               new ExtendedCommunityLocalAdministratorMatch(
                   extcommunitySetRtElemAsDotColon
                       .getLaRangeExpr()
-                      .accept(XrUint16RangeExprToIntMatchExpr.INSTANCE, arg))));
+                      .accept(XrUint16RangeExprToLongMatchExpr.INSTANCE, arg))));
     }
 
     @Override
@@ -488,7 +489,7 @@ public class CiscoXrConversions {
               new ExtendedCommunityLocalAdministratorMatch(
                   extcommunitySetRtElemAsColon
                       .getLaRangeExpr()
-                      .accept(XrUint16RangeExprToIntMatchExpr.INSTANCE, arg))));
+                      .accept(XrUint32RangeExprToLongMatchExpr.INSTANCE, arg))));
     }
   }
 
@@ -533,6 +534,55 @@ public class CiscoXrConversions {
     public IntMatchExpr visitPeerAs(PeerAs peerAs) {
       // TODO: implement. In the meanwhile, prevent matching by using impossible condition
       return new IntComparison(IntComparator.LT, new LiteralInt(0));
+    }
+  }
+
+  /**
+   * Adapts a 16-bit range expression to a {@link LongMatchExpr}, for administrators that are
+   * modeled as 32-bit in the vendor-independent model but can only be 16-bit in this vendor
+   * context.
+   */
+  private static final class XrUint16RangeExprToLongMatchExpr
+      implements Uint16RangeExprVisitor<LongMatchExpr, Configuration> {
+    private static final XrUint16RangeExprToLongMatchExpr INSTANCE =
+        new XrUint16RangeExprToLongMatchExpr();
+
+    @Override
+    public LongMatchExpr visitLiteralUint16(LiteralUint16 literalUint16, Configuration arg) {
+      return new LongComparison(IntComparator.EQ, new LiteralLong(literalUint16.getValue()));
+    }
+
+    @Override
+    public LongMatchExpr visitLiteralUint16Range(
+        LiteralUint16Range literalUint16Range, Configuration arg) {
+      SubRange range = literalUint16Range.getRange();
+      return LongMatchAll.of(
+          new LongComparison(IntComparator.GE, new LiteralLong(range.getStart())),
+          new LongComparison(IntComparator.LE, new LiteralLong(range.getEnd())));
+    }
+
+    @Override
+    public LongMatchExpr visitUint16Reference(Uint16Reference uint16Reference, Configuration arg) {
+      return new LongComparison(IntComparator.EQ, new VarLong(uint16Reference.getVar()));
+    }
+
+    @Override
+    public LongMatchExpr visitWildcardUint16RangeExpr(
+        WildcardUint16RangeExpr wildcardUint16RangeExpr) {
+      return LongMatchAll.of();
+    }
+
+    @Override
+    public LongMatchExpr visitPrivateAs(PrivateAs privateAs) {
+      return LongMatchAll.of(
+          new LongComparison(IntComparator.GE, new LiteralLong(64512)),
+          new LongComparison(IntComparator.LE, new LiteralLong(65534)));
+    }
+
+    @Override
+    public LongMatchExpr visitPeerAs(PeerAs peerAs) {
+      // TODO: implement. In the meanwhile, prevent matching by using impossible condition
+      return new LongComparison(IntComparator.LT, new LiteralLong(0));
     }
   }
 
@@ -642,10 +692,10 @@ public class CiscoXrConversions {
       if (!gaLowExpr.isPresent()) {
         return CommunitySetExprs.empty();
       }
-      Optional<IntExpr> laExpr =
+      Optional<LongExpr> laExpr =
           extcommunitySetRtElemAsDotColon
               .getLaRangeExpr()
-              .accept(XrUint16RangeExprToIntExpr.INSTANCE, null);
+              .accept(XrUint16RangeExprToLongExpr.INSTANCE, null);
       if (!laExpr.isPresent()) {
         return CommunitySetExprs.empty();
       }
@@ -664,10 +714,10 @@ public class CiscoXrConversions {
       if (!gaExpr.isPresent()) {
         return CommunitySetExprs.empty();
       }
-      Optional<IntExpr> laExpr =
+      Optional<LongExpr> laExpr =
           extcommunitySetRtElemAsColon
               .getLaRangeExpr()
-              .accept(XrUint16RangeExprToIntExpr.INSTANCE, null);
+              .accept(XrUint32RangeExprToLongExpr.INSTANCE, null);
       if (!laExpr.isPresent()) {
         return CommunitySetExprs.empty();
       }
@@ -712,6 +762,49 @@ public class CiscoXrConversions {
 
     @Override
     public Optional<IntExpr> visitPeerAs(PeerAs peerAs) {
+      // TODO: implement
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Adapts a 16-bit range expression to a {@link LongExpr}, for administrators that are modeled as
+   * 32-bit in the vendor-independent model but can only be 16-bit in this vendor context.
+   */
+  private static class XrUint16RangeExprToLongExpr
+      implements Uint16RangeExprVisitor<Optional<LongExpr>, Void> {
+
+    private static final XrUint16RangeExprToLongExpr INSTANCE = new XrUint16RangeExprToLongExpr();
+
+    @Override
+    public Optional<LongExpr> visitLiteralUint16(LiteralUint16 literalUint16, Void arg) {
+      return Optional.of(new LiteralLong(literalUint16.getValue()));
+    }
+
+    @Override
+    public Optional<LongExpr> visitLiteralUint16Range(
+        LiteralUint16Range literalUint16Range, Void arg) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<LongExpr> visitUint16Reference(Uint16Reference uint16Reference, Void arg) {
+      return Optional.of(new VarLong(uint16Reference.getVar()));
+    }
+
+    @Override
+    public Optional<LongExpr> visitWildcardUint16RangeExpr(
+        WildcardUint16RangeExpr wildcardUint16RangeExpr) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<LongExpr> visitPrivateAs(PrivateAs privateAs) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<LongExpr> visitPeerAs(PeerAs peerAs) {
       // TODO: implement
       return Optional.empty();
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/ExtcommunitySetRtElemAsColon.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/ExtcommunitySetRtElemAsColon.java
@@ -5,14 +5,20 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
- * A structure representing a space of route-target extended communities given by a 32-bit range
- * expression and 16-bit range expression in the format 'R1:R2' for the 32 bits of the global
- * administrator and the 16 bits of the local administrator respectively.
+ * A structure representing a space of route-target extended communities given by two range
+ * expressions in the format 'R1:R2' for the global administrator and the local administrator
+ * respectively.
+ *
+ * <p>Per RFC 4360, exactly one administrator may be 4 bytes wide: a type-2 route target has a
+ * 4-byte global administrator and a 2-byte local administrator, while a type-0 route target has a
+ * 2-byte global administrator and a 4-byte local administrator. Both are represented here as 32-bit
+ * range expressions; the type is derived from the values when converting, as in {@link
+ * org.batfish.datamodel.bgp.community.ExtendedCommunity#target}.
  */
 @ParametersAreNonnullByDefault
 public final class ExtcommunitySetRtElemAsColon implements ExtcommunitySetRtElem {
 
-  public ExtcommunitySetRtElemAsColon(Uint32RangeExpr gaRangeExpr, Uint16RangeExpr laRangeExpr) {
+  public ExtcommunitySetRtElemAsColon(Uint32RangeExpr gaRangeExpr, Uint32RangeExpr laRangeExpr) {
     _gaRangeExpr = gaRangeExpr;
     _laRangeExpr = laRangeExpr;
   }
@@ -26,7 +32,7 @@ public final class ExtcommunitySetRtElemAsColon implements ExtcommunitySetRtElem
     return _gaRangeExpr;
   }
 
-  public @Nonnull Uint16RangeExpr getLaRangeExpr() {
+  public @Nonnull Uint32RangeExpr getLaRangeExpr() {
     return _laRangeExpr;
   }
 
@@ -48,5 +54,5 @@ public final class ExtcommunitySetRtElemAsColon implements ExtcommunitySetRtElem
   }
 
   private final @Nonnull Uint32RangeExpr _gaRangeExpr;
-  private final @Nonnull Uint16RangeExpr _laRangeExpr;
+  private final @Nonnull Uint32RangeExpr _laRangeExpr;
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub10062Test.java
@@ -5,24 +5,43 @@ import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.main.BatfishTestUtils.DUMMY_SNAPSHOT_1;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.batfish.representation.cisco_xr.CiscoXrConfiguration.computeExtcommunitySetRtName;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.config.Settings;
+import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
+import org.batfish.datamodel.routing_policy.communities.CommunityContext;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExpr;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetExprEvaluator;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
 import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
 import org.batfish.representation.cisco_xr.CiscoXrConfiguration;
+import org.batfish.representation.cisco_xr.ExtcommunitySetRtElemAsColon;
+import org.batfish.representation.cisco_xr.ExtcommunitySetRtElemAsDotColon;
+import org.batfish.representation.cisco_xr.LiteralUint16;
+import org.batfish.representation.cisco_xr.LiteralUint32;
 import org.batfish.representation.cisco_xr.VrfAddressFamily;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +55,10 @@ public final class GitHub10062Test {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   private @Nonnull CiscoXrConfiguration parseVendorConfig(String hostname) {
+    return parseVendorConfig(hostname, new Warnings());
+  }
+
+  private @Nonnull CiscoXrConfiguration parseVendorConfig(String hostname, Warnings warnings) {
     String src = readResource(TESTCONFIGS_PREFIX + hostname, UTF_8);
     Settings settings = new Settings();
     configureBatfishTestSettings(settings);
@@ -45,7 +68,7 @@ public final class GitHub10062Test {
             src,
             ciscoXrParser,
             ConfigurationFormat.CISCO_IOS_XR,
-            new Warnings(),
+            warnings,
             new SilentSyntaxCollection());
     ParserRuleContext tree =
         Batfish.parse(
@@ -56,6 +79,17 @@ public final class GitHub10062Test {
     vendorConfiguration.setFilename(TESTCONFIGS_PREFIX + hostname);
     // crash if not serializable
     return SerializationUtils.clone(vendorConfiguration);
+  }
+
+  private @Nonnull Configuration parseConfig(String hostname) {
+    try {
+      Map<String, Configuration> configs =
+          BatfishTestUtils.parseTextConfigs(_folder, TESTCONFIGS_PREFIX + hostname);
+      assertThat(configs, hasKey(hostname));
+      return configs.get(hostname);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Test
@@ -107,5 +141,75 @@ public final class GitHub10062Test {
             ExtendedCommunity.target(65000L, 100L), ExtendedCommunity.target(4200000001L, 200L)));
     assertThat(
         af.getRouteTargetExport(), containsInAnyOrder(ExtendedCommunity.target(4200000001L, 300L)));
+  }
+
+  @Test
+  public void testExtcommunitySetRtLocalAdministrator32Extraction() {
+    // An RFC 4360 type-0 route target has a 2-byte global administrator and a 4-byte local
+    // administrator; IOS-XR accepts this in an extcommunity-set rt. Both this shape and the
+    // type-2 shape (4-byte GA, 2-byte LA) must extract, and neither may disturb the other.
+    Warnings warnings = new Warnings(true, true, true);
+    CiscoXrConfiguration c = parseVendorConfig("gh10062ecrt", warnings);
+
+    // No set may be damaged, and in particular error recovery must not mis-attribute a failure
+    // in one set to the set that follows it.
+    assertThat(warnings.getParseWarnings(), empty());
+    assertThat(c.getExtcommunitySetRts(), hasKeys("ecrt_la32", "ecrt_ga32", "ecrt_mixed"));
+
+    // type 0: 2-byte ASN GA, 4-byte LA
+    assertThat(
+        c.getExtcommunitySetRts().get("ecrt_la32").getElements(),
+        contains(
+            new ExtcommunitySetRtElemAsColon(
+                new LiteralUint32(65000L), new LiteralUint32(11311111L))));
+    // type 2: 4-byte asplain ASN GA, 2-byte LA
+    assertThat(
+        c.getExtcommunitySetRts().get("ecrt_ga32").getElements(),
+        contains(
+            new ExtcommunitySetRtElemAsColon(
+                new LiteralUint32(4200000001L), new LiteralUint32(100L))));
+    // both widths, plus asdot, in one set
+    assertThat(
+        c.getExtcommunitySetRts().get("ecrt_mixed").getElements(),
+        contains(
+            new ExtcommunitySetRtElemAsColon(
+                new LiteralUint32(65000L), new LiteralUint32(11311111L)),
+            new ExtcommunitySetRtElemAsColon(
+                new LiteralUint32(4200000001L), new LiteralUint32(100L)),
+            new ExtcommunitySetRtElemAsColon(new LiteralUint32(1234L), new LiteralUint32(56L)),
+            new ExtcommunitySetRtElemAsDotColon(
+                new LiteralUint16(12), new LiteralUint16(34), new LiteralUint16(56))));
+  }
+
+  @Test
+  public void testExtcommunitySetRtLocalAdministrator32Conversion() {
+    Configuration c = parseConfig("gh10062ecrt");
+    CommunityContext ctx = CommunityContext.builder().build();
+
+    // Matching: a type-0 route target with a 4-byte local administrator must match itself, and
+    // must not match a route target that merely shares its global administrator.
+    {
+      CommunityMatchExpr expr =
+          c.getCommunityMatchExprs().get(computeExtcommunitySetRtName("ecrt_la32"));
+      assertTrue(
+          expr.accept(
+              ctx.getCommunityMatchExprEvaluator(), ExtendedCommunity.target(65000L, 11311111L)));
+      assertFalse(
+          expr.accept(ctx.getCommunityMatchExprEvaluator(), ExtendedCommunity.target(65000L, 1L)));
+    }
+
+    // Setting: the literal community produced must round-trip to the same 4-byte LA.
+    {
+      CommunitySetExpr expr =
+          c.getCommunitySetExprs().get(computeExtcommunitySetRtName("ecrt_mixed"));
+      assertThat(
+          expr.accept(CommunitySetExprEvaluator.instance(), ctx),
+          equalTo(
+              CommunitySet.of(
+                  ExtendedCommunity.target(65000L, 11311111L),
+                  ExtendedCommunity.target(4200000001L, 100L),
+                  ExtendedCommunity.target(1234L, 56L),
+                  ExtendedCommunity.target((12L << 16) | 34L, 56L))));
+    }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -1393,8 +1393,8 @@ public final class XrGrammarTest {
       assertThat(
           set.getElements(),
           contains(
-              new ExtcommunitySetRtElemAsColon(new LiteralUint32(1234L), new LiteralUint16(56)),
-              new ExtcommunitySetRtElemAsColon(new LiteralUint32(1234L), new LiteralUint16(57)),
+              new ExtcommunitySetRtElemAsColon(new LiteralUint32(1234L), new LiteralUint32(56L)),
+              new ExtcommunitySetRtElemAsColon(new LiteralUint32(1234L), new LiteralUint32(57L)),
               new ExtcommunitySetRtElemAsDotColon(
                   new LiteralUint16(12), new LiteralUint16(34), new LiteralUint16(56))));
     }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh10062ecrt
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh10062ecrt
@@ -1,0 +1,33 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname gh10062ecrt
+!
+! Type 0: 2-byte ASN global administrator, 4-byte local administrator.
+extcommunity-set rt ecrt_la32
+  65000:11311111
+end-set
+!
+! Type 2: 4-byte asplain ASN global administrator, 2-byte local administrator.
+! Defined after the set above to catch error recovery mis-attributing a
+! failure in the preceding set to this one.
+extcommunity-set rt ecrt_ga32
+  4200000001:100
+end-set
+!
+! Mixed widths within a single set, plus asdot form.
+extcommunity-set rt ecrt_mixed
+  65000:11311111,
+  4200000001:100,
+  1234:56,
+  12.34:56
+end-set
+!
+route-policy set-ecrt
+  set extcommunity rt ecrt_la32
+  pass
+end-policy
+!
+route-policy set-ecrt-inline
+  set extcommunity rt ( 65000:11311111, 4200000001:100 )
+  pass
+end-policy

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityExprEvaluator.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityExprEvaluator.java
@@ -20,7 +20,8 @@ public final class CommunityExprEvaluator
       RouteTargetExtendedCommunityExpr routeTargetExtendedCommunityExpr, CommunityContext arg) {
     long ga =
         routeTargetExtendedCommunityExpr.getGaExpr().accept(LongExprEvaluator.instance(), null);
-    int la = routeTargetExtendedCommunityExpr.getLaExpr().accept(IntExprEvaluator.instance(), null);
+    long la =
+        routeTargetExtendedCommunityExpr.getLaExpr().accept(LongExprEvaluator.instance(), null);
     return ExtendedCommunity.target(ga, la);
   }
 

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluator.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluator.java
@@ -162,8 +162,8 @@ public final class CommunityMatchExprEvaluator
     return extendedCommunityLocalAdministratorMatch
         .getExpr()
         .accept(
-            IntMatchExprEvaluator.instance(),
-            new LiteralInt((int) ((ExtendedCommunity) arg).getLocalAdministrator()));
+            LongMatchExprEvaluator.instance(),
+            new LiteralLong(((ExtendedCommunity) arg).getLocalAdministrator()));
   }
 
   @Override

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityLocalAdministratorMatch.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityLocalAdministratorMatch.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.routing_policy.expr.IntMatchExpr;
+import org.batfish.datamodel.routing_policy.expr.LongMatchExpr;
 
 /**
  * An expression that matches an extended community whose local administrator is matched by the
@@ -14,7 +14,7 @@ import org.batfish.datamodel.routing_policy.expr.IntMatchExpr;
  */
 public final class ExtendedCommunityLocalAdministratorMatch extends CommunityMatchExpr {
 
-  public ExtendedCommunityLocalAdministratorMatch(IntMatchExpr expr) {
+  public ExtendedCommunityLocalAdministratorMatch(LongMatchExpr expr) {
     _expr = expr;
   }
 
@@ -24,7 +24,7 @@ public final class ExtendedCommunityLocalAdministratorMatch extends CommunityMat
   }
 
   @JsonProperty(PROP_EXPR)
-  public @Nonnull IntMatchExpr getExpr() {
+  public @Nonnull LongMatchExpr getExpr() {
     return _expr;
   }
 
@@ -48,10 +48,10 @@ public final class ExtendedCommunityLocalAdministratorMatch extends CommunityMat
 
   @JsonCreator
   private static @Nonnull ExtendedCommunityLocalAdministratorMatch create(
-      @JsonProperty(PROP_EXPR) @Nullable IntMatchExpr expr) {
+      @JsonProperty(PROP_EXPR) @Nullable LongMatchExpr expr) {
     checkArgument(expr != null, "Missing %s", PROP_EXPR);
     return new ExtendedCommunityLocalAdministratorMatch(expr);
   }
 
-  private final @Nonnull IntMatchExpr _expr;
+  private final @Nonnull LongMatchExpr _expr;
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunityExpr.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunityExpr.java
@@ -7,16 +7,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.routing_policy.expr.IntExpr;
 import org.batfish.datamodel.routing_policy.expr.LongExpr;
 
 /**
- * An expression representing a route-target extended community via an expression for its global
- * administrator 32 bits and its local administrator 16 bits
+ * An expression representing a route-target extended community via expressions for its global
+ * administrator and its local administrator.
+ *
+ * <p>Per RFC 4360, exactly one of the two may be 4 bytes wide; the type is derived from the values
+ * by {@link org.batfish.datamodel.bgp.community.ExtendedCommunity#target}.
  */
 public class RouteTargetExtendedCommunityExpr extends CommunityExpr {
 
-  public RouteTargetExtendedCommunityExpr(LongExpr gaExpr, IntExpr laExpr) {
+  public RouteTargetExtendedCommunityExpr(LongExpr gaExpr, LongExpr laExpr) {
     _gaExpr = gaExpr;
     _laExpr = laExpr;
   }
@@ -32,7 +34,7 @@ public class RouteTargetExtendedCommunityExpr extends CommunityExpr {
   }
 
   @JsonProperty(PROP_LA_EXPR)
-  public IntExpr getLaExpr() {
+  public @Nonnull LongExpr getLaExpr() {
     return _laExpr;
   }
 
@@ -59,12 +61,12 @@ public class RouteTargetExtendedCommunityExpr extends CommunityExpr {
   @JsonCreator
   private static @Nonnull RouteTargetExtendedCommunityExpr create(
       @JsonProperty(PROP_GA_EXPR) @Nullable LongExpr gaExpr,
-      @JsonProperty(PROP_LA_EXPR) @Nullable IntExpr laExpr) {
+      @JsonProperty(PROP_LA_EXPR) @Nullable LongExpr laExpr) {
     checkArgument(gaExpr != null, "Missing %s", PROP_GA_EXPR);
     checkArgument(laExpr != null, "Missing %s", PROP_LA_EXPR);
     return new RouteTargetExtendedCommunityExpr(gaExpr, laExpr);
   }
 
   private final @Nonnull LongExpr _gaExpr;
-  private final @Nonnull IntExpr _laExpr;
+  private final @Nonnull LongExpr _laExpr;
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityExprEvaluatorTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityExprEvaluatorTest.java
@@ -20,13 +20,13 @@ public final class CommunityExprEvaluatorTest {
     {
       // global administrator fitting within 16 bits
       RouteTargetExtendedCommunityExpr expr =
-          new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralInt(1));
+          new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralLong(1L));
       assertThat(expr.accept(instance(), CTX), equalTo(ExtendedCommunity.target(1L, 1)));
     }
     {
       // global administrator requiring 32 bits
       RouteTargetExtendedCommunityExpr expr =
-          new RouteTargetExtendedCommunityExpr(new LiteralLong(1000000L), new LiteralInt(1));
+          new RouteTargetExtendedCommunityExpr(new LiteralLong(1000000L), new LiteralLong(1L));
       assertThat(expr.accept(instance(), CTX), equalTo(ExtendedCommunity.target(1000000L, 1)));
     }
   }

--- a/projects/common/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluatorTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluatorTest.java
@@ -188,12 +188,22 @@ public final class CommunityMatchExprEvaluatorTest {
   public void testVisitExtendedCommunityLocalAdministratorMatch() {
     assertFalse(
         new ExtendedCommunityLocalAdministratorMatch(
-                new IntComparison(IntComparator.EQ, new LiteralInt(1)))
+                new LongComparison(IntComparator.EQ, new LiteralLong(1L)))
             .accept(EVAL, ExtendedCommunity.of(0, 0L, 0L)));
     assertTrue(
         new ExtendedCommunityLocalAdministratorMatch(
-                new IntComparison(IntComparator.EQ, new LiteralInt(1)))
+                new LongComparison(IntComparator.EQ, new LiteralLong(1L)))
             .accept(EVAL, ExtendedCommunity.of(0, 0L, 1L)));
+    // A type-0 local administrator uses all 32 bits. Narrowing it to a signed int would make
+    // values above 2^31 compare as negative.
+    assertTrue(
+        new ExtendedCommunityLocalAdministratorMatch(
+                new LongComparison(IntComparator.EQ, new LiteralLong(0xFFFFFFFFL)))
+            .accept(EVAL, ExtendedCommunity.of(0, 0L, 0xFFFFFFFFL)));
+    assertTrue(
+        new ExtendedCommunityLocalAdministratorMatch(
+                new LongComparison(IntComparator.GT, new LiteralLong(0L)))
+            .accept(EVAL, ExtendedCommunity.of(0, 0L, 0x80000000L)));
   }
 
   @Test

--- a/projects/common/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityLocalAdministratorMatchTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityLocalAdministratorMatchTest.java
@@ -7,8 +7,8 @@ import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
-import org.batfish.datamodel.routing_policy.expr.IntComparison;
-import org.batfish.datamodel.routing_policy.expr.LiteralInt;
+import org.batfish.datamodel.routing_policy.expr.LiteralLong;
+import org.batfish.datamodel.routing_policy.expr.LongComparison;
 import org.junit.Test;
 
 /** Test of {@link ExtendedCommunityLocalAdministratorMatch}. */
@@ -16,7 +16,7 @@ public final class ExtendedCommunityLocalAdministratorMatchTest {
 
   private static final ExtendedCommunityLocalAdministratorMatch OBJ =
       new ExtendedCommunityLocalAdministratorMatch(
-          new IntComparison(IntComparator.EQ, new LiteralInt(1)));
+          new LongComparison(IntComparator.EQ, new LiteralLong(1L)));
 
   @Test
   public void testJacksonSerialization() {
@@ -38,10 +38,10 @@ public final class ExtendedCommunityLocalAdministratorMatchTest {
             OBJ,
             OBJ,
             new ExtendedCommunityLocalAdministratorMatch(
-                new IntComparison(IntComparator.EQ, new LiteralInt(1))))
+                new LongComparison(IntComparator.EQ, new LiteralLong(1L))))
         .addEqualityGroup(
             new ExtendedCommunityLocalAdministratorMatch(
-                new IntComparison(IntComparator.EQ, new LiteralInt(2))))
+                new LongComparison(IntComparator.EQ, new LiteralLong(2L))))
         .testEquals();
   }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunityExprTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunityExprTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
-import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.junit.Test;
 
@@ -14,7 +13,7 @@ import org.junit.Test;
 public final class RouteTargetExtendedCommunityExprTest {
 
   private static final RouteTargetExtendedCommunityExpr OBJ =
-      new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralInt(1));
+      new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralLong(1L));
 
   @Test
   public void testJacksonSerialization() {
@@ -32,11 +31,13 @@ public final class RouteTargetExtendedCommunityExprTest {
     new EqualsTester()
         .addEqualityGroup(new Object())
         .addEqualityGroup(
-            OBJ, OBJ, new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralInt(1)))
+            OBJ,
+            OBJ,
+            new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralLong(1L)))
         .addEqualityGroup(
-            new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralInt(2)))
+            new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralLong(2L)))
         .addEqualityGroup(
-            new RouteTargetExtendedCommunityExpr(new LiteralLong(2L), new LiteralInt(2)))
+            new RouteTargetExtendedCommunityExpr(new LiteralLong(2L), new LiteralLong(2L)))
         .testEquals();
   }
 }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunityMatchExprToBDDTest.java
@@ -309,7 +309,7 @@ public class CommunityMatchExprToBDDTest {
   public void testVisitExtendedCommunityLocalAdministratorMatch() {
     ExtendedCommunityLocalAdministratorMatch ec =
         new ExtendedCommunityLocalAdministratorMatch(
-            new IntComparison(IntComparator.EQ, new LiteralInt(3)));
+            new LongComparison(IntComparator.EQ, new LiteralLong(3L)));
     _exception.expect(UnsupportedOperationException.class);
     _communityMatchExprToBDD.visitExtendedCommunityLocalAdministratorMatch(ec, _arg);
   }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunityMatchExprCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/collectors/CommunityMatchExprCollectorTest.java
@@ -211,7 +211,7 @@ public class CommunityMatchExprCollectorTest {
   public void testVisitExtendedCommunityLocalAdministratorMatch() {
     ExtendedCommunityLocalAdministratorMatch ec =
         new ExtendedCommunityLocalAdministratorMatch(
-            new IntComparison(IntComparator.EQ, new LiteralInt(3)));
+            new LongComparison(IntComparator.EQ, new LiteralLong(3L)));
     Set<String> result =
         _collector.visitExtendedCommunityLocalAdministratorMatch(
             ec, new Tuple<>(new HashSet<>(), _config));

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunityMatchExprVarCollectorTest.java
@@ -220,7 +220,7 @@ public class CommunityMatchExprVarCollectorTest {
   public void testVisitExtendedCommunityLocalAdministratorMatch() {
     ExtendedCommunityLocalAdministratorMatch ec =
         new ExtendedCommunityLocalAdministratorMatch(
-            new IntComparison(IntComparator.EQ, new LiteralInt(3)));
+            new LongComparison(IntComparator.EQ, new LiteralLong(3L)));
     Set<CommunityVar> result =
         _varCollector.visitExtendedCommunityLocalAdministratorMatch(ec, _baseConfig);
     assertEquals(ImmutableSet.of(), result);


### PR DESCRIPTION
An RFC 4360 type-0 route target has a 2-byte global administrator and a
4-byte local administrator. `extcommunity_set_rt_elem_colon` accepted
only the type-2 shape (`elem_32 COLON elem_16`), so a set element like
`65000:11311111` failed to parse. Adds the `elem_16 COLON elem_32`
alternative, mirroring `ecgalal4_colon` added for IOS in a4f5c8e59a.
The two alternatives are ambiguous when both halves fit in 16 bits;
ANTLR resolves to the existing rule, which extracts the same value.

Both administrators are now modeled as 32-bit range expressions, since
only one of them may be 4 bytes wide and the type is derived from the
values by ExtendedCommunity#target. This widens
ExtendedCommunityLocalAdministratorMatch and the local-administrator
half of RouteTargetExtendedCommunityExpr from Int to Long, matching
their global-administrator counterparts, and drops a narrowing cast in
CommunityMatchExprEvaluator that made a local administrator above 2^31
compare as negative.

Fixes batfish/batfish#10062. The `rd` half was fixed in #10066 and the
vrf address-family route-target half was covered in #10073.

----

Prompt:
```
Investigate https://github.com/batfish/batfish/issues/10062 -- where did we get to?

Look at other vendors. How did we handle that there?

Make the fix using TDD
```
