### PR TITLE
AWS: build IKE phase 1 proposals from phase 1, and drop integrity for AEAD

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -400,8 +400,8 @@ final class VpnConnection implements AwsVpcEntity, Serializable {
   private static @Nonnull List<IkePhase1Proposal> toIkePhase1Proposals(IpsecTunnel ipsecTunnel) {
     List<IkePhase1Proposal> proposals = new ArrayList<>();
     for (Value ikePfs : ipsecTunnel.getIkePerfectForwardSecrecy()) {
-      for (Value authAlgorithm : ipsecTunnel.getIpsecAuthProtocol()) {
-        for (Value encryptionAlgorithm : ipsecTunnel.getIpsecEncryptionProtocol()) {
+      for (Value authAlgorithm : ipsecTunnel.getIkeAuthProtocol()) {
+        for (Value encryptionAlgorithm : ipsecTunnel.getIkeEncryptionProtocol()) {
           IkePhase1Proposal ikePhase1Proposal =
               new IkePhase1Proposal(
                   "ike_proposal_"
@@ -447,22 +447,53 @@ final class VpnConnection implements AwsVpcEntity, Serializable {
     return ikePhase1Key;
   }
 
+  /**
+   * True for ciphers that authenticate internally. AWS omits the integrity algorithms for these,
+   * and a peer configured for such a cipher offers no separate integrity algorithm to match.
+   */
+  private static boolean isAead(EncryptionAlgorithm encryptionAlgorithm) {
+    switch (encryptionAlgorithm) {
+      case AES_128_GCM:
+      case AES_192_GCM:
+      case AES_256_GCM:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private static @Nonnull IpsecPhase2Proposal toIpsecPhase2Proposal(
+      @Nullable IpsecAuthenticationAlgorithm authenticationAlgorithm,
+      EncryptionAlgorithm encryptionAlgorithm,
+      IpsecTunnel ipsecTunnel,
+      Warnings warnings) {
+    IpsecPhase2Proposal proposal = new IpsecPhase2Proposal();
+    proposal.setAuthenticationAlgorithm(authenticationAlgorithm);
+    proposal.setEncryptionAlgorithm(encryptionAlgorithm);
+    proposal.setProtocols(ImmutableSortedSet.of(toIpsecProtocol(ipsecTunnel.getIpsecProtocol())));
+    proposal.setIpsecEncapsulationMode(
+        toIpsecEncapdulationMode(ipsecTunnel.getIpsecMode(), warnings));
+    return proposal;
+  }
+
   private static @Nonnull List<IpsecPhase2Proposal> toIpsecPhase2Proposals(
       IpsecTunnel ipsecTunnel, Warnings warnings) {
     List<IpsecPhase2Proposal> proposals = new ArrayList<>();
 
-    for (Value authAlgorithm : ipsecTunnel.getIpsecAuthProtocol()) {
-      for (Value encryptionAlgorithm : ipsecTunnel.getIpsecEncryptionProtocol()) {
-        IpsecPhase2Proposal ipsecPhase2Proposal = new IpsecPhase2Proposal();
-        ipsecPhase2Proposal.setAuthenticationAlgorithm(
-            toIpsecAuthenticationAlgorithm(authAlgorithm.getValue()));
-        ipsecPhase2Proposal.setEncryptionAlgorithm(
-            toEncryptionAlgorithm(encryptionAlgorithm.getValue()));
-        ipsecPhase2Proposal.setProtocols(
-            ImmutableSortedSet.of(toIpsecProtocol(ipsecTunnel.getIpsecProtocol())));
-        ipsecPhase2Proposal.setIpsecEncapsulationMode(
-            toIpsecEncapdulationMode(ipsecTunnel.getIpsecMode(), warnings));
-        proposals.add(ipsecPhase2Proposal);
+    for (Value encryptionValue : ipsecTunnel.getIpsecEncryptionProtocol()) {
+      EncryptionAlgorithm encryptionAlgorithm = toEncryptionAlgorithm(encryptionValue.getValue());
+      if (isAead(encryptionAlgorithm)) {
+        // Pairing an integrity algorithm with an AEAD cipher would match no peer.
+        proposals.add(toIpsecPhase2Proposal(null, encryptionAlgorithm, ipsecTunnel, warnings));
+        continue;
+      }
+      for (Value authValue : ipsecTunnel.getIpsecAuthProtocol()) {
+        proposals.add(
+            toIpsecPhase2Proposal(
+                toIpsecAuthenticationAlgorithm(authValue.getValue()),
+                encryptionAlgorithm,
+                ipsecTunnel,
+                warnings));
       }
     }
     return proposals;
@@ -585,10 +616,12 @@ final class VpnConnection implements AwsVpcEntity, Serializable {
       List<String> ipsecProposalNames = Lists.newArrayList();
       for (IpsecPhase2Proposal ipsecPhase2Proposal : ipsecProposals) {
         String name =
-            "ipsec_proposal_"
-                + ipsecPhase2Proposal.getAuthenticationAlgorithm()
-                + "_"
-                + ipsecPhase2Proposal.getEncryptionAlgorithm();
+            ipsecPhase2Proposal.getAuthenticationAlgorithm() == null
+                ? "ipsec_proposal_" + ipsecPhase2Proposal.getEncryptionAlgorithm()
+                : "ipsec_proposal_"
+                    + ipsecPhase2Proposal.getAuthenticationAlgorithm()
+                    + "_"
+                    + ipsecPhase2Proposal.getEncryptionAlgorithm();
         if (!seenIpsecPhase2Proposals.contains(name)) {
           ipsecPhase2ProposalMapBuilder.put(name, ipsecPhase2Proposal);
           seenIpsecPhase2Proposals.add(name);

--- a/projects/batfish/src/test/java/org/batfish/grammar/aws/AwsIpsecTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/aws/AwsIpsecTest.java
@@ -347,23 +347,19 @@ public class AwsIpsecTest {
             allOf(
                 IpsecPhase2PolicyMatchers.hasIpsecProposals(
                     equalTo(
+                        // the GCM ciphers authenticate internally, so they yield one
+                        // proposal each rather than one per integrity algorithm
                         ImmutableList.of(
                             "ipsec_proposal_HMAC_SHA1_96_AES_128_CBC",
-                            "ipsec_proposal_HMAC_SHA1_96_AES_256_CBC",
-                            "ipsec_proposal_HMAC_SHA1_96_AES_128_GCM",
-                            "ipsec_proposal_HMAC_SHA1_96_AES_256_GCM",
                             "ipsec_proposal_HMAC_SHA_256_128_AES_128_CBC",
-                            "ipsec_proposal_HMAC_SHA_256_128_AES_256_CBC",
-                            "ipsec_proposal_HMAC_SHA_256_128_AES_128_GCM",
-                            "ipsec_proposal_HMAC_SHA_256_128_AES_256_GCM",
                             "ipsec_proposal_HMAC_SHA_384_AES_128_CBC",
-                            "ipsec_proposal_HMAC_SHA_384_AES_256_CBC",
-                            "ipsec_proposal_HMAC_SHA_384_AES_128_GCM",
-                            "ipsec_proposal_HMAC_SHA_384_AES_256_GCM",
                             "ipsec_proposal_HMAC_SHA_512_AES_128_CBC",
+                            "ipsec_proposal_HMAC_SHA1_96_AES_256_CBC",
+                            "ipsec_proposal_HMAC_SHA_256_128_AES_256_CBC",
+                            "ipsec_proposal_HMAC_SHA_384_AES_256_CBC",
                             "ipsec_proposal_HMAC_SHA_512_AES_256_CBC",
-                            "ipsec_proposal_HMAC_SHA_512_AES_128_GCM",
-                            "ipsec_proposal_HMAC_SHA_512_AES_256_GCM"))),
+                            "ipsec_proposal_AES_128_GCM",
+                            "ipsec_proposal_AES_256_GCM"))),
                 IpsecPhase2PolicyMatchers.hasPfsKeyGroups(
                     hasItems(DiffieHellmanGroup.GROUP2, DiffieHellmanGroup.GROUP5)))));
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/VpnConnectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/VpnConnectionTest.java
@@ -16,6 +16,7 @@ import static org.batfish.representation.aws.VpnConnection.VPN_UNDERLAY_VRF_NAME
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,7 +35,12 @@ import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.DiffieHellmanGroup;
+import org.batfish.datamodel.EncryptionAlgorithm;
+import org.batfish.datamodel.IkeHashingAlgorithm;
+import org.batfish.datamodel.IkePhase1Proposal;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpsecPhase2Proposal;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
@@ -440,6 +446,126 @@ public class VpnConnectionTest {
                 .setStatements(Collections.singletonList(EXPORT_CONNECTED_STATEMENT))
                 .build()));
     assertThat(vgwConfig.getAllInterfaces(), hasKey(BACKBONE_FACING_INTERFACE_NAME));
+  }
+
+  /**
+   * AWS lets phase 1 and phase 2 use different algorithms, and commonly does: CBC for the IKE SA,
+   * GCM for the IPsec SA. The IKE phase 1 proposals must come from the phase 1 lists.
+   */
+  @Test
+  public void testIkePhase1ProposalsUsePhase1Algorithms() {
+    VpnGateway vgw = new VpnGateway("vpn", ImmutableList.of(), ImmutableMap.of(), 64666L);
+    Configuration vgwConfig = Utils.newAwsConfiguration(vgw.getId(), "awstest");
+    VpnConnection.initVpnConnectionsInfrastructure(vgwConfig);
+    Vrf vpnVrf = Vrf.builder().setOwner(vgwConfig).setName("vpn").build();
+    makeBgpProcess(Ip.parse("1.1.1.1"), vpnVrf);
+
+    IpsecTunnel ipsecTunnel =
+        new IpsecTunnel(
+            65301L,
+            Ip.parse("169.254.15.194"),
+            30,
+            Ip.parse("147.75.69.27"),
+            // phase 1: SHA2-256 / AES256 (CBC) / group 19
+            List.of(new Value("SHA2-256")),
+            List.of(new Value("AES256")),
+            28800,
+            "main",
+            List.of(new Value("19")),
+            "7db2fd6e9dcffcf826743b57bc0518cfcbca8f4db0b80a7a2c3f0c3b09deb49a",
+            // phase 2: deliberately different -- SHA1 / AES256-GCM-16 / group 20
+            List.of(new Value("SHA1")),
+            List.of(new Value("AES256-GCM-16")),
+            3600,
+            "tunnel",
+            List.of(new Value("20")),
+            "esp",
+            64666L,
+            Ip.parse("169.254.15.193"),
+            30,
+            Ip.parse("52.27.166.152"));
+
+    VpnConnection vpnConnection =
+        new VpnConnection(
+            true,
+            "vpn-1",
+            "cgw-1",
+            GatewayType.VPN,
+            vgw.getId(),
+            ImmutableList.of(ipsecTunnel),
+            ImmutableList.of(),
+            ImmutableList.of(),
+            false);
+
+    vpnConnection.applyToGateway(
+        vgwConfig, vpnVrf, "ExportPolicy", "ImportPolicy", new Warnings(true, true, true));
+
+    IkePhase1Proposal proposal = getOnlyElement(vgwConfig.getIkePhase1Proposals().values());
+    assertThat(proposal.getEncryptionAlgorithm(), equalTo(EncryptionAlgorithm.AES_256_CBC));
+    assertThat(proposal.getHashingAlgorithm(), equalTo(IkeHashingAlgorithm.SHA_256));
+    assertThat(proposal.getDiffieHellmanGroup(), equalTo(DiffieHellmanGroup.GROUP19));
+  }
+
+  /**
+   * AWS omits the phase 2 integrity algorithms when the phase 2 cipher is AEAD, since the cipher
+   * authenticates internally. The absent list must not be defaulted into HMAC proposals that no
+   * peer configured for that cipher can match.
+   */
+  @Test
+  public void testIpsecPhase2ProposalsAeadHasNoAuthentication() {
+    VpnGateway vgw = new VpnGateway("vpn", ImmutableList.of(), ImmutableMap.of(), 64666L);
+    Configuration vgwConfig = Utils.newAwsConfiguration(vgw.getId(), "awstest");
+    VpnConnection.initVpnConnectionsInfrastructure(vgwConfig);
+    Vrf vpnVrf = Vrf.builder().setOwner(vgwConfig).setName("vpn").build();
+    makeBgpProcess(Ip.parse("1.1.1.1"), vpnVrf);
+
+    IpsecTunnel ipsecTunnel =
+        new IpsecTunnel(
+            65301L,
+            Ip.parse("169.254.15.194"),
+            30,
+            Ip.parse("147.75.69.27"),
+            List.of(new Value("SHA2-256")),
+            List.of(new Value("AES256")),
+            28800,
+            "main",
+            List.of(new Value("19")),
+            "7db2fd6e9dcffcf826743b57bc0518cfcbca8f4db0b80a7a2c3f0c3b09deb49a",
+            // AWS defaults the omitted phase 2 integrity list to every supported HMAC
+            List.of(
+                new Value("SHA1"),
+                new Value("SHA2-256"),
+                new Value("SHA2-384"),
+                new Value("SHA2-512")),
+            List.of(new Value("AES256-GCM-16")),
+            3600,
+            "tunnel",
+            List.of(new Value("19")),
+            "esp",
+            64666L,
+            Ip.parse("169.254.15.193"),
+            30,
+            Ip.parse("52.27.166.152"));
+
+    VpnConnection vpnConnection =
+        new VpnConnection(
+            true,
+            "vpn-1",
+            "cgw-1",
+            GatewayType.VPN,
+            vgw.getId(),
+            ImmutableList.of(ipsecTunnel),
+            ImmutableList.of(),
+            ImmutableList.of(),
+            false);
+
+    vpnConnection.applyToGateway(
+        vgwConfig, vpnVrf, "ExportPolicy", "ImportPolicy", new Warnings(true, true, true));
+
+    // one proposal, not one per HMAC, and it carries no authentication algorithm
+    IpsecPhase2Proposal proposal = getOnlyElement(vgwConfig.getIpsecPhase2Proposals().values());
+    assertThat(proposal.getEncryptionAlgorithm(), equalTo(EncryptionAlgorithm.AES_256_GCM));
+    assertThat(proposal.getAuthenticationAlgorithm(), nullValue());
   }
 
   @Test

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -79530,21 +79530,15 @@
             ],
             "proposals" : [
               "ipsec_proposal_HMAC_SHA1_96_AES_128_CBC",
-              "ipsec_proposal_HMAC_SHA1_96_AES_256_CBC",
-              "ipsec_proposal_HMAC_SHA1_96_AES_128_GCM",
-              "ipsec_proposal_HMAC_SHA1_96_AES_256_GCM",
               "ipsec_proposal_HMAC_SHA_256_128_AES_128_CBC",
-              "ipsec_proposal_HMAC_SHA_256_128_AES_256_CBC",
-              "ipsec_proposal_HMAC_SHA_256_128_AES_128_GCM",
-              "ipsec_proposal_HMAC_SHA_256_128_AES_256_GCM",
               "ipsec_proposal_HMAC_SHA_384_AES_128_CBC",
-              "ipsec_proposal_HMAC_SHA_384_AES_256_CBC",
-              "ipsec_proposal_HMAC_SHA_384_AES_128_GCM",
-              "ipsec_proposal_HMAC_SHA_384_AES_256_GCM",
               "ipsec_proposal_HMAC_SHA_512_AES_128_CBC",
+              "ipsec_proposal_HMAC_SHA1_96_AES_256_CBC",
+              "ipsec_proposal_HMAC_SHA_256_128_AES_256_CBC",
+              "ipsec_proposal_HMAC_SHA_384_AES_256_CBC",
               "ipsec_proposal_HMAC_SHA_512_AES_256_CBC",
-              "ipsec_proposal_HMAC_SHA_512_AES_128_GCM",
-              "ipsec_proposal_HMAC_SHA_512_AES_256_GCM"
+              "ipsec_proposal_AES_128_GCM",
+              "ipsec_proposal_AES_256_GCM"
             ]
           },
           "vpn-ba2e34a8-2" : {
@@ -79565,36 +79559,36 @@
             ],
             "proposals" : [
               "ipsec_proposal_HMAC_SHA1_96_AES_128_CBC",
-              "ipsec_proposal_HMAC_SHA1_96_AES_256_CBC",
-              "ipsec_proposal_HMAC_SHA1_96_AES_128_GCM",
-              "ipsec_proposal_HMAC_SHA1_96_AES_256_GCM",
               "ipsec_proposal_HMAC_SHA_256_128_AES_128_CBC",
-              "ipsec_proposal_HMAC_SHA_256_128_AES_256_CBC",
-              "ipsec_proposal_HMAC_SHA_256_128_AES_128_GCM",
-              "ipsec_proposal_HMAC_SHA_256_128_AES_256_GCM",
               "ipsec_proposal_HMAC_SHA_384_AES_128_CBC",
-              "ipsec_proposal_HMAC_SHA_384_AES_256_CBC",
-              "ipsec_proposal_HMAC_SHA_384_AES_128_GCM",
-              "ipsec_proposal_HMAC_SHA_384_AES_256_GCM",
               "ipsec_proposal_HMAC_SHA_512_AES_128_CBC",
+              "ipsec_proposal_HMAC_SHA1_96_AES_256_CBC",
+              "ipsec_proposal_HMAC_SHA_256_128_AES_256_CBC",
+              "ipsec_proposal_HMAC_SHA_384_AES_256_CBC",
               "ipsec_proposal_HMAC_SHA_512_AES_256_CBC",
-              "ipsec_proposal_HMAC_SHA_512_AES_128_GCM",
-              "ipsec_proposal_HMAC_SHA_512_AES_256_GCM"
+              "ipsec_proposal_AES_128_GCM",
+              "ipsec_proposal_AES_256_GCM"
             ]
           }
         },
         "ipsecPhase2Proposals" : {
-          "ipsec_proposal_HMAC_SHA1_96_AES_128_CBC" : {
-            "authenticationAlgorithm" : "HMAC_SHA1_96",
-            "encryptionAlgorithm" : "AES_128_CBC",
+          "ipsec_proposal_AES_128_GCM" : {
+            "encryptionAlgorithm" : "AES_128_GCM",
             "ipsecEncapsulationMode" : "TUNNEL",
             "protocols" : [
               "ESP"
             ]
           },
-          "ipsec_proposal_HMAC_SHA1_96_AES_128_GCM" : {
+          "ipsec_proposal_AES_256_GCM" : {
+            "encryptionAlgorithm" : "AES_256_GCM",
+            "ipsecEncapsulationMode" : "TUNNEL",
+            "protocols" : [
+              "ESP"
+            ]
+          },
+          "ipsec_proposal_HMAC_SHA1_96_AES_128_CBC" : {
             "authenticationAlgorithm" : "HMAC_SHA1_96",
-            "encryptionAlgorithm" : "AES_128_GCM",
+            "encryptionAlgorithm" : "AES_128_CBC",
             "ipsecEncapsulationMode" : "TUNNEL",
             "protocols" : [
               "ESP"
@@ -79608,25 +79602,9 @@
               "ESP"
             ]
           },
-          "ipsec_proposal_HMAC_SHA1_96_AES_256_GCM" : {
-            "authenticationAlgorithm" : "HMAC_SHA1_96",
-            "encryptionAlgorithm" : "AES_256_GCM",
-            "ipsecEncapsulationMode" : "TUNNEL",
-            "protocols" : [
-              "ESP"
-            ]
-          },
           "ipsec_proposal_HMAC_SHA_256_128_AES_128_CBC" : {
             "authenticationAlgorithm" : "HMAC_SHA_256_128",
             "encryptionAlgorithm" : "AES_128_CBC",
-            "ipsecEncapsulationMode" : "TUNNEL",
-            "protocols" : [
-              "ESP"
-            ]
-          },
-          "ipsec_proposal_HMAC_SHA_256_128_AES_128_GCM" : {
-            "authenticationAlgorithm" : "HMAC_SHA_256_128",
-            "encryptionAlgorithm" : "AES_128_GCM",
             "ipsecEncapsulationMode" : "TUNNEL",
             "protocols" : [
               "ESP"
@@ -79640,25 +79618,9 @@
               "ESP"
             ]
           },
-          "ipsec_proposal_HMAC_SHA_256_128_AES_256_GCM" : {
-            "authenticationAlgorithm" : "HMAC_SHA_256_128",
-            "encryptionAlgorithm" : "AES_256_GCM",
-            "ipsecEncapsulationMode" : "TUNNEL",
-            "protocols" : [
-              "ESP"
-            ]
-          },
           "ipsec_proposal_HMAC_SHA_384_AES_128_CBC" : {
             "authenticationAlgorithm" : "HMAC_SHA_384",
             "encryptionAlgorithm" : "AES_128_CBC",
-            "ipsecEncapsulationMode" : "TUNNEL",
-            "protocols" : [
-              "ESP"
-            ]
-          },
-          "ipsec_proposal_HMAC_SHA_384_AES_128_GCM" : {
-            "authenticationAlgorithm" : "HMAC_SHA_384",
-            "encryptionAlgorithm" : "AES_128_GCM",
             "ipsecEncapsulationMode" : "TUNNEL",
             "protocols" : [
               "ESP"
@@ -79672,14 +79634,6 @@
               "ESP"
             ]
           },
-          "ipsec_proposal_HMAC_SHA_384_AES_256_GCM" : {
-            "authenticationAlgorithm" : "HMAC_SHA_384",
-            "encryptionAlgorithm" : "AES_256_GCM",
-            "ipsecEncapsulationMode" : "TUNNEL",
-            "protocols" : [
-              "ESP"
-            ]
-          },
           "ipsec_proposal_HMAC_SHA_512_AES_128_CBC" : {
             "authenticationAlgorithm" : "HMAC_SHA_512",
             "encryptionAlgorithm" : "AES_128_CBC",
@@ -79688,25 +79642,9 @@
               "ESP"
             ]
           },
-          "ipsec_proposal_HMAC_SHA_512_AES_128_GCM" : {
-            "authenticationAlgorithm" : "HMAC_SHA_512",
-            "encryptionAlgorithm" : "AES_128_GCM",
-            "ipsecEncapsulationMode" : "TUNNEL",
-            "protocols" : [
-              "ESP"
-            ]
-          },
           "ipsec_proposal_HMAC_SHA_512_AES_256_CBC" : {
             "authenticationAlgorithm" : "HMAC_SHA_512",
             "encryptionAlgorithm" : "AES_256_CBC",
-            "ipsecEncapsulationMode" : "TUNNEL",
-            "protocols" : [
-              "ESP"
-            ]
-          },
-          "ipsec_proposal_HMAC_SHA_512_AES_256_GCM" : {
-            "authenticationAlgorithm" : "HMAC_SHA_512",
-            "encryptionAlgorithm" : "AES_256_GCM",
             "ipsecEncapsulationMode" : "TUNNEL",
             "protocols" : [
               "ESP"


### PR DESCRIPTION
Two defects in `VpnConnection`'s IKE/IPsec conversion, both of which stop a correctly configured VPN from negotiating.

### Phase 1 proposals are built from the phase 2 algorithms

```java
for (Value ikePfs : ipsecTunnel.getIkePerfectForwardSecrecy()) {
  for (Value authAlgorithm : ipsecTunnel.getIpsecAuthProtocol()) {
    for (Value encryptionAlgorithm : ipsecTunnel.getIpsecEncryptionProtocol()) {
```

Those are the same two accessors the phase 2 builder uses. `IpsecTunnel` parses both phases correctly from `TunnelOptions`, but `getIkeAuthProtocol()` and `getIkeEncryptionProtocol()` are then read nowhere in `main/` — the phase 1 values are dead. Only the DH group loop uses a phase 1 field, which is why the group numbers look right while the algorithms do not.

A VPN configured with

| | Encryption | Integrity | DH |
|---|---|---|---|
| Phase 1 | `AES256` | `SHA2-256` | 19, 21, 20 |
| Phase 2 | `AES256-GCM-16` | *(omitted)* | 19, 21, 20 |

produced twelve phase 1 proposals, every one `AES256-GCM-16`. `toEncryptionAlgorithm` maps `AES256` to `AES_256_CBC` and `AES256-GCM-16` to `AES_256_GCM`, so a peer offering AES-256-CBC — which is what that tunnel's phase 1 actually asks for — cannot negotiate phase 1.

### An omitted phase 2 integrity list becomes HMACs paired with an AEAD cipher

AWS omits `Phase2IntegrityAlgorithms` when the phase 2 cipher is AEAD, since the cipher authenticates internally. `TunnelOptions.create` defaults each absent list to every supported value, so the omission became four HMAC algorithms, each paired with `AES256-GCM-16`. A peer configured for GCM offers no separate integrity algorithm, so none of those four could ever match.

Emit a single proposal with no authentication algorithm for an AEAD cipher instead, and name it without the null.

### Compatibility

This changes what the AWS side advertises, so it can change session outcomes for any vendor terminating a Site-to-Site VPN, not only the one I hit it with.

- Phase 1 and phase 2 configured the same: no change. This includes every VPN left at AWS defaults, where both phases fall back to the same permissive list — which is why this has gone unnoticed.
- They differ and the peer matches phase 1: previously failed, now negotiates.
- They differ and the peer happened to match phase 2: previously negotiated, now correctly fails.

The AEAD change only removes proposals that could not have matched a conforming peer, so it should turn non-negotiating tunnels into negotiating ones and not the reverse.

### Tests

`testIkePhase1ProposalsUsePhase1Algorithms` builds a tunnel whose phase 1 and phase 2 differ in encryption, integrity and DH group, and asserts the phase 1 proposal carries the phase 1 values. It fails on master with `Expected: <AES_256_CBC> but: was <AES_256_GCM>`.

`testIpsecPhase2ProposalsAeadHasNoAuthentication` gives a tunnel a GCM phase 2 cipher alongside the defaulted HMAC list, and asserts a single proposal with no authentication algorithm.

Measured on a snapshot of four PAN-OS firewalls plus AWS and Arista: established BGP sessions go from 200 to 208, and established IPsec sessions from 16 to 28.

Green locally: the AWS, PAN-OS, Cisco and common-util suites, the parsing corpus, checkstyle and `//tools/format:format.check`.
