### PR TITLE
BGP: build NetworkConfigurations once per iteration instead of once per process per step

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -653,13 +653,20 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
 
   @Override
   public void executeIteration(Map<String, Node> allNodes) {
-    // TODO: optimize, don't recreate the map each iteration
-    NetworkConfigurations nc =
+    executeIteration(
+        allNodes,
         NetworkConfigurations.of(
             allNodes.entrySet().stream()
                 .collect(
                     ImmutableMap.toImmutableMap(
-                        Entry::getKey, e -> e.getValue().getConfiguration())));
+                        Entry::getKey, e -> e.getValue().getConfiguration()))));
+  }
+
+  /**
+   * {@link #executeIteration(Map)} with the {@link NetworkConfigurations} of {@code allNodes}
+   * supplied by the caller, which builds it once per iteration rather than once per process.
+   */
+  public void executeIteration(Map<String, Node> allNodes, NetworkConfigurations nc) {
     if (!_evpnInitializationDelta.isEmpty()) {
       // If initialization delta has not been sent out, do so now
       sendOutEvpnType3Routes(_evpnInitializationDelta, nc, allNodes);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -895,7 +895,7 @@ final class IncrementalBdpEngine {
     vrs.parallelStream().forEach(vr -> vr.ospfIteration(allNodes));
     vrs.parallelStream().forEach(VirtualRouter::mergeOspfRoutesToMainRib);
 
-    computeIterationOfBgpRoutes(iterationLabel, allNodes, vrs);
+    computeIterationOfBgpRoutes(iterationLabel, allNodes, vrs, networkConfigurations);
 
     leakAcrossVrfs(vrs, iterationLabel);
 
@@ -909,9 +909,12 @@ final class IncrementalBdpEngine {
   }
 
   private static void computeIterationOfBgpRoutes(
-      String iterationLabel, Map<String, Node> allNodes, List<VirtualRouter> vrs) {
+      String iterationLabel,
+      Map<String, Node> allNodes,
+      List<VirtualRouter> vrs,
+      NetworkConfigurations nc) {
     LOGGER.info("{}: Init for new BGP iteration", iterationLabel);
-    vrs.parallelStream().forEach(vr -> vr.bgpIteration(allNodes));
+    vrs.parallelStream().forEach(vr -> vr.bgpIteration(allNodes, nc));
     LOGGER.info("{}: Init BGP generated/aggregate routes", iterationLabel);
     // first let's initialize nodes-level generated/aggregate routes
     vrs.parallelStream().forEach(VirtualRouter::initBgpAggregateRoutes);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1711,12 +1711,12 @@ public final class VirtualRouter {
   }
 
   /** Execute one iteration of BGP route propagation. */
-  void bgpIteration(Map<String, Node> allNodes) {
+  void bgpIteration(Map<String, Node> allNodes, NetworkConfigurations nc) {
     if (_bgpRoutingProcess == null) {
       return;
     }
     _bgpRoutingProcess.startOfInnerRound();
-    _bgpRoutingProcess.executeIteration(allNodes);
+    _bgpRoutingProcess.executeIteration(allNodes, nc);
     // If we leak to or from EVPN or leak routes as BGP, do so here.
     if (_vrf.getVrfLeakConfig() != null) {
       bgpVrfLeak();


### PR DESCRIPTION
executeIteration also rebuilt the NetworkConfigurations map of every
node on every call, once per BGP process per schedule step. The engine
already has it and passes it down; the old signature remains and builds
the map itself.

----

Prompt:
```
Upstream building NetworkConfigurations once per dataplane iteration
instead of inside every BGP process's executeIteration, as its own PR.
```
