### PR TITLE
InterfaceDependencies: don't crash if aggregate dependency doesn't exist

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -72,6 +73,7 @@ import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
@@ -703,6 +705,32 @@ public class BatfishTest {
         name -> assertThat(c1.getAllInterfaces().get(name).getActive(), equalTo(true)));
     inactiveIfaces.forEach(
         name -> assertThat(c1.getAllInterfaces().get(name).getActive(), equalTo(false)));
+  }
+
+  @Test
+  public void testPostProcessInterfaceDependenciesAggregateMissingChild() throws IOException {
+    String hostname = "bundle-ether-l3-member";
+
+    SortedMap<String, byte[]> configurationsBytes =
+        ImmutableSortedMap.of(
+            hostname, readResourceBytes("org/batfish/main/testconfigs/" + hostname));
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder().setConfigurationBytes(configurationsBytes).build(), _folder);
+
+    Map<String, Configuration> configurations = batfish.loadConfigurations(batfish.getSnapshot());
+    Configuration c1v = configurations.get(hostname);
+
+    assertThat(c1v.getAllInterfaces(), not(hasKey("HundredGigE0/0/0/1")));
+    assertThat(c1v.getAllInterfaces().get("Bundle-Ether1").getActive(), equalTo(false));
+    assertThat(
+        c1v.getAllInterfaces().get("Bundle-Ether1").getInactiveReason(),
+        equalTo(InactiveReason.INVALID));
+    assertThat(
+        c1v.getAllInterfaces().get("Bundle-Ether1").getDependencies().stream()
+            .map(Dependency::getInterfaceName)
+            .collect(ImmutableSet.toImmutableSet()),
+        equalTo(ImmutableSet.of("HundredGigE0/0/0/1")));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/bundle-ether-l3-member
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/bundle-ether-l3-member
@@ -1,0 +1,9 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname bundle-ether-l3-member
+!
+interface Bundle-Ether1
+  ipv4 address 10.0.0.1 255.255.255.254
+interface HundredGigE0/0/0/1
+  bundle id 1 mode active
+  ipv4 address 10.0.0.1 255.255.255.254

--- a/projects/common/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/interface_dependency/InterfaceDependencies.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.interface_dependency;
 import static org.batfish.common.topology.Layer1Topologies.INVALID_INTERFACE;
 import static org.batfish.datamodel.InactiveReason.AGGREGATE_NEIGHBOR_DOWN;
 import static org.batfish.datamodel.InactiveReason.BIND_DOWN;
+import static org.batfish.datamodel.InactiveReason.INVALID;
 import static org.batfish.datamodel.InactiveReason.LACP_FAILURE;
 import static org.batfish.datamodel.InactiveReason.NO_ACTIVE_MEMBERS;
 import static org.batfish.datamodel.InactiveReason.NO_MEMBERS;
@@ -106,6 +107,21 @@ public class InterfaceDependencies {
                 _logger.warn(
                     "deactivating AGGREGATE/REDUNDANT interface {} with no dependencies", ifaceId);
                 _interfacesToDeactivate.put(ifaceId, NO_MEMBERS);
+                break;
+              }
+
+              // if the aggregate has dependencies, but one of them doesn't actually exist,
+              // deactivate it.
+              if (iface.getDependencies().stream()
+                  .anyMatch(
+                      dep ->
+                          dep.getType() == AGGREGATE
+                              && !allIfaces.containsKey(dep.getInterfaceName()))) {
+                _logger.warn(
+                    "deactivating AGGREGATE/REDUNDANT interface {} because one of its dependencies"
+                        + " is invalid",
+                    ifaceId);
+                _interfacesToDeactivate.put(ifaceId, INVALID);
                 break;
               }
 


### PR DESCRIPTION
Hi!

This PR is my attempt at fixing an unexpected crash wile trying to parse the following minimal invalid configuration:
```
!RANCID-CONTENT-TYPE: cisco-xr
!
hostname bundle-ether-l3-member
!
interface Bundle-Ether1
  ipv4 address 10.0.0.1 255.255.255.254
interface HundredGigE0/0/0/1
  bundle id 1 mode active
  ipv4 address 10.0.0.1 255.255.255.254
```


```
Cannot invoke "org.batfish.datamodel.Interface.getOwner()" because "iface" is null
java.lang.NullPointerException: Cannot invoke "org.batfish.datamodel.Interface.getOwner()" because "iface" is null
	at org.batfish.datamodel.interface_dependency.InterfaceDependencies.getL1Neighbors(InterfaceDependencies.java:232)
	at org.batfish.datamodel.interface_dependency.InterfaceDependencies.getL1Neighbor(InterfaceDependencies.java:267)
	at org.batfish.datamodel.interface_dependency.InterfaceDependencies.lambda$initialize$3(InterfaceDependencies.java:163)
```

The root cause is that `InterfaceDependencies` wrongly assumes that the interface dependency actually exists on its `getL1Neighbor` calls. That seems wrong, especially given the `Interface.Dependency` docstring: `Therefore callers may not assume that the interface named by getInterfaceName() actually exists.`.

This fix instead first checks that the aggregate members actually exist in the configuration before doing anything else: if any member doesn't exist, then that must mean the configuration was invalid anyway so the bundle should just be shutdown in my opinion.

EDIT: to be clear because it took me some time to understand where exactly the member interface got removed, that's done (and rightly so) by `ConvertConfigurationJob.verifyInterfaces` 

I've struggled a bit with where to put the test, I _think_ the place I put it here looks fine, but obviously feel free to tell me.

As a final note: I've seldom written production-grade Java, so if anything looks weird I'll be glad to receive feedback! :grin:  In any case, thank you for maintaining and keeping batfish open!

