### PR TITLE
StaticRoute: intern instances, including on deserialization

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -8,8 +8,12 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -27,7 +31,13 @@ import org.batfish.datamodel.route.nh.NextHopVrf;
  * for determining route preference in RIBs.
  */
 @ParametersAreNonnullByDefault
-public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute> {
+public final class StaticRoute extends AbstractRoute implements Comparable<StaticRoute> {
+
+  // Soft values: let it be garbage collected in times of pressure.
+  // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
+  //   (56 bytes data, would be 56 MiB total ignoring overhead).
+  private static final LoadingCache<StaticRoute, StaticRoute> CACHE =
+      Caffeine.newBuilder().softValues().maximumSize(1 << 20).build(x -> x);
 
   static final long DEFAULT_STATIC_ROUTE_METRIC = 0L;
   private static final String PROP_NEXT_VRF = "nextVrf";
@@ -50,18 +60,19 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
       @JsonProperty(PROP_METRIC) long metric,
       @JsonProperty(PROP_TAG) long tag,
       @JsonProperty(PROP_TRACK) @Nullable String track) {
-    return new StaticRoute(
-        requireNonNull(network),
-        nextVrf != null
-            ? NextHopVrf.of(nextVrf)
-            : NextHop.legacyConverter(nextHopInterface, nextHopIp),
-        administrativeCost,
-        metric,
-        tag,
-        false,
-        false,
-        true,
-        track);
+    return CACHE.get(
+        new StaticRoute(
+            requireNonNull(network),
+            nextVrf != null
+                ? NextHopVrf.of(nextVrf)
+                : NextHop.legacyConverter(nextHopInterface, nextHopIp),
+            administrativeCost,
+            metric,
+            tag,
+            false,
+            false,
+            true,
+            track));
   }
 
   private StaticRoute(
@@ -145,16 +156,17 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
           "Static route cannot have unset %s",
           PROP_ADMINISTRATIVE_COST);
       checkArgument(_nextHop != null, "Static route missing a next hop");
-      return new StaticRoute(
-          getNetwork(),
-          _nextHop,
-          getAdmin(),
-          getMetric(),
-          getTag(),
-          getNonForwarding(),
-          getNonRouting(),
-          _recursive,
-          _track);
+      return CACHE.get(
+          new StaticRoute(
+              getNetwork(),
+              _nextHop,
+              getAdmin(),
+              getMetric(),
+              getTag(),
+              getNonForwarding(),
+              getNonRouting(),
+              _recursive,
+              _track));
     }
 
     @Override
@@ -205,6 +217,12 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
         .setNonForwarding(getNonForwarding())
         .setRecursive(getRecursive())
         .setTrack(_track);
+  }
+
+  /** Re-intern after deserialization. */
+  @Serial
+  private Object readResolve() throws ObjectStreamException {
+    return CACHE.get(this);
   }
 
   @Override

--- a/projects/common/src/test/java/org/batfish/datamodel/StaticRouteTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/StaticRouteTest.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
@@ -118,6 +119,17 @@ public final class StaticRouteTest {
   }
 
   @Test
+  public void testInterning() {
+    StaticRoute.Builder b =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("10.0.0.0/24"))
+            .setNextHop(NextHopIp.of(Ip.parse("10.1.1.1")))
+            .setAdministrativeCost(1);
+
+    assertThat(b.build(), sameInstance(b.build()));
+  }
+
+  @Test
   public void checkJsonSerialization() {
     StaticRoute sr =
         StaticRoute.testBuilder()
@@ -130,7 +142,7 @@ public final class StaticRouteTest {
             .setMetric(123)
             .build();
 
-    assertThat(BatfishObjectMapper.clone(sr, StaticRoute.class), equalTo(sr));
+    assertThat(BatfishObjectMapper.clone(sr, StaticRoute.class), sameInstance(sr));
   }
 
   @Test
@@ -146,6 +158,6 @@ public final class StaticRouteTest {
             .setMetric(123)
             .build();
 
-    assertThat(SerializationUtils.clone(sr), equalTo(sr));
+    assertThat(SerializationUtils.clone(sr), sameInstance(sr));
   }
 }


### PR DESCRIPTION
Deployments that program the same static route onto every device in a
fabric produce snapshots holding enormous numbers of identical
StaticRoute objects. One such snapshot held 25.6M static routes with
only 16.1k distinct values.

Intern them through a Caffeine cache, as FibForward and BgpRoute's
attributes already do. Interning at construction is not sufficient by
itself: the vendor-independent configurations are serialized and
deserialized before the dataplane runs, and Java deserialization
rebuilds each object field by field without calling the builder. Nearly
all of the duplication was in those deserialized copies, so readResolve
is what collapses it. The JSON creator interns too, leaving all three
construction paths in agreement.

Mark the class final. Its only constructor was already private, so it
could not be subclassed outside the file, but interning is only sound if
no subclass can be conflated with an equal instance of the base class,
and final states that rather than leaving it to be re-derived.

The existing serialization tests asserted equality, so they passed
without readResolve; they now assert identity.

----

Prompt:
```
Let's land StaticRoute caching/readresolve - you have to do it in open
source batfish tho, ~/batfish/batfis
```

Context: found while investigating a dataplane memory regression on a
snapshot whose devices each carry ~14k identical static routes.
