### PR TITLE
ForwardingAnalysis: gather unowned ARP IPs in parallel, free the BDDs

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -401,19 +401,32 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
 
   private static Set<Ip> computeUnownedArpIps(
       Map<String, Map<String, Fib>> fibs, IpSpaceToBDD ipSpaceToBDD, BDD unownedIpsBDD) {
-    return fibs.values().stream()
-        .map(Map::values)
-        .flatMap(Collection::stream)
-        .map(Fib::allEntries)
-        .flatMap(Collection::stream)
-        .map(FibEntry::getAction)
-        .filter(FibForward.class::isInstance)
-        .map(fibAction -> ((FibForward) fibAction).getArpIp())
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .distinct()
-        .filter(arpIp -> ipSpaceToBDD.toBDD(arpIp).andSat(unownedIpsBDD))
-        .collect(ImmutableSet.toImmutableSet());
+    // Collect the distinct ARP IPs in parallel, then test them against the BDD sequentially, since
+    // BDDFactory is not thread safe.
+    //
+    // Worth splitting because the two halves have very different shapes: the first walks every FIB
+    // entry in the snapshot, which is tens of millions of them on a large one, while the set it
+    // produces stays in the thousands. Done as a single sequential stream this was one of the few
+    // parts of dataplane computation that used one core, and it runs once per topology iteration.
+    Set<Ip> arpIps =
+        fibs.values().parallelStream()
+            .flatMap(fibsByVrf -> fibsByVrf.values().stream())
+            .flatMap(fib -> fib.allEntries().stream())
+            .map(FibEntry::getAction)
+            .filter(FibForward.class::isInstance)
+            .map(fibAction -> ((FibForward) fibAction).getArpIp())
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toSet());
+    ImmutableSet.Builder<Ip> unownedArpIps = ImmutableSet.builder();
+    for (Ip arpIp : arpIps) {
+      BDD arpIpBdd = ipSpaceToBDD.toBDD(arpIp);
+      if (arpIpBdd.andSat(unownedIpsBDD)) {
+        unownedArpIps.add(arpIp);
+      }
+      arpIpBdd.free();
+    }
+    return unownedArpIps.build();
   }
 
   /**


### PR DESCRIPTION
computeUnownedArpIps walked every FIB entry in the snapshot through a
sequential stream to build a set that stays in the thousands. On a large
snapshot that was one of the few single-threaded stretches of dataplane
computation, and it runs once per topology iteration: 38.1s over 4
calls, down to 2.2s.

Collect the ARP IPs in parallel, then test them against the BDD
sequentially, since BDDFactory is not thread safe. Also free each BDD
from IpSpaceToBDD#toBDD, which hands back a copy the caller owns, rather
than leaking one per ARP IP per iteration.

----

Prompt:
```
Draft the ARP-IP change (parallelizing
ForwardingAnalysisImpl.computeUnownedArpIps).
```

Follow-up: also free the BDD returned by toBDD.
