### PR TITLE
PaloAlto: parse an interface address that carries an sdwan-gateway

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -57,6 +57,8 @@ PROXY_ID_V6: 'proxy-id-v6';
 
 REQUIRE_COOKIE: 'require-cookie';
 
+SDWAN_GATEWAY: 'sdwan-gateway';
+
 TUNNEL_MONITOR: 'tunnel-monitor';
 
 TWO_BYTE: '2-byte';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
@@ -197,6 +197,18 @@ sniel3_common
 sniel3_ip
 :
     IP address = interface_address_or_reference
+    (
+        sniel3_ip_sdwan_gateway_null
+    )?
+;
+
+// On an SD-WAN interface the gateway is nested under the address, so the address is a
+// block with a child rather than a leaf. Flattening yields a single line carrying both,
+// and the address is never emitted on its own -- without this the whole line fails to
+// match and the interface ends up with no address at all.
+sniel3_ip_sdwan_gateway_null
+:
+    SDWAN_GATEWAY null_rest_of_line
 ;
 
 sniel3_mtu

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -436,6 +436,22 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testInterfaceSdwanAddress() {
+    // On an SD-WAN interface the gateway is nested under the address, so flattening emits
+    // one line carrying both and the address never appears on its own. ethernet1/1 is the
+    // ordinary form; ethernet1/2 must resolve to the same kind of address despite the
+    // trailing sdwan-gateway.
+    Configuration c = parseConfig("interface-sdwan-address");
+
+    assertThat(
+        c.getAllInterfaces().get("ethernet1/1").getConcreteAddress(),
+        equalTo(ConcreteInterfaceAddress.parse("10.0.1.1/24")));
+    assertThat(
+        c.getAllInterfaces().get("ethernet1/2").getConcreteAddress(),
+        equalTo(ConcreteInterfaceAddress.parse("198.51.100.6/29")));
+  }
+
+  @Test
   public void testIpsecTunnelExtraction() {
     PaloAltoConfiguration c = parsePaloAltoConfig("ipsec-tunnel");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-sdwan-address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-sdwan-address
@@ -1,0 +1,6 @@
+set deviceconfig system hostname interface-sdwan-address
+
+set network interface ethernet ethernet1/1 layer3 ip 10.0.1.1/24
+set network interface ethernet ethernet1/2 layer3 ip 198.51.100.6/29 sdwan-gateway 198.51.100.5
+
+set network virtual-router default interface [ ethernet1/1 ethernet1/2 ]


### PR DESCRIPTION
On an SD-WAN interface the gateway is nested *under* the address, so the address is a block with a child rather than a leaf. From `show config running` on a PA-1420 running PAN-OS 11.1.13-h3 (addresses replaced with documentation ranges):

```
ethernet1/15 {
  layer3 {
    ip {
      198.51.100.6/29 {
        sdwan-gateway 198.51.100.5;
      }
    }
  }
}
```

`PaloAltoNestedFlattener` emits a set line per leaf statement, so this yields exactly one line:

```
set network interface ethernet ethernet1/15 layer3 ip 198.51.100.6/29 sdwan-gateway 198.51.100.5
```

The address is never emitted on its own. `sniel3_ip` is `IP address = interface_address_or_reference` — an address and nothing after it — so the line does not match and nothing is extracted. The interface reports `Primary_Address: None` and `All_Prefixes: []` despite having a real address configured.

### Why it is expensive to diagnose

The symptom surfaces two subsystems away. An IKE gateway naming that interface as its local-address emits:

```
Cannot resolve a local address for ike-gateway IKE-GW-1 from interface ethernet1/15
```

That warning is correct and points at the IKE code, but the cause is interface address parsing. Following the chain: no interface address, so the gateway has no local IP, so no `IpsecPeerConfig` is built, so no tunnel edge forms, so the BGP sessions over those tunnels stay down.

### The fix

Accept the trailing `sdwan-gateway` as a named `_null` rule on `sniel3_ip`. `exitSniel3_ip` already reads `ctx.address`, so no extraction change is needed.

`sdwan-gateway` is the only sub-key I have observed under an address. I tried to enumerate the rest via CLI tab completion and the result was inconclusive — the probe returned nothing at that depth, and so did a control one level up, so I cannot distinguish "there are no others" from "the probe could not reach it". If PAN-OS allows further sub-keys there, they would still fail to match.

### Tests

`interface-sdwan-address` pairs an ordinary interface with an SD-WAN one, so the plain form stays covered. The test fails without this change and passes with it.

Green locally: the PAN-OS suite, both parsing corpora, checkstyle and `//tools/format:format.check`.
