### PR TITLE
Bgpv4Rib: track next hop IPs in an ordered set instead of mirroring every main RIB prefix

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -55,19 +55,40 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
      */
     private final @Nonnull SetMultimap<Prefix, Bgpv4Route> _bgpRoutesByPrefix;
 
-    private final @Nonnull RibResolutionTrie _mainRibPrefixesAndBgpNhips;
+    /** The keys of {@link #_bgpRoutesByNhip}, ordered so the NHIPs inside a prefix can be found. */
+    private final @Nonnull TreeSet<Ip> _nhips;
+
+    /**
+     * NHIPs in {@link #_bgpRoutesByNhip} that were unresolvable the last time all of their routes
+     * were (de)activated together: when the NHIP's first route arrived, or in {@link
+     * #updateActiveRoutes}. All other tracked NHIPs were resolvable then.
+     */
+    private final @Nonnull Set<Ip> _unresolvableNhips;
+
+    /**
+     * NHIPs for which a route arrived and observed a resolvability different from the one recorded
+     * in {@link #_unresolvableNhips}, so their routes are no longer all in the same state and must
+     * be (de)activated together at the next {@link #updateActiveRoutes}.
+     */
+    private final @Nonnull Set<Ip> _mixedNhips;
 
     private ResolvabilityEnforcer() {
       _bgpRoutesByNhip = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
       _bgpRoutesByPrefix = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
-      _mainRibPrefixesAndBgpNhips = new RibResolutionTrie();
+      _nhips = new TreeSet<>();
+      _unresolvableNhips = new HashSet<>();
+      _mixedNhips = new HashSet<>();
+    }
+
+    boolean isTracked(Ip nhip) {
+      return _bgpRoutesByNhip.containsKey(nhip);
     }
 
     void addBgpRoute(Bgpv4Route route) {
       Ip nhip = route.getNextHopIp();
       if (nhip != null) {
         _bgpRoutesByNhip.put(nhip, route);
-        _mainRibPrefixesAndBgpNhips.addNextHopIp(nhip);
+        _nhips.add(nhip);
       }
       _bgpRoutesByPrefix.put(route.getNetwork(), route);
     }
@@ -77,10 +98,43 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
       if (nhip != null) {
         _bgpRoutesByNhip.remove(nhip, route);
         if (!_bgpRoutesByNhip.containsKey(nhip)) {
-          _mainRibPrefixesAndBgpNhips.removeNextHopIp(nhip);
+          _nhips.remove(nhip);
+          _unresolvableNhips.remove(nhip);
+          _mixedNhips.remove(nhip);
         }
       }
       _bgpRoutesByPrefix.remove(route.getNetwork(), route);
+    }
+
+    /**
+     * Record that all routes with {@code nhip} have just been (de)activated according to {@code
+     * resolvable}.
+     */
+    void setResolvable(Ip nhip, boolean resolvable) {
+      if (resolvable) {
+        _unresolvableNhips.remove(nhip);
+      } else {
+        _unresolvableNhips.add(nhip);
+      }
+      _mixedNhips.remove(nhip);
+    }
+
+    /**
+     * Record that a route with already-tracked {@code nhip} was just (de)activated according to
+     * {@code resolvable}, which may differ from what its other routes saw.
+     */
+    void addedRoute(Ip nhip, boolean resolvable) {
+      if (resolvable == _unresolvableNhips.contains(nhip)) {
+        _mixedNhips.add(nhip);
+      }
+    }
+
+    /**
+     * Whether every route with {@code nhip} is already (de)activated according to {@code
+     * resolvable}, so that (de)activating them again would have no effect.
+     */
+    boolean allRoutesConsistentWith(Ip nhip, boolean resolvable) {
+      return resolvable != _unresolvableNhips.contains(nhip) && !_mixedNhips.contains(nhip);
     }
 
     /** Get all routes with the given {@code prefix} tracked by the resolvability enforcer. */
@@ -89,30 +143,28 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
       return _bgpRoutesByPrefix.get(prefix);
     }
 
+    /**
+     * Returns the tracked NHIPs whose routes may need (de)activating after routes for the given
+     * main RIB prefixes were added or removed: those inside one of the prefixes, plus those whose
+     * routes arrived under different main RIB states (a withdrawal and re-add of the same route in
+     * one delta cancel out, so the delta alone can miss them). NHIPs shadowed by a more specific
+     * main RIB route are included; the caller finds their resolvability unchanged.
+     *
+     * <p>The result is a copy, so the caller may (de)activate routes, which mutates the tracked
+     * NHIPs, while iterating it.
+     */
     @Nonnull
-    Stream<Ip> getAffectedNextHopIps(Stream<Prefix> changedPrefixes) {
-      return changedPrefixes
-          .flatMap(prefix -> _mainRibPrefixesAndBgpNhips.getAffectedNextHopIps(prefix).stream())
-          .distinct();
+    SortedSet<Ip> getAffectedNextHopIps(Stream<Prefix> changedPrefixes) {
+      TreeSet<Ip> affected = new TreeSet<>(_mixedNhips);
+      changedPrefixes.forEach(
+          prefix ->
+              affected.addAll(_nhips.subSet(prefix.getStartIp(), true, prefix.getEndIp(), true)));
+      return affected;
     }
 
     @Nonnull
     Set<Bgpv4Route> getRoutesWithNhip(Ip nhip) {
       return ImmutableSet.copyOf(_bgpRoutesByNhip.get(nhip));
-    }
-
-    void updateMainRibPrefixes(RibDelta<AnnotatedRoute<AbstractRoute>> mainRibDelta) {
-      // TODO Filter to routes that pass the resolution restriction, when one is added
-      for (RouteAdvertisement<AnnotatedRoute<AbstractRoute>> action : mainRibDelta.getActions()) {
-        Prefix prefix = action.getRoute().getNetwork();
-        if (!action.isWithdrawn()) {
-          // Route was added (note that the same route can't be removed in the same delta)
-          _mainRibPrefixesAndBgpNhips.addPrefix(prefix);
-        } else if (_mainRib.getRoutes(prefix).isEmpty()) {
-          // Route was removed, and there are no remaining routes for this prefix
-          _mainRibPrefixesAndBgpNhips.removePrefix(prefix);
-        }
-      }
     }
 
     /**
@@ -214,9 +266,17 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
     if (shouldCheckNextHopReachability(route) && _mainRib != null) {
       assert route.getNextHop() instanceof NextHopIp
           : "shouldCheckNextHopReachability should only return true for NextHopIp";
+      Ip nhip = route.getNextHopIp();
       _resolvabilityEnforcer.evictSamePrefixReceivedFromPathId(route);
+      boolean firstRouteForNhip = !_resolvabilityEnforcer.isTracked(nhip);
       _resolvabilityEnforcer.addBgpRoute(route);
-      if (!isResolvable(route.getNextHopIp())) {
+      boolean resolvable = isResolvable(nhip);
+      if (firstRouteForNhip) {
+        _resolvabilityEnforcer.setResolvable(nhip, resolvable);
+      } else {
+        _resolvabilityEnforcer.addedRoute(nhip, resolvable);
+      }
+      if (!resolvable) {
         return RibDelta.empty();
       }
     } else if (route.isTrackableLocalRoute()) {
@@ -307,10 +367,7 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
     // Should only be null in tests, and those tests shouldn't be using this function
     assert _mainRib != null;
 
-    // Update resolvability enforcer's record of main RIB prefixes
-    _resolvabilityEnforcer.updateMainRibPrefixes(mainRibDelta);
-
-    // (De)activate BGP routes based on updated main RIB
+    // (De)activate BGP routes whose NHIP's resolvability changed with the main RIB update
     RibDelta.Builder<Bgpv4Route> bestPathDelta = RibDelta.builder();
     RibDelta.Builder<Bgpv4Route> multipathDelta = RibDelta.builder();
     _resolvabilityEnforcer
@@ -318,6 +375,11 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
         .forEach(
             nhip -> {
               boolean resolvable = isResolvable(nhip);
+              if (_resolvabilityEnforcer.allRoutesConsistentWith(nhip, resolvable)) {
+                // Re-(de)activating would be a no-op, e.g. the changed prefix is shadowed by a
+                // more specific main RIB route for this NHIP.
+                return;
+              }
               for (Bgpv4Route affectedRoute : _resolvabilityEnforcer.getRoutesWithNhip(nhip)) {
                 MultipathRibDelta<Bgpv4Route> delta;
                 if (resolvable) {
@@ -334,6 +396,8 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
                 bestPathDelta.from(delta.getBestPathDelta());
                 multipathDelta.from(delta.getMultipathDelta());
               }
+              // Set after the loop: removing a route may have cleared this NHIP's record.
+              _resolvabilityEnforcer.setResolvable(nhip, resolvable);
             });
     return new MultipathRibDelta<>(bestPathDelta.build(), multipathDelta.build());
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
@@ -1421,6 +1421,131 @@ public class Bgpv4RibTest {
     }
   }
 
+  /**
+   * A main RIB change to a prefix that contains a next hop IP but is shadowed by a more specific
+   * route must not change the BGP RIB.
+   */
+  @Test
+  public void testUpdateActiveRoutesShadowedPrefix() {
+    Ip nhip = Ip.parse("1.1.1.1");
+    Bgpv4Route dependentRoute =
+        Bgpv4Route.testBuilder()
+            .setNetwork(Prefix.parse("5.0.0.0/8"))
+            .setNextHop(NextHopIp.of(nhip))
+            .build();
+    AnnotatedRoute<AbstractRoute> resolvingRoute =
+        new AnnotatedRoute<>(
+            StaticRoute.testBuilder().setNetwork(nhip.toPrefix()).build(), "default");
+    AnnotatedRoute<AbstractRoute> shadowedRoute =
+        new AnnotatedRoute<>(
+            StaticRoute.testBuilder().setNetwork(Prefix.parse("1.0.0.0/8")).build(), "default");
+    Rib mainRib = new Rib();
+    mainRib.mergeRoute(resolvingRoute);
+    Bgpv4Rib bgpRib =
+        new Bgpv4Rib(
+            mainRib,
+            BgpTieBreaker.ARRIVAL_ORDER,
+            1,
+            null,
+            false,
+            LocalOriginationTypeTieBreaker.NO_PREFERENCE,
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+            ResolutionRestriction.alwaysTrue());
+    assertThat(bgpRib.mergeRouteGetDelta(dependentRoute), equalTo(RibDelta.adding(dependentRoute)));
+
+    // Adding and removing the shadowed prefix does not change resolvability.
+    RibDelta<AnnotatedRoute<AbstractRoute>> mainRibDelta =
+        mainRib.mergeRouteGetDelta(shadowedRoute);
+    assertThat(
+        bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(), equalTo(RibDelta.empty()));
+    mainRibDelta = mainRib.removeRouteGetDelta(shadowedRoute);
+    assertThat(
+        bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(), equalTo(RibDelta.empty()));
+    assertThat(bgpRib.getRoutes(), contains(dependentRoute));
+
+    // Removing the resolving route does, even though the shadowed prefix is present again.
+    mainRib.mergeRoute(shadowedRoute);
+    mainRibDelta = mainRib.removeRouteGetDelta(resolvingRoute);
+    assertThat(
+        bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(), equalTo(RibDelta.empty()));
+    assertThat(bgpRib.getRoutes(), contains(dependentRoute));
+    mainRibDelta = mainRib.removeRouteGetDelta(shadowedRoute);
+    assertThat(
+        bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
+        equalTo(RibDelta.of(RouteAdvertisement.withdrawing(dependentRoute))));
+    assertThat(bgpRib.getRoutes(), empty());
+  }
+
+  /**
+   * Routes with the same next hop IP that arrived under different main RIB states must all be
+   * (de)activated by the next {@link Bgpv4Rib#updateActiveRoutes}, even if that update finds the
+   * next hop's resolvability unchanged from the last time all of them were evaluated.
+   */
+  @Test
+  public void testUpdateActiveRoutesMixedNextHopState() {
+    Ip nhip = Ip.parse("1.1.1.1");
+    Bgpv4Route route1 =
+        Bgpv4Route.testBuilder()
+            .setNetwork(Prefix.parse("5.0.0.0/8"))
+            .setNextHop(NextHopIp.of(nhip))
+            .build();
+    Bgpv4Route route2 = route1.toBuilder().setNetwork(Prefix.parse("6.0.0.0/8")).build();
+    AnnotatedRoute<AbstractRoute> resolvingRoute =
+        new AnnotatedRoute<>(
+            StaticRoute.testBuilder().setNetwork(nhip.toPrefix()).build(), "default");
+    {
+      // route1 arrives unresolvable, route2 after the resolving route was added but before the
+      // BGP RIB heard about it.
+      Rib mainRib = new Rib();
+      Bgpv4Rib bgpRib =
+          new Bgpv4Rib(
+              mainRib,
+              BgpTieBreaker.ARRIVAL_ORDER,
+              1,
+              null,
+              false,
+              LocalOriginationTypeTieBreaker.NO_PREFERENCE,
+              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+              ResolutionRestriction.alwaysTrue());
+      assertThat(bgpRib.mergeRouteGetDelta(route1), equalTo(RibDelta.empty()));
+      RibDelta<AnnotatedRoute<AbstractRoute>> mainRibDelta =
+          mainRib.mergeRouteGetDelta(resolvingRoute);
+      assertThat(bgpRib.mergeRouteGetDelta(route2), equalTo(RibDelta.adding(route2)));
+      assertThat(
+          bgpRib.updateActiveRoutes(mainRibDelta).getMultipathDelta(),
+          equalTo(RibDelta.adding(route1)));
+      assertThat(bgpRib.getRoutes(), containsInAnyOrder(route1, route2));
+    }
+    {
+      // route1 arrives resolvable; the resolving route is removed and re-added within one delta,
+      // and route2 arrives in between, unresolvable.
+      Rib mainRib = new Rib();
+      mainRib.mergeRoute(resolvingRoute);
+      Bgpv4Rib bgpRib =
+          new Bgpv4Rib(
+              mainRib,
+              BgpTieBreaker.ARRIVAL_ORDER,
+              1,
+              null,
+              false,
+              LocalOriginationTypeTieBreaker.NO_PREFERENCE,
+              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+              NextHopIpTieBreaker.HIGHEST_NEXT_HOP_IP,
+              ResolutionRestriction.alwaysTrue());
+      assertThat(bgpRib.mergeRouteGetDelta(route1), equalTo(RibDelta.adding(route1)));
+      RibDelta.Builder<AnnotatedRoute<AbstractRoute>> mainRibDelta = RibDelta.builder();
+      mainRibDelta.from(mainRib.removeRouteGetDelta(resolvingRoute));
+      assertThat(bgpRib.mergeRouteGetDelta(route2), equalTo(RibDelta.empty()));
+      mainRibDelta.from(mainRib.mergeRouteGetDelta(resolvingRoute));
+      assertThat(
+          bgpRib.updateActiveRoutes(mainRibDelta.build()).getMultipathDelta(),
+          equalTo(RibDelta.adding(route2)));
+      assertThat(bgpRib.getRoutes(), containsInAnyOrder(route1, route2));
+    }
+  }
+
   @Test
   public void testRedistributeRoutes() {
     Ip lowestNhip = Ip.parse("10.0.0.1");


### PR DESCRIPTION
The resolvability enforcer kept a RibResolutionTrie holding a copy of
every main RIB prefix, maintained from each round's main RIB delta,
purely so that the next hop IPs affected by a changed prefix could be
found while pruning those shadowed by a more specific route. That is a
second prefix trie the size of the main RIB in every BGP VRF. On a large
snapshot it was 13% of the live heap during BGP convergence.

Keep only the next hop IPs, in a TreeSet, and answer "which next hops
lie inside this prefix" with a sub-set lookup. Shadowed next hops are
now visited, so record each next hop's resolvability as of the last
time all of its routes were (de)activated together and skip the ones
whose resolvability did not change; re-(de)activating them was a no-op
before. A next hop whose routes arrived under different main RIB states
within one round is marked mixed and always revisited. That also fixes a
latent gap: RibDelta.Builder cancels a withdrawal and re-add of the same
route within one delta, so a BGP route that arrived while its next hop's
covering route was transiently absent used to stay withheld.

RIBs and FIBs are identical on the snapshot above; live heap at a
steady-state iteration drops by 1.3 GiB, all of it PrefixTrieMultiMap
storage.

----

Prompt:
```
Next item from the dataplane profiling investigation: drop the main RIB
prefix mirror in the BGP resolvability enforcer and keep a next-hop-only
structure. Measure correctness and benefit internally, then port to open
source and send the PR without revealing internal details.
```
