### PR TITLE
AWS: tolerate a tunnel whose pre-shared key lives in Secrets Manager

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -805,7 +805,11 @@ final class VpnConnection implements AwsVpcEntity, Serializable {
         @JsonProperty(JSON_KEY_PRESHARED_KEY) @Nullable String presharedKey,
         @JsonProperty(JSON_KEY_PHASE2_LIFETIME_SECONDS) @Nullable Integer phase2LifetimeSeconds) {
       checkArgument(outsideIpAddress != null, "OutsideIpAddress cannot be null");
-      checkArgument(presharedKey != null, "PreSharedKey cannot be null");
+      // PreSharedKey is absent whenever the tunnel stores its key in Secrets Manager rather
+      // than in the Site-to-Site VPN service, in which case DescribeVpnConnections returns a
+      // PreSharedKeyArn instead. Nothing reads this field -- the key used for phase 1 comes
+      // from the customer gateway configuration -- so rejecting the tunnel would discard
+      // every VPN in the file over a value that is legitimately absent and never consumed.
       return new TunnelOptions(
           ikeVersions,
           firstNonNull(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/VpnConnectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/VpnConnectionTest.java
@@ -14,6 +14,7 @@ import static org.batfish.representation.aws.VpnConnection.EXPORT_CONNECTED_STAT
 import static org.batfish.representation.aws.VpnConnection.VPN_TO_BACKBONE_EXPORT_POLICY_NAME;
 import static org.batfish.representation.aws.VpnConnection.VPN_UNDERLAY_VRF_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertTrue;
@@ -266,6 +267,22 @@ public class VpnConnectionTest {
                         new VgwTelemetry(5, Ip.parse("52.27.166.152"), "UP", "5 BGP ROUTES"),
                         new VgwTelemetry(5, Ip.parse("52.39.121.126"), "UP", "5 BGP ROUTES")),
                     false))));
+  }
+
+  /**
+   * A tunnel that stores its pre-shared key in Secrets Manager has no PreSharedKey in
+   * DescribeVpnConnections output -- AWS returns a PreSharedKeyArn instead. Rejecting the tunnel
+   * would discard every VPN connection in the file.
+   */
+  @Test
+  public void testDeserializationSecretsManagerPreSharedKey() throws IOException {
+    String text =
+        readResource("org/batfish/representation/aws/VpnConnectionSecretsManagerPsk.json", UTF_8);
+
+    Region region = new Region("r1");
+    region.addConfigElement(BatfishObjectMapper.mapper().readTree(text), null, null);
+
+    assertThat(region.getVpnConnections().keySet(), contains("vpn-secretsmanager"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/VpnConnectionSecretsManagerPsk.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/VpnConnectionSecretsManagerPsk.json
@@ -1,0 +1,139 @@
+{
+  "VpnConnections": [
+    {
+      "Category": "VPN",
+      "CustomerGatewayConfiguration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<vpn_connection id=\"vpn-ba2e34a8\">\n  <customer_gateway_id>cgw-fb76ace5</customer_gateway_id>\n  <vpn_gateway_id>vgw-81fd279f</vpn_gateway_id>\n  <vpn_connection_type>ipsec.1</vpn_connection_type>\n  <ipsec_tunnel>\n    <customer_gateway>\n      <tunnel_outside_address>\n        <ip_address>147.75.69.27</ip_address>\n      </tunnel_outside_address>\n      <tunnel_inside_address>\n        <ip_address>169.254.15.194</ip_address>\n        <network_mask>255.255.255.252</network_mask>\n        <network_cidr>30</network_cidr>\n      </tunnel_inside_address>\n      <bgp>\n        <asn>65301</asn>\n        <hold_time>30</hold_time>\n      </bgp>\n    </customer_gateway>\n    <vpn_gateway>\n      <tunnel_outside_address>\n        <ip_address>52.27.166.152</ip_address>\n      </tunnel_outside_address>\n      <tunnel_inside_address>\n        <ip_address>169.254.15.193</ip_address>\n        <network_mask>255.255.255.252</network_mask>\n        <network_cidr>30</network_cidr>\n      </tunnel_inside_address>\n      <bgp>\n        <asn>65401</asn>\n        <hold_time>30</hold_time>\n      </bgp>\n    </vpn_gateway>\n    <ike>\n      <authentication_protocol>sha1</authentication_protocol>\n      <encryption_protocol>aes-128-cbc</encryption_protocol>\n      <lifetime>28800</lifetime>\n      <perfect_forward_secrecy>group2</perfect_forward_secrecy>\n      <mode>main</mode>\n      <pre_shared_key>QMP5tKPP5qk95Y1Eee9c_82.MofNUJQV</pre_shared_key>\n    </ike>\n    <ipsec>\n      <protocol>esp</protocol>\n      <authentication_protocol>hmac-sha1-96</authentication_protocol>\n      <encryption_protocol>aes-128-cbc</encryption_protocol>\n      <lifetime>3600</lifetime>\n      <perfect_forward_secrecy>group2</perfect_forward_secrecy>\n      <mode>tunnel</mode>\n      <clear_df_bit>true</clear_df_bit>\n      <fragmentation_before_encryption>true</fragmentation_before_encryption>\n      <tcp_mss_adjustment>1379</tcp_mss_adjustment>\n      <dead_peer_detection>\n        <interval>10</interval>\n        <retries>3</retries>\n      </dead_peer_detection>\n    </ipsec>\n  </ipsec_tunnel>\n  <ipsec_tunnel>\n    <customer_gateway>\n      <tunnel_outside_address>\n        <ip_address>147.75.69.27</ip_address>\n      </tunnel_outside_address>\n      <tunnel_inside_address>\n        <ip_address>169.254.13.238</ip_address>\n        <network_mask>255.255.255.252</network_mask>\n        <network_cidr>30</network_cidr>\n      </tunnel_inside_address>\n      <bgp>\n        <asn>65301</asn>\n        <hold_time>30</hold_time>\n      </bgp>\n    </customer_gateway>\n    <vpn_gateway>\n      <tunnel_outside_address>\n        <ip_address>52.39.121.126</ip_address>\n      </tunnel_outside_address>\n      <tunnel_inside_address>\n        <ip_address>169.254.13.237</ip_address>\n        <network_mask>255.255.255.252</network_mask>\n        <network_cidr>30</network_cidr>\n      </tunnel_inside_address>\n      <bgp>\n        <asn>65401</asn>\n        <hold_time>30</hold_time>\n      </bgp>\n    </vpn_gateway>\n    <ike>\n      <authentication_protocol>sha1</authentication_protocol>\n      <encryption_protocol>aes-128-cbc</encryption_protocol>\n      <lifetime>28800</lifetime>\n      <perfect_forward_secrecy>group2</perfect_forward_secrecy>\n      <mode>main</mode>\n      <pre_shared_key>tYrysT4iT0.CRwQnhiBbng.BahDc7YPq</pre_shared_key>\n    </ike>\n    <ipsec>\n      <protocol>esp</protocol>\n      <authentication_protocol>hmac-sha1-96</authentication_protocol>\n      <encryption_protocol>aes-128-cbc</encryption_protocol>\n      <lifetime>3600</lifetime>\n      <perfect_forward_secrecy>group2</perfect_forward_secrecy>\n      <mode>tunnel</mode>\n      <clear_df_bit>true</clear_df_bit>\n      <fragmentation_before_encryption>true</fragmentation_before_encryption>\n      <tcp_mss_adjustment>1379</tcp_mss_adjustment>\n      <dead_peer_detection>\n        <interval>10</interval>\n        <retries>3</retries>\n      </dead_peer_detection>\n    </ipsec>\n  </ipsec_tunnel>\n</vpn_connection>",
+      "CustomerGatewayId": "cgw-fb76ace5",
+      "Options": {
+        "StaticRoutesOnly": false,
+        "TunnelOptions": [
+          {
+            "OutsideIpAddress": "52.27.166.152",
+            "TunnelInsideCidr": "169.254.15.193/30",
+            "Phase1DHGroupNumbers": [
+              {
+                "Value": 2
+              }
+            ],
+            "Phase1EncryptionAlgorithms": [
+              {
+                "Value": "AES128"
+              },
+              {
+                "Value": "AES128-GCM-16"
+              }
+            ],
+            "Phase1IntegrityAlgorithms": [
+              {
+                "Value": "SHA1"
+              },
+              {
+                "Value": "SHA2-512"
+              }
+            ],
+            "Phase2DHGroupNumbers": [
+              {
+                "Value": 15
+              },
+              {
+                "Value": 16
+              }
+            ],
+            "Phase2EncryptionAlgorithms": [
+              {
+                "Value": "AES128"
+              },
+              {
+                "Value": "AES128-GCM-16"
+              }
+            ],
+            "Phase2IntegrityAlgorithms": [
+              {
+                "Value": "SHA2-512"
+              }
+            ],
+            "EnableTunnelLifecycleControl": false
+          },
+          {
+            "OutsideIpAddress": "52.39.121.126",
+            "TunnelInsideCidr": "169.254.13.237/30",
+            "Phase1DHGroupNumbers": [
+              {
+                "Value": 22
+              },
+              {
+                "Value": 23
+              }
+            ],
+            "Phase1EncryptionAlgorithms": [
+              {
+                "Value": "AES256"
+              },
+              {
+                "Value": "AES128-GCM-16"
+              }
+            ],
+            "Phase1IntegrityAlgorithms": [
+              {
+                "Value": "SHA1"
+              },
+              {
+                "Value": "SHA2-512"
+              }
+            ],
+            "Phase2DHGroupNumbers": [
+              {
+                "Value": 14
+              },
+              {
+                "Value": 15
+              },
+              {
+                "Value": 16
+              }
+            ],
+            "Phase2EncryptionAlgorithms": [
+              {
+                "Value": "AES128-GCM-16"
+              }
+            ],
+            "Phase2IntegrityAlgorithms": [
+              {
+                "Value": "SHA2-512"
+              }
+            ],
+            "EnableTunnelLifecycleControl": false
+          }
+        ]
+      },
+      "Routes": [],
+      "State": "available",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "GNS3-BGP-Test"
+        }
+      ],
+      "Type": "ipsec.1",
+      "VgwTelemetry": [
+        {
+          "AcceptedRouteCount": 5,
+          "LastStatusChange": "2017-11-02 16:54:36+00:00",
+          "OutsideIpAddress": "52.27.166.152",
+          "Status": "UP",
+          "StatusMessage": "5 BGP ROUTES"
+        },
+        {
+          "AcceptedRouteCount": 5,
+          "LastStatusChange": "2017-11-03 01:09:56+00:00",
+          "OutsideIpAddress": "52.39.121.126",
+          "Status": "UP",
+          "StatusMessage": "5 BGP ROUTES"
+        }
+      ],
+      "VpnConnectionId": "vpn-secretsmanager",
+      "VpnGatewayId": "vgw-81fd279f",
+      "PreSharedKeyArn": "arn:aws:secretsmanager:us-west-2:123456789012:secret:vpn!vpn-secretsmanager-AbCdEf"
+    }
+  ]
+}


### PR DESCRIPTION
AWS Site-to-Site VPN offers two pre-shared key storage modes. From the [documentation](https://docs.aws.amazon.com/vpn/latest/s2svpn/enhanced-security-storage.html):

> **Standard** — The pre-shared key is stored directly in the Site-to-Site VPN service.
> **Secrets Manager** — The pre-shared key is stored using AWS Secrets Manager.

and, on switching a tunnel to the latter:

> The pre-shared key is removed from the Site-to-Site VPN service. A new Secrets Manager secret is created, if one doesn't already exist. The new pre-shared key is stored in Secrets Manager.

So for such a tunnel `DescribeVpnConnections` returns a top-level `PreSharedKeyArn` and the tunnel options carry no `PreSharedKey`. `TunnelOptions.create` rejects that:

```java
checkArgument(presharedKey != null, "PreSharedKey cannot be null");
```

Because the exception comes from a `@JsonCreator`, it fails deserialization of the enclosing object, and the whole file is discarded with `Exception while parsing 'VpnConnections' ... Cannot construct instance of VpnConnection$TunnelOptions`. Every VPN connection in that region is lost — the transit gateway ends up with no VPN attachment and no VPN interfaces, and the tunnels cannot be modelled at all.

### Why the field can go

`getPresharedKey()` has no caller anywhere in `main/`. The key used to build the phase 1 key comes from the customer gateway configuration:

```java
builder.setIkePreSharedKeyHash(
    CommonUtil.sha256Digest(
        Utils.textOfFirstXmlElementWithTag(ikeElement, AwsVpcEntity.XML_KEY_PRE_SHARED_KEY)
            + CommonUtil.salt()));
```

That element is still present under Secrets Manager storage, with its value masked. It hashes to something non-null and negotiates as an unreadable pre-shared key — which is exactly what it is, and what `negotiateIkePhase1Key` already handles for the mixed encrypted/plaintext case.

### Impact

On a snapshot where one VPN uses Secrets Manager storage, the parse error disappears and the transit gateway gains its four VPN interfaces (two external, two tunnel-inside). The tunnels reach `IPSEC_SESSION_ESTABLISHED` and their BGP sessions come up.

This affects anyone following AWS's own guidance — the Secrets Manager mode is presented as the more secure option, for "compliance with security best practices".

### Tests

`testDeserializationSecretsManagerPreSharedKey` uses a fixture shaped like real output: a `PreSharedKeyArn` on the connection, and tunnel options with no `PreSharedKey`. It fails on master and passes with this change.

Green locally: the AWS suite, the parsing corpus, checkstyle and `//tools/format:format.check`.
