### PR TITLE
statics: resolve a conditional route group's next hop once, and skip merging routes already present

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -3,6 +3,7 @@ package org.batfish.dataplane.ibdp;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.alwaysFalse;
+import static java.util.Objects.requireNonNull;
 import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.common.util.CollectionUtil.toOrderedHashCode;
 import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
@@ -11,6 +12,7 @@ import static org.batfish.dataplane.ibdp.DataplaneUtil.messageQueueStream;
 import static org.batfish.dataplane.protocols.IsisProtocolHelper.convertRouteLevel1ToLevel2;
 import static org.batfish.dataplane.protocols.IsisProtocolHelper.exportNonIsisRouteToIsis;
 import static org.batfish.dataplane.protocols.IsisProtocolHelper.setOverloadOnAllRoutes;
+import static org.batfish.dataplane.protocols.StaticRouteHelper.resolveStaticNextHopIp;
 import static org.batfish.dataplane.protocols.StaticRouteHelper.shouldActivateNextHopIpRoute;
 import static org.batfish.dataplane.rib.AbstractRib.importRib;
 import static org.batfish.dataplane.rib.RibDelta.importRibDelta;
@@ -618,9 +620,9 @@ public final class VirtualRouter {
     if (_conditionalStaticsNeedFullPass) {
       _conditionalStaticsNeedFullPass = false;
       for (List<StaticRoute> group : _conditionalStaticsByNextHopIp.values()) {
-        activateStaticRoutes(trackMethodEvaluator, group);
+        activateStaticRoutesInNhipGroup(trackMethodEvaluator, group);
       }
-      activateStaticRoutes(trackMethodEvaluator, _conditionalStaticsWithoutNextHopIp);
+      activateStaticRoutesInNhipGroup(trackMethodEvaluator, _conditionalStaticsWithoutNextHopIp);
       return;
     }
     // Within a round, only a next hop IP's resolution can change, and only if a main RIB route
@@ -642,25 +644,59 @@ public final class VirtualRouter {
       }
     }
     for (Ip nextHopIp : affectedNextHopIps) {
-      activateStaticRoutes(trackMethodEvaluator, _conditionalStaticsByNextHopIp.get(nextHopIp));
+      activateStaticRoutesInNhipGroup(
+          trackMethodEvaluator, _conditionalStaticsByNextHopIp.get(nextHopIp));
     }
   }
 
-  private void activateStaticRoutes(
+  /**
+   * Activates or deactivates {@code conditionalStatics}, one group of {@link
+   * #_conditionalStaticsByNextHopIp} or the routes without a next hop IP. Routes with a next hop IP
+   * all share it, so it is resolved at most once per recursiveness rather than per route.
+   */
+  private void activateStaticRoutesInNhipGroup(
       TrackMethodEvaluator trackMethodEvaluator, List<StaticRoute> conditionalStatics) {
+    Set<AnnotatedRoute<AbstractRoute>> resolvedRecursive = null;
+    Set<AnnotatedRoute<AbstractRoute>> resolvedNonRecursive = null;
     for (StaticRoute sr : conditionalStatics) {
-      if (shouldActivateConditionalStaticRoute(trackMethodEvaluator, sr)) {
-        _mainRibRouteDeltaBuilder.from(_mainRib.mergeRouteGetDelta(annotateRoute(sr)));
+      Set<AnnotatedRoute<AbstractRoute>> nextHopIpResolution = null;
+      if (sr.getNextHop() instanceof NextHopIp) {
+        if (sr.getRecursive()) {
+          if (resolvedRecursive == null) {
+            resolvedRecursive =
+                resolveStaticNextHopIp(sr.getNextHopIp(), true, _mainRib, _resolutionRestriction);
+          }
+          nextHopIpResolution = resolvedRecursive;
+        } else {
+          if (resolvedNonRecursive == null) {
+            resolvedNonRecursive =
+                resolveStaticNextHopIp(sr.getNextHopIp(), false, _mainRib, _resolutionRestriction);
+          }
+          nextHopIpResolution = resolvedNonRecursive;
+        }
+      }
+      AnnotatedRoute<AbstractRoute> route = annotateRoute(sr);
+      if (shouldActivateConditionalStaticRoute(trackMethodEvaluator, sr, nextHopIpResolution)) {
+        // Merging a route already present is a no-op; skip the work of finding that out.
+        if (!_mainRib.containsRoute(route)) {
+          _mainRibRouteDeltaBuilder.from(_mainRib.mergeRouteGetDelta(route));
+        }
       } else {
-        // No effect if the route is not in the RIB.
-        _mainRibRouteDeltaBuilder.from(_mainRib.removeRouteGetDelta(annotateRoute(sr)));
+        // No effect if the route is not in the RIB or its backups.
+        _mainRibRouteDeltaBuilder.from(_mainRib.removeRouteGetDelta(route));
       }
     }
   }
 
+  /**
+   * @param nextHopIpResolution the routes {@code sr}'s next hop IP resolves through, required when
+   *     {@code sr} has a next hop IP
+   */
   private boolean shouldActivateConditionalStaticRoute(
-      TrackMethodEvaluator trackMethodEvaluator, StaticRoute sr) {
-    if (!shouldActivateConditionalStaticRouteNextHop(sr)) {
+      TrackMethodEvaluator trackMethodEvaluator,
+      StaticRoute sr,
+      @Nullable Set<AnnotatedRoute<AbstractRoute>> nextHopIpResolution) {
+    if (!shouldActivateConditionalStaticRouteNextHop(sr, nextHopIpResolution)) {
       return false;
     }
     if (sr.getTrack() != null && !evaluateTrack(trackMethodEvaluator, sr.getTrack())) {
@@ -670,22 +706,27 @@ public final class VirtualRouter {
     return true;
   }
 
-  private boolean shouldActivateConditionalStaticRouteNextHop(StaticRoute sr) {
-    return new ShouldActivateConditionalStaticRouteNextHop(sr).visit(sr.getNextHop());
+  private boolean shouldActivateConditionalStaticRouteNextHop(
+      StaticRoute sr, @Nullable Set<AnnotatedRoute<AbstractRoute>> nextHopIpResolution) {
+    return new ShouldActivateConditionalStaticRouteNextHop(sr, nextHopIpResolution)
+        .visit(sr.getNextHop());
   }
 
   private final class ShouldActivateConditionalStaticRouteNextHop
       implements NextHopVisitor<Boolean> {
 
-    private ShouldActivateConditionalStaticRouteNextHop(StaticRoute sr) {
+    private ShouldActivateConditionalStaticRouteNextHop(
+        StaticRoute sr, @Nullable Set<AnnotatedRoute<AbstractRoute>> nextHopIpResolution) {
       _sr = sr;
+      _nextHopIpResolution = nextHopIpResolution;
     }
 
     private final @Nonnull StaticRoute _sr;
+    private final @Nullable Set<AnnotatedRoute<AbstractRoute>> _nextHopIpResolution;
 
     @Override
     public Boolean visitNextHopIp(NextHopIp nextHopIp) {
-      return shouldActivateNextHopIpRoute(_sr, _mainRib, _resolutionRestriction);
+      return shouldActivateNextHopIpRoute(_sr, requireNonNull(_nextHopIpResolution));
     }
 
     @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/StaticRouteHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/StaticRouteHelper.java
@@ -15,35 +15,36 @@ import org.batfish.datamodel.StaticRoute;
 public class StaticRouteHelper {
 
   /**
-   * Check if a static route with next hop IP can be activated. If this method returns True, an
-   * attempt should be made to merge it into the RIB. If it returns false, an attempt should be made
-   * to remove it from the RIB.
-   *
-   * @param route a {@link StaticRoute} to check
-   * @param rib the RIB to use for establishing routabilitity to next hop IP
-   * @param restriction predicate that restricts which routes may be used to recursively resolve
-   *     next-hops
+   * The routes in {@code rib} that a static route with next hop {@code nextHopIp} may resolve
+   * through: the longest prefix matches that are connected or, if {@code recursive}, pass {@code
+   * restriction}. Shared by every static route with the same next hop IP and recursiveness, so a
+   * caller with many such routes can resolve once.
+   */
+  public static <R extends AbstractRouteDecorator> Set<R> resolveStaticNextHopIp(
+      Ip nextHopIp, boolean recursive, GenericRib<R> rib, ResolutionRestriction<R> restriction) {
+    return rib.longestPrefixMatch(
+        nextHopIp,
+        r -> {
+          if (r.getAbstractRoute().getProtocol() == RoutingProtocol.CONNECTED) {
+            // All static routes can be activated by a connected route.
+            return true;
+          }
+          if (!recursive) {
+            // Non-recursive static routes cannot be activated by non-connected routes.
+            return false;
+          }
+          // Recursive routes must pass restriction if present.
+          return restriction.test(r);
+        });
+  }
+
+  /**
+   * Whether {@code route} can be activated given {@code matchingRoutes}, the result of {@link
+   * #resolveStaticNextHopIp} for its next hop IP and recursiveness.
    */
   public static <R extends AbstractRouteDecorator> boolean shouldActivateNextHopIpRoute(
-      StaticRoute route, GenericRib<R> rib, ResolutionRestriction<R> restriction) {
-    boolean recursive = route.getRecursive();
+      StaticRoute route, Set<R> matchingRoutes) {
     Ip nextHopIp = route.getNextHopIp();
-    Set<R> matchingRoutes =
-        rib.longestPrefixMatch(
-            nextHopIp,
-            r -> {
-              if (r.getAbstractRoute().getProtocol() == RoutingProtocol.CONNECTED) {
-                // All static routes can be activated by a connected route.
-                return true;
-              }
-              if (!recursive) {
-                // Non-recursive static routes cannot be activated by non-connected routes.
-                return false;
-              }
-              // Recursive routes must pass restriction if present.
-              return restriction.test(r);
-            });
-
     // - If matchingRoutes is empty, cannot activate because the next hop ip is unreachable.
     // - If the prefix of the route to be activated contains the route's next hop, then
     //   a matching route must have a longer prefix. Otherwise, the route will become its own

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/StaticRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/StaticRouteHelperTest.java
@@ -2,15 +2,19 @@ package org.batfish.dataplane.protocols;
 
 import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
 import static org.batfish.dataplane.ibdp.TestUtils.annotateRoute;
+import static org.batfish.dataplane.protocols.StaticRouteHelper.resolveStaticNextHopIp;
 import static org.batfish.dataplane.protocols.StaticRouteHelper.shouldActivateNextHopIpRoute;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.dataplane.rib.Rib;
 import org.junit.Before;
@@ -18,6 +22,12 @@ import org.junit.Test;
 
 /** Tests for {@link StaticRouteHelper} */
 public final class StaticRouteHelperTest {
+
+  private static boolean shouldActivate(
+      StaticRoute sr, Rib rib, ResolutionRestriction<AnnotatedRoute<AbstractRoute>> restriction) {
+    return shouldActivateNextHopIpRoute(
+        sr, resolveStaticNextHopIp(sr.getNextHopIp(), sr.getRecursive(), rib, restriction));
+  }
 
   private Rib _rib;
 
@@ -37,7 +47,7 @@ public final class StaticRouteHelperTest {
             .setNextHopIp(nextHop)
             .setAdministrativeCost(1)
             .build();
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(false));
+    assertThat(shouldActivate(sr, _rib, alwaysTrue()), equalTo(false));
   }
 
   /** Do not activate if no match for nextHop IP exists */
@@ -54,7 +64,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(false));
+    assertThat(shouldActivate(sr, _rib, alwaysTrue()), equalTo(false));
   }
 
   /** Activate if next hop IP matches a route */
@@ -77,7 +87,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
+    assertThat(shouldActivate(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /** Do not activate if the route to the next hop IP has same prefix as route in question. */
@@ -100,7 +110,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(false));
+    assertThat(shouldActivate(sr, _rib, alwaysTrue()), equalTo(false));
   }
 
   /**
@@ -119,7 +129,7 @@ public final class StaticRouteHelperTest {
     _rib.mergeRoute(annotateRoute(matching));
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
+    assertThat(shouldActivate(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /** Activate if route exists for the same prefix but next hop is different */
@@ -151,7 +161,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
+    assertThat(shouldActivate(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /** Allow activation in the RIB even if there would be a FIB resolution loop. */
@@ -185,7 +195,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
+    assertThat(shouldActivate(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /**
@@ -205,7 +215,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertFalse(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()));
+    assertFalse(shouldActivate(sr, _rib, alwaysTrue()));
   }
 
   /**
@@ -230,7 +240,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertTrue(shouldActivateNextHopIpRoute(sr, _rib, r -> r.getNetwork().getPrefixLength() == 8));
+    assertTrue(shouldActivate(sr, _rib, r -> r.getNetwork().getPrefixLength() == 8));
   }
 
   /**
@@ -256,8 +266,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertFalse(
-        shouldActivateNextHopIpRoute(sr, _rib, r -> r.getNetwork().getPrefixLength() == 16));
+    assertFalse(shouldActivate(sr, _rib, r -> r.getNetwork().getPrefixLength() == 16));
   }
 
   /**
@@ -284,7 +293,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertFalse(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()));
+    assertFalse(shouldActivate(sr, _rib, alwaysTrue()));
   }
 
   /**
@@ -305,6 +314,6 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertTrue(shouldActivateNextHopIpRoute(sr, _rib, r -> false));
+    assertTrue(shouldActivate(sr, _rib, r -> false));
   }
 }


### PR DESCRIPTION
Conditional static routes are grouped by next hop IP for re-evaluation,
and the routes of a group differ only in prefix and distance, yet each
was resolved with its own longest prefix match. StaticRouteHelper now
offers resolving a next hop IP, which depends on the IP and on whether
the route is recursive, separately from the check that a route's own
prefix does not swallow it; the combined form is gone, and VirtualRouter
resolves a group at most once per recursiveness and hands the result to
the next hop check. A route that should be active and is already in the
main RIB is not merged again, which was a no-op; deactivation still
runs, since the route may be a backup. On a large snapshot the
per-iteration recomputation of conditional statics went from about five
seconds to under three, with identical routes at every step.

----

Prompt:
```
Upstream 5b of the dataplane batch: static-route activation by next-hop
group.
```