### PR TITLE
storage: store the forwarding analysis per host with the rest of the dataplane

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -53,6 +53,20 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
   // node -> vrf -> forwarding behavior for that VRF.
   private final Map<String, Map<String, VrfForwardingBehavior>> _vrfForwardingBehavior;
 
+  /** A forwarding analysis with the given, already computed, contents, as read from storage. */
+  public static ForwardingAnalysisImpl of(
+      Map<String, Map<String, IpSpace>> arpReplies,
+      Map<String, Map<String, VrfForwardingBehavior>> vrfForwardingBehavior) {
+    return new ForwardingAnalysisImpl(arpReplies, vrfForwardingBehavior);
+  }
+
+  private ForwardingAnalysisImpl(
+      Map<String, Map<String, IpSpace>> arpReplies,
+      Map<String, Map<String, VrfForwardingBehavior>> vrfForwardingBehavior) {
+    _arpReplies = ImmutableMap.copyOf(arpReplies);
+    _vrfForwardingBehavior = ImmutableMap.copyOf(vrfForwardingBehavior);
+  }
+
   /** Helper function to materialize in random order the list of keys in Map of Maps. */
   @VisibleForTesting
   static @Nonnull <T> List<Map.Entry<String, String>> sparseKeys(Map<String, Map<String, T>> map) {

--- a/projects/common/src/main/java/org/batfish/datamodel/InterfaceForwardingBehavior.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/InterfaceForwardingBehavior.java
@@ -3,7 +3,9 @@ package org.batfish.datamodel;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 import java.io.Serializable;
+import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public final class InterfaceForwardingBehavior implements Serializable {
   private final @Nonnull IpSpace _acceptedIps;
@@ -106,5 +108,26 @@ public final class InterfaceForwardingBehavior implements Serializable {
       return new InterfaceForwardingBehavior(
           _accepted, _deliveredToSubnet, _exitsNetwork, _neighborUnreachable, _insufficientInfo);
     }
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof InterfaceForwardingBehavior)) {
+      return false;
+    }
+    InterfaceForwardingBehavior that = (InterfaceForwardingBehavior) o;
+    return _acceptedIps.equals(that._acceptedIps)
+        && _deliveredToSubnet.equals(that._deliveredToSubnet)
+        && _exitsNetwork.equals(that._exitsNetwork)
+        && _neighborUnreachable.equals(that._neighborUnreachable)
+        && _insufficientInfo.equals(that._insufficientInfo);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        _acceptedIps, _deliveredToSubnet, _exitsNetwork, _neighborUnreachable, _insufficientInfo);
   }
 }

--- a/projects/common/src/main/java/org/batfish/datamodel/VrfForwardingBehavior.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/VrfForwardingBehavior.java
@@ -3,7 +3,9 @@ package org.batfish.datamodel;
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public final class VrfForwardingBehavior implements Serializable {
   private final @Nonnull Map<Edge, IpSpace> _arpTrueEdge;
@@ -102,5 +104,26 @@ public final class VrfForwardingBehavior implements Serializable {
       return new VrfForwardingBehavior(
           _arpTrueEdge, _interfaceForwardingBehavior, _nextVrf, _nullRoutedIps, _routableIps);
     }
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof VrfForwardingBehavior)) {
+      return false;
+    }
+    VrfForwardingBehavior that = (VrfForwardingBehavior) o;
+    return _arpTrueEdge.equals(that._arpTrueEdge)
+        && _interfaceForwardingBehavior.equals(that._interfaceForwardingBehavior)
+        && _nextVrf.equals(that._nextVrf)
+        && _nullRoutedIps.equals(that._nullRoutedIps)
+        && _routableIps.equals(that._routableIps);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        _arpTrueEdge, _interfaceForwardingBehavior, _nextVrf, _nullRoutedIps, _routableIps);
   }
 }

--- a/projects/common/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/common/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -13,8 +13,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.io.Closer;
@@ -81,6 +83,7 @@ import org.batfish.common.util.ZipUtility;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.ForwardingAnalysis;
+import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.SnapshotMetadata;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.AnswerMetadata;
@@ -141,7 +144,6 @@ public class FileBasedStorage implements StorageProvider {
   private static final String RELPATH_BATFISH_CONFIGS_DIR = "batfish";
   private static final String RELPATH_SNAPSHOT_ZIP_FILE = "snapshot.zip";
   private static final String RELPATH_DATA_PLANE = "dp";
-  private static final String RELPATH_DATA_PLANE_FORWARDING_ANALYSIS = "forwarding_analysis";
   private static final String RELPATH_SERIALIZED_ENVIRONMENT_BGP_TABLES = "bgp_processed";
   private static final String RELPATH_ENVIRONMENT_BGP_TABLES_ANSWER = "bgp_answer";
   private static final String RELPATH_PARSE_ANSWER_PATH = "parse_answer";
@@ -1543,9 +1545,6 @@ public class FileBasedStorage implements StorageProvider {
     try (DirectoryStream<Path> hostDataPlanes = Files.newDirectoryStream(dataplanePath)) {
       for (Path hostDataPlane : hostDataPlanes) {
         String name = hostDataPlane.getFileName().toString();
-        if (name.equals(RELPATH_DATA_PLANE_FORWARDING_ANALYSIS)) {
-          continue;
-        }
         namesByPath.put(hostDataPlane, fromBase64(name));
       }
     } catch (IOException e) {
@@ -1554,13 +1553,20 @@ public class FileBasedStorage implements StorageProvider {
     Map<String, PerHostDataPlane> perNodeDataPlanes =
         deserializeObjects(namesByPath, PerHostDataPlane.class);
     ForwardingAnalysis forwardingAnalysis =
-        deserializeObjectUnchecked(getDataPlaneForwardingAnalysisPath(snapshot));
+        ForwardingAnalysisImpl.of(
+            Maps.transformValues(perNodeDataPlanes, PerHostDataPlane::getArpReplies),
+            Maps.transformValues(perNodeDataPlanes, PerHostDataPlane::getVrfForwardingBehavior));
     return new SimpleFieldsDataPlane(perNodeDataPlanes, forwardingAnalysis);
   }
 
   @Override
   public void storeDataPlane(DataPlane dataPlane, NetworkSnapshot snapshot) throws IOException {
-    dataPlane.getFibs().keySet().parallelStream()
+    ForwardingAnalysis forwardingAnalysis = dataPlane.getForwardingAnalysis();
+    Set<String> fibHosts = dataPlane.getFibs().keySet();
+    assert fibHosts.containsAll(forwardingAnalysis.getArpReplies().keySet());
+    assert fibHosts.containsAll(forwardingAnalysis.getVrfForwardingBehavior().keySet());
+    ImmutableList<String> hostnames = ImmutableList.copyOf(fibHosts);
+    hostnames.parallelStream()
         .forEach(
             hostname -> {
               PerHostDataPlane dp =
@@ -1570,14 +1576,16 @@ public class FileBasedStorage implements StorageProvider {
                       dataPlane.getEvpnRoutes().row(hostname),
                       dataPlane.getEvpnBackupRoutes().row(hostname),
                       dataPlane.getFibs().get(hostname),
+                      forwardingAnalysis.getArpReplies().getOrDefault(hostname, ImmutableMap.of()),
+                      forwardingAnalysis
+                          .getVrfForwardingBehavior()
+                          .getOrDefault(hostname, ImmutableMap.of()),
                       dataPlane.getLayer2Vnis().row(hostname),
                       dataPlane.getLayer3Vnis().row(hostname),
                       dataPlane.getPrefixTracingInfoSummary().get(hostname),
                       dataPlane.getRibs().row(hostname));
               serializeObject(dp, getDataPlaneHostPath(snapshot, hostname));
             });
-    serializeObject(
-        dataPlane.getForwardingAnalysis(), getDataPlaneForwardingAnalysisPath(snapshot));
   }
 
   @Override
@@ -1701,10 +1709,6 @@ public class FileBasedStorage implements StorageProvider {
 
   private @Nonnull Path getDataPlaneHostPath(NetworkSnapshot snapshot, String hostname) {
     return getDataPlanePath(snapshot).resolve(toBase64(hostname));
-  }
-
-  private @Nonnull Path getDataPlaneForwardingAnalysisPath(NetworkSnapshot snapshot) {
-    return getDataPlanePath(snapshot).resolve(RELPATH_DATA_PLANE_FORWARDING_ANALYSIS);
   }
 
   private @Nonnull Path getReferenceLibraryPath(NetworkId network) {

--- a/projects/common/src/main/java/org/batfish/storage/PerHostDataPlane.java
+++ b/projects/common/src/main/java/org/batfish/storage/PerHostDataPlane.java
@@ -9,7 +9,9 @@ import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.FinalMainRib;
+import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.VrfForwardingBehavior;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
 
@@ -19,6 +21,10 @@ final class PerHostDataPlane implements Serializable {
   private final @Nonnull Map<String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
   private final @Nonnull Map<String, Set<EvpnRoute<?, ?>>> _evpnBackupRoutes;
   private final @Nonnull Map<String, Fib> _fibs;
+  // interface -> IPs the interface replies to ARP for
+  private final @Nonnull Map<String, IpSpace> _arpReplies;
+  // vrf -> forwarding behavior
+  private final @Nonnull Map<String, VrfForwardingBehavior> _vrfForwardingBehavior;
   private final @Nonnull Map<String, Set<Layer2Vni>> _layer2Vnis;
   private final @Nonnull Map<String, Set<Layer3Vni>> _layer3Vnis;
   private final @Nonnull SortedMap<String, Map<Prefix, Map<String, Set<String>>>>
@@ -31,6 +37,8 @@ final class PerHostDataPlane implements Serializable {
       @Nonnull Map<String, Set<EvpnRoute<?, ?>>> evpnRoutes,
       @Nonnull Map<String, Set<EvpnRoute<?, ?>>> evpnBackupRoutes,
       @Nonnull Map<String, Fib> fibs,
+      @Nonnull Map<String, IpSpace> arpReplies,
+      @Nonnull Map<String, VrfForwardingBehavior> vrfForwardingBehavior,
       @Nonnull Map<String, Set<Layer2Vni>> layer2Vnis,
       @Nonnull Map<String, Set<Layer3Vni>> layer3Vnis,
       @Nonnull SortedMap<String, Map<Prefix, Map<String, Set<String>>>> prefixTracingInfoSummary,
@@ -40,6 +48,8 @@ final class PerHostDataPlane implements Serializable {
     _evpnRoutes = evpnRoutes;
     _evpnBackupRoutes = evpnBackupRoutes;
     _fibs = fibs;
+    _arpReplies = arpReplies;
+    _vrfForwardingBehavior = vrfForwardingBehavior;
     _layer2Vnis = layer2Vnis;
     _layer3Vnis = layer3Vnis;
     _prefixTracingInfoSummary = prefixTracingInfoSummary;
@@ -64,6 +74,14 @@ final class PerHostDataPlane implements Serializable {
 
   public @Nonnull Map<String, Fib> getFibs() {
     return _fibs;
+  }
+
+  public @Nonnull Map<String, IpSpace> getArpReplies() {
+    return _arpReplies;
+  }
+
+  public @Nonnull Map<String, VrfForwardingBehavior> getVrfForwardingBehavior() {
+    return _vrfForwardingBehavior;
   }
 
   public @Nonnull Map<String, Set<Layer2Vni>> getLayer2Vnis() {

--- a/projects/common/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.topology.GlobalBroadcastNoPointToPoint;
 import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.IpOwnersBaseImpl;
@@ -365,6 +366,55 @@ public class ForwardingAnalysisImplTest {
                     containsInAnyOrder(
                         AclIpSpaceLine.permit(nextHopIpSpace),
                         AclIpSpaceLine.permit(dstIpSpace))))));
+  }
+
+  /** Java serialization must round-trip everything, for every node. */
+  @Test
+  public void testJavaSerialization() {
+    Configuration n1 = _cb.setHostname("n1").build();
+    Vrf v1 = _vb.setOwner(n1).build();
+    Interface i1 =
+        _ib.setOwner(n1)
+            .setVrf(v1)
+            .setAddress(ConcreteInterfaceAddress.parse("10.0.1.0/31"))
+            .build();
+    Configuration n2 = _cb.setHostname("n2").build();
+    Vrf v2 = _vb.setOwner(n2).build();
+    _ib.setOwner(n2).setVrf(v2).setAddress(ConcreteInterfaceAddress.parse("10.0.1.1/31")).build();
+    Ip nextHop = Ip.parse("10.0.1.1");
+    StaticRoute route =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setNextHopIp(nextHop)
+            .setAdmin(1)
+            .build();
+    MockFib fib1 =
+        MockFib.builder()
+            .setMatchingIps(ImmutableMap.of(route.getNetwork(), route.getNetwork().toIpSpace()))
+            .setFibEntries(
+                ImmutableMap.of(
+                    nextHop,
+                    ImmutableSet.of(
+                        new FibEntry(
+                            FibForward.of(nextHop, i1.getName()), ImmutableList.of(route)))))
+            .build();
+    Map<String, Configuration> configs = ImmutableMap.of("n1", n1, "n2", n2);
+    Map<String, Map<String, Fib>> fibs =
+        ImmutableMap.of(
+            "n1",
+            ImmutableMap.of(v1.getName(), fib1),
+            "n2",
+            ImmutableMap.of(v2.getName(), MockFib.builder().build()));
+    IpOwners ipOwners = new TestIpOwners(configs);
+    ForwardingAnalysisImpl fa =
+        new ForwardingAnalysisImpl(
+            configs, fibs, Topology.EMPTY, computeLocationInfo(ipOwners, configs), ipOwners);
+
+    ForwardingAnalysisImpl clone = SerializationUtils.clone(fa);
+
+    assertThat(fa.getArpReplies().keySet(), equalTo(ImmutableSet.of("n1", "n2")));
+    assertThat(clone.getArpReplies(), equalTo(fa.getArpReplies()));
+    assertThat(clone.getVrfForwardingBehavior(), equalTo(fa.getVrfForwardingBehavior()));
   }
 
   @Test

--- a/projects/common/src/test/java/org/batfish/datamodel/InterfaceForwardingBehaviorTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/InterfaceForwardingBehaviorTest.java
@@ -1,0 +1,24 @@
+package org.batfish.datamodel;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+/** Tests of {@link InterfaceForwardingBehavior}. */
+public final class InterfaceForwardingBehaviorTest {
+  @Test
+  public void testEquals() {
+    IpSpace a = Prefix.parse("10.0.0.0/8").toIpSpace();
+    IpSpace b = Prefix.parse("10.0.0.0/16").toIpSpace();
+    IpSpace e = EmptyIpSpace.INSTANCE;
+    new EqualsTester()
+        .addEqualityGroup(
+            new InterfaceForwardingBehavior(a, e, e, e, e),
+            new InterfaceForwardingBehavior(a, null, null, null, null))
+        .addEqualityGroup(new InterfaceForwardingBehavior(b, e, e, e, e))
+        .addEqualityGroup(new InterfaceForwardingBehavior(a, b, e, e, e))
+        .addEqualityGroup(new InterfaceForwardingBehavior(a, e, b, e, e))
+        .addEqualityGroup(new InterfaceForwardingBehavior(a, e, e, b, e))
+        .addEqualityGroup(new InterfaceForwardingBehavior(a, e, e, e, b))
+        .testEquals();
+  }
+}

--- a/projects/common/src/test/java/org/batfish/datamodel/VrfForwardingBehaviorTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/VrfForwardingBehaviorTest.java
@@ -1,0 +1,39 @@
+package org.batfish.datamodel;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+/** Tests of {@link VrfForwardingBehavior}. */
+public final class VrfForwardingBehaviorTest {
+  @Test
+  public void testEquals() {
+    IpSpace a = Prefix.parse("10.0.0.0/8").toIpSpace();
+    IpSpace b = Prefix.parse("10.0.0.0/16").toIpSpace();
+    IpSpace e = EmptyIpSpace.INSTANCE;
+    InterfaceForwardingBehavior ifb = new InterfaceForwardingBehavior(a, e, e, e, e);
+    Edge edge = Edge.of("n1", "i1", "n2", "i2");
+    new EqualsTester()
+        .addEqualityGroup(
+            new VrfForwardingBehavior(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), e, e),
+            new VrfForwardingBehavior(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), e, e))
+        .addEqualityGroup(
+            new VrfForwardingBehavior(
+                ImmutableMap.of(edge, a), ImmutableMap.of(), ImmutableMap.of(), e, e))
+        .addEqualityGroup(
+            new VrfForwardingBehavior(
+                ImmutableMap.of(), ImmutableMap.of("i1", ifb), ImmutableMap.of(), e, e))
+        .addEqualityGroup(
+            new VrfForwardingBehavior(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of("v2", a), e, e))
+        .addEqualityGroup(
+            new VrfForwardingBehavior(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), a, e))
+        .addEqualityGroup(
+            new VrfForwardingBehavior(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), e, b))
+        .testEquals();
+  }
+}

--- a/projects/common/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/common/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -68,9 +68,11 @@ import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.EvpnType5Route;
 import org.batfish.datamodel.FinalMainRib;
 import org.batfish.datamodel.ForwardingAnalysis;
+import org.batfish.datamodel.InterfaceForwardingBehavior;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MockDataPlane;
 import org.batfish.datamodel.MockFib;
@@ -83,6 +85,7 @@ import org.batfish.datamodel.ReceivedFromIp;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.SnapshotMetadata;
 import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.VrfForwardingBehavior;
 import org.batfish.datamodel.answers.AnswerMetadata;
 import org.batfish.datamodel.answers.AnswerStatus;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
@@ -1026,9 +1029,24 @@ public final class FileBasedStorageTest {
             .setVni(1)
             .build();
     EvpnType5Route evpnBackup = evpn.toBuilder().setNetwork(Prefix.MULTICAST).build();
+    VrfForwardingBehavior vfb =
+        new VrfForwardingBehavior(
+            ImmutableMap.of(),
+            ImmutableMap.of(
+                "i",
+                new InterfaceForwardingBehavior(
+                    Prefix.parse("10.0.0.0/8").toIpSpace(),
+                    EmptyIpSpace.INSTANCE,
+                    EmptyIpSpace.INSTANCE,
+                    EmptyIpSpace.INSTANCE,
+                    EmptyIpSpace.INSTANCE)),
+            ImmutableMap.of(),
+            EmptyIpSpace.INSTANCE,
+            UniverseIpSpace.INSTANCE);
     ForwardingAnalysis fa =
         MockForwardingAnalysis.builder()
             .setArpReplies(ImmutableMap.of("n", ImmutableMap.of("i", UniverseIpSpace.INSTANCE)))
+            .setVrfForwardingBehavior(ImmutableMap.of("n", ImmutableMap.of("v", vfb)))
             .build();
 
     DataPlane dp =
@@ -1057,9 +1075,10 @@ public final class FileBasedStorageTest {
         Iterables.getOnlyElement(dp2.getEvpnBackupRoutes().cellSet()).getValue(),
         contains(evpnBackup));
     assertThat(dp2.getFibs(), hasEntry(equalTo("n"), hasKey("v")));
+    assertThat(dp2.getForwardingAnalysis().getArpReplies(), equalTo(fa.getArpReplies()));
     assertThat(
-        dp2.getForwardingAnalysis().getArpReplies().get("n"),
-        hasEntry("i", UniverseIpSpace.INSTANCE));
+        dp2.getForwardingAnalysis().getVrfForwardingBehavior(),
+        equalTo(fa.getVrfForwardingBehavior()));
     assertThat(dp2.getLayer2Vnis().rowMap(), hasEntry(equalTo("n"), hasKey("v2")));
     assertThat(dp2.getLayer3Vnis().rowMap(), hasEntry(equalTo("n"), hasKey("v3")));
     assertThat(dp2.getPrefixTracingInfoSummary(), hasEntry(equalTo("n"), hasKey("vp")));


### PR DESCRIPTION
The dataplane was written as one file per host in parallel, and then the
forwarding analysis, the largest single object in it, as one file on one
thread. Each host's ARP replies and VRF forwarding behavior now go into
its PerHostDataPlane, and loading assembles a ForwardingAnalysisImpl
from them. On a large snapshot storing the dataplane went from about
eleven and a half seconds to nine.

VrfForwardingBehavior and InterfaceForwardingBehavior get equals and
hashCode so that the round trip can be checked.

----

Prompt:
```
Upstream the storage batch, starting with storing the forwarding
analysis per host inside PerHostDataPlane instead of as one monolithic
file.
```