### PR TITLE
feat(ios): port AAA models to vendor-specific representation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -418,12 +418,6 @@ import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.LongExpr;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.OriginExpr;
-import org.batfish.datamodel.vendor_family.cisco.Aaa;
-import org.batfish.datamodel.vendor_family.cisco.AaaAccounting;
-import org.batfish.datamodel.vendor_family.cisco.AaaAccountingCommands;
-import org.batfish.datamodel.vendor_family.cisco.AaaAccountingDefault;
-import org.batfish.datamodel.vendor_family.cisco.AaaAuthentication;
-import org.batfish.datamodel.vendor_family.cisco.AaaAuthenticationLogin;
 import org.batfish.datamodel.vendor_family.cisco.Buffered;
 import org.batfish.datamodel.vendor_family.cisco.Cable;
 import org.batfish.datamodel.vendor_family.cisco.DepiClass;
@@ -441,7 +435,6 @@ import org.batfish.datamodel.vendor_family.cisco.ServiceClass;
 import org.batfish.datamodel.vendor_family.cisco.Sntp;
 import org.batfish.datamodel.vendor_family.cisco.SntpServer;
 import org.batfish.datamodel.vendor_family.cisco.SshSettings;
-import org.batfish.datamodel.vendor_family.cisco.User;
 import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.BatfishParseTreeWalker;
 import org.batfish.grammar.ControlPlaneExtractor;
@@ -1536,8 +1529,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   private StandardIpv6AccessList _currentStandardIpv6Acl;
 
-  private User _currentUser;
-
   private CiscoUser _currentCiscoUser;
 
   private String _currentVrf;
@@ -1674,11 +1665,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void enterAaa_accounting(Aaa_accountingContext ctx) {
-    // VI extraction
-    if (_configuration.getCf().getAaa().getAccounting() == null) {
-      _configuration.getCf().getAaa().setAccounting(new AaaAccounting());
-    }
-    // VS extraction
     if (_configuration.getAaa().getAccounting() == null) {
       _configuration.getAaa().setAccounting(new CiscoAaaAccounting());
     }
@@ -1686,8 +1672,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void enterAaa_accounting_commands_line(Aaa_accounting_commands_lineContext ctx) {
-    Map<String, AaaAccountingCommands> commands =
-        _configuration.getCf().getAaa().getAccounting().getCommands();
     Set<String> levels = new TreeSet<>();
     if (ctx.levels != null) {
       List<SubRange> range = toRange(ctx.levels);
@@ -1698,43 +1682,25 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         }
       }
     } else {
-      levels.add(AaaAccounting.DEFAULT_COMMANDS);
+      levels.add(CiscoAaaAccounting.DEFAULT_COMMANDS);
     }
-    List<AaaAccountingCommands> currentAaaAccountingCommands = new ArrayList<>();
-    // VI extraction
-    for (String level : levels) {
-      AaaAccountingCommands c = commands.computeIfAbsent(level, k -> new AaaAccountingCommands());
-      currentAaaAccountingCommands.add(c);
-    }
-    // VS extraction
-    SortedMap<String, CiscoAaaAccountingCommands> vsCommands =
+    SortedMap<String, CiscoAaaAccountingCommands> commands =
         _configuration.getAaa().getAccounting().getCommands();
     for (String level : levels) {
-      vsCommands.computeIfAbsent(level, k -> new CiscoAaaAccountingCommands());
+      commands.computeIfAbsent(level, k -> new CiscoAaaAccountingCommands());
     }
   }
 
   @Override
   public void enterAaa_accounting_default(Aaa_accounting_defaultContext ctx) {
-    // VI extraction
-    AaaAccounting accounting = _configuration.getCf().getAaa().getAccounting();
+    CiscoAaaAccounting accounting = _configuration.getAaa().getAccounting();
     if (accounting.getDefault() == null) {
-      accounting.setDefault(new AaaAccountingDefault());
-    }
-    // VS extraction
-    CiscoAaaAccounting vsAccounting = _configuration.getAaa().getAccounting();
-    if (vsAccounting.getDefault() == null) {
-      vsAccounting.setDefault(new CiscoAaaAccountingDefault());
+      accounting.setDefault(new CiscoAaaAccountingDefault());
     }
   }
 
   @Override
   public void enterAaa_authentication(Aaa_authenticationContext ctx) {
-    // VI extraction
-    if (_configuration.getCf().getAaa().getAuthentication() == null) {
-      _configuration.getCf().getAaa().setAuthentication(new AaaAuthentication());
-    }
-    // VS extraction
     if (_configuration.getAaa().getAuthentication() == null) {
       _configuration.getAaa().setAuthentication(new CiscoAaaAuthentication());
     }
@@ -1742,11 +1708,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void enterAaa_authentication_login(Aaa_authentication_loginContext ctx) {
-    // VI extraction
-    if (_configuration.getCf().getAaa().getAuthentication().getLogin() == null) {
-      _configuration.getCf().getAaa().getAuthentication().setLogin(new AaaAuthenticationLogin());
-    }
-    // VS extraction
     if (_configuration.getAaa().getAuthentication().getLogin() == null) {
       _configuration.getAaa().getAuthentication().setLogin(new CiscoAaaAuthenticationLogin());
     }
@@ -1754,10 +1715,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void enterAaa_authentication_login_list(Aaa_authentication_login_listContext ctx) {
-    AaaAuthenticationLogin login = _configuration.getCf().getAaa().getAuthentication().getLogin();
+    CiscoAaaAuthenticationLogin login = _configuration.getAaa().getAuthentication().getLogin();
     String name;
     if (ctx.DEFAULT() != null) {
-      name = AaaAuthenticationLogin.DEFAULT_LIST_NAME;
+      name = CiscoAaaAuthenticationLogin.DEFAULT_LIST_NAME;
     } else if (ctx.variable() != null) {
       name = ctx.variable().getText();
     } else {
@@ -1770,22 +1731,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       methods.add(AuthenticationMethod.toAuthenticationMethod(method.getText()));
     }
 
-    // VI extraction
     _currentAaaAuthenticationLoginList =
         login.getLists().computeIfAbsent(name, k -> new AaaAuthenticationLoginList(methods));
-
-    // VS extraction (reuse the same list instance as the VI model)
-    _configuration
-        .getAaa()
-        .getAuthentication()
-        .getLogin()
-        .getLists()
-        .putIfAbsent(name, _currentAaaAuthenticationLoginList);
 
     // apply the list to each line
     SortedMap<String, Line> lines = _configuration.getCf().getLines();
     for (Line line : lines.values()) {
-      if (name.equals(AaaAuthenticationLogin.DEFAULT_LIST_NAME)) {
+      if (name.equals(CiscoAaaAuthenticationLogin.DEFAULT_LIST_NAME)) {
         // only apply default list if no other list applied
         if (line.getAaaAuthenticationLoginList() == null) {
           line.setAaaAuthenticationLoginList(_currentAaaAuthenticationLoginList);
@@ -3334,11 +3286,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterS_aaa(S_aaaContext ctx) {
     _no = ctx.NO() != null;
-    // VI extraction
-    if (_configuration.getCf().getAaa() == null) {
-      _configuration.getCf().setAaa(new Aaa());
-    }
-    // VS extraction
     if (_configuration.getAaa() == null) {
       _configuration.setAaa(new CiscoAaa());
     }
@@ -3487,11 +3434,11 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     // get the default list or null if Aaa, AaaAuthentication, or AaaAuthenticationLogin is null or
     // default list is undefined
     AaaAuthenticationLoginList defaultList =
-        Optional.ofNullable(_configuration.getCf().getAaa())
-            .map(Aaa::getAuthentication)
-            .map(AaaAuthentication::getLogin)
-            .map(AaaAuthenticationLogin::getLists)
-            .map(lists -> lists.get(AaaAuthenticationLogin.DEFAULT_LIST_NAME))
+        Optional.ofNullable(_configuration.getAaa())
+            .map(CiscoAaa::getAuthentication)
+            .map(CiscoAaaAuthentication::getLogin)
+            .map(CiscoAaaAuthenticationLogin::getLists)
+            .map(lists -> lists.get(CiscoAaaAuthenticationLogin.DEFAULT_LIST_NAME))
             .orElse(null);
 
     for (String name : names) {
@@ -3500,15 +3447,15 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         if (defaultList != null) {
           // if default list defined, apply it to all lines
           line.setAaaAuthenticationLoginList(defaultList);
-          line.setLoginAuthentication(AaaAuthenticationLogin.DEFAULT_LIST_NAME);
-        } else if (_configuration.getCf().getAaa() != null
-            && _configuration.getCf().getAaa().getNewModel()
+          line.setLoginAuthentication(CiscoAaaAuthenticationLogin.DEFAULT_LIST_NAME);
+        } else if (_configuration.getAaa() != null
+            && _configuration.getAaa().getNewModel()
             && line.getLineType() != LineType.CON) {
           // if default list not defined but aaa new-model, apply to all lines except con0
           line.setAaaAuthenticationLoginList(
               new AaaAuthenticationLoginList(
                   Collections.singletonList(AuthenticationMethod.LOCAL)));
-          line.setLoginAuthentication(AaaAuthenticationLogin.DEFAULT_LIST_NAME);
+          line.setLoginAuthentication(CiscoAaaAuthenticationLogin.DEFAULT_LIST_NAME);
         }
         _configuration.getCf().getLines().put(name, line);
       }
@@ -3900,9 +3847,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     } else {
       username = unquote(ctx.quoted_user.getText());
     }
-    // VI extraction
-    _currentUser = _configuration.getCf().getUsers().computeIfAbsent(username, User::new);
-    // VS extraction
     _currentCiscoUser = _configuration.getUsers().computeIfAbsent(username, CiscoUser::new);
   }
 
@@ -4048,9 +3992,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   public void exitAaa_accounting_default_group(Aaa_accounting_default_groupContext ctx) {
     List<String> groups =
         ctx.groups.stream().map(CiscoControlPlaneExtractor::toString).collect(Collectors.toList());
-    // VI extraction
-    _configuration.getCf().getAaa().getAccounting().getDefault().setGroups(groups);
-    // VS extraction
     _configuration.getAaa().getAccounting().getDefault().setGroups(groups);
     for (String group : groups) {
       _configuration.referenceStructure(
@@ -4060,9 +4001,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitAaa_accounting_default_local(Aaa_accounting_default_localContext ctx) {
-    // VI extraction
-    _configuration.getCf().getAaa().getAccounting().getDefault().setLocal(true);
-    // VS extraction
     _configuration.getAaa().getAccounting().getDefault().setLocal(true);
   }
 
@@ -4117,9 +4055,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitAaa_authentication_login_privilege_mode(
       Aaa_authentication_login_privilege_modeContext ctx) {
-    // VI extraction
-    _configuration.getCf().getAaa().getAuthentication().getLogin().setPrivilegeMode(true);
-    // VS extraction
     _configuration.getAaa().getAuthentication().getLogin().setPrivilegeMode(true);
   }
 
@@ -4139,9 +4074,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitAaa_new_model(Aaa_new_modelContext ctx) {
-    // VI extraction
-    _configuration.getCf().getAaa().setNewModel(!_no);
-    // VS extraction
     _configuration.getAaa().setNewModel(!_no);
   }
 
@@ -4960,9 +4892,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       password = ctx.pass.getText() + CommonUtil.salt();
     }
     String passwordRehash = CommonUtil.sha256Digest(password);
-    // VI extraction
-    _configuration.getCf().setEnableSecret(passwordRehash);
-    // VS extraction
     _configuration.setEnableSecret(passwordRehash);
   }
 
@@ -6841,10 +6770,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     // get the authentication list or null if Aaa, AaaAuthentication, or AaaAuthenticationLogin is
     // null or the list is not defined
     AaaAuthenticationLoginList authList =
-        Optional.ofNullable(_configuration.getCf().getAaa())
-            .map(Aaa::getAuthentication)
-            .map(AaaAuthentication::getLogin)
-            .map(AaaAuthenticationLogin::getLists)
+        Optional.ofNullable(_configuration.getAaa())
+            .map(CiscoAaa::getAuthentication)
+            .map(CiscoAaaAuthentication::getLogin)
+            .map(CiscoAaaAuthenticationLogin::getLists)
             .map(lists -> lists.get(list))
             .orElse(null);
 
@@ -9206,7 +9135,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitS_username(S_usernameContext ctx) {
-    _currentUser = null;
     _currentCiscoUser = null;
   }
 
@@ -9891,18 +9819,12 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       throw new BatfishException("Missing username password handling");
     }
     String passwordRehash = CommonUtil.sha256Digest(passwordString + CommonUtil.salt());
-    // VI extraction
-    _currentUser.setPassword(passwordRehash);
-    // VS extraction
     _currentCiscoUser.setPassword(passwordRehash);
   }
 
   @Override
   public void exitU_role(U_roleContext ctx) {
     String role = ctx.role.getText();
-    // VI extraction
-    _currentUser.setRole(role);
-    // VS extraction
     _currentCiscoUser.setRole(role);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -1099,6 +1099,12 @@ import org.batfish.representation.cisco.BgpNetwork6;
 import org.batfish.representation.cisco.BgpPeerGroup;
 import org.batfish.representation.cisco.BgpProcess;
 import org.batfish.representation.cisco.BgpRedistributionPolicy;
+import org.batfish.representation.cisco.CiscoAaa;
+import org.batfish.representation.cisco.CiscoAaaAccounting;
+import org.batfish.representation.cisco.CiscoAaaAccountingCommands;
+import org.batfish.representation.cisco.CiscoAaaAccountingDefault;
+import org.batfish.representation.cisco.CiscoAaaAuthentication;
+import org.batfish.representation.cisco.CiscoAaaAuthenticationLogin;
 import org.batfish.representation.cisco.CiscoConfiguration;
 import org.batfish.representation.cisco.CiscoIosDynamicNat;
 import org.batfish.representation.cisco.CiscoIosNat;
@@ -1107,6 +1113,7 @@ import org.batfish.representation.cisco.CiscoIosNat.RuleAction;
 import org.batfish.representation.cisco.CiscoIosStaticNat;
 import org.batfish.representation.cisco.CiscoStructureType;
 import org.batfish.representation.cisco.CiscoStructureUsage;
+import org.batfish.representation.cisco.CiscoUser;
 import org.batfish.representation.cisco.CryptoMapEntry;
 import org.batfish.representation.cisco.CryptoMapSet;
 import org.batfish.representation.cisco.DeviceTrackingPolicy;
@@ -1531,6 +1538,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   private User _currentUser;
 
+  private CiscoUser _currentCiscoUser;
+
   private String _currentVrf;
 
   private @Nullable VrfAddressFamily _currentVrfAddressFamily;
@@ -1665,8 +1674,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void enterAaa_accounting(Aaa_accountingContext ctx) {
+    // VI extraction
     if (_configuration.getCf().getAaa().getAccounting() == null) {
       _configuration.getCf().getAaa().setAccounting(new AaaAccounting());
+    }
+    // VS extraction
+    if (_configuration.getAaa().getAccounting() == null) {
+      _configuration.getAaa().setAccounting(new CiscoAaaAccounting());
     }
   }
 
@@ -1687,31 +1701,54 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       levels.add(AaaAccounting.DEFAULT_COMMANDS);
     }
     List<AaaAccountingCommands> currentAaaAccountingCommands = new ArrayList<>();
+    // VI extraction
     for (String level : levels) {
       AaaAccountingCommands c = commands.computeIfAbsent(level, k -> new AaaAccountingCommands());
       currentAaaAccountingCommands.add(c);
+    }
+    // VS extraction
+    SortedMap<String, CiscoAaaAccountingCommands> vsCommands =
+        _configuration.getAaa().getAccounting().getCommands();
+    for (String level : levels) {
+      vsCommands.computeIfAbsent(level, k -> new CiscoAaaAccountingCommands());
     }
   }
 
   @Override
   public void enterAaa_accounting_default(Aaa_accounting_defaultContext ctx) {
+    // VI extraction
     AaaAccounting accounting = _configuration.getCf().getAaa().getAccounting();
     if (accounting.getDefault() == null) {
       accounting.setDefault(new AaaAccountingDefault());
+    }
+    // VS extraction
+    CiscoAaaAccounting vsAccounting = _configuration.getAaa().getAccounting();
+    if (vsAccounting.getDefault() == null) {
+      vsAccounting.setDefault(new CiscoAaaAccountingDefault());
     }
   }
 
   @Override
   public void enterAaa_authentication(Aaa_authenticationContext ctx) {
+    // VI extraction
     if (_configuration.getCf().getAaa().getAuthentication() == null) {
       _configuration.getCf().getAaa().setAuthentication(new AaaAuthentication());
+    }
+    // VS extraction
+    if (_configuration.getAaa().getAuthentication() == null) {
+      _configuration.getAaa().setAuthentication(new CiscoAaaAuthentication());
     }
   }
 
   @Override
   public void enterAaa_authentication_login(Aaa_authentication_loginContext ctx) {
+    // VI extraction
     if (_configuration.getCf().getAaa().getAuthentication().getLogin() == null) {
       _configuration.getCf().getAaa().getAuthentication().setLogin(new AaaAuthenticationLogin());
+    }
+    // VS extraction
+    if (_configuration.getAaa().getAuthentication().getLogin() == null) {
+      _configuration.getAaa().getAuthentication().setLogin(new CiscoAaaAuthenticationLogin());
     }
   }
 
@@ -1733,8 +1770,17 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       methods.add(AuthenticationMethod.toAuthenticationMethod(method.getText()));
     }
 
+    // VI extraction
     _currentAaaAuthenticationLoginList =
         login.getLists().computeIfAbsent(name, k -> new AaaAuthenticationLoginList(methods));
+
+    // VS extraction (reuse the same list instance as the VI model)
+    _configuration
+        .getAaa()
+        .getAuthentication()
+        .getLogin()
+        .getLists()
+        .putIfAbsent(name, _currentAaaAuthenticationLoginList);
 
     // apply the list to each line
     SortedMap<String, Line> lines = _configuration.getCf().getLines();
@@ -3288,8 +3334,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterS_aaa(S_aaaContext ctx) {
     _no = ctx.NO() != null;
+    // VI extraction
     if (_configuration.getCf().getAaa() == null) {
       _configuration.getCf().setAaa(new Aaa());
+    }
+    // VS extraction
+    if (_configuration.getAaa() == null) {
+      _configuration.setAaa(new CiscoAaa());
     }
   }
 
@@ -3849,7 +3900,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     } else {
       username = unquote(ctx.quoted_user.getText());
     }
+    // VI extraction
     _currentUser = _configuration.getCf().getUsers().computeIfAbsent(username, User::new);
+    // VS extraction
+    _currentCiscoUser = _configuration.getUsers().computeIfAbsent(username, CiscoUser::new);
   }
 
   @Override
@@ -3994,7 +4048,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   public void exitAaa_accounting_default_group(Aaa_accounting_default_groupContext ctx) {
     List<String> groups =
         ctx.groups.stream().map(CiscoControlPlaneExtractor::toString).collect(Collectors.toList());
+    // VI extraction
     _configuration.getCf().getAaa().getAccounting().getDefault().setGroups(groups);
+    // VS extraction
+    _configuration.getAaa().getAccounting().getDefault().setGroups(groups);
     for (String group : groups) {
       _configuration.referenceStructure(
           AAA_SERVER_GROUP, group, AAA_ACCOUNTING_CONNECTION_DEFAULT, ctx.getStart().getLine());
@@ -4003,7 +4060,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitAaa_accounting_default_local(Aaa_accounting_default_localContext ctx) {
+    // VI extraction
     _configuration.getCf().getAaa().getAccounting().getDefault().setLocal(true);
+    // VS extraction
+    _configuration.getAaa().getAccounting().getDefault().setLocal(true);
   }
 
   @Override
@@ -4057,7 +4117,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitAaa_authentication_login_privilege_mode(
       Aaa_authentication_login_privilege_modeContext ctx) {
+    // VI extraction
     _configuration.getCf().getAaa().getAuthentication().getLogin().setPrivilegeMode(true);
+    // VS extraction
+    _configuration.getAaa().getAuthentication().getLogin().setPrivilegeMode(true);
   }
 
   private static String toString(Aaa_authorization_method_group_nameContext ctx) {
@@ -4076,7 +4139,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitAaa_new_model(Aaa_new_modelContext ctx) {
+    // VI extraction
     _configuration.getCf().getAaa().setNewModel(!_no);
+    // VS extraction
+    _configuration.getAaa().setNewModel(!_no);
   }
 
   @Override
@@ -4894,7 +4960,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       password = ctx.pass.getText() + CommonUtil.salt();
     }
     String passwordRehash = CommonUtil.sha256Digest(password);
+    // VI extraction
     _configuration.getCf().setEnableSecret(passwordRehash);
+    // VS extraction
+    _configuration.setEnableSecret(passwordRehash);
   }
 
   @Override
@@ -9138,6 +9207,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitS_username(S_usernameContext ctx) {
     _currentUser = null;
+    _currentCiscoUser = null;
   }
 
   @Override
@@ -9821,13 +9891,19 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       throw new BatfishException("Missing username password handling");
     }
     String passwordRehash = CommonUtil.sha256Digest(passwordString + CommonUtil.salt());
+    // VI extraction
     _currentUser.setPassword(passwordRehash);
+    // VS extraction
+    _currentCiscoUser.setPassword(passwordRehash);
   }
 
   @Override
   public void exitU_role(U_roleContext ctx) {
     String role = ctx.role.getText();
+    // VI extraction
     _currentUser.setRole(role);
+    // VS extraction
+    _currentCiscoUser.setRole(role);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaa.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaa.java
@@ -1,0 +1,39 @@
+package org.batfish.representation.cisco;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Vendor-specific model of Cisco IOS {@code aaa} configuration */
+@ParametersAreNonnullByDefault
+public final class CiscoAaa implements Serializable {
+
+  private boolean _newModel;
+  private @Nullable CiscoAaaAuthentication _authentication;
+  private @Nullable CiscoAaaAccounting _accounting;
+
+  /** Whether {@code aaa new-model} is configured. */
+  public boolean getNewModel() {
+    return _newModel;
+  }
+
+  public void setNewModel(boolean newModel) {
+    _newModel = newModel;
+  }
+
+  public @Nullable CiscoAaaAuthentication getAuthentication() {
+    return _authentication;
+  }
+
+  public void setAuthentication(@Nullable CiscoAaaAuthentication authentication) {
+    _authentication = authentication;
+  }
+
+  public @Nullable CiscoAaaAccounting getAccounting() {
+    return _accounting;
+  }
+
+  public void setAccounting(@Nullable CiscoAaaAccounting accounting) {
+    _accounting = accounting;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAccounting.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAccounting.java
@@ -1,0 +1,38 @@
+package org.batfish.representation.cisco;
+
+import java.io.Serializable;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Vendor-specific model of Cisco IOS {@code aaa accounting} configuration */
+@ParametersAreNonnullByDefault
+public final class CiscoAaaAccounting implements Serializable {
+
+  public static final String DEFAULT_COMMANDS = "default";
+
+  private @Nonnull SortedMap<String, CiscoAaaAccountingCommands> _commands;
+  private @Nullable CiscoAaaAccountingDefault _default;
+
+  public CiscoAaaAccounting() {
+    _commands = new TreeMap<>();
+  }
+
+  public @Nonnull SortedMap<String, CiscoAaaAccountingCommands> getCommands() {
+    return _commands;
+  }
+
+  public void setCommands(SortedMap<String, CiscoAaaAccountingCommands> commands) {
+    _commands = commands;
+  }
+
+  public @Nullable CiscoAaaAccountingDefault getDefault() {
+    return _default;
+  }
+
+  public void setDefault(@Nullable CiscoAaaAccountingDefault accountingDefault) {
+    _default = accountingDefault;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAccountingCommands.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAccountingCommands.java
@@ -1,0 +1,6 @@
+package org.batfish.representation.cisco;
+
+import java.io.Serializable;
+
+/** Vendor-specific model of a Cisco IOS {@code aaa accounting commands <level>} entry */
+public final class CiscoAaaAccountingCommands implements Serializable {}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAccountingDefault.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAccountingDefault.java
@@ -1,0 +1,32 @@
+package org.batfish.representation.cisco;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Vendor-specific model of Cisco IOS {@code aaa accounting ... default} configuration */
+@ParametersAreNonnullByDefault
+public final class CiscoAaaAccountingDefault implements Serializable {
+
+  private @Nullable List<String> _groups;
+  private @Nullable Boolean _local;
+
+  /** The ordered list of AAA server groups this default accounting method targets */
+  public @Nullable List<String> getGroups() {
+    return _groups;
+  }
+
+  public void setGroups(@Nullable List<String> groups) {
+    _groups = groups;
+  }
+
+  /** Whether {@code local} accounting is configured for the default method */
+  public @Nullable Boolean getLocal() {
+    return _local;
+  }
+
+  public void setLocal(@Nullable Boolean local) {
+    _local = local;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAuthentication.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAuthentication.java
@@ -1,0 +1,20 @@
+package org.batfish.representation.cisco;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Vendor-specific model of Cisco IOS {@code aaa authentication} configuration */
+@ParametersAreNonnullByDefault
+public final class CiscoAaaAuthentication implements Serializable {
+
+  private @Nullable CiscoAaaAuthenticationLogin _login;
+
+  public @Nullable CiscoAaaAuthenticationLogin getLogin() {
+    return _login;
+  }
+
+  public void setLogin(@Nullable CiscoAaaAuthenticationLogin login) {
+    _login = login;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAuthenticationLogin.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoAaaAuthenticationLogin.java
@@ -1,0 +1,44 @@
+package org.batfish.representation.cisco;
+
+import java.io.Serializable;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.AaaAuthenticationLoginList;
+
+/**
+ * Vendor-specific model of Cisco IOS {@code aaa authentication login} configuration.
+ *
+ * <p>Holds the named authentication method lists (the {@code default} list plus any custom lists)
+ * and whether {@code aaa authentication login privilege-mode} is enabled. The method-list values
+ * reuse the shared {@link AaaAuthenticationLoginList} datamodel type.
+ */
+@ParametersAreNonnullByDefault
+public final class CiscoAaaAuthenticationLogin implements Serializable {
+
+  public static final String DEFAULT_LIST_NAME = "default";
+
+  private @Nonnull SortedMap<String, AaaAuthenticationLoginList> _lists;
+  private boolean _privilegeMode;
+
+  public CiscoAaaAuthenticationLogin() {
+    _lists = new TreeMap<>();
+  }
+
+  public @Nonnull SortedMap<String, AaaAuthenticationLoginList> getLists() {
+    return _lists;
+  }
+
+  public void setLists(SortedMap<String, AaaAuthenticationLoginList> lists) {
+    _lists = lists;
+  }
+
+  public boolean getPrivilegeMode() {
+    return _privilegeMode;
+  }
+
+  public void setPrivilegeMode(boolean privilegeMode) {
+    _privilegeMode = privilegeMode;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -399,6 +399,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   private final Map<String, AaaServerGroup> _aaaServerGroups;
 
+  private @Nullable CiscoAaa _aaa;
+
+  private final Map<String, CiscoUser> _users;
+
+  private @Nullable String _enableSecret;
+
   private final Map<String, IpAsPathAccessList> _asPathAccessLists;
 
   private final CiscoFamily _cf;
@@ -570,6 +576,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     _standardIpv6AccessLists = new TreeMap<>();
     _standardCommunityLists = new TreeMap<>();
     _aaaServerGroups = new TreeMap<>();
+    _users = new TreeMap<>();
     _tacacsServers = new TreeSet<>();
     _tracks = new TreeMap<>();
     _vrfs = new TreeMap<>();
@@ -872,6 +879,26 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   public @Nonnull Map<String, AaaServerGroup> getAaaServerGroups() {
     return _aaaServerGroups;
+  }
+
+  public @Nullable CiscoAaa getAaa() {
+    return _aaa;
+  }
+
+  public void setAaa(@Nullable CiscoAaa aaa) {
+    _aaa = aaa;
+  }
+
+  public @Nonnull Map<String, CiscoUser> getUsers() {
+    return _users;
+  }
+
+  public @Nullable String getEnableSecret() {
+    return _enableSecret;
+  }
+
+  public void setEnableSecret(@Nullable String enableSecret) {
+    _enableSecret = enableSecret;
   }
 
   public NavigableSet<String> getTacacsServers() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -197,9 +197,13 @@ import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.routing_policy.statement.TraceableStatement;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.vendor_family.cisco.Aaa;
+import org.batfish.datamodel.vendor_family.cisco.AaaAccounting;
+import org.batfish.datamodel.vendor_family.cisco.AaaAccountingCommands;
+import org.batfish.datamodel.vendor_family.cisco.AaaAccountingDefault;
 import org.batfish.datamodel.vendor_family.cisco.AaaAuthentication;
 import org.batfish.datamodel.vendor_family.cisco.AaaAuthenticationLogin;
 import org.batfish.datamodel.vendor_family.cisco.CiscoFamily;
+import org.batfish.datamodel.vendor_family.cisco.User;
 import org.batfish.representation.cisco.Tunnel.TunnelMode;
 import org.batfish.vendor.VendorConfiguration;
 import org.batfish.vendor.VendorStructureId;
@@ -2554,6 +2558,58 @@ public final class CiscoConfiguration extends VendorConfiguration {
         .build();
   }
 
+  /**
+   * Populates the {@code vendor_family/cisco} AAA model ({@link CiscoFamily}) from the
+   * vendor-specific model for backwards compatibility.
+   */
+  private void convertAaaToVendorFamily() {
+    _cf.setEnableSecret(_enableSecret);
+
+    for (CiscoUser vsUser : _users.values()) {
+      User viUser = new User(vsUser.getName());
+      viUser.setPassword(vsUser.getPassword());
+      viUser.setRole(vsUser.getRole());
+      _cf.getUsers().put(vsUser.getName(), viUser);
+    }
+
+    if (_aaa == null) {
+      return;
+    }
+    Aaa viAaa = new Aaa();
+    viAaa.setNewModel(_aaa.getNewModel());
+
+    CiscoAaaAuthentication vsAuthentication = _aaa.getAuthentication();
+    if (vsAuthentication != null) {
+      AaaAuthentication viAuthentication = new AaaAuthentication();
+      CiscoAaaAuthenticationLogin vsLogin = vsAuthentication.getLogin();
+      if (vsLogin != null) {
+        AaaAuthenticationLogin viLogin = new AaaAuthenticationLogin();
+        viLogin.setPrivilegeMode(vsLogin.getPrivilegeMode());
+        viLogin.getLists().putAll(vsLogin.getLists());
+        viAuthentication.setLogin(viLogin);
+      }
+      viAaa.setAuthentication(viAuthentication);
+    }
+
+    CiscoAaaAccounting vsAccounting = _aaa.getAccounting();
+    if (vsAccounting != null) {
+      AaaAccounting viAccounting = new AaaAccounting();
+      for (String level : vsAccounting.getCommands().keySet()) {
+        viAccounting.getCommands().put(level, new AaaAccountingCommands());
+      }
+      CiscoAaaAccountingDefault vsDefault = vsAccounting.getDefault();
+      if (vsDefault != null) {
+        AaaAccountingDefault viDefault = new AaaAccountingDefault();
+        viDefault.setGroups(vsDefault.getGroups());
+        viDefault.setLocal(vsDefault.getLocal());
+        viAccounting.setDefault(viDefault);
+      }
+      viAaa.setAccounting(viAccounting);
+    }
+
+    _cf.setAaa(viAaa);
+  }
+
   @Override
   public List<Configuration> toVendorIndependentConfigurations() {
     Configuration c = new Configuration(_hostname, _vendor);
@@ -2562,6 +2618,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     if (_vendor == ConfigurationFormat.CISCO_IOS) {
       c.setDeviceModel(DeviceModel.CISCO_UNSPECIFIED);
     }
+    convertAaaToVendorFamily();
     c.getVendorFamily().setCisco(_cf);
     c.setDefaultInboundAction(LineAction.PERMIT);
     c.setDefaultCrossZoneAction(LineAction.PERMIT);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoUser.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoUser.java
@@ -1,0 +1,39 @@
+package org.batfish.representation.cisco;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Vendor-specific model of a Cisco IOS locally-configured {@code username} */
+@ParametersAreNonnullByDefault
+public final class CiscoUser implements Serializable {
+
+  private final @Nonnull String _name;
+  private @Nullable String _password;
+  private @Nullable String _role;
+
+  public CiscoUser(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nullable String getPassword() {
+    return _password;
+  }
+
+  public void setPassword(@Nullable String password) {
+    _password = password;
+  }
+
+  public @Nullable String getRole() {
+    return _role;
+  }
+
+  public void setRole(@Nullable String role) {
+    _role = role;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -568,7 +568,7 @@ public final class CiscoGrammarTest {
         allOf(hasKey("default"), hasKey("MYLIST")));
     assertTrue(viCisco.getAaa().getAuthentication().getLogin().getPrivilegeMode());
     assertThat(
-        viCisco.getAaa().getAuthentication().getLogin().getLists().get("defalut").getMethods,
+        viCisco.getAaa().getAuthentication().getLogin().getLists().get("default").getMethods(),
         contains(GROUP_USER_DEFINED, LOCAL));
     assertThat(
         viCisco.getAaa().getAccounting().getDefault().getGroups(),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -541,14 +541,7 @@ public final class CiscoGrammarTest {
     assertTrue(vc.getAaa().getAuthentication().getLogin().getPrivilegeMode());
     assertThat(
         vc.getAaa().getAuthentication().getLogin().getLists().get("default").getMethods(),
-        equalTo(
-            vc.getCf()
-                .getAaa()
-                .getAuthentication()
-                .getLogin()
-                .getLists()
-                .get("default")
-                .getMethods()));
+        contains(GROUP_USER_DEFINED, LOCAL));
 
     assertThat(vc.getAaa().getAccounting(), notNullValue());
     assertThat(vc.getAaa().getAccounting().getDefault(), notNullValue());
@@ -558,15 +551,33 @@ public final class CiscoGrammarTest {
     assertThat(vc.getAaa().getAccounting().getCommands(), hasKey("15"));
 
     assertThat(vc.getEnableSecret(), notNullValue());
-    assertThat(vc.getEnableSecret(), equalTo(vc.getCf().getEnableSecret()));
 
     assertThat(vc.getUsers(), allOf(hasKey("admin"), hasKey("operator")));
     assertThat(vc.getUsers().get("admin").getPassword(), notNullValue());
     assertThat(vc.getUsers().get("admin").getRole(), nullValue());
     assertThat(vc.getUsers().get("operator").getRole(), equalTo("network-operator"));
+
+    // After conversion, the vendor_family model is reconstructed from the vendor-specific model.
+    org.batfish.datamodel.vendor_family.cisco.CiscoFamily viCisco =
+        parseConfig("iosAaaVsModel").getVendorFamily().getCisco();
+    assertTrue(viCisco.getAaa().getNewModel());
+    assertThat(viCisco.getAaa().getAuthentication(), notNullValue());
+    assertThat(viCisco.getAaa().getAuthentication().getLogin(), notNullValue());
     assertThat(
-        vc.getUsers().get("admin").getPassword(),
-        equalTo(vc.getCf().getUsers().get("admin").getPassword()));
+        viCisco.getAaa().getAuthentication().getLogin().getLists(),
+        allOf(hasKey("default"), hasKey("MYLIST")));
+    assertTrue(viCisco.getAaa().getAuthentication().getLogin().getPrivilegeMode());
+    assertThat(
+        viCisco.getAaa().getAuthentication().getLogin().getLists().get("defalut").getMethods,
+        contains(GROUP_USER_DEFINED, LOCAL));
+    assertThat(
+        viCisco.getAaa().getAccounting().getDefault().getGroups(),
+        contains("myGroup1", "myGroup2"));
+    assertThat(viCisco.getAaa().getAccounting().getDefault().getLocal(), equalTo(true));
+    assertThat(viCisco.getAaa().getAccounting().getCommands(), hasKey("15"));
+    assertThat(viCisco.getUsers(), allOf(hasKey("admin"), hasKey("operator")));
+    assertThat(viCisco.getUsers().get("operator").getRole(), equalTo("network-operator"));
+    assertThat(viCisco.getEnableSecret(), notNullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -527,6 +527,49 @@ public final class CiscoGrammarTest {
   }
 
   @Test
+  public void testAaaVendorSpecificModel() throws IOException {
+    CiscoConfiguration vc = parseCiscoConfig("iosAaaVsModel", ConfigurationFormat.CISCO_IOS);
+
+    assertThat(vc.getAaa(), notNullValue());
+    assertTrue(vc.getAaa().getNewModel());
+
+    assertThat(vc.getAaa().getAuthentication(), notNullValue());
+    assertThat(vc.getAaa().getAuthentication().getLogin(), notNullValue());
+    assertThat(
+        vc.getAaa().getAuthentication().getLogin().getLists(),
+        allOf(hasKey("default"), hasKey("MYLIST")));
+    assertTrue(vc.getAaa().getAuthentication().getLogin().getPrivilegeMode());
+    assertThat(
+        vc.getAaa().getAuthentication().getLogin().getLists().get("default").getMethods(),
+        equalTo(
+            vc.getCf()
+                .getAaa()
+                .getAuthentication()
+                .getLogin()
+                .getLists()
+                .get("default")
+                .getMethods()));
+
+    assertThat(vc.getAaa().getAccounting(), notNullValue());
+    assertThat(vc.getAaa().getAccounting().getDefault(), notNullValue());
+    assertThat(
+        vc.getAaa().getAccounting().getDefault().getGroups(), contains("myGroup1", "myGroup2"));
+    assertThat(vc.getAaa().getAccounting().getDefault().getLocal(), equalTo(true));
+    assertThat(vc.getAaa().getAccounting().getCommands(), hasKey("15"));
+
+    assertThat(vc.getEnableSecret(), notNullValue());
+    assertThat(vc.getEnableSecret(), equalTo(vc.getCf().getEnableSecret()));
+
+    assertThat(vc.getUsers(), allOf(hasKey("admin"), hasKey("operator")));
+    assertThat(vc.getUsers().get("admin").getPassword(), notNullValue());
+    assertThat(vc.getUsers().get("admin").getRole(), nullValue());
+    assertThat(vc.getUsers().get("operator").getRole(), equalTo("network-operator"));
+    assertThat(
+        vc.getUsers().get("admin").getPassword(),
+        equalTo(vc.getCf().getUsers().get("admin").getPassword()));
+  }
+
+  @Test
   public void testEncoding() throws IOException {
     // Don't crash with lexer error
     parseConfig("encoding_test");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosAaaVsModel
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosAaaVsModel
@@ -1,0 +1,18 @@
+!
+hostname iosAaaVsModel
+!
+aaa new-model
+!
+aaa authentication login default group myGroup local
+aaa authentication login MYLIST group myGroup enable
+aaa authentication login privilege-mode
+!
+aaa accounting commands 15 default start-stop group myGroup
+aaa accounting default group myGroup1 myGroup2
+aaa accounting default local
+!
+enable secret 5 $1$enab$leSecretHashValue0
+!
+username admin privilege 15 secret 5 $1$admn$adminSecretHashValue
+username operator role network-operator nopassword
+!


### PR DESCRIPTION
## Summary
  
  Port Cisco IOS `aaa` representation from the shared `vendor_family/cisco` (VI) model to a new vendor-specific (`representation/cisco`) model. This is a straightforward 1:1 remapping with no behavior change  and serves as a 
  stepping stone that establishes the VS home for AAA data before any follow-up work is done to improve AAA support.
  
 The extractor dual-writes to both the vendor_family and the new VS models in parallel for backwards compatibility.
  
  ## Changes
  
  - **VS:** Add vendor-specific model classes in `representation/cisco`: `CiscoAaa` (`newModel`, authentication, accounting), `CiscoAaaAuthentication`, `CiscoAaaAuthenticationLogin` (named method lists +
  `privilegeMode`), `CiscoAaaAccounting`, `CiscoAaaAccountingCommands`, `CiscoAaaAccountingDefault` (groups/local), and `CiscoUser` (password/role). The authentication login lists reuse the shared
  `AaaAuthenticationLoginList` datamodel type.
  
  - **VS:** Add AAA state to `CiscoConfiguration`: `CiscoAaa` (`getAaa`/`setAaa`), a `CiscoUser` map (`getUsers`), and `enableSecret` (`getEnableSecret`/`setEnableSecret`).
  
  - **Extraction:** In `CiscoControlPlaneExtractor`, mirror the AAA `enter*`/`exit*` handlers so each populates the VS model alongside the VI model, marked with `// VI extraction` / `// VS extraction` comments.
  Covers `aaa new-model`, `aaa authentication login` (order lists + privilege-mode), `aaa accounting` (default destinations + command levels), `username` (password/role), and `enable secret`. Authentication login lists reuse the same `AaaAuthenticationLoginList` instance the VI model computes.
  
  - **Scope note:** Line-level login-list linkage (`aaa authentication login` applied to `line` blocks) is intentionally not ported and remains on the VI `Line` model; that is out of scope for this remapping.
  
  ## Testing
  
  - Add an `iosAaaVsModel` testconfig covering `aaa new-model`, default + custom authentication login lists, `privilege-mode`, accounting default group/local + command levels, usernames with password/role, and `enable secret`.
  
  - Add `testAaaVendorSpecificModel` to `CiscoGrammarTest`, asserting the VS model is populated and in parity with the VI model (including that authentication login lists are the same instances and the enable-secret/username password rehashes match).
  
  - All tests pass and no reference tests are affected.
