### PR TITLE
Junos: don't flag then source-class/destination-class in forwarding-table export

### DIFF
--- a/docs/data_plane/fib_export_policy.md
+++ b/docs/data_plane/fib_export_policy.md
@@ -27,9 +27,13 @@ Protocol RIBs  --[table-map]--> Main RIB --[FIB export policy]--> FIB
 
 On Juniper, this policy also supports `then load-balance per-packet` for
 ECMP selection. Batfish models all ECMP paths regardless, so the
-per-packet/per-flow distinction has no behavioral effect. Standard route
-attribute mutations (metric, next-hop, etc.) have no effect in this context
-on real Juniper routers.
+per-packet/per-flow distinction has no behavioral effect. It likewise
+supports `then source-class`/`then destination-class` (SCU/DCU), which
+classify prefixes for per-class accounting; these are only settable from a
+forwarding-table export policy, and Batfish does not model the accounting
+they drive. Standard route attribute mutations (metric, next-hop, etc.) have
+no effect in this context on real Juniper routers, and Batfish emits a RISKY
+warning for them.
 
 The default Junos forwarding-table export action is **accept**: routes that
 fall through the policy without a terminal action (accept/reject) are

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -600,6 +600,8 @@ DESTINATION_ADDRESS_EXCLUDED: 'destination-address-excluded';
 
 DESTINATION_ADDRESS_NAME: 'destination-address-name' -> pushMode(M_Name);
 
+DESTINATION_CLASS: 'destination-class' -> pushMode(M_Name);
+
 DESTINATION_HOST_PROHIBITED: 'destination-host-prohibited';
 
 DESTINATION_HOST_UNKNOWN: 'destination-host-unknown';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_firewall.g4
@@ -123,6 +123,7 @@ fft_from
    (
       fftf_address
       | fftf_destination_address
+      | fftf_destination_class
       | fftf_destination_port
       | fftf_destination_port_except
       | fftf_destination_port_range_optimize
@@ -215,6 +216,11 @@ fftf_destination_address
       | IPV6_ADDRESS
       | IPV6_PREFIX
    ) EXCEPT?
+;
+
+fftf_destination_class
+:
+   DESTINATION_CLASS name = junos_name
 ;
 
 fftf_destination_port: DESTINATION_PORT port_range;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -599,6 +599,7 @@ popst_common
    | popst_cos_next_hop_map
    | popst_default_action_accept
    | popst_default_action_reject
+   | popst_destination_class
    | popst_external
    | popst_forwarding_class
    | popst_install_nexthop
@@ -648,6 +649,11 @@ popst_default_action_accept
 popst_default_action_reject
 :
    DEFAULT_ACTION REJECT
+;
+
+popst_destination_class
+:
+   DESTINATION_CLASS name = junos_name
 ;
 
 popst_external

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -32,6 +32,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_S
 import static org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_SCHEDULER_MAP;
 import static org.batfish.representation.juniper.JuniperStructureType.COMMUNITY;
 import static org.batfish.representation.juniper.JuniperStructureType.CONDITION;
+import static org.batfish.representation.juniper.JuniperStructureType.DESTINATION_CLASS;
 import static org.batfish.representation.juniper.JuniperStructureType.DHCP_RELAY_SERVER_GROUP;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER_TERM;
@@ -127,6 +128,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.CLASS_OF_
 import static org.batfish.representation.juniper.JuniperStructureUsage.DHCP_RELAY_GROUP_ACTIVE_SERVER_GROUP;
 import static org.batfish.representation.juniper.JuniperStructureUsage.FIREWALL_FILTER_DESTINATION_PREFIX_LIST;
 import static org.batfish.representation.juniper.JuniperStructureUsage.FIREWALL_FILTER_DSCP;
+import static org.batfish.representation.juniper.JuniperStructureUsage.FIREWALL_FILTER_FROM_DESTINATION_CLASS;
 import static org.batfish.representation.juniper.JuniperStructureUsage.FIREWALL_FILTER_FROM_SOURCE_CLASS;
 import static org.batfish.representation.juniper.JuniperStructureUsage.FIREWALL_FILTER_PREFIX_LIST;
 import static org.batfish.representation.juniper.JuniperStructureUsage.FIREWALL_FILTER_SOURCE_PREFIX_LIST;
@@ -398,6 +400,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.F_policerContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Ff_termContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_destination_addressContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_destination_classContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_destination_portContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_destination_port_exceptContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Fftf_destination_prefix_listContext;
@@ -678,6 +681,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_community_deleteC
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_community_setContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_default_action_acceptContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_default_action_rejectContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_destination_classContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_externalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_load_balanceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_local_preferenceContext;
@@ -1088,6 +1092,7 @@ import org.batfish.representation.juniper.FwFromApplicationOrApplicationSet;
 import org.batfish.representation.juniper.FwFromDestinationAddress;
 import org.batfish.representation.juniper.FwFromDestinationAddressBookEntry;
 import org.batfish.representation.juniper.FwFromDestinationAddressExcept;
+import org.batfish.representation.juniper.FwFromDestinationClass;
 import org.batfish.representation.juniper.FwFromDestinationPort;
 import org.batfish.representation.juniper.FwFromDestinationPrefixList;
 import org.batfish.representation.juniper.FwFromDestinationPrefixListExcept;
@@ -1243,6 +1248,7 @@ import org.batfish.representation.juniper.PsThenCommunityDelete;
 import org.batfish.representation.juniper.PsThenCommunitySet;
 import org.batfish.representation.juniper.PsThenDefaultActionAccept;
 import org.batfish.representation.juniper.PsThenDefaultActionReject;
+import org.batfish.representation.juniper.PsThenDestinationClass;
 import org.batfish.representation.juniper.PsThenExternal;
 import org.batfish.representation.juniper.PsThenLoadBalance;
 import org.batfish.representation.juniper.PsThenLoadBalance.LoadBalanceMethod;
@@ -5363,6 +5369,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   }
 
   @Override
+  public void exitFftf_destination_class(Fftf_destination_classContext ctx) {
+    todo(ctx);
+    String name = toString(ctx.name);
+    FwFrom from = new FwFromDestinationClass(name);
+    _currentFwTerm.getFroms().add(from);
+    _configuration.referenceStructure(
+        DESTINATION_CLASS, name, FIREWALL_FILTER_FROM_DESTINATION_CLASS, getLine(ctx.name.start));
+  }
+
+  @Override
   public void exitFftf_destination_port(Fftf_destination_portContext ctx) {
     SubRange ports = toSubRange(ctx.port_range());
     FwFrom from = new FwFromDestinationPort(ports);
@@ -7103,6 +7119,14 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitPopst_default_action_reject(Popst_default_action_rejectContext ctx) {
     addPsThen(new PsThenDefaultActionReject(), ctx);
+  }
+
+  @Override
+  public void exitPopst_destination_class(Popst_destination_classContext ctx) {
+    todo(ctx);
+    String name = toString(ctx.name);
+    addPsThen(new PsThenDestinationClass(name), ctx);
+    _configuration.defineSingleLineStructure(DESTINATION_CLASS, name, getLine(ctx.name.start));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationClass.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationClass.java
@@ -1,0 +1,40 @@
+package org.batfish.representation.juniper;
+
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.representation.juniper.FwTerm.Field;
+
+/** Class for firewall filter from destination-class */
+public final class FwFromDestinationClass implements FwFrom {
+
+  private final @Nonnull String _name;
+
+  public FwFromDestinationClass(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  @Override
+  public Field getField() {
+    return Field.DESTINATION;
+  }
+
+  @Override
+  public AclLineMatchExpr toAclLineMatchExpr(JuniperConfiguration jc, Configuration c, Warnings w) {
+    // Destination-class matching is used for accounting/metering in Junos based on routes
+    // classified by policy-statement "then destination-class" actions.
+    // Batfish does not currently model this functionality.
+    return new FalseExpr(getTraceElement());
+  }
+
+  private TraceElement getTraceElement() {
+    return TraceElement.of(String.format("Matched destination-class %s", _name));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -4436,8 +4436,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   /**
    * Emit warnings for policy actions that have no effect in the forwarding-table export context. On
-   * Junos, only accept/reject and load-balance/source-class are meaningful; all other attribute
-   * mutations (metric, next-hop, community, etc.) are no-ops.
+   * Junos, only accept/reject, load-balance, and source-class/destination-class are meaningful; all
+   * other attribute mutations (metric, next-hop, community, etc.) are no-ops.
    */
   private void warnForwardingTableExportActions(String policyName) {
     PolicyStatement ps = _masterLogicalSystem.getPolicyStatements().get(policyName);
@@ -4458,13 +4458,16 @@ public final class JuniperConfiguration extends VendorConfiguration {
           || then instanceof PsThenDefaultActionReject
           || then instanceof PsThenNextPolicy
           || then instanceof PsThenNextTerm
-          || then instanceof PsThenLoadBalance) {
-        // Control flow or forwarding-table-specific actions — no warning.
+          || then instanceof PsThenLoadBalance
+          || then instanceof PsThenSourceClass
+          || then instanceof PsThenDestinationClass) {
+        // Control flow or forwarding-table-specific actions — no warning. Source-class and
+        // destination-class (SCU/DCU) are only settable from a forwarding-table export policy.
         continue;
       }
       _w.riskyRedFlag(
-          "forwarding-table export %s term %s: %s has no effect"
-              + " (only accept/reject affects forwarding-table export)",
+          "forwarding-table export %s term %s: %s has no effect (only accept/reject, load-balance,"
+              + " and source-class/destination-class affect forwarding-table export)",
           policyName, term.getName(), then.getClass().getSimpleName());
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureType.java
@@ -34,6 +34,7 @@ public enum JuniperStructureType implements StructureType {
   CLASS_OF_SERVICE_SCHEDULER_MAP("class-of-service scheduler-map"),
   COMMUNITY("community"),
   CONDITION("condition"),
+  DESTINATION_CLASS("destination-class"),
   DHCP_RELAY_SERVER_GROUP("dhcp-relay server-group"),
   FIREWALL_FILTER("firewall filter"),
   FIREWALL_INET6_FILTER("firewall family inet6 filter"),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -101,6 +101,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   DHCP_RELAY_GROUP_ACTIVE_SERVER_GROUP("dhcp relay group active-server-group"),
   FIREWALL_FILTER_DESTINATION_PREFIX_LIST("firewall filter destination prefix-list"),
   FIREWALL_FILTER_DSCP("firewall filter dscp"),
+  FIREWALL_FILTER_FROM_DESTINATION_CLASS("firewall filter from destination-class"),
   FIREWALL_FILTER_FROM_SOURCE_CLASS("firewall filter from source-class"),
   FIREWALL_FILTER_PREFIX_LIST("firewall filter prefix-list"),
   FIREWALL_FILTER_SOURCE_PREFIX_LIST("firewall filter source prefix-list"),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenDestinationClass.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenDestinationClass.java
@@ -1,0 +1,51 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * Represents the action in Juniper's routing policy (policy statement) which sets the
+ * destination-class for a matched route. Destination-class is used for accounting/metering traffic
+ * in firewall filters.
+ */
+public final class PsThenDestinationClass extends PsThen {
+
+  private final @Nonnull String _destinationClassName;
+
+  public PsThenDestinationClass(String destinationClassName) {
+    _destinationClassName = destinationClassName;
+  }
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings warnings) {
+    // Destination-class assignment is used for accounting/metering in Junos.
+    // Batfish does not currently model this functionality.
+  }
+
+  public @Nonnull String getDestinationClassName() {
+    return _destinationClassName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenDestinationClass)) {
+      return false;
+    }
+    PsThenDestinationClass that = (PsThenDestinationClass) o;
+    return _destinationClassName.equals(that._destinationClassName);
+  }
+
+  @Override
+  public int hashCode() {
+    return _destinationClassName.hashCode();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThens.java
@@ -126,6 +126,7 @@ public final class PsThens implements Serializable {
           "metric2",
           "load-balance",
           "source-class",
+          "destination-class",
           "tunnel-attribute set",
           "tunnel-attribute remove",
           "add-path send-count");
@@ -170,6 +171,8 @@ public final class PsThens implements Serializable {
       return "tunnel-attribute remove";
     } else if (then instanceof PsThenSourceClass) {
       return "source-class";
+    } else if (then instanceof PsThenDestinationClass) {
+      return "destination-class";
     } else if (then instanceof PsThenAddPathSendCount) {
       return "add-path send-count";
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -174,6 +174,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.BRIDGE_DOM
 import static org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_DSCP_CODE_POINT_ALIAS;
 import static org.batfish.representation.juniper.JuniperStructureType.CLASS_OF_SERVICE_FORWARDING_CLASS;
 import static org.batfish.representation.juniper.JuniperStructureType.COMMUNITY;
+import static org.batfish.representation.juniper.JuniperStructureType.DESTINATION_CLASS;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_INTERFACE_SET;
@@ -431,6 +432,7 @@ import org.batfish.representation.juniper.EvpnIpPrefixRoutesAdvertise;
 import org.batfish.representation.juniper.ExtendedCommunityOrAuto;
 import org.batfish.representation.juniper.FirewallFilter;
 import org.batfish.representation.juniper.FwFrom;
+import org.batfish.representation.juniper.FwFromDestinationClass;
 import org.batfish.representation.juniper.FwFromDestinationPort;
 import org.batfish.representation.juniper.FwFromFragmentOffset;
 import org.batfish.representation.juniper.FwFromHopLimit;
@@ -509,6 +511,7 @@ import org.batfish.representation.juniper.PsThenAsPathPrepend;
 import org.batfish.representation.juniper.PsThenCommunityAdd;
 import org.batfish.representation.juniper.PsThenCommunityDelete;
 import org.batfish.representation.juniper.PsThenCommunitySet;
+import org.batfish.representation.juniper.PsThenDestinationClass;
 import org.batfish.representation.juniper.PsThenLoadBalance;
 import org.batfish.representation.juniper.PsThenLoadBalance.LoadBalanceMethod;
 import org.batfish.representation.juniper.PsThenLocalPreference;
@@ -11178,6 +11181,86 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testDestinationClassExtraction() {
+    JuniperConfiguration c = parseJuniperConfig("destination-class");
+    Map<String, PolicyStatement> policies = c.getMasterLogicalSystem().getPolicyStatements();
+    Map<String, FirewallFilter> filters = c.getMasterLogicalSystem().getFirewallFilters();
+
+    // Test policy-statement then destination-class extraction (definition)
+    PolicyStatement exportDcu = policies.get("EXPORT-DCU");
+    assertThat(exportDcu, notNullValue());
+
+    PsTerm termA = exportDcu.getTerms().get("REGION-A");
+    assertThat(termA.getThens().getAllThens(), hasSize(1));
+    assertThat(
+        getOnlyElement(termA.getThens().getAllThens()),
+        equalTo(new PsThenDestinationClass("DEST-CLASS-A")));
+
+    PsTerm termB = exportDcu.getTerms().get("REGION-B");
+    assertThat(termB.getThens().getAllThens(), hasSize(1));
+    assertThat(
+        getOnlyElement(termB.getThens().getAllThens()),
+        equalTo(new PsThenDestinationClass("DEST-CLASS-B")));
+
+    // Test firewall filter from destination-class extraction (reference)
+    assertThat(filters, hasEntry(equalTo("METERING"), instanceOf(ConcreteFirewallFilter.class)));
+    ConcreteFirewallFilter meteringFilter = (ConcreteFirewallFilter) filters.get("METERING");
+    assertThat(meteringFilter.getTerms(), hasKeys("METER-A", "METER-B", "METER-UNDEF", "ACCEPT"));
+
+    FwTerm fwTermA = meteringFilter.getTerms().get("METER-A");
+    assertThat(fwTermA.getFroms(), hasSize(1));
+    FwFrom fromA = getOnlyElement(fwTermA.getFroms());
+    assertThat(fromA, instanceOf(FwFromDestinationClass.class));
+    assertThat(((FwFromDestinationClass) fromA).getName(), equalTo("DEST-CLASS-A"));
+
+    FwTerm fwTermB = meteringFilter.getTerms().get("METER-B");
+    assertThat(fwTermB.getFroms(), hasSize(1));
+    FwFrom fromB = getOnlyElement(fwTermB.getFroms());
+    assertThat(fromB, instanceOf(FwFromDestinationClass.class));
+    assertThat(((FwFromDestinationClass) fromB).getName(), equalTo("DEST-CLASS-B"));
+
+    // Test undefined destination-class reference
+    FwTerm fwTermUndef = meteringFilter.getTerms().get("METER-UNDEF");
+    assertThat(fwTermUndef.getFroms(), hasSize(1));
+    FwFrom fromUndef = getOnlyElement(fwTermUndef.getFroms());
+    assertThat(fromUndef, instanceOf(FwFromDestinationClass.class));
+    assertThat(((FwFromDestinationClass) fromUndef).getName(), equalTo("DEST-CLASS-UNDEFINED"));
+
+    // Test IPv6 filter with destination-class
+    assertThat(filters, hasEntry(equalTo("METERING-V6"), instanceOf(ConcreteFirewallFilter.class)));
+    ConcreteFirewallFilter meteringV6Filter = (ConcreteFirewallFilter) filters.get("METERING-V6");
+    assertThat(meteringV6Filter.getTerms(), hasKeys("METER-A", "ACCEPT"));
+
+    FwTerm fwTermV6 = meteringV6Filter.getTerms().get("METER-A");
+    assertThat(fwTermV6.getFroms(), hasSize(1));
+    FwFrom fromV6 = getOnlyElement(fwTermV6.getFroms());
+    assertThat(fromV6, instanceOf(FwFromDestinationClass.class));
+    assertThat(((FwFromDestinationClass) fromV6).getName(), equalTo("DEST-CLASS-A"));
+  }
+
+  @Test
+  public void testDestinationClassDefinitionAndReferences() throws IOException {
+    String hostname = "destination-class";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Verify destination-class definitions are tracked
+    assertThat(ccae, hasDefinedStructure(filename, DESTINATION_CLASS, "DEST-CLASS-A"));
+    assertThat(ccae, hasDefinedStructure(filename, DESTINATION_CLASS, "DEST-CLASS-B"));
+
+    // Verify destination-class references are tracked
+    // DEST-CLASS-A is referenced 2 times (once in inet filter, once in inet6 filter)
+    assertThat(ccae, hasNumReferrers(filename, DESTINATION_CLASS, "DEST-CLASS-A", 2));
+    // DEST-CLASS-B is referenced 1 time (in inet filter)
+    assertThat(ccae, hasNumReferrers(filename, DESTINATION_CLASS, "DEST-CLASS-B", 1));
+
+    // Verify undefined destination-class reference is identified
+    assertThat(ccae, hasUndefinedReference(filename, DESTINATION_CLASS, "DEST-CLASS-UNDEFINED"));
+  }
+
+  @Test
   public void testPolicyStatementFromProtocol() {
     JuniperConfiguration vc = parseJuniperConfig("policy-statement-from-protocol");
     PolicyStatement ps = vc.getMasterLogicalSystem().getPolicyStatements().get("PS");
@@ -11379,6 +11462,27 @@ public final class FlatJuniperGrammarTest {
     Fib fib = dp.getFibs().get(hostname).get(Configuration.DEFAULT_VRF_NAME);
     assertThat(fib.get(Ip.parse("192.168.0.1")), not(empty()));
     assertThat(fib.get(Ip.parse("192.168.1.1")), not(empty()));
+  }
+
+  /**
+   * {@code then source-class}/{@code then destination-class} (SCU/DCU) are only settable from a
+   * forwarding-table export policy, so they must not be reported as having no effect there. Other
+   * attribute mutations, like {@code then metric}, still are.
+   */
+  @Test
+  public void testForwardingTableExport_classActionsNotFlagged() throws IOException {
+    String hostname = "forwarding-table-export-classes";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    assertThat(
+        ccae.getWarnings().get(hostname).getRedFlagWarnings(),
+        contains(
+            WarningMatchers.hasText(
+                "RISK: forwarding-table export FIB_CLASSES term class-a: PsThenMetric has no effect"
+                    + " (only accept/reject, load-balance, and source-class/destination-class"
+                    + " affect forwarding-table export)")));
   }
 
   private final BddTestbed _b = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/destination-class
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/destination-class
@@ -1,0 +1,20 @@
+set system host-name destination-class
+
+# Policy statement with destination-class assignment (definition)
+set policy-options policy-statement EXPORT-DCU term REGION-A then destination-class DEST-CLASS-A
+set policy-options policy-statement EXPORT-DCU term REGION-B then destination-class DEST-CLASS-B
+
+# Firewall filter with destination-class matching (reference)
+set firewall family inet filter METERING term METER-A from destination-class DEST-CLASS-A
+set firewall family inet filter METERING term METER-A then count TO-IPv4-A
+set firewall family inet filter METERING term METER-B from destination-class DEST-CLASS-B
+set firewall family inet filter METERING term METER-B then count TO-IPv4-B
+# Undefined destination-class reference
+set firewall family inet filter METERING term METER-UNDEF from destination-class DEST-CLASS-UNDEFINED
+set firewall family inet filter METERING term METER-UNDEF then count TO-IPv4-UNDEF
+set firewall family inet filter METERING term ACCEPT then accept
+
+# IPv6 filter with destination-class matching
+set firewall family inet6 filter METERING-V6 term METER-A from destination-class DEST-CLASS-A
+set firewall family inet6 filter METERING-V6 term METER-A then count TO-IPv6-A
+set firewall family inet6 filter METERING-V6 term ACCEPT then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/forwarding-table-export-classes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/forwarding-table-export-classes
@@ -1,0 +1,18 @@
+#
+set system host-name forwarding-table-export-classes
+
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+
+set routing-options static route 192.168.0.0/24 next-hop 10.0.0.2
+
+# SCU/DCU classification: source-class and destination-class are only settable from a
+# forwarding-table export policy, so they must not be flagged as having no effect. `then metric`
+# is a genuine no-op in this context and should be flagged.
+set policy-options policy-statement FIB_CLASSES term class-a from route-filter 192.168.0.0/24 exact
+set policy-options policy-statement FIB_CLASSES term class-a then source-class CLASS-A
+set policy-options policy-statement FIB_CLASSES term class-a then destination-class CLASS-B
+set policy-options policy-statement FIB_CLASSES term class-a then metric 100
+set policy-options policy-statement FIB_CLASSES term class-a then accept
+
+set routing-options forwarding-table export FIB_CLASSES


### PR DESCRIPTION
The "has no effect (only accept/reject affects forwarding-table export)"
warning added in batfish/batfish#9863 fired on `then source-class`, even
though the javadoc introduced alongside it already listed source-class
as meaningful. Source-class and destination-class (SCU/DCU) classify
prefixes for per-class accounting and are only settable from a
forwarding-table export policy, so the warning was a false positive on
every SCU policy.

Exempts both from the warning and rewords it to name the full set of
actions that do take effect. `then destination-class` was not parsed at
all, so add it: lexer token, policy-statement and firewall filter
grammar rules, PsThenDestinationClass, FwFromDestinationClass, and
DESTINATION_CLASS structure definition/reference tracking, all mirroring
the existing source-class support.

----

Prompt:
```
On a Junos router config, this was logged:

(RISK: forwarding-table export <policy> term <term>: PsThenSourceClass
has no effect (only accept/reject affects forwarding-table export))

However, this appears to be a false positive. source-class is one other
thing you can set, per the Junos `export (routing-options)` reference and
the SCU/DCU forwarding-table export example.

1/ Figure out when we added this and on what basis.
2/ Fix the support for then source-class/destination-class to not be
logged as risky.
```
