### PR TITLE
PaloAlto: report an absent ipsec dh-group, and only warn on a genuinely ambiguous IKE version

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/CryptoProfile.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/CryptoProfile.java
@@ -79,7 +79,9 @@ public final class CryptoProfile implements Serializable {
         && Objects.equals(_dhGroups, rhs._dhGroups)
         && Objects.equals(_encryptionAlgorithms, rhs._encryptionAlgorithms)
         && Objects.equals(_hashAlgorithm, rhs._hashAlgorithm)
-        && Objects.equals(_lifetimeSeconds, rhs._lifetimeSeconds);
+        && Objects.equals(_lifetimeSeconds, rhs._lifetimeSeconds)
+        && Objects.equals(_protocol, rhs._protocol)
+        && _noPfs == rhs._noPfs;
   }
 
   public boolean getNoPfs() {
@@ -143,7 +145,9 @@ public final class CryptoProfile implements Serializable {
         _dhGroups,
         _encryptionAlgorithms,
         _hashAlgorithm,
-        _lifetimeSeconds);
+        _lifetimeSeconds,
+        _protocol,
+        _noPfs);
   }
 
   public void setAuthAlgorithm(@Nullable IpsecAuthenticationAlgorithm authAlgorithm) {
@@ -173,6 +177,8 @@ public final class CryptoProfile implements Serializable {
         .add("encrypt-algos", _encryptionAlgorithms)
         .add("hash-algo", _hashAlgorithm)
         .add("life", _lifetimeSeconds)
+        .add("protocol", _protocol)
+        .add("no-pfs", _noPfs)
         .toString();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/IkeGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/IkeGateway.java
@@ -136,10 +136,14 @@ public final class IkeGateway implements Serializable {
 
   /**
    * True when the config does not say which IKE version applies and the gateway configures a
-   * profile for both, so the choice of preference order is an assumption rather than the config.
+   * different profile for each, so the choice of preference order is an assumption rather than the
+   * config. Naming the same profile on both versions is common and leaves nothing to assume.
    */
   public boolean hasAmbiguousIkeVersion() {
-    return _version == null && _ikeV1CryptoProfile != null && _ikeV2CryptoProfile != null;
+    return _version == null
+        && _ikeV1CryptoProfile != null
+        && _ikeV2CryptoProfile != null
+        && !_ikeV1CryptoProfile.equals(_ikeV2CryptoProfile);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -3664,16 +3664,18 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       CryptoProfile cp, IpsecTunnel tunnel, List<String> proposals) {
     IpsecPhase2Policy policy = new IpsecPhase2Policy();
     policy.setProposals(proposals);
-    if (cp.getNoPfs()) {
-      // negotiateIpsecP2 requires a non-empty intersection of PFS groups, so a profile with
-      // perfect forward secrecy disabled cannot negotiate in the model even though the device
-      // would bring the tunnel up.
+    if (cp.getDhGroups().isEmpty()) {
+      // negotiateIpsecP2 requires a non-empty intersection of PFS groups, so a profile with no
+      // group to offer cannot negotiate in the model even though the device would bring the
+      // tunnel up. That is true whether the group is explicitly disabled or simply absent, and
+      // PAN-OS documents no default to fall back on.
       _w.redFlagf(
-          "ipsec-crypto-profile %s for ipsec tunnel %s disables perfect forward secrecy, which is"
-              + " not modeled; the tunnel will not negotiate",
-          cp.getName(), tunnel.getName());
-    }
-    if (!cp.getDhGroups().isEmpty()) {
+          "ipsec-crypto-profile %s for ipsec tunnel %s %s, which is not modeled; the tunnel will"
+              + " not negotiate",
+          cp.getName(),
+          tunnel.getName(),
+          cp.getNoPfs() ? "disables perfect forward secrecy" : "configures no dh-group");
+    } else {
       policy.setPfsKeyGroups(ImmutableSortedSet.copyOf(cp.getDhGroups()));
     }
     return policy;

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -552,7 +552,8 @@ public final class PaloAltoGrammarTest {
             "TUN-OBJDEF",
             "TUN-NOPFS",
             "TUN-DHLIST",
-            "TUN-NULLS"));
+            "TUN-NULLS",
+            "TUN-BUILTIN"));
 
     // an ike-crypto-profile takes a list of dh groups, and IkePhase1Proposal holds one, so the
     // proposals are the cross product of encryption algorithm and dh group
@@ -742,6 +743,25 @@ public final class PaloAltoGrammarTest {
             PaloAltoStructureType.ADDRESS_OBJECT,
             computeObjectName(DEFAULT_VSYS_NAME, "PEER-OBJ"),
             1));
+
+    // PAN-OS ships these profiles predefined, so a config may reference one without defining it;
+    // that must not be reported as undefined
+    assertThat(
+        ccae,
+        not(
+            hasUndefinedReference(
+                filename,
+                IKE_CRYPTO_PROFILE,
+                "Suite-B-GCM-128",
+                PaloAltoStructureUsage.IKE_GATEWAY_IKE_CRYPTO_PROFILE)));
+    assertThat(
+        ccae,
+        not(
+            hasUndefinedReference(
+                filename,
+                IPSEC_CRYPTO_PROFILE,
+                "default",
+                PaloAltoStructureUsage.IPSEC_TUNNEL_IPSEC_CRYPTO_PROFILE)));
   }
 
   @Test
@@ -798,6 +818,14 @@ public final class PaloAltoGrammarTest {
             containsString(
                 "ipsec-crypto-profile IPSEC-NOPFS for ipsec tunnel TUN-NOPFS disables perfect"
                     + " forward secrecy")));
+    // an absent dh-group leaves nothing to negotiate, exactly as no-pfs does, so it must warn too
+    assertThat(
+        warnings,
+        hasItem(
+            containsString(
+                "ipsec-crypto-profile IPSEC-AH for ipsec tunnel TUN-AH configures no dh-group")));
+    // naming the same profile on both IKE versions leaves nothing to assume, so it must not warn
+    assertThat(warnings, not(hasItem(containsString("ike-gateway GW-SAMEPROF"))));
   }
 
   @Test
@@ -1784,25 +1812,29 @@ public final class PaloAltoGrammarTest {
   public void testIpsecCryptoProfiles() {
     PaloAltoConfiguration c = parsePaloAltoConfig("ipsec-crypto-profiles");
 
-    assertThat(
-        c.getCryptoProfiles(),
-        containsInAnyOrder(
-            new CryptoProfile(
-                "default",
-                Type.IPSEC,
-                IpsecAuthenticationAlgorithm.HMAC_SHA1_96,
-                DiffieHellmanGroup.GROUP2,
-                ImmutableList.of(EncryptionAlgorithm.AES_128_CBC, EncryptionAlgorithm.DES_CBC),
-                null,
-                60),
-            new CryptoProfile(
-                "profile1",
-                Type.IPSEC,
-                null,
-                DiffieHellmanGroup.GROUP14,
-                ImmutableList.of(EncryptionAlgorithm.AES_128_GCM),
-                null,
-                24 * 3600)));
+    // both profiles configure `esp`, so both record the protocol explicitly
+    CryptoProfile defaultProfile =
+        new CryptoProfile(
+            "default",
+            Type.IPSEC,
+            IpsecAuthenticationAlgorithm.HMAC_SHA1_96,
+            DiffieHellmanGroup.GROUP2,
+            ImmutableList.of(EncryptionAlgorithm.AES_128_CBC, EncryptionAlgorithm.DES_CBC),
+            null,
+            60);
+    defaultProfile.setProtocol(IpsecProtocol.ESP);
+    CryptoProfile profile1 =
+        new CryptoProfile(
+            "profile1",
+            Type.IPSEC,
+            null,
+            DiffieHellmanGroup.GROUP14,
+            ImmutableList.of(EncryptionAlgorithm.AES_128_GCM),
+            null,
+            24 * 3600);
+    profile1.setProtocol(IpsecProtocol.ESP);
+
+    assertThat(c.getCryptoProfiles(), containsInAnyOrder(defaultProfile, profile1));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/BUILD.bazel
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/BUILD.bazel
@@ -22,6 +22,7 @@ junit_tests(
         "//projects/batfish/src/test/java/org/batfish/representation/palo_alto/application_definitions:testlib",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
         "@maven//:junit_junit",
         "@maven//:org_hamcrest_hamcrest",
     ],

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/CryptoProfileTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/CryptoProfileTest.java
@@ -1,0 +1,38 @@
+package org.batfish.representation.palo_alto;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.DiffieHellmanGroup;
+import org.batfish.datamodel.IpsecProtocol;
+import org.batfish.representation.palo_alto.CryptoProfile.Type;
+import org.junit.Test;
+
+/** Tests of {@link CryptoProfile} */
+public class CryptoProfileTest {
+
+  private static CryptoProfile ipsecProfile() {
+    return new CryptoProfile("name", Type.IPSEC);
+  }
+
+  @Test
+  public void testEquals() {
+    CryptoProfile withProtocol = ipsecProfile();
+    withProtocol.setProtocol(IpsecProtocol.AH);
+
+    CryptoProfile withNoPfs = ipsecProfile();
+    withNoPfs.setNoPfs(true);
+
+    CryptoProfile withDhGroups = ipsecProfile();
+    withDhGroups.setDhGroups(ImmutableList.of(DiffieHellmanGroup.GROUP14));
+
+    new EqualsTester()
+        .addEqualityGroup(ipsecProfile(), ipsecProfile())
+        .addEqualityGroup(new CryptoProfile("other", Type.IPSEC))
+        .addEqualityGroup(new CryptoProfile("name", Type.IKE))
+        // protocol and no-pfs both distinguish otherwise-identical profiles
+        .addEqualityGroup(withProtocol)
+        .addEqualityGroup(withNoPfs)
+        .addEqualityGroup(withDhGroups)
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ipsec-tunnel
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ipsec-tunnel
@@ -240,3 +240,12 @@ set network tunnel global-protect-gateway GP-GW tunnel-interface tunnel.20
 set network tunnel global-protect-site-to-site GP-S2S portal-address 192.0.2.50
 set network ike crypto-profiles ike-crypto-profiles IKE-PROF authentication-multiple 0
 set network ike crypto-profiles ipsec-crypto-profiles IPSEC-PROF lifesize gb 20
+set network interface tunnel units tunnel.21 ip 169.254.10.82/30
+set network ike gateway GW-BUILTIN protocol ikev2 ike-crypto-profile Suite-B-GCM-128
+set network ike gateway GW-BUILTIN protocol version ikev2
+set network ike gateway GW-BUILTIN local-address interface ethernet1/1
+set network ike gateway GW-BUILTIN peer-address ip 192.0.2.42
+set network ike gateway GW-BUILTIN authentication pre-shared-key key -AQ==encrypted/blob+18=
+set network tunnel ipsec TUN-BUILTIN auto-key ike-gateway GW-BUILTIN
+set network tunnel ipsec TUN-BUILTIN auto-key ipsec-crypto-profile default
+set network tunnel ipsec TUN-BUILTIN tunnel-interface tunnel.21


### PR DESCRIPTION
An ipsec-crypto-profile with no dh-group left the phase 2 policy's pfs
key groups empty, which negotiateIpsecP2 treats the same as no-pfs: the
tunnel cannot negotiate. Only the explicit no-pfs case warned, so the
absent case was silent. Both now report, and PAN-OS documents no default
dh group to fall back on. The IPSEC-AH profile in the fixture is in this
state, so the tunnel it backs never formed an edge.

hasAmbiguousIkeVersion fired whenever a gateway named a profile for
both IKE versions with no protocol version, including when both named
the same profile. Naming one profile for both versions is common and
leaves nothing to assume, so it no longer warns.

CryptoProfile.equals and hashCode omitted the protocol and no-pfs
fields. That is load-bearing: testIpsecCryptoProfiles compares parsed
profiles against expected ones and was passing only because the
protocol was ignored.

Also covers the IKE_CRYPTO_PROFILE_OR_NONE and
IPSEC_CRYPTO_PROFILE_OR_NONE paths, which existed to keep references to
the profiles PAN-OS ships predefined from being reported undefined but
had no test.

Left for follow-up: the post-quantum dh-group values and the
ike-crypto-profile ake subtree are parse errors on valid 11.1 config.
Both need keyword sets confirmed against a device rather than guessed.

For batfish/batfish#10156.

----

Prompt:
```
Decide which of the open follow-ups from the batfish/batfish#10156 review
to fix and send immediately, now that the PR has been squash-merged, and
implement them.
```
