### PR TITLE
init: serialize the convert answer element per file in parallel

### DIFF
--- a/projects/common/src/main/java/org/batfish/common/util/ParallelMapSerializer.java
+++ b/projects/common/src/main/java/org/batfish/common/util/ParallelMapSerializer.java
@@ -1,0 +1,85 @@
+package org.batfish.common.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Java serialization of a large map one entry at a time, in parallel. Default serialization writes
+ * everything through one {@link ObjectOutputStream} on one thread; here each value is serialized to
+ * its own byte array, in parallel, and the arrays are written in the map's iteration order. Reading
+ * does the reverse. This suits maps whose values share nothing but strings, such as per-device
+ * data: an object referenced from two values is written into both, and comes back as two objects.
+ */
+@ParametersAreNonnullByDefault
+public final class ParallelMapSerializer {
+
+  /** Writes {@code byKey} so that {@link #readMap} can read it back. */
+  public static void writeMap(ObjectOutputStream out, Map<String, ?> byKey) throws IOException {
+    List<byte[]> chunks =
+        byKey.values().parallelStream()
+            .map(
+                value -> {
+                  ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                  try (ObjectOutputStream chunk = new ObjectOutputStream(bytes)) {
+                    chunk.writeObject(value);
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                  return bytes.toByteArray();
+                })
+            .collect(Collectors.toList());
+    out.writeInt(chunks.size());
+    int i = 0;
+    for (String key : byKey.keySet()) {
+      out.writeUTF(key);
+      byte[] chunk = chunks.get(i++);
+      out.writeInt(chunk.length);
+      out.write(chunk);
+    }
+  }
+
+  /** Reads a map written by {@link #writeMap}, with the entries in the order written. */
+  @SuppressWarnings("unchecked")
+  public static <V> Map<String, V> readMap(ObjectInputStream in) throws IOException {
+    int count = in.readInt();
+    List<String> keys = new ArrayList<>(count);
+    List<byte[]> chunks = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      keys.add(in.readUTF());
+      byte[] chunk = new byte[in.readInt()];
+      in.readFully(chunk);
+      chunks.add(chunk);
+    }
+    List<V> values =
+        chunks.parallelStream()
+            .map(
+                chunk -> {
+                  try (ObjectInputStream chunkIn =
+                      new ObjectInputStream(new ByteArrayInputStream(chunk))) {
+                    return (V) chunkIn.readObject();
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  } catch (ClassNotFoundException e) {
+                    throw new IllegalStateException(e);
+                  }
+                })
+            .collect(Collectors.toList());
+    Map<String, V> result = new LinkedHashMap<>(count * 2);
+    for (int i = 0; i < count; i++) {
+      result.put(keys.get(i), values.get(i));
+    }
+    return result;
+  }
+
+  private ParallelMapSerializer() {}
+}

--- a/projects/common/src/main/java/org/batfish/datamodel/answers/ConvertConfigurationAnswerElement.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/answers/ConvertConfigurationAnswerElement.java
@@ -9,6 +9,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Set;
 import java.util.SortedMap;
@@ -19,6 +23,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.ErrorDetails;
 import org.batfish.common.Warnings;
+import org.batfish.common.util.ParallelMapSerializer;
 import org.batfish.datamodel.DefinedStructureInfo;
 import org.batfish.version.BatfishVersion;
 
@@ -43,15 +48,17 @@ public class ConvertConfigurationAnswerElement extends InitStepAnswerElement
   // This will only be null in legacy objects, which used _failed set instead
   private @Nullable SortedMap<String, ConvertStatus> _convertStatus;
 
-  // filename -> structType -> structName -> info
-  private @Nonnull SortedMap<String, SortedMap<String, SortedMap<String, DefinedStructureInfo>>>
+  // filename -> structType -> structName -> info. Serialized per file in parallel; see writeObject.
+  private transient @Nonnull SortedMap<
+          String, SortedMap<String, SortedMap<String, DefinedStructureInfo>>>
       _definedStructures;
 
   /* Map of source filename to generated nodes (e.g. "configs/j1.cfg" -> ["j1_master", "j1_logical_system1"]) */
   private @Nonnull Multimap<String, String> _fileMap;
 
-  // filename -> structType -> structName -> usage -> lines
-  private @Nonnull SortedMap<
+  // filename -> structType -> structName -> usage -> lines. Serialized per file in parallel; see
+  // writeObject.
+  private transient @Nonnull SortedMap<
           String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
       _referencedStructures;
 
@@ -73,6 +80,25 @@ public class ConvertConfigurationAnswerElement extends InitStepAnswerElement
 
   public ConvertConfigurationAnswerElement() {
     this(null, null, null, null, null, null, null, null, null);
+  }
+
+  /*
+   * The defined and referenced structures are by far the largest part of this object: a file with
+   * many statements referencing the same structures records a line number per statement. They are
+   * serialized per file, in parallel; see ParallelMapSerializer.
+   */
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    ParallelMapSerializer.writeMap(out, _definedStructures);
+    ParallelMapSerializer.writeMap(out, _referencedStructures);
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    _definedStructures = new TreeMap<>(ParallelMapSerializer.readMap(in));
+    _referencedStructures = new TreeMap<>(ParallelMapSerializer.readMap(in));
   }
 
   @VisibleForTesting

--- a/projects/common/src/test/java/org/batfish/datamodel/answers/BUILD.bazel
+++ b/projects/common/src/test/java/org/batfish/datamodel/answers/BUILD.bazel
@@ -17,6 +17,7 @@ junit_tests(
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_guava_guava_testlib",
         "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
 )

--- a/projects/common/src/test/java/org/batfish/datamodel/answers/ConvertConfigurationAnswerElementTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/answers/ConvertConfigurationAnswerElementTest.java
@@ -2,15 +2,25 @@ package org.batfish.datamodel.answers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Range;
+import com.google.common.collect.TreeRangeSet;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishException.BatfishStackTrace;
+import org.batfish.common.Warnings;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.DefinedStructureInfo;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +44,53 @@ public class ConvertConfigurationAnswerElementTest {
   @Before
   public void setUp() {
     _element = new ConvertConfigurationAnswerElement();
+  }
+
+  /**
+   * Defined and referenced structures take a hand-written serialized form; they must round-trip.
+   */
+  @Test
+  public void testJavaSerializationOfStructures() throws Exception {
+    ConvertConfigurationAnswerElement ccae = new ConvertConfigurationAnswerElement();
+    SortedMap<String, SortedMap<String, DefinedStructureInfo>> definedInF1 = new TreeMap<>();
+    definedInF1.put(
+        "interface",
+        new TreeMap<>(
+            ImmutableMap.of(
+                "eth0",
+                    new DefinedStructureInfo(
+                        TreeRangeSet.create(ImmutableList.of(Range.closed(1, 3))), 2),
+                "eth1",
+                    new DefinedStructureInfo(
+                        TreeRangeSet.create(ImmutableList.of(Range.singleton(7))), 0))));
+    ccae.getDefinedStructures().put("f1", definedInF1);
+    ccae.getDefinedStructures().put("f2", new TreeMap<>());
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> referencedInF1 =
+        new TreeMap<>();
+    referencedInF1.put(
+        "interface",
+        new TreeMap<>(
+            ImmutableMap.of(
+                "eth0",
+                new TreeMap<>(
+                    ImmutableMap.of(
+                        "static route", new TreeSet<>(ImmutableList.of(10, 11, 12)))))));
+    ccae.getReferencedStructures().put("f1", referencedInF1);
+    ccae.getWarnings().put("f1", new Warnings());
+
+    ConvertConfigurationAnswerElement clone = SerializationUtils.clone(ccae);
+
+    // DefinedStructureInfo has no equals; compare its JSON form.
+    assertThat(
+        BatfishObjectMapper.writeString(clone.getDefinedStructures()),
+        equalTo(BatfishObjectMapper.writeString(ccae.getDefinedStructures())));
+    assertThat(clone.getReferencedStructures(), equalTo(ccae.getReferencedStructures()));
+    assertThat(clone.getWarnings().keySet(), equalTo(ccae.getWarnings().keySet()));
+    // Empty maps round-trip too.
+    ConvertConfigurationAnswerElement emptyClone =
+        SerializationUtils.clone(new ConvertConfigurationAnswerElement());
+    assertThat(emptyClone.getDefinedStructures(), anEmptyMap());
+    assertThat(emptyClone.getReferencedStructures(), anEmptyMap());
   }
 
   @Test


### PR DESCRIPTION
ConvertConfigurationAnswerElement's defined and referenced structures
are by far the largest part of it, a line number per statement that
references a structure, and default serialization wrote them through one
ObjectOutputStream on one thread after the parallel per-configuration
writes had finished. Each file's entry is now serialized to its own byte
array in parallel and the arrays are written in order; reading does the
reverse. This is factored into ParallelMapSerializer for other
per-device maps. On a large snapshot the write went from about ten
seconds to three and the read from about two seconds to a fraction of
one, for a file roughly a tenth larger.

----

Prompt:
```
Upstream the second batch: chunked parallel serialization of the
convert configuration answer element's defined and referenced
structures.
```

An earlier revision also kept the converted configurations in the cache
instead of reloading them from disk during initialization; that was
dropped because the reload is what checks that a cold cache sees the
same data as a hot one.