### PR TITLE
PrefixTrieMultiMap: pack nodes into int records

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibResolutionTrie.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibResolutionTrie.java
@@ -3,7 +3,6 @@ package org.batfish.dataplane.rib;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.BiPredicate;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -68,11 +67,8 @@ public final class RibResolutionTrie {
     // - whose prefix contains newPrefix.
     // - whose prefix is contained within newPrefix, and do not contain a previously added prefix,
     //   i.e., an intermediate node, or one with just an NHIP.
-    BiPredicate<Prefix, Set<ResolutionTrieValue>> visitNode =
-        (prefix, values) ->
-            prefix.containsPrefix(newPrefix)
-                || (newPrefix.containsPrefix(prefix) && !values.contains(PREFIX));
-    _prefixesAndNextHops.traverseEntries(collectNextHopIp, visitNode);
+    _prefixesAndNextHops.traverseEntriesAround(
+        newPrefix, values -> !values.contains(PREFIX), collectNextHopIp);
     return affectedNextHopIps.build();
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -118,6 +118,7 @@ public final class FibImpl implements Fib {
         .map(AbstractRouteDecorator::getAbstractRoute)
         .filter(r -> !r.getNonForwarding() && fibExportFilter.test(r))
         .forEach(r -> _root.putAll(r.getNetwork(), resolveRoute(rib, r, restriction)));
+    _root.trimToSize();
     initSuppliers();
   }
 

--- a/projects/common/src/main/java/org/batfish/datamodel/FinalMainRib.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/FinalMainRib.java
@@ -92,6 +92,7 @@ public final class FinalMainRib implements Serializable {
     if (!curRoutes.isEmpty()) {
       ret.putAll(curPrefix[0], curRoutes);
     }
+    ret.trimToSize();
     return ret;
   }
 

--- a/projects/common/src/main/java/org/batfish/datamodel/Ip.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Ip.java
@@ -129,6 +129,14 @@ public class Ip implements Comparable<Ip>, Serializable {
     _ip = ipAsInt;
   }
 
+  /**
+   * An {@link Ip} that bypasses the cache: equal to, but not the same instance as, {@link
+   * #create}'s.
+   */
+  static Ip uncached(int ipAsInt) {
+    return new Ip(ipAsInt);
+  }
+
   @JsonCreator
   public static Ip parse(String ipAsString) {
     return create(ipStrToInt(ipAsString));

--- a/projects/common/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/Prefix.java
@@ -113,6 +113,16 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
     return CACHE.get(p);
   }
 
+  /**
+   * A {@link Prefix} that bypasses the cache: equal to, but not the same instance as, the one
+   * {@link #create} returns. For transient use where the cache traffic would cost more than the
+   * object.
+   */
+  static Prefix uncached(int bits, int prefixLength) {
+    int networkBits = bits & (int) ~wildcardMaskForPrefixLength(prefixLength);
+    return new Prefix(Ip.uncached(networkBits), prefixLength);
+  }
+
   public static Prefix create(Ip address, Ip mask) {
     return create(address, mask.numSubnetBits());
   }

--- a/projects/common/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -1,26 +1,24 @@
 package org.batfish.datamodel;
 
-import static org.batfish.datamodel.Prefix.longestCommonPrefix;
+import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -37,53 +35,57 @@ import javax.annotation.ParametersAreNonnullByDefault;
  *
  * <p>Internally, this data structure employs path compression which optimizes look-ups, since
  * branching does not have to be done on each bit of the prefix.
+ *
+ * <p>Nodes are records in an {@code int[]} rather than objects: prefix bits, prefix length, child
+ * offsets and flags take three ints, so a lookup step reads one place in one array and never
+ * follows a reference until it has found its answer. A node that has been given elements carries a
+ * fourth int, a slot into the element and key arrays, so the branching nodes that path compression
+ * creates cost twelve bytes and nothing else. A node with a single element stores the element
+ * itself rather than a singleton set.
  */
 @ParametersAreNonnullByDefault
 public final class PrefixTrieMultiMap<T> implements Serializable {
 
   /**
-   * Combine two nodes into a tree -- a newly created node, and an existing node. The existing node
-   * cannot be the parent of the new node.
+   * Interface of fold operations. A fold applies the same operation at each node of the trie,
+   * bottom-up. The operation's inputs are the return values of the recursive calls on the subtries,
+   * plus the prefix and values at that node.
    */
-  static @Nonnull <T> Node<T> combine(@Nonnull Node<T> newNode, @Nullable Node<T> oldNode) {
-    // No existing node, newNode is the tree
-    if (oldNode == null) {
-      return newNode;
+  public interface FoldOperator<T, R> {
+    @Nonnull
+    R fold(Prefix prefix, Set<T> elems, @Nullable R leftResult, @Nullable R rightResult);
+  }
+
+  /**
+   * The elements at one prefix, found (or created) once and then read and modified without
+   * searching the trie again. Valid until the trie is {@link #clear() cleared}.
+   */
+  public final class Handle {
+    private final int _node;
+
+    private Handle(int node) {
+      _node = node;
     }
 
-    Prefix newPrefix = newNode._prefix;
-    Prefix oldPrefix = oldNode._prefix;
-
-    assert !oldPrefix.containsPrefix(newPrefix);
-
-    /* If the newNode's prefix contains the oldNode's prefix, the existing node is a child of
-     * the newNode.
-     */
-    if (newPrefix.containsPrefix(oldPrefix)) {
-      boolean currentBit = oldPrefix.getStartIp().getBitAtPosition(newPrefix.getPrefixLength());
-      if (currentBit) {
-        newNode._right = oldNode;
-      } else {
-        newNode._left = oldNode;
-      }
-      return newNode;
+    /** The elements at this prefix; empty if there are none. */
+    public @Nonnull Set<T> get() {
+      return elementsAt(_node);
     }
 
-    /* Find the least-upper-bound of the two prefixes, i.e. the one for which the newNode branches
-     * one way and the oldNode branches the other.
-     */
-    Prefix lcp = longestCommonPrefix(newPrefix, oldPrefix);
-    Node<T> parent = new Node<>(lcp);
-
-    boolean newNodeRight = newPrefix.getStartIp().getBitAtPosition(lcp.getPrefixLength());
-    if (newNodeRight) {
-      parent.setRight(newNode);
-      parent.setLeft(oldNode);
-    } else {
-      parent.setRight(oldNode);
-      parent.setLeft(newNode);
+    /** As {@link PrefixTrieMultiMap#put}. */
+    public boolean add(T e) {
+      return addElement(_node, e);
     }
-    return parent;
+
+    /** As {@link PrefixTrieMultiMap#replaceAll}. */
+    public boolean replaceAll(T e) {
+      return replaceAllAt(_node, e);
+    }
+
+    /** As {@link PrefixTrieMultiMap#remove}. */
+    public boolean remove(T e) {
+      return removeAt(_node, e);
+    }
   }
 
   @VisibleForTesting
@@ -100,208 +102,555 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
         && childPrefix.getStartIp().getBitAtPosition(parentPrefix.getPrefixLength());
   }
 
-  /**
-   * Interface of fold operations. A fold applies the same operation at each node of the trie,
-   * bottom-up. The operation's inputs are the return values of the recursive calls on the subtries,
-   * plus the prefix and values at that node.
+  /** Offset used for "no node"; also "no slot". */
+  private static final int NONE = -1;
+
+  /*
+   * A node is a record in _nodes at offset n:
+   *
+   *   _nodes[n]     prefix bits
+   *   _nodes[n + 1] [left child offset + 1: 26][prefix length: 6]
+   *   _nodes[n + 2] [right child offset + 1: 26][DEAD][HAS_SLOT][MULTI][HAS_VALUE][unused: 2]
+   *   _nodes[n + 3] slot, present only if HAS_SLOT
+   *
+   * Child offsets are stored plus one so that zero, the value of a fresh word, means NONE. A node
+   * that must gain a slot after creation is copied to a new four-int record and the old record is
+   * marked DEAD; iteration over records skips it.
    */
-  public interface FoldOperator<T, R> {
-    @Nonnull
-    R fold(Prefix prefix, Set<T> elems, @Nullable R leftResult, @Nullable R rightResult);
-  }
+  private static final int LOW_BITS = 6;
+  private static final int LEN_MASK = (1 << LOW_BITS) - 1;
+  private static final int HAS_VALUE = 1;
+  private static final int MULTI = 1 << 1;
+  private static final int HAS_SLOT = 1 << 2;
+  private static final int DEAD = 1 << 3;
+  private static final int FLAGS = HAS_VALUE | MULTI | HAS_SLOT | DEAD;
 
-  private static final class Node<T> implements Serializable {
+  /** The largest record offset a child field can address. */
+  private static final int MAX_OFFSET = (1 << (Integer.SIZE - LOW_BITS)) - 2;
 
-    private final @Nonnull Prefix _prefix;
-    private @Nonnull ImmutableSet<T> _elements;
+  private static final int BRANCH_RECORD = 3;
+  private static final int SLOTTED_RECORD = 4;
+  private static final int INITIAL_CAPACITY = 8 * SLOTTED_RECORD;
+  private static final int[] EMPTY_NODES = new int[0];
+  private static final Object[] EMPTY_VALUES = new Object[0];
+  private static final Prefix[] EMPTY_KEYS = new Prefix[0];
 
-    private @Nullable Node<T> _left;
-    private @Nullable Node<T> _right;
+  private int[] _nodes;
 
-    Node(Prefix prefix) {
-      this(prefix, ImmutableSet.of());
-    }
+  /** The number of ints of {@link #_nodes} in use. */
+  private int _used;
 
-    Node(Prefix prefix, Collection<T> elements) {
-      _prefix = prefix;
-      _elements = ImmutableSet.copyOf(elements);
-    }
+  private int _root;
 
-    private @Nonnull Node<T> createChild(Prefix prefix) {
-      assert _prefix.containsPrefix(prefix);
-      boolean currentBit = prefix.getStartIp().getBitAtPosition(_prefix.getPrefixLength());
+  /** Slot s holds the element ({@code T}) or elements ({@link ImmutableSet}) of one node. */
+  private Object[] _values;
 
-      Node<T> node = new Node<>(prefix);
-      if (currentBit) {
-        _right = combine(node, _right);
-      } else {
-        _left = combine(node, _left);
-      }
-      return node;
-    }
+  /** Slot s holds the {@link Prefix} of the node, sharing the caller's instance. */
+  private Prefix[] _keys;
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      Node<?> that = (Node<?>) o;
-      return _prefix.equals(that._prefix)
-          && _elements.equals(that._elements)
-          && Objects.equals(_left, that._left)
-          && Objects.equals(_right, that._right);
-    }
-
-    /** Find or create a node for a given prefix (must be an exact match) */
-    private @Nonnull Node<T> findOrCreateNode(Prefix prefix) {
-      assert _prefix.containsPrefix(prefix);
-
-      Node<T> node = findLongestPrefixMatchNode(prefix);
-      return node._prefix.equals(prefix) ? node : node.createChild(prefix);
-    }
-
-    @Nonnull
-    <R> R fold(FoldOperator<T, R> operator) {
-      R leftResult = _left == null ? null : _left.fold(operator);
-      R rightResult = _right == null ? null : _right.fold(operator);
-      return operator.fold(_prefix, _elements, leftResult, rightResult);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(_prefix, _elements, _left, _right);
-    }
-
-    /** Returns the node with the longest prefix match for a given prefix. */
-    @Nonnull
-    Node<T> findLongestPrefixMatchNode(Prefix prefix) {
-      return findLongestPrefixMatchNode(prefix.getStartIp(), prefix.getPrefixLength());
-    }
-
-    /** Returns the node with the longest prefix match for a given prefix. */
-    @Nonnull
-    Node<T> findLongestPrefixMatchNode(Ip ip, int prefixLength) {
-      assert _prefix.containsPrefix(ip, prefixLength);
-
-      Node<T> node = this;
-      while (true) {
-        // Choose which child might have a longer match
-        Node<T> child = node.matchingChild(ip, prefixLength);
-        if (child == null) {
-          return node;
-        }
-        node = child;
-      }
-    }
-
-    @Nullable
-    Node<T> findLongestPrefixMatchNonEmptyNode(Ip ip, int maxPrefixLength) {
-      assert _prefix.containsPrefix(ip, maxPrefixLength);
-
-      Node<T> longestNonEmpty = null;
-      Node<T> node = this;
-      while (node != null) {
-        if (!node._elements.isEmpty()) {
-          longestNonEmpty = node;
-        }
-
-        // Choose which child might have a longer match
-        node = node.matchingChild(ip, maxPrefixLength);
-      }
-
-      return longestNonEmpty;
-    }
-
-    @Nullable
-    Node<T> matchingChild(Ip ip, int prefixLength) {
-      if (_prefix.getPrefixLength() == Prefix.MAX_PREFIX_LENGTH) {
-        return null;
-      }
-      Node<T> child = ip.getBitAtPosition(_prefix.getPrefixLength()) ? _right : _left;
-      return child == null || !child._prefix.containsPrefix(ip, prefixLength) ? null : child;
-    }
-
-    private void setLeft(@Nullable Node<T> left) {
-      assert left == null || legalLeftChildPrefix(_prefix, left._prefix);
-      _left = left;
-    }
-
-    private void setRight(@Nullable Node<T> right) {
-      assert right == null || legalRightChildPrefix(_prefix, right._prefix);
-      _right = right;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this).add("prefix", _prefix).toString();
-    }
-
-    /**
-     * Returns true iff there is a {@link Prefix} key in this subtree included in {@code
-     * prefixRange}.
-     */
-    private boolean intersectsPrefixRange(PrefixRange prefixRange) {
-      // Overview:
-      // - If this prefix's length is greater than prefixRange's max length, return false.
-      // - If this prefix is contained in prefixRange and this node has any elements (making this
-      //   prefix a key), return true.
-      // - If either of this prefix or prefixRange's match prefix contains the other, then check
-      //   this node's children.
-      // - Else return false.
-
-      int currentLength = _prefix.getPrefixLength();
-      int maxLength = prefixRange.getLengthRange().getEnd();
-      if (currentLength > maxLength) {
-        return false;
-      }
-
-      if (prefixRange.includesPrefixRange(PrefixRange.fromPrefix(_prefix))
-          && !_elements.isEmpty()) {
-        return true;
-      }
-
-      Prefix rangePrefix = prefixRange.getPrefix();
-      return (_prefix.containsPrefix(rangePrefix) || rangePrefix.containsPrefix(_prefix))
-          && ((_left != null && _left.intersectsPrefixRange(prefixRange))
-              || (_right != null && _right.intersectsPrefixRange(prefixRange)));
-    }
-
-    Stream<Map.Entry<Prefix, Set<T>>> getOverlappingEntries(RangeSet<Ip> ips) {
-      RangeSet<Ip> matchingIps =
-          ips.subRangeSet(Range.closed(_prefix.getStartIp(), _prefix.getEndIp()));
-      if (matchingIps.isEmpty()) {
-        return Stream.of();
-      }
-      Stream<Map.Entry<Prefix, Set<T>>> elementsHere =
-          _elements.isEmpty() ? Stream.of() : Stream.of(Maps.immutableEntry(_prefix, _elements));
-      return Stream.concat(
-          // recurse lazily
-          Stream.of(_left, _right)
-              .filter(Objects::nonNull)
-              .flatMap(child -> child.getOverlappingEntries(matchingIps)),
-          // post-order
-          elementsHere);
-    }
-  }
-
-  private @Nullable Node<T> _root;
+  private int _numSlots;
+  private int _numElements;
 
   public PrefixTrieMultiMap() {
-    _root = null;
+    clear();
   }
+
+  // Bit arithmetic on prefixes given as (bits, length).
+
+  /** A mask selecting the top {@code len} bits, for {@code 0 <= len <= 32}. */
+  private static int prefixMask(int len) {
+    return (int) (0xFFFFFFFFL << (Prefix.MAX_PREFIX_LENGTH - len));
+  }
+
+  /** Whether the prefix (bits, len) contains the prefix (otherBits, otherLen). */
+  private static boolean contains(int bits, int len, int otherBits, int otherLen) {
+    return len <= otherLen && ((bits ^ otherBits) & prefixMask(len)) == 0;
+  }
+
+  /** The bit of {@code bits} at {@code pos}, where 0 is the most significant bit and pos < 32. */
+  private static boolean bitAt(int bits, int pos) {
+    return ((bits >>> (Prefix.MAX_PREFIX_LENGTH - 1 - pos)) & 1) != 0;
+  }
+
+  private static int bitsOf(Prefix p) {
+    return (int) p.getStartIp().asLong();
+  }
+
+  // Record field accessors. "a" is the second int of a record and "b" the third.
+
+  private static int lenOf(int a) {
+    return a & LEN_MASK;
+  }
+
+  private static int leftOf(int a) {
+    return (a >>> LOW_BITS) - 1;
+  }
+
+  private static int rightOf(int b) {
+    return (b >>> LOW_BITS) - 1;
+  }
+
+  private static boolean valued(int b) {
+    return (b & HAS_VALUE) != 0;
+  }
+
+  private static boolean multi(int b) {
+    return (b & MULTI) != 0;
+  }
+
+  private static boolean slotted(int b) {
+    return (b & HAS_SLOT) != 0;
+  }
+
+  private static int recordSize(int b) {
+    return slotted(b) ? SLOTTED_RECORD : BRANCH_RECORD;
+  }
+
+  private int bits(int n) {
+    return _nodes[n];
+  }
+
+  private int len(int n) {
+    return lenOf(_nodes[n + 1]);
+  }
+
+  private int left(int n) {
+    return leftOf(_nodes[n + 1]);
+  }
+
+  private int right(int n) {
+    return rightOf(_nodes[n + 2]);
+  }
+
+  private boolean hasValue(int n) {
+    return valued(_nodes[n + 2]);
+  }
+
+  /** The slot of node {@code n}, which must have one. */
+  private int slotOf(int n) {
+    assert slotted(_nodes[n + 2]);
+    return _nodes[n + 3];
+  }
+
+  private void setLeft(int n, int child) {
+    _nodes[n + 1] = (_nodes[n + 1] & LEN_MASK) | ((child + 1) << LOW_BITS);
+  }
+
+  private void setRight(int n, int child) {
+    _nodes[n + 2] = (_nodes[n + 2] & FLAGS) | ((child + 1) << LOW_BITS);
+  }
+
+  private void setValueFlags(int n, int flags) {
+    assert (flags & ~(HAS_VALUE | MULTI)) == 0;
+    _nodes[n + 2] = (_nodes[n + 2] & ~(HAS_VALUE | MULTI)) | flags;
+  }
+
+  /** The number of elements at node {@code n}. */
+  private int countAt(int n) {
+    int b = _nodes[n + 2];
+    if (!valued(b)) {
+      return 0;
+    }
+    return multi(b) ? ((ImmutableSet<?>) _values[_nodes[n + 3]]).size() : 1;
+  }
+
+  @SuppressWarnings("unchecked")
+  private @Nonnull ImmutableSet<T> elementsAt(int n) {
+    int b = _nodes[n + 2];
+    if (!valued(b)) {
+      return ImmutableSet.of();
+    }
+    Object v = _values[_nodes[n + 3]];
+    return multi(b) ? (ImmutableSet<T>) v : ImmutableSet.of((T) v);
+  }
+
+  private int elementsHashAt(int n) {
+    // Set.hashCode is the sum of the element hash codes, so a bare element hashes like its set.
+    return hasValue(n) ? _values[slotOf(n)].hashCode() : 0;
+  }
+
+  private void setSingle(int n, T element) {
+    Objects.requireNonNull(element);
+    _numElements += 1 - countAt(n);
+    _values[slotOf(n)] = element;
+    setValueFlags(n, HAS_VALUE);
+  }
+
+  private void setElements(int n, ImmutableSet<T> elements) {
+    if (elements.isEmpty()) {
+      clearElements(n);
+    } else if (elements.size() == 1) {
+      setSingle(n, elements.iterator().next());
+    } else {
+      _numElements += elements.size() - countAt(n);
+      _values[slotOf(n)] = elements;
+      setValueFlags(n, HAS_VALUE | MULTI);
+    }
+  }
+
+  private void clearElements(int n) {
+    if (!hasValue(n)) {
+      return;
+    }
+    _numElements -= countAt(n);
+    _values[slotOf(n)] = null;
+    setValueFlags(n, 0);
+  }
+
+  /**
+   * The prefix of node {@code n}. Nodes that have held elements return the caller's {@link Prefix}
+   * instance; branching nodes return a fresh, equal instance that bypasses the {@link Prefix}
+   * cache.
+   */
+  private @Nonnull Prefix keyOf(int n) {
+    if (slotted(_nodes[n + 2])) {
+      Prefix k = _keys[_nodes[n + 3]];
+      if (k != null) {
+        return k;
+      }
+    }
+    return Prefix.uncached(bits(n), len(n));
+  }
+
+  // Node creation.
+
+  private static int grownCapacity(int oldCapacity, int minimum) {
+    return Math.max(
+        minimum, oldCapacity == 0 ? INITIAL_CAPACITY : oldCapacity + Math.max(1, oldCapacity >> 1));
+  }
+
+  private int allocateSlot() {
+    if (_numSlots == _values.length) {
+      int newCapacity = grownCapacity(_values.length, _numSlots + 1);
+      _values = Arrays.copyOf(_values, newCapacity);
+      _keys = Arrays.copyOf(_keys, newCapacity);
+    }
+    return _numSlots++;
+  }
+
+  /** Appends a record for the prefix (bits, len) with no children and returns its offset. */
+  private int newNode(int bits, int len, boolean withSlot) {
+    int size = withSlot ? SLOTTED_RECORD : BRANCH_RECORD;
+    if (_used + size > _nodes.length) {
+      _nodes = Arrays.copyOf(_nodes, grownCapacity(_nodes.length, _used + size));
+    }
+    int n = _used;
+    checkState(n <= MAX_OFFSET, "PrefixTrieMultiMap cannot hold more than %s ints", MAX_OFFSET);
+    _used += size;
+    _nodes[n] = bits;
+    _nodes[n + 1] = len;
+    if (withSlot) {
+      _nodes[n + 2] = HAS_SLOT;
+      _nodes[n + 3] = allocateSlot();
+    } else {
+      _nodes[n + 2] = 0;
+    }
+    return n;
+  }
+
+  /** Create a slotted node for {@code p}, remembering the instance as its key. */
+  private int newKeyedNode(Prefix p) {
+    int n = newNode(bitsOf(p), p.getPrefixLength(), true);
+    _keys[_nodes[n + 3]] = p;
+    return n;
+  }
+
+  /**
+   * Gives branching node {@code n} a slot by copying it to a slotted record, re-pointing its parent
+   * (or the root) at the copy. Returns the offset of the copy.
+   */
+  private int relocateWithSlot(int n, int parent, boolean rightSide) {
+    assert !slotted(_nodes[n + 2]);
+    int copy = newNode(_nodes[n], lenOf(_nodes[n + 1]), true);
+    setLeft(copy, left(n));
+    setRight(copy, right(n));
+    _nodes[n + 2] |= DEAD;
+    if (parent == NONE) {
+      assert _root == n;
+      _root = copy;
+    } else if (rightSide) {
+      setRight(parent, copy);
+    } else {
+      setLeft(parent, copy);
+    }
+    return copy;
+  }
+
+  /** Release the slack in the backing arrays. Call once a trie is no longer being modified. */
+  public void trimToSize() {
+    if (_used < _nodes.length) {
+      _nodes = Arrays.copyOf(_nodes, _used);
+    }
+    if (_numSlots < _values.length) {
+      _values = Arrays.copyOf(_values, _numSlots);
+      _keys = Arrays.copyOf(_keys, _numSlots);
+    }
+  }
+
+  /**
+   * Combine two nodes into a tree -- a newly created node, and an existing node (or {@link #NONE}).
+   * The existing node's prefix must not contain the new node's prefix. Returns the root of the
+   * combined tree.
+   */
+  private int combine(int newNode, int oldNode) {
+    if (oldNode == NONE) {
+      return newNode;
+    }
+    int newBits = bits(newNode);
+    int newLen = len(newNode);
+    int oldBits = bits(oldNode);
+    int oldLen = len(oldNode);
+    assert !contains(oldBits, oldLen, newBits, newLen);
+
+    // If the new node's prefix contains the old node's prefix, the old node is its child.
+    if (contains(newBits, newLen, oldBits, oldLen)) {
+      if (bitAt(oldBits, newLen)) {
+        setRight(newNode, oldNode);
+      } else {
+        setLeft(newNode, oldNode);
+      }
+      return newNode;
+    }
+
+    // Otherwise branch at the longest common prefix. Neither prefix contains the other, so they
+    // differ within the shorter length and the common prefix is strictly shorter than both.
+    int lcpLen = Integer.numberOfLeadingZeros(newBits ^ oldBits);
+    assert lcpLen < Math.min(newLen, oldLen);
+    int parent = newNode(newBits & prefixMask(lcpLen), lcpLen, false);
+    if (bitAt(newBits, lcpLen)) {
+      setRight(parent, newNode);
+      setLeft(parent, oldNode);
+    } else {
+      setLeft(parent, newNode);
+      setRight(parent, oldNode);
+    }
+    return parent;
+  }
+
+  // Lookups.
+
+  /**
+   * Returns the deepest node whose prefix contains the prefix (bits, len), or {@link #NONE} if the
+   * root does not.
+   */
+  private int longestMatchNode(int bits, int len) {
+    int[] nodes = _nodes;
+    int node = _root;
+    int found = NONE;
+    while (node != NONE) {
+      int a = nodes[node + 1];
+      int nodeLen = lenOf(a);
+      if (nodeLen > len || ((nodes[node] ^ bits) & prefixMask(nodeLen)) != 0) {
+        break;
+      }
+      found = node;
+      if (nodeLen >= len) {
+        break;
+      }
+      node = bitAt(bits, nodeLen) ? rightOf(nodes[node + 2]) : leftOf(a);
+    }
+    return found;
+  }
+
+  /**
+   * Returns the deepest node that has elements and whose prefix contains {@code ip} with length at
+   * most {@code maxLen}, or {@link #NONE}.
+   */
+  private int longestMatchNonEmptyNode(int ip, int maxLen) {
+    int[] nodes = _nodes;
+    int node = _root;
+    int best = NONE;
+    while (node != NONE) {
+      int a = nodes[node + 1];
+      int nodeLen = lenOf(a);
+      if (nodeLen > maxLen || ((nodes[node] ^ ip) & prefixMask(nodeLen)) != 0) {
+        break;
+      }
+      int b = nodes[node + 2];
+      if (valued(b)) {
+        best = node;
+      }
+      if (nodeLen >= maxLen) {
+        break;
+      }
+      node = bitAt(ip, nodeLen) ? rightOf(b) : leftOf(a);
+    }
+    return best;
+  }
+
+  private int exactMatchNode(Prefix p) {
+    int len = p.getPrefixLength();
+    int node = longestMatchNode(bitsOf(p), len);
+    return node != NONE && len(node) == len ? node : NONE;
+  }
+
+  /** Find or create the slotted node for exactly the given prefix. */
+  private int findOrCreateNode(Prefix p) {
+    int bits = bitsOf(p);
+    int len = p.getPrefixLength();
+    if (_root == NONE) {
+      _root = newKeyedNode(p);
+      return _root;
+    }
+    int[] nodes = _nodes;
+    int node = _root;
+    if (!contains(nodes[node], lenOf(nodes[node + 1]), bits, len)) {
+      int created = newKeyedNode(p);
+      _root = combine(created, _root);
+      return created;
+    }
+    int parent = NONE;
+    boolean rightSide = false;
+    while (true) {
+      int a = nodes[node + 1];
+      int nodeLen = lenOf(a);
+      if (nodeLen == len) {
+        if (!slotted(nodes[node + 2])) {
+          node = relocateWithSlot(node, parent, rightSide);
+        }
+        int slot = _nodes[node + 3];
+        if (_keys[slot] == null) {
+          _keys[slot] = p;
+        }
+        return node;
+      }
+      // node's prefix strictly contains p: descend, or hang p off the appropriate child slot.
+      boolean side = bitAt(bits, nodeLen);
+      int child = side ? rightOf(nodes[node + 2]) : leftOf(a);
+      if (child == NONE || !contains(nodes[child], lenOf(nodes[child + 1]), bits, len)) {
+        int created = newKeyedNode(p);
+        int combined = combine(created, child);
+        if (side) {
+          setRight(node, combined);
+        } else {
+          setLeft(node, combined);
+        }
+        return created;
+      }
+      parent = node;
+      rightSide = side;
+      node = child;
+    }
+  }
+
+  // Element updates at a slotted node.
+
+  @SuppressWarnings("unchecked")
+  private boolean addElement(int node, T e) {
+    int b = _nodes[node + 2];
+    if (!valued(b)) {
+      setSingle(node, e);
+      return true;
+    }
+    Object v = _values[_nodes[node + 3]];
+    if (!multi(b)) {
+      if (v.equals(e)) {
+        return false;
+      }
+      setElements(node, ImmutableSet.of((T) v, e));
+      return true;
+    }
+    ImmutableSet<T> existing = (ImmutableSet<T>) v;
+    if (existing.contains(e)) {
+      return false;
+    }
+    setElements(
+        node,
+        ImmutableSet.<T>builderWithExpectedSize(existing.size() + 1)
+            .addAll(existing)
+            .add(e)
+            .build());
+    return true;
+  }
+
+  @SuppressWarnings("unchecked")
+  private boolean addElements(int node, Collection<T> elements) {
+    int b = _nodes[node + 2];
+    if (!valued(b)) {
+      if (elements.size() == 1) {
+        setSingle(node, elements.iterator().next());
+        return true;
+      }
+      ImmutableSet<T> set = ImmutableSet.copyOf(elements);
+      if (set.isEmpty()) {
+        return false;
+      }
+      setElements(node, set);
+      return true;
+    }
+    Object v = _values[_nodes[node + 3]];
+    if (!multi(b)) {
+      boolean allSame = true;
+      for (T e : elements) {
+        if (!v.equals(e)) {
+          allSame = false;
+          break;
+        }
+      }
+      if (allSame) {
+        return false;
+      }
+      setElements(
+          node,
+          ImmutableSet.<T>builderWithExpectedSize(elements.size() + 1)
+              .add((T) v)
+              .addAll(elements)
+              .build());
+      return true;
+    }
+    ImmutableSet<T> existing = (ImmutableSet<T>) v;
+    if (existing.containsAll(elements)) {
+      return false;
+    }
+    setElements(
+        node,
+        ImmutableSet.<T>builderWithExpectedSize(existing.size() + elements.size())
+            .addAll(existing)
+            .addAll(elements)
+            .build());
+    return true;
+  }
+
+  @SuppressWarnings("unchecked")
+  private boolean removeAt(int node, T e) {
+    int b = _nodes[node + 2];
+    if (!valued(b)) {
+      return false;
+    }
+    Object v = _values[_nodes[node + 3]];
+    if (!multi(b)) {
+      if (!v.equals(e)) {
+        return false;
+      }
+      clearElements(node);
+      return true;
+    }
+    ImmutableSet<T> existing = (ImmutableSet<T>) v;
+    if (!existing.contains(e)) {
+      return false;
+    }
+    setElements(
+        node, existing.stream().filter(el -> !el.equals(e)).collect(ImmutableSet.toImmutableSet()));
+    return true;
+  }
+
+  private boolean replaceAllAt(int node, T e) {
+    int b = _nodes[node + 2];
+    if (valued(b) && !multi(b) && _values[_nodes[node + 3]].equals(e)) {
+      return false;
+    }
+    setSingle(node, e);
+    return true;
+  }
+
+  // Public API.
 
   /**
    * Post-order traversal over the entries. Entries will always contain non-null keys and values.
    * The traversal may not mutate the entries (the values are immutable sets).
    */
   public void traverseEntries(BiConsumer<Prefix, Set<T>> consumer) {
-    // Chose null instead of something like BiPredicates.alwaysTrue() because:
-    // - it doesn't exist
-    // - could not get custom version to type-check
-    traverseEntriesImpl(consumer, null);
+    traverseEntriesImpl(_root, consumer, null);
   }
 
   /**
@@ -309,66 +658,109 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
    * The traversal may not mutate the entries (the values are immutable sets).
    *
    * <p>A node will only be visited if {@code visitNode} returns {@code true} for its prefix and
-   * elements.
+   * elements. It is also evaluated at branching nodes that have no elements, whose prefixes are
+   * fresh instances that bypass the {@link Prefix} cache.
    */
   public void traverseEntries(
       BiConsumer<Prefix, Set<T>> consumer, BiPredicate<Prefix, Set<T>> visitChild) {
-    traverseEntriesImpl(consumer, visitChild);
+    traverseEntriesImpl(_root, consumer, visitChild);
   }
 
   private void traverseEntriesImpl(
-      BiConsumer<Prefix, Set<T>> consumer, @Nullable BiPredicate<Prefix, Set<T>> visitNode) {
-    Consumer<Node<T>> nodeConsumer =
-        node -> {
-          if (!node._elements.isEmpty()) {
-            consumer.accept(node._prefix, node._elements);
-          }
-        };
-    if (visitNode == null) {
-      traverseNodes(nodeConsumer);
+      int node, BiConsumer<Prefix, Set<T>> consumer, @Nullable BiPredicate<Prefix, Set<T>> visit) {
+    if (node == NONE) {
+      return;
+    }
+    if (visit != null && !visit.test(keyOf(node), elementsAt(node))) {
+      return;
+    }
+    traverseEntriesImpl(left(node), consumer, visit);
+    traverseEntriesImpl(right(node), consumer, visit);
+    if (hasValue(node)) {
+      consumer.accept(keyOf(node), elementsAt(node));
+    }
+  }
+
+  /**
+   * Post-order traversal over the entries whose prefix contains {@code prefix} or is contained in
+   * it. Below {@code prefix}, a node and its subtree are visited only if {@code descendThrough}
+   * accepts the node's elements (empty at branching nodes). Equivalent to {@link
+   * #traverseEntries(BiConsumer, BiPredicate)} with the predicate {@code (p, elems) ->
+   * p.containsPrefix(prefix) || (prefix.containsPrefix(p) && descendThrough.test(elems))}, but it
+   * follows a single path to {@code prefix} and materializes no prefixes for branching nodes.
+   */
+  public void traverseEntriesAround(
+      Prefix prefix, Predicate<Set<T>> descendThrough, BiConsumer<Prefix, Set<T>> consumer) {
+    traverseEntriesAroundImpl(
+        _root, bitsOf(prefix), prefix.getPrefixLength(), descendThrough, consumer);
+  }
+
+  private void traverseEntriesAroundImpl(
+      int node,
+      int bits,
+      int len,
+      Predicate<Set<T>> descendThrough,
+      BiConsumer<Prefix, Set<T>> consumer) {
+    if (node == NONE) {
+      return;
+    }
+    int nodeBits = _nodes[node];
+    int nodeLen = len(node);
+    if (contains(nodeBits, nodeLen, bits, len)) {
+      if (nodeLen < len) {
+        // An ancestor: only the child toward the prefix can contain or be contained in it.
+        traverseEntriesAroundImpl(
+            bitAt(bits, nodeLen) ? right(node) : left(node), bits, len, descendThrough, consumer);
+      } else {
+        // The prefix itself: everything below is contained in it.
+        traverseEntriesBelowImpl(left(node), descendThrough, consumer);
+        traverseEntriesBelowImpl(right(node), descendThrough, consumer);
+      }
+    } else if (contains(bits, len, nodeBits, nodeLen)) {
+      // Strictly below the prefix without passing through its node (the path branched above it).
+      traverseEntriesBelowImpl(node, descendThrough, consumer);
+      return;
     } else {
-      traverseNodes(nodeConsumer, node -> visitNode.test(node._prefix, node._elements));
+      return;
+    }
+    if (hasValue(node)) {
+      consumer.accept(keyOf(node), elementsAt(node));
+    }
+  }
+
+  private void traverseEntriesBelowImpl(
+      int node, Predicate<Set<T>> descendThrough, BiConsumer<Prefix, Set<T>> consumer) {
+    if (node == NONE) {
+      return;
+    }
+    Set<T> elements = elementsAt(node);
+    if (!descendThrough.test(elements)) {
+      return;
+    }
+    traverseEntriesBelowImpl(left(node), descendThrough, consumer);
+    traverseEntriesBelowImpl(right(node), descendThrough, consumer);
+    if (!elements.isEmpty()) {
+      consumer.accept(keyOf(node), elements);
     }
   }
 
   /**
    * Perform a fold over the trie. The fold applies the same operation at each node of the trie,
    * bottom-up. The operation's inputs are the return values of the recursive calls on the subtries,
-   * plus the prefix and values at that node.
+   * plus the prefix and values at that node. Branching nodes that have no elements receive prefixes
+   * that are fresh instances bypassing the {@link Prefix} cache.
    */
   public <R> R fold(FoldOperator<T, R> operator) {
-    if (_root == null) {
+    return foldImpl(_root, operator);
+  }
+
+  private @Nullable <R> R foldImpl(int node, FoldOperator<T, R> operator) {
+    if (node == NONE) {
       return null;
     }
-    return _root.fold(operator);
-  }
-
-  private void traverseNodes(Consumer<Node<T>> consumer) {
-    traverseNodes(consumer, Predicates.alwaysTrue());
-  }
-
-  private void traverseNodes(Consumer<Node<T>> consumer, Predicate<Node<T>> visitNode) {
-    traverseNodes(_root, consumer, visitNode);
-  }
-
-  /**
-   * A depth-first post-order consumption of the tree rooted at {@code node}, stopping early if
-   * {@code visitNode} returns {@code false}.
-   */
-  private static <T> void traverseNodes(
-      @Nullable Node<T> node, Consumer<Node<T>> consumer, Predicate<Node<T>> visitNode) {
-    if (node == null || !visitNode.test(node)) {
-      return;
-    }
-    traverseNodes(node._left, consumer, visitNode);
-    traverseNodes(node._right, consumer, visitNode);
-    consumer.accept(node);
-  }
-
-  private @Nullable Node<T> exactMatchNode(Prefix p) {
-    int prefixLength = p.getPrefixLength();
-    Node<T> node = longestMatchNode(p.getStartIp(), prefixLength);
-    return node == null || node._prefix.getPrefixLength() != prefixLength ? null : node;
+    R leftResult = foldImpl(left(node), operator);
+    R rightResult = foldImpl(right(node), operator);
+    return operator.fold(keyOf(node), elementsAt(node), leftResult, rightResult);
   }
 
   @Override
@@ -379,115 +771,44 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     if (!(o instanceof PrefixTrieMultiMap<?>)) {
       return false;
     }
-    PrefixTrieMultiMap<?> map = (PrefixTrieMultiMap<?>) o;
-    return Objects.equals(_root, map._root);
+    PrefixTrieMultiMap<?> that = (PrefixTrieMultiMap<?>) o;
+    if (_numElements != that._numElements) {
+      return false;
+    }
+    // Every entry here matches an entry there, and the element counts agree, so there are no
+    // entries there that are missing here.
+    for (int n = 0; n < _used; n += recordSize(_nodes[n + 2])) {
+      if (hasValue(n)) {
+        int other = that.longestMatchNode(bits(n), len(n));
+        if (other == NONE || that.len(other) != len(n)) {
+          return false;
+        }
+        if (!elementsAt(n).equals(that.elementsAt(other))) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 0;
+    for (int n = 0; n < _used; n += recordSize(_nodes[n + 2])) {
+      if (hasValue(n)) {
+        hash += 31 * (31 * bits(n) + len(n)) + elementsHashAt(n);
+      }
+    }
+    return hash;
   }
 
   /**
    * Retrieve an immutable copy of elements for the given prefix (anywhere in the subtree). Returns
    * empty set if the prefix is not in the subtree.
-   *
-   * @return null if the prefix is not contained in the trie.
    */
   public @Nonnull Set<T> get(Prefix p) {
-    Node<T> node = exactMatchNode(p);
-    return node == null ? ImmutableSet.of() : node._elements;
-  }
-
-  /**
-   * @return all elements in the trie.
-   */
-  public @Nonnull Set<T> getAllElements() {
-    Builder<T> b = ImmutableSet.builder();
-    traverseNodes(node -> b.addAll(node._elements));
-    return b.build();
-  }
-
-  /** Equivalent to {@link #getAllElements()}.{@link Set#size}. */
-  public int getNumElements() {
-    int[] ret = new int[] {0};
-    traverseNodes(node -> ret[0] += node._elements.size());
-    return ret[0];
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(_root);
-  }
-
-  private @Nullable Node<T> longestMatchNode(Ip ip, int maxPrefixLength) {
-    return _root == null || !_root._prefix.containsPrefix(ip, maxPrefixLength)
-        ? null
-        : _root.findLongestPrefixMatchNode(ip, maxPrefixLength);
-  }
-
-  /**
-   * Returns the node that contains the given {@link Ip} with the longest prefix, up to {@code
-   * prefixLength}.
-   */
-  private @Nullable Node<T> longestMatchNonEmptyNode(Ip ip, int maxPrefixLength) {
-    return _root == null || !_root._prefix.containsPrefix(ip, maxPrefixLength)
-        ? null
-        : _root.findLongestPrefixMatchNonEmptyNode(ip, maxPrefixLength);
-  }
-
-  /** Find the elements associated with the longest matching prefix of a given IP address. */
-  public @Nonnull Set<T> longestPrefixMatch(Ip address) {
-    return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
-  }
-
-  /**
-   * Find the elements associated with the longest matching prefix of a given IP address, up to the
-   * given maximum length.
-   */
-  public @Nonnull Set<T> longestPrefixMatch(Ip address, int maxPrefixLength) {
-    Node<T> node = longestMatchNonEmptyNode(address, maxPrefixLength);
-    assert node == null || !node._elements.isEmpty();
-    return node == null ? ImmutableSet.of() : node._elements;
-  }
-
-  /**
-   * Return all values whose keys intersect with the input {@link RangeSet}. Values are returned as
-   * a {@link Stream} in post-order, so if prefix p1 contains p2, values for p2 will be returned
-   * before values for p1.
-   */
-  public @Nonnull Stream<Map.Entry<Prefix, Set<T>>> getOverlappingEntries(RangeSet<Ip> ips) {
-    if (_root == null) {
-      return Stream.of();
-    }
-    return _root.getOverlappingEntries(ips);
-  }
-
-  /**
-   * The elements at one prefix, found (or created) once and then read and modified without
-   * searching the trie again. Valid until the trie is {@link #clear() cleared}.
-   */
-  public final class Handle {
-    private final @Nonnull Node<T> _node;
-
-    private Handle(Node<T> node) {
-      _node = node;
-    }
-
-    /** The elements at this prefix; empty if there are none. */
-    public @Nonnull Set<T> get() {
-      return _node._elements;
-    }
-
-    /** As {@link PrefixTrieMultiMap#put}. */
-    public boolean add(T e) {
-      return addAll(_node, ImmutableList.of(e));
-    }
-
-    /** As {@link PrefixTrieMultiMap#replaceAll}. */
-    public boolean replaceAll(T e) {
-      return replaceAllAt(_node, e);
-    }
-
-    /** As {@link PrefixTrieMultiMap#remove}. */
-    public boolean remove(T e) {
-      return removeAt(_node, e);
-    }
+    int node = exactMatchNode(p);
+    return node == NONE ? ImmutableSet.of() : elementsAt(node);
   }
 
   /**
@@ -503,56 +824,85 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
    * #handle}, this never adds to the trie.
    */
   public @Nullable Handle existingHandle(Prefix p) {
-    Node<T> node = exactMatchNode(p);
-    return node == null || node._elements.isEmpty() ? null : new Handle(node);
+    int node = exactMatchNode(p);
+    return node == NONE || !hasValue(node) ? null : new Handle(node);
   }
 
-  private @Nonnull Node<T> findOrCreateNode(Prefix p) {
-    if (_root == null || !_root._prefix.containsPrefix(p)) {
-      Node<T> node = new Node<>(p);
-      _root = combine(node, _root);
-      return node;
-    }
-    return _root.findOrCreateNode(p);
+  /**
+   * @return all elements in the trie.
+   */
+  public @Nonnull Set<T> getAllElements() {
+    ImmutableSet.Builder<T> b = ImmutableSet.builderWithExpectedSize(_numElements);
+    collectElements(_root, b);
+    return b.build();
   }
 
-  private static <T> boolean addAll(Node<T> node, Collection<T> elements) {
-    if (node._elements.containsAll(elements)) {
-      return false;
+  @SuppressWarnings("unchecked")
+  private void collectElements(int node, ImmutableSet.Builder<T> builder) {
+    if (node == NONE) {
+      return;
     }
-    if (node._elements.isEmpty()) {
-      node._elements = ImmutableSet.copyOf(elements);
-    } else {
-      node._elements =
-          ImmutableSet.<T>builderWithExpectedSize(node._elements.size() + elements.size())
-              .addAll(node._elements)
-              .addAll(elements)
-              .build();
+    int a = _nodes[node + 1];
+    int b = _nodes[node + 2];
+    collectElements(leftOf(a), builder);
+    collectElements(rightOf(b), builder);
+    if (valued(b)) {
+      Object v = _values[_nodes[node + 3]];
+      if (multi(b)) {
+        builder.addAll((ImmutableSet<T>) v);
+      } else {
+        builder.add((T) v);
+      }
     }
-    return true;
   }
 
-  private static <T> boolean removeAt(Node<T> node, T e) {
-    if (!node._elements.contains(e)) {
-      return false;
-    }
-    if (node._elements.size() == 1) {
-      node._elements = ImmutableSet.of();
-    } else {
-      node._elements =
-          node._elements.stream()
-              .filter(el -> !el.equals(e))
-              .collect(ImmutableSet.toImmutableSet());
-    }
-    return true;
+  /** Equivalent to {@link #getAllElements()}.{@link Set#size}. */
+  public int getNumElements() {
+    return _numElements;
   }
 
-  private static <T> boolean replaceAllAt(Node<T> node, T e) {
-    if (node._elements.size() == 1 && node._elements.contains(e)) {
-      return false;
+  /** Find the elements associated with the longest matching prefix of a given IP address. */
+  public @Nonnull Set<T> longestPrefixMatch(Ip address) {
+    return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
+  }
+
+  /**
+   * Find the elements associated with the longest matching prefix of a given IP address, up to the
+   * given maximum length.
+   */
+  public @Nonnull Set<T> longestPrefixMatch(Ip address, int maxPrefixLength) {
+    int node = longestMatchNonEmptyNode((int) address.asLong(), maxPrefixLength);
+    return node == NONE ? ImmutableSet.of() : elementsAt(node);
+  }
+
+  /**
+   * Return all values whose keys intersect with the input {@link RangeSet}. Values are returned as
+   * a {@link Stream} in post-order, so if prefix p1 contains p2, values for p2 will be returned
+   * before values for p1.
+   */
+  public @Nonnull Stream<Map.Entry<Prefix, Set<T>>> getOverlappingEntries(RangeSet<Ip> ips) {
+    return getOverlappingEntriesImpl(_root, ips);
+  }
+
+  private Stream<Map.Entry<Prefix, Set<T>>> getOverlappingEntriesImpl(int node, RangeSet<Ip> ips) {
+    if (node == NONE) {
+      return Stream.of();
     }
-    node._elements = ImmutableSet.of(e);
-    return true;
+    Prefix prefix = keyOf(node);
+    RangeSet<Ip> matchingIps =
+        ips.subRangeSet(Range.closed(prefix.getStartIp(), prefix.getEndIp()));
+    if (matchingIps.isEmpty()) {
+      return Stream.of();
+    }
+    Stream<Map.Entry<Prefix, Set<T>>> elementsHere =
+        hasValue(node) ? Stream.of(Maps.immutableEntry(prefix, elementsAt(node))) : Stream.of();
+    return Stream.concat(
+        // recurse lazily
+        Stream.of(left(node), right(node))
+            .filter(child -> child != NONE)
+            .flatMap(child -> getOverlappingEntriesImpl(child, matchingIps)),
+        // post-order
+        elementsHere);
   }
 
   /**
@@ -561,7 +911,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
    * @return whether the multimap was modified.
    */
   public boolean put(Prefix p, T e) {
-    return putAll(p, ImmutableList.of(e));
+    return addElement(findOrCreateNode(p), e);
   }
 
   /**
@@ -570,7 +920,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
    * @return whether the multimap was modified.
    */
   public boolean putAll(Prefix p, Collection<T> elements) {
-    return addAll(findOrCreateNode(p), elements);
+    return addElements(findOrCreateNode(p), elements);
   }
 
   /**
@@ -579,8 +929,8 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
    * @return whether the multimap was modified.
    */
   public boolean remove(Prefix p, T e) {
-    Node<T> node = exactMatchNode(p);
-    return node != null && removeAt(node, e);
+    int node = exactMatchNode(p);
+    return node != NONE && removeAt(node, e);
   }
 
   /**
@@ -594,7 +944,13 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
 
   /** Remove all elements from the multimap. */
   public void clear() {
-    _root = null;
+    _nodes = EMPTY_NODES;
+    _used = 0;
+    _root = NONE;
+    _values = EMPTY_VALUES;
+    _keys = EMPTY_KEYS;
+    _numSlots = 0;
+    _numElements = 0;
   }
 
   /**
@@ -602,8 +958,52 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
    * trie and the provided {@code prefixSpace}.
    */
   public boolean intersectsPrefixSpace(PrefixSpace prefixSpace) {
-    return _root != null
-        && prefixSpace.getPrefixRanges().stream().anyMatch(_root::intersectsPrefixRange);
+    return _root != NONE
+        && prefixSpace.getPrefixRanges().stream()
+            .anyMatch(range -> intersectsPrefixRangeImpl(_root, range));
+  }
+
+  /**
+   * Returns true iff there is a {@link Prefix} key in the subtree rooted at {@code node} included
+   * in {@code prefixRange}.
+   */
+  private boolean intersectsPrefixRangeImpl(int node, PrefixRange prefixRange) {
+    // Overview:
+    // - If this prefix's length is greater than prefixRange's max length, return false.
+    // - If this prefix is contained in prefixRange and this node has any elements (making this
+    //   prefix a key), return true.
+    // - If either of this prefix or prefixRange's match prefix contains the other, then check
+    //   this node's children.
+    // - Else return false.
+    int len = len(node);
+    SubRange lengthRange = prefixRange.getLengthRange();
+    if (len > lengthRange.getEnd()) {
+      return false;
+    }
+    int bits = bits(node);
+    Prefix rangePrefix = prefixRange.getPrefix();
+    int rangeBits = bitsOf(rangePrefix);
+    int rangeLen = rangePrefix.getPrefixLength();
+    if (hasValue(node)
+        && ((rangeBits ^ bits) & prefixMask(rangeLen)) == 0
+        && lengthRange.getStart() <= len) {
+      return true;
+    }
+    if (!contains(bits, len, rangeBits, rangeLen) && !contains(rangeBits, rangeLen, bits, len)) {
+      return false;
+    }
+    int left = left(node);
+    int right = right(node);
+    return (left != NONE && intersectsPrefixRangeImpl(left, prefixRange))
+        || (right != NONE && intersectsPrefixRangeImpl(right, prefixRange));
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("numElements", _numElements)
+        .add("numKeys", _numSlots)
+        .toString();
   }
 
   private static class SerializedForm<T> implements Serializable {
@@ -632,6 +1032,7 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
       for (int i = 0; i < _keys.size(); ++i) {
         ret.putAll(_keys.get(i), _values.get(i));
       }
+      ret.trimToSize();
       return ret;
     }
   }

--- a/projects/common/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -9,19 +9,28 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.testing.EqualsTester;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -542,6 +551,245 @@ public class PrefixTrieMultiMapTest {
     assertThat(ptmm, equalTo(SerializationUtils.clone(ptmm)));
   }
 
+  /** A naive model of the multimap, for differential testing. */
+  private static final class Model {
+    private final Map<Prefix, Set<Integer>> _map = new HashMap<>();
+
+    boolean put(Prefix p, int e) {
+      return _map.computeIfAbsent(p, k -> new HashSet<>()).add(e);
+    }
+
+    boolean putAll(Prefix p, Collection<Integer> es) {
+      return _map.computeIfAbsent(p, k -> new HashSet<>()).addAll(es);
+    }
+
+    boolean remove(Prefix p, int e) {
+      Set<Integer> s = _map.get(p);
+      return s != null && s.remove(e);
+    }
+
+    boolean replaceAll(Prefix p, int e) {
+      Set<Integer> old = _map.put(p, new HashSet<>(ImmutableSet.of(e)));
+      return old == null || !old.equals(ImmutableSet.of(e));
+    }
+
+    Set<Integer> get(Prefix p) {
+      return _map.getOrDefault(p, ImmutableSet.of());
+    }
+
+    Set<Integer> longestPrefixMatch(Ip ip, int maxLen) {
+      Prefix best = null;
+      for (Map.Entry<Prefix, Set<Integer>> e : _map.entrySet()) {
+        Prefix p = e.getKey();
+        if (e.getValue().isEmpty() || p.getPrefixLength() > maxLen || !p.containsIp(ip)) {
+          continue;
+        }
+        if (best == null || p.getPrefixLength() > best.getPrefixLength()) {
+          best = p;
+        }
+      }
+      return best == null ? ImmutableSet.of() : _map.get(best);
+    }
+
+    Set<Integer> allElements() {
+      return _map.values().stream().flatMap(Set::stream).collect(ImmutableSet.toImmutableSet());
+    }
+
+    int numElements() {
+      return _map.values().stream().mapToInt(Set::size).sum();
+    }
+
+    /** Post-order over a prefix trie is ascending end IP, then descending start IP. */
+    List<Prefix> keysInPostOrder() {
+      return _map.entrySet().stream()
+          .filter(e -> !e.getValue().isEmpty())
+          .map(Map.Entry::getKey)
+          .sorted(
+              Comparator.comparing(Prefix::getEndIp)
+                  .thenComparing(Prefix::getStartIp, Comparator.reverseOrder()))
+          .collect(ImmutableList.toImmutableList());
+    }
+
+    boolean intersectsPrefixSpace(PrefixSpace space) {
+      return _map.entrySet().stream()
+          .filter(e -> !e.getValue().isEmpty())
+          .anyMatch(
+              e ->
+                  space.getPrefixRanges().stream()
+                      .anyMatch(r -> r.includesPrefixRange(PrefixRange.fromPrefix(e.getKey()))));
+    }
+
+    Set<Prefix> overlappingKeys(RangeSet<Ip> ips) {
+      return _map.entrySet().stream()
+          .filter(e -> !e.getValue().isEmpty())
+          .map(Map.Entry::getKey)
+          .filter(p -> ips.intersects(Range.closed(p.getStartIp(), p.getEndIp())))
+          .collect(ImmutableSet.toImmutableSet());
+    }
+  }
+
+  /** Random prefixes clustered enough that they nest, collide, and sit in the same subtrees. */
+  private static Prefix randomPrefix(Random rng) {
+    int len = rng.nextInt(33);
+    long ip;
+    switch (rng.nextInt(3)) {
+      case 0:
+        ip = rng.nextInt() & 0xFFFFFFFFL;
+        break;
+      case 1:
+        ip = 0x0A000000L | rng.nextInt(1 << 16);
+        break;
+      default:
+        ip = 0x0A000000L | (rng.nextInt(8) << 8) | rng.nextInt(4);
+        break;
+    }
+    return Prefix.create(Ip.create(ip), len);
+  }
+
+  private static void assertMatchesModel(
+      PrefixTrieMultiMap<Integer> trie, Model model, Random rng) {
+    assertThat(trie.getNumElements(), equalTo(model.numElements()));
+    assertThat(trie.getAllElements(), equalTo(model.allElements()));
+    assertThat(keysInPostOrder(trie), equalTo(model.keysInPostOrder()));
+    for (int i = 0; i < 50; ++i) {
+      Prefix p = randomPrefix(rng);
+      assertThat(trie.get(p), equalTo(model.get(p)));
+      Ip ip = p.getStartIp();
+      int maxLen = rng.nextInt(33);
+      assertThat(
+          "lpm " + ip + " maxLen " + maxLen,
+          trie.longestPrefixMatch(ip, maxLen),
+          equalTo(model.longestPrefixMatch(ip, maxLen)));
+      assertThat(trie.longestPrefixMatch(ip), equalTo(model.longestPrefixMatch(ip, 32)));
+      PrefixSpace space = new PrefixSpace(new PrefixRange(p, new SubRange(rng.nextInt(33), 32)));
+      assertThat(
+          space.toString(),
+          trie.intersectsPrefixSpace(space),
+          equalTo(model.intersectsPrefixSpace(space)));
+      RangeSet<Ip> ips = toRangeSet(p);
+      assertThat(
+          trie.getOverlappingEntries(ips)
+              .map(Map.Entry::getKey)
+              .collect(ImmutableSet.toImmutableSet()),
+          equalTo(model.overlappingKeys(ips)));
+    }
+  }
+
+  @Test
+  public void testRandomizedAgainstModel() {
+    Random rng = new Random(20260901);
+    for (int trial = 0; trial < 20; ++trial) {
+      PrefixTrieMultiMap<Integer> trie = new PrefixTrieMultiMap<>();
+      Model model = new Model();
+      List<Prefix> used = new ArrayList<>();
+      int ops = 50 + rng.nextInt(400);
+      for (int i = 0; i < ops; ++i) {
+        Prefix p =
+            !used.isEmpty() && rng.nextInt(3) == 0
+                ? used.get(rng.nextInt(used.size()))
+                : randomPrefix(rng);
+        used.add(p);
+        int e = rng.nextInt(6);
+        switch (rng.nextInt(5)) {
+          case 0:
+          case 1:
+            assertThat(trie.put(p, e), equalTo(model.put(p, e)));
+            break;
+          case 2:
+            List<Integer> es = ImmutableList.of(e, rng.nextInt(6), rng.nextInt(6));
+            assertThat(trie.putAll(p, es), equalTo(model.putAll(p, es)));
+            break;
+          case 3:
+            assertThat(trie.remove(p, e), equalTo(model.remove(p, e)));
+            break;
+          default:
+            assertThat(trie.replaceAll(p, e), equalTo(model.replaceAll(p, e)));
+            break;
+        }
+        if (rng.nextInt(20) == 0) {
+          trie.trimToSize();
+        }
+      }
+      assertMatchesModel(trie, model, rng);
+
+      // Equality and hashing are over entries, whatever the insertion history.
+      PrefixTrieMultiMap<Integer> rebuilt = new PrefixTrieMultiMap<>();
+      List<Prefix> keys = new ArrayList<>(model.keysInPostOrder());
+      Collections.shuffle(keys, rng);
+      for (Prefix k : keys) {
+        rebuilt.putAll(k, model.get(k));
+      }
+      assertThat(rebuilt, equalTo(trie));
+      assertThat(rebuilt.hashCode(), equalTo(trie.hashCode()));
+      assertThat(SerializationUtils.clone(trie), equalTo(trie));
+
+      // Adding one more element breaks equality.
+      if (!keys.isEmpty()) {
+        rebuilt.put(keys.get(0), 100);
+        assertThat(rebuilt, not(equalTo(trie)));
+      }
+    }
+  }
+
+  @Test
+  public void testManyHostRoutes() {
+    // Enough nodes to grow the backing arrays several times, in a shape that maximizes depth.
+    PrefixTrieMultiMap<Integer> trie = new PrefixTrieMultiMap<>();
+    int n = 5000;
+    for (int i = 0; i < n; ++i) {
+      assertTrue(trie.put(Prefix.create(Ip.create(0x0A000000L + i * 7L), 32), i));
+    }
+    assertThat(trie.getNumElements(), equalTo(n));
+    for (int i = 0; i < n; ++i) {
+      Ip ip = Ip.create(0x0A000000L + i * 7L);
+      assertThat(trie.longestPrefixMatch(ip), equalTo(ImmutableSet.of(i)));
+      assertThat(trie.longestPrefixMatch(Ip.create(ip.asLong() + 1)), empty());
+    }
+    trie.put(Prefix.parse("10.0.0.0/8"), -1);
+    for (int i = 0; i < n; ++i) {
+      Ip ip = Ip.create(0x0A000000L + i * 7L + 1);
+      assertThat(trie.longestPrefixMatch(ip), equalTo(ImmutableSet.of(-1)));
+    }
+    for (int i = 0; i < n; i += 2) {
+      assertTrue(trie.remove(Prefix.create(Ip.create(0x0A000000L + i * 7L), 32), i));
+    }
+    assertThat(trie.getNumElements(), equalTo(n / 2 + 1));
+    assertThat(trie.getAllElements(), hasSize(n / 2 + 1));
+  }
+
+  @Test
+  public void testValueTransitions() {
+    PrefixTrieMultiMap<Integer> trie = new PrefixTrieMultiMap<>();
+    Prefix p = Prefix.parse("10.0.0.0/8");
+    // empty -> single -> multi -> single -> empty
+    assertTrue(trie.put(p, 1));
+    assertFalse(trie.put(p, 1));
+    assertTrue(trie.put(p, 2));
+    assertThat(trie.get(p), equalTo(ImmutableSet.of(1, 2)));
+    assertFalse(trie.putAll(p, ImmutableList.of(1, 2)));
+    assertTrue(trie.remove(p, 1));
+    assertThat(trie.get(p), equalTo(ImmutableSet.of(2)));
+    assertThat(trie.getNumElements(), equalTo(1));
+    assertFalse(trie.remove(p, 1));
+    assertTrue(trie.remove(p, 2));
+    assertThat(trie.get(p), empty());
+    assertThat(trie.getNumElements(), equalTo(0));
+    assertThat(trie.longestPrefixMatch(Ip.parse("10.1.1.1")), empty());
+    // empty node stays in the structure; a longer prefix still resolves past it
+    assertTrue(trie.put(Prefix.ZERO, 0));
+    assertThat(trie.longestPrefixMatch(Ip.parse("10.1.1.1")), equalTo(ImmutableSet.of(0)));
+    // replaceAll on multi and on single
+    trie.putAll(p, ImmutableList.of(3, 4));
+    assertTrue(trie.replaceAll(p, 5));
+    assertFalse(trie.replaceAll(p, 5));
+    assertThat(trie.get(p), equalTo(ImmutableSet.of(5)));
+    assertThat(trie.getNumElements(), equalTo(2));
+    // putAll of a single element onto an equal single element is a no-op
+    assertFalse(trie.putAll(p, ImmutableList.of(5, 5)));
+    assertTrue(trie.putAll(p, ImmutableList.of(5, 6)));
+    assertThat(trie.get(p), equalTo(ImmutableSet.of(5, 6)));
+  }
+
   @Test
   public void testHandle() {
     PrefixTrieMultiMap<Integer> trie = new PrefixTrieMultiMap<>();
@@ -592,6 +840,95 @@ public class PrefixTrieMultiMapTest {
     assertThat(h.get(), equalTo(ImmutableSet.of(2)));
     assertTrue(h.remove(2));
     assertThat(trie.existingHandle(Prefix.parse("10.1.0.0/16")), nullValue());
+  }
+
+  @Test
+  public void testTraverseEntriesAround() {
+    PrefixTrieMultiMap<Integer> trie = new PrefixTrieMultiMap<>();
+    trie.put(Prefix.ZERO, 0);
+    trie.put(Prefix.parse("10.0.0.0/8"), 8);
+    trie.put(Prefix.parse("10.1.0.0/16"), 16);
+    trie.put(Prefix.parse("10.1.1.0/24"), 24);
+    trie.put(Prefix.parse("10.1.1.1/32"), 32);
+    trie.put(Prefix.parse("10.1.2.0/24"), -24);
+    trie.put(Prefix.parse("10.2.0.0/16"), 17);
+    trie.put(Prefix.parse("11.0.0.0/8"), 11);
+    // Ancestors and everything below, in post-order.
+    assertThat(
+        aroundKeys(trie, Prefix.parse("10.1.0.0/16"), s -> true),
+        contains(
+            Prefix.parse("10.1.1.1/32"),
+            Prefix.parse("10.1.1.0/24"),
+            Prefix.parse("10.1.2.0/24"),
+            Prefix.parse("10.1.0.0/16"),
+            Prefix.parse("10.0.0.0/8"),
+            Prefix.ZERO));
+    // Below the prefix, stop at (and exclude) nodes with negative elements; ancestors are exempt.
+    assertThat(
+        aroundKeys(trie, Prefix.parse("10.1.0.0/16"), s -> s.stream().allMatch(e -> e >= 0)),
+        contains(
+            Prefix.parse("10.1.1.1/32"),
+            Prefix.parse("10.1.1.0/24"),
+            Prefix.parse("10.1.0.0/16"),
+            Prefix.parse("10.0.0.0/8"),
+            Prefix.ZERO));
+    assertThat(
+        aroundKeys(trie, Prefix.parse("10.1.0.0/16"), s -> !s.contains(24)),
+        contains(
+            Prefix.parse("10.1.2.0/24"),
+            Prefix.parse("10.1.0.0/16"),
+            Prefix.parse("10.0.0.0/8"),
+            Prefix.ZERO));
+    // A prefix with no node of its own: ancestors plus the contained subtree.
+    assertThat(
+        aroundKeys(trie, Prefix.parse("10.0.0.0/12"), s -> true),
+        contains(
+            Prefix.parse("10.1.1.1/32"),
+            Prefix.parse("10.1.1.0/24"),
+            Prefix.parse("10.1.2.0/24"),
+            Prefix.parse("10.1.0.0/16"),
+            Prefix.parse("10.2.0.0/16"),
+            Prefix.parse("10.0.0.0/8"),
+            Prefix.ZERO));
+    // A prefix disjoint from everything but the default route.
+    assertThat(aroundKeys(trie, Prefix.parse("12.0.0.0/8"), s -> true), contains(Prefix.ZERO));
+    assertThat(aroundKeys(new PrefixTrieMultiMap<Integer>(), Prefix.ZERO, s -> true), empty());
+    // Agrees with the general traversal for random prefixes.
+    Random rng = new Random(3);
+    for (int i = 0; i < 300; ++i) {
+      Prefix p = randomPrefix(rng);
+      int excluded = rng.nextInt(40) - 30;
+      Predicate<Set<Integer>> descend = s -> !s.contains(excluded);
+      List<Prefix> expected = new ArrayList<>();
+      trie.traverseEntries(
+          (k, v) -> expected.add(k),
+          (k, v) -> k.containsPrefix(p) || (p.containsPrefix(k) && descend.test(v)));
+      assertThat(p.toString(), aroundKeys(trie, p, descend), equalTo(expected));
+    }
+  }
+
+  private static List<Prefix> aroundKeys(
+      PrefixTrieMultiMap<Integer> trie, Prefix prefix, Predicate<Set<Integer>> descendThrough) {
+    List<Prefix> keys = new ArrayList<>();
+    trie.traverseEntriesAround(prefix, descendThrough, (k, v) -> keys.add(k));
+    return keys;
+  }
+
+  @Test
+  public void testPutOnInternalNode() {
+    PrefixTrieMultiMap<Integer> trie = new PrefixTrieMultiMap<>();
+    trie.put(Prefix.parse("10.0.0.0/16"), 1);
+    trie.put(Prefix.parse("10.1.0.0/16"), 2);
+    // 10.0.0.0/15 is the internal node created above; give it elements.
+    Prefix internal = Prefix.parse("10.0.0.0/15");
+    assertThat(trie.get(internal), empty());
+    assertTrue(trie.put(internal, 3));
+    assertThat(trie.get(internal), equalTo(ImmutableSet.of(3)));
+    assertThat(trie.longestPrefixMatch(Ip.parse("10.1.2.3")), equalTo(ImmutableSet.of(2)));
+    assertThat(trie.longestPrefixMatch(Ip.parse("10.1.2.3"), 15), equalTo(ImmutableSet.of(3)));
+    assertThat(
+        keysInPostOrder(trie),
+        contains(Prefix.parse("10.0.0.0/16"), Prefix.parse("10.1.0.0/16"), internal));
   }
 
   private static RangeSet<Ip> toRangeSet(Prefix prefix) {

--- a/tools/benchmarks/BUILD.bazel
+++ b/tools/benchmarks/BUILD.bazel
@@ -68,3 +68,13 @@ jmh_java_benchmarks(
         "@maven//:commons_io_commons_io",
     ],
 )
+
+jmh_java_benchmarks(
+    name = "prefixTrie",
+    srcs = ["PrefixTrieMultiMapBenchmarks.java"],
+    deps = [
+        "//projects/common",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+    ],
+)

--- a/tools/benchmarks/PrefixTrieMultiMapBenchmarks.java
+++ b/tools/benchmarks/PrefixTrieMultiMapBenchmarks.java
@@ -1,0 +1,138 @@
+package tools.benchmarks;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixTrieMultiMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** {@link PrefixTrieMultiMap} operations on a real prefix list (one prefix per line). */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+public class PrefixTrieMultiMapBenchmarks {
+  @Param({"REQUIRED INPUT PARAM"})
+  public String prefixFile;
+
+  private Prefix[] _prefixes;
+  private Ip[] _queries;
+  private Prefix[] _shuffled;
+  private PrefixTrieMultiMap<Integer> _trie;
+  private int _counter;
+
+  @Setup(Level.Trial)
+  public void setUp() throws IOException {
+    List<Prefix> ps =
+        Files.readAllLines(Path.of(prefixFile)).stream()
+            .map(String::trim)
+            .filter(l -> !l.isEmpty())
+            .distinct()
+            .map(Prefix::parse)
+            .collect(Collectors.toList());
+    Random rng = new Random(1);
+    Collections.shuffle(ps, rng);
+    _prefixes = ps.toArray(new Prefix[0]);
+    List<Prefix> sh = new ArrayList<>(ps);
+    Collections.shuffle(sh, rng);
+    _shuffled = sh.toArray(new Prefix[0]);
+    _queries = new Ip[_prefixes.length];
+    for (int i = 0; i < _prefixes.length; ++i) {
+      Prefix p = _prefixes[i];
+      long span = p.getEndIp().asLong() - p.getStartIp().asLong() + 1;
+      _queries[i] = Ip.create(p.getStartIp().asLong() + (Math.abs(rng.nextLong()) % span));
+    }
+    _trie = new PrefixTrieMultiMap<>();
+    for (int i = 0; i < _prefixes.length; ++i) {
+      _trie.put(_prefixes[i], i);
+    }
+    // Some ECMP-like multi-valued nodes.
+    for (int i = 0; i < _prefixes.length; i += 10) {
+      _trie.put(_prefixes[i], i + 1_000_000);
+    }
+  }
+
+  @Benchmark
+  public void lpm(Blackhole bh) {
+    for (Ip ip : _queries) {
+      bh.consume(_trie.longestPrefixMatch(ip));
+    }
+  }
+
+  @Benchmark
+  public void get(Blackhole bh) {
+    for (Prefix p : _shuffled) {
+      bh.consume(_trie.get(p));
+    }
+  }
+
+  @Benchmark
+  public Object build() {
+    PrefixTrieMultiMap<Integer> t = new PrefixTrieMultiMap<>();
+    for (int i = 0; i < _prefixes.length; ++i) {
+      t.put(_prefixes[i], i);
+    }
+    return t;
+  }
+
+  /** RibTree.mergeRoute-like: read the current elements, then replace them. */
+  @Benchmark
+  public void churn(Blackhole bh) {
+    int c = ++_counter;
+    for (Prefix p : _shuffled) {
+      Set<Integer> cur = _trie.get(p);
+      bh.consume(cur);
+      _trie.replaceAll(p, c);
+    }
+  }
+
+  /** The same, through a {@link PrefixTrieMultiMap.Handle}, as RibTree.mergeRoute now does. */
+  @Benchmark
+  public void churnHandle(Blackhole bh) {
+    int c = ++_counter;
+    for (Prefix p : _shuffled) {
+      PrefixTrieMultiMap<Integer>.Handle h = _trie.handle(p);
+      bh.consume(h.get());
+      h.replaceAll(c);
+    }
+  }
+
+  @Benchmark
+  public Object allElements() {
+    return _trie.getAllElements();
+  }
+
+  /** RibResolutionTrie.getAffectedNextHopIps-like traversal. */
+  @Benchmark
+  public void traverse(Blackhole bh) {
+    for (int i = 0; i < 64; ++i) {
+      Prefix q = _shuffled[i];
+      _trie.traverseEntries(
+          (p, s) -> bh.consume(p),
+          (p, s) -> p.containsPrefix(q) || (q.containsPrefix(p) && !s.contains(-1)));
+    }
+  }
+}


### PR DESCRIPTION
Store trie nodes as records in an int[] instead of objects: three ints
(prefix bits, left child and length, right child and flags) for the
branching nodes that path compression creates, four for nodes that hold
elements, whose fourth int indexes parallel element and key arrays. A
node with one element stores the element itself rather than a singleton
set. Lookups read one array location per step and never follow a
reference until they have found their answer. equals and hashCode are
over the entries rather than the node structure.

Add traverseEntriesAround for RibResolutionTrie, which visited a
prefix's ancestors and subtree through the general predicate traversal
and would otherwise pay to materialize a Prefix at every branching node
it passed. FinalMainRib and FibImpl trim their tries once built.

On a 250-device subset of a large snapshot, with identical RIB and FIB
contents before and after: the trie's share of the live heap falls from
684 MB to 326 MB, the live heap from 1.34 GB to 1.00 GB, and dataplane
CPU samples by about a fifth, of which the trie's own fall by about a
quarter. On the whole snapshot (2267 devices, 30M main RIB routes) the
dataplane completes with 9.6 GB live; before, a 20 GB heap ran out of
memory during forwarding analysis. On one of those RIBs the JMH
benchmark in tools/benchmarks shows LPM 1.8x, build 2.5x and
getAllElements 2.2x faster than the object trie.

----

Prompt:
```
PrefixTrieMultiMap is our biggest memory use and biggest CPU use. How
can we improve it by 2x-3x on both? If you want a snapshot to test with,
use a recent snapshot of a large network.

Goal set: design, implement, and test improvements to the way we
represent and lookup/LPM prefixes. Don't run out of disk space. Continue
until you've made a 2x improvement or are truly out of ideas.
```