### PR TITLE
feat(fastpath): add password-policy parsing and extraction

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathLexer.g4
@@ -16,6 +16,8 @@ AAA: 'aaa';
 
 ACCOUNTING: 'accounting';
 
+AGING: 'aging';
+
 ALERT: 'alert';
 
 AUTHENTICATION: 'authentication';
@@ -27,6 +29,8 @@ BGP: 'bgp';
 BROADCAST: 'broadcast';
 
 BUFFERED: 'buffered';
+
+CHARACTER_CLASSES: 'character-classes';
 
 CLI_COMMAND: 'cli-command';
 
@@ -41,6 +45,8 @@ COMMANDS
     }
   }
 ;
+
+CONSECUTIVE_CHARACTERS: 'consecutive-characters';
 
 CONSOLE: 'console';
 
@@ -85,6 +91,8 @@ ENCRYPTED: 'encrypted';
 
 ERROR: 'error';
 
+EXCLUDE_KEYWORD: 'exclude-keyword' -> pushMode ( M_Word );
+
 EXEC
 :
   'exec'
@@ -98,6 +106,8 @@ EXEC
 EXECUTE: 'execute';
 
 EXIT: 'exit';
+
+HISTORY: 'history';
 
 HOST
 :
@@ -143,6 +153,8 @@ LIST: 'list';
 
 LOCAL: 'local';
 
+LOCK_OUT: 'lock-out';
+
 LOGGING: 'logging';
 
 LOGIN
@@ -158,6 +170,14 @@ LOGIN
 LOOKUP: 'lookup';
 
 LOOPBACK: 'loopback';
+
+LOWERCASE_LETTERS: 'lowercase-letters';
+
+MAXIMUM: 'maximum';
+
+MIN_LENGTH: 'min-length';
+
+MINIMUM: 'minimum';
 
 MODE: 'mode';
 
@@ -181,6 +201,8 @@ NOPASSWORD: 'nopassword';
 
 NOTICE: 'notice';
 
+NUMERIC_CHARACTERS: 'numeric-characters';
+
 OSPF: 'ospf';
 
 OVERRIDE_COMPLEXITY_CHECK: 'override-complexity-check';
@@ -196,6 +218,8 @@ PASSWORD
     }
   }
 ;
+
+PASSWORDS: 'passwords';
 
 PERSISTENT: 'persistent';
 
@@ -219,6 +243,8 @@ READ: 'read';
 RECONFIGURE: 'reconfigure';
 
 REMOVE: 'remove';
+
+REPEATED_CHARACTERS: 'repeated-characters';
 
 RETRY: 'retry';
 
@@ -247,6 +273,8 @@ SNTP: 'sntp';
 
 SOURCE_INTERFACE: 'source-interface';
 
+SPECIAL_CHARACTERS: 'special-characters';
+
 START_STOP: 'start-stop';
 
 STATUS
@@ -255,6 +283,10 @@ STATUS
 ;
 
 STOP_ONLY: 'stop-only';
+
+STRENGTH: 'strength';
+
+STRENGTH_CHECK: 'strength-check';
 
 SYSLOG: 'syslog';
 
@@ -278,6 +310,8 @@ TUNNEL: 'tunnel';
 UNICAST: 'unicast';
 
 UNLOCK: 'unlock';
+
+UPPERCASE_LETTERS: 'uppercase-letters';
 
 USERGROUP
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
@@ -752,17 +752,17 @@ ps_maximum
 :
   MAXIMUM
   (
-    psm_consecutive_characters
-    | psm_repeated_characters
+    psmax_consecutive_characters
+    | psmax_repeated_characters
   )
 ;
 
-psm_consecutive_characters
+psmax_consecutive_characters
 :
   CONSECUTIVE_CHARACTERS count = uint8 NEWLINE
 ;
 
-psm_repeated_characters
+psmax_repeated_characters
 :
   REPEATED_CHARACTERS count = uint8 NEWLINE
 ;
@@ -771,42 +771,42 @@ ps_minimum
 :
   MINIMUM
   (
-    psm_uppercase_letters
-    | psm_lowercase_letters
-    | psm_numeric_characters
-    | psm_special_characters
-    | psm_character_classes
+    psmin_uppercase_letters
+    | psmin_lowercase_letters
+    | psmin_numeric_characters
+    | psmin_special_characters
+    | psmin_character_classes
   )
 ;
 
-psm_uppercase_letters
+psmin_uppercase_letters
 :
   UPPERCASE_LETTERS count = uint8 NEWLINE
 ;
 
-psm_lowercase_letters
+psmin_lowercase_letters
 :
   LOWERCASE_LETTERS count = uint8 NEWLINE
 ;
 
-psm_numeric_characters
+psmin_numeric_characters
 :
   NUMERIC_CHARACTERS count = uint8 NEWLINE
 ;
 
-psm_special_characters
+psmin_special_characters
 :
   SPECIAL_CHARACTERS count = uint8 NEWLINE
 ;
 
-psm_character_classes
+psmin_character_classes
 :
   CHARACTER_CLASSES count = uint8 NEWLINE
 ;
 
 ps_exclude_keyword
 :
-  EXCLUDE_KEYWORD keyword = WORD NEWLINE
+  EXCLUDE_KEYWORD keyword = word NEWLINE
 ;
 
 passwords_strength_check

--- a/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/vendor/fastpath/grammar/FastpathParser.g4
@@ -20,6 +20,7 @@ statement
   | s_ip
   | s_logging
   | s_no
+  | s_passwords
   | s_set
   | s_sntp
   | s_tacacs_server
@@ -704,3 +705,111 @@ no_username_null
   USERNAME null_rest_of_line
 ;
 
+s_passwords
+:
+  PASSWORDS
+  (
+    passwords_aging
+    | passwords_history
+    | passwords_lock_out
+    | passwords_min_length
+    | passwords_strength
+    | passwords_strength_check
+  )
+;
+
+passwords_aging
+:
+  AGING count = uint16 NEWLINE
+;
+
+passwords_history
+:
+  HISTORY count = uint8 NEWLINE
+;
+
+passwords_lock_out
+:
+  LOCK_OUT count = uint8 NEWLINE
+;
+
+passwords_min_length
+:
+  MIN_LENGTH count = uint8 NEWLINE
+;
+
+passwords_strength
+:
+  STRENGTH
+  (
+    ps_maximum
+    | ps_minimum
+    | ps_exclude_keyword
+  )
+;
+
+ps_maximum
+:
+  MAXIMUM
+  (
+    psm_consecutive_characters
+    | psm_repeated_characters
+  )
+;
+
+psm_consecutive_characters
+:
+  CONSECUTIVE_CHARACTERS count = uint8 NEWLINE
+;
+
+psm_repeated_characters
+:
+  REPEATED_CHARACTERS count = uint8 NEWLINE
+;
+
+ps_minimum
+:
+  MINIMUM
+  (
+    psm_uppercase_letters
+    | psm_lowercase_letters
+    | psm_numeric_characters
+    | psm_special_characters
+    | psm_character_classes
+  )
+;
+
+psm_uppercase_letters
+:
+  UPPERCASE_LETTERS count = uint8 NEWLINE
+;
+
+psm_lowercase_letters
+:
+  LOWERCASE_LETTERS count = uint8 NEWLINE
+;
+
+psm_numeric_characters
+:
+  NUMERIC_CHARACTERS count = uint8 NEWLINE
+;
+
+psm_special_characters
+:
+  SPECIAL_CHARACTERS count = uint8 NEWLINE
+;
+
+psm_character_classes
+:
+  CHARACTER_CLASSES count = uint8 NEWLINE
+;
+
+ps_exclude_keyword
+:
+  EXCLUDE_KEYWORD keyword = WORD NEWLINE
+;
+
+passwords_strength_check
+:
+  STRENGTH_CHECK NEWLINE
+;

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
@@ -55,6 +55,19 @@ import org.batfish.vendor.fastpath.grammar.FastpathParser.Ls_enableContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Ls_source_interfaceContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Noipd_lookupContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Nol_consoleContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Passwords_agingContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Passwords_historyContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Passwords_lock_outContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Passwords_min_lengthContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Passwords_strength_checkContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Ps_exclude_keywordContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_character_classesContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_consecutive_charactersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_lowercase_lettersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_numeric_charactersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_repeated_charactersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_special_charactersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_uppercase_lettersContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Quoted_textContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.S_hostnameContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.S_taskgroupContext;
@@ -120,6 +133,18 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   private static final String DEFAULT_LIST_NAME = "default";
 
   private static final IntegerSpace USER_LEVEL_RANGE = IntegerSpace.of(Range.closed(0, 15));
+
+  private static final IntegerSpace PASSWORD_LOCKOUT_RANGE = IntegerSpace.of(Range.closed(1, 5));
+  private static final IntegerSpace PASSWORD_AGING_RANGE = IntegerSpace.of(Range.closed(1, 365));
+  private static final IntegerSpace PASSWORD_HISTORY_RANGE = IntegerSpace.of(Range.closed(0, 10));
+  private static final IntegerSpace PASSWORD_MIN_LENGTH_RANGE =
+      IntegerSpace.of(Range.closed(0, 64));
+  private static final IntegerSpace PASSWORD_STRENGTH_MAX_CHARACTERS_RANGE =
+      IntegerSpace.of(Range.closed(0, 15));
+  private static final IntegerSpace PASSWORD_STRENGTH_MIN_LETTERS_RANGE =
+      IntegerSpace.of(Range.closed(0, 16));
+  private static final IntegerSpace PASSWORD_STRENGTH_MIN_CHARACTER_CLASSES_RANGE =
+      IntegerSpace.of(Range.closed(0, 4));
 
   public FastpathConfigurationBuilder(
       FastpathCombinedParser parser,
@@ -512,6 +537,110 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   @Override
   public void exitUsergroup_taskgroup(Usergroup_taskgroupContext ctx) {
     _currentUsergroup.getTaskgroups().add(toString(ctx.name));
+  }
+
+  @Override
+  public void exitPasswords_lock_out(Passwords_lock_outContext ctx) {
+    toIntegerInSpace(ctx, ctx.count, PASSWORD_LOCKOUT_RANGE, "passwords lock-out")
+        .ifPresent(_c.getPasswordPolicy()::setLockOut);
+  }
+
+  @Override
+  public void exitPasswords_aging(Passwords_agingContext ctx) {
+    toIntegerInSpace(ctx, ctx.count, PASSWORD_AGING_RANGE, "passwords aging")
+        .ifPresent(_c.getPasswordPolicy()::setAging);
+  }
+
+  @Override
+  public void exitPasswords_history(Passwords_historyContext ctx) {
+    toIntegerInSpace(ctx, ctx.count, PASSWORD_HISTORY_RANGE, "passwords history")
+        .ifPresent(_c.getPasswordPolicy()::setHistory);
+  }
+
+  @Override
+  public void exitPasswords_min_length(Passwords_min_lengthContext ctx) {
+    toIntegerInSpace(ctx, ctx.count, PASSWORD_MIN_LENGTH_RANGE, "passwords min-length")
+        .ifPresent(_c.getPasswordPolicy()::setMinLength);
+  }
+
+  @Override
+  public void exitPasswords_strength_check(Passwords_strength_checkContext ctx) {
+    _c.getPasswordPolicy().setStrengthCheck(true);
+  }
+
+  @Override
+  public void exitPsm_consecutive_characters(Psm_consecutive_charactersContext ctx) {
+    toIntegerInSpace(
+            ctx,
+            ctx.count,
+            PASSWORD_STRENGTH_MAX_CHARACTERS_RANGE,
+            "passwords strength maximum consecutive-characters")
+        .ifPresent(_c.getPasswordPolicy()::setMaxConsecutiveCharacters);
+  }
+
+  @Override
+  public void exitPsm_repeated_characters(Psm_repeated_charactersContext ctx) {
+    toIntegerInSpace(
+            ctx,
+            ctx.count,
+            PASSWORD_STRENGTH_MAX_CHARACTERS_RANGE,
+            "passwords strength maximum repeated-characters")
+        .ifPresent(_c.getPasswordPolicy()::setMaxRepeatedCharacters);
+  }
+
+  @Override
+  public void exitPsm_uppercase_letters(Psm_uppercase_lettersContext ctx) {
+    toIntegerInSpace(
+            ctx,
+            ctx.count,
+            PASSWORD_STRENGTH_MIN_LETTERS_RANGE,
+            "passwords strength minimum uppercase-letters")
+        .ifPresent(_c.getPasswordPolicy()::setMinUppercaseLetters);
+  }
+
+  @Override
+  public void exitPsm_lowercase_letters(Psm_lowercase_lettersContext ctx) {
+    toIntegerInSpace(
+            ctx,
+            ctx.count,
+            PASSWORD_STRENGTH_MIN_LETTERS_RANGE,
+            "passwords strength minimum lowercase-letters")
+        .ifPresent(_c.getPasswordPolicy()::setMinLowercaseLetters);
+  }
+
+  @Override
+  public void exitPsm_numeric_characters(Psm_numeric_charactersContext ctx) {
+    toIntegerInSpace(
+            ctx,
+            ctx.count,
+            PASSWORD_STRENGTH_MIN_LETTERS_RANGE,
+            "passwords strength minimum numeric-characters")
+        .ifPresent(_c.getPasswordPolicy()::setMinNumericCharacters);
+  }
+
+  @Override
+  public void exitPsm_special_characters(Psm_special_charactersContext ctx) {
+    toIntegerInSpace(
+            ctx,
+            ctx.count,
+            PASSWORD_STRENGTH_MIN_LETTERS_RANGE,
+            "passwords strength minimum special-characters")
+        .ifPresent(_c.getPasswordPolicy()::setMinSpecialCharacters);
+  }
+
+  @Override
+  public void exitPsm_character_classes(Psm_character_classesContext ctx) {
+    toIntegerInSpace(
+            ctx,
+            ctx.count,
+            PASSWORD_STRENGTH_MIN_CHARACTER_CLASSES_RANGE,
+            "passwords strength minimum character-classes")
+        .ifPresent(_c.getPasswordPolicy()::setMinCharacterClasses);
+  }
+
+  @Override
+  public void exitPs_exclude_keyword(Ps_exclude_keywordContext ctx) {
+    _c.getPasswordPolicy().getExcludeKeywords().add(ctx.keyword.getText());
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/grammar/FastpathConfigurationBuilder.java
@@ -61,13 +61,13 @@ import org.batfish.vendor.fastpath.grammar.FastpathParser.Passwords_lock_outCont
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Passwords_min_lengthContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Passwords_strength_checkContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Ps_exclude_keywordContext;
-import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_character_classesContext;
-import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_consecutive_charactersContext;
-import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_lowercase_lettersContext;
-import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_numeric_charactersContext;
-import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_repeated_charactersContext;
-import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_special_charactersContext;
-import org.batfish.vendor.fastpath.grammar.FastpathParser.Psm_uppercase_lettersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psmax_consecutive_charactersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psmax_repeated_charactersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psmin_character_classesContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psmin_lowercase_lettersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psmin_numeric_charactersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psmin_special_charactersContext;
+import org.batfish.vendor.fastpath.grammar.FastpathParser.Psmin_uppercase_lettersContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.Quoted_textContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.S_hostnameContext;
 import org.batfish.vendor.fastpath.grammar.FastpathParser.S_taskgroupContext;
@@ -569,7 +569,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   }
 
   @Override
-  public void exitPsm_consecutive_characters(Psm_consecutive_charactersContext ctx) {
+  public void exitPsmax_consecutive_characters(Psmax_consecutive_charactersContext ctx) {
     toIntegerInSpace(
             ctx,
             ctx.count,
@@ -579,7 +579,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   }
 
   @Override
-  public void exitPsm_repeated_characters(Psm_repeated_charactersContext ctx) {
+  public void exitPsmax_repeated_characters(Psmax_repeated_charactersContext ctx) {
     toIntegerInSpace(
             ctx,
             ctx.count,
@@ -589,7 +589,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   }
 
   @Override
-  public void exitPsm_uppercase_letters(Psm_uppercase_lettersContext ctx) {
+  public void exitPsmin_uppercase_letters(Psmin_uppercase_lettersContext ctx) {
     toIntegerInSpace(
             ctx,
             ctx.count,
@@ -599,7 +599,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   }
 
   @Override
-  public void exitPsm_lowercase_letters(Psm_lowercase_lettersContext ctx) {
+  public void exitPsmin_lowercase_letters(Psmin_lowercase_lettersContext ctx) {
     toIntegerInSpace(
             ctx,
             ctx.count,
@@ -609,7 +609,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   }
 
   @Override
-  public void exitPsm_numeric_characters(Psm_numeric_charactersContext ctx) {
+  public void exitPsmin_numeric_characters(Psmin_numeric_charactersContext ctx) {
     toIntegerInSpace(
             ctx,
             ctx.count,
@@ -619,7 +619,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   }
 
   @Override
-  public void exitPsm_special_characters(Psm_special_charactersContext ctx) {
+  public void exitPsmin_special_characters(Psmin_special_charactersContext ctx) {
     toIntegerInSpace(
             ctx,
             ctx.count,
@@ -629,7 +629,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
   }
 
   @Override
-  public void exitPsm_character_classes(Psm_character_classesContext ctx) {
+  public void exitPsmin_character_classes(Psmin_character_classesContext ctx) {
     toIntegerInSpace(
             ctx,
             ctx.count,
@@ -640,7 +640,7 @@ public final class FastpathConfigurationBuilder extends FastpathParserBaseListen
 
   @Override
   public void exitPs_exclude_keyword(Ps_exclude_keywordContext ctx) {
-    _c.getPasswordPolicy().getExcludeKeywords().add(ctx.keyword.getText());
+    _c.getPasswordPolicy().getExcludeKeywords().add(toString(ctx.keyword));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/FastpathConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/FastpathConfiguration.java
@@ -32,6 +32,7 @@ public final class FastpathConfiguration extends VendorConfiguration {
   private final Map<String, UserAccount> _users;
   private final Map<String, Taskgroup> _taskgroups;
   private final Map<String, Usergroup> _usergroups;
+  private final PasswordPolicy _passwordPolicy;
 
   private transient Configuration _c;
 
@@ -44,6 +45,7 @@ public final class FastpathConfiguration extends VendorConfiguration {
     _users = new LinkedHashMap<>();
     _taskgroups = new LinkedHashMap<>();
     _usergroups = new LinkedHashMap<>();
+    _passwordPolicy = new PasswordPolicy();
   }
 
   @Override
@@ -93,6 +95,10 @@ public final class FastpathConfiguration extends VendorConfiguration {
 
   public @Nonnull Map<String, Usergroup> getUsergroups() {
     return _usergroups;
+  }
+
+  public @Nonnull PasswordPolicy getPasswordPolicy() {
+    return _passwordPolicy;
   }
 
   private @Nonnull Configuration toVendorIndependentConfiguration() {

--- a/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/PasswordPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/vendor/fastpath/representation/PasswordPolicy.java
@@ -1,0 +1,128 @@
+package org.batfish.vendor.fastpath.representation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * FastPath password-policy settings ({@code passwords ...}): lockout count, aging, history depth,
+ * minimum length, and the {@code passwords strength ...} rules.
+ */
+public final class PasswordPolicy implements Serializable {
+
+  private @Nullable Integer _lockOut;
+  private @Nullable Integer _aging;
+  private @Nullable Integer _history;
+  private @Nullable Integer _minLength;
+  private boolean _strengthCheck;
+  private @Nullable Integer _maxConsecutiveCharacters;
+  private @Nullable Integer _maxRepeatedCharacters;
+  private @Nullable Integer _minUppercaseLetters;
+  private @Nullable Integer _minLowercaseLetters;
+  private @Nullable Integer _minNumericCharacters;
+  private @Nullable Integer _minSpecialCharacters;
+  private @Nullable Integer _minCharacterClasses;
+  private final @Nonnull List<String> _excludeKeywords = new ArrayList<>();
+
+  public @Nullable Integer getLockOut() {
+    return _lockOut;
+  }
+
+  public void setLockOut(@Nullable Integer lockOut) {
+    _lockOut = lockOut;
+  }
+
+  public @Nullable Integer getAging() {
+    return _aging;
+  }
+
+  public void setAging(@Nullable Integer aging) {
+    _aging = aging;
+  }
+
+  public @Nullable Integer getHistory() {
+    return _history;
+  }
+
+  public void setHistory(@Nullable Integer history) {
+    _history = history;
+  }
+
+  public @Nullable Integer getMinLength() {
+    return _minLength;
+  }
+
+  public void setMinLength(@Nullable Integer minLength) {
+    _minLength = minLength;
+  }
+
+  public boolean getStrengthCheck() {
+    return _strengthCheck;
+  }
+
+  public void setStrengthCheck(boolean strengthCheck) {
+    _strengthCheck = strengthCheck;
+  }
+
+  public @Nullable Integer getMaxConsecutiveCharacters() {
+    return _maxConsecutiveCharacters;
+  }
+
+  public void setMaxConsecutiveCharacters(@Nullable Integer maxConsecutiveCharacters) {
+    _maxConsecutiveCharacters = maxConsecutiveCharacters;
+  }
+
+  public @Nullable Integer getMaxRepeatedCharacters() {
+    return _maxRepeatedCharacters;
+  }
+
+  public void setMaxRepeatedCharacters(@Nullable Integer maxRepeatedCharacters) {
+    _maxRepeatedCharacters = maxRepeatedCharacters;
+  }
+
+  public @Nullable Integer getMinUppercaseLetters() {
+    return _minUppercaseLetters;
+  }
+
+  public void setMinUppercaseLetters(@Nullable Integer minUppercaseLetters) {
+    _minUppercaseLetters = minUppercaseLetters;
+  }
+
+  public @Nullable Integer getMinLowercaseLetters() {
+    return _minLowercaseLetters;
+  }
+
+  public void setMinLowercaseLetters(@Nullable Integer minLowercaseLetters) {
+    _minLowercaseLetters = minLowercaseLetters;
+  }
+
+  public @Nullable Integer getMinNumericCharacters() {
+    return _minNumericCharacters;
+  }
+
+  public void setMinNumericCharacters(@Nullable Integer minNumericCharacters) {
+    _minNumericCharacters = minNumericCharacters;
+  }
+
+  public @Nullable Integer getMinSpecialCharacters() {
+    return _minSpecialCharacters;
+  }
+
+  public void setMinSpecialCharacters(@Nullable Integer minSpecialCharacters) {
+    _minSpecialCharacters = minSpecialCharacters;
+  }
+
+  public @Nullable Integer getMinCharacterClasses() {
+    return _minCharacterClasses;
+  }
+
+  public void setMinCharacterClasses(@Nullable Integer minCharacterClasses) {
+    _minCharacterClasses = minCharacterClasses;
+  }
+
+  public @Nonnull List<String> getExcludeKeywords() {
+    return _excludeKeywords;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
@@ -468,7 +468,7 @@ public final class FastpathGrammarTest {
     assertThat(p.getMinNumericCharacters(), equalTo(3));
     assertThat(p.getMinSpecialCharacters(), equalTo(4));
     assertThat(p.getMinCharacterClasses(), equalTo(4));
-    assertThat(p.getExcludeKeywords(), equalTo(ImmutableList.of("admin", "password")));
+    assertThat(p.getExcludeKeywords(), equalTo(ImmutableList.of("admin", "password", "Passw0rd")));
     assertThat(p.getStrengthCheck(), equalTo(true));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/vendor/fastpath/grammar/FastpathGrammarTest.java
@@ -53,6 +53,7 @@ import org.batfish.vendor.fastpath.representation.FastpathConfiguration;
 import org.batfish.vendor.fastpath.representation.Logging;
 import org.batfish.vendor.fastpath.representation.LoggingBuffered;
 import org.batfish.vendor.fastpath.representation.LoggingServer;
+import org.batfish.vendor.fastpath.representation.PasswordPolicy;
 import org.batfish.vendor.fastpath.representation.Sntp;
 import org.batfish.vendor.fastpath.representation.Tacacs;
 import org.batfish.vendor.fastpath.representation.TacacsServer;
@@ -450,6 +451,25 @@ public final class FastpathGrammarTest {
     assertThat(usergroups.get("builder").getTaskgroups(), equalTo(ImmutableList.of("builder")));
     assertThat(usergroups.get("admin").getTaskgroups(), equalTo(ImmutableList.of("admin")));
     assertThat(usergroups.get("ops").getTaskgroups(), equalTo(ImmutableList.of("ops")));
+  }
+
+  @Test
+  public void testPasswordPolicyExtraction() {
+    FastpathConfiguration c = parseVendorConfig("fastpath_passwords");
+    PasswordPolicy p = c.getPasswordPolicy();
+    assertThat(p.getLockOut(), equalTo(3));
+    assertThat(p.getAging(), equalTo(90));
+    assertThat(p.getHistory(), equalTo(5));
+    assertThat(p.getMinLength(), equalTo(8));
+    assertThat(p.getMaxConsecutiveCharacters(), equalTo(3));
+    assertThat(p.getMaxRepeatedCharacters(), equalTo(2));
+    assertThat(p.getMinUppercaseLetters(), equalTo(1));
+    assertThat(p.getMinLowercaseLetters(), equalTo(2));
+    assertThat(p.getMinNumericCharacters(), equalTo(3));
+    assertThat(p.getMinSpecialCharacters(), equalTo(4));
+    assertThat(p.getMinCharacterClasses(), equalTo(4));
+    assertThat(p.getExcludeKeywords(), equalTo(ImmutableList.of("admin", "password")));
+    assertThat(p.getStrengthCheck(), equalTo(true));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_passwords
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_passwords
@@ -16,4 +16,5 @@ passwords strength minimum special-characters 4
 passwords strength minimum character-classes 4
 passwords strength exclude-keyword admin
 passwords strength exclude-keyword password
+passwords strength exclude-keyword "Passw0rd"
 passwords strength-check

--- a/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_passwords
+++ b/projects/batfish/src/test/resources/org/batfish/vendor/fastpath/grammar/testconfigs/fastpath_passwords
@@ -1,0 +1,19 @@
+!Current Configuration:
+!
+!System Software Version "3.4.3.10"
+!
+hostname "fastpath_passwords"
+passwords lock-out 3
+passwords aging 90
+passwords history 5
+passwords min-length 8
+passwords strength maximum consecutive-characters 3
+passwords strength maximum repeated-characters 2
+passwords strength minimum uppercase-letters 1
+passwords strength minimum lowercase-letters 2
+passwords strength minimum numeric-characters 3
+passwords strength minimum special-characters 4
+passwords strength minimum character-classes 4
+passwords strength exclude-keyword admin
+passwords strength exclude-keyword password
+passwords strength-check


### PR DESCRIPTION
 ## Summary
  
  Add parsing and extraction for the global `passwords` policy. The `passwords` block is captured into a new vendor-specific `PasswordPolicy` model covering account controls (`lock-out`, `aging`, `history`, `min-length`) and the `passwords strength` complexity rules (`maximum consecutive-characters`/`repeated-characters`; `minimum uppercase-letters`/`lowercase-letters`/`numeric-characters`/`special-characters`/`character-classes`), the free-form `exclude-keyword` list, and the `strength-check` toggle. Each numeric value is validated against its documented range. None of this is converted to the vendor-independent model.
  
  ## Changes
  
  - **Lexer:** Add keyword tokens `AGING`, `HISTORY`, `LOCK_OUT`, `MIN_LENGTH`, `PASSWORDS`, `STRENGTH`, `STRENGTH_CHECK`, and the `passwords strength` sub-keywords `MAXIMUM`, `MINIMUM`, `CONSECUTIVE_CHARACTERS`, `REPEATED_CHARACTERS`, `UPPERCASE_LETTERS`, `LOWERCASE_LETTERS`, `NUMERIC_CHARACTERS`, `SPECIAL_CHARACTERS`, `CHARACTER_CLASSES`, and `EXCLUDE_KEYWORD`.
  
  - **Lexer:** `EXCLUDE_KEYWORD` pushes `M_Word` so the `exclude-keyword <value>` operand lexes as `word`. This keeps the argument free-form even when it collides with a global keyword.
  
  - **Grammar:** Add `s_passwords` to `statement`. `s_passwords` dispatches to `passwords_lock_out`, `passwords_aging`, `passwords_history`, `passwords_min_length`, `passwords_strength`, and `passwords_strength_check`. `passwords_strength` splits into `ps_maximum` (`consecutive-characters`/`repeated-characters`), `ps_minimum` (`uppercase-letters`/`lowercase-letters`/`numeric-characters`/`special-characters`/`character-classes`), and `ps_exclude_keyword` (`exclude-keyword <word>`). Counts are matched with `uint8` (`aging` uses `uint16`).
  
  - **VS:** Add the `representation` class `PasswordPolicy` holding nullable `Integer` fields for `lockOut`, `aging`, `history`, `minLength`, the `strength` maximum/minimum thresholds, and `minCharacterClasses`; a `boolean strengthCheck`; and an ordered `List<String>` of exclude keywords.
  
  - **VS:** Add a single `_passwordPolicy` instance to `FastpathConfiguration.java` with a `getPasswordPolicy()` accessor.
  
  - **Extraction:** Populate handlers in `FastpathConfigurationBuilder.java`. Each numeric value is validated with `toIntegerInSpace` against a documented `IntegerSpace`: lock-out `1–5`, aging `1–365`, history `0–10`, min-length `0–64`, `strength maximum` counts `0–15`, `strength minimum` letter/character counts `0–16`, and `strength minimum character-classes` `0–4`. `strength-check` sets a boolean flag; `exclude-keyword` values are appended to the list.
  
  ## Testing
  
  - Add a `fastpath_passwords` testconfig exercising every `passwords` line: `lock-out`, `aging`, `history`, `min-length`, each `strength maximum`/`minimum` threshold, two `exclude-keyword` values (including the keyword-colliding `password`), and `strength-check`.
  
  - Add `testPasswordPolicyExtraction` to `FastpathGrammarTest`, asserting the extracted `PasswordPolicy` values.
  
  - All tests pass locally and no reference tests are affected.