### PR TITLE
RibTree: skip straight to the next shorter match when a longest match is unusable

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
@@ -94,13 +94,21 @@ final class RibTree<R extends AbstractRouteDecorator> implements Serializable {
   }
 
   private boolean hasAllowedForwardingRoute(Set<R> routes, ResolutionRestriction<R> restriction) {
-    return routes.stream()
-        .anyMatch(r -> !r.getAbstractRoute().getNonForwarding() && restriction.test(r));
+    for (R r : routes) {
+      if (!r.getAbstractRoute().getNonForwarding() && restriction.test(r)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private boolean onlyAllowedForwardingRoutes(Set<R> routes, ResolutionRestriction<R> restriction) {
-    return routes.stream()
-        .noneMatch(r -> r.getAbstractRoute().getNonForwarding() || !restriction.test(r));
+    for (R r : routes) {
+      if (r.getAbstractRoute().getNonForwarding() || !restriction.test(r)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -113,16 +121,28 @@ final class RibTree<R extends AbstractRouteDecorator> implements Serializable {
   @Nonnull
   Set<R> getLongestPrefixMatch(
       Ip address, int maxPrefixLength, ResolutionRestriction<R> restriction) {
-    for (int pl = maxPrefixLength; pl >= 0; pl--) {
+    int pl = maxPrefixLength;
+    while (pl >= 0) {
       Set<R> routes = _root.longestPrefixMatch(address, pl);
+      if (routes.isEmpty()) {
+        // No prefix of length at most pl contains the address, so no shorter one does either.
+        return routes;
+      }
       if (hasAllowedForwardingRoute(routes, restriction)) {
         if (onlyAllowedForwardingRoutes(routes, restriction)) {
           return routes;
         }
-        return routes.stream()
-            .filter(r -> !r.getAbstractRoute().getNonForwarding() && restriction.test(r))
-            .collect(ImmutableSet.toImmutableSet());
+        ImmutableSet.Builder<R> allowed = ImmutableSet.builderWithExpectedSize(routes.size());
+        for (R r : routes) {
+          if (!r.getAbstractRoute().getNonForwarding() && restriction.test(r)) {
+            allowed.add(r);
+          }
+        }
+        return allowed.build();
       }
+      // Nothing usable at this prefix; the next candidate is the longest match strictly shorter
+      // than it, so skip the lengths in between rather than searching once per length.
+      pl = routes.iterator().next().getNetwork().getPrefixLength() - 1;
     }
     return ImmutableSet.of();
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -191,6 +192,42 @@ public class AbstractRibTest {
 
     match = _rib.longestPrefixMatch(Ip.parse("11.1.1.1"), restriction);
     assertThat(match, empty());
+  }
+
+  /**
+   * The longest match is skipped when none of its routes are usable, whether because they are
+   * non-forwarding or fail the restriction, and a partly usable match is filtered.
+   */
+  @Test
+  public void testLongestPrefixMatchSkipsUnusableMatches() {
+    StaticRoute.Builder srb = StaticRoute.testBuilder().setMetric(0L).setTag(0L);
+    StaticRoute slash8 = srb.setNetwork(Prefix.parse("10.0.0.0/8")).build();
+    StaticRoute slash16 = srb.setNetwork(Prefix.parse("10.1.0.0/16")).build();
+    StaticRoute slash24Forwarding = srb.setNetwork(Prefix.parse("10.1.1.0/24")).build();
+    StaticRoute slash24NonForwarding =
+        srb.setNetwork(Prefix.parse("10.1.1.0/24")).setNonForwarding(true).setTag(1L).build();
+    StaticRoute slash32 =
+        srb.setNetwork(Prefix.parse("10.1.1.1/32")).setNonForwarding(true).setTag(0L).build();
+    for (StaticRoute r :
+        ImmutableList.of(slash8, slash16, slash24Forwarding, slash24NonForwarding, slash32)) {
+      _rib.mergeRouteGetDelta(r);
+    }
+    Ip ip = Ip.parse("10.1.1.1");
+
+    // /32 is non-forwarding; /24 has one forwarding route, which is returned alone.
+    assertThat(_rib.longestPrefixMatch(ip, alwaysTrue()), contains(slash24Forwarding));
+    // With the /24 also rejected by the restriction, fall through to the /16.
+    ResolutionRestriction<StaticRoute> not24 = r -> r.getNetwork().getPrefixLength() != 24;
+    assertThat(_rib.longestPrefixMatch(ip, not24), contains(slash16));
+    // Reject everything longer than a /8.
+    ResolutionRestriction<StaticRoute> only8 = r -> r.getNetwork().getPrefixLength() == 8;
+    assertThat(_rib.longestPrefixMatch(ip, only8), contains(slash8));
+    // Reject everything.
+    assertThat(_rib.longestPrefixMatch(ip, r -> false), empty());
+    // The maximum length bounds the search before the restriction applies.
+    assertThat(_rib.longestPrefixMatch(ip, 20, alwaysTrue()), contains(slash16));
+    assertThat(_rib.longestPrefixMatch(ip, 20, not24), contains(slash16));
+    assertThat(_rib.longestPrefixMatch(ip, 15, alwaysTrue()), contains(slash8));
   }
 
   /**


### PR DESCRIPTION
getLongestPrefixMatch looked up the longest match for every prefix
length from the maximum down to zero whenever the longest match held no
usable forwarding route. Each iteration searched the trie again and
re-tested the same set until the length dropped below that set's prefix.
Static-route activation under a resolution restriction hits this on
every check, and in one large snapshot it was 46% of dataplane CPU.

Jump to one less than the matched prefix's length instead, stop as soon
as a lookup finds nothing, and test the route sets with loops rather
than streams.

----

Prompt:
```
make a PR(s) for any other changes that aren't related to the
PrefixTrieMultiMap refactor. I see some more stream rewrites I think
```

Split out of a session optimizing PrefixTrieMultiMap, where profiling
showed this loop rather than the trie itself as the top cost.
