### PR TITLE
ibdp: re-evaluate a conditional static route only when its next hop's resolution can have changed

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -38,6 +38,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -190,8 +191,27 @@ public final class VirtualRouter {
    */
   List<StaticRoute> _unconditionalStatics;
 
-  /** Static routes needing activation each iteration, in {@link Vrf#getStaticRoutes} order. */
-  List<StaticRoute> _conditionalStatics;
+  /**
+   * Static routes needing activation whose next hop is an IP, grouped by that IP. A group's
+   * activation can only change when a main RIB route whose network contains the IP is added or
+   * removed, so between rounds only groups touched by the previous round's main RIB delta are
+   * re-evaluated. Within a group, routes are in {@link Vrf#getStaticRoutes} order.
+   */
+  ImmutableSortedMap<Ip, ImmutableList<StaticRoute>> _conditionalStaticsByNextHopIp;
+
+  /**
+   * Static routes needing activation whose next hop is not an IP: interface next hops, and discard,
+   * VRF, or VTEP next hops with a track. Their activation depends on interface and track state,
+   * which only change between topology rounds, so they are evaluated once per round.
+   */
+  ImmutableList<StaticRoute> _conditionalStaticsWithoutNextHopIp;
+
+  /**
+   * Whether the next {@link #activateStaticRoutes} must evaluate every conditional static route:
+   * true at init and at the start of every topology round, when interface state, track state, or
+   * the main RIB may have changed without being reported in {@link #_mainRibDeltaPrevRound}.
+   */
+  private boolean _conditionalStaticsNeedFullPass = true;
 
   /** FIB (forwarding information base) built from the main RIB */
   private Fib _fib;
@@ -445,6 +465,8 @@ public final class VirtualRouter {
       TopologyContext topologyContext, TrackMethodEvaluatorProvider trackMethodEvaluatorProvider) {
     assert _mainRibRouteDeltaBuilder.isEmpty(); // or else invariant is not maintained
 
+    // Interface state, track state, and the main RIB may have changed between rounds.
+    _conditionalStaticsNeedFullPass = true;
     initQueuesAndDeltaBuilders(topologyContext);
     if (_bgpRoutingProcess != null) {
       // If the process exists, update the topology and BGP track states
@@ -593,13 +615,44 @@ public final class VirtualRouter {
    * <p>Removes static route from the main RIB for which next-hop-ip has become unreachable.
    */
   void activateStaticRoutes(TrackMethodEvaluator trackMethodEvaluator) {
-    for (StaticRoute sr : _conditionalStatics) {
+    if (_conditionalStaticsNeedFullPass) {
+      _conditionalStaticsNeedFullPass = false;
+      for (List<StaticRoute> group : _conditionalStaticsByNextHopIp.values()) {
+        activateStaticRoutes(trackMethodEvaluator, group);
+      }
+      activateStaticRoutes(trackMethodEvaluator, _conditionalStaticsWithoutNextHopIp);
+      return;
+    }
+    // Within a round, only a next hop IP's resolution can change, and only if a main RIB route
+    // whose network contains that IP was added or removed since the last activation. Every such
+    // change since then is in the previous round's main RIB delta.
+    if (_mainRibDeltaPrevRound.isEmpty() || _conditionalStaticsByNextHopIp.isEmpty()) {
+      return;
+    }
+    SortedSet<Ip> affectedNextHopIps = new TreeSet<>();
+    for (RouteAdvertisement<AnnotatedRoute<AbstractRoute>> action :
+        _mainRibDeltaPrevRound.getActions()) {
+      Prefix network = action.getRoute().getNetwork();
+      affectedNextHopIps.addAll(
+          _conditionalStaticsByNextHopIp
+              .subMap(network.getStartIp(), true, network.getEndIp(), true)
+              .keySet());
+      if (affectedNextHopIps.size() == _conditionalStaticsByNextHopIp.size()) {
+        break;
+      }
+    }
+    for (Ip nextHopIp : affectedNextHopIps) {
+      activateStaticRoutes(trackMethodEvaluator, _conditionalStaticsByNextHopIp.get(nextHopIp));
+    }
+  }
+
+  private void activateStaticRoutes(
+      TrackMethodEvaluator trackMethodEvaluator, List<StaticRoute> conditionalStatics) {
+    for (StaticRoute sr : conditionalStatics) {
       if (shouldActivateConditionalStaticRoute(trackMethodEvaluator, sr)) {
         _mainRibRouteDeltaBuilder.from(_mainRib.mergeRouteGetDelta(annotateRoute(sr)));
       } else {
-        /*
-         * If the route is not in the RIB, this has no effect. But might add some overhead (TODO)
-         */
+        // No effect if the route is not in the RIB.
         _mainRibRouteDeltaBuilder.from(_mainRib.removeRouteGetDelta(annotateRoute(sr)));
       }
     }
@@ -1136,7 +1189,9 @@ public final class VirtualRouter {
     _ripRib = new RipRib();
 
     // Static
-    _conditionalStatics = ImmutableList.of();
+    _conditionalStaticsByNextHopIp = ImmutableSortedMap.of();
+    _conditionalStaticsWithoutNextHopIp = ImmutableList.of();
+    _conditionalStaticsNeedFullPass = true;
     _unconditionalStatics = ImmutableList.of();
   }
 
@@ -1151,17 +1206,37 @@ public final class VirtualRouter {
   /** Initialize the static route RIBs from the VRF config. */
   @VisibleForTesting
   void initStaticRibs() {
-    ImmutableList.Builder<StaticRoute> conditional = ImmutableList.builder();
+    Map<Ip, ImmutableList.Builder<StaticRoute>> conditionalByNextHopIp = new HashMap<>();
+    ImmutableList.Builder<StaticRoute> conditionalWithoutNextHopIp = ImmutableList.builder();
     ImmutableList.Builder<StaticRoute> unconditional = ImmutableList.builder();
     for (StaticRoute sr : _vrf.getStaticRoutes()) {
-      if (isConditionalStaticRoute(sr)) {
-        conditional.add(sr);
-      } else {
+      if (!isConditionalStaticRoute(sr)) {
         unconditional.add(sr);
+      } else if (sr.getNextHop() instanceof NextHopIp) {
+        conditionalByNextHopIp
+            .computeIfAbsent(((NextHopIp) sr.getNextHop()).getIp(), ip -> ImmutableList.builder())
+            .add(sr);
+      } else {
+        conditionalWithoutNextHopIp.add(sr);
       }
     }
-    _conditionalStatics = conditional.build();
+    _conditionalStaticsByNextHopIp =
+        conditionalByNextHopIp.entrySet().stream()
+            .collect(
+                ImmutableSortedMap.toImmutableSortedMap(
+                    Ordering.natural(), Entry::getKey, e -> e.getValue().build()));
+    _conditionalStaticsWithoutNextHopIp = conditionalWithoutNextHopIp.build();
+    _conditionalStaticsNeedFullPass = true;
     _unconditionalStatics = unconditional.build();
+  }
+
+  /** All static routes needing activation. */
+  @VisibleForTesting
+  List<StaticRoute> getConditionalStatics() {
+    return Streams.concat(
+            _conditionalStaticsByNextHopIp.values().stream().flatMap(List::stream),
+            _conditionalStaticsWithoutNextHopIp.stream())
+        .collect(ImmutableList.toImmutableList());
   }
 
   @Nullable

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -244,12 +244,86 @@ public class VirtualRouterTest {
     vr.initStaticRibs();
     vr.activateStaticRoutes(new PreDataPlaneTrackMethodEvaluator(vr.getConfiguration()));
 
-    // Test: remove baseRoute, rerun activation
-    vr.getMainRib().removeRoute(new AnnotatedRoute<>(baseRoute, DEFAULT_VRF_NAME));
+    // Test: remove baseRoute, report it in the previous round's delta, rerun activation
+    AnnotatedRoute<AbstractRoute> annotatedBaseRoute =
+        new AnnotatedRoute<>(baseRoute, DEFAULT_VRF_NAME);
+    vr.getMainRib().removeRoute(annotatedBaseRoute);
+    vr._mainRibDeltaPrevRound = RibDelta.of(RouteAdvertisement.withdrawing(annotatedBaseRoute));
     vr.activateStaticRoutes(new PreDataPlaneTrackMethodEvaluator(vr.getConfiguration()));
 
     // Assert dependent route is not there
     assertThat(vr.getMainRib().getUnannotatedRoutes(), not(hasItem(dependentRoute)));
+  }
+
+  /**
+   * Test that within a round, {@link VirtualRouter#activateStaticRoutes(TrackMethodEvaluator)} only
+   * re-evaluates static routes whose next hop IP is covered by a route in the previous round's main
+   * RIB delta.
+   */
+  @Test
+  public void testActivateStaticRoutesOnlyForAffectedNextHops() {
+    VirtualRouter vr = makeIosVirtualRouter("n1");
+    addInterfaces(vr.getConfiguration(), exampleInterfaceAddresses);
+
+    ConnectedRoute baseRoute = new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Ethernet1");
+    StaticRoute dependentRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("2.2.2.2/32"))
+            .setNextHopIp(Ip.parse("1.1.1.1"))
+            .setAdministrativeCost(1)
+            .build();
+    StaticRoute unresolvableRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("3.3.3.3/32"))
+            .setNextHopIp(Ip.parse("9.9.9.9"))
+            .setAdministrativeCost(1)
+            .build();
+    vr.getConfiguration()
+        .getVrfs()
+        .get(DEFAULT_VRF_NAME)
+        .setStaticRoutes(ImmutableSortedSet.of(dependentRoute, unresolvableRoute));
+    vr.initStaticRibs();
+    AnnotatedRoute<AbstractRoute> annotatedBaseRoute =
+        new AnnotatedRoute<>(baseRoute, DEFAULT_VRF_NAME);
+    vr.getMainRib().mergeRoute(annotatedBaseRoute);
+    TrackMethodEvaluator evaluator = new PreDataPlaneTrackMethodEvaluator(vr.getConfiguration());
+
+    // Initial activation is a full pass
+    vr.activateStaticRoutes(evaluator);
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), hasItem(dependentRoute));
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), not(hasItem(unresolvableRoute)));
+
+    // Remove baseRoute behind the delta's back. A delta not covering 1.1.1.1 must not re-evaluate
+    // the dependent route, so it stays in the RIB.
+    vr.getMainRib().removeRoute(annotatedBaseRoute);
+    vr._mainRibDeltaPrevRound =
+        RibDelta.of(
+            RouteAdvertisement.adding(
+                new AnnotatedRoute<>(
+                    new ConnectedRoute(Prefix.parse("5.5.5.0/24"), "Ethernet1"),
+                    DEFAULT_VRF_NAME)));
+    vr.activateStaticRoutes(evaluator);
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), hasItem(dependentRoute));
+
+    // An empty delta must not re-evaluate anything either.
+    vr._mainRibDeltaPrevRound = RibDelta.empty();
+    vr.activateStaticRoutes(evaluator);
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), hasItem(dependentRoute));
+
+    // A delta covering 1.1.1.1 re-evaluates the dependent route, which is now unresolvable.
+    vr._mainRibDeltaPrevRound = RibDelta.of(RouteAdvertisement.withdrawing(annotatedBaseRoute));
+    vr.activateStaticRoutes(evaluator);
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), not(hasItem(dependentRoute)));
+
+    // A new topology round forces a full pass regardless of the delta.
+    vr.getMainRib().mergeRoute(annotatedBaseRoute);
+    vr.endOfEgpRound(); // clears the delta builder, as the engine does before a new round
+    vr._mainRibDeltaPrevRound = RibDelta.empty();
+    vr.activateStaticRoutes(evaluator);
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), not(hasItem(dependentRoute)));
+    vr.initForEgpComputationWithNewTopology(TopologyContext.builder().build(), c -> evaluator);
+    vr.activateStaticRoutes(evaluator);
+    assertThat(vr.getMainRib().getUnannotatedRoutes(), hasItem(dependentRoute));
   }
 
   /** Check that initialization of Connected RIB is as expected */
@@ -419,7 +493,8 @@ public class VirtualRouterTest {
 
     assertThat(vr._unconditionalStatics, containsInAnyOrder(routes.get(3)));
     assertThat(
-        vr._conditionalStatics, containsInAnyOrder(routes.get(0), routes.get(1), routes.get(2)));
+        vr.getConditionalStatics(),
+        containsInAnyOrder(routes.get(0), routes.get(1), routes.get(2)));
   }
 
   @Test
@@ -431,7 +506,7 @@ public class VirtualRouterTest {
 
     // Simple RIBs
     assertThat(vr.getConnectedRib().getUnannotatedRoutes(), empty());
-    assertThat(vr._conditionalStatics, empty());
+    assertThat(vr.getConditionalStatics(), empty());
     assertThat(vr._unconditionalStatics, empty());
     assertThat(vr.getMainRib().getUnannotatedRoutes(), empty());
 
@@ -499,7 +574,7 @@ public class VirtualRouterTest {
     // Test
     vr.initStaticRibs();
 
-    assertThat(vr._conditionalStatics, containsInAnyOrder(routeSet.toArray()));
+    assertThat(vr.getConditionalStatics(), containsInAnyOrder(routeSet.toArray()));
   }
 
   /** Test basic message queuing operations */


### PR DESCRIPTION
activateStaticRoutes ran a longest-prefix match and a merge or remove
for every conditional static route in every iteration, and the removal
allocated a fresh AnnotatedRoute each time, even in iterations where the
main RIB had not changed at all. On a large snapshot whose devices carry
many recursive statics this was ~13% of dataplane wall time, most of it
in iterations that produced no static route change.

Whether a next-hop-IP static activates depends only on the main RIB
routes whose network contains the next hop, so within a topology round
it can only change if the previous round's main RIB delta added or
removed such a route. Group conditional statics by next hop IP and
re-evaluate only the groups whose IP lies inside a delta prefix. Statics
whose next hop is an interface, discard, VRF, or VTEP depend on
interface and track state, which only change between rounds. Every route
is still evaluated at init and at the start of each topology round, when
those inputs and the RIB may have changed without going through the
delta.

The resulting RIBs and FIBs are identical on the snapshot above; the
static pass drops from ~13% of wall time to ~3%, and total wall time
by ~8%.

----

Prompt:
```
Implement the top-ranked item from the dataplane profiling
investigation: stop re-evaluating every conditional static route each
iteration, and only re-evaluate the ones whose next hop resolution can
have changed. Measure correctness and benefit internally, then port to
open source, make sure master is up to date, and send the PR without
revealing internal details.
```
