### PR TITLE
Junos: don't flag routing-instance default as an undefined reference

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.Names.bgpNeighborStructureName;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.representation.juniper.CommunityMemberParseResult.parseCommunityMember;
 import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_GLOBAL_POLICY;
+import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_ROUTING_INSTANCE_ALIAS;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeFirewallFilterTermName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePolicyStatementTermName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeSecurityPolicyTermName;
@@ -1451,6 +1452,18 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     if (BUILT_IN_STRUCTURES.containsEntry(type, name)) {
       _configuration.defineSingleLineStructure(type, name, 0);
     }
+  }
+
+  /**
+   * Reference the routing instance {@code name}, unless it is the reserved word {@link
+   * JuniperConfiguration#DEFAULT_ROUTING_INSTANCE_ALIAS default}, which names no configured
+   * structure.
+   */
+  private void referenceRoutingInstance(String name, JuniperStructureUsage usage, int line) {
+    if (DEFAULT_ROUTING_INSTANCE_ALIAS.equals(name)) {
+      return;
+    }
+    _configuration.referenceStructure(ROUTING_INSTANCE, name, usage, line);
   }
 
   public static @Nonnull NamedPort getNamedPort(Named_portContext ctx) {
@@ -4742,8 +4755,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void enterSnmpcls_routing_instance(Snmpcls_routing_instanceContext ctx) {
     String name = toString(ctx.name);
-    _configuration.referenceStructure(
-        ROUTING_INSTANCE, name, SNMP_COMMUNITY_ROUTING_INSTANCE, getLine(ctx.name.getStart()));
+    referenceRoutingInstance(name, SNMP_COMMUNITY_ROUTING_INSTANCE, getLine(ctx.name.getStart()));
     RoutingInstance ri = _currentLogicalSystem.getRoutingInstances().get(name);
     if (ri != null) {
       // dummy, deliberately not hooked up.
@@ -4866,16 +4878,14 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitSyns_routing_instance(Syns_routing_instanceContext ctx) {
     String name = toString(ctx.name);
-    _configuration.referenceStructure(
-        ROUTING_INSTANCE, name, NTP_SERVER_ROUTING_INSTANCE, getLine(ctx.getStart()));
+    referenceRoutingInstance(name, NTP_SERVER_ROUTING_INSTANCE, getLine(ctx.getStart()));
   }
 
   @Override
   public void exitSyn_source_address(Syn_source_addressContext ctx) {
     if (ctx.ri != null) {
       String name = toString(ctx.ri);
-      _configuration.referenceStructure(
-          ROUTING_INSTANCE, name, NTP_SOURCE_ADDRESS_ROUTING_INSTANCE, getLine(ctx.getStart()));
+      referenceRoutingInstance(name, NTP_SOURCE_ADDRESS_ROUTING_INSTANCE, getLine(ctx.getStart()));
     }
   }
 
@@ -5885,8 +5895,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
     String name = toString(ctx.name);
     _currentFwTerm.getThens().add(new FwThenRoutingInstance(name));
     _currentFilter.setUsedForFBF(true);
-    _configuration.referenceStructure(
-        ROUTING_INSTANCE, name, FIREWALL_FILTER_THEN_ROUTING_INSTANCE, getLine(ctx.getStart()));
+    referenceRoutingInstance(name, FIREWALL_FILTER_THEN_ROUTING_INSTANCE, getLine(ctx.getStart()));
   }
 
   @Override
@@ -6797,11 +6806,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   @Override
   public void exitPopsf_instance(Popsf_instanceContext ctx) {
     String instanceName = toString(ctx.name);
-    _configuration.referenceStructure(
-        ROUTING_INSTANCE,
-        instanceName,
-        POLICY_STATEMENT_FROM_INSTANCE,
-        getLine(ctx.name.getStart()));
+    referenceRoutingInstance(
+        instanceName, POLICY_STATEMENT_FROM_INSTANCE, getLine(ctx.name.getStart()));
     _currentPsTerm.getFroms().setFromInstance(new PsFromInstance(instanceName));
   }
 
@@ -7946,8 +7952,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
           ctx.FROM() != null
               ? NAT_RULE_SET_FROM_ROUTING_INSTANCE
               : NAT_RULE_SET_TO_ROUTING_INSTANCE;
-      _configuration.referenceStructure(
-          ROUTING_INSTANCE, ri, usage, getLine(ctx.rs_routing_instance().name.start));
+      referenceRoutingInstance(ri, usage, getLine(ctx.rs_routing_instance().name.start));
     } else if (ctx.rs_zone() != null) {
       packetLocation.setZone(toString(ctx.rs_zone().name));
     }
@@ -9506,8 +9511,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void exitSysh_routing_instance(Sysh_routing_instanceContext ctx) {
     String name = toString(ctx.ri);
     _currentSyslogHost.setRoutingInstance(name);
-    _configuration.referenceStructure(
-        ROUTING_INSTANCE, name, SYSLOG_HOST_ROUTING_INSTANCE, getLine(ctx.ri.getStart()));
+    referenceRoutingInstance(name, SYSLOG_HOST_ROUTING_INSTANCE, getLine(ctx.ri.getStart()));
   }
 
   private static @Nonnull JunosSyslogFacility toJunosSyslogFacility(Syslog_facilityContext ctx) {
@@ -9600,8 +9604,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener
   public void exitSyt_routing_instance(Syt_routing_instanceContext ctx) {
     String name = toString(ctx.name);
     _currentJuniperTacplusServer.setRoutingInstance(name);
-    _configuration.referenceStructure(
-        ROUTING_INSTANCE, name, TACPLUS_SERVER_ROUTING_INSTANCE, getLine(ctx.name.getStart()));
+    referenceRoutingInstance(name, TACPLUS_SERVER_ROUTING_INSTANCE, getLine(ctx.name.getStart()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -240,6 +240,13 @@ public final class JuniperConfiguration extends VendorConfiguration {
   /** Juniper's default routing instance is called "master". */
   public static final @Nonnull String DEFAULT_ROUTING_INSTANCE_NAME = "master";
 
+  /**
+   * Junos reserves the word "default" to mean the default routing instance where a routing instance
+   * is referenced, e.g. {@code firewall filter ... then routing-instance default}. It cannot be the
+   * name of a configured routing instance.
+   */
+  public static final @Nonnull String DEFAULT_ROUTING_INSTANCE_ALIAS = "default";
+
   /** Normalize to VI VRF name. */
   public static @Nonnull String toVrfName(String routingInstanceName) {
     if (routingInstanceName.equals(DEFAULT_ROUTING_INSTANCE_NAME)) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -184,6 +184,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.LOGIN_CLAS
 import static org.batfish.representation.juniper.JuniperStructureType.POLICY_STATEMENT;
 import static org.batfish.representation.juniper.JuniperStructureType.POLICY_STATEMENT_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.PREFIX_LIST;
+import static org.batfish.representation.juniper.JuniperStructureType.ROUTING_INSTANCE;
 import static org.batfish.representation.juniper.JuniperStructureType.RTF_PREFIX_LIST;
 import static org.batfish.representation.juniper.JuniperStructureType.SECURITY_POLICY_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.SOURCE_CLASS;
@@ -382,6 +383,10 @@ import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.ospf.OspfProcess;
 import org.batfish.datamodel.ospf.StubType;
+import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.LiteralVrfName;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.route.nh.NextHopVrf;
@@ -2774,6 +2779,46 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         ccae.getWarnings().get(hostname).getRedFlagWarnings(),
         everyItem(WarningMatchers.hasText(containsString("missing action in firewall filter"))));
+  }
+
+  @Test
+  public void testFirewallFilterThenRoutingInstanceReferences() throws IOException {
+    String hostname = "firewall-filter-then-routing-instance";
+    String filename = "configs/" + hostname;
+
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // 'default' is a reserved word for the master routing instance, so it is not a reference to any
+    // configured structure.
+    assertThat(ccae, not(hasUndefinedReference(filename, ROUTING_INSTANCE, "default")));
+
+    // Other names are still tracked: 2 self-referencing definition lines plus the filter term.
+    assertThat(ccae, hasNumReferrers(filename, ROUTING_INSTANCE, "RI_DEFINED", 3));
+    assertThat(ccae, hasUndefinedReference(filename, ROUTING_INSTANCE, "RI_UNDEFINED"));
+  }
+
+  @Test
+  public void testFirewallFilterThenRoutingInstanceConversion() {
+    Configuration c = parseConfig("firewall-filter-then-routing-instance");
+
+    PacketPolicy policy = c.getPacketPolicies().get("FBF");
+    assertThat(policy, notNullValue());
+
+    // One statement per term, in term order. 'default' forwards into the master instance, i.e. the
+    // VI default VRF.
+    assertThat(fibLookupVrfs(policy), contains(DEFAULT_VRF_NAME, "RI_DEFINED", "RI_UNDEFINED"));
+  }
+
+  /** Extract the VRF each term of {@code policy} does its FIB lookup in, in term order. */
+  private static List<String> fibLookupVrfs(PacketPolicy policy) {
+    return policy.getStatements().stream()
+        .flatMap(s -> ((org.batfish.datamodel.packet_policy.If) s).getTrueStatements().stream())
+        .filter(s -> s instanceof Return && ((Return) s).getAction() instanceof FibLookup)
+        .map(s -> (FibLookup) ((Return) s).getAction())
+        .map(fibLookup -> ((LiteralVrfName) fibLookup.getVrfExpr()).getVrfName())
+        .collect(ImmutableList.toImmutableList());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filter-then-routing-instance
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filter-then-routing-instance
@@ -1,0 +1,13 @@
+set system host-name firewall-filter-then-routing-instance
+# 'default' is a reserved word for the master routing instance in reference position, not the name
+# of a configured instance: Junos rejects 'set routing-instances default'.
+set firewall family inet filter FBF term T_DEFAULT then routing-instance default
+set firewall family inet filter FBF term T_DEFINED then routing-instance RI_DEFINED
+set firewall family inet filter FBF term T_UNDEFINED then routing-instance RI_UNDEFINED
+#
+# Apply the filter on an interface owned by a virtual-router instance, i.e. filter-based forwarding
+# from that instance back into the master instance.
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24
+set interfaces ge-0/0/0 unit 0 family inet filter input FBF
+set routing-instances RI_DEFINED instance-type virtual-router
+set routing-instances RI_DEFINED interface ge-0/0/0.0


### PR DESCRIPTION
Junos reserves the word default to mean the master routing instance
where a routing instance is referenced, e.g. firewall filter ... then
routing-instance default, and forbids it as the name of a configured
instance. Skip reference tracking for that name at all eight routing
instance reference sites.

The conversion path already produced the right VRF, since the VI default
VRF is itself named "default"; a test now pins that.

----

Prompt:
```
We're debugging an issue where we're getting undefined references for
Junos routing-instance default. Another model claims master and default
are aliases for the same default routing instance: master is the
canonical name reported by `show route instance`, default is used in
configuration statements such as `routing-instance default` in a
firewall filter, and Junos prevents creating a user routing instance
literally named default. Check the cited Juniper documentation and make
up your own mind.

Follow-ups: confirmed against a real Junos config whose only undefined
routing-instance reference is `then routing-instance default` on an
interface owned by a virtual-router instance. Decided the right fix is
to not add a reference at all when the value is specifically default,
rather than remapping it to master.
```
