### PR TITLE
PaloAlto: drop log-forwarding payloads before they break config nesting

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto_nested/PaloAltoNestedLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto_nested/PaloAltoNestedLexer.g4
@@ -54,6 +54,23 @@ SHOW_CONFIG_LINE
   F_NonNewlineChar* 'show' F_WhitespaceChar+ 'config' F_NonNewlineChar* F_NewlineChar+ -> channel(HIDDEN)
 ;
 
+// An HTTP log-forwarding profile stores its webhook body as a quoted string, and PAN-OS
+// emits that string with its inner double quotes unescaped. F_QuotedString stops at the
+// first of those, after which the body's own braces lex as OPEN_BRACE/CLOSE_BRACE and
+// desynchronise config nesting for the remainder of the device -- typically leaving it with
+// no interfaces at all, and no warning saying why.
+//
+// The body is not modeled: s_log_settings offers no http alternative, and no HTTP token
+// exists in the PAN-OS grammar. So consume the whole statement, terminator included, and
+// drop it. This must happen here rather than in PaloAltoNestedFlattener or the main
+// grammar, both of which run after the tree has already been mis-nested.
+LOG_PROFILE_PAYLOAD
+:
+   'payload'
+   {lastTokenType() == -1 || lastTokenType() == NEWLINE || lastTokenType() == SHOW_CONFIG_LINE}?
+   F_WhitespaceChar+ '"' .*? '";' -> skip
+;
+
 WORD
 :
    F_QuotedString

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -436,6 +436,20 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testLogProfilePayloadDoesNotBreakNesting() {
+    // PAN-OS emits an HTTP log-forwarding payload as a quoted string whose inner double
+    // quotes are unescaped. If the lexer stops at the first of those, the body's braces
+    // become structural and every later statement is mis-nested. The payload sits before
+    // the interface in this config, so the address proves nesting survived it.
+    Configuration c = parseConfig("log-profile-payload");
+
+    assertThat(c.getAllInterfaces(), hasKey("ethernet1/1"));
+    assertThat(
+        c.getAllInterfaces().get("ethernet1/1").getConcreteAddress(),
+        equalTo(ConcreteInterfaceAddress.parse("10.0.1.1/24")));
+  }
+
+  @Test
   public void testInterfaceSdwanAddress() {
     // On an SD-WAN interface the gateway is nested under the address, so flattening emits
     // one line carrying both and the address never appears on its own. ethernet1/1 is the

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/log-profile-payload
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/log-profile-payload
@@ -1,0 +1,50 @@
+config {
+  shared {
+    log-settings {
+      http {
+        webhook-profile {
+          format {
+            system {
+              payload "{
+  "attachments": [
+    {
+      "fallback": "$device_name reports $severity",
+      "color": "danger",
+      "text": "*Time:* $time_generated"
+    }
+  ]
+}";
+            }
+          }
+        }
+      }
+    }
+  }
+  devices {
+    localhost.localdomain {
+      deviceconfig {
+        system {
+          hostname log-profile-payload;
+        }
+      }
+      network {
+        interface {
+          ethernet {
+            ethernet1/1 {
+              layer3 {
+                ip {
+                  10.0.1.1/24;
+                }
+              }
+            }
+          }
+        }
+        virtual-router {
+          default {
+            interface [ ethernet1/1 ];
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
An HTTP log-forwarding profile stores its webhook body as a quoted string, and PAN-OS emits that string with its inner double quotes **unescaped**:

```
payload "{\n  "attachments": [\n    {\n      "fallback": "$device_name reports $severity",\n ...
```

`F_QuotedString` is `'"' ~'"'* '"'`, so the token ends at the first inner quote — after `"{\n  "`. Everything past that lexes as ordinary tokens, including the body's `{` and `}`, and those are structural. Config nesting desynchronises for the remainder of the device.

The result is a device that converts with **no interfaces at all**, and nothing in the output identifies the cause. On a snapshot containing four PAN-OS firewalls alongside AWS and Arista devices, established BGP sessions drop from 200 to 182 and 16 sessions disappear from the model entirely.

### The fix

Consume the payload statement, terminator included, and skip it. Nothing is lost: `s_log_settings` offers only `config`, `profiles`, `syslog`, `system` and `userid`, and no `HTTP` token exists anywhere in the PAN-OS grammar, so this subtree is already unmodeled.

It has to be done in the lexer. A `_null` rule in the main grammar, or skipping the subtree in `PaloAltoNestedFlattener`, would both run after `PaloAltoNestedParser` has already built a mis-nested tree.

I considered the more general shape — treating a quoted value as running to the `"` that precedes its `;` — and decided against it. A bracketed list (`[ "a" "b" ]`) has no terminator, so that rule would consume across list elements. The targeted form has an unambiguous terminator, and the real payloads contain no `";` before their own.

### Tests

Two testconfigs that differ only in the payload block. `log-profile-control` establishes that the fixture is sound; `log-profile-payload` fails during parsing without this change and passes with it.

Green locally: the PAN-OS suite, both parsing corpora, checkstyle and `//tools/format:format.check`.

### Provenance

Observed on PA-1420s running PAN-OS 11.1.13-h3 and 11.1.13-h5. In the first 2000 characters of one payload: 47 bare `"`, zero `\"`.
