### PR TITLE
IPsec: treat a mixed encrypted/plaintext pre-shared key pair as unverifiable

### DIFF
--- a/projects/common/src/main/java/org/batfish/common/util/IpsecUtil.java
+++ b/projects/common/src/main/java/org/batfish/common/util/IpsecUtil.java
@@ -252,7 +252,9 @@ public class IpsecUtil {
 
   /**
    * Negotiates key for IKE phase 1 and sets it in the provided ipsecSessionBuilder. Negotiated IKE
-   * P1 key in the ipsecSessionBuilder will be null if no valid key was detected or negotiated
+   * P1 key in the ipsecSessionBuilder will be null if no valid key was detected or negotiated. If
+   * the two key types differ but both are pre-shared keys, one side's value is unreadable, so an
+   * empty key is set rather than none.
    */
   @VisibleForTesting
   static void negotiateIkePhase1Key(
@@ -260,6 +262,14 @@ public class IpsecUtil {
       IkePhase1Key responderKey,
       IpsecSession.Builder ipsecSessionBuilder) {
     if (responderKey.getKeyType() != initiatorKey.getKeyType()) {
+      // Key types differ, so the values cannot be compared. If both are pre-shared keys then one
+      // side is unreadable and the configs do not prove the keys differ, so continue with an
+      // empty key, as for two encrypted pre-shared keys below.
+      if (isPreSharedKey(initiatorKey.getKeyType()) && isPreSharedKey(responderKey.getKeyType())) {
+        IkePhase1Key unverifiableKey = new IkePhase1Key();
+        unverifiableKey.setKeyType(IkeKeyType.PRE_SHARED_KEY_ENCRYPTED);
+        ipsecSessionBuilder.setNegotiatedIkeP1Key(unverifiableKey);
+      }
       return;
     }
     IkePhase1Key negotiatedIkePhase1Key = new IkePhase1Key();
@@ -274,6 +284,11 @@ public class IpsecUtil {
       negotiatedIkePhase1Key.setKeyHash(initiatorKey.getKeyHash());
       ipsecSessionBuilder.setNegotiatedIkeP1Key(negotiatedIkePhase1Key);
     }
+  }
+
+  private static boolean isPreSharedKey(IkeKeyType keyType) {
+    return keyType == IkeKeyType.PRE_SHARED_KEY_ENCRYPTED
+        || keyType == IkeKeyType.PRE_SHARED_KEY_UNENCRYPTED;
   }
 
   /**

--- a/projects/common/src/test/java/org/batfish/common/util/IpsecUtilTest.java
+++ b/projects/common/src/test/java/org/batfish/common/util/IpsecUtilTest.java
@@ -14,7 +14,9 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 import java.util.HashMap;
@@ -22,12 +24,17 @@ import java.util.Map;
 import java.util.Set;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
+import org.batfish.datamodel.IkePhase1Policy;
+import org.batfish.datamodel.IkePhase1Proposal;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpsecPeerConfigId;
+import org.batfish.datamodel.IpsecPhase2Policy;
 import org.batfish.datamodel.IpsecPhase2Proposal;
 import org.batfish.datamodel.IpsecSession;
 import org.batfish.datamodel.IpsecStaticPeerConfig;
@@ -261,6 +268,154 @@ public class IpsecUtilTest {
     assertThat(
         ipsecSessionBuilder.getNegotiatedIkeP1Key().getKeyType(),
         equalTo(IkeKeyType.PRE_SHARED_KEY_ENCRYPTED));
+  }
+
+  @Test
+  public void testNegotiateIkePhase1KeyMixedPsk() {
+    // A device whose config exposes the plaintext key (e.g. AWS) peering with one whose config
+    // only ever contains an encrypted key (e.g. Cisco 'key 6', or any Palo Alto gateway). The
+    // values cannot be compared, so negotiation continues with an empty key rather than failing.
+    IpsecSession.Builder ipsecSessionBuilder = IpsecSession.builder();
+    IkePhase1Key initiatorKey = new IkePhase1Key();
+    initiatorKey.setKeyType(IkeKeyType.PRE_SHARED_KEY_ENCRYPTED);
+    initiatorKey.setKeyHash("encrypted-blob");
+    IkePhase1Key responderKey = new IkePhase1Key();
+    responderKey.setKeyType(IkeKeyType.PRE_SHARED_KEY_UNENCRYPTED);
+    responderKey.setKeyHash("plaintext");
+
+    negotiateIkePhase1Key(initiatorKey, responderKey, ipsecSessionBuilder);
+
+    assertThat(ipsecSessionBuilder.getNegotiatedIkeP1Key(), notNullValue());
+    assertThat(
+        ipsecSessionBuilder.getNegotiatedIkeP1Key().getKeyType(),
+        equalTo(IkeKeyType.PRE_SHARED_KEY_ENCRYPTED));
+    assertThat(ipsecSessionBuilder.getNegotiatedIkeP1Key().getKeyHash(), nullValue());
+  }
+
+  @Test
+  public void testNegotiateIkePhase1KeyMixedPskOrderIndependent() {
+    // same as above with the roles swapped
+    IpsecSession.Builder ipsecSessionBuilder = IpsecSession.builder();
+    IkePhase1Key initiatorKey = new IkePhase1Key();
+    initiatorKey.setKeyType(IkeKeyType.PRE_SHARED_KEY_UNENCRYPTED);
+    initiatorKey.setKeyHash("plaintext");
+    IkePhase1Key responderKey = new IkePhase1Key();
+    responderKey.setKeyType(IkeKeyType.PRE_SHARED_KEY_ENCRYPTED);
+    responderKey.setKeyHash("encrypted-blob");
+
+    negotiateIkePhase1Key(initiatorKey, responderKey, ipsecSessionBuilder);
+
+    assertThat(ipsecSessionBuilder.getNegotiatedIkeP1Key(), notNullValue());
+    assertThat(
+        ipsecSessionBuilder.getNegotiatedIkeP1Key().getKeyType(),
+        equalTo(IkeKeyType.PRE_SHARED_KEY_ENCRYPTED));
+    assertThat(ipsecSessionBuilder.getNegotiatedIkeP1Key().getKeyHash(), nullValue());
+  }
+
+  @Test
+  public void testNegotiateIkePhase1KeyRsaVersusPskFail() {
+    // Different authentication methods entirely - not merely an unreadable key - must still fail.
+    IpsecSession.Builder ipsecSessionBuilder = IpsecSession.builder();
+    IkePhase1Key initiatorKey = new IkePhase1Key();
+    initiatorKey.setKeyType(IkeKeyType.RSA_PUB_KEY);
+    initiatorKey.setKeyHash("key1");
+    IkePhase1Key responderKey = new IkePhase1Key();
+    responderKey.setKeyType(IkeKeyType.PRE_SHARED_KEY_UNENCRYPTED);
+    responderKey.setKeyHash("key1");
+
+    negotiateIkePhase1Key(initiatorKey, responderKey, ipsecSessionBuilder);
+
+    assertThat(ipsecSessionBuilder.getNegotiatedIkeP1Key(), nullValue());
+
+    // the guard is a conjunction over both operands, so check every RSA/PSK combination
+    for (IkeKeyType psk :
+        ImmutableList.of(
+            IkeKeyType.PRE_SHARED_KEY_UNENCRYPTED, IkeKeyType.PRE_SHARED_KEY_ENCRYPTED)) {
+      for (boolean rsaIsInitiator : ImmutableList.of(true, false)) {
+        IkePhase1Key rsaKey = new IkePhase1Key();
+        rsaKey.setKeyType(IkeKeyType.RSA_PUB_KEY);
+        rsaKey.setKeyHash("key1");
+        IkePhase1Key pskKey = new IkePhase1Key();
+        pskKey.setKeyType(psk);
+        pskKey.setKeyHash("key1");
+        IpsecSession.Builder builder = IpsecSession.builder();
+
+        negotiateIkePhase1Key(
+            rsaIsInitiator ? rsaKey : pskKey, rsaIsInitiator ? pskKey : rsaKey, builder);
+
+        assertThat(builder.getNegotiatedIkeP1Key(), nullValue());
+      }
+    }
+  }
+
+  @Test
+  public void testGetIpsecSessionMixedPskNegotiatesPhase2() {
+    // End to end: a peer whose key is encrypted and one whose key is plaintext must still reach
+    // phase 2, since retainCompatibleTunnelEdges drops any session with no negotiated P2 proposal.
+    IkePhase1Proposal ikeProposal = new IkePhase1Proposal("ike-proposal");
+    ikeProposal.setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS);
+    IpsecPhase2Proposal ipsecProposal = new IpsecPhase2Proposal();
+    IpsecPhase2Policy ipsecPolicy = new IpsecPhase2Policy();
+    ipsecPolicy.setProposals(ImmutableList.of("ipsec-proposal"));
+    // negotiateIpsecP2 requires a non-empty intersection of PFS groups
+    ipsecPolicy.setPfsKeyGroups(ImmutableSortedSet.of(DiffieHellmanGroup.GROUP14));
+
+    Configuration initiatorOwner =
+        configWithIpsec(
+            ikeProposal, ipsecProposal, ipsecPolicy, IkeKeyType.PRE_SHARED_KEY_ENCRYPTED);
+    Configuration responderOwner =
+        configWithIpsec(
+            ikeProposal, ipsecProposal, ipsecPolicy, IkeKeyType.PRE_SHARED_KEY_UNENCRYPTED);
+
+    IpsecStaticPeerConfig initiator =
+        IpsecStaticPeerConfig.builder()
+            .setSourceInterface("interface1")
+            .setTunnelInterface("Tunnel1")
+            .setLocalAddress(Ip.parse("1.1.1.1"))
+            .setDestinationAddress(Ip.parse("2.2.2.2"))
+            .setIkePhase1Policy("ike-policy")
+            .setIpsecPolicy("ipsec-policy")
+            .build();
+    IpsecStaticPeerConfig responder =
+        IpsecStaticPeerConfig.builder()
+            .setSourceInterface("interface2")
+            .setTunnelInterface("Tunnel2")
+            .setLocalAddress(Ip.parse("2.2.2.2"))
+            .setDestinationAddress(Ip.parse("1.1.1.1"))
+            .setIkePhase1Policy("ike-policy")
+            .setIpsecPolicy("ipsec-policy")
+            .build();
+
+    IpsecSession session = getIpsecSession(initiatorOwner, responderOwner, initiator, responder);
+
+    assertThat(session.getNegotiatedIkeP1Key(), notNullValue());
+    assertThat(session.getNegotiatedIkeP1Proposal(), notNullValue());
+    assertThat(session.getNegotiatedIpsecP2Proposal(), notNullValue());
+  }
+
+  private static Configuration configWithIpsec(
+      IkePhase1Proposal ikeProposal,
+      IpsecPhase2Proposal ipsecProposal,
+      IpsecPhase2Policy ipsecPolicy,
+      IkeKeyType keyType) {
+    Configuration c =
+        Configuration.builder()
+            .setHostname("host-" + keyType)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    IkePhase1Key key = new IkePhase1Key();
+    key.setKeyType(keyType);
+    if (keyType == IkeKeyType.PRE_SHARED_KEY_UNENCRYPTED) {
+      key.setKeyHash("plaintext");
+    }
+    IkePhase1Policy ikePolicy = new IkePhase1Policy("ike-policy");
+    ikePolicy.setIkePhase1Key(key);
+    ikePolicy.setIkePhase1Proposals(ImmutableList.of("ike-proposal"));
+    c.setIkePhase1Proposals(ImmutableSortedMap.of("ike-proposal", ikeProposal));
+    c.setIkePhase1Policies(ImmutableSortedMap.of("ike-policy", ikePolicy));
+    c.setIpsecPhase2Proposals(ImmutableSortedMap.of("ipsec-proposal", ipsecProposal));
+    c.setIpsecPhase2Policies(ImmutableSortedMap.of("ipsec-policy", ipsecPolicy));
+    return c;
   }
 
   @Test


### PR DESCRIPTION
## What

`negotiateIkePhase1Key` returns early when the initiator's and responder's `IkeKeyType` differ. When one side's config carries an encrypted pre-shared key and the other's carries the plaintext value, there is no negotiated phase 1 key, so `getIpsecSession` never runs phase 2 and `retainCompatibleTunnelEdges` drops the edge.

## Why this is an inconsistency rather than a new policy

Batfish already treats an unreadable pre-shared key as *unverifiable*, not as wrong. `IpsecUtilTest.testNegotiatedIkePhase1EncryptedPsk` asserts that two `PRE_SHARED_KEY_ENCRYPTED` keys with deliberately different hashes (`key1` vs `key2`) negotiate successfully, and the main-code comment says as much: "encrypted PSKs will not be equal and there is no common negotiated key so creating an empty negotiated key".

A mixed pair is epistemically identical — one side's value is unreadable, so the configs cannot prove the keys differ — but it fails a key-type equality check before reaching that logic. This change extends the existing rule to the mixed case, leaving the negotiated hash unset so nothing asserts the keys match.

## What this changes for users

`ipsecSessionStatus` moves from `IKE_PHASE1_KEY_MISMATCH` to `IPSEC_SESSION_ESTABLISHED` for these pairs. That is a deliberate trade and I think the more honest answer: in the mixed case Batfish never had evidence the keys differ — one side is a raw ciphertext, the other a salted hash — so the old verdict was a false negative presented as a check. Every configuration in which the keys are provably different is a same-type pair, and the `UNENCRYPTED`/`UNENCRYPTED` path still enforces hash equality unchanged.

## Who is affected

Vendors disagree about whether the key is recoverable from a config:

| Vendor | Key type |
|---|---|
| Cisco IOS / XR / ASA / Arista | `ENCRYPTED` for `key 6`, `UNENCRYPTED` for `key 0`; keyring-derived keys are always `UNENCRYPTED` |
| Juniper | `UNENCRYPTED` — `$9$` values are decrypted, then hashed |
| VyOS, AWS | `UNENCRYPTED` |

So a Cisco device using `crypto isakmp key 6` against an AWS VPN connection forms no tunnel today. That case is real but uncommon, since it needs type-6 encryption enabled.

In fairness, the broader trigger is my own #10156, which adds PAN-OS IPsec modeling: PAN-OS has no plaintext pre-shared key form at all, so once that lands every PAN-OS↔non-PAN-OS tunnel would hit this. The two changes are independent — this branch is cut from master, contains none of the PAN-OS work, and stands on the Cisco case alone — but I would rather flag the connection than have it discovered. Reviewing them in either order is fine.

## Testing

`IpsecUtilTest`: the mixed pair in both directions, RSA against both pre-shared key flavours in both directions (the guard is a conjunction over both operands), and an end-to-end `getIpsecSession` test asserting a negotiated phase 2 proposal, which is what `retainCompatibleTunnelEdges` actually filters on.

`common/util` 77 tests, plus the Cisco, AWS, PAN-OS and question suites all pass unchanged — no existing test depended on the previous outcome.
