### PR TITLE
ibdp: hash and count RIB routes without materializing the route set each iteration

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -1143,7 +1143,7 @@ final class IncrementalBdpEngine {
     ae.getBgpMultipathRibRoutesByIteration()
         .put(dependentRoutesIterations, numBgpMultipathRibRoutes);
     int numMainRibRoutes =
-        vrs.parallelStream().mapToInt(vr -> vr.getMainRib().getRoutes().size()).sum();
+        vrs.parallelStream().mapToInt(vr -> vr.getMainRib().getNumRoutes()).sum();
     ae.getMainRibRoutesByIteration().put(dependentRoutesIterations, numMainRibRoutes);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -1703,7 +1703,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
             _activatedGeneratedRoutes.stream(),
             // RIB state
             Stream.of(_intraAreaRib, _interAreaRib, _internalSummaryRib, _type1Rib, _type2Rib)
-                .map(AbstractRib::getRoutes))
+                .map(AbstractRib::getRoutesHashCode))
         .collect(toOrderedHashCode());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1603,8 +1603,8 @@ public final class VirtualRouter {
    */
   int computeIterationHashCode() {
     return Streams.concat(
-            // RIB State
-            Stream.of(_mainRib.getRoutes()),
+            // RIB State: Set.hashCode of the main RIB routes, without materializing the set
+            Stream.of(_mainRib.getRoutesHashCode()),
             // Message queues
             messageQueueStream(_isisIncomingRoutes),
             messageQueueStream(_crossVrfIncomingRoutes),

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -35,6 +35,12 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   private transient @Nullable Set<R> _allRoutes;
 
   /**
+   * {@link Set#hashCode()} of {@link #getRoutes()}, the sum of the routes' hash codes, maintained
+   * as routes come and go so that hashing the RIB state need not materialize the set.
+   */
+  private int _routesHashCode;
+
+  /**
    * Routes this RIB was offered that are not currently in {@link #_tree}, because a preferred route
    * for the same prefix is. Used to update the RIB if best routes are withdrawn. Most prefixes are
    * only ever offered the routes they hold, so this is far smaller than the RIB.
@@ -114,6 +120,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   public final void clear() {
     _tree.clear();
     _allRoutes = null;
+    _routesHashCode = 0;
   }
 
   @Override
@@ -150,6 +157,17 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
       _allRoutes = computeRoutes();
     }
     return _allRoutes;
+  }
+
+  /** Number of routes in this RIB, without materializing {@link #getRoutes()}. */
+  public final int getNumRoutes() {
+    return _tree.getNumRoutes();
+  }
+
+  /** {@link Set#hashCode()} of {@link #getRoutes()}, without materializing it. */
+  public final int getRoutesHashCode() {
+    assert _routesHashCode == _tree.getRoutes().hashCode();
+    return _routesHashCode;
   }
 
   protected @Nonnull Set<R> computeRoutes() {
@@ -216,12 +234,15 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
       }
       return delta;
     }
-    if (_backupRoutes != null) {
-      for (RouteAdvertisement<R> action : delta.getActions()) {
-        if (action.getReason() == Reason.REPLACE) {
+    for (RouteAdvertisement<R> action : delta.getActions()) {
+      if (action.isWithdrawn()) {
+        _routesHashCode -= action.getRoute().hashCode();
+        if (_backupRoutes != null && action.getReason() == Reason.REPLACE) {
           // Displaced by the new route: now a backup.
           _backupRoutes.put(action.getRoute().getNetwork(), action.getRoute());
         }
+      } else {
+        _routesHashCode += action.getRoute().hashCode();
       }
     }
     // A change to routes has been made
@@ -257,9 +278,12 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
       }
       return delta;
     }
-    if (_backupRoutes != null) {
-      for (RouteAdvertisement<R> action : delta.getActions()) {
-        if (!action.isWithdrawn()) {
+    for (RouteAdvertisement<R> action : delta.getActions()) {
+      if (action.isWithdrawn()) {
+        _routesHashCode -= action.getRoute().hashCode();
+      } else {
+        _routesHashCode += action.getRoute().hashCode();
+        if (_backupRoutes != null) {
           // Promoted from backup to replace the removed route.
           _backupRoutes.remove(action.getRoute().getNetwork(), action.getRoute());
         }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Set;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Bgpv4Route;
@@ -121,6 +122,61 @@ public class RibTest {
     rib.removeRoute(r2);
     assertThat(rib.getRoutes(), empty());
     assertThat(rib.getBackupRoutes(), empty());
+  }
+
+  /** The maintained hash code tracks {@link Set#hashCode()} of the routes through every change. */
+  @Test
+  public void testRoutesHashCode() {
+    Prefix prefix = Prefix.strict("1.0.0.0/31");
+    Rib rib = new Rib();
+    AnnotatedRoute<AbstractRoute> worse =
+        annotateRoute(
+            OspfIntraAreaRoute.builder()
+                .setNetwork(prefix)
+                .setArea(0L)
+                .setNextHopInterface("foo")
+                .setAdmin(110)
+                .setMetric(1L)
+                .setNextHopIp(Ip.parse("2.0.0.1"))
+                .build());
+    AnnotatedRoute<AbstractRoute> better =
+        annotateRoute(
+            Bgpv4Route.testBuilder()
+                .setAdmin(20)
+                .setNetwork(prefix)
+                .setNextHopInterface("bar")
+                .setOriginatorIp(Ip.parse("1.1.1.1"))
+                .setOriginType(OriginType.IGP)
+                .setProtocol(RoutingProtocol.BGP)
+                .build());
+    AnnotatedRoute<AbstractRoute> other =
+        annotateRoute(new ConnectedRoute(Prefix.strict("2.0.0.0/24"), "baz"));
+    assertThat(rib.getRoutesHashCode(), equalTo(rib.getRoutes().hashCode()));
+    rib.mergeRoute(worse);
+    assertThat(rib.getRoutesHashCode(), equalTo(rib.getRoutes().hashCode()));
+    rib.mergeRoute(other);
+    assertThat(rib.getRoutesHashCode(), equalTo(rib.getRoutes().hashCode()));
+    // replaces worse
+    rib.mergeRoute(better);
+    assertThat(rib.getRoutesHashCode(), equalTo(rib.getRoutes().hashCode()));
+    int installed = rib.getRoutesHashCode();
+    // duplicate offer, no change
+    assertThat(rib.mergeRoute(better), equalTo(false));
+    assertThat(rib.getRoutesHashCode(), equalTo(installed));
+    // loses to better, kept only as a backup, no change
+    assertThat(rib.mergeRoute(worse), equalTo(false));
+    assertThat(rib.getRoutesHashCode(), equalTo(installed));
+    // not present, no change
+    assertThat(rib.removeRoute(annotateRoute(new ConnectedRoute(prefix, "qux"))), equalTo(false));
+    assertThat(rib.getRoutesHashCode(), equalTo(installed));
+    assertThat(rib.getRoutesHashCode(), equalTo(rib.getRoutes().hashCode()));
+    // restores worse
+    rib.removeRoute(better);
+    assertThat(rib.getRoutesHashCode(), equalTo(rib.getRoutes().hashCode()));
+    rib.removeRoute(other);
+    rib.removeRoute(worse);
+    assertThat(rib.getRoutes(), empty());
+    assertThat(rib.getRoutesHashCode(), equalTo(0));
   }
 
   @Test


### PR DESCRIPTION
Every iteration hashes each VRF's main RIB and OSPF RIBs for oscillation
detection and counts the main RIB routes for statistics. Both went
through getRoutes(), which builds an ImmutableSet of every route in the
RIB whenever the RIB changed since the last call, so a changed RIB paid
a full copy per iteration and the copies of all main RIBs stayed live
between iterations.

Maintain Set.hashCode() of the routes in AbstractRib as merges and
removals report their deltas, and expose it with getRoutesHashCode();
expose the tree's route count with getNumRoutes(). Hash the RIB state
and count main RIB routes with those. The hash value is unchanged, so
oscillation detection behaves as before, and getRoutesHashCode() asserts
against the materialized value.

On a large snapshot the per-iteration statistics went from about seven
seconds to two over a dataplane computation, with identical results.

----

Prompt:
```
Upstream the next performance change: maintain the main RIB's
Set.hashCode incrementally so iteration hashing and statistics need not
materialize the route set.
```
