### PR TITLE
Junos: parse cRPD eth interfaces, syslog archive option lists, and scrubbed names

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -3774,6 +3774,7 @@ F_InterfaceMediaType
    'em' |
    'es' |
    'et' |
+   'eth' | // Linux netdev name, used by cRPD
    'fab' |
    'fe' |
    'fti' |
@@ -3955,6 +3956,9 @@ F_NameChar
   | ':'
   // Junos allows '>' in names, e.g. LSP name "WASH->ATLA".
   | '>'
+  // An anonymizer that redacted part of a name leaves its marker inside the
+  // name, e.g. certificate name "local-cert-%CENSORED%".
+  | F_Scrubbed
 ;
 
 // Any number of newlines, allowing whitespace in between

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_system.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_system.g4
@@ -909,6 +909,8 @@ sys_file
    )
 ;
 
+// Junos allows any number of archive options on a single statement, e.g.
+// "archive size 1m files 5 binary-data".
 sysf_archive
 :
    ARCHIVE
@@ -921,7 +923,7 @@ sysf_archive
       | sysfa_start_time_null
       | sysfa_transfer_interval_null
       | sysfa_world_readable_null
-   )?
+   )*
 ;
 
 sysfa_file

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -1326,8 +1326,9 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testSyslogFileArchiveExtraction() {
     JuniperConfiguration c = parseJuniperConfig("juniper-syslog-file-archive");
+    assertThat(c.getWarnings().getParseWarnings(), empty());
     Map<String, JunosSyslogFile> files = c.getMasterLogicalSystem().getSyslogFiles();
-    assertThat(files, hasKeys("messages", "bytes-only", "count-only"));
+    assertThat(files, hasKeys("messages", "bytes-only", "count-only", "combined", "bare-archive"));
 
     // Archive size with unit (10m -> 10 * 1024 * 1024 bytes) and archive file count both set
     JunosSyslogFile messages = files.get("messages");
@@ -1343,6 +1344,16 @@ public final class FlatJuniperGrammarTest {
     JunosSyslogFile countOnly = files.get("count-only");
     assertThat(countOnly.getArchiveSizeBytes(), nullValue());
     assertThat(countOnly.getArchiveFileCount(), equalTo(3));
+
+    // Several archive options on one statement
+    JunosSyslogFile combined = files.get("combined");
+    assertThat(combined.getArchiveSizeBytes(), equalTo(1024L * 1024));
+    assertThat(combined.getArchiveFileCount(), equalTo(5));
+
+    // Archive with no options
+    JunosSyslogFile bareArchive = files.get("bare-archive");
+    assertThat(bareArchive.getArchiveSizeBytes(), nullValue());
+    assertThat(bareArchive.getArchiveFileCount(), nullValue());
   }
 
   @Test
@@ -8553,6 +8564,51 @@ public final class FlatJuniperGrammarTest {
                             .build())
                     .build());
     assertThat(result.getBooleanValue(), equalTo(false));
+  }
+
+  @Test
+  public void testCrpdEthInterfaces() throws IOException {
+    String hostname = "juniper-crpd-eth-interfaces";
+    String filename = "configs/" + hostname;
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Configuration config =
+        batfish.loadConfigurations(batfish.getSnapshot()).get(hostname.toLowerCase());
+
+    assertThat(config.getAllInterfaces(), hasKeys("eth0", "eth0.0", "eth1", "eth1.0"));
+
+    // "from interface eth0.0" matches a connected route on that unit's prefix.
+    RoutingPolicy unit = config.getRoutingPolicies().get("UNIT");
+    assertTrue(
+        unit.call(
+                Environment.builder(config)
+                    .setOriginalRoute(new ConnectedRoute(Prefix.parse("1.1.1.1/24"), "eth0.0"))
+                    .build())
+            .getBooleanValue());
+    assertFalse(
+        unit.call(
+                Environment.builder(config)
+                    .setOriginalRoute(new ConnectedRoute(Prefix.parse("3.3.3.3/24"), "eth0.0"))
+                    .build())
+            .getBooleanValue());
+
+    // "from interface eth1" names the parent, which carries no addresses, so it
+    // matches nothing -- not even a connected route on one of its units.
+    RoutingPolicy parent = config.getRoutingPolicies().get("PARENT");
+    assertFalse(
+        parent
+            .call(
+                Environment.builder(config)
+                    .setOriginalRoute(new ConnectedRoute(Prefix.parse("2.2.2.2/24"), "eth1.0"))
+                    .build())
+            .getBooleanValue());
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    // Each is referred to by its own "set interfaces" line and by "from interface".
+    assertThat(ccae, hasNumReferrers(filename, INTERFACE, "eth0.0", 2));
+    assertThat(ccae, hasNumReferrers(filename, INTERFACE, "eth1", 2));
+    // An interface that is only a device netdev is an undefined reference.
+    assertThat(ccae, hasUndefinedReference(filename, INTERFACE, "eth9"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-media-types
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-media-types
@@ -27,6 +27,7 @@ set interfaces ae-0/0/0 unit 0 family inet address 1.1.1.1/31
 set interfaces em0 unit 0 family inet address 1.1.1.1/31
 # TODO: 'es'
 set interfaces et-0/0/0 unit 0 family inet address 1.1.1.1/31
+set interfaces eth0 unit 0 family inet address 1.1.1.1/31
 # TODO: 'fab'
 set interfaces fe-0/0/0 unit 0 family inet address 1.1.1.1/31
 set interfaces fxp0 unit 0 family inet address 1.1.1.1/31

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-crpd-eth-interfaces
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-crpd-eth-interfaces
@@ -1,0 +1,19 @@
+#
+set system host-name juniper-crpd-eth-interfaces
+#
+# cRPD runs on Linux netdevs, so interface names look like eth0, not ge-0/0/0.
+set interfaces eth0 unit 0 family inet address 1.1.1.1/24
+set interfaces eth1 unit 0 family inet address 2.2.2.2/24
+#
+# A logical unit, which carries the addresses.
+set policy-options policy-statement UNIT term TERM1 from interface eth0.0
+set policy-options policy-statement UNIT term TERM1 then accept
+#
+# The bare parent interface. Addresses live on the unit, so the parent has none.
+set policy-options policy-statement PARENT term TERM1 from interface eth1
+set policy-options policy-statement PARENT term TERM1 then accept
+#
+# cRPD configs often have no interfaces stanza at all, leaving the interface a
+# device netdev that Batfish never sees.
+set policy-options policy-statement UNDEFINED term TERM1 from interface eth9
+set policy-options policy-statement UNDEFINED term TERM1 then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-security-misc
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-security-misc
@@ -1,3 +1,8 @@
 set system host-name juniper-security-misc
 #
 set security certificates local MY_CERT <SCRUBBED>
+#
+# Names whose original text was partly replaced by an anonymizer
+set security certificates local local-cert-%CENSORED% "%CENSORED%"
+set security certificates local local-cert-<SCRUBBED> <SCRUBBED>
+set security certificates local "quoted cert %CENSORED%" <SCRUBBED>

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-syslog-file-archive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-syslog-file-archive
@@ -10,3 +10,9 @@ set system syslog file bytes-only archive size 65536
 #
 # File with only an archive file count
 set system syslog file count-only archive files 3
+#
+# Several archive options on one statement
+set system syslog file combined archive size 1m files 5 binary-data
+#
+# Archive with no options at all
+set system syslog file bare-archive archive


### PR DESCRIPTION
Three unrecognized-syntax parse warnings on a cRPD route server:

- "eth" is now an interface media type, so cRPD's Linux netdev names
  (eth0, eth1.100) lex as interface ids. Extraction, conversion, and
  INTERFACE reference tracking already covered these once the name
  lexes.
- "system syslog file <f> archive" accepts a list of options rather than
  at most one, e.g. "archive size 1m files 5 binary-data".
- F_NameChar accepts a scrubbing marker, so a name that embeds one
  lexes, e.g. the certificate name "local-cert-%CENSORED%". Config
  management left the marker inside the name in every pre-deployment
  rendering of this config; only the rendering read back off the device
  carried the original name.

----

Prompt:
```
Adding parsing so that there are no "this syntax is unrecognized" parse
warnings in this config.
```

Follow-ups during the task: implement extraction, conversion, reference
tracking, and todos as applicable, not just parsing; and drop support
for anything that would not show up in a config read back off a device.
The config supplied was a pre-deployment rendering, so each pattern was
checked against the device-collected rendering too. That ruled out
speculative support for archive option lists that lead with a
no-argument flag.
