### PR TITLE
BGP: import from all neighbors in parallel, then merge into the RIBs in order

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -945,9 +945,19 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       _externalAdvertisements = null;
     }
 
-    // Process updates from each neighbor
-    for (EdgeId edgeId : _bgpv4Edges) {
-      pullV4UnicastMessages(bgpTopology, nc, nodes, edgeId, _unicastEdgesWentUp.contains(edgeId));
+    // Process updates from each neighbor. What a neighbor sends and how it looks after import
+    // processing depend on the neighbor and our configuration, not on our RIBs, so that is done
+    // for all neighbors in parallel: a node with many neighbors would otherwise hold up the whole
+    // iteration. The results go into the RIBs neighbor by neighbor, in the same order as always.
+    List<PreparedEdge> prepared =
+        _bgpv4Edges.asList().parallelStream()
+            .map(
+                edgeId ->
+                    prepareV4UnicastMessages(
+                        bgpTopology, nc, nodes, edgeId, _unicastEdgesWentUp.contains(edgeId)))
+            .collect(ImmutableList.toImmutableList());
+    for (PreparedEdge edge : prepared) {
+      applyV4UnicastMessages(nodes, edge);
     }
 
     initBgpAggregateRoutes();
@@ -989,31 +999,35 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     }
   }
 
-  /** Pull v4Unicast routes from our neighbors' deltas, merge them into our own RIBs */
-  private void pullV4UnicastMessages(
+  /** A route a neighbor sent us that passed import processing, as it goes into our RIBs. */
+  private record ImportedRoute(Bgpv4Route transformed, boolean withdrawn) {}
+
+  /** Everything {@link #applyV4UnicastMessages} needs about one neighbor's routes. */
+  private record PreparedEdge(
+      BgpSessionProperties ourSessionProperties,
+      BgpPeerConfig ourBgpConfig,
+      List<ImportedRoute> routes) {}
+
+  /**
+   * Pulls v4Unicast routes from the neighbor on {@code edgeId} and runs them through import
+   * processing. Depends on the neighbor's state and our configuration, not on our RIBs, so it can
+   * run for all neighbors at once; {@link #applyV4UnicastMessages} then merges the results.
+   */
+  private PreparedEdge prepareV4UnicastMessages(
       BgpTopology bgpTopology,
       NetworkConfigurations nc,
       Map<String, Node> nodes,
       EdgeId edgeId,
       boolean isNewSession) {
-
     // Setup helper vars
     BgpPeerConfigId remoteConfigId = edgeId.tail();
     BgpPeerConfigId ourConfigId = edgeId.head();
     // Verify that "ourConfigId" really is ours.
     assert ourConfigId.getHostname().equals(_hostname);
-
     BgpSessionProperties ourSessionProperties =
         getBgpSessionProperties(bgpTopology, edgeId.reverse());
     BgpPeerConfig ourBgpConfig = requireNonNull(nc.getBgpPeerConfig(edgeId.head()));
     assert ourBgpConfig.getIpv4UnicastAddressFamily() != null;
-    // sessionProperties represents the incoming edge, so its tailIp is the remote peer's IP
-    boolean useRibGroups =
-        ourBgpConfig.getAppliedRibGroup() != null
-            && !ourBgpConfig.getAppliedRibGroup().getImportRibs().isEmpty();
-
-    Builder<AnnotatedRoute<AbstractRoute>> perNeighborDeltaForRibGroups = RibDelta.builder();
-
     BgpRoutingProcess remoteProcess = getNeighborBgpProcess(remoteConfigId, nodes);
     Iterator<RouteAdvertisement<Bgpv4Route>> exportedRoutes =
         remoteProcess
@@ -1023,21 +1037,27 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             // route and another added route, the add should be applied second.
             .sorted(Comparator.comparing(ra -> !ra.isWithdrawn()))
             .iterator();
+    // Note whether new route is received from route reflector client
+    AddressFamily ourAfSettingsForPeer = ourBgpConfig.getIpv4UnicastAddressFamily();
+    assert ourAfSettingsForPeer
+        != null; // invariant of proper queue setup and route exchange for this AF type
+    boolean receivedFromRouteReflectorClient =
+        !ourSessionProperties.isEbgp() && ourAfSettingsForPeer.getRouteReflectorClient();
+    // TODO: ensure there is always an import policy
+    String importPolicyName = ourAfSettingsForPeer.getImportPolicy();
+    RoutingPolicy importPolicy =
+        importPolicyName == null ? null : _policies.get(importPolicyName).orElse(null);
 
-    // Process all routes from neighbor
+    List<ImportedRoute> routes = new ArrayList<>();
     while (exportedRoutes.hasNext()) {
       // consume exported routes
       RouteAdvertisement<Bgpv4Route> remoteRouteAdvert = exportedRoutes.next();
       Bgpv4Route remoteRoute = remoteRouteAdvert.getRoute();
-
       Bgpv4Route.Builder transformedIncomingRouteBuilder =
           transformBgpRouteOnImport(
               remoteRoute,
               ourSessionProperties.getLocalAs(),
-              ourBgpConfig
-                  .getIpv4UnicastAddressFamily()
-                  .getAddressFamilyCapabilities()
-                  .getAllowLocalAsIn(),
+              ourAfSettingsForPeer.getAddressFamilyCapabilities().getAllowLocalAsIn(),
               ourSessionProperties.isEbgp(),
               _process,
               ourSessionProperties.getRemoteIp(),
@@ -1053,31 +1073,16 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             IN);
         continue;
       }
-
-      // Note whether new route is received from route reflector client
-      AddressFamily ourAfSettingsForPeer = ourBgpConfig.getIpv4UnicastAddressFamily();
-      assert ourAfSettingsForPeer
-          != null; // invariant of proper queue setup and route exchange for this AF type
       transformedIncomingRouteBuilder.setReceivedFromRouteReflectorClient(
-          !ourSessionProperties.isEbgp() && ourAfSettingsForPeer.getRouteReflectorClient());
-
+          receivedFromRouteReflectorClient);
       // Process route through import policy, if one exists
-      String importPolicyName = ourBgpConfig.getIpv4UnicastAddressFamily().getImportPolicy();
-      boolean acceptIncoming = true;
-      // TODO: ensure there is always an import policy
-      if (importPolicyName != null) {
-        RoutingPolicy importPolicy = _policies.get(importPolicyName).orElse(null);
-        if (importPolicy != null) {
-          acceptIncoming =
-              importPolicy.processBgpRoute(
-                  remoteRoute,
-                  transformedIncomingRouteBuilder,
-                  ourSessionProperties,
-                  IN,
-                  _successfulWatchedTracks::contains);
-        }
-      }
-      if (!acceptIncoming) {
+      if (importPolicy != null
+          && !importPolicy.processBgpRoute(
+              remoteRoute,
+              transformedIncomingRouteBuilder,
+              ourSessionProperties,
+              IN,
+              _successfulWatchedTracks::contains)) {
         // Route could not be imported due to routing policy
         _prefixTracer.filtered(
             remoteRoute.getNetwork(),
@@ -1089,31 +1094,45 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         continue;
       }
       Bgpv4Route transformedIncomingRoute = transformedIncomingRouteBuilder.build();
-
-      // If new route gets leaked to other VRFs via RibGroup, this VRF should be its source VRF.
-      AnnotatedRoute<AbstractRoute> annotatedTransformedRoute =
-          annotateRoute(transformedIncomingRoute);
-
-      if (remoteRouteAdvert.isWithdrawn()) {
-        // Remove from target and overall RIBs and update deltas
-        processRemoveInEbgpOrIbgpRib(transformedIncomingRoute, ourSessionProperties.isEbgp());
-        processRemoveInBgpRib(transformedIncomingRoute);
-        if (useRibGroups) {
-          perNeighborDeltaForRibGroups.remove(annotatedTransformedRoute, Reason.WITHDRAW);
-        }
-      } else {
-        // Merge into target and overall RIBs and update deltas
-        processMergeInEbgpOrIbgpRib(transformedIncomingRoute, ourSessionProperties.isEbgp());
-        processMergeInBgpRib(transformedIncomingRoute);
-        if (useRibGroups) {
-          perNeighborDeltaForRibGroups.add(annotatedTransformedRoute);
-        }
+      if (!remoteRouteAdvert.isWithdrawn()) {
         _prefixTracer.installed(
             transformedIncomingRoute.getNetwork(),
             remoteConfigId.getHostname(),
             ourSessionProperties.getRemoteIp(),
             remoteConfigId.getVrfName(),
             importPolicyName);
+      }
+      routes.add(new ImportedRoute(transformedIncomingRoute, remoteRouteAdvert.isWithdrawn()));
+    }
+    return new PreparedEdge(ourSessionProperties, ourBgpConfig, routes);
+  }
+
+  /** Merges the routes of {@link #prepareV4UnicastMessages} into our RIBs and updates deltas. */
+  private void applyV4UnicastMessages(Map<String, Node> nodes, PreparedEdge prepared) {
+    BgpSessionProperties ourSessionProperties = prepared.ourSessionProperties();
+    BgpPeerConfig ourBgpConfig = prepared.ourBgpConfig();
+    boolean useRibGroups =
+        ourBgpConfig.getAppliedRibGroup() != null
+            && !ourBgpConfig.getAppliedRibGroup().getImportRibs().isEmpty();
+    Builder<AnnotatedRoute<AbstractRoute>> perNeighborDeltaForRibGroups = RibDelta.builder();
+    for (ImportedRoute imported : prepared.routes()) {
+      Bgpv4Route transformedIncomingRoute = imported.transformed();
+      if (imported.withdrawn()) {
+        // Remove from target and overall RIBs and update deltas
+        processRemoveInEbgpOrIbgpRib(transformedIncomingRoute, ourSessionProperties.isEbgp());
+        processRemoveInBgpRib(transformedIncomingRoute);
+        if (useRibGroups) {
+          perNeighborDeltaForRibGroups.remove(
+              annotateRoute(transformedIncomingRoute), Reason.WITHDRAW);
+        }
+      } else {
+        // Merge into target and overall RIBs and update deltas
+        processMergeInEbgpOrIbgpRib(transformedIncomingRoute, ourSessionProperties.isEbgp());
+        processMergeInBgpRib(transformedIncomingRoute);
+        if (useRibGroups) {
+          // If new route gets leaked to other VRFs via RibGroup, this VRF should be its source VRF.
+          perNeighborDeltaForRibGroups.add(annotateRoute(transformedIncomingRoute));
+        }
       }
     }
     // Apply rib groups if any


### PR DESCRIPTION
A node pulled routes from its neighbors one edge at a time: for each
edge, run the neighbor's export (its export policy on every changed
route), then our import transform and import policy, then merge into our
RIBs. A node with many neighbors held up its whole schedule step. The
first two parts are now done for all edges in parallel and only the
merges stay sequential, edge by edge in the same order as before, with
each edge's routes in the same order (the sort is stable). Everything
the parallel part reads is fixed for the iteration: the neighbor's
export state, which several importers in one color already read at once,
our configuration and policies, the session properties, and the watched
track states; PrefixTracer is backed by concurrent collections. Route
transformation does not consult our RIBs, so deferring the merges cannot
change what is merged. Only the routes that pass import are held until
they are merged, as the transformed route and a withdrawn flag; rejected
routes are reported to the prefix tracer as they are seen, as are
installed ones, since its collections are concurrent and order does not
matter to it. Peak heap measured on a large snapshot is unchanged. On a
large snapshot the BGP portion of the dataplane went from about 32 to 25
seconds, with identical routes at every step.

----

Prompt:
```
Upstream the dataplane parallelism batch, starting with the two-phase per-neighbor BGP import.
```

Split from a PR that also built NetworkConfigurations once per
iteration; that is its own PR now.