### PR TITLE
docs: record that the cisco grammar is for Cisco IOS only

### DIFF
--- a/.claude/skills/review-vendor-pr/SKILL.md
+++ b/.claude/skills/review-vendor-pr/SKILL.md
@@ -233,6 +233,12 @@ independently-written CLIs; an existing `representation/cisco_asa` class is not
 evidence about IOS. A sibling PR for another OS tells you what a reviewer accepted
 there, not what this device parses — check this platform's own book.
 
+**In the `cisco` grammar, IOS fidelity wins.** ARUBAOS, CADANT, FORCE10, and FOUNDRY
+configs are still routed through this parser, but it is deliberately being narrowed to
+Cisco IOS(-XE), and where those four work it is largely by accident. Do not raise input
+they lose as a finding, and do not go looking for their manuals. See
+[`docs/parsing/vendors/cisco_ios.md`](../../../docs/parsing/vendors/cisco_ios.md).
+
 ## 3. Trace by reading, not by running
 
 For each hypothesis, answer it by reading both revisions. The question is always

--- a/docs/parsing/README.md
+++ b/docs/parsing/README.md
@@ -17,6 +17,7 @@ then processed by an [extractor](../extraction/README.md).
 
 Different vendors have unique configuration formats and parsing requirements. For vendor-specific guidance, see:
 
+- [Cisco IOS](vendors/cisco_ios.md) - why the `cisco` grammar is IOS-only, and what that means for the formats still routed through it
 - [Cisco IOS-XR](vendors/ios_xr.md) - IOS-XR-specific parsing and extraction details
 - [Juniper](vendors/juniper.md) - Juniper-specific parsing and extraction details
 - [Nokia SR-OS](vendors/sros.md) - SR-OS-specific parsing and extraction details

--- a/docs/parsing/vendors/cisco_ios.md
+++ b/docs/parsing/vendors/cisco_ios.md
@@ -1,0 +1,17 @@
+# Cisco IOS-Specific Parsing and Extraction
+
+## The `cisco` grammar is for Cisco IOS, not for vendors that copied its syntax
+
+Batfish once maintained the `cisco` grammar as a single "Frankenparser" spanning every vendor whose
+CLI resembles IOS. That proved a maintenance and correctness burden, and we are unwinding it by
+making this vendor specific to Cisco IOS(-XE). `ParseVendorConfigurationJob` still routes ARUBAOS,
+CADANT, FORCE10, and FOUNDRY configs through this parser, but where they work it is largely by
+accident, and that is expected to get worse over time. A few rules exist only to serve them: the
+`FACILITY` clause of `logging_host` was added for Cadant and is not documented for IOS.
+
+**So when IOS syntax or semantics conflict with one of those four formats, model IOS.** Narrowing a
+parser rule or a value range to match the IOS command reference is acceptable even when it drops
+input that previously parsed for ArubaOS, Cadant, Force10, or Foundry. None of the four has a
+vendor-specific representation, conversion, lab validation, or test configuration in this
+repository. Name the format that loses coverage in the commit message, but do not consult its
+manual to justify the change.


### PR DESCRIPTION
New docs/parsing/vendors/cisco_ios.md explains that the Cisco
"Frankenparser" is being unwound into an IOS(-XE)-specific vendor, so
the ARUBAOS, CADANT, FORCE10, and FOUNDRY configs still routed through
it work largely by accident. Narrowing a parser rule or a value range
to match the IOS command reference is therefore acceptable even when
those four lose input that used to parse. The review-vendor-pr skill
now says not to report that lost coverage as a finding.

----

Prompt:
```
Changes that improve IOS fidelity at the cost of non-Cisco-IOS variants such as Aruba or Cadant are fine. Maybe we shuold record that explicitly in the repo docs.
```

Later in the same task: keep the skill's advice specific to IOS rather
than stating a generic multi-format rule, and trim the doc to the
minimum.
