### PR TITLE
profiling: delete the dataplane runner's temp storage on exit, and accept debug flags

### DIFF
--- a/tools/profiling/BUILD.bazel
+++ b/tools/profiling/BUILD.bazel
@@ -81,6 +81,7 @@ java_binary(
         "//projects/batfish:batfish_testlib",
         "//projects/common",
         "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
         "@maven//:org_apache_logging_log4j_log4j_core",
         "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],

--- a/tools/profiling/DataplaneRunner.java
+++ b/tools/profiling/DataplaneRunner.java
@@ -2,6 +2,8 @@ package tools.profiling;
 
 import static org.batfish.main.TestrigText.loadTestrig;
 
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +31,7 @@ import org.batfish.main.BatfishTestUtils;
  *
  * <pre>
  * dataplaneRunner SNAPSHOT_DIR [--filter REGEX] [--histogram N] [--retain dataplane|nothing]
- *                              [--dump-prefixes FILE] [--jfr FILE]
+ *                              [--dump-prefixes FILE] [--jfr FILE] [--debug-flag FLAG]...
  * </pre>
  *
  * <ul>
@@ -43,6 +45,8 @@ import org.batfish.main.BatfishTestUtils;
  *   <li>{@code --jfr FILE}: dump the running flight recording there with reference chains to GC
  *       roots; start the JVM with {@code -XX:StartFlightRecording:settings=profile,
  *       path-to-gc-roots=true} for old-object samples to be in it.
+ *   <li>{@code --debug-flag FLAG}: enable a Batfish debug flag, e.g. {@code
+ *       enableTopologyContextModifier} as production does; may be repeated.
  * </ul>
  *
  * <p>The RIB and FIB lines give total counts and order-independent hashes, so two builds can be
@@ -56,7 +60,8 @@ public final class DataplaneRunner {
     if (args.length == 0) {
       System.err.println(
           "Usage: dataplaneRunner SNAPSHOT_DIR [--filter REGEX] [--histogram N]"
-              + " [--retain dataplane|nothing] [--dump-prefixes FILE] [--jfr FILE]");
+              + " [--retain dataplane|nothing] [--dump-prefixes FILE] [--jfr FILE]"
+              + " [--debug-flag FLAG]...");
       System.exit(2);
     }
     String snapshotDir = args[0];
@@ -65,6 +70,7 @@ public final class DataplaneRunner {
     String retain = "all";
     Path dumpPrefixes = null;
     Path jfr = null;
+    List<String> debugFlags = new ArrayList<>();
     for (int i = 1; i < args.length; i += 2) {
       String value = i + 1 < args.length ? args[i + 1] : null;
       switch (args[i]) {
@@ -73,6 +79,7 @@ public final class DataplaneRunner {
         case "--retain" -> retain = required(args[i], value);
         case "--dump-prefixes" -> dumpPrefixes = Path.of(required(args[i], value));
         case "--jfr" -> jfr = Path.of(required(args[i], value));
+        case "--debug-flag" -> debugFlags.add(required(args[i], value));
         default -> throw new IllegalArgumentException("Unknown option " + args[i]);
       }
     }
@@ -90,6 +97,7 @@ public final class DataplaneRunner {
     settings.setHaltOnParseError(false);
     settings.setThrowOnLexerError(false);
     settings.setThrowOnParserError(false);
+    settings.setDebugFlags(debugFlags);
     NetworkSnapshot snapshot = batfish.getSnapshot();
     SortedMap<String, Configuration> configs = batfish.loadConfigurations(snapshot);
     long t1 = System.currentTimeMillis();
@@ -116,6 +124,8 @@ public final class DataplaneRunner {
       diagnosticCommand("jfrDump", "filename=" + jfr, "path-to-gc-roots=true");
       System.out.println("JFR dumped to " + jfr);
     }
+    // The snapshot storage under tmp is several GB and tmp is often a tmpfs, so do not leave it.
+    MoreFiles.deleteRecursively(tmp, RecursiveDeleteOption.ALLOW_INSECURE);
     System.out.println("DONE");
     System.out.flush();
     Runtime.getRuntime().halt(0);

--- a/tools/profiling/README.md
+++ b/tools/profiling/README.md
@@ -205,7 +205,8 @@ java -Xmx12g -jar bazel-bin/tools/profiling/dataplaneRunner_deploy.jar \
   /path/to/snapshot --filter '^dc1-' --histogram 20
 ```
 
-Options: `--filter REGEX` loads only matching config files; `--histogram N`
+Options: `--filter REGEX` loads only matching config files; `--debug-flag
+FLAG` enables a Batfish debug flag (repeatable); `--histogram N`
 prints the top N classes after a full GC; `--retain dataplane|nothing` drops
 the `Batfish` instance (and the dataplane) first, to see what a server would
 keep; `--dump-prefixes FILE` writes the largest main RIB's prefixes for


### PR DESCRIPTION
The runner parses into a temp directory under java.io.tmpdir and left
it behind, several GB of snapshot storage per run. On a host where tmp
is a tmpfs that is RAM, and enough leftover runs got later JVMs killed
by the OOM killer.

Also add `--debug-flag FLAG` so the runner can enable the same debug
flags a production client would pass to generate-dataplane.

----

Prompt:
```
Side fix while profiling the dataplane: the headless runner leaves its
temp snapshot storage in /tmp, which is a tmpfs here and was causing
OOM kills. Make it clean up, and let it take debug flags like the
production client does. Send as an open-source PR.
```
