### PR TITLE
Fib: answer matching IPs per prefix instead of materializing a map

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/IpsRoutedOutInterfacesFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/IpsRoutedOutInterfacesFactory.java
@@ -18,7 +18,6 @@ import org.batfish.datamodel.FibForward;
 import org.batfish.datamodel.FibNextVrf;
 import org.batfish.datamodel.FibNullRoute;
 import org.batfish.datamodel.IpSpace;
-import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.visitors.FibActionVisitor;
 
 /**
@@ -82,14 +81,13 @@ public final class IpsRoutedOutInterfacesFactory {
 
   @VisibleForTesting
   static Map<String, IpSpace> computeIpsRoutedOutInterfacesMap(Fib fib) {
-    Map<Prefix, IpSpace> matchingIps = fib.getMatchingIps();
     return fib.allEntries().stream()
         .filter(fibEntry -> fibEntry.getAction().accept(ResolvedInterface.INSTANCE).isPresent())
         .collect(
             groupingBy(
                 fibEntry -> fibEntry.getAction().accept(ResolvedInterface.INSTANCE).get(),
                 mapping(
-                    fibEntry -> matchingIps.get(fibEntry.getTopLevelRoute().getNetwork()),
+                    fibEntry -> fib.matchingIps(fibEntry.getTopLevelRoute().getNetwork()),
                     collectingAndThen(
                         Collectors.toList(),
                         ipSpaces ->

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/IpsRoutedOutInterfacesFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/IpsRoutedOutInterfacesFactoryTest.java
@@ -72,7 +72,7 @@ public class IpsRoutedOutInterfacesFactoryTest {
           ImmutableMap.of(), IpsRoutedOutInterfacesFactory.computeIpsRoutedOutInterfacesMap(fib));
     }
 
-    // single fib entry with missing matching Ips
+    // single fib entry whose matching Ips are empty
     {
       Fib fib =
           MockFib.builder()
@@ -81,6 +81,7 @@ public class IpsRoutedOutInterfacesFactoryTest {
                       Ip.ZERO,
                       ImmutableSet.of(
                           new FibEntry(FibForward.of(Ip.ZERO, iface1), ImmutableList.of(route1)))))
+              .setMatchingIps(ImmutableMap.of(prefix1, EmptyIpSpace.INSTANCE))
               .build();
       Map<String, IpSpace> map =
           IpsRoutedOutInterfacesFactory.computeIpsRoutedOutInterfacesMap(fib);

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/PacketPolicyToBddTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/PacketPolicyToBddTest.java
@@ -45,6 +45,7 @@ import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.common.bdd.PrimedBDDInteger;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.FibEntry;
@@ -406,7 +407,7 @@ public final class PacketPolicyToBddTest {
       assertTrue(toBdd.visit(expr).isZero());
     }
 
-    // single fib entry with missing matching Ips
+    // single fib entry whose matching Ips are empty
     {
       Fib fib =
           MockFib.builder()
@@ -415,6 +416,7 @@ public final class PacketPolicyToBddTest {
                       Ip.ZERO,
                       ImmutableSet.of(
                           new FibEntry(FibForward.of(Ip.ZERO, iface1), ImmutableList.of(route1)))))
+              .setMatchingIps(ImmutableMap.of(prefix1, EmptyIpSpace.INSTANCE))
               .build();
       IpsRoutedOutInterfaces ipsRoutedOutInterfaces = new IpsRoutedOutInterfaces(fib);
       BoolExprToBdd toBdd = new BoolExprToBdd(_ipAccessListToBdd, ipsRoutedOutInterfaces);

--- a/projects/common/src/main/java/org/batfish/datamodel/Fib.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Fib.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel;
 
 import java.io.Serializable;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -18,9 +17,11 @@ public interface Fib extends Serializable {
   Set<FibEntry> allEntries();
 
   /**
-   * Returns a mapping from prefixes of forwarding routes in the RIB to the IPs for which that
-   * prefix is the longest match in the RIB (among prefixes of forwarding routes).
+   * Returns the IPs for which {@code prefix} is the longest match in the RIB, among prefixes of
+   * forwarding routes.
+   *
+   * <p>{@code prefix} must be the network of a forwarding route in this FIB.
    */
   @Nonnull
-  Map<Prefix, IpSpace> getMatchingIps();
+  IpSpace matchingIps(Prefix prefix);
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -93,6 +93,12 @@ public final class FibImpl implements Fib {
 
   private transient Supplier<Set<FibEntry>> _entries;
 
+  /**
+   * Matching IPs for the forwarding prefixes that have a more specific forwarding prefix beneath
+   * them. See {@link #matchingIps}.
+   */
+  private transient Supplier<Map<Prefix, IpSpace>> _nonTrivialMatchingIps;
+
   public <R extends AbstractRouteDecorator> FibImpl(
       GenericRib<R> rib, ResolutionRestriction<R> restriction) {
     this(rib, restriction, r -> true);
@@ -117,6 +123,7 @@ public final class FibImpl implements Fib {
 
   private void initSuppliers() {
     _entries = Suppliers.memoize(this::computeEntries);
+    _nonTrivialMatchingIps = Suppliers.memoize(this::computeNonTrivialMatchingIps);
   }
 
   private Set<FibEntry> computeEntries() {
@@ -311,7 +318,15 @@ public final class FibImpl implements Fib {
   }
 
   @Override
-  public @Nonnull Map<Prefix, IpSpace> getMatchingIps() {
+  public @Nonnull IpSpace matchingIps(Prefix prefix) {
+    assert !_root.get(prefix).isEmpty() : prefix + " is not a forwarding prefix in this FIB";
+    IpSpace nonTrivial = _nonTrivialMatchingIps.get().get(prefix);
+    // With nothing more specific beneath it, a prefix is the longest match for exactly the IPs it
+    // contains, so the answer is recoverable from the key and is not stored.
+    return nonTrivial != null ? nonTrivial : prefix.toIpSpace();
+  }
+
+  private @Nonnull Map<Prefix, IpSpace> computeNonTrivialMatchingIps() {
     ImmutableMap.Builder<Prefix, IpSpace> builder = ImmutableMap.builder();
 
     /* Do a fold over the trie. At each node, create the matching Ips for that prefix (adding it
@@ -351,10 +366,10 @@ public final class FibImpl implements Fib {
 
             IpWildcard wc = IpWildcard.create(prefix);
 
-            if (subTriePrefixes.isEmpty()) {
-              builder.put(prefix, prefix.toIpSpace());
-            } else {
-              // Ips matching prefix are those in prefix and not in any subtrie prefixes.
+            if (!subTriePrefixes.isEmpty()) {
+              // Ips matching prefix are those in prefix and not in any subtrie prefixes. With no
+              // subtrie prefix they are just the IPs in prefix, which matchingIps recovers from the
+              // prefix rather than storing.
               builder.put(
                   prefix, IpWildcardSetIpSpace.create(subTriePrefixes, ImmutableSet.of(wc)));
             }

--- a/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -93,9 +93,6 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
     Set<Ip> unownedArpIps = computeUnownedArpIps(fibs, ipSpaceToBDD, unownedIpsBDD);
 
     LOGGER.info("Aggregating information about routing entries");
-    // IpSpaces matched by each prefix
-    // -- only will have entries for active interfaces if FIB is correct
-    Map<String, Map<String, Map<Prefix, IpSpace>>> matchingIps = computeMatchingIps(fibs, allVrfs);
     // Set of routes that forward out each interface
     Map<String, Map<String, Map<String, Set<AbstractRoute>>>> routesWithNextHop =
         computeRoutesWithNextHop(fibs, allVrfs);
@@ -110,7 +107,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
       // interface. Should only include active interfaces.
       LOGGER.info("Computing IPs routed out interfaces");
       Map<String, Map<String, Map<String, IpSpace>>> ipsRoutedOutInterfaces =
-          computeIpsRoutedOutInterfaces(matchingIps, routesWithNextHop, allVrfs);
+          computeIpsRoutedOutInterfaces(fibs, routesWithNextHop, allVrfs);
       LOGGER.info("Computing ARP replies");
       _arpReplies =
           computeArpReplies(configurations, ipsRoutedOutInterfaces, interfaceOwnedIps, routableIps);
@@ -150,7 +147,6 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                               ipOwners,
                               fibs.get(node).get(vrf),
                               unownedArpIps,
-                              matchingIps.get(node).get(vrf),
                               ownedIps,
                               interfacesWithMissingDevices,
                               internalIps,
@@ -184,7 +180,6 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
       IpOwners ipOwners,
       Fib fib,
       Set<Ip> unownedArpIps,
-      Map<Prefix, IpSpace> matchingIps,
       IpSpace ownedIps,
       Multimap<String, String> interfacesWithMissingDevices,
       IpSpace internalIps,
@@ -225,7 +220,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
      * due to route leaking, etc
      */
     Map<Edge, IpSpace> arpTrueEdgeDestIp =
-        computeArpTrueEdgeDestIp(matchingIps, routesWithDestIpEdge, _arpReplies);
+        computeArpTrueEdgeDestIp(fib, routesWithDestIpEdge, _arpReplies);
 
     /* edge -> routes for which an arp true response will be received when they are the lpm of
      * the dest IP
@@ -244,7 +239,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
      * due to route leaking, etc
      */
     Map<Edge, IpSpace> arpTrueEdgeNextHopIp =
-        computeArpTrueEdgeNextHopIp(matchingIps, routesWithNextHopIpArpTrue);
+        computeArpTrueEdgeNextHopIp(fib, routesWithNextHopIpArpTrue);
 
     Map<Edge, IpSpace> arpTrueEdge = computeArpTrueEdge(arpTrueEdgeDestIp, arpTrueEdgeNextHopIp);
 
@@ -275,13 +270,12 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                * for the dst ip itself with no reply
                */
               IpSpace arpFalseDestIp =
-                  computeArpFalseDestIp(
-                      matchingIps, routesWhereDstIpCanBeArpIp.get(iface), someoneReplies);
+                  computeArpFalseDestIp(fib, routesWhereDstIpCanBeArpIp.get(iface), someoneReplies);
 
               /* dst ips for which this vrf forwards out that interface,
                * ARPing for a next-hop IP and receiving no reply
                */
-              IpSpace arpFalseNextHopIp = computeArpFalseNextHopIp(matchingIps, arpFalseNhipRoutes);
+              IpSpace arpFalseNextHopIp = computeArpFalseNextHopIp(fib, arpFalseNhipRoutes);
 
               IpSpace arpFalse = AclIpSpace.union(arpFalseDestIp, arpFalseNextHopIp);
 
@@ -301,13 +295,13 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                * for some unowned next-hop IP with no reply
                */
               IpSpace dstIpsWithUnownedNextHopIpArpFalse =
-                  computeRouteMatchConditions(arpFalseNhipRoutesWithUnownedArpIp, matchingIps);
+                  computeRouteMatchConditions(arpFalseNhipRoutesWithUnownedArpIp, fib);
 
               /* dst IPs for which that VRF forwards out that interface, ARPing
                * for some owned next-hop IP with no reply.
                */
               IpSpace dstIpsWithOwnedNextHopIpArpFalse =
-                  computeRouteMatchConditions(arpFalseNhipRoutesWithOwnedArpIp, matchingIps);
+                  computeRouteMatchConditions(arpFalseNhipRoutesWithOwnedArpIp, fib);
 
               IpSpace deliveredToSubnet =
                   computeDeliveredToSubnet(arpFalseDestIp, externalArpIps, ownedIps);
@@ -349,10 +343,10 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
             });
 
     // destination IPs that will be null routes
-    IpSpace nullRoutedIps = computeNullRoutedIps(matchingIps, fib);
+    IpSpace nullRoutedIps = computeNullRoutedIps(fib);
 
     // nextVrf -> dest IPs that vrf delegates to nextVrf
-    Map<String, IpSpace> nextVrfIps = computeNextVrfIps(matchingIps, fib);
+    Map<String, IpSpace> nextVrfIps = computeNextVrfIps(fib);
 
     return VrfForwardingBehavior.builder()
         .setArpTrueEdge(arpTrueEdge)
@@ -537,7 +531,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
 
   @VisibleForTesting
   static Map<Edge, IpSpace> computeArpTrueEdgeDestIp(
-      Map<Prefix, IpSpace> matchingIps,
+      Fib fib,
       Map<Edge, Set<AbstractRoute>> routesWithDestIpEdge,
       Map<String, Map<String, IpSpace>> arpReplies) {
     return toImmutableMap(
@@ -546,7 +540,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
         edgeEntry -> {
           Edge edge = edgeEntry.getKey();
           Set<AbstractRoute> routes = edgeEntry.getValue();
-          IpSpace dstIpMatchesSomeRoutePrefix = computeRouteMatchConditions(routes, matchingIps);
+          IpSpace dstIpMatchesSomeRoutePrefix = computeRouteMatchConditions(routes, fib);
           String recvNode = edge.getNode2();
           String recvInterface = edge.getInt2();
           IpSpace recvReplies = arpReplies.get(recvNode).get(recvInterface);
@@ -558,11 +552,11 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
 
   @VisibleForTesting
   static Map<Edge, IpSpace> computeArpTrueEdgeNextHopIp(
-      Map<Prefix, IpSpace> matchingIps, Map<Edge, Set<AbstractRoute>> routesWithNextHopIpArpTrue) {
+      Fib fib, Map<Edge, Set<AbstractRoute>> routesWithNextHopIpArpTrue) {
     return toImmutableMap(
         routesWithNextHopIpArpTrue,
         Entry::getKey, // edge
-        edgeEntry -> computeRouteMatchConditions(edgeEntry.getValue(), matchingIps));
+        edgeEntry -> computeRouteMatchConditions(edgeEntry.getValue(), fib));
   }
 
   @VisibleForTesting
@@ -641,7 +635,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
 
   @VisibleForTesting
   static Map<String, Map<String, Map<String, IpSpace>>> computeIpsRoutedOutInterfaces(
-      Map<String, Map<String, Map<Prefix, IpSpace>>> matchingIps,
+      Map<String, Map<String, Fib>> fibs,
       Map<String, Map<String, Map<String, Set<AbstractRoute>>>> routesWithNextHop,
       List<Map.Entry<String, String>> allVrfs) {
     return allVrfs.parallelStream()
@@ -652,7 +646,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                 e -> {
                   String hostname = e.getKey();
                   String vrf = e.getValue();
-                  Map<Prefix, IpSpace> vrfMatchingIps = matchingIps.get(hostname).get(vrf);
+                  Fib vrfFib = fibs.get(hostname).get(vrf);
                   return (Map<String, IpSpace>)
                       routesWithNextHop.get(hostname).get(vrf).entrySet().stream()
                           /*
@@ -667,7 +661,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                                 String iface = ifaceEntry.getKey();
                                 Set<AbstractRoute> routes = ifaceEntry.getValue();
                                 return Maps.immutableEntry(
-                                    iface, computeRouteMatchConditions(routes, vrfMatchingIps));
+                                    iface, computeRouteMatchConditions(routes, vrfFib));
                               })
                           .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
                 }))
@@ -676,36 +670,28 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
 
   @VisibleForTesting
   static IpSpace computeArpFalseDestIp(
-      Map<Prefix, IpSpace> matchingIps,
-      Set<AbstractRoute> routesWhereDstIpCanBeArpIp,
-      IpSpace someoneReplies) {
-    IpSpace ipsRoutedOutInterface =
-        computeRouteMatchConditions(routesWhereDstIpCanBeArpIp, matchingIps);
+      Fib fib, Set<AbstractRoute> routesWhereDstIpCanBeArpIp, IpSpace someoneReplies) {
+    IpSpace ipsRoutedOutInterface = computeRouteMatchConditions(routesWhereDstIpCanBeArpIp, fib);
     return AclIpSpace.rejecting(someoneReplies).thenPermitting(ipsRoutedOutInterface).build();
   }
 
   @VisibleForTesting
-  static IpSpace computeArpFalseNextHopIp(
-      Map<Prefix, IpSpace> matchingIps, Set<AbstractRoute> routesWithNextHopIpArpFalse) {
-    return computeRouteMatchConditions(routesWithNextHopIpArpFalse, matchingIps);
+  static IpSpace computeArpFalseNextHopIp(Fib fib, Set<AbstractRoute> routesWithNextHopIpArpFalse) {
+    return computeRouteMatchConditions(routesWithNextHopIpArpFalse, fib);
   }
 
   @VisibleForTesting
-  static IpSpace computeNullRoutedIps(Map<Prefix, IpSpace> matchingIps, Fib fib) {
+  static IpSpace computeNullRoutedIps(Fib fib) {
     Set<AbstractRoute> nullRoutes =
         fib.allEntries().stream()
             .filter(fibEntry -> fibEntry.getAction() instanceof FibNullRoute)
             .map(FibEntry::getTopLevelRoute)
             .collect(ImmutableSet.toImmutableSet());
-    return computeRouteMatchConditions(nullRoutes, matchingIps);
+    return computeRouteMatchConditions(nullRoutes, fib);
   }
 
   @VisibleForTesting
-  static Map<String, IpSpace> computeNextVrfIps(Map<Prefix, IpSpace> matchingIps, Fib fib) {
-    return computeNextVrfIps(fib, matchingIps);
-  }
-
-  private static Map<String, IpSpace> computeNextVrfIps(Fib fib, Map<Prefix, IpSpace> matchingIps) {
+  static Map<String, IpSpace> computeNextVrfIps(Fib fib) {
     return fib.allEntries().stream()
         .filter(fibEntry -> fibEntry.getAction() instanceof FibNextVrf)
         .collect(
@@ -719,7 +705,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                 Entry::getKey /* nextVrf */,
                 routesByNextVrfEntry ->
                     computeRouteMatchConditions(
-                        routesByNextVrfEntry.getValue() /* routes */, matchingIps)));
+                        routesByNextVrfEntry.getValue() /* routes */, fib)));
   }
 
   @VisibleForTesting
@@ -771,20 +757,8 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
         .rowMap();
   }
 
-  static Map<String, Map<String, Map<Prefix, IpSpace>>> computeMatchingIps(
-      Map<String, Map<String, Fib>> fibs, List<Entry<String, String>> allVrfs) {
-    return allVrfs.parallelStream()
-        .collect(
-            ImmutableTable.toImmutableTable(
-                Entry::getKey,
-                Entry::getValue,
-                e -> fibs.get(e.getKey()).get(e.getValue()).getMatchingIps()))
-        .rowMap();
-  }
-
   @VisibleForTesting
-  static IpSpace computeRouteMatchConditions(
-      Collection<AbstractRoute> routes, Map<Prefix, IpSpace> matchingIps) {
+  static IpSpace computeRouteMatchConditions(Collection<AbstractRoute> routes, Fib fib) {
     // get the union of IpSpace that match one of the routes
     // get the union of IpSpace that match one of the routes
     return firstNonNull(
@@ -792,7 +766,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
             routes.stream()
                 .map(AbstractRoute::getNetwork)
                 .distinct()
-                .map(matchingIps::get)
+                .map(fib::matchingIps)
                 .toArray(IpSpace[]::new)),
         EmptyIpSpace.INSTANCE);
   }

--- a/projects/common/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -85,11 +85,6 @@ public class ForwardingAnalysisImplTest {
 
   private Vrf.Builder _vb;
 
-  private static Map<String, Map<String, Map<Prefix, IpSpace>>> computeMatchingIps(
-      Map<String, Map<String, Fib>> fibs) {
-    return ForwardingAnalysisImpl.computeMatchingIps(fibs, ForwardingAnalysisImpl.sparseKeys(fibs));
-  }
-
   @Before
   public void setup() {
     NetworkFactory nf = new NetworkFactory();
@@ -410,9 +405,7 @@ public class ForwardingAnalysisImplTest {
                     .build()));
     Map<Edge, IpSpace> result =
         computeArpTrueEdgeDestIp(
-            computeMatchingIps(fibs).get(c1.getHostname()).get(vrf1.getName()),
-            routesWithDestIpEdge,
-            arpReplies);
+            fibs.get(c1.getHostname()).get(vrf1.getName()), routesWithDestIpEdge, arpReplies);
 
     /* Respond to request for IP on i2. */
     assertThat(result, hasEntry(equalTo(edge), containsIp(i2Ip)));
@@ -464,8 +457,7 @@ public class ForwardingAnalysisImplTest {
                     .build()));
     Map<Edge, IpSpace> result =
         computeArpTrueEdgeNextHopIp(
-            computeMatchingIps(fibs).get(c1.getHostname()).get(vrf1.getName()),
-            routesWithNextHopIpArpTrue);
+            fibs.get(c1.getHostname()).get(vrf1.getName()), routesWithNextHopIpArpTrue);
 
     /*
      * Respond for any destination IP in network not matching more specific route not going out i1.
@@ -613,8 +605,7 @@ public class ForwardingAnalysisImplTest {
                     ImmutableSet.of(nullRoute))));
     List<Entry<String, String>> allVrfs = sparseKeys(fibs);
     Map<String, Map<String, Map<String, IpSpace>>> result =
-        computeIpsRoutedOutInterfaces(
-            ForwardingAnalysisImpl.computeMatchingIps(fibs, allVrfs), routesWithNextHop, allVrfs);
+        computeIpsRoutedOutInterfaces(fibs, routesWithNextHop, allVrfs);
 
     /* Should contain IPs matching the route */
     assertThat(
@@ -680,8 +671,7 @@ public class ForwardingAnalysisImplTest {
     Set<AbstractRoute> routesWhereDstIpCanBeArpIp = ImmutableSet.of(ifaceRoute);
     IpSpace someoneReplies = P1.getEndIp().toIpSpace();
     IpSpace result =
-        computeArpFalseDestIp(
-            computeMatchingIps(fibs).get(c1).get(v1), routesWhereDstIpCanBeArpIp, someoneReplies);
+        computeArpFalseDestIp(fibs.get(c1).get(v1), routesWhereDstIpCanBeArpIp, someoneReplies);
 
     /* Should contain IP in the route's prefix that sees no reply */
     assertThat(result, containsIp(P1.getStartIp()));
@@ -705,8 +695,7 @@ public class ForwardingAnalysisImplTest {
     Set<AbstractRoute> routesWhereDstIpCanBeArpIp = ImmutableSet.of(ifaceRoute);
     IpSpace someoneReplies = EmptyIpSpace.INSTANCE;
     IpSpace result =
-        computeArpFalseDestIp(
-            computeMatchingIps(fibs).get(c1).get(v1), routesWhereDstIpCanBeArpIp, someoneReplies);
+        computeArpFalseDestIp(fibs.get(c1).get(v1), routesWhereDstIpCanBeArpIp, someoneReplies);
 
     /*
      * Since _someoneReplies is empty, all IPs for which longest-prefix-match route has no
@@ -736,9 +725,7 @@ public class ForwardingAnalysisImplTest {
             ImmutableMap.of(
                 v1, MockFib.builder().setMatchingIps(ImmutableMap.of(P1, P1.toIpSpace())).build()));
 
-    IpSpace result =
-        computeArpFalseNextHopIp(
-            computeMatchingIps(fibs).get(c1).get(v1), routesWithNextHopIpArpFalse);
+    IpSpace result = computeArpFalseNextHopIp(fibs.get(c1).get(v1), routesWithNextHopIpArpFalse);
 
     /* IPs matching some route on interface with no response should appear */
     assertThat(result, containsIp(P1.getStartIp()));
@@ -792,13 +779,10 @@ public class ForwardingAnalysisImplTest {
                     .build()));
 
     // Each VRF should delegate the matching IpSpace for its nextVrf route to the other VRF.
-    Map<String, Map<Prefix, IpSpace>> matchingIps = computeMatchingIps(fibs).get(c1);
     assertThat(
-        computeNextVrfIps(matchingIps.get(v1), fibs.get(c1).get(v1)),
-        equalTo(ImmutableMap.of(v2, P1_1.toIpSpace())));
+        computeNextVrfIps(fibs.get(c1).get(v1)), equalTo(ImmutableMap.of(v2, P1_1.toIpSpace())));
     assertThat(
-        computeNextVrfIps(matchingIps.get(v2), fibs.get(c1).get(v2)),
-        equalTo(ImmutableMap.of(v1, P2_2.toIpSpace())));
+        computeNextVrfIps(fibs.get(c1).get(v2)), equalTo(ImmutableMap.of(v1, P2_2.toIpSpace())));
   }
 
   @Test
@@ -834,8 +818,7 @@ public class ForwardingAnalysisImplTest {
                                     FibForward.of(null, otherRoute.getNextHopInterface()),
                                     ImmutableList.of(otherRoute)))))
                     .build()));
-    IpSpace result =
-        computeNullRoutedIps(computeMatchingIps(fibs).get(c1).get(v1), fibs.get(c1).get(v1));
+    IpSpace result = computeNullRoutedIps(fibs.get(c1).get(v1));
 
     /* IPs for the null route should appear */
     assertThat(result, containsIp(P1.getStartIp()));
@@ -929,11 +912,11 @@ public class ForwardingAnalysisImplTest {
   public void testComputeRouteMatchConditions() {
     Set<AbstractRoute> routes =
         ImmutableSet.of(new ConnectedRoute(P1, INTERFACE1), new ConnectedRoute(P2, INTERFACE2));
-    Map<Prefix, IpSpace> matchingIps = ImmutableMap.of(P1, IPSPACE1, P2, IPSPACE2);
+    Fib fib = MockFib.builder().setMatchingIps(ImmutableMap.of(P1, IPSPACE1, P2, IPSPACE2)).build();
 
     /* Resulting IP space should permit matching IPs */
     assertThat(
-        ForwardingAnalysisImpl.computeRouteMatchConditions(routes, matchingIps),
+        ForwardingAnalysisImpl.computeRouteMatchConditions(routes, fib),
         isAclIpSpaceThat(
             hasLines(
                 containsInAnyOrder(

--- a/projects/common/src/test/java/org/batfish/datamodel/MockFib.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/MockFib.java
@@ -61,7 +61,10 @@ public class MockFib implements Fib {
   }
 
   @Override
-  public @Nonnull Map<Prefix, IpSpace> getMatchingIps() {
-    return _matchingIps;
+  public @Nonnull IpSpace matchingIps(Prefix prefix) {
+    // Mirror FibImpl: a prefix with nothing more specific beneath it matches exactly its own IPs,
+    // so tests only need to set the prefixes whose matching IPs are not the prefix itself.
+    IpSpace matchingIps = _matchingIps.get(prefix);
+    return matchingIps != null ? matchingIps : prefix.toIpSpace();
   }
 }


### PR DESCRIPTION
Replace Fib.getMatchingIps() with Fib.matchingIps(Prefix), and store
only the forwarding prefixes that have a more specific forwarding prefix
beneath them. Every other prefix is the longest match for exactly the
IPs it contains, so its matching IPs come from the key. In one region
that was 27,695,281 of 27,891,892 forwarding prefixes.

----

Prompt:
```
Every stack I sampled dies in the same place — ForwardingAnalysisImpl.computeMatchingIps → FibImpl.getMatchingIps, i.e. forwarding-analysis during dataplane computation.

Is there something we can do ther?
```

