### PR TITLE
feat(fastpath): add local users, usergroups, and taskgroups

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
@@ -8,6 +8,7 @@ tokens {
   DEFAULT,
   QUOTED_TEXT,
   REMAINDER,
+  SECRET,
   WORD
 }
 
@@ -20,6 +21,8 @@ ALERT: 'alert';
 AUTHENTICATION: 'authentication';
 
 AUTHORIZATION: 'authorization';
+
+BGP: 'bgp';
 
 BROADCAST: 'broadcast';
 
@@ -92,6 +95,8 @@ EXEC
   }
 ;
 
+EXECUTE: 'execute';
+
 EXIT: 'exit';
 
 HOST
@@ -129,6 +134,8 @@ KEY
 ;
 
 KEYSTRING: 'keystring';
+
+LEVEL: 'level';
 
 LINE: 'line';
 
@@ -170,11 +177,24 @@ NO: 'no';
 
 NONE: 'none';
 
+NOPASSWORD: 'nopassword';
+
 NOTICE: 'notice';
+
+OSPF: 'ospf';
+
+OVERRIDE_COMPLEXITY_CHECK: 'override-complexity-check';
 
 PASSWORD
 :
-  'password' -> pushMode ( M_Remainder )
+  'password'
+  {
+    if (lastTokenType() == NEWLINE) {
+      pushMode(M_Remainder);
+    } else {
+      pushMode(M_Secret);
+    }
+  }
 ;
 
 PERSISTENT: 'persistent';
@@ -193,6 +213,8 @@ PROMPT
 ;
 
 RADIUS: 'radius';
+
+READ: 'read';
 
 RECONFIGURE: 'reconfigure';
 
@@ -240,6 +262,10 @@ TACACS: 'tacacs';
 
 TACACS_SERVER: 'tacacs-server';
 
+TASK: 'task';
+
+TASKGROUP: 'taskgroup';
+
 TIMEOUT: 'timeout';
 
 TRAPS: 'traps';
@@ -247,6 +273,13 @@ TRAPS: 'traps';
 TUNNEL: 'tunnel';
 
 UNICAST: 'unicast';
+
+UNLOCK: 'unlock';
+
+USERGROUP
+:
+  'usergroup' -> pushMode ( M_Word )
+;
 
 USERNAME
 :
@@ -258,6 +291,8 @@ VLAN: 'vlan';
 WARNING: 'warning';
 
 WRAP: 'wrap';
+
+WRITE: 'write';
 
 // Other Tokens
 
@@ -397,6 +432,12 @@ fragment
 F_NonNewlineChar
 :
   ~[\r\n]
+;
+
+fragment
+F_NonWhitespaceChar
+:
+  ~[ \t\u000C\r\n]
 ;
 
 fragment
@@ -573,6 +614,23 @@ M_Key_WS
 ;
 
 M_Key_NEWLINE
+:
+  F_Newline -> type ( NEWLINE ) , popMode
+;
+
+mode M_Secret;
+
+M_Secret_SECRET
+:
+  F_NonWhitespaceChar+ -> type ( SECRET ) , popMode
+;
+
+M_Secret_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN )
+;
+
+M_Secret_NEWLINE
 :
   F_Newline -> type ( NEWLINE ) , popMode
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
@@ -264,7 +264,10 @@ TACACS_SERVER: 'tacacs-server';
 
 TASK: 'task';
 
-TASKGROUP: 'taskgroup';
+TASKGROUP
+:
+  'taskgroup' -> pushMode ( M_Word )
+;
 
 TIMEOUT: 'timeout';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
@@ -23,6 +23,9 @@ statement
   | s_set
   | s_sntp
   | s_tacacs_server
+  | s_taskgroup
+  | s_usergroup
+  | s_username
 ;
 
 s_hostname
@@ -311,6 +314,7 @@ s_no
   (
     no_ip
     | no_logging
+    | no_username_null
   )
 ;
 
@@ -608,3 +612,95 @@ aaa_session_id_null
 :
   SESSION_ID null_rest_of_line
 ;
+
+s_username
+:
+  USERNAME name = double_quoted_string
+  (
+    u_password
+    | u_nopassword_null
+    | u_usergroup
+    | u_unlock_null
+    | u_level_null
+  )
+;
+
+u_password
+:
+  PASSWORD SECRET
+  (
+    ENCRYPTED OVERRIDE_COMPLEXITY_CHECK?
+    | LEVEL level = uint16
+      (
+        ENCRYPTED OVERRIDE_COMPLEXITY_CHECK?
+      )?
+    | OVERRIDE_COMPLEXITY_CHECK
+  )? NEWLINE
+;
+
+// `username <name> level <n> [override-complexity-check] password` prompts for the password
+// interactively
+u_level_null
+:
+  LEVEL uint16 OVERRIDE_COMPLEXITY_CHECK? PASSWORD NEWLINE
+;
+
+u_nopassword_null
+:
+  NOPASSWORD null_rest_of_line
+;
+
+u_unlock_null
+:
+  UNLOCK null_rest_of_line
+;
+
+u_usergroup
+:
+  USERGROUP group = word NEWLINE
+;
+
+s_usergroup
+:
+  USERGROUP name = double_quoted_string NEWLINE
+  usergroup_taskgroup*
+  EXIT NEWLINE
+;
+
+usergroup_taskgroup
+:
+  TASKGROUP name = double_quoted_string NEWLINE
+;
+
+s_taskgroup
+:
+  TASKGROUP name = double_quoted_string NEWLINE
+  taskgroup_task*
+  EXIT NEWLINE
+;
+
+taskgroup_task
+:
+  TASK task_permission+ task_component NEWLINE
+;
+
+task_permission
+:
+  READ
+  | WRITE
+  | EXECUTE
+  | DEBUG
+;
+
+task_component
+:
+  AAA
+  | OSPF
+  | BGP
+;
+
+no_username_null
+:
+  USERNAME null_rest_of_line
+;
+

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
@@ -615,7 +615,7 @@ aaa_session_id_null
 
 s_username
 :
-  USERNAME name = double_quoted_string
+  USERNAME name = word
   (
     u_password
     | u_nopassword_null
@@ -662,19 +662,19 @@ u_usergroup
 
 s_usergroup
 :
-  USERGROUP name = double_quoted_string NEWLINE
+  USERGROUP name = word NEWLINE
   usergroup_taskgroup*
   EXIT NEWLINE
 ;
 
 usergroup_taskgroup
 :
-  TASKGROUP name = double_quoted_string NEWLINE
+  TASKGROUP name = word NEWLINE
 ;
 
 s_taskgroup
 :
-  TASKGROUP name = double_quoted_string NEWLINE
+  TASKGROUP name = word NEWLINE
   taskgroup_task*
   EXIT NEWLINE
 ;

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
@@ -433,7 +433,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
 
   @Override
   public void enterS_username(S_usernameContext ctx) {
-    String name = toString(ctx.name.text);
+    String name = toString(ctx.name);
     _currentUser = _c.getUsers().computeIfAbsent(name, UserAccount::new);
   }
 
@@ -459,7 +459,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
 
   @Override
   public void enterS_taskgroup(S_taskgroupContext ctx) {
-    _currentTaskgroup = _c.getTaskgroups().computeIfAbsent(toString(ctx.name.text), Taskgroup::new);
+    _currentTaskgroup = _c.getTaskgroups().computeIfAbsent(toString(ctx.name), Taskgroup::new);
   }
 
   @Override
@@ -501,7 +501,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
 
   @Override
   public void enterS_usergroup(S_usergroupContext ctx) {
-    _currentUsergroup = _c.getUsergroups().computeIfAbsent(toString(ctx.name.text), Usergroup::new);
+    _currentUsergroup = _c.getUsergroups().computeIfAbsent(toString(ctx.name), Usergroup::new);
   }
 
   @Override
@@ -511,7 +511,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
 
   @Override
   public void exitUsergroup_taskgroup(Usergroup_taskgroupContext ctx) {
-    _currentUsergroup.getTaskgroups().add(toString(ctx.name.text));
+    _currentUsergroup.getTaskgroups().add(toString(ctx.name));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
@@ -2,8 +2,10 @@ package org.batfish.vendor.fastpath.grammar;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -55,12 +57,18 @@ import org.batfish.vendor.fastpath.grammar.FastpathParser.Noipd_lookupContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Nol_consoleContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Quoted_textContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.S_hostnameContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.S_taskgroupContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.S_usergroupContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.S_usernameContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Set_promptContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Sntp_client_modeContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Sntp_source_interfaceContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Sntpc_modeContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Sntpc_portContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Ss_hostContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Task_componentContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Task_permissionContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Taskgroup_taskContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Ts_hostContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Ts_keyContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Ts_source_interfaceContext;
@@ -69,6 +77,9 @@ import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_keyContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_portContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_priorityContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Tsh_timeoutContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.U_passwordContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.U_usergroupContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Usergroup_taskgroupContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.WordContext;
 import org.batfish.vendor.fastpath.representation.AaaMethod;
 import org.batfish.vendor.fastpath.representation.Accounting;
@@ -80,6 +91,11 @@ import org.batfish.vendor.fastpath.representation.LoggingBuffered;
 import org.batfish.vendor.fastpath.representation.LoggingServer;
 import org.batfish.vendor.fastpath.representation.Sntp;
 import org.batfish.vendor.fastpath.representation.TacacsServer;
+import org.batfish.vendor.fastpath.representation.TaskComponent;
+import org.batfish.vendor.fastpath.representation.TaskPermission;
+import org.batfish.vendor.fastpath.representation.Taskgroup;
+import org.batfish.vendor.fastpath.representation.UserAccount;
+import org.batfish.vendor.fastpath.representation.Usergroup;
 
 /** Populates a {@link FastpathConfiguration} by walking a FastPath parse tree. */
 public final class FastpathConfigurationBuilder extends FastpathParserBaseListener
@@ -103,6 +119,8 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
    */
   private static final String DEFAULT_LIST_NAME = "default";
 
+  private static final IntegerSpace USER_LEVEL_RANGE = IntegerSpace.of(Range.closed(0, 15));
+
   public FastpathConfigurationBuilder(
       FastpathCombinedParser parser,
       String text,
@@ -123,6 +141,9 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   private final @Nonnull Warnings _w;
 
   private @Nullable TacacsServer _currentTacacsServer;
+  private @Nullable Taskgroup _currentTaskgroup;
+  private @Nullable UserAccount _currentUser;
+  private @Nullable Usergroup _currentUsergroup;
 
   @Override
   public void exitS_hostname(S_hostnameContext ctx) {
@@ -408,6 +429,89 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
     }
     assert ctx.NONE() != null;
     return Accounting.RecordType.NONE;
+  }
+
+  @Override
+  public void enterS_username(S_usernameContext ctx) {
+    String name = toString(ctx.name.text);
+    _currentUser = _c.getUsers().computeIfAbsent(name, UserAccount::new);
+  }
+
+  @Override
+  public void exitS_username(S_usernameContext ctx) {
+    _currentUser = null;
+  }
+
+  @Override
+  public void exitU_password(U_passwordContext ctx) {
+    _currentUser.setHasPassword(true);
+    _currentUser.setEncrypted(ctx.ENCRYPTED() != null);
+    if (ctx.level != null) {
+      toIntegerInSpace(ctx, ctx.level, USER_LEVEL_RANGE, "username level")
+          .ifPresent(_currentUser::setLevel);
+    }
+  }
+
+  @Override
+  public void exitU_usergroup(U_usergroupContext ctx) {
+    _currentUser.setUserGroup(toString(ctx.group));
+  }
+
+  @Override
+  public void enterS_taskgroup(S_taskgroupContext ctx) {
+    _currentTaskgroup = _c.getTaskgroups().computeIfAbsent(toString(ctx.name.text), Taskgroup::new);
+  }
+
+  @Override
+  public void exitS_taskgroup(S_taskgroupContext ctx) {
+    _currentTaskgroup = null;
+  }
+
+  @Override
+  public void exitTaskgroup_task(Taskgroup_taskContext ctx) {
+    TaskComponent component = toTaskComponent(ctx.task_component());
+    Set<TaskPermission> permissions =
+        _currentTaskgroup
+            .getTasks()
+            .computeIfAbsent(component, c -> EnumSet.noneOf(TaskPermission.class));
+    ctx.task_permission().forEach(p -> permissions.add(toTaskPermission(p)));
+  }
+
+  private static @Nonnull TaskPermission toTaskPermission(Task_permissionContext ctx) {
+    if (ctx.READ() != null) {
+      return TaskPermission.READ;
+    } else if (ctx.WRITE() != null) {
+      return TaskPermission.WRITE;
+    } else if (ctx.EXECUTE() != null) {
+      return TaskPermission.EXECUTE;
+    }
+    assert ctx.DEBUG() != null;
+    return TaskPermission.DEBUG;
+  }
+
+  private static @Nonnull TaskComponent toTaskComponent(Task_componentContext ctx) {
+    if (ctx.AAA() != null) {
+      return TaskComponent.AAA;
+    } else if (ctx.OSPF() != null) {
+      return TaskComponent.OSPF;
+    }
+    assert ctx.BGP() != null;
+    return TaskComponent.BGP;
+  }
+
+  @Override
+  public void enterS_usergroup(S_usergroupContext ctx) {
+    _currentUsergroup = _c.getUsergroups().computeIfAbsent(toString(ctx.name.text), Usergroup::new);
+  }
+
+  @Override
+  public void exitS_usergroup(S_usergroupContext ctx) {
+    _currentUsergroup = null;
+  }
+
+  @Override
+  public void exitUsergroup_taskgroup(Usergroup_taskgroupContext ctx) {
+    _currentUsergroup.getTaskgroups().add(toString(ctx.name.text));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/FastpathConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/FastpathConfiguration.java
@@ -6,7 +6,9 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.VendorConversionException;
@@ -27,6 +29,9 @@ public final class FastpathConfiguration extends VendorConfiguration {
   private final Logging _logging;
   private final Tacacs _tacacs;
   private final Aaa _aaa;
+  private final Map<String, UserAccount> _users;
+  private final Map<String, Taskgroup> _taskgroups;
+  private final Map<String, Usergroup> _usergroups;
 
   private transient Configuration _c;
 
@@ -36,6 +41,9 @@ public final class FastpathConfiguration extends VendorConfiguration {
     _logging = new Logging();
     _tacacs = new Tacacs();
     _aaa = new Aaa();
+    _users = new LinkedHashMap<>();
+    _taskgroups = new LinkedHashMap<>();
+    _usergroups = new LinkedHashMap<>();
   }
 
   @Override
@@ -73,6 +81,18 @@ public final class FastpathConfiguration extends VendorConfiguration {
 
   public @Nonnull Aaa getAaa() {
     return _aaa;
+  }
+
+  public @Nonnull Map<String, UserAccount> getUsers() {
+    return _users;
+  }
+
+  public @Nonnull Map<String, Taskgroup> getTaskgroups() {
+    return _taskgroups;
+  }
+
+  public @Nonnull Map<String, Usergroup> getUsergroups() {
+    return _usergroups;
   }
 
   private @Nonnull Configuration toVendorIndependentConfiguration() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/TaskComponent.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/TaskComponent.java
@@ -1,0 +1,8 @@
+package org.batfish.vendor.fastpath.representation;
+
+/** A component that a FastPath {@code task} line grants {@link TaskPermission}s on. */
+public enum TaskComponent {
+  AAA,
+  OSPF,
+  BGP
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/TaskPermission.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/TaskPermission.java
@@ -1,0 +1,9 @@
+package org.batfish.vendor.fastpath.representation;
+
+/** A permission that a FastPath {@code task} line can grant on a {@link TaskComponent}. */
+public enum TaskPermission {
+  READ,
+  WRITE,
+  EXECUTE,
+  DEBUG
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Taskgroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Taskgroup.java
@@ -1,0 +1,31 @@
+package org.batfish.vendor.fastpath.representation;
+
+import java.io.Serializable;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/**
+ * A FastPath taskgroup: a named set of CLI task permissions ({@code taskgroup "<name>"} followed by
+ * one or more {@code task ...} lines). Each {@code task} line grants a set of {@link
+ * TaskPermission}s on a single {@link TaskComponent}.
+ */
+public final class Taskgroup implements Serializable {
+
+  private final @Nonnull String _name;
+  private final @Nonnull Map<TaskComponent, Set<TaskPermission>> _tasks;
+
+  public Taskgroup(String name) {
+    _name = name;
+    _tasks = new EnumMap<>(TaskComponent.class);
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nonnull Map<TaskComponent, Set<TaskPermission>> getTasks() {
+    return _tasks;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/UserAccount.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/UserAccount.java
@@ -1,0 +1,55 @@
+package org.batfish.vendor.fastpath.representation;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** A FastPath local user account, from {@code username ...}. */
+public final class UserAccount implements Serializable {
+
+  private final @Nonnull String _name;
+  private @Nullable Integer _level;
+  private boolean _hasPassword;
+  private boolean _encrypted;
+  private @Nullable String _userGroup;
+
+  public UserAccount(String name) {
+    _name = name;
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nullable Integer getLevel() {
+    return _level;
+  }
+
+  public void setLevel(@Nullable Integer level) {
+    _level = level;
+  }
+
+  public boolean getHasPassword() {
+    return _hasPassword;
+  }
+
+  public void setHasPassword(boolean hasPassword) {
+    _hasPassword = hasPassword;
+  }
+
+  public boolean getEncrypted() {
+    return _encrypted;
+  }
+
+  public void setEncrypted(boolean encrypted) {
+    _encrypted = encrypted;
+  }
+
+  public @Nullable String getUserGroup() {
+    return _userGroup;
+  }
+
+  public void setUserGroup(@Nullable String userGroup) {
+    _userGroup = userGroup;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Usergroup.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/Usergroup.java
@@ -1,0 +1,29 @@
+package org.batfish.vendor.fastpath.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * A FastPath usergroup: a named user class associated with one or more taskgroups ({@code usergroup
+ * "<name>"} followed by {@code taskgroup "<name>"}).
+ */
+public final class Usergroup implements Serializable {
+
+  private final @Nonnull String _name;
+  private final @Nonnull List<String> _taskgroups;
+
+  public Usergroup(String name) {
+    _name = name;
+    _taskgroups = new ArrayList<>();
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nonnull List<String> getTaskgroups() {
+    return _taskgroups;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
@@ -19,11 +19,13 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -54,6 +56,11 @@ import org.batfish.vendor.fastpath.representation.LoggingServer;
 import org.batfish.vendor.fastpath.representation.Sntp;
 import org.batfish.vendor.fastpath.representation.Tacacs;
 import org.batfish.vendor.fastpath.representation.TacacsServer;
+import org.batfish.vendor.fastpath.representation.TaskComponent;
+import org.batfish.vendor.fastpath.representation.TaskPermission;
+import org.batfish.vendor.fastpath.representation.Taskgroup;
+import org.batfish.vendor.fastpath.representation.UserAccount;
+import org.batfish.vendor.fastpath.representation.Usergroup;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -350,6 +357,87 @@ public final class FastpathGrammarTest {
     assertThat(
         aaa.getAuthentication().get(AuthenticationType.ENABLE).get("net-enable").getMethods(),
         equalTo(ImmutableList.of(AaaMethod.TACACS, AaaMethod.ENABLE)));
+  }
+
+  @Test
+  public void testUsersTasksParseWithoutWarnings() {
+    FastpathConfiguration c = parseVendorConfig("fastpath_users_tasks");
+    assertThat(c.getWarnings().getParseWarnings(), empty());
+  }
+
+  @Test
+  public void testUsernameExtraction() {
+    FastpathConfiguration c = parseVendorConfig("fastpath_users_tasks");
+    Map<String, UserAccount> users = c.getUsers();
+    assertThat(
+        users.keySet(),
+        equalTo(ImmutableSet.of("admin", "operator", "seagull", "monitor", "policy")));
+
+    UserAccount admin = users.get("admin");
+    assertThat(admin.getHasPassword(), equalTo(true));
+    assertThat(admin.getEncrypted(), equalTo(true));
+    assertThat(admin.getLevel(), equalTo(15));
+    assertThat(admin.getUserGroup(), nullValue());
+
+    UserAccount operator = users.get("operator");
+    assertThat(operator.getHasPassword(), equalTo(true));
+    assertThat(operator.getEncrypted(), equalTo(false));
+    assertThat(operator.getLevel(), equalTo(1));
+    assertThat(operator.getUserGroup(), nullValue());
+
+    UserAccount seagull = users.get("seagull");
+    assertThat(seagull.getHasPassword(), equalTo(true));
+    assertThat(seagull.getEncrypted(), equalTo(true));
+    assertThat(seagull.getLevel(), equalTo(15));
+    assertThat(seagull.getUserGroup(), equalTo("builder"));
+
+    // `username "monitor" nopassword level 1` is parsed but not extracted, so the account exists
+    // with no password and no recorded level.
+    UserAccount monitor = users.get("monitor");
+    assertThat(monitor.getHasPassword(), equalTo(false));
+    assertThat(monitor.getEncrypted(), equalTo(false));
+    assertThat(monitor.getLevel(), nullValue());
+    assertThat(monitor.getUserGroup(), nullValue());
+
+    // `override-complexity-check` is parsed but ignored; the rest of the password form still
+    // extracts.
+    UserAccount policy = users.get("policy");
+    assertThat(policy.getHasPassword(), equalTo(true));
+    assertThat(policy.getEncrypted(), equalTo(true));
+    assertThat(policy.getLevel(), equalTo(5));
+    assertThat(policy.getUserGroup(), nullValue());
+  }
+
+  @Test
+  public void testTaskgroupExtraction() {
+    FastpathConfiguration c = parseVendorConfig("fastpath_users_tasks");
+    Map<String, Taskgroup> taskgroups = c.getTaskgroups();
+    assertThat(taskgroups.keySet(), equalTo(ImmutableSet.of("builder", "admin")));
+    Set<TaskPermission> allPermissions =
+        ImmutableSet.of(
+            TaskPermission.READ,
+            TaskPermission.WRITE,
+            TaskPermission.EXECUTE,
+            TaskPermission.DEBUG);
+    assertThat(
+        taskgroups.get("builder").getTasks(),
+        equalTo(
+            ImmutableMap.of(
+                TaskComponent.AAA, allPermissions,
+                TaskComponent.OSPF, allPermissions,
+                TaskComponent.BGP, allPermissions)));
+    assertThat(
+        taskgroups.get("admin").getTasks(),
+        equalTo(ImmutableMap.of(TaskComponent.AAA, allPermissions)));
+  }
+
+  @Test
+  public void testUsergroupExtraction() {
+    FastpathConfiguration c = parseVendorConfig("fastpath_users_tasks");
+    Map<String, Usergroup> usergroups = c.getUsergroups();
+    assertThat(usergroups.keySet(), equalTo(ImmutableSet.of("builder", "admin")));
+    assertThat(usergroups.get("builder").getTaskgroups(), equalTo(ImmutableList.of("builder")));
+    assertThat(usergroups.get("admin").getTaskgroups(), equalTo(ImmutableList.of("admin")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
@@ -371,7 +371,7 @@ public final class FastpathGrammarTest {
     Map<String, UserAccount> users = c.getUsers();
     assertThat(
         users.keySet(),
-        equalTo(ImmutableSet.of("admin", "operator", "seagull", "monitor", "policy")));
+        equalTo(ImmutableSet.of("admin", "operator", "seagull", "monitor", "policy", "bob")));
 
     UserAccount admin = users.get("admin");
     assertThat(admin.getHasPassword(), equalTo(true));
@@ -406,13 +406,19 @@ public final class FastpathGrammarTest {
     assertThat(policy.getEncrypted(), equalTo(true));
     assertThat(policy.getLevel(), equalTo(5));
     assertThat(policy.getUserGroup(), nullValue());
+
+    UserAccount bob = users.get("bob");
+    assertThat(bob.getHasPassword(), equalTo(true));
+    assertThat(bob.getEncrypted(), equalTo(false));
+    assertThat(bob.getLevel(), equalTo(15));
+    assertThat(bob.getUserGroup(), nullValue());
   }
 
   @Test
   public void testTaskgroupExtraction() {
     FastpathConfiguration c = parseVendorConfig("fastpath_users_tasks");
     Map<String, Taskgroup> taskgroups = c.getTaskgroups();
-    assertThat(taskgroups.keySet(), equalTo(ImmutableSet.of("builder", "admin")));
+    assertThat(taskgroups.keySet(), equalTo(ImmutableSet.of("builder", "admin", "ops")));
     Set<TaskPermission> allPermissions =
         ImmutableSet.of(
             TaskPermission.READ,
@@ -429,15 +435,21 @@ public final class FastpathGrammarTest {
     assertThat(
         taskgroups.get("admin").getTasks(),
         equalTo(ImmutableMap.of(TaskComponent.AAA, allPermissions)));
+    assertThat(
+        taskgroups.get("ops").getTasks(),
+        equalTo(
+            ImmutableMap.of(
+                TaskComponent.OSPF, ImmutableSet.of(TaskPermission.READ, TaskPermission.EXECUTE))));
   }
 
   @Test
   public void testUsergroupExtraction() {
     FastpathConfiguration c = parseVendorConfig("fastpath_users_tasks");
     Map<String, Usergroup> usergroups = c.getUsergroups();
-    assertThat(usergroups.keySet(), equalTo(ImmutableSet.of("builder", "admin")));
+    assertThat(usergroups.keySet(), equalTo(ImmutableSet.of("builder", "admin", "ops")));
     assertThat(usergroups.get("builder").getTaskgroups(), equalTo(ImmutableList.of("builder")));
     assertThat(usergroups.get("admin").getTaskgroups(), equalTo(ImmutableList.of("admin")));
+    assertThat(usergroups.get("ops").getTaskgroups(), equalTo(ImmutableList.of("ops")));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_users_tasks
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_users_tasks
@@ -1,0 +1,33 @@
+!Current Configuration:
+!
+!System Software Version "3.4.3.10"
+!
+hostname "fastpath_users_tasks"
+!
+taskgroup "builder"
+task read write execute debug aaa
+task read write execute debug ospf
+task read write execute debug bgp
+exit
+!
+taskgroup "admin"
+task read write execute debug aaa
+exit
+!
+usergroup "builder"
+taskgroup "builder"
+exit
+!
+usergroup "admin"
+taskgroup "admin"
+exit
+!
+username "admin" password abc123 level 15 encrypted
+username "operator" password xyz789 level 1
+username "seagull" password %CENSORED% level 15 encrypted
+username "seagull" usergroup builder
+username "operator" unlock
+username "monitor" nopassword level 1
+username "policy" password abc123 level 5 encrypted override-complexity-check
+username "admin" level 15 password
+no username guest

--- a/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_users_tasks
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_users_tasks
@@ -14,12 +14,20 @@ taskgroup "admin"
 task read write execute debug aaa
 exit
 !
+taskgroup ops
+task read execute ospf
+exit
+!
 usergroup "builder"
 taskgroup "builder"
 exit
 !
 usergroup "admin"
 taskgroup "admin"
+exit
+!
+usergroup ops
+taskgroup ops
 exit
 !
 username "admin" password abc123 level 15 encrypted
@@ -30,4 +38,5 @@ username "operator" unlock
 username "monitor" nopassword level 1
 username "policy" password abc123 level 5 encrypted override-complexity-check
 username "admin" level 15 password
+username bob password xxxyyymmmm level 15
 no username guest


### PR DESCRIPTION
## Summary

Add parsing and extraction for the local RBAC surface: `username`, `usergroup`, and `taskgroup`. Local accounts are captured with their password presence (and `encrypted` flag), privilege `level`, or `usergroup` binding; `usergroup`/`taskgroup` blocks are captured as a named set of task permissions (`read`/`write`/`execute`/`debug`) on a component (`aaa`/`ospf`/`bgp`). This is recorded in new vendor-specific `representation` models (`UserAccount`, `Usergroup`, `Taskgroup`). None of it is converted to the vendor-independent model.

## Changes

- **Lexer:** Add keyword tokens `BGP`, `EXECUTE`, `LEVEL`, `NOPASSWORD`, `OSPF`, `OVERRIDE_COMPLEXITY_CHECK`, `READ`, `TASK`, `UNLOCK`, `WRITE`, and `USERGROUP`/`TASKGROUP` tokens that push `M_Word` (so usergroup/taskgroup names lex as `word`).

- **Lexer:** Make `PASSWORD` context-sensitive: it pushes `M_Remainder` when it is line-initial (the `aaa ias-user` `password …` body, which is dropped) and `M_Secret` otherwise (the `username … password <secret>` operand). `M_Secret` emits a distinct `SECRET` token (declared in `tokens {}`) for the entire non-whitespace password value and then pops, so trailing `level`/`encrypted`/`override-complexity-check` keywords are still recognized.

- **Grammar:** Add `s_username`, `s_usergroup`, and `s_taskgroup` to `statement`, and `no_username_null` to `s_no`. Names are matched with `word`, so both the quoted form the device emits and the unquoted form the CLI accepts parse. `s_username` accepts `u_password` (`password <secret>` optionally followed by `level <n>`, `encrypted`, and/or the strength-bypass flag `override-complexity-check`), `u_usergroup` (a `usergroup` binding), and parsed-but-ignored `u_nopassword_null`, `u_unlock_null`, and `u_level_null` (the interactive `level <n> [override-complexity-check] password` form). `s_usergroup` holds `usergroup_taskgroup` lines; `s_taskgroup` holds `taskgroup_task` lines, each granting `task_permission+` (`read`/`write`/`execute`/`debug`) on a `task_component` (`aaa`/`ospf`/`bgp`).

- **VS:** Add `representation` classes `UserAccount` (name, level, hasPassword, encrypted, usergroup), `Usergroup` (name, ordered taskgroup names), and `Taskgroup` (name, `EnumMap<TaskComponent, EnumSet<TaskPermission>>`), and the `TaskComponent` (`AAA`/`OSPF`/`BGP`) and `TaskPermission` (`READ`/`WRITE`/`EXECUTE`/`DEBUG`) enums.

- **VS:** Add RBAC state to `FastpathConfiguration.java`: insertion-ordered (`LinkedHashMap`) `_users`, `_usergroups`, and `_taskgroups` maps with `getUsers()`/`getUsergroups()`/`getTaskgroups()` accessors.

- **Extraction:** Populate handlers in `FastpathConfigurationBuilder.java` using `_currentUser`/`_currentUsergroup`/`_currentTaskgroup` fields. Level is validated against `USER_LEVEL_RANGE` (0–15). `task` permission/component keywords convert via helpers that assert on the final alternative, so adding a grammar alternative without extraction fails loudly. `override-complexity-check`, `nopassword`, `unlock`, the interactive `level … password` form, and `no username <name>` are parsed but not extracted.

## Testing

- Add a `fastpath_users_tasks` testconfig covering `taskgroup`/`usergroup` blocks (quoted and bare-word names), all `username` forms (`password [level] [encrypted] [override-complexity-check]`, `usergroup`, `nopassword`, `unlock`, interactive `level … password`, unquoted name, `no username`), and a username reused across two lines.

- Add `testUsersTasksParseWithoutWarnings`, `testUsernameExtraction`, `testTaskgroupExtraction`, and `testUsergroupExtraction` to `FastpathGrammarTest`.

- All tests pass locally and no reference tests are affected.