### PR TITLE
ForwardingAnalysisImpl: group each VRF's FIB entries by interface and ARP IP, not per route

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import java.io.Serializable;
@@ -20,17 +19,18 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import net.sf.javabdd.BDD;
@@ -93,9 +93,6 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
     Set<Ip> unownedArpIps = computeUnownedArpIps(fibs, ipSpaceToBDD, unownedIpsBDD);
 
     LOGGER.info("Aggregating information about routing entries");
-    // Set of routes that forward out each interface
-    Map<String, Map<String, Map<String, Set<AbstractRoute>>>> routesWithNextHop =
-        computeRoutesWithNextHop(fibs, allVrfs);
     // Node -> vrf -> destination IPs that can be routed
     Map<String, Map<String, IpSpace>> routableIps = computeRoutableIps(fibs, allVrfs);
 
@@ -107,7 +104,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
       // interface. Should only include active interfaces.
       LOGGER.info("Computing IPs routed out interfaces");
       Map<String, Map<String, Map<String, IpSpace>>> ipsRoutedOutInterfaces =
-          computeIpsRoutedOutInterfaces(fibs, routesWithNextHop, allVrfs);
+          computeIpsRoutedOutInterfaces(fibs, allVrfs);
       LOGGER.info("Computing ARP replies");
       _arpReplies =
           computeArpReplies(configurations, ipsRoutedOutInterfaces, interfaceOwnedIps, routableIps);
@@ -151,8 +148,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                               interfacesWithMissingDevices,
                               internalIps,
                               externalIps,
-                              routableIps,
-                              routesWithNextHop.get(node).get(vrf));
+                              routableIps);
                       int processed = done.incrementAndGet();
                       if (processed % 100 == 0) {
                         LOGGER.info(
@@ -184,34 +180,23 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
       Multimap<String, String> interfacesWithMissingDevices,
       IpSpace internalIps,
       IpSpace externalIps,
-      Map<String, Map<String, IpSpace>> routableIps,
-      Map<String, Set<AbstractRoute>> routesWithNextHop) {
+      Map<String, Map<String, IpSpace>> routableIps) {
     Map<String, IpSpace> accepted =
         ipOwners
             .getVrfIfaceOwnedIpSpaces()
             .getOrDefault(node, ImmutableMap.of())
             .getOrDefault(vrf, ImmutableMap.of());
-    /*
-     * Mapping: route -> nexthopinterface -> resolved nextHopIps (where Optional.empty() indicates
-     *                                       dest IP should be used for ARP)
-     */
-    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
-        computeNextHopInterfaces(fib);
+    VrfForwardingIndex index = new VrfForwardingIndex(fib);
 
-    /* interface -> set of routes on that vrf that forward out that interface,
-     * ARPing for the destination IP
-     */
-    Map<String, Set<AbstractRoute>> routesWhereDstIpCanBeArpIp =
-        computeRoutesWhereDstIpCanBeArpIp(nextHopInterfaces, routesWithNextHop);
-
-    /* edge -> routes in this vrf that forward out the source of that edge,
-     * ARPing for the dest IP and receiving a response from the target of the edge.
+    /* interface -> dst IPs for which this vrf forwards out that interface, ARPing for the dest IP.
      *
-     * Note: the source interface of the edge must be in the node, but may not be in the vrf,
-     * due to route leaking, etc
+     * Note: the interface must be in the node, but may not be in the vrf, due to route leaking, etc
      */
-    Map<Edge, Set<AbstractRoute>> routesWithDestIpEdge =
-        computeRoutesWithDestIpEdge(node, topology, routesWhereDstIpCanBeArpIp);
+    Map<String, IpSpace> dstIpsArpingForDestIp =
+        toImmutableMap(
+            index.getInterfaces(),
+            Function.identity(),
+            iface -> index.matchingIps(index.getRoutesArpingForDestIp(iface)));
 
     /* edge -> dst ips for which this vrf forwards out the source of the edge,
      * ARPing for the dest IP and receiving a reply from the target of the edge.
@@ -220,17 +205,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
      * due to route leaking, etc
      */
     Map<Edge, IpSpace> arpTrueEdgeDestIp =
-        computeArpTrueEdgeDestIp(fib, routesWithDestIpEdge, _arpReplies);
-
-    /* edge -> routes for which an arp true response will be received when they are the lpm of
-     * the dest IP
-     *
-     * Note: the source interface of the edge must be in the node, but may not be in the vrf,
-     * due to route leaking, etc
-     */
-    Map<Edge, Set<AbstractRoute>> routesWithNextHopIpArpTrue =
-        computeRoutesWithNextHopIpArpTrue(
-            node, nextHopInterfaces, topology, _arpReplies, routesWithNextHop);
+        computeArpTrueEdgeDestIp(node, topology, dstIpsArpingForDestIp, _arpReplies);
 
     /* edge -> dst ips for which this vrf forwards out the source of the edge,
      * ARPing for some next-hop IP and receiving a reply from the target of the edge.
@@ -239,16 +214,15 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
      * due to route leaking, etc
      */
     Map<Edge, IpSpace> arpTrueEdgeNextHopIp =
-        computeArpTrueEdgeNextHopIp(fib, routesWithNextHopIpArpTrue);
+        computeArpTrueEdgeNextHopIp(node, index, topology, _arpReplies);
 
     Map<Edge, IpSpace> arpTrueEdge = computeArpTrueEdge(arpTrueEdgeDestIp, arpTrueEdgeNextHopIp);
 
     Map<String, InterfaceForwardingBehavior> interfaceForwardingBehavior =
         toImmutableMap(
-            // routesWithNextHop may include interfaces in other VRFs that we
-            // forward out through due to VRF leaking. All active interfaces
-            // in this VRF are included due to local routes.
-            routesWithNextHop.keySet(),
+            // The index may include interfaces in other VRFs that we forward out through due to
+            // VRF leaking. All active interfaces in this VRF are included due to local routes.
+            index.getInterfaces(),
             Function.identity(),
             iface -> {
               IpSpace externalArpIps =
@@ -263,19 +237,18 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                * with a next hop ip that gets no arp replies
                */
               Set<AbstractRoute> arpFalseNhipRoutes =
-                  computeArpFalseNhipRoutes(
-                      iface, nextHopInterfaces, routesWithNextHop.get(iface), someoneReplies);
+                  computeArpFalseNhipRoutes(index, iface, someoneReplies);
 
               /* dst IPs for which this VRF forwards out that interface, ARPing
                * for the dst ip itself with no reply
                */
               IpSpace arpFalseDestIp =
-                  computeArpFalseDestIp(fib, routesWhereDstIpCanBeArpIp.get(iface), someoneReplies);
+                  computeArpFalseDestIp(dstIpsArpingForDestIp.get(iface), someoneReplies);
 
               /* dst ips for which this vrf forwards out that interface,
                * ARPing for a next-hop IP and receiving no reply
                */
-              IpSpace arpFalseNextHopIp = computeArpFalseNextHopIp(fib, arpFalseNhipRoutes);
+              IpSpace arpFalseNextHopIp = index.matchingIps(arpFalseNhipRoutes);
 
               IpSpace arpFalse = AclIpSpace.union(arpFalseDestIp, arpFalseNextHopIp);
 
@@ -286,7 +259,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
               List<AbstractRoute> arpFalseNhipRoutesWithOwnedArpIp = new ArrayList<>();
               classifyArpFalseNhipRoutes(
                   unownedArpIps,
-                  nextHopInterfaces,
+                  index,
                   arpFalseNhipRoutes,
                   arpFalseNhipRoutesWithUnownedArpIp::add,
                   arpFalseNhipRoutesWithOwnedArpIp::add);
@@ -295,13 +268,13 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
                * for some unowned next-hop IP with no reply
                */
               IpSpace dstIpsWithUnownedNextHopIpArpFalse =
-                  computeRouteMatchConditions(arpFalseNhipRoutesWithUnownedArpIp, fib);
+                  index.matchingIps(arpFalseNhipRoutesWithUnownedArpIp);
 
               /* dst IPs for which that VRF forwards out that interface, ARPing
                * for some owned next-hop IP with no reply.
                */
               IpSpace dstIpsWithOwnedNextHopIpArpFalse =
-                  computeRouteMatchConditions(arpFalseNhipRoutesWithOwnedArpIp, fib);
+                  index.matchingIps(arpFalseNhipRoutesWithOwnedArpIp);
 
               IpSpace deliveredToSubnet =
                   computeDeliveredToSubnet(arpFalseDestIp, externalArpIps, ownedIps);
@@ -364,33 +337,28 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
    */
   private static void classifyArpFalseNhipRoutes(
       Set<Ip> unownedArpIps,
-      Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces,
+      VrfForwardingIndex index,
       Set<AbstractRoute> routesWithNextHopIpArpFalse,
       Consumer<AbstractRoute> arpFalseNhipRoutesWithUnownedArpIp,
       Consumer<AbstractRoute> arpFalseNhipRoutesWithOwnedArpIp) {
-    routesWithNextHopIpArpFalse.forEach(
-        route -> {
-          // Iterate over the arpIps for this route, checking whether each is owned. Stop once
-          // we've found one owned and one unowned.
-          Iterator<Ip> it =
-              nextHopInterfaces.get(route).values().stream()
-                  .flatMap(Set::stream)
-                  .filter(Optional::isPresent)
-                  .map(Optional::get)
-                  .iterator();
-          boolean foundUnowned = false;
-          boolean foundOwned = false;
-          while (it.hasNext() && !(foundUnowned && foundOwned)) {
-            Ip arpIp = it.next();
-            if (!foundUnowned && unownedArpIps.contains(arpIp)) {
-              foundUnowned = true;
-              arpFalseNhipRoutesWithUnownedArpIp.accept(route);
-            } else if (!foundOwned) {
-              foundOwned = true;
-              arpFalseNhipRoutesWithOwnedArpIp.accept(route);
-            }
-          }
-        });
+    for (AbstractRoute route : routesWithNextHopIpArpFalse) {
+      // Iterate over the arpIps for this route (on any interface), checking whether each is owned.
+      // Stop once we've found one owned and one unowned.
+      boolean foundUnowned = false;
+      boolean foundOwned = false;
+      for (Ip arpIp : index.getArpIps(route)) {
+        if (!foundUnowned && unownedArpIps.contains(arpIp)) {
+          foundUnowned = true;
+          arpFalseNhipRoutesWithUnownedArpIp.accept(route);
+        } else if (!foundOwned) {
+          foundOwned = true;
+          arpFalseNhipRoutesWithOwnedArpIp.accept(route);
+        }
+        if (foundUnowned && foundOwned) {
+          break;
+        }
+      }
+    }
   }
 
   private static Set<Ip> computeUnownedArpIps(
@@ -529,34 +497,61 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
         edge -> AclIpSpace.union(arpTrueEdgeDestIp.get(edge), arpTrueEdgeNextHopIp.get(edge)));
   }
 
+  /**
+   * Mapping: edge -&gt; dst IPs for which this node forwards out the source of the edge, ARPing for
+   * the dest IP and receiving a reply from the target of the edge.
+   *
+   * @param dstIpsArpingForDestIp interface -&gt; dst IPs forwarded out that interface, ARPing for
+   *     the dest IP
+   */
   @VisibleForTesting
   static Map<Edge, IpSpace> computeArpTrueEdgeDestIp(
-      Fib fib,
-      Map<Edge, Set<AbstractRoute>> routesWithDestIpEdge,
+      String node,
+      Topology topology,
+      Map<String, IpSpace> dstIpsArpingForDestIp,
       Map<String, Map<String, IpSpace>> arpReplies) {
-    return toImmutableMap(
-        routesWithDestIpEdge,
-        Entry::getKey, // edge
-        edgeEntry -> {
-          Edge edge = edgeEntry.getKey();
-          Set<AbstractRoute> routes = edgeEntry.getValue();
-          IpSpace dstIpMatchesSomeRoutePrefix = computeRouteMatchConditions(routes, fib);
-          String recvNode = edge.getNode2();
-          String recvInterface = edge.getInt2();
-          IpSpace recvReplies = arpReplies.get(recvNode).get(recvInterface);
-          return AclIpSpace.rejecting(dstIpMatchesSomeRoutePrefix.complement())
-              .thenPermitting(recvReplies)
-              .build();
+    ImmutableMap.Builder<Edge, IpSpace> result = ImmutableMap.builder();
+    dstIpsArpingForDestIp.forEach(
+        (iface, dstIpMatchesSomeRoutePrefix) -> {
+          NodeInterfacePair out = NodeInterfacePair.of(node, iface);
+          for (NodeInterfacePair receiver : topology.getNeighbors(out)) {
+            IpSpace recvReplies =
+                arpReplies.get(receiver.getHostname()).get(receiver.getInterface());
+            result.put(
+                new Edge(out, receiver),
+                AclIpSpace.rejecting(dstIpMatchesSomeRoutePrefix.complement())
+                    .thenPermitting(recvReplies)
+                    .build());
+          }
         });
+    return result.build();
   }
 
+  /**
+   * Mapping: edge -&gt; dst IPs for which this node forwards out the source of the edge, ARPing for
+   * some next-hop IP and receiving a reply from the target of the edge. Only edges with such IPs
+   * are present.
+   */
   @VisibleForTesting
-  static Map<Edge, IpSpace> computeArpTrueEdgeNextHopIp(
-      Fib fib, Map<Edge, Set<AbstractRoute>> routesWithNextHopIpArpTrue) {
-    return toImmutableMap(
-        routesWithNextHopIpArpTrue,
-        Entry::getKey, // edge
-        edgeEntry -> computeRouteMatchConditions(edgeEntry.getValue(), fib));
+  static @Nonnull Map<Edge, IpSpace> computeArpTrueEdgeNextHopIp(
+      String node,
+      VrfForwardingIndex index,
+      Topology topology,
+      Map<String, Map<String, IpSpace>> arpReplies) {
+    ImmutableMap.Builder<Edge, IpSpace> result = ImmutableMap.builder();
+    for (String iface : index.getInterfaces()) {
+      NodeInterfacePair out = NodeInterfacePair.of(node, iface);
+      for (NodeInterfacePair receiver : topology.getNeighbors(out)) {
+        IpSpace recvReplies = arpReplies.get(receiver.getHostname()).get(receiver.getInterface());
+        Set<AbstractRoute> routes =
+            index.getRoutesArpingForNextHopIp(
+                iface, nextHopIp -> recvReplies.containsIp(nextHopIp, ImmutableMap.of()));
+        if (!routes.isEmpty()) {
+          result.put(new Edge(out, receiver), index.matchingIps(routes));
+        }
+      }
+    }
+    return result.build();
   }
 
   @VisibleForTesting
@@ -635,49 +630,49 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
 
   @VisibleForTesting
   static Map<String, Map<String, Map<String, IpSpace>>> computeIpsRoutedOutInterfaces(
-      Map<String, Map<String, Fib>> fibs,
-      Map<String, Map<String, Map<String, Set<AbstractRoute>>>> routesWithNextHop,
-      List<Map.Entry<String, String>> allVrfs) {
+      Map<String, Map<String, Fib>> fibs, List<Map.Entry<String, String>> allVrfs) {
     return allVrfs.parallelStream()
         .collect(
             ImmutableTable.toImmutableTable(
                 Entry::getKey,
                 Entry::getValue,
-                e -> {
-                  String hostname = e.getKey();
-                  String vrf = e.getValue();
-                  Fib vrfFib = fibs.get(hostname).get(vrf);
-                  return (Map<String, IpSpace>)
-                      routesWithNextHop.get(hostname).get(vrf).entrySet().stream()
-                          /*
-                           *  Cannot determine IPs for null interface here because it is
-                           *  not tied to a single VRF.
-                           */
-                          .filter(
-                              ifaceEntry ->
-                                  !ifaceEntry.getKey().equals(Interface.NULL_INTERFACE_NAME))
-                          .map(
-                              ifaceEntry -> {
-                                String iface = ifaceEntry.getKey();
-                                Set<AbstractRoute> routes = ifaceEntry.getValue();
-                                return Maps.immutableEntry(
-                                    iface, computeRouteMatchConditions(routes, vrfFib));
-                              })
-                          .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
-                }))
+                e -> computeIpsRoutedOutInterfaces(fibs.get(e.getKey()).get(e.getValue()))))
         .rowMap();
   }
 
+  /** Mapping: interface -&gt; dst IPs for which the given FIB forwards out that interface. */
   @VisibleForTesting
-  static IpSpace computeArpFalseDestIp(
-      Fib fib, Set<AbstractRoute> routesWhereDstIpCanBeArpIp, IpSpace someoneReplies) {
-    IpSpace ipsRoutedOutInterface = computeRouteMatchConditions(routesWhereDstIpCanBeArpIp, fib);
-    return AclIpSpace.rejecting(someoneReplies).thenPermitting(ipsRoutedOutInterface).build();
+  static Map<String, IpSpace> computeIpsRoutedOutInterfaces(Fib fib) {
+    // interface -> the distinct networks of routes forwarding out it, in FIB entry order
+    Map<String, Set<Prefix>> networksByInterface = new LinkedHashMap<>();
+    for (FibEntry entry : fib.allEntries()) {
+      if (!(entry.getAction() instanceof FibForward)) {
+        continue;
+      }
+      String iface = ((FibForward) entry.getAction()).getInterfaceName();
+      // Cannot determine IPs for null interface here because it is not tied to a single VRF.
+      if (iface.equals(Interface.NULL_INTERFACE_NAME)) {
+        continue;
+      }
+      networksByInterface
+          .computeIfAbsent(iface, i -> new LinkedHashSet<>())
+          .add(entry.getTopLevelRoute().getNetwork());
+    }
+    return toImmutableMap(
+        networksByInterface,
+        Entry::getKey,
+        ifaceEntry -> matchingIps(ifaceEntry.getValue(), fib::matchingIps));
   }
 
+  /**
+   * dst IPs for which this VRF forwards out an interface, ARPing for the dst IP itself with no
+   * reply.
+   *
+   * @param dstIpsArpingForDestIp dst IPs forwarded out the interface, ARPing for the dest IP
+   */
   @VisibleForTesting
-  static IpSpace computeArpFalseNextHopIp(Fib fib, Set<AbstractRoute> routesWithNextHopIpArpFalse) {
-    return computeRouteMatchConditions(routesWithNextHopIpArpFalse, fib);
+  static IpSpace computeArpFalseDestIp(IpSpace dstIpsArpingForDestIp, IpSpace someoneReplies) {
+    return AclIpSpace.rejecting(someoneReplies).thenPermitting(dstIpsArpingForDestIp).build();
   }
 
   @VisibleForTesting
@@ -757,152 +752,142 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
         .rowMap();
   }
 
+  /** The dst IPs whose longest match in {@code fib} is one of the given routes. */
   @VisibleForTesting
   static IpSpace computeRouteMatchConditions(Collection<AbstractRoute> routes, Fib fib) {
-    // get the union of IpSpace that match one of the routes
-    // get the union of IpSpace that match one of the routes
-    return firstNonNull(
-        AclIpSpace.union(
-            routes.stream()
-                .map(AbstractRoute::getNetwork)
-                .distinct()
-                .map(fib::matchingIps)
-                .toArray(IpSpace[]::new)),
-        EmptyIpSpace.INSTANCE);
+    return matchingIps(distinctNetworks(routes), fib::matchingIps);
   }
 
-  /**
-   * Mapping: interfacename -&gt; a set of routes where each route has at least one unset final next
-   * hop ip
-   */
-  @VisibleForTesting
-  static Map<String, Set<AbstractRoute>> computeRoutesWhereDstIpCanBeArpIp(
-      Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces,
-      Map<String, Set<AbstractRoute>> routesWithNextHop) {
-    return toImmutableMap(
-        routesWithNextHop,
-        Entry::getKey /* interface */,
-        ifaceEntry -> {
-          String iface = ifaceEntry.getKey();
-          // return a set of routes where each route has
-          // some final next hop ip unset
-          return ifaceEntry
-              .getValue() // routes with this interface as
-              // outgoing interfaces
-              .stream()
-              .filter(
-                  route ->
-                      nextHopInterfaces
-                          .get(route)
-                          .get(iface) // final next hop ips
-                          .contains(Optional.<Ip>empty()))
-              .collect(ImmutableSet.toImmutableSet());
-        });
+  private static @Nonnull Set<Prefix> distinctNetworks(Collection<AbstractRoute> routes) {
+    Set<Prefix> networks = new LinkedHashSet<>();
+    for (AbstractRoute route : routes) {
+      networks.add(route.getNetwork());
+    }
+    return networks;
   }
 
-  @VisibleForTesting
-  static Map<Edge, Set<AbstractRoute>> computeRoutesWithDestIpEdge(
-      String node, Topology topology, Map<String, Set<AbstractRoute>> routesWhereDstIpCanBeArpIp) {
-    return routesWhereDstIpCanBeArpIp.entrySet().stream()
-        .flatMap(
-            ifaceEntry -> {
-              NodeInterfacePair out = NodeInterfacePair.of(node, ifaceEntry.getKey());
-              Set<AbstractRoute> routes = ifaceEntry.getValue();
-              return topology.getNeighbors(out).stream()
-                  .map(receiver -> Maps.immutableEntry(new Edge(out, receiver), routes));
-            })
-        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+  /** The union of {@code matchingIps} over the given networks, in order. */
+  private static @Nonnull IpSpace matchingIps(
+      Collection<Prefix> networks, Function<Prefix, IpSpace> matchingIps) {
+    if (networks.isEmpty()) {
+      return EmptyIpSpace.INSTANCE;
+    }
+    IpSpace[] spaces = new IpSpace[networks.size()];
+    int i = 0;
+    for (Prefix network : networks) {
+      spaces[i++] = matchingIps.apply(network);
+    }
+    return firstNonNull(AclIpSpace.union(spaces), EmptyIpSpace.INSTANCE);
   }
 
   /* Mapping: hostname -&gt; vrfname -&gt; interfacename -&gt; set of associated routes (i.e.,
-   * routes that use the interface as outgoing interface */
-  @VisibleForTesting
-  static Map<String, Map<String, Map<String, Set<AbstractRoute>>>> computeRoutesWithNextHop(
-      Map<String, Map<String, Fib>> fibs, List<Map.Entry<String, String>> allVrfs) {
-    return allVrfs.parallelStream()
-        .collect(
-            ImmutableTable.toImmutableTable(
-                Entry::getKey,
-                Entry::getValue,
-                e ->
-                    fibs.get(e.getKey()).get(e.getValue()).allEntries().stream()
-                        .filter(fibEntry -> fibEntry.getAction() instanceof FibForward)
-                        .collect(
-                            Collectors.groupingBy(
-                                fibEntry -> ((FibForward) fibEntry.getAction()).getInterfaceName(),
-                                Collectors.mapping(
-                                    FibEntry::getTopLevelRoute, Collectors.toSet())))))
-        .rowMap();
-  }
-
+  /**
+   * Routes that forward out {@code iface} ARPing for a next-hop IP that gets no reply from any
+   * neighbor.
+   */
   @VisibleForTesting
   static Set<AbstractRoute> computeArpFalseNhipRoutes(
-      String iface,
-      Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces,
-      Set<AbstractRoute> routesWithNextHop,
-      IpSpace someoneReplies) {
-    return computeRoutesWithNextHopIpArpFalseForInterface(
-        nextHopInterfaces, iface, routesWithNextHop, someoneReplies);
+      VrfForwardingIndex index, String iface, IpSpace someoneReplies) {
+    return index.getRoutesArpingForNextHopIp(
+        iface, nextHopIp -> !someoneReplies.containsIp(nextHopIp, ImmutableMap.of()));
   }
 
+  /**
+   * The forwarding entries of one VRF's FIB, grouped by outgoing interface and by the IP ARPed for
+   * out that interface ({@link Optional#empty()} when it is the destination IP). Every per-route
+   * decision in forwarding analysis depends only on that pair, so the routes in a group are handled
+   * together and an ARP reply check runs once per group rather than once per route. Routes keep FIB
+   * entry order.
+   */
   @VisibleForTesting
-  static Set<AbstractRoute> computeRoutesWithNextHopIpArpFalseForInterface(
-      Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces,
-      String outInterface,
-      Set<AbstractRoute> candidateRoutes,
-      IpSpace someoneReplies) {
-    return candidateRoutes.stream()
-        .filter(
-            candidateRoute ->
-                nextHopInterfaces.get(candidateRoute).get(outInterface).stream()
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .anyMatch(
-                        nextHopIp -> !someoneReplies.containsIp(nextHopIp, ImmutableMap.of())))
-        .collect(ImmutableSet.toImmutableSet());
-  }
+  static final class VrfForwardingIndex {
+    private final @Nonnull Fib _fib;
 
-  @VisibleForTesting
-  static @Nonnull Map<Edge, Set<AbstractRoute>> computeRoutesWithNextHopIpArpTrue(
-      String node,
-      Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces,
-      Topology topology,
-      Map<String, Map<String, IpSpace>> arpReplies,
-      Map<String, Set<AbstractRoute>> routesWithNextHop) {
-    return routesWithNextHop.entrySet().stream()
-        .flatMap(
-            ifaceEntry -> {
-              String outInterface = ifaceEntry.getKey();
-              Set<AbstractRoute> candidateRoutes = ifaceEntry.getValue();
-              NodeInterfacePair out = NodeInterfacePair.of(node, outInterface);
-              Set<NodeInterfacePair> receivers = topology.getNeighbors(out);
-              return receivers.stream()
-                  .map(
-                      receiver -> {
-                        String recvNode = receiver.getHostname();
-                        String recvInterface = receiver.getInterface();
-                        IpSpace recvReplies = arpReplies.get(recvNode).get(recvInterface);
-                        Edge edge = new Edge(out, receiver);
-                        Set<AbstractRoute> routes =
-                            candidateRoutes.stream()
-                                .filter(
-                                    route ->
-                                        nextHopInterfaces
-                                            .get(route)
-                                            .get(outInterface) // nextHopIps
-                                            .stream()
-                                            .filter(Optional::isPresent)
-                                            .map(Optional::get)
-                                            .anyMatch(
-                                                nextHopIp ->
-                                                    recvReplies.containsIp(
-                                                        nextHopIp, ImmutableMap.of())))
-                                .collect(ImmutableSet.toImmutableSet());
-                        return routes.isEmpty() ? null : Maps.immutableEntry(edge, routes);
-                      })
-                  .filter(Objects::nonNull);
-            })
-        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+    /** interface -&gt; ARP IP -&gt; routes forwarding out that interface ARPing for that IP. */
+    private final @Nonnull Map<String, Map<Optional<Ip>, Set<AbstractRoute>>>
+        _routesByInterfaceAndArpIp;
+
+    /** route -&gt; the next-hop IPs it ARPs for on any interface. */
+    private final @Nonnull Map<AbstractRoute, Set<Ip>> _arpIpsByRoute;
+
+    /** {@link Fib#matchingIps} memoized across the several unions each network takes part in. */
+    private final @Nonnull Map<Prefix, IpSpace> _matchingIps;
+
+    VrfForwardingIndex(Fib fib) {
+      _fib = fib;
+      Map<String, Map<Optional<Ip>, ImmutableSet.Builder<AbstractRoute>>> groups =
+          new LinkedHashMap<>();
+      Map<AbstractRoute, ImmutableSet.Builder<Ip>> arpIps = new HashMap<>();
+      for (FibEntry entry : fib.allEntries()) {
+        if (!(entry.getAction() instanceof FibForward)) {
+          continue;
+        }
+        FibForward forward = (FibForward) entry.getAction();
+        AbstractRoute route = entry.getTopLevelRoute();
+        groups
+            .computeIfAbsent(forward.getInterfaceName(), i -> new LinkedHashMap<>())
+            .computeIfAbsent(forward.getArpIp(), ip -> ImmutableSet.builder())
+            .add(route);
+        if (forward.getArpIp().isPresent()) {
+          arpIps.computeIfAbsent(route, r -> ImmutableSet.builder()).add(forward.getArpIp().get());
+        }
+      }
+      _routesByInterfaceAndArpIp =
+          toImmutableMap(
+              groups,
+              Entry::getKey,
+              ifaceEntry ->
+                  toImmutableMap(
+                      ifaceEntry.getValue(), Entry::getKey, group -> group.getValue().build()));
+      _arpIpsByRoute = toImmutableMap(arpIps, Entry::getKey, e -> e.getValue().build());
+      _matchingIps = new HashMap<>();
+    }
+
+    /** Interfaces some route forwards out of, in FIB entry order. */
+    @Nonnull
+    Set<String> getInterfaces() {
+      return _routesByInterfaceAndArpIp.keySet();
+    }
+
+    /** Routes forwarding out {@code iface} that ARP for the destination IP. */
+    @Nonnull
+    Set<AbstractRoute> getRoutesArpingForDestIp(String iface) {
+      return _routesByInterfaceAndArpIp
+          .getOrDefault(iface, ImmutableMap.of())
+          .getOrDefault(Optional.empty(), ImmutableSet.of());
+    }
+
+    /**
+     * Routes forwarding out {@code iface} that ARP for a next-hop IP accepted by {@code test},
+     * which is evaluated once per distinct next-hop IP.
+     */
+    @Nonnull
+    Set<AbstractRoute> getRoutesArpingForNextHopIp(String iface, Predicate<Ip> test) {
+      ImmutableSet.Builder<AbstractRoute> routes = ImmutableSet.builder();
+      _routesByInterfaceAndArpIp
+          .getOrDefault(iface, ImmutableMap.of())
+          .forEach(
+              (arpIp, groupRoutes) -> {
+                if (arpIp.isPresent() && test.test(arpIp.get())) {
+                  routes.addAll(groupRoutes);
+                }
+              });
+      return routes.build();
+    }
+
+    /** The next-hop IPs {@code route} ARPs for on any interface. */
+    @Nonnull
+    Set<Ip> getArpIps(AbstractRoute route) {
+      return _arpIpsByRoute.getOrDefault(route, ImmutableSet.of());
+    }
+
+    /** The dst IPs whose longest match in this FIB is one of the given routes. */
+    @Nonnull
+    IpSpace matchingIps(Collection<AbstractRoute> routes) {
+      return ForwardingAnalysisImpl.matchingIps(
+          distinctNetworks(routes),
+          network -> _matchingIps.computeIfAbsent(network, _fib::matchingIps));
+    }
   }
 
   @VisibleForTesting
@@ -1192,23 +1177,5 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
     Interface iface = c.getAllInterfaces().get(i);
     assert iface != null : node + "[" + i + "] is null";
     assert iface.getActive() : node + "[" + i + "] is not active";
-  }
-
-  /**
-   * Mapping: route -&gt; nexthopinterface -&gt; resolved nextHopIps (or {@link Optional#empty()})
-   * if dest IP should be used for ARP
-   */
-  private static @Nonnull Map<AbstractRoute, Map<String, Set<Optional<Ip>>>>
-      computeNextHopInterfaces(Fib fib) {
-    return fib.allEntries().stream()
-        .filter(fibEntry -> fibEntry.getAction() instanceof FibForward)
-        .collect(
-            Collectors.groupingBy(
-                FibEntry::getTopLevelRoute,
-                Collectors.groupingBy(
-                    fibEntry -> ((FibForward) fibEntry.getAction()).getInterfaceName(),
-                    Collectors.mapping(
-                        fibEntry -> ((FibForward) fibEntry.getAction()).getArpIp(),
-                        Collectors.toSet()))));
   }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel;
 
 import static org.batfish.datamodel.ForwardingAnalysisImpl.computeArpFalseDestIp;
-import static org.batfish.datamodel.ForwardingAnalysisImpl.computeArpFalseNextHopIp;
 import static org.batfish.datamodel.ForwardingAnalysisImpl.computeArpFalseNhipRoutes;
 import static org.batfish.datamodel.ForwardingAnalysisImpl.computeArpReplies;
 import static org.batfish.datamodel.ForwardingAnalysisImpl.computeArpTrueEdge;
@@ -17,10 +16,7 @@ import static org.batfish.datamodel.ForwardingAnalysisImpl.computeNeighborUnreac
 import static org.batfish.datamodel.ForwardingAnalysisImpl.computeNextVrfIps;
 import static org.batfish.datamodel.ForwardingAnalysisImpl.computeNullRoutedIps;
 import static org.batfish.datamodel.ForwardingAnalysisImpl.computeOwnedIpsByVrf;
-import static org.batfish.datamodel.ForwardingAnalysisImpl.computeRoutesWhereDstIpCanBeArpIp;
-import static org.batfish.datamodel.ForwardingAnalysisImpl.computeRoutesWithDestIpEdge;
-import static org.batfish.datamodel.ForwardingAnalysisImpl.computeRoutesWithNextHopIpArpFalseForInterface;
-import static org.batfish.datamodel.ForwardingAnalysisImpl.computeRoutesWithNextHopIpArpTrue;
+import static org.batfish.datamodel.ForwardingAnalysisImpl.computeRouteMatchConditions;
 import static org.batfish.datamodel.ForwardingAnalysisImpl.computeSomeoneReplies;
 import static org.batfish.datamodel.ForwardingAnalysisImpl.routableSpace;
 import static org.batfish.datamodel.ForwardingAnalysisImpl.sparseKeys;
@@ -32,8 +28,10 @@ import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.specifier.LocationInfoUtils.computeLocationInfo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
@@ -50,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import org.batfish.common.topology.GlobalBroadcastNoPointToPoint;
 import org.batfish.common.topology.IpOwners;
@@ -379,22 +376,22 @@ public class ForwardingAnalysisImplTest {
     Interface i1 = _ib.setOwner(c1).setVrf(vrf1).build();
     Ip i2Ip = Ip.create(P1.getStartIp().asLong() + 1);
     Interface i2 = _ib.setOwner(c2).setVrf(vrf2).build();
-    Map<String, Map<String, Fib>> fibs =
-        ImmutableMap.of(
-            c1.getHostname(),
-            ImmutableMap.of(
-                vrf1.getName(),
-                MockFib.builder()
-                    .setMatchingIps(
-                        ImmutableMap.of(
-                            P1,
-                            AclIpSpace.rejecting(P1.getEndIp().toIpSpace())
-                                .thenPermitting(P1.toIpSpace())
-                                .build()))
-                    .build()));
+    Fib fib =
+        MockFib.builder()
+            .setMatchingIps(
+                ImmutableMap.of(
+                    P1,
+                    AclIpSpace.rejecting(P1.getEndIp().toIpSpace())
+                        .thenPermitting(P1.toIpSpace())
+                        .build()))
+            .build();
     Edge edge = Edge.of(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
-    Map<Edge, Set<AbstractRoute>> routesWithDestIpEdge =
-        ImmutableMap.of(edge, ImmutableSet.of(new ConnectedRoute(P1, i1.getName())));
+    Topology topology = new Topology(ImmutableSortedSet.of(edge));
+    Map<String, IpSpace> dstIpsArpingForDestIp =
+        ImmutableMap.of(
+            i1.getName(),
+            computeRouteMatchConditions(
+                ImmutableSet.of(new ConnectedRoute(P1, i1.getName())), fib));
     Map<String, Map<String, IpSpace>> arpReplies =
         ImmutableMap.of(
             c2.getHostname(),
@@ -404,8 +401,7 @@ public class ForwardingAnalysisImplTest {
                     .thenPermitting(P1.getEndIp().toIpSpace())
                     .build()));
     Map<Edge, IpSpace> result =
-        computeArpTrueEdgeDestIp(
-            fibs.get(c1.getHostname()).get(vrf1.getName()), routesWithDestIpEdge, arpReplies);
+        computeArpTrueEdgeDestIp(c1.getHostname(), topology, dstIpsArpingForDestIp, arpReplies);
 
     /* Respond to request for IP on i2. */
     assertThat(result, hasEntry(equalTo(edge), containsIp(i2Ip)));
@@ -433,31 +429,39 @@ public class ForwardingAnalysisImplTest {
             .setAddress(ConcreteInterfaceAddress.create(i2Ip, P1.getPrefixLength()))
             .build();
     Edge edge = Edge.of(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
-    Map<String, Map<String, Fib>> fibs =
+    Topology topology = new Topology(ImmutableSortedSet.of(edge));
+    AbstractRoute route =
+        StaticRoute.testBuilder()
+            .setNetwork(P1)
+            .setNextHopIp(P2.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
+    Fib fib =
+        MockFib.builder()
+            .setFibEntries(
+                ImmutableMap.of(
+                    P1.getStartIp(),
+                    ImmutableSet.of(
+                        new FibEntry(
+                            FibForward.of(P2.getStartIp(), i1.getName()),
+                            ImmutableList.of(route)))))
+            .setMatchingIps(
+                ImmutableMap.of(
+                    P1,
+                    AclIpSpace.rejecting(P1.getEndIp().toIpSpace())
+                        .thenPermitting(P1.toIpSpace())
+                        .build()))
+            .build();
+    // i2 replies for the route's next hop IP
+    Map<String, Map<String, IpSpace>> arpReplies =
         ImmutableMap.of(
-            c1.getHostname(),
-            ImmutableMap.of(
-                vrf1.getName(),
-                MockFib.builder()
-                    .setMatchingIps(
-                        ImmutableMap.of(
-                            P1,
-                            AclIpSpace.rejecting(P1.getEndIp().toIpSpace())
-                                .thenPermitting(P1.toIpSpace())
-                                .build()))
-                    .build()));
-    Map<Edge, Set<AbstractRoute>> routesWithNextHopIpArpTrue =
-        ImmutableMap.of(
-            edge,
-            ImmutableSet.of(
-                StaticRoute.testBuilder()
-                    .setNetwork(P1)
-                    .setNextHopIp(P2.getStartIp())
-                    .setAdministrativeCost(1)
-                    .build()));
+            c2.getHostname(), ImmutableMap.of(i2.getName(), P2.getStartIp().toIpSpace()));
     Map<Edge, IpSpace> result =
         computeArpTrueEdgeNextHopIp(
-            fibs.get(c1.getHostname()).get(vrf1.getName()), routesWithNextHopIpArpTrue);
+            c1.getHostname(),
+            new ForwardingAnalysisImpl.VrfForwardingIndex(fib),
+            topology,
+            arpReplies);
 
     /*
      * Respond for any destination IP in network not matching more specific route not going out i1.
@@ -472,6 +476,16 @@ public class ForwardingAnalysisImplTest {
     /* Do not respond for destination IPs not matching route */
     assertThat(result, hasEntry(equalTo(edge), not(containsIp(P2.getStartIp()))));
     assertThat(result, hasEntry(equalTo(edge), not(containsIp(P2.getEndIp()))));
+
+    // No neighbor replies for the next hop IP: no edge at all
+    assertThat(
+        computeArpTrueEdgeNextHopIp(
+            c1.getHostname(),
+            new ForwardingAnalysisImpl.VrfForwardingIndex(fib),
+            topology,
+            ImmutableMap.of(
+                c2.getHostname(), ImmutableMap.of(i2.getName(), P2.getEndIp().toIpSpace()))),
+        anEmptyMap());
   }
 
   @Test
@@ -591,21 +605,21 @@ public class ForwardingAnalysisImplTest {
             ImmutableMap.of(
                 v1,
                 MockFib.builder()
+                    .setFibEntries(
+                        ImmutableMap.of(
+                            P1.getStartIp(),
+                            ImmutableSet.of(
+                                new FibEntry(FibForward.of(null, i1), ImmutableList.of(r1))),
+                            P2.getStartIp(),
+                            ImmutableSet.of(
+                                new FibEntry(
+                                    FibForward.of(null, Interface.NULL_INTERFACE_NAME),
+                                    ImmutableList.of(nullRoute)))))
                     .setMatchingIps(ImmutableMap.of(P1, P1.toIpSpace(), P2, P2.toIpSpace()))
                     .build()));
-    Map<String, Map<String, Map<String, Set<AbstractRoute>>>> routesWithNextHop =
-        ImmutableMap.of(
-            c1,
-            ImmutableMap.of(
-                v1,
-                ImmutableMap.of(
-                    i1,
-                    ImmutableSet.of(r1),
-                    Interface.NULL_INTERFACE_NAME,
-                    ImmutableSet.of(nullRoute))));
     List<Entry<String, String>> allVrfs = sparseKeys(fibs);
     Map<String, Map<String, Map<String, IpSpace>>> result =
-        computeIpsRoutedOutInterfaces(fibs, routesWithNextHop, allVrfs);
+        computeIpsRoutedOutInterfaces(fibs, allVrfs);
 
     /* Should contain IPs matching the route */
     assertThat(
@@ -624,7 +638,9 @@ public class ForwardingAnalysisImplTest {
             equalTo(c1),
             hasEntry(equalTo(v1), hasEntry(equalTo(i1), not(containsIp(P2.getStartIp()))))));
     /* Null interface should be excluded because we would not be able to tie back to single VRF. */
-    assertThat(result, hasEntry(equalTo(c1), not(hasKey(equalTo(Interface.NULL_INTERFACE_NAME)))));
+    assertThat(
+        result,
+        hasEntry(equalTo(c1), hasEntry(equalTo(v1), not(hasKey(Interface.NULL_INTERFACE_NAME)))));
   }
 
   @Test
@@ -671,7 +687,9 @@ public class ForwardingAnalysisImplTest {
     Set<AbstractRoute> routesWhereDstIpCanBeArpIp = ImmutableSet.of(ifaceRoute);
     IpSpace someoneReplies = P1.getEndIp().toIpSpace();
     IpSpace result =
-        computeArpFalseDestIp(fibs.get(c1).get(v1), routesWhereDstIpCanBeArpIp, someoneReplies);
+        computeArpFalseDestIp(
+            computeRouteMatchConditions(routesWhereDstIpCanBeArpIp, fibs.get(c1).get(v1)),
+            someoneReplies);
 
     /* Should contain IP in the route's prefix that sees no reply */
     assertThat(result, containsIp(P1.getStartIp()));
@@ -695,7 +713,9 @@ public class ForwardingAnalysisImplTest {
     Set<AbstractRoute> routesWhereDstIpCanBeArpIp = ImmutableSet.of(ifaceRoute);
     IpSpace someoneReplies = EmptyIpSpace.INSTANCE;
     IpSpace result =
-        computeArpFalseDestIp(fibs.get(c1).get(v1), routesWhereDstIpCanBeArpIp, someoneReplies);
+        computeArpFalseDestIp(
+            computeRouteMatchConditions(routesWhereDstIpCanBeArpIp, fibs.get(c1).get(v1)),
+            someoneReplies);
 
     /*
      * Since _someoneReplies is empty, all IPs for which longest-prefix-match route has no
@@ -725,7 +745,7 @@ public class ForwardingAnalysisImplTest {
             ImmutableMap.of(
                 v1, MockFib.builder().setMatchingIps(ImmutableMap.of(P1, P1.toIpSpace())).build()));
 
-    IpSpace result = computeArpFalseNextHopIp(fibs.get(c1).get(v1), routesWithNextHopIpArpFalse);
+    IpSpace result = computeRouteMatchConditions(routesWithNextHopIpArpFalse, fibs.get(c1).get(v1));
 
     /* IPs matching some route on interface with no response should appear */
     assertThat(result, containsIp(P1.getStartIp()));
@@ -916,7 +936,7 @@ public class ForwardingAnalysisImplTest {
 
     /* Resulting IP space should permit matching IPs */
     assertThat(
-        ForwardingAnalysisImpl.computeRouteMatchConditions(routes, fib),
+        computeRouteMatchConditions(routes, fib),
         isAclIpSpaceThat(
             hasLines(
                 containsInAnyOrder(
@@ -924,7 +944,7 @@ public class ForwardingAnalysisImplTest {
   }
 
   @Test
-  public void testComputeRoutesWhereDstIpCanBeArpIp() {
+  public void testVrfForwardingIndexRoutesArpingForDestIp() {
     String i1 = "i1";
     AbstractRoute r1 =
         StaticRoute.testBuilder()
@@ -933,80 +953,30 @@ public class ForwardingAnalysisImplTest {
             .setAdministrativeCost(1)
             .build();
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, i1);
-    Map<String, Set<AbstractRoute>> routesWithNextHop =
-        ImmutableMap.of(i1, ImmutableSet.of(r1, ifaceRoute));
-    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
-        ImmutableMap.of(
-            r1,
-            ImmutableMap.of(i1, ImmutableSet.of(Optional.of(r1.getNextHopIp()))),
-            ifaceRoute,
-            ImmutableMap.of(i1, ImmutableSet.of(Optional.empty())));
-    Map<String, Set<AbstractRoute>> result =
-        computeRoutesWhereDstIpCanBeArpIp(nextHopInterfaces, routesWithNextHop);
+    ForwardingAnalysisImpl.VrfForwardingIndex index =
+        new ForwardingAnalysisImpl.VrfForwardingIndex(
+            MockFib.builder()
+                .setFibEntries(
+                    ImmutableMap.of(
+                        P1.getStartIp(),
+                        ImmutableSet.of(
+                            new FibEntry(
+                                FibForward.of(r1.getNextHopIp(), i1), ImmutableList.of(r1))),
+                        P2.getStartIp(),
+                        ImmutableSet.of(
+                            new FibEntry(FibForward.of(null, i1), ImmutableList.of(ifaceRoute)))))
+                .build());
 
-    /* Only the interface route should show up */
-    assertThat(result, equalTo(ImmutableMap.of(i1, ImmutableSet.of(ifaceRoute))));
+    assertThat(index.getInterfaces(), contains(i1));
+    /* Only the interface route ARPs for the destination IP */
+    assertThat(index.getRoutesArpingForDestIp(i1), contains(ifaceRoute));
+    assertThat(index.getRoutesArpingForDestIp("other"), empty());
+    assertThat(index.getArpIps(r1), contains(r1.getNextHopIp()));
+    assertThat(index.getArpIps(ifaceRoute), empty());
   }
 
   @Test
-  public void testComputeRoutesWithDestIpEdge() {
-    String c1 = "c1";
-    String c2 = "c2";
-    String i1 = "i1";
-    String i2 = "i2";
-    AbstractRoute r1 = new ConnectedRoute(P1, i1);
-    Map<String, Set<AbstractRoute>> routesWhereDstIpCanBeArpIp =
-        ImmutableMap.of(i1, ImmutableSet.of(r1));
-    Edge e1 = Edge.of(c1, i1, c2, i2);
-    Topology topology = new Topology(ImmutableSortedSet.of(e1));
-    Map<Edge, Set<AbstractRoute>> result =
-        computeRoutesWithDestIpEdge(c1, topology, routesWhereDstIpCanBeArpIp);
-
-    assertThat(result, equalTo(ImmutableMap.of(e1, ImmutableSet.of(r1))));
-  }
-
-  @Test
-  public void testComputeRoutesWithNextHop() {
-    String c1 = "c1";
-    String v1 = "v1";
-    String v2 = "v2";
-    String i1 = "i1";
-    ConnectedRoute r1 = new ConnectedRoute(P1, i1);
-    MockFib mockFib =
-        MockFib.builder()
-            .setFibEntries(
-                ImmutableMap.of(
-                    P1.getFirstHostIp(),
-                    ImmutableSet.of(new FibEntry(FibForward.of(null, i1), ImmutableList.of(r1)))))
-            .build();
-    Map<String, Map<String, Fib>> fibs =
-        ImmutableMap.of(
-            c1,
-            ImmutableMap.of(
-                v1, mockFib,
-                v2, mockFib));
-
-    Configuration config = _cb.setHostname(c1).build();
-    Vrf vrf1 = _vb.setName(v1).setOwner(config).build();
-    _vb.setName(v2).setOwner(config).build();
-    _ib.setName(i1).setVrf(vrf1).setOwner(config).build();
-    Map<String, Map<String, Map<String, Set<AbstractRoute>>>> result =
-        ForwardingAnalysisImpl.computeRoutesWithNextHop(fibs, sparseKeys(fibs));
-
-    assertThat(
-        result,
-        equalTo(
-            ImmutableMap.of(
-                c1,
-                ImmutableMap.of(
-                    v1,
-                    ImmutableMap.of(i1, ImmutableSet.of(r1)),
-                    v2,
-                    ImmutableMap.of(i1, ImmutableSet.of(r1))))));
-  }
-
-  @Test
-  public void testComputeRoutesWithNextHopIpArpFalse() {
+  public void testComputeArpFalseNhipRoutes() {
     String i1 = "i1";
     AbstractRoute r1 =
         StaticRoute.testBuilder()
@@ -1014,18 +984,23 @@ public class ForwardingAnalysisImplTest {
             .setNextHopIp(P2.getStartIp())
             .setAdministrativeCost(1)
             .build();
-    Set<AbstractRoute> routesWithNextHop = ImmutableSet.of(r1);
-    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
-        ImmutableMap.of(r1, ImmutableMap.of(i1, ImmutableSet.of(Optional.of(r1.getNextHopIp()))));
+    ForwardingAnalysisImpl.VrfForwardingIndex index =
+        new ForwardingAnalysisImpl.VrfForwardingIndex(
+            MockFib.builder()
+                .setFibEntries(
+                    ImmutableMap.of(
+                        P1.getStartIp(),
+                        ImmutableSet.of(
+                            new FibEntry(
+                                FibForward.of(r1.getNextHopIp(), i1), ImmutableList.of(r1)))))
+                .build());
     IpSpace someoneReplies = P2.getEndIp().toIpSpace();
-    Set<AbstractRoute> result =
-        computeArpFalseNhipRoutes(i1, nextHopInterfaces, routesWithNextHop, someoneReplies);
 
-    assertThat(result, equalTo(ImmutableSet.of(r1)));
+    assertThat(computeArpFalseNhipRoutes(index, i1, someoneReplies), equalTo(ImmutableSet.of(r1)));
   }
 
   @Test
-  public void testComputeRoutesWithNextHopIpArpFalseForInterface() {
+  public void testComputeArpFalseNhipRoutesForInterface() {
     String outInterface = "i1";
     AbstractRoute nextHopIpRoute1 =
         StaticRoute.testBuilder()
@@ -1040,79 +1015,45 @@ public class ForwardingAnalysisImplTest {
             .setAdministrativeCost(1)
             .build();
     AbstractRoute ifaceRoute = new ConnectedRoute(P2, outInterface);
-    Set<AbstractRoute> candidateRoutes =
-        ImmutableSet.of(nextHopIpRoute1, nextHopIpRoute2, ifaceRoute);
-    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
-        ImmutableMap.of(
-            nextHopIpRoute1,
-            ImmutableMap.of(
-                outInterface, ImmutableSet.of(Optional.of(nextHopIpRoute1.getNextHopIp()))),
-            nextHopIpRoute2,
-            ImmutableMap.of(
-                outInterface, ImmutableSet.of(Optional.of(nextHopIpRoute2.getNextHopIp()))),
-            ifaceRoute,
-            ImmutableMap.of(outInterface, ImmutableSet.of(Optional.empty())));
-    Set<AbstractRoute> result =
-        computeRoutesWithNextHopIpArpFalseForInterface(
-            nextHopInterfaces, outInterface, candidateRoutes, P2.getStartIp().toIpSpace());
+    ForwardingAnalysisImpl.VrfForwardingIndex index =
+        new ForwardingAnalysisImpl.VrfForwardingIndex(
+            MockFib.builder()
+                .setFibEntries(
+                    ImmutableMap.of(
+                        P1.getStartIp(),
+                        ImmutableSet.of(
+                            new FibEntry(
+                                FibForward.of(nextHopIpRoute1.getNextHopIp(), outInterface),
+                                ImmutableList.of(nextHopIpRoute1)),
+                            new FibEntry(
+                                FibForward.of(nextHopIpRoute2.getNextHopIp(), outInterface),
+                                ImmutableList.of(nextHopIpRoute2))),
+                        P2.getStartIp(),
+                        ImmutableSet.of(
+                            new FibEntry(
+                                FibForward.of(null, outInterface), ImmutableList.of(ifaceRoute)))))
+                .build());
 
     /*
-     * Should only contain nextHopIpRoute1 since it is the only route with a next-hop-ip for which
+     * Should only contain nextHopIpRoute2 since it is the only route with a next-hop-ip for which
      * there is no ARP reply.
      */
-    assertThat(result, contains(nextHopIpRoute2));
-  }
-
-  @Test
-  public void testComputeRoutesWithNextHopIpArpFalseForInterfaceNoNeighbors() {
-    String outInterface = "i1";
-    AbstractRoute nextHopIpRoute1 =
-        StaticRoute.testBuilder()
-            .setNetwork(P1)
-            .setNextHopIp(P2.getStartIp())
-            .setAdministrativeCost(1)
-            .build();
-    AbstractRoute nextHopIpRoute2 =
-        StaticRoute.testBuilder()
-            .setNetwork(P1)
-            .setNextHopIp(P2.getEndIp())
-            .setAdministrativeCost(1)
-            .build();
-    AbstractRoute ifaceRoute = new ConnectedRoute(P2, outInterface);
-    Set<AbstractRoute> candidateRoutes =
-        ImmutableSet.of(nextHopIpRoute1, nextHopIpRoute2, ifaceRoute);
-    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
-        ImmutableMap.of(
-            nextHopIpRoute1,
-            ImmutableMap.of(
-                outInterface, ImmutableSet.of(Optional.of(nextHopIpRoute1.getNextHopIp()))),
-            nextHopIpRoute2,
-            ImmutableMap.of(
-                outInterface, ImmutableSet.of(Optional.of(nextHopIpRoute2.getNextHopIp()))),
-            ifaceRoute,
-            ImmutableMap.of(outInterface, ImmutableSet.of(Optional.empty())));
-    Set<AbstractRoute> result =
-        computeRoutesWithNextHopIpArpFalseForInterface(
-            nextHopInterfaces, outInterface, candidateRoutes, EmptyIpSpace.INSTANCE);
+    assertThat(
+        computeArpFalseNhipRoutes(index, outInterface, P2.getStartIp().toIpSpace()),
+        contains(nextHopIpRoute2));
 
     /*
-     * Should contain both nextHopIpRoute1 and nextHopIpRoute2, since:
-     * 1) They are the only routes with a next hop IP.
-     * 2) Their next hop IPs do not receive ARP reply since _someoneReplies is empty.
+     * With no replies at all, both next-hop-IP routes are present; the interface route ARPs for
+     * the destination IP and is not.
      */
-    assertThat(result, equalTo(ImmutableSet.of(nextHopIpRoute1, nextHopIpRoute2)));
+    assertThat(
+        computeArpFalseNhipRoutes(index, outInterface, EmptyIpSpace.INSTANCE),
+        equalTo(ImmutableSet.of(nextHopIpRoute1, nextHopIpRoute2)));
   }
 
   @Test
-  public void testComputeRoutesWithNextHopIpArpTrue() {
-    String c1 = "c1";
+  public void testVrfForwardingIndexRoutesArpingForNextHopIp() {
     String i1 = "i1";
-    String c2 = "c2";
-    String i2 = "i2";
-    Edge e1 = Edge.of(c1, i1, c2, i2);
-    Map<String, Map<String, IpSpace>> arpReplies =
-        ImmutableMap.of(c2, ImmutableMap.of(i2, P2.getStartIp().toIpSpace()));
-    Topology topology = new Topology(ImmutableSortedSet.of(e1));
     AbstractRoute r1 =
         StaticRoute.testBuilder()
             .setNetwork(P1)
@@ -1125,20 +1066,40 @@ public class ForwardingAnalysisImplTest {
             .setNextHopIp(P2.getEndIp())
             .setAdministrativeCost(1)
             .build();
-    Map<String, Set<AbstractRoute>> routesWithNextHop =
-        ImmutableMap.of(i1, ImmutableSet.of(r1, r2));
-    Map<AbstractRoute, Map<String, Set<Optional<Ip>>>> nextHopInterfaces =
-        ImmutableMap.of(
-            r1,
-            ImmutableMap.of(i1, ImmutableSet.of(Optional.of(r1.getNextHopIp()))),
-            r2,
-            ImmutableMap.of(i1, ImmutableSet.of(Optional.of(r2.getNextHopIp()))));
-    Map<Edge, Set<AbstractRoute>> result =
-        computeRoutesWithNextHopIpArpTrue(
-            c1, nextHopInterfaces, topology, arpReplies, routesWithNextHop);
+    // r3 ECMPs over both next hops
+    AbstractRoute r3 =
+        StaticRoute.testBuilder()
+            .setNetwork(P2)
+            .setNextHopIp(P2.getStartIp())
+            .setAdministrativeCost(1)
+            .build();
+    ForwardingAnalysisImpl.VrfForwardingIndex index =
+        new ForwardingAnalysisImpl.VrfForwardingIndex(
+            MockFib.builder()
+                .setFibEntries(
+                    ImmutableMap.of(
+                        P1.getStartIp(),
+                        ImmutableSet.of(
+                            new FibEntry(
+                                FibForward.of(r1.getNextHopIp(), i1), ImmutableList.of(r1)),
+                            new FibEntry(
+                                FibForward.of(r2.getNextHopIp(), i1), ImmutableList.of(r2))),
+                        P2.getStartIp(),
+                        ImmutableSet.of(
+                            new FibEntry(FibForward.of(P2.getStartIp(), i1), ImmutableList.of(r3)),
+                            new FibEntry(FibForward.of(P2.getEndIp(), i1), ImmutableList.of(r3)))))
+                .build());
+    IpSpace replies = P2.getStartIp().toIpSpace();
 
-    /* Only the route with the next hop ip that gets a reply should be present. */
-    assertThat(result, equalTo(ImmutableMap.of(e1, ImmutableSet.of(r1))));
+    /* Only the routes with a next hop ip that gets a reply should be present. */
+    assertThat(
+        index.getRoutesArpingForNextHopIp(i1, ip -> replies.containsIp(ip, ImmutableMap.of())),
+        containsInAnyOrder(r1, r3));
+    assertThat(
+        index.getRoutesArpingForNextHopIp(i1, ip -> !replies.containsIp(ip, ImmutableMap.of())),
+        containsInAnyOrder(r2, r3));
+    assertThat(index.getRoutesArpingForNextHopIp("other", ip -> true), empty());
+    assertThat(index.getArpIps(r3), containsInAnyOrder(P2.getStartIp(), P2.getEndIp()));
   }
 
   @Test


### PR DESCRIPTION
Per VRF, forwarding analysis built a route -> interface -> ARP IPs map
and then, for every interface and again for every neighbor of it, ran a
stream over every route out that interface to look up its ARP IPs and
test them against the neighbor's ARP replies. Every one of those
decisions depends only on the (interface, ARP IP) pair, and a VRF has
orders of magnitude fewer distinct next hops than routes, so the work
was dominated by stream setup, map lookups, and repeated Fib#matchingIps
calls for the same prefix. On a large snapshot this was 23% of all
dataplane CPU, more than BGP message passing.

Replace the per-route maps with a VrfForwardingIndex built in one pass
over the FIB: interface -> ARP IP -> routes, plus route -> ARP IPs for
the owned/unowned classification. ARP reply checks run once per group.
Fib#matchingIps is memoized per VRF across the unions that share a
prefix, the dest-IP match condition is computed once per interface
rather than once per neighbor edge, and the network-wide route ->
interface map that was held across both phases is gone. The IPs routed
out an interface are read straight from the FIB entries.

Results are unchanged: on two large snapshots every IpSpace of the new
analysis was compared as a BDD against the old implementation's and
found equal, and the analysis takes half the wall time it did. Line
order inside some AclIpSpace unions changes, so structural equality with
the old output does not hold.

----

Prompt:
```
A CPU profile of a full dataplane computation showed forwarding
analysis as the largest bucket, 23% of CPU, with the self time in Java
stream machinery and hash lookups inside the per-route ARP helpers.
Rewrite those to group routes by next hop and verify the output is
semantically identical.
```