### PR TITLE
rib: keep only the routes that lost in BackupRoutes, not every route ever offered

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -1,8 +1,8 @@
 package org.batfish.dataplane.rib;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,8 +35,9 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   private transient @Nullable Set<R> _allRoutes;
 
   /**
-   * Keep a (insert ordered) set of alternative routes. Used to update the RIB if best routes are
-   * withdrawn.
+   * Routes this RIB was offered that are not currently in {@link #_tree}, because a preferred route
+   * for the same prefix is. Used to update the RIB if best routes are withdrawn. Most prefixes are
+   * only ever offered the routes they hold, so this is far smaller than the RIB.
    */
   protected final @Nullable BackupRoutes<R> _backupRoutes;
 
@@ -109,17 +110,6 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
     return builder.build();
   }
 
-  /**
-   * Add route to backup route map if the route map is not null
-   *
-   * @param route Route to add
-   */
-  private void addBackupRoute(R route) {
-    if (_backupRoutes != null) {
-      _backupRoutes.put(route.getNetwork(), route);
-    }
-  }
-
   /** Clear all routes from the RIB */
   public final void clear() {
     _tree.clear();
@@ -166,23 +156,34 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
     return ImmutableSet.copyOf(_tree.getRoutes());
   }
 
+  /**
+   * Every route this RIB was offered and has not been asked to remove: every route it holds, before
+   * any filtering a subclass applies in {@link #getRoutes()}, plus the backups that lost to them.
+   * Empty if this RIB keeps no backups.
+   */
   @Override
   public @Nonnull Set<R> getBackupRoutes() {
-    return Optional.ofNullable(_backupRoutes)
-        .map(BackupRoutes::values)
-        .map(ImmutableSet::copyOf)
-        .orElse(ImmutableSet.of());
+    if (_backupRoutes == null) {
+      return ImmutableSet.of();
+    }
+    return ImmutableSet.<R>builder()
+        .addAll(_tree.getRoutes())
+        .addAll(_backupRoutes.values())
+        .build();
   }
 
   /**
-   * Remove a route from backup route map if it was present and backup route map exists
-   *
-   * @param route Route to remove
+   * Every route this RIB was offered for {@code prefix} and has not been asked to remove: every
+   * route it holds for it, before any filtering a subclass applies in {@link #getRoutes(Prefix)},
+   * plus the backups that lost to them.
    */
-  private void removeBackupRoute(R route) {
-    if (_backupRoutes != null) {
-      _backupRoutes.remove(route.getNetwork(), route);
+  protected final @Nonnull Set<R> getRoutesAndBackups(Prefix prefix) {
+    Set<R> routes = _tree.getRoutes(prefix);
+    if (_backupRoutes == null) {
+      return routes;
     }
+    Set<R> backups = _backupRoutes.get(prefix);
+    return backups.isEmpty() ? routes : Sets.union(routes, backups);
   }
 
   @Override
@@ -208,11 +209,23 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    */
   public @Nonnull RibDelta<R> mergeRouteGetDelta(R route) {
     RibDelta<R> delta = _tree.mergeRoute(route);
-    addBackupRoute(route);
-    if (!delta.isEmpty()) {
-      // A change to routes has been made
-      _allRoutes = null;
+    if (delta.isEmpty()) {
+      if (_backupRoutes != null && !_tree.containsRoute(route)) {
+        // Lost to a preferred route for its prefix: keep it in case that route is withdrawn.
+        _backupRoutes.put(route.getNetwork(), route);
+      }
+      return delta;
     }
+    if (_backupRoutes != null) {
+      for (RouteAdvertisement<R> action : delta.getActions()) {
+        if (action.getReason() == Reason.REPLACE) {
+          // Displaced by the new route: now a backup.
+          _backupRoutes.put(action.getRoute().getNetwork(), action.getRoute());
+        }
+      }
+    }
+    // A change to routes has been made
+    _allRoutes = null;
     return delta;
   }
 
@@ -236,13 +249,24 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    *     route was not present in the RIB
    */
   public @Nonnull RibDelta<R> removeRouteGetDelta(R route) {
-    // Remove the backup route first, then remove route from rib
-    removeBackupRoute(route);
     RibDelta<R> delta = _tree.removeRouteGetDelta(route, Reason.WITHDRAW);
-    if (!delta.isEmpty()) {
-      // A change to routes has been made
-      _allRoutes = null;
+    if (delta.isEmpty()) {
+      if (_backupRoutes != null) {
+        // Not held, so if it was offered it is a backup.
+        _backupRoutes.remove(route.getNetwork(), route);
+      }
+      return delta;
     }
+    if (_backupRoutes != null) {
+      for (RouteAdvertisement<R> action : delta.getActions()) {
+        if (!action.isWithdrawn()) {
+          // Promoted from backup to replace the removed route.
+          _backupRoutes.remove(action.getRoute().getNetwork(), action.getRoute());
+        }
+      }
+    }
+    // A change to routes has been made
+    _allRoutes = null;
     return delta;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BackupRoutes.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BackupRoutes.java
@@ -13,13 +13,14 @@ import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.Prefix;
 
 /**
- * Maps a prefix to the insertion-ordered set of alternative routes a RIB holds for it, so a route
- * can be restored when a better one is withdrawn.
+ * Maps a prefix to the insertion-ordered set of routes a RIB was offered for it but does not hold,
+ * because it prefers other routes for that prefix, so one can be restored when a better route is
+ * withdrawn.
  *
- * <p>A RIB records a backup for every route it is ever offered, making this one of the larger
- * structures in a dataplane computation. Nearly every prefix has only one or two backups, so a
- * value is the route itself when there is exactly one and a small list otherwise, rather than a
- * per-prefix set carrying its own hash table.
+ * <p>Only prefixes that were offered a losing route have an entry; on most snapshots that is a
+ * small fraction of the RIB. Nearly every such prefix has only one or two backups, so a value is
+ * the route itself when there is exactly one and a small list otherwise, rather than a per-prefix
+ * set carrying its own hash table.
  *
  * <p>Ordering is per prefix: {@link #values} returns routes grouped by prefix, not in global
  * insertion order.

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -258,9 +258,7 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
    */
   private @Nonnull RibDelta<R> evictSamePrefixReceivedFromPathId(R route) {
     Prefix prefix = route.getNetwork();
-    R oldRoute =
-        getRouteSamePrefixReceivedFromPathId(
-            route, _backupRoutes != null ? _backupRoutes.get(prefix) : super.getRoutes(prefix));
+    R oldRoute = getRouteSamePrefixReceivedFromPathId(route, getRoutesAndBackups(prefix));
     if (oldRoute == null || route.equals(oldRoute)) {
       return RibDelta.empty();
     } else {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -220,8 +220,7 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
     private @Nonnull RibDelta<AnnotatedRoute<AbstractRoute>> processAffectedRoute(
         AnnotatedRoute<AbstractRoute> affectedRoute,
         Collection<AnnotatedRoute<AbstractRoute>> remainingAffectedRoutes) {
-      if (_backupRoutes.containsEntry(affectedRoute.getNetwork(), affectedRoute)
-          && !getRoutes(affectedRoute.getNetwork()).contains(affectedRoute)) {
+      if (_backupRoutes.containsEntry(affectedRoute.getNetwork(), affectedRoute)) {
         // The affected route is currently in backup. It cannot be activated nor deactivated until
         // all better routes have been removed/deactivated. It has already been removed from the
         // resolution graph, and its affected routes should have already been queued when a better

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -102,10 +102,25 @@ public class RibTest {
                 .build());
     rib.mergeRoute(r1);
     assertThat(rib.longestPrefixMatch(ip, ResolutionRestriction.alwaysTrue()), contains(r1));
+    assertThat(rib.getBackupRoutes(), contains(r1));
+    // r2 is preferred: r1 is displaced into backup
     rib.mergeRoute(r2);
     assertThat(rib.longestPrefixMatch(ip, ResolutionRestriction.alwaysTrue()), contains(r2));
+    assertThat(rib.getBackupRoutes(), containsInAnyOrder(r1, r2));
+    // offering r1 again changes nothing
+    assertThat(rib.mergeRoute(r1), equalTo(false));
+    assertThat(rib.getBackupRoutes(), containsInAnyOrder(r1, r2));
+    // withdrawing r2 promotes r1
     rib.removeRoute(r2);
     assertThat(rib.longestPrefixMatch(ip, ResolutionRestriction.alwaysTrue()), contains(r1));
+    assertThat(rib.getBackupRoutes(), contains(r1));
+    // a losing route can be withdrawn while in backup
+    rib.mergeRoute(r2);
+    assertThat(rib.removeRoute(r1), equalTo(false));
+    assertThat(rib.getBackupRoutes(), contains(r2));
+    rib.removeRoute(r2);
+    assertThat(rib.getRoutes(), empty());
+    assertThat(rib.getBackupRoutes(), empty());
   }
 
   @Test


### PR DESCRIPTION
BackupRoutes recorded every route a RIB was offered, keyed by prefix,
so that the best remaining route could be restored when the held one
was withdrawn. That made it a hash map with an entry for every prefix
in the RIB, on top of the prefix trie that already indexes them. On a
large snapshot the map nodes and tables were the largest class in the
heap, 36% of the live set during convergence, while only a small
fraction of prefixes had ever been offered a losing route.

Track only the routes the RIB does not hold: a merged route that lost
on preference, and the routes displaced when a better one arrives, both
read off the merge delta. A restored route leaves the set when the
withdrawal delta promotes it, and a losing route withdrawn while in
backup is removed directly. Callers that want every offered route, the
dataplane's BGP backup routes and the same-prefix eviction in BgpRib,
now read the trie's routes together with the losers, using the trie
rather than getRoutes() because a multipath BgpRib hides same-next-hop
duplicates there. Rib's resolvability enforcer only needed the "in
backup" test, which is now a direct lookup.

DataplaneUtil's TODO on this, that backups should not store best
routes, still holds for the public getBackupRoutes(); this change keeps
that view identical and shrinks the storage behind it.

----

Prompt:
```
Heap histograms of large dataplane runs show HashMap nodes and tables
as the largest class, and they trace to BackupRoutes holding an entry
for every prefix in every main RIB. Store only the losing routes
instead, keeping the RIB results identical.
```
