### PR TITLE
Junos: parse bare vstp interface entries

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_protocols.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_protocols.g4
@@ -282,7 +282,7 @@ pvstp_interface
       | pvstpi_mode_null
       | pvstpi_no_root_port_null
       | pvstpi_priority_null
-   )
+   )?
 ;
 
 pvstpi_edge_null
@@ -304,4 +304,3 @@ pvstpi_priority_null
 :
    PRIORITY null_filler
 ;
-

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -9737,6 +9737,7 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testXstpInterfaceExtraction() {
     JuniperConfiguration jc = parseJuniperConfig("xstp-interface-validation");
+    assertThat(jc.getWarnings().getParseWarnings(), empty());
     Set<String> xstpInterfaces = jc.getMasterLogicalSystem().getXstpInterfaceNames();
     // Should contain the specific interfaces but not "all"
     assertThat(xstpInterfaces, containsInAnyOrder("xe-0/0/1.0", "xe-0/0/2.0", "ge-0/0/0.0"));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/xstp-interface-validation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/xstp-interface-validation
@@ -14,6 +14,7 @@ set interfaces ge-0/0/0 unit 0 family ethernet-switching interface-mode access
 set vlans v100 vlan-id 100
 #
 # VSTP: xe-0/0/1 is valid, xe-0/0/2 should produce fatal error
+set protocols vstp interface xe-0/0/1
 set protocols vstp vlan v100 interface xe-0/0/1 mode point-to-point
 set protocols vstp vlan v100 interface xe-0/0/2 mode point-to-point
 #


### PR DESCRIPTION
Allow "set protocols vstp interface <name>" without requiring a
trailing mode, edge, priority, or no-root-port substatement.

Add the bare form to xstp-interface-validation and assert it parses
without warnings.
