### PR TITLE
ibdp: merge protocol-independent routes into the main RIB directly

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -979,7 +979,6 @@ final class IncrementalBdpEngine {
     vrs.parallelStream()
         .forEach(
             vr -> {
-              importRib(vr.getMainRib(), vr._independentRib);
               // Use static evaluator since we don't have dataplane yet
               vr.activateStaticRoutes(new PreDataPlaneTrackMethodEvaluator(vr.getConfiguration()));
             });
@@ -1241,7 +1240,7 @@ final class IncrementalBdpEngine {
           .forEach(
               vr -> {
                 importRib(vr._ripRib, vr._ripInternalRib);
-                importRib(vr._independentRib, vr._ripRib, vr.getName());
+                importRib(vr.getMainRib(), vr._ripRib, vr.getName());
               });
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -141,12 +141,6 @@ public final class VirtualRouter {
   private SortedMap<CrossVrfEdgeId, Queue<RouteAdvertisement<AnnotatedRoute<AbstractRoute>>>>
       _crossVrfIncomingRoutes;
 
-  /**
-   * The independent RIB contains connected and static routes, which are unaffected by BDP
-   * iterations (hence, independent).
-   */
-  Rib _independentRib;
-
   /** Incoming messages into this router from each IS-IS circuit */
   SortedMap<IsisEdge, Queue<RouteAdvertisement<IsisRoute>>> _isisIncomingRoutes;
 
@@ -192,7 +186,7 @@ public final class VirtualRouter {
 
   /**
    * Static routes needing no activation, in {@link Vrf#getStaticRoutes} order. Merged into {@link
-   * #_independentRib} once, at init.
+   * #_mainRib} once, at init.
    */
   List<StaticRoute> _unconditionalStatics;
 
@@ -309,13 +303,11 @@ public final class VirtualRouter {
     initLocalRib();
     initStaticRibs();
     // Always import local and connected routes into your own rib
-    importRib(_independentRib, _connectedRib);
-    importRib(_independentRib, _localRib);
-    for (StaticRoute sr : _unconditionalStatics) {
-      _independentRib.mergeRoute(annotateRoute(sr));
-    }
-    importRib(_mainRib, _independentRib);
     importRib(_mainRib, _connectedRib);
+    importRib(_mainRib, _localRib);
+    for (StaticRoute sr : _unconditionalStatics) {
+      _mainRib.mergeRoute(annotateRoute(sr));
+    }
 
     _ospfProcesses =
         _vrf.getOspfProcesses().entrySet().stream()
@@ -861,7 +853,7 @@ public final class VirtualRouter {
    * redistribution.
    *
    * <ul>
-   *   <li>Kernel routes with no dependencies are added to {@code _independentRib}.
+   *   <li>Kernel routes with no dependencies are added to {@code _mainRib}.
    *   <li>Kernel routes with dependencies are stored in {@code _kernelConditionalRoutes}, to be
    *       processed each data plane iteration.
    * </ul>
@@ -873,7 +865,7 @@ public final class VirtualRouter {
       if (kernelRoute.getRequiredOwnedIp() != null) {
         kernelConditionalRoutesBuilder.add(kernelRoute);
       } else {
-        _independentRib.mergeRoute(annotateRoute(kernelRoute));
+        _mainRib.mergeRoute(annotateRoute(kernelRoute));
       }
     }
     _kernelConditionalRoutes = kernelConditionalRoutesBuilder.build();
@@ -1130,7 +1122,6 @@ public final class VirtualRouter {
     _connectedRib = new ConnectedRib();
     _localRib = new LocalRib();
     _generatedRib = new Rib();
-    _independentRib = new Rib();
 
     // ISIS
     _isisRib = new IsisRib(isL1Only());
@@ -1427,11 +1418,6 @@ public final class VirtualRouter {
      * RIBs not read from can just be re-initialized
      */
     _ripRib = new RipRib();
-
-    /*
-     * Add routes that cannot change (does not affect below computation)
-     */
-    _mainRibRouteDeltaBuilder.from(importRib(_mainRib, _independentRib));
 
     /*
      * Re-add independent RIP routes to ripRib for tie-breaking

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -51,6 +51,7 @@ import org.batfish.datamodel.ConnectedRouteMetadata;
 import org.batfish.datamodel.EigrpExternalRoute;
 import org.batfish.datamodel.EigrpInternalRoute;
 import org.batfish.datamodel.GeneratedRoute;
+import org.batfish.datamodel.InactiveReason;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IsisRoute;
@@ -309,11 +310,10 @@ public class VirtualRouterTest {
     vr.initKernelRoutes();
 
     // Assert that all kernel routes have been processed
-    // The kernel routes not requiring owned IPs should be present in the independent RIB.
+    // The kernel routes not requiring owned IPs should be present in the main RIB.
     // All others should be present in _kernelConditionalRoutes.
     assertThat(
-        vr._independentRib.getRoutes(),
-        containsInAnyOrder(vr.annotateRoute(noRequiredOwnedIpRoute)));
+        vr.getMainRib().getRoutes(), containsInAnyOrder(vr.annotateRoute(noRequiredOwnedIpRoute)));
     assertThat(
         vr._kernelConditionalRoutes,
         containsInAnyOrder(missingRequiredOwnedIpRoute, presentRequiredOwnedIpRoute));
@@ -433,7 +433,7 @@ public class VirtualRouterTest {
     assertThat(vr.getConnectedRib().getUnannotatedRoutes(), empty());
     assertThat(vr._conditionalStatics, empty());
     assertThat(vr._unconditionalStatics, empty());
-    assertThat(vr._independentRib.getUnannotatedRoutes(), empty());
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), empty());
 
     // RIP RIBs
     assertThat(vr._ripInternalRib.getUnannotatedRoutes(), empty());
@@ -1014,5 +1014,28 @@ public class VirtualRouterTest {
           PreDataPlaneTrackMethodEvaluator::new,
           false);
     }
+  }
+
+  /**
+   * Connected and local routes withdrawn because autostate took their interface down must stay out
+   * of the main RIB for the rest of the computation.
+   */
+  @Test
+  public void testAutostateChangeDoesNotResurrectConnectedRoutes() {
+    VirtualRouter vr = makeIosVirtualRouter(null);
+    Configuration c = vr.getConfiguration();
+    addInterfaces(c, ImmutableMap.of("Ethernet1", ConcreteInterfaceAddress.parse("10.1.0.1/16")));
+    vr.initRibs();
+    vr.initForIgpComputation(TopologyContext.builder().build());
+    ConnectedRoute connected = new ConnectedRoute(Prefix.parse("10.1.0.0/16"), "Ethernet1");
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), hasItem(connected));
+
+    // Autostate takes the interface down during a topology iteration.
+    c.getAllInterfaces().get("Ethernet1").deactivate(InactiveReason.AUTOSTATE_FAILURE);
+    vr.updateConnectedAndLocalRoutesForAutostateChange();
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), not(hasItem(connected)));
+
+    vr.reinitForNewIteration();
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), not(hasItem(connected)));
   }
 }


### PR DESCRIPTION
The independent RIB existed so that reinitForNewIteration() could
re-seed a main RIB that was rebuilt from scratch every iteration; the
main RIB has been final and persistent since. Merge connected, local,
unconditional static, kernel and RIP-internal routes straight into it
and drop the RIB. On a 2,135-device snapshot the re-import it fed ran
123,708 times across 53 iterations without once changing the main RIB.

Fixes an autostate bug that this exposes: withdrawing an interface's
connected and local routes from the main RIB left them in the
independent RIB, so the next iteration's re-import put them back.

----

Prompt:
```
Over and over again, we keep coming to RAM used in PrefixTrieMultiMap. Have we investigated how to improve its memory use?
```

Followed by a request to move everything importing into the independent
RIB to import into the main RIB instead, and to fix the autostate bug
with red/green TDD.
