### PR TITLE
topology: compute per-device ARP replies, host subnet IPs, owned IP spaces, and location info in parallel

### DIFF
--- a/projects/common/src/main/java/org/batfish/common/topology/IpOwnersBaseImpl.java
+++ b/projects/common/src/main/java/org/batfish/common/topology/IpOwnersBaseImpl.java
@@ -4,12 +4,14 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.Maps.immutableEntry;
 import static org.batfish.common.topology.TopologyUtil.computeNodeInterfaces;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
+import static org.batfish.common.util.CollectionUtil.toImmutableMapParallel;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -249,7 +251,7 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
   @VisibleForTesting
   static @Nonnull Map<String, Map<String, IpSpace>> computeInterfaceHostSubnetIps(
       Map<String, Configuration> configs, boolean excludeInactive) {
-    return toImmutableMap(
+    return toImmutableMapParallel(
         configs,
         Entry::getKey, /* hostname */
         nodeEntry ->
@@ -839,7 +841,9 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
    */
   private static @Nonnull Map<String, Map<String, Map<String, IpSpace>>> computeIfaceOwnedIpSpaces(
       Map<Ip, Map<String, Map<String, Set<String>>>> ipIfaceOwners) {
-    Map<String, Map<String, Map<String, IpWildcardSetIpSpace.Builder>>> builders = new HashMap<>();
+    // Invert to node -> vrf -> interface -> IPs, then build the IP spaces, the expensive part, per
+    // node in parallel. Each interface's IPs stay in the order they were visited.
+    Map<String, Map<String, Map<String, List<Ip>>>> ips = new HashMap<>();
     ipIfaceOwners.forEach(
         (ip, nodeMap) ->
             nodeMap.forEach(
@@ -848,13 +852,12 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
                         (vrf, ifaces) ->
                             ifaces.forEach(
                                 iface ->
-                                    builders
-                                        .computeIfAbsent(node, k -> new HashMap<>())
+                                    ips.computeIfAbsent(node, k -> new HashMap<>())
                                         .computeIfAbsent(vrf, k -> new HashMap<>())
-                                        .computeIfAbsent(iface, k -> IpWildcardSetIpSpace.builder())
-                                        .including(IpWildcard.create(ip))))));
-    return toImmutableMap(
-        builders,
+                                        .computeIfAbsent(iface, k -> new ArrayList<>())
+                                        .add(ip)))));
+    return toImmutableMapParallel(
+        ips,
         Entry::getKey, /* node */
         nodeEntry ->
             toImmutableMap(
@@ -864,7 +867,13 @@ public abstract class IpOwnersBaseImpl implements IpOwners {
                     toImmutableMap(
                         vrfEntry.getValue(),
                         Entry::getKey, /* interface */
-                        ifaceEntry -> ifaceEntry.getValue().build())));
+                        ifaceEntry -> {
+                          IpWildcardSetIpSpace.Builder space = IpWildcardSetIpSpace.builder();
+                          for (Ip ip : ifaceEntry.getValue()) {
+                            space.including(IpWildcard.create(ip));
+                          }
+                          return space.build();
+                        })));
   }
 
   /**

--- a/projects/common/src/main/java/org/batfish/common/util/CollectionUtil.java
+++ b/projects/common/src/main/java/org/batfish/common/util/CollectionUtil.java
@@ -67,6 +67,20 @@ public final class CollectionUtil {
     return map.entrySet().stream().collect(ImmutableMap.toImmutableMap(keyFunction, valueFunction));
   }
 
+  /**
+   * {@link #toImmutableMap(Map, Function, Function)} with the functions applied in parallel. For
+   * maps with a value function expensive enough to be worth the fork-join overhead, such as one
+   * doing per-device work; the functions must be safe to call concurrently. The result has the same
+   * iteration order as the sequential version.
+   */
+  public static <K1, K2, V1, V2> Map<K2, V2> toImmutableMapParallel(
+      Map<K1, V1> map,
+      Function<Entry<K1, V1>, K2> keyFunction,
+      Function<Entry<K1, V1>, V2> valueFunction) {
+    return map.entrySet().parallelStream()
+        .collect(ImmutableMap.toImmutableMap(keyFunction, valueFunction));
+  }
+
   public static <K1, K2, V> Map<K2, V> toMap(
       Set<K1> set, Function<K1, K2> keyFunction, Function<K1, V> valueFunction) {
     return set.stream().collect(Collectors.toMap(keyFunction, valueFunction));

--- a/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/common/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
+import static org.batfish.common.util.CollectionUtil.toImmutableMapParallel;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -426,7 +427,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis, Seriali
       Map<String, Map<String, Set<Ip>>> interfaceOwnedIps,
       // node -> vrf -> routable IPs
       Map<String, Map<String, IpSpace>> routableIps) {
-    return toImmutableMap(
+    return toImmutableMapParallel(
         configurations,
         Entry::getKey,
         nodeEntry -> {

--- a/projects/common/src/main/java/org/batfish/specifier/LocationInfoUtils.java
+++ b/projects/common/src/main/java/org/batfish/specifier/LocationInfoUtils.java
@@ -80,8 +80,8 @@ public final class LocationInfoUtils {
       IpSpace snapshotDeviceOwnedIps,
       Map<String, Map<String, IpSpace>> interfaceOwnedIps,
       Map<String, Configuration> configs) {
-
-    return configs.values().stream()
+    // Per device, in parallel; the collector keeps the encounter order.
+    return configs.values().parallelStream()
         .flatMap(
             config -> {
               Map<Location, LocationInfo> locationInfo =


### PR DESCRIPTION
Four per-round computations ran sequentially over all devices, each a
pure function of one device's configuration and read-only shared inputs:
ARP replies and interface host subnet IPs in the forwarding analysis,
the owned-IP inversion in IpOwnersBaseImpl, and computeLocationInfo.

Add CollectionUtil.toImmutableMapParallel, the parallel form of
toImmutableMap with the same iteration order, and use it for the first
three. Run computeLocationInfo as a parallel stream; its collector keeps
the encounter order. In the owned-IP inversion, collect each interface's
IPs into a list first and build the IpWildcardSetIpSpaces, the expensive
part, per device in parallel.

Worth about two seconds per dataplane on a large snapshot, with
identical results.

----

Prompt:
```
Send the two small remaining OSS PRs: the parallel per-device ARP
replies and location info, and the schedule computed once per topology
round.
```
