### PR TITLE
rib: store backup routes without a per-prefix multimap

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -1,8 +1,6 @@
 package org.batfish.dataplane.rib;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Multimap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -40,11 +38,11 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    * Keep a (insert ordered) set of alternative routes. Used to update the RIB if best routes are
    * withdrawn.
    */
-  protected final @Nullable LinkedHashMultimap<Prefix, R> _backupRoutes;
+  protected final @Nullable BackupRoutes<R> _backupRoutes;
 
   protected AbstractRib(boolean withBackupRoutes) {
     _allRoutes = ImmutableSet.of();
-    _backupRoutes = withBackupRoutes ? LinkedHashMultimap.create() : null;
+    _backupRoutes = withBackupRoutes ? new BackupRoutes<>() : null;
     _tree = new RibTree<>(this);
   }
 
@@ -171,7 +169,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   @Override
   public @Nonnull Set<R> getBackupRoutes() {
     return Optional.ofNullable(_backupRoutes)
-        .map(Multimap::values)
+        .map(BackupRoutes::values)
         .map(ImmutableSet::copyOf)
         .orElse(ImmutableSet.of());
   }
@@ -183,10 +181,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    */
   private void removeBackupRoute(R route) {
     if (_backupRoutes != null) {
-      Set<R> routes = _backupRoutes.get(route.getNetwork());
-      if (routes != null) {
-        routes.remove(route);
-      }
+      _backupRoutes.remove(route.getNetwork(), route);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BackupRoutes.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BackupRoutes.java
@@ -1,0 +1,123 @@
+package org.batfish.dataplane.rib;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.AbstractRouteDecorator;
+import org.batfish.datamodel.Prefix;
+
+/**
+ * Maps a prefix to the insertion-ordered set of alternative routes a RIB holds for it, so a route
+ * can be restored when a better one is withdrawn.
+ *
+ * <p>A RIB records a backup for every route it is ever offered, making this one of the larger
+ * structures in a dataplane computation. Nearly every prefix has only one or two backups, so a
+ * value is the route itself when there is exactly one and a small list otherwise, rather than a
+ * per-prefix set carrying its own hash table.
+ *
+ * <p>Ordering is per prefix: {@link #values} returns routes grouped by prefix, not in global
+ * insertion order.
+ */
+@ParametersAreNonnullByDefault
+final class BackupRoutes<R extends AbstractRouteDecorator> {
+
+  private final Map<Prefix, Object> _byPrefix = new HashMap<>();
+
+  /** Adds {@code route} under {@code prefix}, if not already present. */
+  @SuppressWarnings("unchecked")
+  void put(Prefix prefix, R route) {
+    Object existing = _byPrefix.get(prefix);
+    if (existing == null) {
+      _byPrefix.put(prefix, route);
+      return;
+    }
+    if (!(existing instanceof List)) {
+      if (existing.equals(route)) {
+        return;
+      }
+      List<R> grown = new ArrayList<>(2);
+      grown.add((R) existing);
+      grown.add(route);
+      _byPrefix.put(prefix, grown);
+      return;
+    }
+    List<R> routes = (List<R>) existing;
+    if (!routes.contains(route)) {
+      routes.add(route);
+    }
+  }
+
+  /** The routes stored under {@code prefix} in insertion order, or empty if there are none. */
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  Set<R> get(Prefix prefix) {
+    Object existing = _byPrefix.get(prefix);
+    if (existing == null) {
+      return ImmutableSet.of();
+    }
+    if (!(existing instanceof List)) {
+      return ImmutableSet.of((R) existing);
+    }
+    return ImmutableSet.copyOf((List<R>) existing);
+  }
+
+  /** Whether {@code route} is stored under {@code prefix}. */
+  @SuppressWarnings("unchecked")
+  boolean containsEntry(Prefix prefix, R route) {
+    Object existing = _byPrefix.get(prefix);
+    if (existing == null) {
+      return false;
+    }
+    if (!(existing instanceof List)) {
+      return existing.equals(route);
+    }
+    return ((List<R>) existing).contains(route);
+  }
+
+  /** Removes {@code route} from {@code prefix}, if present. */
+  @SuppressWarnings("unchecked")
+  void remove(Prefix prefix, R route) {
+    Object existing = _byPrefix.get(prefix);
+    if (existing == null) {
+      return;
+    }
+    if (!(existing instanceof List)) {
+      if (existing.equals(route)) {
+        _byPrefix.remove(prefix);
+      }
+      return;
+    }
+    List<R> routes = (List<R>) existing;
+    routes.remove(route);
+    if (routes.isEmpty()) {
+      _byPrefix.remove(prefix);
+    } else if (routes.size() == 1) {
+      _byPrefix.put(prefix, routes.get(0));
+    }
+  }
+
+  /** Every stored route. See the class javadoc on ordering. */
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  Collection<R> values() {
+    List<R> out = new ArrayList<>(_byPrefix.size());
+    for (Object value : _byPrefix.values()) {
+      if (value instanceof List) {
+        out.addAll((List<R>) value);
+      } else {
+        out.add((R) value);
+      }
+    }
+    return out;
+  }
+
+  void clear() {
+    _byPrefix.clear();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/BackupRoutesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/BackupRoutesTest.java
@@ -1,0 +1,135 @@
+package org.batfish.dataplane.rib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.Prefix;
+import org.junit.Test;
+
+/** Tests of {@link BackupRoutes} */
+public final class BackupRoutesTest {
+
+  private static final Prefix P1 = Prefix.parse("1.1.1.0/24");
+  private static final Prefix P2 = Prefix.parse("2.2.2.0/24");
+
+  private static ConnectedRoute route(Prefix prefix, String iface) {
+    return new ConnectedRoute(prefix, iface);
+  }
+
+  @Test
+  public void testEmpty() {
+    BackupRoutes<ConnectedRoute> backups = new BackupRoutes<>();
+
+    assertThat(backups.get(P1), empty());
+    assertThat(backups.values(), empty());
+    assertFalse(backups.containsEntry(P1, route(P1, "i1")));
+  }
+
+  @Test
+  public void testSingleRoutePerPrefix() {
+    BackupRoutes<ConnectedRoute> backups = new BackupRoutes<>();
+    ConnectedRoute r1 = route(P1, "i1");
+    ConnectedRoute r2 = route(P2, "i2");
+    backups.put(P1, r1);
+    backups.put(P2, r2);
+
+    assertThat(backups.get(P1), contains(r1));
+    assertThat(backups.get(P2), contains(r2));
+    assertThat(backups.values(), containsInAnyOrder(r1, r2));
+    assertTrue(backups.containsEntry(P1, r1));
+    assertFalse(backups.containsEntry(P1, r2));
+  }
+
+  /** Several routes for one prefix must be kept in insertion order. */
+  @Test
+  public void testMultipleRoutesPerPrefix() {
+    BackupRoutes<ConnectedRoute> backups = new BackupRoutes<>();
+    ConnectedRoute r1 = route(P1, "i1");
+    ConnectedRoute r2 = route(P1, "i2");
+    ConnectedRoute r3 = route(P1, "i3");
+    backups.put(P1, r1);
+    backups.put(P1, r2);
+    backups.put(P1, r3);
+
+    assertThat(backups.get(P1), contains(r1, r2, r3));
+    assertThat(backups.values(), contains(r1, r2, r3));
+    assertTrue(backups.containsEntry(P1, r3));
+  }
+
+  /** Set semantics: re-adding an equal route is a no-op, whether stored alone or in a list. */
+  @Test
+  public void testPutIsIdempotent() {
+    BackupRoutes<ConnectedRoute> backups = new BackupRoutes<>();
+    ConnectedRoute r1 = route(P1, "i1");
+    ConnectedRoute r2 = route(P1, "i2");
+    backups.put(P1, r1);
+    backups.put(P1, route(P1, "i1"));
+
+    assertThat(backups.get(P1), contains(r1));
+
+    backups.put(P1, r2);
+    backups.put(P1, route(P1, "i2"));
+
+    assertThat(backups.get(P1), contains(r1, r2));
+  }
+
+  @Test
+  public void testRemoveSoleRoute() {
+    BackupRoutes<ConnectedRoute> backups = new BackupRoutes<>();
+    ConnectedRoute r1 = route(P1, "i1");
+    backups.put(P1, r1);
+    backups.remove(P1, r1);
+
+    assertThat(backups.get(P1), empty());
+    assertThat(backups.values(), empty());
+  }
+
+  /** Removing down to one route must still behave as a populated prefix. */
+  @Test
+  public void testRemoveFromMultiple() {
+    BackupRoutes<ConnectedRoute> backups = new BackupRoutes<>();
+    ConnectedRoute r1 = route(P1, "i1");
+    ConnectedRoute r2 = route(P1, "i2");
+    backups.put(P1, r1);
+    backups.put(P1, r2);
+
+    backups.remove(P1, r1);
+    assertThat(backups.get(P1), contains(r2));
+    assertTrue(backups.containsEntry(P1, r2));
+
+    backups.put(P1, r1);
+    assertThat(backups.get(P1), contains(r2, r1));
+
+    backups.remove(P1, r1);
+    backups.remove(P1, r2);
+    assertThat(backups.get(P1), empty());
+  }
+
+  @Test
+  public void testRemoveAbsent() {
+    BackupRoutes<ConnectedRoute> backups = new BackupRoutes<>();
+    ConnectedRoute r1 = route(P1, "i1");
+    backups.put(P1, r1);
+
+    backups.remove(P1, route(P1, "other"));
+    backups.remove(P2, r1);
+
+    assertThat(backups.get(P1), contains(r1));
+  }
+
+  @Test
+  public void testClear() {
+    BackupRoutes<ConnectedRoute> backups = new BackupRoutes<>();
+    backups.put(P1, route(P1, "i1"));
+    backups.put(P2, route(P2, "i2"));
+    backups.clear();
+
+    assertThat(backups.values(), empty());
+    assertThat(backups.get(P1), empty());
+  }
+}


### PR DESCRIPTION
AbstractRib keeps a backup for every route it is ever offered, and
LinkedHashMultimap spends a ValueSet with its own hash table per prefix
plus a linked ValueEntry per route on that. Nearly every prefix has one
or two backups, so hold the route directly when there is one and a small
list otherwise. On a snapshot with ~28M backups this cut peak heap by
8.5 GiB.

get() now returns an immutable copy rather than a live view, so
removeBackupRoute removes through the map instead of through the
returned set. values() groups by prefix rather than using global
insertion order; only getBackupRoutes reads it, as a Set.

----

Prompt:
```
Land the backup-route compaction in open source batfish, first part only
(the prefix -> route-or-list change, not the open-addressed index).
```
