### PR TITLE
datamodel: compact serialized forms for AclIpSpace, IpWildcardSetIpSpace, and PrefixTrieMultiMap

### DIFF
--- a/projects/common/src/main/java/org/batfish/datamodel/AclIpSpace.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/AclIpSpace.java
@@ -10,6 +10,10 @@ import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Streams;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -283,12 +287,63 @@ public class AclIpSpace extends IpSpace {
     return builder().thenPermitting(nonEmptySpaces).build();
   }
 
-  private final @Nonnull List<AclIpSpaceLine> _lines;
+  // Serialized compactly; see writeObject.
+  private transient @Nonnull List<AclIpSpaceLine> _lines;
 
   @JsonCreator
   private AclIpSpace(@JsonProperty(PROP_LINES) @Nullable List<AclIpSpaceLine> lines) {
     checkArgument(lines != null, "Missing %s", PROP_LINES);
     _lines = lines;
+  }
+
+  private static final byte SPACE_OTHER = 0;
+  private static final byte SPACE_IP = 1;
+  private static final byte SPACE_PREFIX = 2;
+
+  /*
+   * A line is an action and a space, and the spaces are nearly always a single prefix or address:
+   * a forwarding analysis has such a line per route. Default serialization writes three objects per
+   * such line; this writes the action and the address as bytes, and only other spaces as objects.
+   */
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    out.writeInt(_lines.size());
+    for (AclIpSpaceLine line : _lines) {
+      out.writeBoolean(line.getAction() == LineAction.PERMIT);
+      IpSpace space = line.getIpSpace();
+      if (space instanceof IpIpSpace) {
+        out.writeByte(SPACE_IP);
+        out.writeInt((int) ((IpIpSpace) space).getIp().asLong());
+      } else if (space instanceof PrefixIpSpace) {
+        out.writeByte(SPACE_PREFIX);
+        Prefix prefix = ((PrefixIpSpace) space).getPrefix();
+        out.writeInt((int) prefix.getStartIp().asLong());
+        out.writeByte(prefix.getPrefixLength());
+      } else {
+        out.writeByte(SPACE_OTHER);
+        out.writeObject(space);
+      }
+    }
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    int count = in.readInt();
+    ImmutableList.Builder<AclIpSpaceLine> lines = ImmutableList.builderWithExpectedSize(count);
+    for (int i = 0; i < count; i++) {
+      boolean permit = in.readBoolean();
+      IpSpace space;
+      switch (in.readByte()) {
+        case SPACE_IP -> space = IpIpSpace.create(Ip.create(in.readInt()));
+        case SPACE_PREFIX ->
+            space = PrefixIpSpace.create(Prefix.create(Ip.create(in.readInt()), in.readByte()));
+        default -> space = (IpSpace) in.readObject();
+      }
+      lines.add(permit ? AclIpSpaceLine.permit(space) : AclIpSpaceLine.reject(space));
+    }
+    _lines = lines.build();
   }
 
   @Override

--- a/projects/common/src/main/java/org/batfish/datamodel/IpWildcardSetIpSpace.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/IpWildcardSetIpSpace.java
@@ -9,6 +9,9 @@ import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.util.Arrays;
@@ -77,14 +80,53 @@ public final class IpWildcardSetIpSpace extends IpSpace {
     return new Builder();
   }
 
-  private final @Nonnull Set<IpWildcard> _blacklist;
+  // Serialized compactly; see writeObject.
+  private transient @Nonnull Set<IpWildcard> _blacklist;
 
-  private final @Nonnull Set<IpWildcard> _whitelist;
+  private transient @Nonnull Set<IpWildcard> _whitelist;
 
   private IpWildcardSetIpSpace(
       @Nonnull Set<IpWildcard> blacklist, @Nonnull Set<IpWildcard> whitelist) {
     _blacklist = ImmutableSet.copyOf(blacklist);
     _whitelist = ImmutableSet.copyOf(whitelist);
+  }
+
+  /*
+   * A wildcard is an address and a mask. A forwarding analysis holds a wildcard per route under a
+   * prefix; default serialization writes an object and an Ip per wildcard, this writes the numbers.
+   */
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    writeWildcards(out, _blacklist);
+    writeWildcards(out, _whitelist);
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    _blacklist = readWildcards(in);
+    _whitelist = readWildcards(in);
+  }
+
+  private static void writeWildcards(ObjectOutputStream out, Set<IpWildcard> wildcards)
+      throws IOException {
+    out.writeInt(wildcards.size());
+    for (IpWildcard w : wildcards) {
+      out.writeInt((int) w.getIp().asLong());
+      out.writeInt((int) w.getWildcardMaskAsIp().asLong());
+    }
+  }
+
+  private static Set<IpWildcard> readWildcards(ObjectInputStream in) throws IOException {
+    int count = in.readInt();
+    ImmutableSet.Builder<IpWildcard> wildcards = ImmutableSet.builderWithExpectedSize(count);
+    for (int i = 0; i < count; i++) {
+      wildcards.add(
+          IpWildcard.ipWithWildcardMask(
+              Ip.create(in.readInt()), Integer.toUnsignedLong(in.readInt())));
+    }
+    return wildcards.build();
   }
 
   @JsonCreator

--- a/projects/common/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -4,12 +4,13 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
-import java.io.ObjectStreamException;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -135,7 +136,8 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
   private static final Object[] EMPTY_VALUES = new Object[0];
   private static final Prefix[] EMPTY_KEYS = new Prefix[0];
 
-  private int[] _nodes;
+  // The arrays are written compactly; see writeObject.
+  private transient int[] _nodes;
 
   /** The number of ints of {@link #_nodes} in use. */
   private int _used;
@@ -143,16 +145,81 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
   private int _root;
 
   /** Slot s holds the element ({@code T}) or elements ({@link ImmutableSet}) of one node. */
-  private Object[] _values;
+  private transient Object[] _values;
 
   /** Slot s holds the {@link Prefix} of the node, sharing the caller's instance. */
-  private Prefix[] _keys;
+  private transient Prefix[] _keys;
 
   private int _numSlots;
   private int _numElements;
 
   public PrefixTrieMultiMap() {
     clear();
+  }
+
+  private static final int VALUE_NONE = -2;
+  private static final int VALUE_SINGLE = -1;
+
+  /*
+   * The records are written as the ints in use, each slot's prefix as its address and length, and
+   * each slot's value as its elements, so that nothing but the elements themselves is an object
+   * in the stream. Reading fills the arrays directly; nothing is rebuilt.
+   */
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    for (int i = 0; i < _used; i++) {
+      out.writeInt(_nodes[i]);
+    }
+    for (int s = 0; s < _numSlots; s++) {
+      Prefix key = _keys[s];
+      if (key == null) {
+        out.writeByte(-1);
+      } else {
+        out.writeByte(key.getPrefixLength());
+        out.writeInt((int) key.getStartIp().asLong());
+      }
+      Object value = _values[s];
+      if (value == null) {
+        out.writeInt(VALUE_NONE);
+      } else if (value instanceof ImmutableSet) {
+        Set<?> elements = (Set<?>) value;
+        out.writeInt(elements.size());
+        for (Object e : elements) {
+          out.writeObject(e);
+        }
+      } else {
+        out.writeInt(VALUE_SINGLE);
+        out.writeObject(value);
+      }
+    }
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    _nodes = new int[_used];
+    for (int i = 0; i < _used; i++) {
+      _nodes[i] = in.readInt();
+    }
+    _keys = new Prefix[_numSlots];
+    _values = new Object[_numSlots];
+    for (int s = 0; s < _numSlots; s++) {
+      byte len = in.readByte();
+      if (len >= 0) {
+        _keys[s] = Prefix.create(Ip.create(in.readInt()), len);
+      }
+      int count = in.readInt();
+      if (count == VALUE_SINGLE) {
+        _values[s] = in.readObject();
+      } else if (count != VALUE_NONE) {
+        ImmutableSet.Builder<Object> elements = ImmutableSet.builderWithExpectedSize(count);
+        for (int i = 0; i < count; i++) {
+          elements.add(in.readObject());
+        }
+        _values[s] = elements.build();
+      }
+    }
   }
 
   // Bit arithmetic on prefixes given as (bits, length).
@@ -1004,41 +1071,5 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
         .add("numElements", _numElements)
         .add("numKeys", _numSlots)
         .toString();
-  }
-
-  private static class SerializedForm<T> implements Serializable {
-    private final ImmutableList<Prefix> _keys;
-    private final ImmutableList<Set<T>> _values;
-
-    private SerializedForm(ImmutableList<Prefix> keys, ImmutableList<Set<T>> values) {
-      _keys = keys;
-      _values = values;
-    }
-
-    public static <T> SerializedForm<T> of(PrefixTrieMultiMap<T> map) {
-      ImmutableList.Builder<Prefix> keys = ImmutableList.builder();
-      ImmutableList.Builder<Set<T>> values = ImmutableList.builder();
-      map.traverseEntries(
-          (prefix, elements) -> {
-            keys.add(prefix);
-            values.add(elements);
-          });
-      return new SerializedForm<>(keys.build(), values.build());
-    }
-
-    @Serial
-    public Object readResolve() throws ObjectStreamException {
-      PrefixTrieMultiMap<T> ret = new PrefixTrieMultiMap<>();
-      for (int i = 0; i < _keys.size(); ++i) {
-        ret.putAll(_keys.get(i), _values.get(i));
-      }
-      ret.trimToSize();
-      return ret;
-    }
-  }
-
-  @Serial
-  private Object writeReplace() throws ObjectStreamException {
-    return SerializedForm.of(this);
   }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
@@ -83,4 +83,24 @@ public class AclIpSpaceTest {
             .build();
     assertThat(space, equalTo(expected));
   }
+
+  /** Lines over addresses and prefixes take a compact serialized form; others are written whole. */
+  @Test
+  public void testJavaSerializationCompactLines() {
+    IpSpace space =
+        AclIpSpace.builder()
+            .thenPermitting(Ip.parse("10.1.1.1").toIpSpace())
+            .thenRejecting(Prefix.parse("10.0.0.0/8").toIpSpace())
+            .thenPermitting(Prefix.parse("255.255.255.255/32").toIpSpace())
+            .thenPermitting(
+                IpWildcardSetIpSpace.builder()
+                    .including(IpWildcard.parse("1.2.3.4:0.0.0.255"))
+                    .excluding(IpWildcard.create(Prefix.parse("1.2.3.0/30")))
+                    .build())
+            .thenRejecting(UniverseIpSpace.INSTANCE)
+            .build();
+    IpSpace clone = org.apache.commons.lang3.SerializationUtils.clone(space);
+    assertThat(clone, equalTo(space));
+    assertThat(((AclIpSpace) clone).getLines(), equalTo(((AclIpSpace) space).getLines()));
+  }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/IpWildcardSetIpSpaceTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/IpWildcardSetIpSpaceTest.java
@@ -43,4 +43,23 @@ public class IpWildcardSetIpSpaceTest {
         IpWildcardSetIpSpace.builder().excluding(IpWildcard.parse("1.2.3.0/24")).build();
     assertThat(actuallyEmpty.complement(), is(UniverseIpSpace.INSTANCE));
   }
+
+  @Test
+  public void testJavaSerializationCompact() {
+    IpWildcardSetIpSpace space =
+        IpWildcardSetIpSpace.builder()
+            .including(
+                IpWildcard.parse("1.2.3.4:0.0.0.255"), IpWildcard.create(Ip.parse("0.0.0.0")))
+            .excluding(
+                IpWildcard.create(Prefix.parse("1.2.3.0/30")),
+                IpWildcard.parse("255.255.255.255:255.255.255.255"))
+            .build();
+    IpWildcardSetIpSpace clone = org.apache.commons.lang3.SerializationUtils.clone(space);
+    assertThat(clone, equalTo(space));
+    assertThat(clone.getBlacklist(), equalTo(space.getBlacklist()));
+    assertThat(clone.getWhitelist(), equalTo(space.getWhitelist()));
+    assertThat(
+        org.apache.commons.lang3.SerializationUtils.clone(IpWildcardSetIpSpace.builder().build()),
+        equalTo(IpWildcardSetIpSpace.builder().build()));
+  }
 }

--- a/projects/common/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
+++ b/projects/common/src/test/java/org/batfish/datamodel/PrefixTrieMultiMapTest.java
@@ -934,4 +934,26 @@ public class PrefixTrieMultiMapTest {
   private static RangeSet<Ip> toRangeSet(Prefix prefix) {
     return ImmutableRangeSet.of(Range.closed(prefix.getStartIp(), prefix.getEndIp()));
   }
+
+  @Test
+  public void testJavaSerializationCompact() {
+    PrefixTrieMultiMap<String> map = new PrefixTrieMultiMap<>();
+    map.put(Prefix.parse("0.0.0.0/0"), "default");
+    map.put(Prefix.parse("10.0.0.0/8"), "a");
+    map.put(Prefix.parse("10.0.0.0/8"), "b");
+    map.put(Prefix.parse("255.255.255.255/32"), "c");
+    map.put(Prefix.parse("128.0.0.0/1"), "d");
+    // A node whose only element was removed keeps its slot with no value.
+    map.put(Prefix.parse("192.168.0.0/16"), "gone");
+    map.remove(Prefix.parse("192.168.0.0/16"), "gone");
+    PrefixTrieMultiMap<String> clone = org.apache.commons.lang3.SerializationUtils.clone(map);
+    assertThat(clone, equalTo(map));
+    assertThat(clone.get(Prefix.parse("10.0.0.0/8")), equalTo(ImmutableSet.of("a", "b")));
+    assertThat(clone.getAllElements(), equalTo(map.getAllElements()));
+    assertThat(clone.get(Prefix.parse("192.168.0.0/16")), equalTo(ImmutableSet.of()));
+    assertThat(clone.longestPrefixMatch(Ip.parse("192.168.1.1")), equalTo(ImmutableSet.of("d")));
+    assertThat(
+        org.apache.commons.lang3.SerializationUtils.clone(new PrefixTrieMultiMap<String>()),
+        equalTo(new PrefixTrieMultiMap<String>()));
+  }
 }


### PR DESCRIPTION
A stored dataplane is mostly these three: a forwarding analysis holds an
ACL line per route out of each interface and a wildcard per route under
each prefix, and every RIB and FIB is a prefix trie. Default
serialization wrote three objects per ACL line (line, space, address)
and an object and an Ip per wildcard; the trie went through a
SerializedForm of two lists that wrote a Prefix, an Ip, and a set with
its backing array per key and rebuilt the trie on reading. Each class
now writes the numbers instead: an action and address bytes per line,
with spaces other than a single prefix or address still written as
objects; address and mask per wildcard; and for the trie its packed
records as ints, each slot's prefix as address and length, and each
slot's value as its elements, read straight back into the arrays with
nothing rebuilt. The SerializedForm is gone. On a large snapshot storing
the dataplane went from about nine seconds to three, and loading gains
similarly.

----

Prompt:
```
Upstream the second half of the storage batch: compact writeObject and
readObject for AclIpSpace lines, IpWildcardSetIpSpace wildcards, and the
PrefixTrieMultiMap serialized form.
```