### PR TITLE
PrefixTrieMultiMap: add Handle to read and then update one prefix in a single search

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
@@ -50,14 +50,14 @@ final class RibTree<R extends AbstractRouteDecorator> implements Serializable {
     assert reason != Reason.ADD : "cannot remove a route with reason ADD";
 
     Prefix network = route.getNetwork();
-    boolean removed = _root.remove(network, route);
-    if (!removed) {
+    PrefixTrieMultiMap<R>.Handle handle = _root.existingHandle(network);
+    if (handle == null || !handle.remove(route)) {
       return RibDelta.empty();
     }
 
     RouteAdvertisement<R> removeRoute = new RouteAdvertisement<>(route, reason);
 
-    if (!_root.get(network).isEmpty()) {
+    if (!handle.get().isEmpty()) {
       // we still have a route for the network, so don't need to re-merge backups
       return RibDelta.of(removeRoute);
     }
@@ -175,9 +175,10 @@ final class RibTree<R extends AbstractRouteDecorator> implements Serializable {
    */
   @Nonnull
   RibDelta<R> mergeRoute(R route) {
-    Set<R> routes = _root.get(route.getNetwork());
+    PrefixTrieMultiMap<R>.Handle handle = _root.handle(route.getNetwork());
+    Set<R> routes = handle.get();
     if (routes.isEmpty()) {
-      _root.put(route.getNetwork(), route);
+      handle.add(route);
       return RibDelta.adding(route);
     }
     /*
@@ -194,7 +195,7 @@ final class RibTree<R extends AbstractRouteDecorator> implements Serializable {
     }
     if (preferenceComparison == 0) { // equal preference, so add for multipath routing
       // Otherwise add the route
-      if (_root.put(route.getNetwork(), route)) {
+      if (handle.add(route)) {
         return RibDelta.adding(route);
       } else {
         return RibDelta.empty();
@@ -205,7 +206,7 @@ final class RibTree<R extends AbstractRouteDecorator> implements Serializable {
      * Better than all existing routes for this prefix, so
      * replace them with this one.
      */
-    if (_root.replaceAll(route.getNetwork(), route)) {
+    if (handle.replaceAll(route)) {
       // build the RibDelta directly, since we know the routes are distinct
       List<RouteAdvertisement<R>> actions =
           Streams.concat(

--- a/projects/common/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -459,25 +459,64 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
   }
 
   /**
-   * Stores a key-value pair in the multimap.
-   *
-   * @return whether the multimap was modified.
+   * The elements at one prefix, found (or created) once and then read and modified without
+   * searching the trie again. Valid until the trie is {@link #clear() cleared}.
    */
-  public boolean put(Prefix p, T e) {
-    return putAll(p, ImmutableList.of(e));
+  public final class Handle {
+    private final @Nonnull Node<T> _node;
+
+    private Handle(Node<T> node) {
+      _node = node;
+    }
+
+    /** The elements at this prefix; empty if there are none. */
+    public @Nonnull Set<T> get() {
+      return _node._elements;
+    }
+
+    /** As {@link PrefixTrieMultiMap#put}. */
+    public boolean add(T e) {
+      return addAll(_node, ImmutableList.of(e));
+    }
+
+    /** As {@link PrefixTrieMultiMap#replaceAll}. */
+    public boolean replaceAll(T e) {
+      return replaceAllAt(_node, e);
+    }
+
+    /** As {@link PrefixTrieMultiMap#remove}. */
+    public boolean remove(T e) {
+      return removeAt(_node, e);
+    }
   }
 
   /**
-   * Stores multiple key-value pairs for a single key in the multimap.
-   *
-   * @return whether the multimap was modified.
+   * A {@link Handle} on the elements at {@code p}, creating the prefix's node if needed. Use it to
+   * read and then update one prefix with a single search.
    */
-  public boolean putAll(Prefix p, Collection<T> elements) {
+  public @Nonnull Handle handle(Prefix p) {
+    return new Handle(findOrCreateNode(p));
+  }
+
+  /**
+   * A {@link Handle} on the elements at {@code p}, or {@code null} if there are none. Unlike {@link
+   * #handle}, this never adds to the trie.
+   */
+  public @Nullable Handle existingHandle(Prefix p) {
+    Node<T> node = exactMatchNode(p);
+    return node == null || node._elements.isEmpty() ? null : new Handle(node);
+  }
+
+  private @Nonnull Node<T> findOrCreateNode(Prefix p) {
     if (_root == null || !_root._prefix.containsPrefix(p)) {
-      _root = combine(new Node<T>(p, elements), _root);
-      return true;
+      Node<T> node = new Node<>(p);
+      _root = combine(node, _root);
+      return node;
     }
-    Node<T> node = _root.findOrCreateNode(p);
+    return _root.findOrCreateNode(p);
+  }
+
+  private static <T> boolean addAll(Node<T> node, Collection<T> elements) {
     if (node._elements.containsAll(elements)) {
       return false;
     }
@@ -493,14 +532,8 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     return true;
   }
 
-  /**
-   * Remove a key-value pair from the multimap.
-   *
-   * @return whether the multimap was modified.
-   */
-  public boolean remove(Prefix p, T e) {
-    Node<T> node = exactMatchNode(p);
-    if (node == null || !node._elements.contains(e)) {
+  private static <T> boolean removeAt(Node<T> node, T e) {
+    if (!node._elements.contains(e)) {
       return false;
     }
     if (node._elements.size() == 1) {
@@ -514,21 +547,49 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     return true;
   }
 
+  private static <T> boolean replaceAllAt(Node<T> node, T e) {
+    if (node._elements.size() == 1 && node._elements.contains(e)) {
+      return false;
+    }
+    node._elements = ImmutableSet.of(e);
+    return true;
+  }
+
+  /**
+   * Stores a key-value pair in the multimap.
+   *
+   * @return whether the multimap was modified.
+   */
+  public boolean put(Prefix p, T e) {
+    return putAll(p, ImmutableList.of(e));
+  }
+
+  /**
+   * Stores multiple key-value pairs for a single key in the multimap.
+   *
+   * @return whether the multimap was modified.
+   */
+  public boolean putAll(Prefix p, Collection<T> elements) {
+    return addAll(findOrCreateNode(p), elements);
+  }
+
+  /**
+   * Remove a key-value pair from the multimap.
+   *
+   * @return whether the multimap was modified.
+   */
+  public boolean remove(Prefix p, T e) {
+    Node<T> node = exactMatchNode(p);
+    return node != null && removeAt(node, e);
+  }
+
   /**
    * Replace any elements associated with prefix {@code p} with a given element.
    *
    * @return whether the multimap was modified
    */
   public boolean replaceAll(Prefix p, T e) {
-    Node<T> node = _root == null || !_root._prefix.containsPrefix(p) ? null : exactMatchNode(p);
-    if (node == null) {
-      return put(p, e);
-    }
-    if (node._elements.size() == 1 && node._elements.contains(e)) {
-      return false;
-    }
-    node._elements = ImmutableSet.of(e);
-    return true;
+    return replaceAllAt(findOrCreateNode(p), e);
   }
 
   /** Remove all elements from the multimap. */

--- a/projects/common/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -539,6 +540,58 @@ public class PrefixTrieMultiMapTest {
     ptmm.put(Prefix.parse("20.0.0.0/8"), ++i);
     ptmm.put(Prefix.parse("192.168.0.0/16"), ++i);
     assertThat(ptmm, equalTo(SerializationUtils.clone(ptmm)));
+  }
+
+  @Test
+  public void testHandle() {
+    PrefixTrieMultiMap<Integer> trie = new PrefixTrieMultiMap<>();
+    Prefix p = Prefix.parse("10.0.0.0/8");
+    PrefixTrieMultiMap<Integer>.Handle h = trie.handle(p);
+    assertThat(h.get(), empty());
+    assertThat(trie.getNumElements(), equalTo(0));
+    assertTrue(h.add(1));
+    assertFalse(h.add(1));
+    assertThat(h.get(), equalTo(ImmutableSet.of(1)));
+    assertThat(trie.get(p), equalTo(ImmutableSet.of(1)));
+    assertTrue(h.add(2));
+    assertThat(trie.get(p), equalTo(ImmutableSet.of(1, 2)));
+    assertTrue(h.replaceAll(3));
+    assertFalse(h.replaceAll(3));
+    assertThat(trie.get(p), equalTo(ImmutableSet.of(3)));
+    assertFalse(h.remove(1));
+    assertTrue(h.remove(3));
+    assertThat(trie.get(p), empty());
+    assertThat(trie.getNumElements(), equalTo(0));
+    // The handle stays valid while the trie grows around it, including above it.
+    for (int i = 0; i < 1000; ++i) {
+      trie.put(Prefix.create(Ip.create(0x0B000000L + i), 32), i);
+    }
+    trie.put(Prefix.ZERO, -1);
+    assertTrue(h.add(4));
+    assertThat(trie.get(p), equalTo(ImmutableSet.of(4)));
+    assertThat(trie.longestPrefixMatch(Ip.parse("10.1.1.1")), equalTo(ImmutableSet.of(4)));
+    assertThat(trie.handle(p).get(), equalTo(ImmutableSet.of(4)));
+    assertThat(trie.existingHandle(p).get(), equalTo(ImmutableSet.of(4)));
+  }
+
+  @Test
+  public void testExistingHandle() {
+    PrefixTrieMultiMap<Integer> trie = new PrefixTrieMultiMap<>();
+    trie.put(Prefix.parse("10.0.0.0/16"), 1);
+    trie.put(Prefix.parse("10.1.0.0/16"), 2);
+    // Prefixes without elements, including the branching node the two puts created, have no
+    // handle...
+    assertThat(trie.existingHandle(Prefix.parse("10.0.0.0/15")), nullValue());
+    assertThat(trie.existingHandle(Prefix.parse("10.0.0.0/8")), nullValue());
+    assertThat(trie.existingHandle(Prefix.parse("10.0.0.0/24")), nullValue());
+    assertThat(trie.existingHandle(Prefix.parse("11.0.0.0/16")), nullValue());
+    assertThat(new PrefixTrieMultiMap<Integer>().existingHandle(Prefix.ZERO), nullValue());
+    // ...and asking did not add them.
+    assertThat(keysInPostOrder(trie), hasSize(2));
+    PrefixTrieMultiMap<Integer>.Handle h = trie.existingHandle(Prefix.parse("10.1.0.0/16"));
+    assertThat(h.get(), equalTo(ImmutableSet.of(2)));
+    assertTrue(h.remove(2));
+    assertThat(trie.existingHandle(Prefix.parse("10.1.0.0/16")), nullValue());
   }
 
   private static RangeSet<Ip> toRangeSet(Prefix prefix) {


### PR DESCRIPTION
RibTree.mergeRoute searched the trie for a prefix's routes and then
searched again to add or replace them; removeRouteGetDelta searched to
remove and again to see what was left. handle(prefix) finds or creates
the node once and returns a Handle whose get, add, replaceAll and remove
operate on that node. existingHandle(prefix) returns null rather than
creating anything, so removing a route that was never present adds no
node.

On 250 devices of one region the trie work under mergeRoute falls from
about 10.5% to 8.6% of dataplane CPU samples, around 2% overall and
within run-to-run noise of wall time. The API is groundwork for a
change of node representation, where a second search costs more.

----

Prompt:
```
Would it be useful to send Handle as its own PR?
Do it. including measuring perf
```

Split out of a session optimizing PrefixTrieMultiMap.
