### PR TITLE
ibdp: retain annotated main RIBs only when a debug flag asks

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -432,6 +432,16 @@ final class IncrementalBdpEngine {
       TopologyContext initialTopologyContext,
       Set<BgpAdvertisement> externalAdverts,
       IpOwners initialIpOwners) {
+    return computeDataPlane(
+        configurations, initialTopologyContext, externalAdverts, initialIpOwners, false);
+  }
+
+  ComputeDataPlaneResult computeDataPlane(
+      Map<String, Configuration> configurations,
+      TopologyContext initialTopologyContext,
+      Set<BgpAdvertisement> externalAdverts,
+      IpOwners initialIpOwners,
+      boolean retainAnnotatedRibs) {
     LOGGER.info("Computing Data Plane using iBDP");
 
     Map<Ip, Map<String, Set<String>>> initialIpVrfOwners = initialIpOwners.getIpVrfOwners();
@@ -606,6 +616,7 @@ final class IncrementalBdpEngine {
         IncrementalDataPlane.builder()
             .setNodes(nodes)
             .setPartialDataplane(currentDataplane)
+            .setRetainAnnotatedRibs(retainAnnotatedRibs)
             .build();
     return new IbdpResult(answerElement, finalDataplane, currentTopologyContext, nodes);
   }
@@ -1139,15 +1150,15 @@ final class IncrementalBdpEngine {
   @VisibleForTesting
   static SortedMap<String, SortedMap<String, Set<AbstractRoute>>> getRoutes(
       IncrementalDataPlane dp) {
-    // Scan through all Nodes and their virtual routers, retrieve main rib routes
+    // Scan through all Nodes and their VRFs, retrieve main rib routes
     return toImmutableSortedMap(
-        dp.getRibsForTesting(),
+        dp.getRibs().rowMap(),
         Entry::getKey,
         nodeEntry ->
             toImmutableSortedMap(
                 nodeEntry.getValue(),
                 Entry::getKey,
-                vrfEntry -> ImmutableSet.copyOf(vrfEntry.getValue().getUnannotatedRoutes())));
+                vrfEntry -> ImmutableSet.copyOf(vrfEntry.getValue().getRoutes())));
   }
 
   private static final int MAX_OSPF_INTERNAL_ITERATIONS = 100000;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -1,6 +1,7 @@
 package org.batfish.dataplane.ibdp;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.common.util.StreamUtil.toListInRandomOrder;
 
@@ -100,9 +101,21 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     return _ribs;
   }
 
+  /**
+   * The main RIBs as they were at the end of routing simulation, with route annotations intact.
+   *
+   * <p>Only available when {@link IncrementalDataPlanePlugin#DEBUG_FLAG_RETAIN_ANNOTATED_RIBS} is
+   * set, since retaining them keeps every VRF's pre-finalization RIB -- prefix trie, annotations
+   * and backup routes -- alive for as long as the dataplane is, on top of the {@link FinalMainRib}s
+   * that supersede them. Use {@link #getRibs()} unless the annotations are the thing under test.
+   */
   @VisibleForTesting
   public @Nonnull SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
       getRibsForTesting() {
+    checkState(
+        _annotatedRibs != null,
+        "Annotated RIBs were not retained; set the %s debug flag",
+        IncrementalDataPlanePlugin.DEBUG_FLAG_RETAIN_ANNOTATED_RIBS);
     return _annotatedRibs;
   }
 
@@ -114,6 +127,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
 
     private @Nullable Map<String, Node> _nodes;
     private @Nullable PartialDataplane _partialDataplane;
+    private boolean _retainAnnotatedRibs;
 
     public Builder setNodes(@Nonnull Map<String, Node> nodes) {
       _nodes = ImmutableMap.copyOf(nodes);
@@ -122,6 +136,12 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
 
     public Builder setPartialDataplane(PartialDataplane partialDataplane) {
       _partialDataplane = partialDataplane;
+      return this;
+    }
+
+    /** See {@link IncrementalDataPlane#getRibsForTesting}. */
+    public Builder setRetainAnnotatedRibs(boolean retainAnnotatedRibs) {
+      _retainAnnotatedRibs = retainAnnotatedRibs;
       return this;
     }
 
@@ -148,7 +168,8 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   private final @Nonnull Table<String, String, Set<Layer2Vni>> _layer2VniSettings;
   private final @Nonnull Table<String, String, Set<Layer3Vni>> _layer3VniSettings;
 
-  private final @Nonnull SortedMap<
+  /** Null unless retention was requested; see {@link #getRibsForTesting}. */
+  private final @Nullable SortedMap<
           String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
       _annotatedRibs;
 
@@ -183,8 +204,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     _layer2VniSettings = DataplaneUtil.computeLayer2VniSettings(nodes);
     _layer3VniSettings = DataplaneUtil.computeLayer3VniSettings(nodes);
 
-    // For testing only
-    _annotatedRibs = computeAnnotatedRibs(nodes);
+    _annotatedRibs = builder._retainAnnotatedRibs ? computeAnnotatedRibs(nodes) : null;
   }
 
   private static @Nonnull SortedMap<

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -22,6 +22,12 @@ public final class IncrementalDataPlanePlugin extends DataPlanePlugin {
 
   public static final String PLUGIN_NAME = "ibdp";
 
+  /**
+   * Debug flag requesting that the main RIBs be kept with their route annotations, for tests that
+   * assert on annotations. See {@link IncrementalDataPlane#getRibsForTesting}.
+   */
+  public static final String DEBUG_FLAG_RETAIN_ANNOTATED_RIBS = "retainAnnotatedRibs";
+
   private IncrementalBdpEngine _engine;
 
   public IncrementalDataPlanePlugin() {}
@@ -52,7 +58,8 @@ public final class IncrementalDataPlanePlugin extends DataPlanePlugin {
             configurations,
             topologyContext,
             externalAdverts,
-            topologyProvider.getInitialIpOwners(snapshot));
+            topologyProvider.getInitialIpOwners(snapshot),
+            _batfish.debugFlagEnabled(DEBUG_FLAG_RETAIN_ANNOTATED_RIBS));
     _logger.infof(
         "Generated data-plane for snapshot:%s; iterations:%s",
         snapshot.getSnapshot(),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalBdpEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalBdpEngineTest.java
@@ -550,11 +550,9 @@ public final class IncrementalBdpEngineTest {
 
     // r1 should have the kernel route, but r2 should not.
     assertThat(
-        dp.getRibsForTesting().get("r1").get(DEFAULT_VRF_NAME).getRoutes(kernelRoutePrefix),
-        contains(new AnnotatedRoute<>(kernelRoute, DEFAULT_VRF_NAME)));
-    assertThat(
-        dp.getRibsForTesting().get("r2").get(DEFAULT_VRF_NAME).getRoutes(kernelRoutePrefix),
-        empty());
+        dp.getRibs().get("r1", DEFAULT_VRF_NAME).getRoutes(kernelRoutePrefix),
+        contains(kernelRoute));
+    assertThat(dp.getRibs().get("r2", DEFAULT_VRF_NAME).getRoutes(kernelRoutePrefix), empty());
   }
 
   // ---- updateVxlanAutostate tests ----

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -11,6 +11,7 @@ import static org.batfish.common.util.Resources.readResourceBytes;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -94,6 +95,7 @@ public class BatfishTestUtils {
       SortedMap<String, Configuration> configurations, @Nonnull TemporaryFolder tempFolder)
       throws IOException {
     Settings settings = new Settings(new String[] {});
+    retainAnnotatedRibs(settings);
     settings.setLogger(new BatfishLogger("debug", false));
     final Cache<NetworkSnapshot, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
 
@@ -125,6 +127,7 @@ public class BatfishTestUtils {
       @Nonnull TemporaryFolder tempFolder)
       throws IOException {
     Settings settings = new Settings(new String[] {});
+    retainAnnotatedRibs(settings);
     settings.setLogger(new BatfishLogger("debug", false));
     final Cache<NetworkSnapshot, SortedMap<String, Configuration>> testrigs = makeTestrigCache();
 
@@ -161,8 +164,22 @@ public class BatfishTestUtils {
     ibdpPlugin.initialize(batfish);
   }
 
+  /**
+   * Retain the annotated main RIBs, which production does not: a handful of tests assert on route
+   * annotations, and {@code IncrementalDataPlane#getRibsForTesting} is only populated when this is
+   * set.
+   */
+  private static void retainAnnotatedRibs(Settings settings) {
+    settings.setDebugFlags(
+        ImmutableList.<String>builder()
+            .addAll(settings.getDebugFlags())
+            .add(IncrementalDataPlanePlugin.DEBUG_FLAG_RETAIN_ANNOTATED_RIBS)
+            .build());
+  }
+
   /** Configure common Batfish settings for tests (e.g. disable recovery, debug level logging) */
   public static void configureBatfishTestSettings(Settings settings) {
+    retainAnnotatedRibs(settings);
     settings.setLogger(new BatfishLogger("debug", false));
     settings.setDisableUnrecognized(true);
     settings.setHaltOnConvertError(true);
@@ -210,6 +227,7 @@ public class BatfishTestUtils {
     ConversionContext conversionContext = testrigText.getConversionContext();
 
     Settings settings = new Settings(new String[] {});
+    retainAnnotatedRibs(settings);
     configureBatfishTestSettings(settings);
     settings.setStorageBase(tempFolder);
     setNextTestNetworkSnapshot(settings);
@@ -316,6 +334,7 @@ public class BatfishTestUtils {
   public static Batfish getBatfish(
       @Nonnull StorageProvider storageProvider, @Nonnull IdResolver idResolver) {
     Settings settings = new Settings(new String[] {});
+    retainAnnotatedRibs(settings);
     settings.setLogger(new BatfishLogger("debug", false));
     setNextTestNetworkSnapshot(settings);
     Batfish batfish =


### PR DESCRIPTION
IncrementalDataPlane always kept every VRF's pre-finalization main RIB,
whose only readers are tests. Because the dataplane outlives the
computation, that pinned each RIB's prefix trie, route annotations and
backup routes for as long as the dataplane was held, alongside the
FinalMainRibs that supersede them. On a snapshot with ~25M main RIB
routes it was 6.4 GiB of retained heap; peak is unaffected, since the
RIBs are live during convergence either way.

Populate the field only when the retainAnnotatedRibs debug flag is set,
which BatfishTestUtils now does for tests, and have getRibsForTesting
fail with that flag's name rather than returning nothing. Tests that
assert on route annotations keep working; those that only wanted routes
read getRibs() instead, as most already did.

----

Prompt:
```
Land the _annotatedRibs change, using a flag that tests set rather than
retaining the RIBs in production.
```
