### PR TITLE
feat(fastpath): add AAA support

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
@@ -5,12 +5,21 @@ options {
 }
 
 tokens {
+  DEFAULT,
   QUOTED_TEXT,
   REMAINDER,
   WORD
 }
 
+AAA: 'aaa';
+
+ACCOUNTING: 'accounting';
+
 ALERT: 'alert';
+
+AUTHENTICATION: 'authentication';
+
+AUTHORIZATION: 'authorization';
 
 BROADCAST: 'broadcast';
 
@@ -20,15 +29,37 @@ CLI_COMMAND: 'cli-command';
 
 CLIENT: 'client';
 
+COMMANDS
+:
+  'commands'
+  {
+    if (lastTokenType() == AUTHORIZATION || lastTokenType() == ACCOUNTING) {
+      pushMode(M_AaaListName);
+    }
+  }
+;
+
 CONSOLE: 'console';
 
 CRITICAL: 'critical';
 
 DEBUG: 'debug';
 
+DENY: 'deny';
+
 DNS: 'dns';
 
 DOMAIN: 'domain';
+
+DOT1X
+:
+  'dot1x'
+  {
+    if (lastTokenType() == ACCOUNTING) {
+      pushMode(M_AaaListName);
+    }
+  }
+;
 
 EMAIL
 :
@@ -37,9 +68,29 @@ EMAIL
 
 EMERGENCY: 'emergency';
 
+ENABLE
+:
+  'enable'
+  {
+    if (lastTokenType() == AUTHENTICATION) {
+      pushMode(M_AaaListName);
+    }
+  }
+;
+
 ENCRYPTED: 'encrypted';
 
 ERROR: 'error';
+
+EXEC
+:
+  'exec'
+  {
+    if (lastTokenType() == AUTHORIZATION || lastTokenType() == ACCOUNTING) {
+      pushMode(M_AaaListName);
+    }
+  }
+;
 
 EXIT: 'exit';
 
@@ -60,6 +111,8 @@ HOSTNAME
   'hostname' -> pushMode ( M_Word )
 ;
 
+IAS_USER: 'ias-user';
+
 INFO: 'info';
 
 IP: 'ip';
@@ -75,9 +128,23 @@ KEY
 
 KEYSTRING: 'keystring';
 
+LINE: 'line';
+
 LIST: 'list';
 
+LOCAL: 'local';
+
 LOGGING: 'logging';
+
+LOGIN
+:
+  'login'
+  {
+    if (lastTokenType() == AUTHENTICATION) {
+      pushMode(M_AaaListName);
+    }
+  }
+;
 
 LOOKUP: 'lookup';
 
@@ -99,7 +166,14 @@ NAME
 
 NO: 'no';
 
+NONE: 'none';
+
 NOTICE: 'notice';
+
+PASSWORD
+:
+  'password' -> pushMode ( M_Remainder )
+;
 
 PERSISTENT: 'persistent';
 
@@ -115,6 +189,8 @@ PROMPT
 :
   'prompt' -> pushMode ( M_Word )
 ;
+
+RADIUS: 'radius';
 
 RECONFIGURE: 'reconfigure';
 
@@ -136,18 +212,29 @@ SERVER
 
 SERVICEPORT: 'serviceport';
 
+SESSION_ID
+:
+  'session-id' -> pushMode ( M_Remainder )
+;
+
 SET: 'set';
 
 SNTP: 'sntp';
 
 SOURCE_INTERFACE: 'source-interface';
 
+START_STOP: 'start-stop';
+
 STATUS
 :
   'status' -> pushMode ( M_Remainder )
 ;
 
+STOP_ONLY: 'stop-only';
+
 SYSLOG: 'syslog';
+
+TACACS: 'tacacs';
 
 TACACS_SERVER: 'tacacs-server';
 
@@ -158,6 +245,11 @@ TRAPS: 'traps';
 TUNNEL: 'tunnel';
 
 UNICAST: 'unicast';
+
+USERNAME
+:
+  'username' -> pushMode ( M_Word )
+;
 
 VLAN: 'vlan';
 
@@ -425,6 +517,33 @@ M_HostValue_WS
 ;
 
 M_HostValue_NEWLINE
+:
+  F_Newline -> type ( NEWLINE ) , popMode
+;
+
+mode M_AaaListName;
+
+M_AaaListName_DEFAULT
+:
+  'default' -> type ( DEFAULT ) , popMode
+;
+
+M_AaaListName_DOUBLE_QUOTE
+:
+  '"' -> type ( DOUBLE_QUOTE ) , mode ( M_DoubleQuote )
+;
+
+M_AaaListName_WORD
+:
+  F_Word -> type ( WORD ) , popMode
+;
+
+M_AaaListName_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN )
+;
+
+M_AaaListName_NEWLINE
 :
   F_Newline -> type ( NEWLINE ) , popMode
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
@@ -55,7 +55,7 @@ DOT1X
 :
   'dot1x'
   {
-    if (lastTokenType() == ACCOUNTING) {
+    if (lastTokenType() == ACCOUNTING || lastTokenType() == AUTHENTICATION) {
       pushMode(M_AaaListName);
     }
   }
@@ -110,6 +110,8 @@ HOSTNAME
 :
   'hostname' -> pushMode ( M_Word )
 ;
+
+IAS: 'ias';
 
 IAS_USER: 'ias-user';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
@@ -15,7 +15,8 @@ fastpath_configuration
 
 statement
 :
-  s_hostname
+  s_aaa
+  | s_hostname
   | s_ip
   | s_logging
   | s_no
@@ -440,4 +441,147 @@ ts_keystring_null
 ts_timeout
 :
   TIMEOUT timeout = uint8 NEWLINE
+;
+
+s_aaa
+:
+  AAA
+  (
+    aaa_accounting
+    | aaa_authentication
+    | aaa_authorization
+    | aaa_ias_user
+    | aaa_session_id_null
+  )
+;
+
+aaa_authentication
+:
+  AUTHENTICATION
+  (
+    aaa_authentication_enable
+    | aaa_authentication_login
+  )
+;
+
+aaa_authentication_login
+:
+  LOGIN name = aaa_list_name aaa_authentication_method+ NEWLINE
+;
+
+aaa_authentication_enable
+:
+  ENABLE name = aaa_list_name aaa_authentication_method+ NEWLINE
+;
+
+aaa_authentication_method
+:
+  DENY
+  | ENABLE
+  | LINE
+  | LOCAL
+  | NONE
+  | RADIUS
+  | TACACS
+;
+
+aaa_authorization
+:
+  AUTHORIZATION
+  (
+    aaa_authorization_commands
+    | aaa_authorization_exec
+  )
+;
+
+aaa_authorization_commands
+:
+  COMMANDS name = aaa_list_name aaa_authorization_method+ NEWLINE
+;
+
+aaa_authorization_exec
+:
+  EXEC name = aaa_list_name aaa_authorization_method+ NEWLINE
+;
+
+// Both authorization types share one documented method set, so `local` is accepted here even though
+// the device rejects it for `commands` authorization specifically
+aaa_authorization_method
+:
+  LOCAL
+  | NONE
+  | RADIUS
+  | TACACS
+;
+
+aaa_accounting
+:
+  ACCOUNTING
+  (
+    aaa_accounting_commands
+    | aaa_accounting_dot1x
+    | aaa_accounting_exec
+  )
+;
+
+aaa_accounting_exec
+:
+  EXEC name = aaa_list_name record = aaa_accounting_record aaa_accounting_method* NEWLINE
+;
+
+aaa_accounting_commands
+:
+  COMMANDS name = aaa_list_name record = aaa_accounting_record aaa_accounting_method* NEWLINE
+;
+
+aaa_accounting_dot1x
+:
+  DOT1X DEFAULT record = aaa_dot1x_accounting_record RADIUS? NEWLINE
+;
+
+aaa_list_name
+:
+  DEFAULT
+  | word
+;
+
+aaa_accounting_record
+:
+  NONE
+  | START_STOP
+  | STOP_ONLY
+;
+
+aaa_dot1x_accounting_record
+:
+  NONE
+  | START_STOP
+;
+
+aaa_accounting_method
+:
+  RADIUS
+  | TACACS
+;
+
+// `aaa ias-user username <user>` enters AAA IAS User Config mode, whose body is optional
+// `password` statements then `exit`
+aaa_ias_user
+:
+  IAS_USER USERNAME user = word NEWLINE aaaiu_block
+;
+
+aaaiu_block
+:
+  aaaiu_password_null* EXIT NEWLINE
+;
+
+aaaiu_password_null
+:
+  PASSWORD null_rest_of_line
+;
+
+aaa_session_id_null
+:
+  SESSION_ID null_rest_of_line
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
@@ -459,30 +459,53 @@ aaa_authentication
 :
   AUTHENTICATION
   (
-    aaa_authentication_enable
+    aaa_authentication_dot1x
+    | aaa_authentication_enable
     | aaa_authentication_login
   )
 ;
 
 aaa_authentication_login
 :
-  LOGIN name = aaa_list_name aaa_authentication_method+ NEWLINE
+  LOGIN name = aaa_list_name aaa_authentication_login_method+ NEWLINE
 ;
 
 aaa_authentication_enable
 :
-  ENABLE name = aaa_list_name aaa_authentication_method+ NEWLINE
+  ENABLE name = aaa_list_name aaa_authentication_enable_method+ NEWLINE
 ;
 
-aaa_authentication_method
+aaa_authentication_dot1x
 :
-  DENY
-  | ENABLE
+  DOT1X DEFAULT aaa_authentication_dot1x_method+ NEWLINE
+;
+
+aaa_authentication_login_method
+:
+  ENABLE
   | LINE
   | LOCAL
   | NONE
   | RADIUS
   | TACACS
+;
+
+aaa_authentication_enable_method
+:
+  DENY
+  | ENABLE
+  | LINE
+  | NONE
+  | RADIUS
+  | TACACS
+;
+
+aaa_authentication_dot1x_method
+:
+  IAS
+  | LOCAL
+  | NONE
+  | RADIUS
 ;
 
 aaa_authorization

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
@@ -1,6 +1,8 @@
 package org.batfish.vendor.fastpath.grammar;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -14,6 +16,19 @@ import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.SilentSyntaxListener;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_commandsContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_dot1xContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_execContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_methodContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_recordContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_enableContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_loginContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_methodContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authorization_commandsContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authorization_execContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authorization_methodContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_dot1x_accounting_recordContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_list_nameContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Host_valueContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.HostnameContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Interface_nameContext;
@@ -52,6 +67,11 @@ import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_portContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_priorityContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_timeoutContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.WordContext;
+import org.batfish.vendor.fastpath.representation.AaaMethod;
+import org.batfish.vendor.fastpath.representation.Accounting;
+import org.batfish.vendor.fastpath.representation.AccountingType;
+import org.batfish.vendor.fastpath.representation.AuthenticationType;
+import org.batfish.vendor.fastpath.representation.AuthorizationType;
 import org.batfish.vendor.fastpath.representation.FastpathConfiguration;
 import org.batfish.vendor.fastpath.representation.LoggingBuffered;
 import org.batfish.vendor.fastpath.representation.LoggingServer;
@@ -73,6 +93,12 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
       IntegerSpace.of(Range.closed(1, 65535));
 
   private static final IntegerSpace TACACS_TIMEOUT_RANGE = IntegerSpace.of(Range.closed(1, 30));
+
+  /**
+   * Name recorded for an AAA method list declared with the {@code default} keyword rather than a
+   * user-specified name.
+   */
+  private static final String DEFAULT_LIST_NAME = "default";
 
   public FastpathConfigurationBuilder(
       FastpathCombinedParser parser,
@@ -183,6 +209,152 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   @Override
   public void exitTs_source_interface(Ts_source_interfaceContext ctx) {
     _c.getTacacs().setSourceInterface(toInterfaceName(ctx.iface));
+  }
+
+  @Override
+  public void exitAaa_authentication_login(Aaa_authentication_loginContext ctx) {
+    _c.getAaa()
+        .defineAuthentication(
+            AuthenticationType.LOGIN,
+            toString(ctx.name),
+            toMethods(ctx.aaa_authentication_method()));
+  }
+
+  @Override
+  public void exitAaa_authentication_enable(Aaa_authentication_enableContext ctx) {
+    _c.getAaa()
+        .defineAuthentication(
+            AuthenticationType.ENABLE,
+            toString(ctx.name),
+            toMethods(ctx.aaa_authentication_method()));
+  }
+
+  @Override
+  public void exitAaa_authorization_commands(Aaa_authorization_commandsContext ctx) {
+    _c.getAaa()
+        .defineAuthorization(
+            AuthorizationType.COMMANDS,
+            toString(ctx.name),
+            toAuthorizationMethods(ctx.aaa_authorization_method()));
+  }
+
+  @Override
+  public void exitAaa_authorization_exec(Aaa_authorization_execContext ctx) {
+    _c.getAaa()
+        .defineAuthorization(
+            AuthorizationType.EXEC,
+            toString(ctx.name),
+            toAuthorizationMethods(ctx.aaa_authorization_method()));
+  }
+
+  @Override
+  public void exitAaa_accounting_exec(Aaa_accounting_execContext ctx) {
+    _c.getAaa()
+        .defineAccounting(
+            AccountingType.EXEC,
+            toString(ctx.name),
+            toAccountingRecordType(ctx.record),
+            toAccountingMethods(ctx.aaa_accounting_method()));
+  }
+
+  @Override
+  public void exitAaa_accounting_commands(Aaa_accounting_commandsContext ctx) {
+    _c.getAaa()
+        .defineAccounting(
+            AccountingType.COMMANDS,
+            toString(ctx.name),
+            toAccountingRecordType(ctx.record),
+            toAccountingMethods(ctx.aaa_accounting_method()));
+  }
+
+  @Override
+  public void exitAaa_accounting_dot1x(Aaa_accounting_dot1xContext ctx) {
+    // The grammar hardcodes the `default` list, the only one dot1x accounting supports, and radius
+    // is the only method it accepts.
+    _c.getAaa()
+        .defineAccounting(
+            AccountingType.DOT1X,
+            DEFAULT_LIST_NAME,
+            toAccountingRecordType(ctx.record),
+            ctx.RADIUS() != null ? ImmutableList.of(AaaMethod.RADIUS) : ImmutableList.of());
+  }
+
+  private static @Nonnull List<AaaMethod> toMethods(List<Aaa_authentication_methodContext> ctxs) {
+    return ctxs.stream()
+        .map(FastpathConfigurationBuilder::toMethod)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private static @Nonnull List<AaaMethod> toAuthorizationMethods(
+      List<Aaa_authorization_methodContext> ctxs) {
+    return ctxs.stream()
+        .map(FastpathConfigurationBuilder::toMethod)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private static @Nonnull List<AaaMethod> toAccountingMethods(
+      List<Aaa_accounting_methodContext> ctxs) {
+    return ctxs.stream()
+        .map(FastpathConfigurationBuilder::toMethod)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private static @Nonnull AaaMethod toMethod(Aaa_authentication_methodContext ctx) {
+    if (ctx.DENY() != null) {
+      return AaaMethod.DENY;
+    } else if (ctx.ENABLE() != null) {
+      return AaaMethod.ENABLE;
+    } else if (ctx.LINE() != null) {
+      return AaaMethod.LINE;
+    } else if (ctx.LOCAL() != null) {
+      return AaaMethod.LOCAL;
+    } else if (ctx.NONE() != null) {
+      return AaaMethod.NONE;
+    } else if (ctx.RADIUS() != null) {
+      return AaaMethod.RADIUS;
+    }
+    assert ctx.TACACS() != null;
+    return AaaMethod.TACACS;
+  }
+
+  private static @Nonnull AaaMethod toMethod(Aaa_authorization_methodContext ctx) {
+    if (ctx.LOCAL() != null) {
+      return AaaMethod.LOCAL;
+    } else if (ctx.NONE() != null) {
+      return AaaMethod.NONE;
+    } else if (ctx.RADIUS() != null) {
+      return AaaMethod.RADIUS;
+    }
+    assert ctx.TACACS() != null;
+    return AaaMethod.TACACS;
+  }
+
+  private static @Nonnull AaaMethod toMethod(Aaa_accounting_methodContext ctx) {
+    if (ctx.RADIUS() != null) {
+      return AaaMethod.RADIUS;
+    }
+    assert ctx.TACACS() != null;
+    return AaaMethod.TACACS;
+  }
+
+  private static @Nonnull Accounting.RecordType toAccountingRecordType(
+      Aaa_accounting_recordContext ctx) {
+    if (ctx.START_STOP() != null) {
+      return Accounting.RecordType.START_STOP;
+    } else if (ctx.STOP_ONLY() != null) {
+      return Accounting.RecordType.STOP_ONLY;
+    }
+    assert ctx.NONE() != null;
+    return Accounting.RecordType.NONE;
+  }
+
+  private static @Nonnull Accounting.RecordType toAccountingRecordType(
+      Aaa_dot1x_accounting_recordContext ctx) {
+    if (ctx.START_STOP() != null) {
+      return Accounting.RecordType.START_STOP;
+    }
+    assert ctx.NONE() != null;
+    return Accounting.RecordType.NONE;
   }
 
   @Override
@@ -356,6 +528,17 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   }
 
   private static @Nonnull String toString(HostnameContext ctx) {
+    return toString(ctx.word());
+  }
+
+  /**
+   * Returns the name of an AAA method list. The {@code default} keyword is recorded as the literal
+   * name {@link #DEFAULT_LIST_NAME}; see {@code aaa_list_name} in the parser grammar.
+   */
+  private static @Nonnull String toString(Aaa_list_nameContext ctx) {
+    if (ctx.DEFAULT() != null) {
+      return DEFAULT_LIST_NAME;
+    }
     return toString(ctx.word());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
@@ -21,9 +21,12 @@ import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_dot1xCo
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_execContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_methodContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_accounting_recordContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_dot1xContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_dot1x_methodContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_enableContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_enable_methodContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_loginContext;
-import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_methodContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authentication_login_methodContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authorization_commandsContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authorization_execContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Aaa_authorization_methodContext;
@@ -217,7 +220,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
         .defineAuthentication(
             AuthenticationType.LOGIN,
             toString(ctx.name),
-            toMethods(ctx.aaa_authentication_method()));
+            toLoginMethods(ctx.aaa_authentication_login_method()));
   }
 
   @Override
@@ -226,7 +229,16 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
         .defineAuthentication(
             AuthenticationType.ENABLE,
             toString(ctx.name),
-            toMethods(ctx.aaa_authentication_method()));
+            toEnableMethods(ctx.aaa_authentication_enable_method()));
+  }
+
+  @Override
+  public void exitAaa_authentication_dot1x(Aaa_authentication_dot1xContext ctx) {
+    _c.getAaa()
+        .defineAuthentication(
+            AuthenticationType.DOT1X,
+            DEFAULT_LIST_NAME,
+            toDot1xMethods(ctx.aaa_authentication_dot1x_method()));
   }
 
   @Override
@@ -279,7 +291,22 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
             ctx.RADIUS() != null ? ImmutableList.of(AaaMethod.RADIUS) : ImmutableList.of());
   }
 
-  private static @Nonnull List<AaaMethod> toMethods(List<Aaa_authentication_methodContext> ctxs) {
+  private static @Nonnull List<AaaMethod> toLoginMethods(
+      List<Aaa_authentication_login_methodContext> ctxs) {
+    return ctxs.stream()
+        .map(FastpathConfigurationBuilder::toMethod)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private static @Nonnull List<AaaMethod> toEnableMethods(
+      List<Aaa_authentication_enable_methodContext> ctxs) {
+    return ctxs.stream()
+        .map(FastpathConfigurationBuilder::toMethod)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private static @Nonnull List<AaaMethod> toDot1xMethods(
+      List<Aaa_authentication_dot1x_methodContext> ctxs) {
     return ctxs.stream()
         .map(FastpathConfigurationBuilder::toMethod)
         .collect(ImmutableList.toImmutableList());
@@ -299,10 +326,8 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
         .collect(ImmutableList.toImmutableList());
   }
 
-  private static @Nonnull AaaMethod toMethod(Aaa_authentication_methodContext ctx) {
-    if (ctx.DENY() != null) {
-      return AaaMethod.DENY;
-    } else if (ctx.ENABLE() != null) {
+  private static @Nonnull AaaMethod toMethod(Aaa_authentication_login_methodContext ctx) {
+    if (ctx.ENABLE() != null) {
       return AaaMethod.ENABLE;
     } else if (ctx.LINE() != null) {
       return AaaMethod.LINE;
@@ -315,6 +340,34 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
     }
     assert ctx.TACACS() != null;
     return AaaMethod.TACACS;
+  }
+
+  private static @Nonnull AaaMethod toMethod(Aaa_authentication_enable_methodContext ctx) {
+    if (ctx.DENY() != null) {
+      return AaaMethod.DENY;
+    } else if (ctx.ENABLE() != null) {
+      return AaaMethod.ENABLE;
+    } else if (ctx.LINE() != null) {
+      return AaaMethod.LINE;
+    } else if (ctx.NONE() != null) {
+      return AaaMethod.NONE;
+    } else if (ctx.RADIUS() != null) {
+      return AaaMethod.RADIUS;
+    }
+    assert ctx.TACACS() != null;
+    return AaaMethod.TACACS;
+  }
+
+  private static @Nonnull AaaMethod toMethod(Aaa_authentication_dot1x_methodContext ctx) {
+    if (ctx.IAS() != null) {
+      return AaaMethod.IAS;
+    } else if (ctx.LOCAL() != null) {
+      return AaaMethod.LOCAL;
+    } else if (ctx.NONE() != null) {
+      return AaaMethod.NONE;
+    }
+    assert ctx.RADIUS() != null;
+    return AaaMethod.RADIUS;
   }
 
   private static @Nonnull AaaMethod toMethod(Aaa_authorization_methodContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Aaa.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Aaa.java
@@ -1,0 +1,66 @@
+package org.batfish.vendor.fastpath.representation;
+
+import java.io.Serializable;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * Aggregates a FastPath device's AAA ({@code aaa ...}) method-list configuration.
+ *
+ * <p>Each family (authentication, authorization, accounting) is keyed first by its type and then by
+ * list name. FastPath list names are unique only within a type (e.g. the same name may be used for
+ * both {@code accounting exec} and {@code accounting commands}), so the type is part of the key.
+ *
+ * <p>The {@code define*} methods replace any existing list of the same type and name, matching the
+ * device: re-issuing a command for an existing list overwrites its record type and method list
+ * rather than appending to it.
+ */
+public final class Aaa implements Serializable {
+
+  private final @Nonnull Map<AuthenticationType, Map<String, Authentication>> _authentication;
+  private final @Nonnull Map<AuthorizationType, Map<String, Authorization>> _authorization;
+  private final @Nonnull Map<AccountingType, Map<String, Accounting>> _accounting;
+
+  public Aaa() {
+    _authentication = new EnumMap<>(AuthenticationType.class);
+    _authorization = new EnumMap<>(AuthorizationType.class);
+    _accounting = new EnumMap<>(AccountingType.class);
+  }
+
+  public @Nonnull Map<AuthenticationType, Map<String, Authentication>> getAuthentication() {
+    return _authentication;
+  }
+
+  public @Nonnull Map<AuthorizationType, Map<String, Authorization>> getAuthorization() {
+    return _authorization;
+  }
+
+  public @Nonnull Map<AccountingType, Map<String, Accounting>> getAccounting() {
+    return _accounting;
+  }
+
+  /** Defines the {@link Authentication} list of the given type and name. */
+  public void defineAuthentication(AuthenticationType type, String name, List<AaaMethod> methods) {
+    _authentication
+        .computeIfAbsent(type, t -> new LinkedHashMap<>())
+        .put(name, new Authentication(type, name, methods));
+  }
+
+  /** Defines the {@link Authorization} list of the given type and name. */
+  public void defineAuthorization(AuthorizationType type, String name, List<AaaMethod> methods) {
+    _authorization
+        .computeIfAbsent(type, t -> new LinkedHashMap<>())
+        .put(name, new Authorization(type, name, methods));
+  }
+
+  /** Defines the {@link Accounting} list of the given type and name. */
+  public void defineAccounting(
+      AccountingType type, String name, Accounting.RecordType recordType, List<AaaMethod> methods) {
+    _accounting
+        .computeIfAbsent(type, t -> new LinkedHashMap<>())
+        .put(name, new Accounting(type, name, recordType, methods));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AaaMethod.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AaaMethod.java
@@ -1,0 +1,12 @@
+package org.batfish.vendor.fastpath.representation;
+
+/** An AAA authentication/authorization/accounting method (i.e. where a request is sent). */
+public enum AaaMethod {
+  DENY,
+  ENABLE,
+  LINE,
+  LOCAL,
+  NONE,
+  RADIUS,
+  TACACS
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AaaMethod.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AaaMethod.java
@@ -4,6 +4,7 @@ package org.batfish.vendor.fastpath.representation;
 public enum AaaMethod {
   DENY,
   ENABLE,
+  IAS,
   LINE,
   LOCAL,
   NONE,

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Accounting.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Accounting.java
@@ -1,0 +1,46 @@
+package org.batfish.vendor.fastpath.representation;
+
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/** A single {@code aaa accounting {exec|commands|dot1x}} method list. */
+public final class Accounting implements Serializable {
+
+  /** When accounting notices are emitted. */
+  public enum RecordType {
+    NONE,
+    START_STOP,
+    STOP_ONLY
+  }
+
+  private final @Nonnull AccountingType _type;
+  private final @Nonnull String _name;
+  private final @Nonnull RecordType _recordType;
+  private final @Nonnull List<AaaMethod> _methods;
+
+  public Accounting(
+      AccountingType type, String name, RecordType recordType, List<AaaMethod> methods) {
+    _type = type;
+    _name = name;
+    _recordType = recordType;
+    _methods = ImmutableList.copyOf(methods);
+  }
+
+  public @Nonnull AccountingType getType() {
+    return _type;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nonnull RecordType getRecordType() {
+    return _recordType;
+  }
+
+  public @Nonnull List<AaaMethod> getMethods() {
+    return _methods;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AccountingType.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AccountingType.java
@@ -1,0 +1,8 @@
+package org.batfish.vendor.fastpath.representation;
+
+/** The kind of {@code aaa accounting} method list. */
+public enum AccountingType {
+  EXEC,
+  COMMANDS,
+  DOT1X
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Authentication.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Authentication.java
@@ -1,0 +1,32 @@
+package org.batfish.vendor.fastpath.representation;
+
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/** A single {@code aaa authentication {login|enable}} method list. */
+public final class Authentication implements Serializable {
+
+  private final @Nonnull AuthenticationType _type;
+  private final @Nonnull String _name;
+  private final @Nonnull List<AaaMethod> _methods;
+
+  public Authentication(AuthenticationType type, String name, List<AaaMethod> methods) {
+    _type = type;
+    _name = name;
+    _methods = ImmutableList.copyOf(methods);
+  }
+
+  public @Nonnull AuthenticationType getType() {
+    return _type;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nonnull List<AaaMethod> getMethods() {
+    return _methods;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AuthenticationType.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AuthenticationType.java
@@ -1,0 +1,7 @@
+package org.batfish.vendor.fastpath.representation;
+
+/** The kind of {@code aaa authentication} method list. */
+public enum AuthenticationType {
+  LOGIN,
+  ENABLE
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AuthenticationType.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AuthenticationType.java
@@ -3,5 +3,6 @@ package org.batfish.vendor.fastpath.representation;
 /** The kind of {@code aaa authentication} method list. */
 public enum AuthenticationType {
   LOGIN,
-  ENABLE
+  ENABLE,
+  DOT1X
 }

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Authorization.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Authorization.java
@@ -1,0 +1,32 @@
+package org.batfish.vendor.fastpath.representation;
+
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/** A single {@code aaa authorization {commands|exec}} method list. */
+public final class Authorization implements Serializable {
+
+  private final @Nonnull AuthorizationType _type;
+  private final @Nonnull String _name;
+  private final @Nonnull List<AaaMethod> _methods;
+
+  public Authorization(AuthorizationType type, String name, List<AaaMethod> methods) {
+    _type = type;
+    _name = name;
+    _methods = ImmutableList.copyOf(methods);
+  }
+
+  public @Nonnull AuthorizationType getType() {
+    return _type;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nonnull List<AaaMethod> getMethods() {
+    return _methods;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AuthorizationType.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/AuthorizationType.java
@@ -1,0 +1,7 @@
+package org.batfish.vendor.fastpath.representation;
+
+/** The kind of {@code aaa authorization} method list. */
+public enum AuthorizationType {
+  COMMANDS,
+  EXEC
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/FastpathConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/FastpathConfiguration.java
@@ -26,6 +26,7 @@ public final class FastpathConfiguration extends VendorConfiguration {
   private final Sntp _sntp;
   private final Logging _logging;
   private final Tacacs _tacacs;
+  private final Aaa _aaa;
 
   private transient Configuration _c;
 
@@ -34,6 +35,7 @@ public final class FastpathConfiguration extends VendorConfiguration {
     _sntp = new Sntp();
     _logging = new Logging();
     _tacacs = new Tacacs();
+    _aaa = new Aaa();
   }
 
   @Override
@@ -67,6 +69,10 @@ public final class FastpathConfiguration extends VendorConfiguration {
 
   public @Nonnull Tacacs getTacacs() {
     return _tacacs;
+  }
+
+  public @Nonnull Aaa getAaa() {
+    return _aaa;
   }
 
   private @Nonnull Configuration toVendorIndependentConfiguration() {

--- a/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Arrays;
@@ -37,6 +38,14 @@ import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
+import org.batfish.vendor.fastpath.representation.Aaa;
+import org.batfish.vendor.fastpath.representation.AaaMethod;
+import org.batfish.vendor.fastpath.representation.Accounting;
+import org.batfish.vendor.fastpath.representation.AccountingType;
+import org.batfish.vendor.fastpath.representation.Authentication;
+import org.batfish.vendor.fastpath.representation.AuthenticationType;
+import org.batfish.vendor.fastpath.representation.Authorization;
+import org.batfish.vendor.fastpath.representation.AuthorizationType;
 import org.batfish.vendor.fastpath.representation.Dns;
 import org.batfish.vendor.fastpath.representation.FastpathConfiguration;
 import org.batfish.vendor.fastpath.representation.Logging;
@@ -176,6 +185,152 @@ public final class FastpathGrammarTest {
 
   private @Nonnull String tacacsSourceInterface(String tacacsLine) {
     return parseVendorConfigText(tacacsLine, "source_interface").getTacacs().getSourceInterface();
+  }
+
+  @Test
+  public void testAaaParsesWithoutWarnings() {
+    FastpathConfiguration c = parseVendorConfig("fastpath_aaa");
+    assertThat(c.getWarnings().getParseWarnings(), empty());
+  }
+
+  @Test
+  public void testAaaExtraction() {
+    Aaa aaa = parseVendorConfig("fastpath_aaa").getAaa();
+
+    Authentication login = aaa.getAuthentication().get(AuthenticationType.LOGIN).get("user-authen");
+    assertThat(login.getType(), equalTo(AuthenticationType.LOGIN));
+    assertThat(login.getMethods(), equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.LOCAL)));
+    Authentication enable =
+        aaa.getAuthentication().get(AuthenticationType.ENABLE).get("user-enable");
+    assertThat(enable.getType(), equalTo(AuthenticationType.ENABLE));
+    assertThat(
+        enable.getMethods(),
+        equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.ENABLE, AaaMethod.RADIUS)));
+
+    Authorization authorizationCommands =
+        aaa.getAuthorization().get(AuthorizationType.COMMANDS).get("user-auth");
+    assertThat(authorizationCommands.getType(), equalTo(AuthorizationType.COMMANDS));
+    assertThat(
+        authorizationCommands.getMethods(),
+        equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.NONE)));
+    Authorization authorizationExec =
+        aaa.getAuthorization().get(AuthorizationType.EXEC).get("user-auth");
+    assertThat(authorizationExec.getType(), equalTo(AuthorizationType.EXEC));
+    assertThat(
+        authorizationExec.getMethods(),
+        equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.NONE)));
+    Authorization authorizationExecLocal =
+        aaa.getAuthorization().get(AuthorizationType.EXEC).get("execLocal");
+    assertThat(
+        authorizationExecLocal.getMethods(),
+        equalTo(ImmutableList.of(AaaMethod.LOCAL, AaaMethod.NONE)));
+
+    Accounting exec = aaa.getAccounting().get(AccountingType.EXEC).get("user-acct");
+    assertThat(exec.getType(), equalTo(AccountingType.EXEC));
+    assertThat(exec.getRecordType(), equalTo(Accounting.RecordType.START_STOP));
+    assertThat(exec.getMethods(), equalTo(ImmutableList.of(AaaMethod.TACACS)));
+    Accounting commands = aaa.getAccounting().get(AccountingType.COMMANDS).get("user-acct");
+    assertThat(commands.getType(), equalTo(AccountingType.COMMANDS));
+    assertThat(commands.getRecordType(), equalTo(Accounting.RecordType.STOP_ONLY));
+    assertThat(commands.getMethods(), equalTo(ImmutableList.of(AaaMethod.TACACS)));
+  }
+
+  @Test
+  public void testAaaListNameFormsExtraction() {
+    // The list name may be the `default` keyword, a quoted string, or a bare word. `default` is
+    // recorded as the literal name "default".
+    Aaa aaa = parseVendorConfig("fastpath_aaa").getAaa();
+
+    Authentication loginDefault =
+        aaa.getAuthentication().get(AuthenticationType.LOGIN).get("default");
+    assertThat(
+        loginDefault.getMethods(), equalTo(ImmutableList.of(AaaMethod.LINE, AaaMethod.NONE)));
+    // A bare name that starts with `default` is a name, not the keyword.
+    Authentication defaultList =
+        aaa.getAuthentication().get(AuthenticationType.LOGIN).get("defaultList");
+    assertThat(defaultList.getMethods(), equalTo(ImmutableList.of(AaaMethod.LOCAL)));
+    Authentication enableNetList =
+        aaa.getAuthentication().get(AuthenticationType.ENABLE).get("enableNetList");
+    assertThat(
+        enableNetList.getMethods(), equalTo(ImmutableList.of(AaaMethod.ENABLE, AaaMethod.DENY)));
+
+    Accounting execList = aaa.getAccounting().get(AccountingType.EXEC).get("ExecList");
+    assertThat(execList.getRecordType(), equalTo(Accounting.RecordType.START_STOP));
+    assertThat(
+        execList.getMethods(), equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.RADIUS)));
+
+    // `none` disables accounting for the list and carries no method.
+    Accounting dot1x = aaa.getAccounting().get(AccountingType.DOT1X).get("default");
+    assertThat(dot1x.getType(), equalTo(AccountingType.DOT1X));
+    assertThat(dot1x.getRecordType(), equalTo(Accounting.RecordType.NONE));
+    assertThat(dot1x.getMethods(), empty());
+
+    // radius is the only method dot1x accounting accepts.
+    Accounting dot1xRadius =
+        parseVendorConfigText("aaa accounting dot1x default start-stop radius\n", "aaa_dot1x")
+            .getAaa()
+            .getAccounting()
+            .get(AccountingType.DOT1X)
+            .get("default");
+    assertThat(dot1xRadius.getRecordType(), equalTo(Accounting.RecordType.START_STOP));
+    assertThat(dot1xRadius.getMethods(), equalTo(ImmutableList.of(AaaMethod.RADIUS)));
+  }
+
+  @Test
+  public void testAaaListRedefinitionReplaces() {
+    // Re-issuing the command for the same type and list name replaces the record type and the
+    // method list; it does not append to it.
+    Aaa aaa =
+        parseVendorConfigText(
+                """
+                aaa accounting exec ExecList stop-only tacacs
+                aaa accounting exec ExecList start-stop tacacs radius
+                aaa authentication login "user-authen" tacacs
+                aaa authentication login "user-authen" local none
+                """,
+                "aaa_redefinition")
+            .getAaa();
+
+    Accounting exec = aaa.getAccounting().get(AccountingType.EXEC).get("ExecList");
+    assertThat(exec.getRecordType(), equalTo(Accounting.RecordType.START_STOP));
+    assertThat(exec.getMethods(), equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.RADIUS)));
+
+    Authentication login = aaa.getAuthentication().get(AuthenticationType.LOGIN).get("user-authen");
+    assertThat(login.getMethods(), equalTo(ImmutableList.of(AaaMethod.LOCAL, AaaMethod.NONE)));
+  }
+
+  @Test
+  public void testAaaIasUserBlockIsSilent() {
+    FastpathConfiguration c =
+        parseVendorConfigText(
+            """
+            aaa ias-user username client-1
+            password a45c74fdf50a558a2b5cf05573cd633bac2c6c598d54497ad4c46104918f2c encrypted
+            exit
+            hostname "after-block"
+            """,
+            "aaa_ias_user");
+    assertThat(c.getWarnings().getParseWarnings(), empty());
+    // The block terminates, so a following global command is still parsed.
+    assertThat(c.getHostname(), equalTo("after-block"));
+  }
+
+  @Test
+  public void testCompleteConfigAaaExtraction() throws IOException {
+    // AAA has no vendor-independent representation yet, so pin the two method lists in
+    // fastpath_complete_config on the vendor model.
+    String hostname = "fastpath_complete_config";
+    Batfish batfish = getBatfishAllowUnrecognized(hostname);
+    FastpathConfiguration vc =
+        (FastpathConfiguration)
+            batfish.loadVendorConfigurations(batfish.getSnapshot()).get(hostname);
+    Aaa aaa = vc.getAaa();
+    assertThat(
+        aaa.getAuthentication().get(AuthenticationType.LOGIN).get("net-authen").getMethods(),
+        equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.LOCAL)));
+    assertThat(
+        aaa.getAuthentication().get(AuthenticationType.ENABLE).get("net-enable").getMethods(),
+        equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.ENABLE)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
@@ -300,6 +300,25 @@ public final class FastpathGrammarTest {
   }
 
   @Test
+  public void testAaaAuthenticationDot1xExtraction() {
+    Aaa aaa = parseVendorConfig("fastpath_aaa").getAaa();
+    Authentication dot1x = aaa.getAuthentication().get(AuthenticationType.DOT1X).get("default");
+    assertThat(dot1x.getType(), equalTo(AuthenticationType.DOT1X));
+    assertThat(
+        dot1x.getMethods(),
+        equalTo(
+            ImmutableList.of(AaaMethod.IAS, AaaMethod.LOCAL, AaaMethod.RADIUS, AaaMethod.NONE)));
+    assertThat(
+        parseVendorConfigText("aaa authentication dot1x default ias none\n", "aaa_authen_dot1x")
+            .getAaa()
+            .getAuthentication()
+            .get(AuthenticationType.DOT1X)
+            .get("default")
+            .getMethods(),
+        equalTo(ImmutableList.of(AaaMethod.IAS, AaaMethod.NONE)));
+  }
+
+  @Test
   public void testAaaIasUserBlockIsSilent() {
     FastpathConfiguration c =
         parseVendorConfigText(

--- a/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_aaa
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_aaa
@@ -1,0 +1,27 @@
+!Current Configuration:
+!
+!System Software Version "3.4.3.10"
+!
+hostname "fastpath_aaa"
+!
+aaa authentication login "user-authen" tacacs local
+aaa authentication enable "user-enable" tacacs enable radius
+aaa authentication login default line none
+aaa authentication login defaultList local
+aaa authentication enable enableNetList enable deny
+!
+aaa authorization commands "user-auth" tacacs none
+aaa authorization exec "user-auth" tacacs none
+aaa authorization exec execLocal local none
+!
+aaa accounting exec "user-acct" start-stop tacacs
+aaa accounting commands "user-acct" stop-only tacacs
+aaa accounting exec ExecList start-stop tacacs radius
+aaa accounting dot1x default none
+!
+aaa session-id common
+aaa ias-user username client-1
+password a45c74fdf50a558a2b5cf05573cd633bac2c6c598d54497ad4c46104918f2c encrypted
+exit
+aaa ias-user username client-2
+exit

--- a/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_aaa
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_aaa
@@ -9,6 +9,7 @@ aaa authentication enable "user-enable" tacacs enable radius
 aaa authentication login default line none
 aaa authentication login defaultList local
 aaa authentication enable enableNetList enable deny
+aaa authentication dot1x default ias local radius none
 !
 aaa authorization commands "user-auth" tacacs none
 aaa authorization exec "user-auth" tacacs none


### PR DESCRIPTION
## Summary

Add FastPath extraction for the `aaa` command to capture the device's AAA method lists: `aaa authentication {login|enable}`, `aaa authorization {commands|exec}`, and `aaa accounting {exec|commands|dot1x}`. Each is recorded with its list name and the ordered methods the device will try. This is captured in a new vendor-specific `representation` `Aaa` model.

## Changes

- **Lexer:** Add lexer tokens `AAA`, `ACCOUNTING`, `AUTHENTICATION`, `AUTHORIZATION`, `COMMANDS`, `DENY`, `DOT1X`, `ENABLE`, `EXEC`, `IAS_USER`, `LINE`, `LOCAL`, `LOGIN`, `NONE`, `PASSWORD`, `RADIUS`, `SESSION_ID`, `START_STOP`, `STOP_ONLY`, `TACACS`, and `USERNAME`, plus a virtual `DEFAULT` token alongside the existing `WORD`/`QUOTED_TEXT`/`REMAINDER`.

- **Lexer:** Add an `M_AaaListName` mode so a list name accepts the `default` keyword, a quoted string, or a bare word. It is entered only from the default mode via `lastTokenType()` predicates on `COMMANDS`, `DOT1X`, `ENABLE`, `EXEC`, and `LOGIN`, so those generic keywords only push a mode in AAA position.

- **Lexer:** Add `PASSWORD` and `SESSION_ID` mode-pushes to `M_Remainder` so password and session-id operands are matched and dropped rather than retained, and `USERNAME` to `M_Word`.

- **Grammar:** Add the `s_aaa` grammar rule with `aaa_authentication`, `aaa_authorization`, and `aaa_accounting` families, each terminating in a leaf that consumes its own `NEWLINE`. Method and record-type sets are per family: authentication accepts `deny`/`enable`/`line`/`local`/`none`/`radius`/`tacacs`, authorization accepts `local`/`none`/`radius`/`tacacs` (`local` is shared by both authorization types even though the device rejects it for `commands` specifically), and accounting accepts `radius`/`tacacs`. `aaa_dot1x_accounting_record` is split from `aaa_accounting_record` because dot1x supports only `start-stop` and `none`, and `aaa_accounting_dot1x` hardcodes the `default` list and an optional `radius`, the only list and method it supports.

- **Grammar:** Add `aaa_ias_user` for the `aaa ias-user username <user>` … `exit` submode: an `aaaiu_block` of optional `aaaiu_password_null` lines terminated by `exit`, so the `password … encrypted` body is consumed by the grammar rather than surfacing as an unrecognized line whose warning text would repeat the password. Add a parsed-but-ignored `aaa_session_id_null`.

- **VS:** Add VS model classes in `representation`: `AaaMethod`, `Authentication`/`AuthenticationType`, `Authorization`/`AuthorizationType`, `Accounting`/`AccountingType` (carrying a non-null `RecordType`), and `Aaa`, which holds each family in an insertion-ordered map keyed by type and then list name, since the same name may be reused across types.

- **VS:** Add AAA state to `FastpathConfiguration.java`: an `Aaa` field with a `getAaa()` accessor.

- **Extraction:** Populate handlers in `FastpathConfigurationBuilder.java`. The list classes are immutable and `Aaa.define*` replaces any existing list of the same type and name, matching the device, where re-issuing a command for an existing list overwrites its record type and methods rather than appending. Method-keyword conversion asserts on the final alternative so adding a grammar alternative without extraction fails loudly. The `default` keyword is recorded as the literal list name `"default"` via a shared constant.

## Testing

- Add a `fastpath_aaa` testconfig covering all three families, both authentication types, both authorization types, all three accounting types, every list-name form, and both ias-user block shapes.

- Add `testAaaParsesWithoutWarnings`, `testAaaExtraction`, `testAaaListNameFormsExtraction`, `testAaaListRedefinitionReplaces`, `testAaaIasUserBlockIsSilent`, and `testCompleteConfigAaaExtraction` to `FastpathGrammarTest`.

- All tests pass locally and no reference tests are affected.
