### PR TITLE
profiling: add a headless dataplane runner

### DIFF
--- a/tools/profiling/BUILD.bazel
+++ b/tools/profiling/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_java//java:java_binary.bzl", "java_binary")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
@@ -67,4 +68,20 @@ py_binary(
     srcs = ["analyze_profile.py"],
     legacy_create_init = 0,
     python_version = "PY3",
+)
+
+java_binary(
+    name = "dataplaneRunner",
+    testonly = True,
+    srcs = ["DataplaneRunner.java"],
+    main_class = "tools.profiling.DataplaneRunner",
+    deps = [
+        "//projects/allinone",
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/common",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ],
 )

--- a/tools/profiling/DataplaneRunner.java
+++ b/tools/profiling/DataplaneRunner.java
@@ -1,0 +1,189 @@
+package tools.profiling;
+
+import static org.batfish.main.TestrigText.loadTestrig;
+
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import javax.management.ObjectName;
+import org.batfish.common.NetworkSnapshot;
+import org.batfish.config.Settings;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.FibEntry;
+import org.batfish.datamodel.FinalMainRib;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+
+/**
+ * Parses a snapshot directory and computes its dataplane with no coordinator or client, then
+ * reports timing, a digest of the result, and optionally the live heap.
+ *
+ * <pre>
+ * dataplaneRunner SNAPSHOT_DIR [--filter REGEX] [--histogram N] [--retain dataplane|nothing]
+ *                              [--dump-prefixes FILE] [--jfr FILE]
+ * </pre>
+ *
+ * <ul>
+ *   <li>{@code --filter REGEX}: only load configs whose file name matches (find, not full match).
+ *   <li>{@code --histogram N}: after a full GC, print the heap in use and the top N lines of the
+ *       class histogram, taken in-process so nothing has to attach to the JVM.
+ *   <li>{@code --retain dataplane}: drop the {@link Batfish} instance before the histogram, leaving
+ *       what a server holds to answer questions; {@code --retain nothing} also drops the dataplane.
+ *   <li>{@code --dump-prefixes FILE}: write the prefixes of the largest main RIB, one per line, for
+ *       use as microbenchmark input.
+ *   <li>{@code --jfr FILE}: dump the running flight recording there with reference chains to GC
+ *       roots; start the JVM with {@code -XX:StartFlightRecording:settings=profile,
+ *       path-to-gc-roots=true} for old-object samples to be in it.
+ * </ul>
+ *
+ * <p>The RIB and FIB lines give total counts and order-independent hashes, so two builds can be
+ * checked for identical results. Exits with {@link Runtime#halt} because Batfish leaves non-daemon
+ * threads that would otherwise keep the JVM alive.
+ */
+public final class DataplaneRunner {
+  private DataplaneRunner() {}
+
+  public static void main(String[] args) throws Exception {
+    if (args.length == 0) {
+      System.err.println(
+          "Usage: dataplaneRunner SNAPSHOT_DIR [--filter REGEX] [--histogram N]"
+              + " [--retain dataplane|nothing] [--dump-prefixes FILE] [--jfr FILE]");
+      System.exit(2);
+    }
+    String snapshotDir = args[0];
+    Pattern filter = null;
+    int histoLines = 0;
+    String retain = "all";
+    Path dumpPrefixes = null;
+    Path jfr = null;
+    for (int i = 1; i < args.length; i += 2) {
+      String value = i + 1 < args.length ? args[i + 1] : null;
+      switch (args[i]) {
+        case "--filter" -> filter = Pattern.compile(required(args[i], value));
+        case "--histogram" -> histoLines = Integer.parseInt(required(args[i], value));
+        case "--retain" -> retain = required(args[i], value);
+        case "--dump-prefixes" -> dumpPrefixes = Path.of(required(args[i], value));
+        case "--jfr" -> jfr = Path.of(required(args[i], value));
+        default -> throw new IllegalArgumentException("Unknown option " + args[i]);
+      }
+    }
+
+    Path tmp = Files.createTempDirectory("DataplaneRunner");
+    long t0 = System.currentTimeMillis();
+    Pattern configFilter = filter;
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            loadTestrig(snapshotDir, f -> configFilter == null || configFilter.matcher(f).find()),
+            tmp);
+    Settings settings = batfish.getSettings();
+    settings.setDisableUnrecognized(false);
+    settings.setHaltOnConvertError(false);
+    settings.setHaltOnParseError(false);
+    settings.setThrowOnLexerError(false);
+    settings.setThrowOnParserError(false);
+    NetworkSnapshot snapshot = batfish.getSnapshot();
+    SortedMap<String, Configuration> configs = batfish.loadConfigurations(snapshot);
+    long t1 = System.currentTimeMillis();
+    System.out.printf("PARSE_CONVERT configs=%d ms=%d%n", configs.size(), t1 - t0);
+    batfish.computeDataPlane(snapshot);
+    long t2 = System.currentTimeMillis();
+    System.out.printf("DATAPLANE ms=%d%n", t2 - t1);
+    DataPlane dp = batfish.loadDataPlane(snapshot);
+    reportDigest(dp);
+    if (dumpPrefixes != null) {
+      dumpPrefixes(dp, dumpPrefixes);
+    }
+    if (histoLines > 0) {
+      if (!retain.equals("all")) {
+        batfish = null;
+        configs = null;
+      }
+      if (retain.equals("nothing")) {
+        dp = null;
+      }
+      histogram(histoLines);
+    }
+    if (jfr != null) {
+      diagnosticCommand("jfrDump", "filename=" + jfr, "path-to-gc-roots=true");
+      System.out.println("JFR dumped to " + jfr);
+    }
+    System.out.println("DONE");
+    System.out.flush();
+    Runtime.getRuntime().halt(0);
+  }
+
+  private static String required(String option, @Nullable String value) {
+    if (value == null) {
+      throw new IllegalArgumentException(option + " needs a value");
+    }
+    return value;
+  }
+
+  private static void reportDigest(DataPlane dp) {
+    long ribRoutes = 0;
+    long ribHash = 0;
+    for (FinalMainRib rib : dp.getRibs().values()) {
+      for (AbstractRoute r : rib.getRoutes()) {
+        ribRoutes++;
+        ribHash += r.hashCode();
+      }
+    }
+    long fibEntries = 0;
+    long fibHash = 0;
+    for (Map<String, Fib> byVrf : dp.getFibs().values()) {
+      for (Fib fib : byVrf.values()) {
+        for (FibEntry e : fib.allEntries()) {
+          fibEntries++;
+          fibHash += e.hashCode();
+        }
+      }
+    }
+    System.out.printf(
+        "RIB_ROUTES %d hash=%x FIB_ENTRIES %d hash=%x%n", ribRoutes, ribHash, fibEntries, fibHash);
+  }
+
+  private static void dumpPrefixes(DataPlane dp, Path file) throws Exception {
+    FinalMainRib largest = null;
+    for (FinalMainRib rib : dp.getRibs().values()) {
+      if (largest == null || rib.getRoutes().size() > largest.getRoutes().size()) {
+        largest = rib;
+      }
+    }
+    List<String> lines = new ArrayList<>();
+    if (largest != null) {
+      for (AbstractRoute r : largest.getRoutes()) {
+        lines.add(r.getNetwork().toString());
+      }
+    }
+    Files.write(file, lines);
+    System.out.printf("DUMPED %d prefixes (one per route) to %s%n", lines.size(), file);
+  }
+
+  private static void histogram(int lines) throws Exception {
+    System.gc();
+    System.gc();
+    Runtime rt = Runtime.getRuntime();
+    System.out.printf("HEAP_USED_MB %d%n", (rt.totalMemory() - rt.freeMemory()) >> 20);
+    // Three header lines precede the entries.
+    diagnosticCommand("gcClassHistogram").lines().limit(lines + 3).forEach(System.out::println);
+  }
+
+  private static String diagnosticCommand(String command, String... commandArgs) throws Exception {
+    return (String)
+        ManagementFactory.getPlatformMBeanServer()
+            .invoke(
+                new ObjectName("com.sun.management:type=DiagnosticCommand"),
+                command,
+                new Object[] {commandArgs},
+                new String[] {String[].class.getName()});
+  }
+}

--- a/tools/profiling/README.md
+++ b/tools/profiling/README.md
@@ -190,3 +190,27 @@ Output shows regressions:
 - [async-profiler documentation](https://github.com/async-profiler/async-profiler)
 - [Profiling guide](https://krzysztofslusarski.github.io/2022/12/12/async-manual.html)
 - [Flame graph interpretation](http://www.brendangregg.com/flamegraphs.html)
+
+## Headless dataplane runs
+
+`//tools/profiling:dataplaneRunner` parses a snapshot directory and computes its
+dataplane in one JVM, with no coordinator or client, so the profiler sees only
+that work. It prints parse and dataplane times, route and FIB counts with
+order-independent hashes (to check that two builds agree), and optionally a
+class histogram of the live heap.
+
+```bash
+bazel build //tools/profiling:dataplaneRunner_deploy.jar
+java -Xmx12g -jar bazel-bin/tools/profiling/dataplaneRunner_deploy.jar \
+  /path/to/snapshot --filter '^dc1-' --histogram 20
+```
+
+Options: `--filter REGEX` loads only matching config files; `--histogram N`
+prints the top N classes after a full GC; `--retain dataplane|nothing` drops
+the `Batfish` instance (and the dataplane) first, to see what a server would
+keep; `--dump-prefixes FILE` writes the largest main RIB's prefixes for
+microbenchmarks; `--jfr FILE` dumps a flight recording started with
+`-XX:StartFlightRecording:settings=profile,path-to-gc-roots=true`. Add
+`-agentpath:<libasyncProfiler>=start,event=cpu,file=out.collapsed,collapsed`
+to the java command to profile it.
+


### PR DESCRIPTION
dataplaneRunner parses a snapshot directory and computes its dataplane
in one JVM with no coordinator or client, so a profiler attached to it
sees only that work. It prints parse and dataplane times, route and FIB
counts with order-independent hashes so two builds can be checked for
identical results, and on request a class histogram of the live heap
taken in-process, what a server would retain, a flight recording with
GC-root chains, or the largest main RIB's prefixes as benchmark input.

It exits through Runtime.halt: Batfish leaves non-daemon threads behind
that keep the JVM alive after main returns, and attaching jcmd for a
histogram hung against a large heap.

----

Prompt:
```
make a PR(s) for any other changes that aren't related to the
PrefixTrieMultiMap refactor. I see some more stream rewrites I think
```

Split out of a session optimizing PrefixTrieMultiMap, where this was
the harness for every before/after measurement.
