### PR TITLE
feat(fastpath): add tacacs-server parsing and extraction

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
@@ -47,6 +47,8 @@ HOST
 :
   'host'
   {
+    // `logging host <host>` / `tacacs-server host <host>`: the host (quoted, IP, or bare word)
+    // follows in M_HostValue. `ip host ...` is consumed as a null rest-of-line in DEFAULT mode.
     if (lastTokenType() == LOGGING || lastTokenType() == TACACS_SERVER) {
       pushMode(M_HostValue);
     }
@@ -379,12 +381,12 @@ M_Remainder_NEWLINE
   F_Newline -> type ( NEWLINE ) , popMode
 ;
 
-// Host value for `sntp server` / `logging host`: a quoted string, a bare IP, or a bare word
-// (hostname). The keyword alternatives that can appear in this position instead of a host are
-// recognized explicitly so they route to their own parser rules: `status` (sntp operational
-// leakage) and `reconfigure`/`remove` (logging host maintenance). Emits exactly one token then
-// returns to DEFAULT so any trailing tokens (priority/version/port, address-type, severity) lex
-// normally.
+// Host value for `sntp server` / `logging host` / `tacacs-server host`: a quoted string, a bare IP,
+// or a bare word (hostname). The keyword alternatives that can appear in this position instead of
+// a host are recognized explicitly so they route to their own parser rules: `status` (sntp
+// operational leakage) and `reconfigure`/`remove` (logging host maintenance). Emits exactly one
+// token then returns to DEFAULT so any trailing tokens (priority/version/port, address-type,
+// severity) lex normally.
 mode M_HostValue;
 
 M_HostValue_STATUS
@@ -432,6 +434,11 @@ mode M_Key;
 M_Key_ENCRYPTED
 :
   'encrypted' -> type ( ENCRYPTED )
+;
+
+M_Key_DOUBLE_QUOTE
+:
+  '"' -> type ( DOUBLE_QUOTE ) , mode ( M_DoubleQuote )
 ;
 
 M_Key_WORD

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
@@ -37,15 +37,17 @@ EMAIL
 
 EMERGENCY: 'emergency';
 
+ENCRYPTED: 'encrypted';
+
 ERROR: 'error';
+
+EXIT: 'exit';
 
 HOST
 :
   'host'
   {
-    // `logging host <host>`: the host (quoted, IP, or bare word) follows in M_HostValue.
-    // `ip host ...` is consumed as a null rest-of-line in DEFAULT mode.
-    if (lastTokenType() == LOGGING) {
+    if (lastTokenType() == LOGGING || lastTokenType() == TACACS_SERVER) {
       pushMode(M_HostValue);
     }
   }
@@ -63,6 +65,13 @@ IP: 'ip';
 IPV4: 'ipv4';
 
 IPV6: 'ipv6';
+
+KEY
+:
+  'key' -> pushMode ( M_Key )
+;
+
+KEYSTRING: 'keystring';
 
 LIST: 'list';
 
@@ -97,6 +106,8 @@ POLL_INTERVAL: 'poll-interval';
 POLL_RETRY: 'poll-retry';
 
 PORT: 'port';
+
+PRIORITY: 'priority';
 
 PROMPT
 :
@@ -135,6 +146,8 @@ STATUS
 ;
 
 SYSLOG: 'syslog';
+
+TACACS_SERVER: 'tacacs-server';
 
 TIMEOUT: 'timeout';
 
@@ -410,6 +423,28 @@ M_HostValue_WS
 ;
 
 M_HostValue_NEWLINE
+:
+  F_Newline -> type ( NEWLINE ) , popMode
+;
+
+mode M_Key;
+
+M_Key_ENCRYPTED
+:
+  'encrypted' -> type ( ENCRYPTED )
+;
+
+M_Key_WORD
+:
+  F_Word -> type ( WORD ) , popMode
+;
+
+M_Key_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN )
+;
+
+M_Key_NEWLINE
 :
   F_Newline -> type ( NEWLINE ) , popMode
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
@@ -393,7 +393,10 @@ tsh_block
 
 tsh_key
 :
-  KEY ENCRYPTED? WORD NEWLINE
+  KEY
+  (
+    ENCRYPTED? word
+  )? NEWLINE
 ;
 
 tsh_keystring_null
@@ -423,7 +426,10 @@ ts_source_interface
 
 ts_key
 :
-  KEY ENCRYPTED? WORD NEWLINE
+  KEY
+  (
+    ENCRYPTED? word
+  )? NEWLINE
 ;
 
 ts_keystring_null

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
@@ -21,6 +21,7 @@ statement
   | s_no
   | s_set
   | s_sntp
+  | s_tacacs_server
 ;
 
 s_hostname
@@ -360,4 +361,77 @@ logging_severity_keyword
   | INFO
   | NOTICE
   | WARNING
+;
+
+s_tacacs_server
+:
+  TACACS_SERVER
+  (
+    ts_host
+    | ts_key
+    | ts_keystring_null
+    | ts_source_interface
+    | ts_timeout
+  )
+;
+
+ts_host
+:
+  HOST host_value NEWLINE tsh_block
+;
+
+tsh_block
+:
+  (
+    tsh_key
+    | tsh_keystring_null
+    | tsh_port
+    | tsh_priority
+    | tsh_timeout
+  )* EXIT NEWLINE
+;
+
+tsh_key
+:
+  KEY ENCRYPTED? WORD NEWLINE
+;
+
+tsh_keystring_null
+:
+  KEYSTRING null_rest_of_line
+;
+
+tsh_port
+:
+  PORT port = uint16 NEWLINE
+;
+
+tsh_priority
+:
+  PRIORITY priority = uint16 NEWLINE
+;
+
+tsh_timeout
+:
+  TIMEOUT timeout = uint8 NEWLINE
+;
+
+ts_source_interface
+:
+  SOURCE_INTERFACE iface = interface_name NEWLINE
+;
+
+ts_key
+:
+  KEY ENCRYPTED? WORD NEWLINE
+;
+
+ts_keystring_null
+:
+  KEYSTRING null_rest_of_line
+;
+
+ts_timeout
+:
+  TIMEOUT timeout = uint8 NEWLINE
 ;

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
@@ -148,11 +148,13 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
 
   @Override
   public void exitTsh_port(Tsh_portContext ctx) {
+    // grammar enforces range (0-65535), so no toIntegerInSpace range check needed
     _currentTacacsServer.setPort(Integer.parseInt(ctx.port.getText()));
   }
 
   @Override
   public void exitTsh_priority(Tsh_priorityContext ctx) {
+    // grammar enforces range (0-65535), so no toIntegerInSpace range check needed
     _currentTacacsServer.setPriority(Integer.parseInt(ctx.priority.getText()));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
@@ -43,11 +43,20 @@ import org.batfish.vendor.fastpath.grammar.FastpathParser.Sntp_source_interfaceC
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Sntpc_modeContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Sntpc_portContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Ss_hostContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Ts_hostContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Ts_keyContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Ts_source_interfaceContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Ts_timeoutContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_keyContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_portContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_priorityContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_timeoutContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.WordContext;
 import org.batfish.vendor.fastpath.representation.FastpathConfiguration;
 import org.batfish.vendor.fastpath.representation.LoggingBuffered;
 import org.batfish.vendor.fastpath.representation.LoggingServer;
 import org.batfish.vendor.fastpath.representation.Sntp;
+import org.batfish.vendor.fastpath.representation.TacacsServer;
 
 /** Populates a {@link FastpathConfiguration} by walking a FastPath parse tree. */
 public final class FastpathConfigurationBuilder extends FastpathParserBaseListener
@@ -63,6 +72,8 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   private static final IntegerSpace SNTP_CLIENT_PORT_RANGE =
       IntegerSpace.of(Range.closed(1, 65535));
 
+  private static final IntegerSpace TACACS_TIMEOUT_RANGE = IntegerSpace.of(Range.closed(1, 30));
+
   public FastpathConfigurationBuilder(
       FastpathCombinedParser parser,
       String text,
@@ -75,6 +86,14 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
     _c = configuration;
     _silentSyntax = silentSyntax;
   }
+
+  private final @Nonnull FastpathConfiguration _c;
+  private final @Nonnull FastpathCombinedParser _parser;
+  private final @Nonnull SilentSyntaxCollection _silentSyntax;
+  private final @Nonnull String _text;
+  private final @Nonnull Warnings _w;
+
+  private @Nullable TacacsServer _currentTacacsServer;
 
   @Override
   public void exitS_hostname(S_hostnameContext ctx) {
@@ -114,6 +133,54 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   @Override
   public void exitSs_host(Ss_hostContext ctx) {
     _c.getSntp().addServer(toString(ctx.host_value()));
+  }
+
+  @Override
+  public void enterTs_host(Ts_hostContext ctx) {
+    _currentTacacsServer =
+        _c.getTacacs().getServers().computeIfAbsent(toString(ctx.host_value()), TacacsServer::new);
+  }
+
+  @Override
+  public void exitTs_host(Ts_hostContext ctx) {
+    _currentTacacsServer = null;
+  }
+
+  @Override
+  public void exitTsh_port(Tsh_portContext ctx) {
+    _currentTacacsServer.setPort(Integer.parseInt(ctx.port.getText()));
+  }
+
+  @Override
+  public void exitTsh_priority(Tsh_priorityContext ctx) {
+    _currentTacacsServer.setPriority(Integer.parseInt(ctx.priority.getText()));
+  }
+
+  @Override
+  public void exitTsh_timeout(Tsh_timeoutContext ctx) {
+    toIntegerInSpace(ctx, ctx.timeout, TACACS_TIMEOUT_RANGE, "tacacs-server host timeout")
+        .ifPresent(_currentTacacsServer::setTimeout);
+  }
+
+  @Override
+  public void exitTsh_key(Tsh_keyContext ctx) {
+    _currentTacacsServer.setKeyEncrypted(ctx.ENCRYPTED() != null);
+  }
+
+  @Override
+  public void exitTs_key(Ts_keyContext ctx) {
+    _c.getTacacs().setKeyEncrypted(ctx.ENCRYPTED() != null);
+  }
+
+  @Override
+  public void exitTs_timeout(Ts_timeoutContext ctx) {
+    toIntegerInSpace(ctx, ctx.timeout, TACACS_TIMEOUT_RANGE, "tacacs-server timeout")
+        .ifPresent(_c.getTacacs()::setTimeout);
+  }
+
+  @Override
+  public void exitTs_source_interface(Ts_source_interfaceContext ctx) {
+    _c.getTacacs().setSourceInterface(toInterfaceName(ctx.iface));
   }
 
   @Override
@@ -349,14 +416,4 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   public @Nonnull Warnings getWarnings() {
     return _w;
   }
-
-  private final @Nonnull FastpathConfiguration _c;
-
-  private final @Nonnull FastpathCombinedParser _parser;
-
-  private final @Nonnull SilentSyntaxCollection _silentSyntax;
-
-  private final @Nonnull String _text;
-
-  private final @Nonnull Warnings _w;
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/FastpathConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/FastpathConfiguration.java
@@ -25,6 +25,7 @@ public final class FastpathConfiguration extends VendorConfiguration {
   private final Dns _dns;
   private final Sntp _sntp;
   private final Logging _logging;
+  private final Tacacs _tacacs;
 
   private transient Configuration _c;
 
@@ -32,6 +33,7 @@ public final class FastpathConfiguration extends VendorConfiguration {
     _dns = new Dns();
     _sntp = new Sntp();
     _logging = new Logging();
+    _tacacs = new Tacacs();
   }
 
   @Override
@@ -63,6 +65,10 @@ public final class FastpathConfiguration extends VendorConfiguration {
     return _logging;
   }
 
+  public @Nonnull Tacacs getTacacs() {
+    return _tacacs;
+  }
+
   private @Nonnull Configuration toVendorIndependentConfiguration() {
     _c = new Configuration(_hostname, ConfigurationFormat.FASTPATH);
     _c.setHumanName(_rawHostname);
@@ -81,6 +87,8 @@ public final class FastpathConfiguration extends VendorConfiguration {
     convertNtpSourceInterface();
     convertLoggingServers();
     convertLoggingSourceInterface();
+    convertTacacsServers();
+    convertTacacsSourceInterface();
 
     return _c;
   }
@@ -118,6 +126,16 @@ public final class FastpathConfiguration extends VendorConfiguration {
   private void convertLoggingSourceInterface() {
     if (_logging.getSourceInterface() != null) {
       _c.setLoggingSourceInterface(_logging.getSourceInterface());
+    }
+  }
+
+  private void convertTacacsServers() {
+    _c.setTacacsServers(ImmutableSet.copyOf(_tacacs.getServers().keySet()));
+  }
+
+  private void convertTacacsSourceInterface() {
+    if (_tacacs.getSourceInterface() != null) {
+      _c.setTacacsSourceInterface(_tacacs.getSourceInterface());
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Tacacs.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Tacacs.java
@@ -12,7 +12,7 @@ public final class Tacacs implements Serializable {
   private final @Nonnull Map<String, TacacsServer> _servers;
   private @Nullable String _sourceInterface;
   private @Nullable Integer _timeout;
-  private boolean _keyEncrypted;
+  private @Nullable Boolean _keyEncrypted;
 
   public Tacacs() {
     _servers = new LinkedHashMap<>();
@@ -38,11 +38,12 @@ public final class Tacacs implements Serializable {
     _timeout = timeout;
   }
 
-  public boolean getKeyEncrypted() {
+  /** Whether the global {@code key} is encrypted, or {@code null} if no {@code key} was set. */
+  public @Nullable Boolean getKeyEncrypted() {
     return _keyEncrypted;
   }
 
-  public void setKeyEncrypted(boolean keyEncrypted) {
+  public void setKeyEncrypted(@Nullable Boolean keyEncrypted) {
     _keyEncrypted = keyEncrypted;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Tacacs.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Tacacs.java
@@ -1,0 +1,48 @@
+package org.batfish.vendor.fastpath.representation;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Aggregates a FastPath device's TACACS+ ({@code tacacs-server}) configuration */
+public final class Tacacs implements Serializable {
+
+  private final @Nonnull Map<String, TacacsServer> _servers;
+  private @Nullable String _sourceInterface;
+  private @Nullable Integer _timeout;
+  private boolean _keyEncrypted;
+
+  public Tacacs() {
+    _servers = new LinkedHashMap<>();
+  }
+
+  public @Nonnull Map<String, TacacsServer> getServers() {
+    return _servers;
+  }
+
+  public @Nullable String getSourceInterface() {
+    return _sourceInterface;
+  }
+
+  public void setSourceInterface(String sourceInterface) {
+    _sourceInterface = sourceInterface;
+  }
+
+  public @Nullable Integer getTimeout() {
+    return _timeout;
+  }
+
+  public void setTimeout(@Nullable Integer timeout) {
+    _timeout = timeout;
+  }
+
+  public boolean getKeyEncrypted() {
+    return _keyEncrypted;
+  }
+
+  public void setKeyEncrypted(boolean keyEncrypted) {
+    _keyEncrypted = keyEncrypted;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/TacacsServer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/TacacsServer.java
@@ -1,0 +1,59 @@
+package org.batfish.vendor.fastpath.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A single TACACS+ server host, from {@code tacacs-server host <host>} and its host-config submode
+ * options ({@code port}/{@code priority}/{@code timeout}/{@code key}).
+ */
+public final class TacacsServer implements Serializable {
+
+  private final @Nonnull String _host;
+  private @Nullable Integer _port;
+  private @Nullable Integer _priority;
+  private @Nullable Integer _timeout;
+  private boolean _keyEncrypted;
+
+  public TacacsServer(String host) {
+    _host = host;
+  }
+
+  /** The server IP address or hostname. */
+  public @Nonnull String getHost() {
+    return _host;
+  }
+
+  public @Nullable Integer getPort() {
+    return _port;
+  }
+
+  public void setPort(@Nullable Integer port) {
+    _port = port;
+  }
+
+  public @Nullable Integer getPriority() {
+    return _priority;
+  }
+
+  public void setPriority(@Nullable Integer priority) {
+    _priority = priority;
+  }
+
+  public @Nullable Integer getTimeout() {
+    return _timeout;
+  }
+
+  public void setTimeout(@Nullable Integer timeout) {
+    _timeout = timeout;
+  }
+
+  public boolean getKeyEncrypted() {
+    return _keyEncrypted;
+  }
+
+  public void setKeyEncrypted(boolean keyEncrypted) {
+    _keyEncrypted = keyEncrypted;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/TacacsServer.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/TacacsServer.java
@@ -14,7 +14,7 @@ public final class TacacsServer implements Serializable {
   private @Nullable Integer _port;
   private @Nullable Integer _priority;
   private @Nullable Integer _timeout;
-  private boolean _keyEncrypted;
+  private @Nullable Boolean _keyEncrypted;
 
   public TacacsServer(String host) {
     _host = host;
@@ -49,11 +49,12 @@ public final class TacacsServer implements Serializable {
     _timeout = timeout;
   }
 
-  public boolean getKeyEncrypted() {
+  /** Whether this server's {@code key} is encrypted, or {@code null} if no {@code key} was set. */
+  public @Nullable Boolean getKeyEncrypted() {
     return _keyEncrypted;
   }
 
-  public void setKeyEncrypted(boolean keyEncrypted) {
+  public void setKeyEncrypted(@Nullable Boolean keyEncrypted) {
     _keyEncrypted = keyEncrypted;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
@@ -114,7 +114,7 @@ public final class FastpathGrammarTest {
     Configuration c = parseConfig("fastpath_tacacs");
     assertThat(
         c.getTacacsServers(),
-        equalTo(ImmutableSet.of("1.1.1.1", "2.2.2.2", "tacacs.example.com", "3.3.3.3")));
+        equalTo(ImmutableSet.of("1.1.1.1", "2.2.2.2", "tacacs.example.com", "3.3.3.3", "4.4.4.4")));
     assertThat(c.getTacacsSourceInterface(), equalTo("serviceport"));
   }
 
@@ -123,7 +123,7 @@ public final class FastpathGrammarTest {
     Tacacs tacacs = parseVendorConfig("fastpath_tacacs").getTacacs();
     assertThat(
         tacacs.getServers().keySet(),
-        equalTo(ImmutableSet.of("1.1.1.1", "2.2.2.2", "tacacs.example.com", "3.3.3.3")));
+        equalTo(ImmutableSet.of("1.1.1.1", "2.2.2.2", "tacacs.example.com", "3.3.3.3", "4.4.4.4")));
     assertThat(tacacs.getSourceInterface(), equalTo("serviceport"));
     assertThat(tacacs.getTimeout(), equalTo(10));
     assertThat(tacacs.getKeyEncrypted(), equalTo(true));
@@ -144,13 +144,38 @@ public final class FastpathGrammarTest {
     assertThat(server3.getPort(), nullValue());
     assertThat(server3.getPriority(), nullValue());
     assertThat(server3.getTimeout(), nullValue());
-    assertThat(server3.getKeyEncrypted(), equalTo(false));
+    assertThat(server3.getKeyEncrypted(), nullValue());
 
     TacacsServer server4 = tacacs.getServers().get("3.3.3.3");
     assertThat(server4.getPort(), equalTo(49));
     assertThat(server4.getPriority(), equalTo(1));
     assertThat(server4.getTimeout(), equalTo(10));
     assertThat(server4.getKeyEncrypted(), equalTo(true));
+
+    TacacsServer server5 = tacacs.getServers().get("4.4.4.4");
+    assertThat(server5.getPort(), nullValue());
+    assertThat(server5.getPriority(), nullValue());
+    assertThat(server5.getTimeout(), nullValue());
+    assertThat(server5.getKeyEncrypted(), equalTo(false));
+  }
+
+  @Test
+  public void testTacacsSourceInterfaceForms() {
+    // Covers the source-interface forms in toInterfaceName that aren't covered by tacacs testconfig
+    // The source-interface is single-valued, so each form is parsed as its own snippet
+    assertThat(
+        tacacsSourceInterface("tacacs-server source-interface loopback 0\n"),
+        equalTo("loopback 0"));
+    assertThat(tacacsSourceInterface("tacacs-server source-interface 0/1\n"), equalTo("0/1"));
+    assertThat(tacacsSourceInterface("tacacs-server source-interface 1/0/1\n"), equalTo("1/0/1"));
+    assertThat(
+        tacacsSourceInterface("tacacs-server source-interface tunnel 5\n"), equalTo("tunnel 5"));
+    assertThat(
+        tacacsSourceInterface("tacacs-server source-interface vlan 10\n"), equalTo("vlan 10"));
+  }
+
+  private @Nonnull String tacacsSourceInterface(String tacacsLine) {
+    return parseVendorConfigText(tacacsLine, "source_interface").getTacacs().getSourceInterface();
   }
 
   @Test
@@ -422,6 +447,8 @@ public final class FastpathGrammarTest {
     // Syslog
     assertThat(c.getLoggingServers(), equalTo(ImmutableSet.of("3.3.3.1", "3.3.3.2")));
     assertThat(c.getLoggingSourceInterface(), equalTo("serviceport"));
+    // TACACS
+    assertThat(c.getTacacsServers(), equalTo(ImmutableSet.of("9.9.9.9")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
@@ -43,6 +43,8 @@ import org.batfish.vendor.fastpath.representation.Logging;
 import org.batfish.vendor.fastpath.representation.LoggingBuffered;
 import org.batfish.vendor.fastpath.representation.LoggingServer;
 import org.batfish.vendor.fastpath.representation.Sntp;
+import org.batfish.vendor.fastpath.representation.Tacacs;
+import org.batfish.vendor.fastpath.representation.TacacsServer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -99,6 +101,56 @@ public final class FastpathGrammarTest {
     vc = SerializationUtils.clone(vc);
     vc.setWarnings(warnings);
     return vc;
+  }
+
+  @Test
+  public void testTacacsParsesWithoutWarnings() {
+    FastpathConfiguration c = parseVendorConfig("fastpath_tacacs");
+    assertThat(c.getWarnings().getParseWarnings(), empty());
+  }
+
+  @Test
+  public void testTacacs() throws IOException {
+    Configuration c = parseConfig("fastpath_tacacs");
+    assertThat(
+        c.getTacacsServers(),
+        equalTo(ImmutableSet.of("1.1.1.1", "2.2.2.2", "tacacs.example.com", "3.3.3.3")));
+    assertThat(c.getTacacsSourceInterface(), equalTo("serviceport"));
+  }
+
+  @Test
+  public void testTacacsExtraction() {
+    Tacacs tacacs = parseVendorConfig("fastpath_tacacs").getTacacs();
+    assertThat(
+        tacacs.getServers().keySet(),
+        equalTo(ImmutableSet.of("1.1.1.1", "2.2.2.2", "tacacs.example.com", "3.3.3.3")));
+    assertThat(tacacs.getSourceInterface(), equalTo("serviceport"));
+    assertThat(tacacs.getTimeout(), equalTo(10));
+    assertThat(tacacs.getKeyEncrypted(), equalTo(true));
+
+    TacacsServer server1 = tacacs.getServers().get("1.1.1.1");
+    assertThat(server1.getPort(), nullValue());
+    assertThat(server1.getPriority(), nullValue());
+    assertThat(server1.getTimeout(), nullValue());
+    assertThat(server1.getKeyEncrypted(), equalTo(false));
+
+    TacacsServer server2 = tacacs.getServers().get("2.2.2.2");
+    assertThat(server2.getPort(), nullValue());
+    assertThat(server2.getPriority(), nullValue());
+    assertThat(server2.getTimeout(), nullValue());
+    assertThat(server2.getKeyEncrypted(), equalTo(false));
+
+    TacacsServer server3 = tacacs.getServers().get("tacacs.example.com");
+    assertThat(server3.getPort(), nullValue());
+    assertThat(server3.getPriority(), nullValue());
+    assertThat(server3.getTimeout(), nullValue());
+    assertThat(server3.getKeyEncrypted(), equalTo(false));
+
+    TacacsServer server4 = tacacs.getServers().get("3.3.3.3");
+    assertThat(server4.getPort(), equalTo(49));
+    assertThat(server4.getPriority(), equalTo(1));
+    assertThat(server4.getTimeout(), equalTo(10));
+    assertThat(server4.getKeyEncrypted(), equalTo(true));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_tacacs
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_tacacs
@@ -15,6 +15,7 @@ exit
 !
 tacacs-server host 2.2.2.2
 keystring
+key "%CENSORED% with spaces"
 exit
 !
 tacacs-server host "tacacs.example.com"
@@ -25,4 +26,8 @@ timeout 10
 port 49
 priority 1
 key encrypted %CENSORED%
+exit
+!
+tacacs-server host 4.4.4.4
+key
 exit

--- a/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_tacacs
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_tacacs
@@ -1,0 +1,28 @@
+!Current Configuration:
+!
+!System Software Version "3.4.3.10"
+!
+hostname "fastpath_tacacs"
+!
+tacacs-server source-interface serviceport
+tacacs-server timeout 10
+tacacs-server key encrypted %CENSORED%
+tacacs-server keystring
+!
+tacacs-server host "1.1.1.1"
+key %CENSORED%
+exit
+!
+tacacs-server host 2.2.2.2
+keystring
+exit
+!
+tacacs-server host "tacacs.example.com"
+exit
+!
+tacacs-server host "3.3.3.3"
+timeout 10
+port 49
+priority 1
+key encrypted %CENSORED%
+exit


### PR DESCRIPTION
## Summary
  
  Add FastPath extraction for the `tacacs-server` command to capture TACACS+ resolver state: which servers are configured along with their port, priority, and timeout, plus the global source-interface, timeout, and whether the shared key is encrypted. This is captured in a new vendor-specific `representation` Tacacs model, feeding server hosts and the source-interface to the vendor-independent tacacsServers` and `tacacsSourceInterface` fields.
  
  ## Changes
  
  - Add lexer tokens `ENCRYPTED`, `EXIT`, `KEY`, `KEYSTRING`, `PRIORITY`, and `TACACS_SERVER`, plus an `M_Key` mode so key material is matched and dropped rather than retained. Extend the `HOST` mode-push predicate to fire after `TACACS_SERVER` as well as `LOGGING`, reusing the existing `M_HostValue` mode so hosts accept quoted strings, bare IPs, and hostnames.
  
  - Add the `s_tacacs_server` grammar rule with global `ts_*` sub-rules (`key`, `source-interface`, `timeout`, and a parsed-but-ignored `ts_keystring_null`) and per-host `tsh_*` sub-rules for the `tacacs-server host <host>` … `exit` submode (`key`, `port`, `priority`, `timeout`, and `tsh_keystring_null`).
  
  - Add two VS model classes in `representation`: `TacacsServer` (a single host with nullable `port`/`priority`/`timeout` and a `keyEncrypted` flag) and `Tacacs` (an insertion-ordered host map keyed by host text, plus the global `sourceInterface`, `timeout`, and `keyEncrypted`).
  
  - Add TACACS state to `FastpathConfiguration.java`: a `Tacacs` field with a `getTacacs()` accessor, and `convertTacacsServers`/`convertTacacsSourceInterface` populating the VI `Configuration`.
  
  - Populate handlers in `FastpathConfigurationBuilder.java`: `enterTs_host`/`exitTs_host` track the current server via `computeIfAbsent`, so repeated blocks for one host merge; the `key` handlers record only `ENCRYPTED() != null`; global and per-host `timeout` are validated against `1-30` via `toIntegerInSpace`, so out-of-range values are warned and dropped rather than stored.
  
  ## Testing
  
  - Add a `fastpath_tacacs` testconfig covering all three host forms, both key variants, and the `keystring` no-op lines.
 
  - Add `testTacacsParsesWithoutWarnings`, `testTacacsExtraction` (per-server port/priority/timeout/keyEncrypted plus globals), and `testTacacs` (VI `getTacacsServers()`/`getTacacsSourceInterface()`) to `FastpathGrammarTest`.
  
  - All tests pass locally and no reference tests are affected.
  ````
