### PR TITLE
ibdp: pass NetworkConfigurations to every RoutingProcess.executeIteration

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -21,7 +21,6 @@ import static org.batfish.dataplane.rib.RibDelta.importDeltaToBuilder;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -652,20 +651,6 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   }
 
   @Override
-  public void executeIteration(Map<String, Node> allNodes) {
-    executeIteration(
-        allNodes,
-        NetworkConfigurations.of(
-            allNodes.entrySet().stream()
-                .collect(
-                    ImmutableMap.toImmutableMap(
-                        Entry::getKey, e -> e.getValue().getConfiguration()))));
-  }
-
-  /**
-   * {@link #executeIteration(Map)} with the {@link NetworkConfigurations} of {@code allNodes}
-   * supplied by the caller, which builds it once per iteration rather than once per process.
-   */
   public void executeIteration(Map<String, Node> allNodes, NetworkConfigurations nc) {
     if (!_evpnInitializationDelta.isEmpty()) {
       // If initialization delta has not been sent out, do so now

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -7,7 +7,6 @@ import static org.batfish.dataplane.ibdp.DataplaneUtil.messageQueueStream;
 import static org.batfish.dataplane.rib.RibDelta.importRibDelta;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Sets;
@@ -15,7 +14,6 @@ import com.google.common.collect.Streams;
 import com.google.common.graph.Network;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
@@ -150,15 +148,8 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   }
 
   @Override
-  public void executeIteration(Map<String, Node> allNodes) {
+  public void executeIteration(Map<String, Node> allNodes, NetworkConfigurations nc) {
     _changeSet = RibDelta.builder();
-    // TODO: optimize, don't recreate the map each iteration
-    NetworkConfigurations nc =
-        NetworkConfigurations.of(
-            allNodes.entrySet().stream()
-                .collect(
-                    ImmutableMap.toImmutableMap(
-                        Entry::getKey, e -> e.getValue().getConfiguration())));
 
     if (!_initializationDelta.isEmpty()) {
       // If we haven't sent out the first round of updates after initialization, do so now. Then

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -466,7 +466,7 @@ final class IncrementalBdpEngine {
      */
     IncrementalBdpAnswerElement answerElement = new IncrementalBdpAnswerElement();
     // TODO: eventually, IGP needs to be part of fixed-point below, because tunnels.
-    computeIgpDataPlane(nodes, vrs, initialTopologyContext, answerElement);
+    computeIgpDataPlane(nodes, vrs, initialTopologyContext, networkConfigurations, answerElement);
 
     LOGGER.info("Initialize virtual routers before topology fixed point");
     vrs.parallelStream()
@@ -863,7 +863,7 @@ final class IncrementalBdpEngine {
 
     // EIGRP
     LOGGER.info("{}: Propagate EIGRP routes", iterationLabel);
-    vrs.parallelStream().forEach(vr -> vr.eigrpIteration(allNodes));
+    vrs.parallelStream().forEach(vr -> vr.eigrpIteration(allNodes, networkConfigurations));
     vrs.parallelStream().forEach(VirtualRouter::mergeEigrpRoutesToMainRib);
 
     // Re-initialize IS-IS exports.
@@ -892,7 +892,7 @@ final class IncrementalBdpEngine {
     }
 
     LOGGER.info("{}: Propagate OSPF external", iterationLabel);
-    vrs.parallelStream().forEach(vr -> vr.ospfIteration(allNodes));
+    vrs.parallelStream().forEach(vr -> vr.ospfIteration(allNodes, networkConfigurations));
     vrs.parallelStream().forEach(VirtualRouter::mergeOspfRoutesToMainRib);
 
     computeIterationOfBgpRoutes(iterationLabel, allNodes, vrs, networkConfigurations);
@@ -956,6 +956,7 @@ final class IncrementalBdpEngine {
       SortedMap<String, Node> nodes,
       List<VirtualRouter> vrs,
       TopologyContext topologyContext,
+      NetworkConfigurations nc,
       IncrementalBdpAnswerElement ae) {
     LOGGER.info("Compute IGP");
     int numOspfInternalIterations;
@@ -972,7 +973,8 @@ final class IncrementalBdpEngine {
     vrs.stream().forEach(VirtualRouter::applyRibGroupsForIgp);
 
     // OSPF internal routes
-    numOspfInternalIterations = initOspfInternalRoutes(nodes, topologyContext.getOspfTopology());
+    numOspfInternalIterations =
+        initOspfInternalRoutes(nodes, topologyContext.getOspfTopology(), nc);
 
     // RIP internal routes
     initRipInternalRoutes(nodes, vrs, topologyContext.getLayer3Topology());
@@ -1172,7 +1174,8 @@ final class IncrementalBdpEngine {
    * @param ospfTopology graph of OSPF adjacencies
    * @return the number of iterations it took for internal OSPF routes to converge
    */
-  private int initOspfInternalRoutes(Map<String, Node> allNodes, OspfTopology ospfTopology) {
+  private int initOspfInternalRoutes(
+      Map<String, Node> allNodes, OspfTopology ospfTopology, NetworkConfigurations nc) {
     int ospfInternalIterations = 0;
     boolean dirty = true;
 
@@ -1193,7 +1196,7 @@ final class IncrementalBdpEngine {
             toListInRandomOrder(
                 scheduleNodes.values().stream().flatMap(n -> n.getVirtualRouters().stream()));
         scheduleVrs.parallelStream()
-            .forEach(virtualRouter -> virtualRouter.ospfIteration(allNodes));
+            .forEach(virtualRouter -> virtualRouter.ospfIteration(allNodes, nc));
         scheduleVrs.parallelStream().forEach(VirtualRouter::mergeOspfRoutesToMainRib);
       }
       dirty =

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -34,6 +34,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.OspfExternalRoute;
 import org.batfish.datamodel.OspfExternalType1Route;
 import org.batfish.datamodel.OspfExternalType2Route;
@@ -199,7 +200,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   }
 
   @Override
-  public void executeIteration(Map<String, Node> allNodes) {
+  public void executeIteration(Map<String, Node> allNodes, NetworkConfigurations nc) {
     if (!_initializationDelta.isEmpty()) {
       // If we haven't sent out the first round of updates after initialization, do so now. Then
       // clear the initialization delta

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RoutingProcess.java
@@ -6,6 +6,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.dataplane.rib.RibDelta;
 
 /**
@@ -36,8 +37,9 @@ public interface RoutingProcess<T, R extends AbstractRouteDecorator> {
    * <p>Called exactly once per iteration (of route propagation)
    *
    * @param allNodes map of all available nodes that are participating in the computation.
+   * @param nc the configurations of {@code allNodes}, built once per iteration by the caller.
    */
-  void executeIteration(final Map<String, Node> allNodes);
+  void executeIteration(Map<String, Node> allNodes, NetworkConfigurations nc);
 
   /**
    * Must return a {@link RibDelta} indicating which RIB updates need to be propagated to the main

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1701,13 +1701,13 @@ public final class VirtualRouter {
         || (_bgpRoutingProcess != null && _bgpRoutingProcess.isDirty());
   }
 
-  void eigrpIteration(Map<String, Node> allNodes) {
-    _eigrpProcesses.values().forEach(p -> p.executeIteration(allNodes));
+  void eigrpIteration(Map<String, Node> allNodes, NetworkConfigurations nc) {
+    _eigrpProcesses.values().forEach(p -> p.executeIteration(allNodes, nc));
   }
 
   /** Execute one OSPF iteration, for all processes */
-  void ospfIteration(Map<String, Node> allNodes) {
-    _ospfProcesses.values().forEach(p -> p.executeIteration(allNodes));
+  void ospfIteration(Map<String, Node> allNodes, NetworkConfigurations nc) {
+    _ospfProcesses.values().forEach(p -> p.executeIteration(allNodes, nc));
   }
 
   /** Execute one iteration of BGP route propagation. */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -39,6 +39,7 @@ import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -61,6 +62,7 @@ import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.EvpnType3Route;
 import org.batfish.datamodel.EvpnType5Route;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OriginMechanism;
 import org.batfish.datamodel.OriginType;
@@ -435,7 +437,8 @@ public class BgpRoutingProcessTest {
     4. Ensure BGP rib state (at least type 3 routes) are sent to new neighbors.
     */
     routingProcNode1.initialize(node);
-    routingProcNode1.executeIteration(ImmutableMap.of());
+    routingProcNode1.executeIteration(
+        ImmutableMap.of(), NetworkConfigurations.of(ImmutableMap.of()));
     // Update topology
     MutableValueGraph<BgpPeerConfigId, BgpSessionProperties> graph =
         ValueGraphBuilder.directed().build();
@@ -467,12 +470,20 @@ public class BgpRoutingProcessTest {
         sessionBuilderReverse.setAddressFamilies(ImmutableSet.of(Type.EVPN)).build());
     routingProcNode1.updateTopology(new BgpTopology(graph));
     routingProcNode2.updateTopology(new BgpTopology(graph));
-    routingProcNode1.executeIteration(
+    Map<String, Node> nodes =
         ImmutableSortedMap.of(
             node.getConfiguration().getHostname(),
             node,
             node2.getConfiguration().getHostname(),
-            node2));
+            node2);
+    routingProcNode1.executeIteration(
+        nodes,
+        NetworkConfigurations.of(
+            ImmutableMap.of(
+                node.getConfiguration().getHostname(),
+                node.getConfiguration(),
+                node2.getConfiguration().getHostname(),
+                node2.getConfiguration())));
 
     assertThat(
         routingProcNode2._evpnType3IncomingRoutes.get(new BgpTopology.EdgeId(peer1Id, peer2Id)),
@@ -661,7 +672,8 @@ public class BgpRoutingProcessTest {
 
     Node node = new Node(_c);
     _routingProcess.initialize(node);
-    _routingProcess.executeIteration(ImmutableMap.of());
+    _routingProcess.executeIteration(
+        ImmutableMap.of(), NetworkConfigurations.of(ImmutableMap.of()));
     assertThat(
         _routingProcess._bgpv4Rib.getUnannotatedRoutes(),
         contains(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -46,6 +46,7 @@ import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpLink;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OspfExternalRoute;
 import org.batfish.datamodel.OspfExternalType1Route;
@@ -334,7 +335,8 @@ public class OspfRoutingProcessTest {
   public void testNotDirtyAfterOneIteration() {
     _routingProcess.initialize(new Node(_c));
     // Empty map in this particular case just means no valid neighbors.
-    _routingProcess.executeIteration(ImmutableMap.of());
+    _routingProcess.executeIteration(
+        ImmutableMap.of(), NetworkConfigurations.of(ImmutableMap.of()));
     assertTrue("Still have updates to main RIB", _routingProcess.isDirty());
     _routingProcess.getUpdatesForMainRib();
 


### PR DESCRIPTION
The interface took only the node map, so BgpRoutingProcess kept a
one-argument executeIteration that built the NetworkConfigurations map
itself and existed only to satisfy the interface and for tests, and
EigrpRoutingProcess still rebuilt that map on every call. The interface
method now takes the NetworkConfigurations the engine already has, all
three processes receive it, and the IGP entry points and the OSPF
initialization loop pass it through.

----

Prompt:
```
Change RoutingProcess.executeIteration to take NetworkConfigurations so
that BgpRoutingProcess has a single executeIteration, as its own PR
after the per-iteration NetworkConfigurations change merged.
```
